### PR TITLE
fix: resolve UTF-8 decoding crash in serve_index

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,7 +600,7 @@ app.include_router(setup_contacts_routes())
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
     """Read an HTML file and inject the CSP nonce into inline <script> tags."""
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         html = f.read()
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)


### PR DESCRIPTION
## Summary

Fixes a 500 Internal Server Error on / caused by incorrect HTML file encoding handling.

## Issue

The server crashed due to improper file encoding handling, leading to Unicode decoding errors and invalid file read usage on Windows environments.

## Fix

HTML file is now read using explicit UTF-8 encoding, ensuring consistent and safe behavior across platforms.

Impact
Fixes homepage crash (GET /)
Removes Windows/Linux encoding inconsistencies
Improves static file reliability