### PR TITLE
Add macOS startup helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,10 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Misc
 # ============================================================
 
+# Optional Docker host binding for Odysseus. Use a bare port or host:port.
+# scripts/odysseus-mac docker --port overrides this for that run.
+# ODYSSEUS_BIND=7000
+
 # Cleanup interval in hours (default: 24)
 # CLEANUP_INTERVAL_HOURS=24
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ docker compose up -d --build
 Compose starts Odysseus, ChromaDB, SearXNG, and ntfy. First run does a full
 image build. Open `http://localhost:7000` after the containers are healthy.
 
+On macOS, the helper can do the same Docker startup with a few local checks:
+```bash
+scripts/odysseus-mac doctor
+scripts/odysseus-mac docker
+```
+It checks Docker Desktop, writes your host UID/GID to `.env` for editable
+bind-mounted files, and moves bundled SearXNG if `127.0.0.1:8080` is busy.
+
 Cookbook remote servers use an Odysseus-owned SSH key from `./data/ssh`
 inside Docker. In **Cookbook -> Settings -> Servers**, generate/copy the
 public key and add it to the remote server's `~/.ssh/authorized_keys`.
@@ -107,6 +115,10 @@ pip install -r requirements.txt
 python setup.py            # creates data dirs and prints an initial admin password
 uvicorn app:app --host 0.0.0.0 --port 7000
 ```
+
+For full native search/vector-memory support, also run ChromaDB and SearXNG
+locally. On macOS, use Docker unless you need native Python; if you do,
+`scripts/odysseus-mac native --with-services` handles the sidecar services.
 
 ### Option 3: Manual install — Windows (PowerShell)
 ```powershell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   odysseus:
     build: .
     ports:
-      - "7000:7000"
+      - "${ODYSSEUS_BIND:-7000}:7000"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
@@ -13,7 +13,8 @@ services:
       # container, so persist its HuggingFace cache under ./data/huggingface.
       - ./data/huggingface:/app/.cache/huggingface
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - SEARXNG_INSTANCE=http://searxng:8080
       - CHROMADB_HOST=chromadb
@@ -48,12 +49,12 @@ services:
   searxng:
     image: searxng/searxng:latest
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${SEARXNG_BIND:-127.0.0.1:8080}:8080"
     volumes:
       - searxng-data:/etc/searxng
       - ./config/searxng/settings.yml:/etc/searxng/settings.yml
     environment:
-      - SEARXNG_BASE_URL=http://localhost:8080/
+      - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://localhost:8080/}
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
       interval: 5s

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -902,7 +902,8 @@ def setup_calendar_routes() -> APIRouter:
                     lines.append(f"DTSTART:{ev.dtstart.strftime('%Y%m%dT%H%M%S')}")
                     lines.append(f"DTEND:{ev.dtend.strftime('%Y%m%dT%H%M%S')}")
                 if ev.description:
-                    lines.append(f"DESCRIPTION:{ev.description.replace(chr(10), '\\n')}")
+                    description = ev.description.replace("\n", "\\n")
+                    lines.append(f"DESCRIPTION:{description}")
                 if ev.location:
                     lines.append(f"LOCATION:{ev.location}")
                 if ev.rrule:

--- a/scripts/_completion/odysseus.zsh
+++ b/scripts/_completion/odysseus.zsh
@@ -1,4 +1,4 @@
-#compdef odysseus odysseus-backup odysseus-calendar odysseus-contacts odysseus-cookbook odysseus-docs odysseus-gallery odysseus-mail odysseus-mcp odysseus-memory odysseus-notes odysseus-personal odysseus-preset odysseus-research odysseus-sessions odysseus-signature odysseus-skills odysseus-tasks odysseus-theme odysseus-webhook
+#compdef odysseus odysseus-backup odysseus-calendar odysseus-contacts odysseus-cookbook odysseus-docs odysseus-gallery odysseus-mac odysseus-mail odysseus-mcp odysseus-memory odysseus-notes odysseus-personal odysseus-preset odysseus-research odysseus-sessions odysseus-signature odysseus-skills odysseus-tasks odysseus-theme odysseus-webhook
 # Zsh tab-completion for the odysseus umbrella + sub-CLIs.
 #
 # Drop in any directory on $fpath, e.g.:

