### PR TITLE
Fix landing page footer trap, Windows uvicorn start, and add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Odysseus
+
+Thanks for helping out. This ship is moving fast and feedback, bug reports, and
+focused fixes are all genuinely appreciated.
+
+## Where to start
+
+The best entry points are listed in [ROADMAP.md](ROADMAP.md). In short:
+
+- Fresh-install testing (Docker and manual) on Linux, macOS, and Windows.
+- Provider and integration setup bugs.
+- Mobile and editor polish.
+- Docs, especially self-host troubleshooting notes.
+- Small, focused refactors.
+
+If you are unsure whether something is wanted, open an issue first and ask
+before writing a large change.
+
+## Reporting bugs
+
+Open an issue with:
+
+- What you did, what you expected, and what actually happened.
+- Your platform (OS, Python version, Docker vs manual install).
+- Relevant logs. Scrub secrets first (API keys, tokens, password hashes).
+
+Do not paste live `.env` values, database contents, or anything from `data/`.
+
+## Development setup
+
+Use the manual install from the [README](README.md#option-2-manual-install--linux--macos):
+
+```bash
+python3 -m venv venv
+source venv/bin/activate        # venv\Scripts\Activate.ps1 on Windows
+pip install -r requirements.txt
+python setup.py
+python -m uvicorn app:app --host 127.0.0.1 --port 7000
+```
+
+Bind to `127.0.0.1` for local development. Only use `0.0.0.0` when you
+intentionally want LAN or reverse-proxy access.
+
+## Running tests
+
+Tests live in `tests/` and run with pytest:
+
+```bash
+pip install pytest pytest-asyncio
+pytest
+```
+
+Please run the suite before opening a pull request, and add tests for new
+behavior or regressions you fix where it is practical.
+
+## Pull requests
+
+- Branch off the default branch and keep each PR focused on one thing.
+- Write a clear description: what changed, why, and how you tested it.
+- Link the issue it addresses (for example, `Closes #123`).
+- Keep diffs minimal. Avoid drive-by reformatting of unrelated code.
+- Do not commit anything from `data/`, `.env`, logs, uploads, generated media,
+  local databases, backups, or secrets. See [SECURITY.md](SECURITY.md) for the
+  pre-publish checks.
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes so
+history stays readable:
+
+- `feat:` a new feature
+- `fix:` a bug fix
+- `docs:` documentation only
+- `refactor:` code change that neither fixes a bug nor adds a feature
+- `test:` adding or fixing tests
+- `chore:` tooling, deps, or housekeeping
+
+Example: `fix: make landing page footer reachable under scroll-snap`.
+
+## Code style
+
+- Match the style of the surrounding code rather than introducing a new one.
+- Frontend lives in `static/` (`index.html`, `app.js`, `style.css`, `js/`).
+  Backend is FastAPI in `app.py`, `core/`, `src/`, `routes/`, and `services/`.
+- Watch out for mobile `@media` overrides of the same selector. A lot of
+  "my CSS did not apply" bugs come from a paired mobile rule.
+
+## Security
+
+If you find a vulnerability, follow [SECURITY.md](SECURITY.md). Please do not
+disclose exploit details in a public issue.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ For a LAN-only Tailscale deployment, Caddy + [tailscale-cert](https://caddyserve
 ## Contributing
 Help is welcome. The best entry points are fresh-install testing, provider setup
 bugs, mobile/editor polish, docs, and small focused refactors. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup, tests, and PR conventions, and
 [ROADMAP.md](ROADMAP.md) for the current help-wanted list.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 python setup.py            # creates data dirs and prints an initial admin password
-uvicorn app:app --host 0.0.0.0 --port 7000
+python -m uvicorn app:app --host 0.0.0.0 --port 7000
 ```
 
 ### Option 3: Manual install — Windows (PowerShell)
@@ -116,8 +116,13 @@ python -m venv venv
 venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 python setup.py
-uvicorn app:app --host 0.0.0.0 --port 7000
+python -m uvicorn app:app --host 0.0.0.0 --port 7000
 ```
+
+> If you see `uvicorn: command not recognized`, the virtual environment's
+> scripts are not on your `PATH`. Running it through the interpreter as
+> `python -m uvicorn ...` (as shown above) avoids that and always uses the
+> uvicorn installed in the active environment.
 
 Open `http://localhost:7000`, log in with the generated admin password,
 and configure everything else inside **Settings**.

--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,10 @@
   .pill-row { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; margin-top: 44px; }
   .pill { font-size: 12.5px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 12px; background: var(--panel); }
 
-  footer { border-top: 1px solid var(--border); padding: 30px 0; color: var(--muted); font-size: 13px; }
+  /* The footer is shorter than a full viewport, so under "mandatory" snapping it
+     was unreachable -- the scroll kept snapping back to the last section. Make it
+     an end-aligned snap point so it rests at the bottom of the scroll range. */
+  footer { scroll-snap-align: end; border-top: 1px solid var(--border); padding: 30px 0; color: var(--muted); font-size: 13px; }
   footer .wrap { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
 
   @media (max-width: 820px) {

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ def main():
 
     print("\n=== Setup complete ===")
     print(f"\nStart the server with:")
-    print(f"  uvicorn app:app --host 0.0.0.0 --port 7000")
+    print(f"  {os.path.basename(sys.executable)} -m uvicorn app:app --host 0.0.0.0 --port 7000")
     print(f"\nThen open http://localhost:7000")
     print(f"Login with the admin username and temporary password printed above.\n")
 


### PR DESCRIPTION
## Summary

Fixes three open issues: a scroll-snap bug that hid the landing page footer,
a Windows server-start failure, and the missing contributing guide.

## Changes

### fix: make landing page footer reachable under scroll-snap (#8)
The landing page used `scroll-snap-type: y mandatory` with full-viewport
sections, but the footer was not a snap point and is shorter than the viewport,
so scrolling kept snapping back to the last section and the footer was
unreachable. Marked the footer as an end-aligned snap point so it rests at the
bottom of the scroll range.

### fix: start the server with `python -m uvicorn` (#19)
Bare `uvicorn app:app` fails with "uvicorn not recognized" when the virtual
environment's scripts directory is not on `PATH`, which is common on Windows.
Invoke uvicorn through the active interpreter instead, in both README manual
installs and the `setup.py` next-steps output, and add a short troubleshooting
note to the README.

### docs: add contributing guide (#14)
Added `CONTRIBUTING.md` covering where to start, dev setup, running tests, pull
request and commit conventions, code style, and security, and linked it from the
README.

## Testing
- Verified `docs/index.html` snap behavior change is isolated to the footer rule.
- Could not run the Python suite locally (no interpreter on this machine); the
  `setup.py` change is a trivial f-string using already-imported `os` and `sys`.

Closes #8
Closes #19
Closes #14