### PR TITLE
Fix Windows decode error when serving index HTML

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,7 +600,7 @@ app.include_router(setup_contacts_routes())
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
     """Read an HTML file and inject the CSP nonce into inline <script> tags."""
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         html = f.read()
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)


### PR DESCRIPTION
This pull request makes a minor update to the way HTML files are read in the `_serve_html_with_nonce` function. The change ensures that files are opened with UTF-8 encoding, which improves compatibility with non-ASCII characters.

Tested on Windows only.