--- a/scripts/odysseus-mac
+++ b/scripts/odysseus-mac
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Small macOS launcher for Odysseus."""
+from __future__ import annotations
+
+import argparse
+import errno
+import os
+import platform
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+APP_PORT, SEARX_PORT, CHROMA_PORT, NTFY_PORT = 7000, 8080, 8100, 8091
+
+
+def run(args, root=ROOT, check=False, quiet=False):
+    if not quiet:
+        print("$ " + " ".join(map(str, args)), flush=True)
+    if check:
+        subprocess.run(list(map(str, args)), cwd=root, check=True)
+        return 0, ""
+    try:
+        p = subprocess.run(list(map(str, args)), cwd=root, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+        return p.returncode, p.stdout.strip()
+    except Exception as exc:
+        return 1, str(exc)
+
+
+def parse_python_version(text):
+    m = re.search(r"Python\s+(\d+)\.(\d+)(?:\.(\d+))?", text)
+    return None if not m else (int(m[1]), int(m[2]), int(m[3] or 0))
+
+
+def classify_python_version(version):
+    if version is None:
+        return "unknown"
+    if version[0] != 3:
+        return "unsupported"
+    if version[1] in (11, 12):
+        return "supported"
+    return "too_new" if version[1] >= 13 else "too_old"
+
+
+def py_version(exe):
+    code, out = run([exe, "--version"], quiet=True)
+    return parse_python_version(out) if code == 0 else None
+
+
+def supported_python():
+    for name in ("python3.11", "python3.12", "python3"):
+        exe = shutil.which(name)
+        version = py_version(exe) if exe else None
+        if version and classify_python_version(version) == "supported":
+            return exe, version
+    return None
+
+
+def active_env_text(root):
+    env, example = root / ".env", root / ".env.example"
+    return env.read_text() if env.exists() else example.read_text() if example.exists() else ""
+
+
+def env_values(root):
+    values = {}
+    for line in active_env_text(root).splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in line:
+            key, val = line.split("=", 1)
+            values[key.strip()] = val.strip()
+    return values
+
+
+def set_env(root, updates):
+    text = active_env_text(root)
+    for key, val in updates.items():
+        line = f"{key}={val}"
+        if re.search(rf"^{re.escape(key)}\s*=", text, flags=re.M):
+            text = re.sub(rf"^{re.escape(key)}\s*=.*$", line, text, flags=re.M)
+        else:
+            text += ("\n" if text and not text.endswith("\n") else "") + line + "\n"
+    path = root / ".env"
+    path.write_text(text.rstrip() + "\n")
+    return path
+
+
+def split_bind(value, default_host, default_port):
+    raw = (value or str(default_port)).strip() or str(default_port)
+    host, port = default_host, raw
+    if ":" in raw:
+        host, port = raw.rsplit(":", 1)
+        host = host or default_host
+    try:
+        port = int(port)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid port binding {raw!r}. Use a bare port or host:port.") from exc
+    return host, port
+
+
+def public_url(host, port):
+    return f"http://{'localhost' if host in {'', '0.0.0.0', '::'} else host}:{port}"
+
+
+def probe_host(host):
+    return "127.0.0.1" if host in {"", "0.0.0.0", "::"} else host
+
+
+def port_free(port, host="127.0.0.1"):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind((host, port))
+        return True, f"{host}:{port} is free"
+    except OSError as exc:
+        if exc.errno in {errno.EPERM, errno.EACCES}:
+            try:
+                with socket.create_connection((host, port), timeout=0.25):
+                    return False, f"{host}:{port} accepts connections"
+            except OSError:
+                return True, f"{host}:{port} did not accept a connection; bind check was not permitted"
+        return False, f"{host}:{port} is not available ({exc})"
+    finally:
+        sock.close()
+
+
+def prepare_env(root, docker_port=None, services=False, uid=None, gid=None, searx_bind=None, auto_searx=True):
+    values = env_values(root)
+    updates = {"PUID": str(os.getuid() if uid is None else uid), "PGID": str(os.getgid() if gid is None else gid)}
+    if docker_port is not None:
+        updates["ODYSSEUS_BIND"] = str(docker_port)
+    existing_bind = values.get("SEARXNG_BIND")
+    bind = existing_bind or searx_bind
+    if not bind and auto_searx and not port_free(SEARX_PORT)[0]:
+        bind = next((f"127.0.0.1:{p}" for p in (18080, 18081, 18082, 28080) if port_free(p)[0]), None)
+        if bind:
+            print(f"[WARN] 127.0.0.1:8080 is in use; binding bundled SearXNG to {bind}")
+    if bind and bind != existing_bind:
+        updates["SEARXNG_BIND"] = bind
+    if bind:
+        base = public_url(*split_bind(bind, "localhost", SEARX_PORT))
+        updates.setdefault("SEARXNG_BASE_URL", base + "/")
+        if services:
+            updates["SEARXNG_INSTANCE"] = base
+    return set_env(root, updates)
+
+
+def docker_ready(root):
+    if not shutil.which("docker"):
+        return False, "docker was not found on PATH"
+    code, out = run(["docker", "info"], root=root, quiet=True)
+    return (True, "Docker daemon is reachable") if code == 0 else (False, out.splitlines()[-1] if out else "Docker daemon is not reachable")
+
+
+def check_ports(root, include_app):
+    values = env_values(root)
+    code, out = run(["docker", "compose", "ps", "--services", "--status", "running"], root=root, quiet=True)
+    running = set(out.splitlines()) if code == 0 else set()
+    reqs = [("ChromaDB", "chromadb", "127.0.0.1", CHROMA_PORT), ("ntfy", "ntfy", "127.0.0.1", NTFY_PORT)]
+    if include_app:
+        host, port = split_bind(values.get("ODYSSEUS_BIND"), "127.0.0.1", APP_PORT)
+        reqs.append(("Odysseus", "odysseus", probe_host(host), port))
+    if values.get("SEARXNG_BIND"):
+        host, port = split_bind(values["SEARXNG_BIND"], "127.0.0.1", SEARX_PORT)
+        reqs.append(("SearXNG", "searxng", probe_host(host), port))
+    failures = []
+    for name, service, host, port in reqs:
+        if service in running:
+            continue
+        ok, detail = port_free(port, host)
+        if not ok:
+            failures.append(f"{name} needs {host}:{port}, but {detail}")
+    for failure in failures:
+        print(f"[FAIL] {failure}", file=sys.stderr)
+    if failures:
+        print("Stop the conflicting process, then rerun this command.", file=sys.stderr)
+    return bool(failures)
+
+
+def ensure_venv(root):
+    py = root / "venv" / "bin" / "python"
+    if py.exists():
+        version = py_version(str(py))
+        if classify_python_version(version) != "supported":
+            shown = "unknown" if version is None else ".".join(map(str, version))
+            raise SystemExit(f"Existing venv uses Python {shown}. Remove venv/ and rerun with python3.11 or python3.12.")
+        return py
+    choice = supported_python()
+    if not choice:
+        raise SystemExit("No supported Python found. Install python3.11 or python3.12, or use Docker.")
+    run([choice[0], "-m", "venv", "venv"], root=root, check=True)
+    return py
+
+
+def wait_for_health(url, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                if 200 <= response.status < 300:
+                    return True
+        except Exception:
+            time.sleep(2)
+    return False
+
+
+def doctor(args):
+    def row(name, status, detail):
+        print(f"[{status:<4}] {name}: {detail}")
+    row("Operating system", "OK" if platform.system() == "Darwin" else "WARN", platform.system())
+    row("CPU architecture", "OK" if platform.machine() in {"arm64", "x86_64"} else "WARN", platform.machine())
+    docker = shutil.which("docker")
+    row("Docker CLI", "OK" if docker else "FAIL", docker or "Install Docker Desktop")
+    if docker:
+        code, out = run(["docker", "compose", "version"], root=args.repo_root, quiet=True)
+        row("Docker Compose", "OK" if code == 0 else "FAIL", out or "docker compose failed")
+        ok, detail = docker_ready(args.repo_root)
+        row("Docker daemon", "OK" if ok else "WARN", detail)
+    py = shutil.which("python3")
+    version = py_version(py) if py else None
+    kind = classify_python_version(version)
+    hint = "; use python3.11 or python3.12" if kind in {"too_new", "too_old"} else ""
+    row("Default python3", "OK" if kind == "supported" else "WARN", f"{py or 'missing'} {version or ''}{hint}")
+    choice = supported_python()
+    row("Supported Python", "OK" if choice else "FAIL", f"{choice[0]} {choice[1]}" if choice else "Install python@3.11 or python@3.12")
+    row("tmux", "OK" if shutil.which("tmux") else "WARN", shutil.which("tmux") or "Install tmux for Cookbook")
+    for port in (APP_PORT, SEARX_PORT, NTFY_PORT, CHROMA_PORT):
+        ok, detail = port_free(port)
+        row(f"Port {port}", "OK" if ok else "WARN", detail)
+    return 0
+
+
+def docker(args):
+    prepare_env(args.repo_root, docker_port=args.port)
+    (args.repo_root / "data").mkdir(exist_ok=True)
+    (args.repo_root / "logs").mkdir(exist_ok=True)
+    ok, detail = docker_ready(args.repo_root)
+    if not ok:
+        print(f"[FAIL] Docker daemon: {detail}\nStart Docker Desktop, then rerun scripts/odysseus-mac docker.", file=sys.stderr)
+        return 1
+    if check_ports(args.repo_root, include_app=True):
+        return 1
+    try:
+        run(["docker", "compose", "up", "-d", "--build"], root=args.repo_root, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"[FAIL] docker compose up failed with exit code {exc.returncode}.\nRun: docker compose logs --tail=120", file=sys.stderr)
+        return exc.returncode
+    host, port = split_bind(env_values(args.repo_root).get("ODYSSEUS_BIND"), "127.0.0.1", APP_PORT)
+    url = public_url(host, port)
+    if not wait_for_health(f"{url}/api/health", args.timeout):
+        print(f"[WARN] Odysseus did not become healthy within {int(args.timeout)}s.\nRun: docker compose logs --tail=120 odysseus", file=sys.stderr)
+        return 1
+    print(f"Odysseus is running: {url}")
+    return 0
+
+
+def native(args):
+    prepare_env(args.repo_root, services=args.with_services)
+    (args.repo_root / "data").mkdir(exist_ok=True)
+    (args.repo_root / "logs").mkdir(exist_ok=True)
+    ok, detail = port_free(args.port, probe_host(args.host))
+    if not ok:
+        print(f"[FAIL] Native Odysseus needs {args.host}:{args.port}, but {detail}", file=sys.stderr)
+        return 1
+    if args.with_services:
+        ok, detail = docker_ready(args.repo_root)
+        if not ok:
+            print(f"[FAIL] Docker daemon: {detail}\nStart Docker Desktop, then rerun scripts/odysseus-mac native --with-services.", file=sys.stderr)
+            return 1
+        if check_ports(args.repo_root, include_app=False):
+            return 1
+    py = ensure_venv(args.repo_root)
+    run([py, "-m", "pip", "install", "-r", "requirements.txt"], root=args.repo_root, check=True)
+    run([py, "setup.py"], root=args.repo_root, check=True)
+    if args.with_services:
+        run(["docker", "compose", "up", "-d", "chromadb", "searxng", "ntfy"], root=args.repo_root, check=True)
+    print(f"Odysseus starting on http://localhost:{args.port}")
+    return subprocess.call([py, "-m", "uvicorn", "app:app", "--host", args.host, "--port", str(args.port)], cwd=args.repo_root)
+
+
+def main(argv=None, repo_root=ROOT):
+    parser = argparse.ArgumentParser(description="MacBook launcher for Odysseus")
+    parser.set_defaults(repo_root=repo_root)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("doctor", help="check macOS launch prerequisites").set_defaults(func=doctor)
+    d = sub.add_parser("docker", help="start the full Docker Compose stack")
+    d.add_argument("--port", type=int, default=None, help="persist an Odysseus host port override for Docker")
+    d.add_argument("--timeout", type=float, default=120.0)
+    d.set_defaults(func=docker)
+    n = sub.add_parser("native", help="start a native Python server")
+    n.add_argument("--with-services", action="store_true", help="start ChromaDB, SearXNG, and ntfy with Compose")
+    n.add_argument("--host", default="127.0.0.1")
+    n.add_argument("--port", type=int, default=APP_PORT)
+    n.set_defaults(func=native)
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mac_launch.py
+++ b/tests/test_mac_launch.py
@@ -1,0 +1,78 @@
+import importlib.machinery
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_mac_launch():
+    root = Path(__file__).resolve().parents[1]
+    path = root / "scripts" / "odysseus-mac"
+    loader = importlib.machinery.SourceFileLoader("odysseus_mac", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+mac_launch = load_mac_launch()
+
+
+class MacLaunchTests(unittest.TestCase):
+    def test_parse_and_classify_python_versions(self):
+        self.assertEqual(mac_launch.parse_python_version("Python 3.11.15"), (3, 11, 15))
+        self.assertEqual(mac_launch.parse_python_version("Python 3.14"), (3, 14, 0))
+        self.assertEqual(mac_launch.classify_python_version((3, 11, 15)), "supported")
+        self.assertEqual(mac_launch.classify_python_version((3, 12, 9)), "supported")
+        self.assertEqual(mac_launch.classify_python_version((3, 14, 5)), "too_new")
+        self.assertEqual(mac_launch.classify_python_version((3, 10, 14)), "too_old")
+
+    def test_set_env_updates_and_appends(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".env.example").write_text("AUTH_ENABLED=true\nPUID=1000\n")
+            text = mac_launch.set_env(root, {"PUID": "501", "PGID": "20"}).read_text()
+        self.assertIn("AUTH_ENABLED=true\n", text)
+        self.assertIn("PUID=501\n", text)
+        self.assertIn("PGID=20\n", text)
+        self.assertNotIn("PUID=1000", text)
+
+    def test_split_bind_accepts_bare_port_and_host_port(self):
+        self.assertEqual(mac_launch.split_bind("7001", "127.0.0.1", 7000), ("127.0.0.1", 7001))
+        self.assertEqual(mac_launch.split_bind("0.0.0.0:18080", "127.0.0.1", 8080), ("0.0.0.0", 18080))
+
+    def test_prepare_env_persists_explicit_port_and_searxng_base_url(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".env.example").write_text("SEARXNG_INSTANCE=http://localhost:8080\n")
+            env_path = mac_launch.prepare_env(
+                root,
+                docker_port=7777,
+                searx_bind="127.0.0.1:18080",
+                auto_searx=False,
+                uid=501,
+                gid=20,
+            )
+            text = env_path.read_text()
+        self.assertIn("ODYSSEUS_BIND=7777\n", text)
+        self.assertIn("PUID=501\n", text)
+        self.assertIn("PGID=20\n", text)
+        self.assertIn("SEARXNG_BIND=127.0.0.1:18080\n", text)
+        self.assertIn("SEARXNG_BASE_URL=http://127.0.0.1:18080/\n", text)
+
+    def test_prepare_env_sets_native_searxng_instance(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".env.example").write_text(
+                "SEARXNG_INSTANCE=http://localhost:8080\n"
+                "SEARXNG_BIND=127.0.0.1:18080\n"
+            )
+            text = mac_launch.prepare_env(root, services=True, auto_searx=False, uid=501, gid=20).read_text()
+        self.assertIn("SEARXNG_INSTANCE=http://127.0.0.1:18080\n", text)
+        self.assertIn("SEARXNG_BASE_URL=http://127.0.0.1:18080/\n", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a small macOS startup helper for Docker and native runs, while keeping the standard Docker Compose setup unchanged.

## Changes

### feat: add macOS startup helper

Adds `scripts/odysseus-mac` with `doctor`, `docker`, and `native` commands. The helper checks Docker Desktop, writes host `PUID`/`PGID` for editable bind mounts, detects Python 3.11/3.12 for native runs, and validates startup health.

### fix: make Docker startup friendlier on macOS

Allows optional `.env` loading in Compose and supports `ODYSSEUS_BIND` for changing the app host port without editing `docker-compose.yml`. SearXNG bind/base URL can also be adjusted consistently when the helper needs to avoid a local port conflict.

### fix: keep calendar routes importable on Python 3.11

Moves the newline escaping out of an f-string expression so the app imports cleanly on Python 3.11.

### docs: keep standard setup first and add macOS notes

Keeps the normal Docker Compose flow at the top of the README, keeps the optional `cp .env.example .env` command, and documents the macOS helper as an additional convenience path.

## Testing

- `docker compose config --quiet`
- `python3.11 -m unittest tests.test_mac_launch`
- `python3.11 -m py_compile scripts/odysseus-mac routes/calendar_routes.py`
- `git diff --check`
- `scripts/odysseus-mac docker --timeout 30` reached `/api/health`
- `scripts/odysseus-mac native --port 7001` reached `/api/health`

## AI Assistance

I prepared this with assistance from OpenAI Codex. Feedback and suggestions are welcome.

Refs #16