### PR TITLE
security: multiple command injection vulnerabilities

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -472,7 +472,7 @@ def setup_shell_routes() -> APIRouter:
         return StreamingResponse(generate(), media_type="text/event-stream")
 
     @router.get("/api/cookbook/packages")
-    async def list_packages(host: str | None = None, ssh_port: str | None = None, venv: str | None = None):
+    async def list_packages(request: Request, host: str | None = None, ssh_port: str | None = None, venv: str | None = None):
         """Check which optional packages are installed.
 
         Local-target packages are checked in-process. Remote-target packages
@@ -480,6 +480,13 @@ def setup_shell_routes() -> APIRouter:
         server over SSH, inside its venv — otherwise installing on a remote box
         never reflected because the check only ever looked at the local host.
         """
+        _require_admin(request)
+        if ssh_port and not ssh_port.isdigit():
+            raise HTTPException(400, "ssh_port must be a number")
+        
+        # Build the shared port arg string
+        port_arg = f"-p {ssh_port} " if ssh_port and ssh_port != "22" else ""
+
         import importlib, shlex, json as _json
         packages = [
             # ── System ── OS binaries, not pip packages
@@ -520,9 +527,8 @@ def setup_shell_routes() -> APIRouter:
                     # the && short-circuits and every package reads as missing).
                     src = f". {act} && "
                 inner = f"{src}python3 -c {shlex.quote(py)}"
-                pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
                 ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {pf}"
+                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
                     f"{shlex.quote(host)} {shlex.quote(inner)}"
                 )
                 proc = await asyncio.create_subprocess_shell(
@@ -545,9 +551,8 @@ def setup_shell_routes() -> APIRouter:
                     qn = shlex.quote(name)
                     checks.append(f"if command -v {qn} >/dev/null 2>&1; then echo {qn}=1; else echo {qn}=0; fi")
                 inner = " ; ".join(checks)
-                pf = f"-p {ssh_port} " if ssh_port and ssh_port not in ("", "22") else ""
                 ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {pf}"
+                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
                     f"{shlex.quote(host)} {shlex.quote(inner)}"
                 )
                 proc = await asyncio.create_subprocess_shell(

--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -278,7 +278,9 @@ async def action_run_script(owner: str, script: str = "", host: str = "", **kwar
         return "No script specified", False
     target_host = (host or os.getenv("ODYSSEUS_SCRIPT_HOST", "localhost")).strip()
     if target_host in ("", "localhost", "127.0.0.1", "local"):
-        return await _run_subprocess(script, shell=True, timeout=300, label="Script")
+        import shlex
+        safe_args = shlex.split(script)
+        return await _run_subprocess(safe_args, shell=False, timeout=300, label="Script")
     return await _run_subprocess(["ssh", target_host, script], timeout=300, label="Script")
 
 
@@ -286,7 +288,9 @@ async def action_run_local(owner: str, script: str = "", **kwargs) -> Tuple[str,
     """Run a script locally (no SSH)."""
     if not script:
         return "No script specified", False
-    return await _run_subprocess(script, shell=True, timeout=300, label="Script")
+    import shlex
+    safe_args = shlex.split(script)
+    return await _run_subprocess(safe_args, shell=False, timeout=300, label="Script")
 
 
 async def action_tidy_research(owner: str, **kwargs) -> Tuple[str, bool]:


### PR DESCRIPTION
This PR fixes a couple of critical Remote Code Execution (RCE) vulnerabilities related to how the app handles shell commands.

**1. Prompt Injection to RCE (`builtin_actions.py`)** 
The agent's built-in actions (`action_run_local` and `action_run_script`) were passing raw strings directly to `subprocess.run` with `shell=True`. This meant if the agent read a malicious file, summarized a bad webpage, or processed a weird email (Indirect Prompt Injection), an attacker could trick the agent into silently running arbitrary shell commands on the host server. I updated these to safely parse the arguments using `shlex.split()` and set `shell=False`.

**2. API Command Injection & Missing Auth (`shell_routes.py`)**
Over in `routes/shell_routes.py`, the `GET /api/cookbook/packages` endpoint was completely missing its admin check, meaning any authenticated user could hit it. Worse, the `ssh_port` parameter was being interpolated straight into an SSH command string without any sanitization. An attacker could sneak in bash commands (like `ssh_port="22; malicious_command"`). I added the missing `_require_admin(request)` check and locked down the port parameter down so it only accepts numbers (`isdigit()`).