### PR TITLE
fix(llm): strip internal message metadata before provider requests

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -124,6 +124,22 @@ def _get_cached_response(cache_key: str) -> Optional[str]:
     """Get cached response if it exists."""
     return _response_cache.get(cache_key)
 
+
+_INTERNAL_MESSAGE_KEYS = {"metadata", "_protected"}
+
+
+def _sanitize_messages_for_api(messages: List[Dict]) -> List[Dict]:
+    """Remove Odysseus-only fields before sending messages upstream."""
+    return [
+        {
+            key: value
+            for key, value in message.items()
+            if key not in _INTERNAL_MESSAGE_KEYS
+        }
+        for message in messages
+    ]
+
+
 def _set_cached_response(cache_key: str, response: str) -> None:
     """Store response in cache."""
     if len(_response_cache) > 128:
@@ -409,7 +425,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
     if isinstance(headers, dict):
         h.update(headers)
 
-    messages_copy = [msg.copy() for msg in messages]
+    messages_copy = _sanitize_messages_for_api(messages)
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -517,7 +533,7 @@ async def llm_call_async(
 ) -> str:
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
     provider = _detect_provider(url)
-    messages_copy = [msg.copy() for msg in messages]
+    messages_copy = _sanitize_messages_for_api(messages)
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -614,7 +630,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
       - data: [DONE]                       — end of stream
     """
     provider = _detect_provider(url)
-    messages_copy = [msg.copy() for msg in messages]
+    messages_copy = _sanitize_messages_for_api(messages)
 
     # Consolidate multiple system messages into one at the start.
     # Some models (e.g. Qwen3.5) reject system messages that aren't first.

--- a/tests/test_llm_message_sanitization.py
+++ b/tests/test_llm_message_sanitization.py
@@ -1,0 +1,138 @@
+"""Regression tests for provider-boundary chat message sanitization."""
+
+import pytest
+
+from src import llm_core
+
+
+MESSAGES_WITH_INTERNAL_FIELDS = [
+    {
+        "role": "user",
+        "content": "hello",
+        "metadata": {"source": "ui", "_db_id": "123"},
+        "_protected": True,
+    },
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "call-1", "type": "function"}],
+        "metadata": {"model": "test-model"},
+    },
+    {
+        "role": "tool",
+        "content": "done",
+        "tool_call_id": "call-1",
+    },
+]
+
+
+def _assert_sanitized(messages):
+    assert messages == [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call-1", "type": "function"}],
+        },
+        {"role": "tool", "content": "done", "tool_call_id": "call-1"},
+    ]
+
+
+def test_sanitize_messages_removes_internal_fields_without_mutating_input():
+    messages = [dict(message) for message in MESSAGES_WITH_INTERNAL_FIELDS]
+
+    sanitized = llm_core._sanitize_messages_for_api(messages)
+
+    _assert_sanitized(sanitized)
+    assert "metadata" in messages[0]
+    assert "_protected" in messages[0]
+
+
+def test_llm_call_sanitizes_messages_before_post(monkeypatch):
+    captured = {}
+
+    class Response:
+        is_success = True
+
+        @staticmethod
+        def json():
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured["messages"] = json["messages"]
+        return Response()
+
+    monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+
+    llm_core.llm_call(
+        "http://sync-provider.test/v1/chat/completions",
+        "test-model",
+        MESSAGES_WITH_INTERNAL_FIELDS,
+    )
+
+    _assert_sanitized(captured["messages"])
+
+
+@pytest.mark.asyncio
+async def test_llm_call_async_sanitizes_messages_before_post(monkeypatch):
+    captured = {}
+
+    class Response:
+        is_success = True
+
+        @staticmethod
+        def json():
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class Client:
+        async def post(self, url, *, headers, json, timeout):
+            captured["messages"] = json["messages"]
+            return Response()
+
+    monkeypatch.setattr(llm_core, "_get_http_client", lambda: Client())
+
+    await llm_core.llm_call_async(
+        "http://async-provider.test/v1/chat/completions",
+        "test-model",
+        MESSAGES_WITH_INTERNAL_FIELDS,
+    )
+
+    _assert_sanitized(captured["messages"])
+
+
+@pytest.mark.asyncio
+async def test_stream_llm_sanitizes_messages_before_post(monkeypatch):
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+        async def aiter_lines(self):
+            yield 'data: {"choices": [{"delta": {"content": "ok"}}]}'
+            yield "data: [DONE]"
+
+    class StreamContext:
+        async def __aenter__(self):
+            return Response()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    class Client:
+        def stream(self, method, url, *, json, headers, timeout):
+            captured["messages"] = json["messages"]
+            return StreamContext()
+
+    monkeypatch.setattr(llm_core, "_get_http_client", lambda: Client())
+
+    chunks = [
+        chunk
+        async for chunk in llm_core.stream_llm(
+            "http://stream-provider.test/v1/chat/completions",
+            "test-model",
+            MESSAGES_WITH_INTERNAL_FIELDS,
+        )
+    ]
+
+    _assert_sanitized(captured["messages"])
+    assert chunks[-1] == "data: [DONE]\n\n"


### PR DESCRIPTION
## Summary

Strip Odysseus-only message fields before sending chat payloads to external LLM providers.

## Why

Persisted chat messages include internal `metadata` used by the UI and session layer. Those dictionaries were forwarded unchanged through the OpenAI-compatible request paths. Groq rejects the extra property with:

```text
property 'metadata' is unsupported
```

The fix removes `metadata` and `_protected` only at the outbound provider boundary. Internal persistence and UI behavior are unchanged, while standard provider fields such as `tool_calls` and `tool_call_id` are preserved.

Closes #40.

## Validation

- `python -m pytest tests/test_llm_message_sanitization.py -q` (`4 passed`)
- `python -m compileall -q src/llm_core.py tests/test_llm_message_sanitization.py`
- `git diff --check`
- Full suite on this branch: `264 passed, 2 failed`
- Full suite on untouched `origin/main`: `260 passed, 2 failed`

The two existing full-suite failures reproduce on `origin/main`: the structure test expects a local `.env` file, and the Anthropic probe test has an order-dependent module-stubbing failure.
