### PR TITLE
fix: strip CRLF from entrypoint.sh on Windows hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN mkdir -p data logs
 # update them) silently fails on EPERM, breaking skill extraction,
 # prefs persistence, mail attachments, etc.
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN sed -i 's/\r//' /usr/local/bin/entrypoint.sh \
+    && chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 7000
 


### PR DESCRIPTION
Windows git checkouts may give `entrypoint.sh` CRLF line endings, causing the container to fail at startup:

```
exec /usr/local/bin/entrypoint.sh: no such file or directory
```

Linux reads the shebang as `#!/bin/bash\r` — a path that doesn't exist.

Fix: strip `\r` in the same `RUN` step as `chmod`, before the entrypoint is invoked.