### PR TITLE
Fix MCP server "Add" form silently failing (422 from Form vs JSON mismatch)

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -4089,17 +4089,26 @@ async function initUnifiedIntegrations() {
       el('uf-mcp-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
       el('uf-mcp-save').addEventListener('click', async () => {
         const transport = el('uf-mcp-transport').value;
-        const body = { name: el('uf-mcp-name').value, transport };
+        // routes/mcp_routes.py uses FastAPI Form(...) — send multipart, not JSON.
+        const fd = new FormData();
+        fd.append('name', el('uf-mcp-name').value);
+        fd.append('transport', transport);
         if (transport === 'stdio') {
-          body.command = el('uf-mcp-cmd').value;
-          try { body.args = JSON.parse(el('uf-mcp-args').value || '[]'); } catch (_) { body.args = []; }
-          try { body.env = JSON.parse(el('uf-mcp-env').value || '{}'); } catch (_) { body.env = {}; }
+          fd.append('command', el('uf-mcp-cmd').value);
+          let args = '[]'; try { args = JSON.stringify(JSON.parse(el('uf-mcp-args').value || '[]')); } catch (_) {}
+          let env  = '{}'; try { env  = JSON.stringify(JSON.parse(el('uf-mcp-env').value  || '{}')); } catch (_) {}
+          fd.append('args', args);
+          fd.append('env', env);
         } else {
-          body.url = el('uf-mcp-url').value;
+          fd.append('url', el('uf-mcp-url').value);
         }
         try {
-          await fetch('/api/mcp/servers', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-          el('uf-mcp-msg').textContent = 'Saved'; formEl.style.display = 'none'; await renderList();
+          const r = await fetch('/api/mcp/servers', { method: 'POST', credentials: 'same-origin', body: fd });
+          if (r.ok) {
+            el('uf-mcp-msg').textContent = 'Saved'; formEl.style.display = 'none'; await renderList();
+          } else {
+            el('uf-mcp-msg').textContent = `Failed (${r.status})`;
+          }
         } catch (_) { el('uf-mcp-msg').textContent = 'Failed'; }
       });
     }


### PR DESCRIPTION
### Bug

`POST /api/mcp/servers` is declared with FastAPI `Form(...)` params in `routes/mcp_routes.py`, but the Save handler in `static/js/settings.js` was sending `Content-Type: application/json` with a JSON body. The `Form` parser sees no fields and returns:

```
422 Unprocessable Entity
{"detail": [{"type": "missing", "loc": ["body", "name"], "msg": "Field required", "input": null}, ...]}
```

The previous code did not check `r.ok`, so the user clicked Save and the form silently closed with no feedback — the new MCP server never appeared in the integrations list.

### Repro

1. Settings → Integrations → Add Integration → MCP Server
2. Fill any valid stdio server (e.g. `name: filesystem`, `command: npx`, `args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]`)
3. Hit Save → form closes silently, nothing in the integrations list, Network tab shows 422

### Fix

- Build a `FormData` object and let the browser set `multipart/form-data` with the correct boundary.
- `args` / `env` get JSON-stringified per the controller contract (defaults `"[]"` / `"{}"`). Bad JSON in those fields still falls back to defaults, same as before.
- Check `r.ok` and surface non-2xx in `#uf-mcp-msg` — the previous code never checked status, so a 422 looked like success.

Diff: 16 insertions, 7 deletions, all inside the existing Save handler. Matches the `FormData` pattern already used in this same file for the toggle-enable PATCH (`uf-mcp-toggle`, ~L4036) against the same controller.

### Verified

Tested locally against a real stdio MCP server end-to-end: POST returns 200, the new server appears in the integrations list, tool discovery completes successfully. The previously-silent 422 now renders as `Failed (422)` in the form-status span.
