### PR TITLE
Fix Windows CRLF entrypoint crash: add .gitattributes to force LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings. Shell scripts MUST be LF or they break inside Linux
+# containers (a CRLF shebang yields "no such file or directory" on exec).
+* text=auto eol=lf
+
+*.sh text eol=lf
+docker/entrypoint.sh text eol=lf
+
+# Treat common binaries as binary so they are never line-ending converted.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
## Problem

On Windows, the container built from `docker/entrypoint.sh` crash-loops on startup with:

```
exec /usr/local/bin/entrypoint.sh: no such file or directory
```

The file clearly exists and is `chmod +x`'d in the Dockerfile, so the error is misleading.

## Root cause

This repo had **no `.gitattributes`**, and Git on Windows defaults to `core.autocrlf=true`. On checkout, Git rewrites the LF-stored `docker/entrypoint.sh` to **CRLF** line endings. The shebang line then becomes:

```
#!/bin/sh\r
```

When the Linux container execs the script, the kernel reads the interpreter path including the trailing carriage return and tries to run an interpreter literally named `/bin/sh\r`, which does not exist. Docker surfaces this as `no such file or directory` against the *script* path, which is what makes it confusing — the missing file is the (non-existent) `\r`-suffixed interpreter, not the entrypoint.

Confirmed locally:

```
$ file docker/entrypoint.sh
docker/entrypoint.sh: POSIX shell script ... with CRLF line terminators
$ git ls-files --eol docker/entrypoint.sh
i/lf    w/crlf  attr/   docker/entrypoint.sh
```

The blob in Git was already LF (`i/lf`); only the working-tree checkout was corrupted (`w/crlf`) by autocrlf.

## Fix

Add a `.gitattributes` that:

- pins `*.sh` and `docker/entrypoint.sh` explicitly to `eol=lf`,
- normalizes text files with `* text=auto eol=lf`,
- marks common binary assets (images, fonts) as `binary` so they are never line-ending converted.

This guarantees shell scripts are checked out with LF regardless of the user's `core.autocrlf` setting or platform, so the container starts correctly on Windows, macOS, and Linux alike.

## Verification

After applying `.gitattributes` and re-checking out the file:

```
$ git ls-files --eol docker/entrypoint.sh
i/lf    w/lf    attr/text eol=lf   docker/entrypoint.sh
$ file docker/entrypoint.sh
docker/entrypoint.sh: POSIX shell script ...   # no more CRLF
```

Rebuilt with `docker compose build --no-cache odysseus` and `docker compose up -d` — the `odysseus` container now reaches `Up` on port 7000 and boots normally instead of crash-looping.

## Notes for existing Windows clones

This fixes new checkouts. Anyone with an already-corrupted working tree can refresh it after pulling:

```
git rm --cached -r .
git reset --hard
```

(or `git add --renormalize . && git checkout -- .`)

