### PR TITLE
Fix Windows CRLF breaking Docker entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Normalize line endings across platforms.
+#
+# Without this, Windows clones (Git default core.autocrlf=true) check shell
+# scripts out with CRLF. Inside the Linux container the kernel then reads the
+# shebang as "#!/bin/sh\r" and looks for an interpreter literally named
+# "/bin/sh\r", which does not exist — Docker reports:
+#   exec /usr/local/bin/entrypoint.sh: no such file or directory
+#
+# Force LF on everything that runs inside the container or is parsed by a
+# POSIX tool, on every platform, no matter the user's git settings.
+
+# Default: let git decide text vs binary, normalize text to LF in the repo.
+* text=auto eol=lf
+
+# Files that MUST be LF (executed/parsed in Linux). Explicit so intent is clear.
+*.sh        text eol=lf
+*.bash      text eol=lf
+docker/entrypoint.sh text eol=lf
+Dockerfile  text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+
+# Windows-only scripts keep CRLF.
+*.ps1       text eol=crlf
+*.cmd       text eol=crlf
+*.bat       text eol=crlf
+
+# Binaries: never touch.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.woff      binary
+*.woff2     binary
+*.pdf       binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,13 @@ RUN mkdir -p data logs
 # update them) silently fails on EPERM, breaking skill extraction,
 # prefs persistence, mail attachments, etc.
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+# Strip any CRLF line endings before making it executable. .gitattributes
+# already forces LF in the repo, but a stray Windows checkout (or an editor
+# that rewrote the file) would otherwise turn the shebang into "#!/bin/sh\r"
+# and the kernel would fail with "no such file or directory". sed -i makes
+# the image robust regardless of how the build context was checked out.
+RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh \
+    && chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 7000
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ MemoryVectorStore initialized
 The Cookbook model catalog check should print a non-zero count. If it prints
 `0`, rebuild the Odysseus image with `docker compose build --no-cache odysseus`.
 
+**Windows: `entrypoint.sh: no such file or directory`** — if the `odysseus`
+container restart-loops with
+`exec /usr/local/bin/entrypoint.sh: no such file or directory`, the shell
+script was checked out with Windows CRLF line endings, so the container's
+shebang becomes `#!/bin/sh\r`. The repo's `.gitattributes` and a Dockerfile
+`sed` step now prevent this. If you cloned before that fix, re-normalize and
+rebuild:
+```powershell
+git rm --cached -r .
+git reset --hard
+docker compose build --no-cache odysseus
+docker compose up -d
+```
+
 ### Option 2: Manual install — Linux / macOS
 **Requirements:** Python 3.11+. On Linux/Termux, Cookbook also requires `tmux`
 for background model downloads and serves.


### PR DESCRIPTION
Windows clones using `core.autocrlf=true` can check out shell scripts with CRLF line endings. When `docker/entrypoint.sh` is copied into the Linux container, the CRLF shebang can cause startup to fail with:

`exec /usr/local/bin/entrypoint.sh: no such file or directory`

- Add .gitattributes pinning shell scripts, Dockerfile, and YAML to LF regardless of host git config (the root-cause fix).
- Harden Dockerfile with a sed step stripping CR from entrypoint before chmod, so a stray CRLF checkout still produces a working image.
- Add README troubleshooting note with re-normalize steps for old clones.