### PR TITLE
Fix/landing and uvicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 python setup.py            # creates data dirs and prints an initial admin password
-uvicorn app:app --host 0.0.0.0 --port 7000
+python -m uvicorn app:app --host 0.0.0.0 --port 7000
 ```
 
 ### Option 3: Manual install — Windows (PowerShell)
@@ -116,8 +116,13 @@ python -m venv venv
 venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 python setup.py
-uvicorn app:app --host 0.0.0.0 --port 7000
+python -m uvicorn app:app --host 0.0.0.0 --port 7000
 ```
+
+> If you see `uvicorn: command not recognized`, the virtual environment's
+> scripts are not on your `PATH`. Running it through the interpreter as
+> `python -m uvicorn ...` (as shown above) avoids that and always uses the
+> uvicorn installed in the active environment.
 
 Open `http://localhost:7000`, log in with the generated admin password,
 and configure everything else inside **Settings**.

--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,10 @@
   .pill-row { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; margin-top: 44px; }
   .pill { font-size: 12.5px; color: var(--muted); border: 1px solid var(--border); border-radius: 999px; padding: 5px 12px; background: var(--panel); }
 
-  footer { border-top: 1px solid var(--border); padding: 30px 0; color: var(--muted); font-size: 13px; }
+  /* The footer is shorter than a full viewport, so under "mandatory" snapping it
+     was unreachable -- the scroll kept snapping back to the last section. Make it
+     an end-aligned snap point so it rests at the bottom of the scroll range. */
+  footer { scroll-snap-align: end; border-top: 1px solid var(--border); padding: 30px 0; color: var(--muted); font-size: 13px; }
   footer .wrap { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
 
   @media (max-width: 820px) {

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ def main():
 
     print("\n=== Setup complete ===")
     print(f"\nStart the server with:")
-    print(f"  uvicorn app:app --host 0.0.0.0 --port 7000")
+    print(f"  {os.path.basename(sys.executable)} -m uvicorn app:app --host 0.0.0.0 --port 7000")
     print(f"\nThen open http://localhost:7000")
     print(f"Login with the admin username and temporary password printed above.\n")
 


### PR DESCRIPTION
### fix: make landing page footer reachable under scroll-snap (#8)
The landing page used scroll-snap-type: y mandatory with full-viewport sections,
but the footer was not a snap point and is shorter than the viewport, so
scrolling kept snapping back to the last section and the footer was unreachable.
Marked the footer as an end-aligned snap point so it rests at the bottom of the
scroll range.

### fix: start the server with python -m uvicorn (#19)
Bare `uvicorn app:app` fails with "uvicorn not recognized" when the virtual
environment's scripts directory is not on PATH, common on Windows. Invoke
uvicorn through the active interpreter in both README manual installs and the
setup.py next-steps output, plus a short README troubleshooting note.

Closes #8
Closes #19