### PR TITLE
Fix Windows compatibility: pty/fcntl imports and UTF-8 encoding

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,7 +600,7 @@ app.include_router(setup_contacts_routes())
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
     """Read an HTML file and inject the CSP nonce into inline <script> tags."""
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         html = f.read()
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -4,14 +4,18 @@ import asyncio
 import json
 import logging
 import os
-import pty
-import fcntl
 import shlex
 import shutil
+import sys
 import uuid
 import tempfile
 from pathlib import Path
 from typing import Dict, Any
+
+_PTY_AVAILABLE = sys.platform != "win32"
+if _PTY_AVAILABLE:
+    import pty
+    import fcntl
 
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import StreamingResponse
@@ -97,6 +101,10 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, An
 
 async def _generate_pty(cmd: str, timeout: int, request: Request):
     """Run command in a pseudo-TTY so tqdm/progress bars work natively."""
+    if not _PTY_AVAILABLE:
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': 'PTY mode is not supported on Windows; re-run without use_pty.'})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        return
     loop = asyncio.get_event_loop()
     master_fd, slave_fd = pty.openpty()
 


### PR DESCRIPTION
- routes/shell_routes.py: pty and fcntl are Unix-only modules. Made imports conditional on sys.platform so the app starts on Windows. _generate_pty() returns an error on Windows instead of crashing at startup.

- app.py: _serve_html_with_nonce() opened index.html without specifying encoding, causing Python to fall back to the system locale (e.g. cp1250 on Czech/Polish Windows). Added encoding=utf-8 so the HTML is always read correctly.

Tested on Windows 11 with Python 3.14.