### PR TITLE
security: Fix CORS wildcard headers with credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ app.add_middleware(
     allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization", "X-Requested-With", "X-Tz-Offset", "X-Odysseus-Owner", "X-Odysseus-Internal-Token"],
 )
 
 # ========= SECURITY HEADERS MIDDLEWARE =========


### PR DESCRIPTION
Replace `allow_headers=["*"]` with an explicit list. The CORS spec disallows wildcard headers combined with `allow_credentials=True`, and it allows injecting arbitrary headers on credentialed cross-origin requests in non-compliant clients. Enumerated all headers the app actually reads from incoming requests.