### PR TITLE
Fix Windows startup by guarding PTY imports

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -4,8 +4,6 @@ import asyncio
 import json
 import logging
 import os
-import pty
-import fcntl
 import shlex
 import shutil
 import uuid
@@ -16,6 +14,15 @@ from typing import Dict, Any
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+
+if os.name != "nt":
+    import pty
+    import fcntl
+else:
+    pty = None
+    fcntl = None
+
+HAS_PTY_SUPPORT = pty is not None and fcntl is not None
 
 
 def _require_admin(request: Request):
@@ -97,6 +104,11 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, An
 
 async def _generate_pty(cmd: str, timeout: int, request: Request):
     """Run command in a pseudo-TTY so tqdm/progress bars work natively."""
+    if not HAS_PTY_SUPPORT:
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': 'PTY mode is not supported on Windows. Retry with use_pty=false.'})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        return
+
     loop = asyncio.get_event_loop()
     master_fd, slave_fd = pty.openpty()
 


### PR DESCRIPTION
This pull request improves cross-platform compatibility for the shell execution routes by conditionally importing modules and handling PTY (pseudo-terminal) support based on the operating system. The most significant changes ensure that the code gracefully handles environments where PTY is not available, such as Windows, and provides clear feedback to users.

**Cross-platform compatibility and PTY support:**

* Conditional imports for `pty` and `fcntl` are introduced, importing them only on non-Windows systems, and defining `HAS_PTY_SUPPORT` to indicate PTY availability. (`routes/shell_routes.py`) [[1]](diffhunk://#diff-3bd106cbef8e390ad0677bd3c01ff31f72eac92155b34c0ea6eff60672b9d6dcL7-L8) [[2]](diffhunk://#diff-3bd106cbef8e390ad0677bd3c01ff31f72eac92155b34c0ea6eff60672b9d6dcR18-R26)
* The `_generate_pty` function now checks for PTY support and, if unavailable (e.g., on Windows), streams an error message and exit code to the client instead of attempting to use PTY. (`routes/shell_routes.py`)