### PR TITLE
Fix inconsistent SearXNG default URL

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -28,7 +28,8 @@ OPENAI_COMPAT_PATH = "/v1/chat/completions"
 DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")
 LLM_HOSTS = [h.strip() for h in os.getenv("LLM_HOSTS", "").split(",") if h.strip()]
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-SEARXNG_INSTANCE = os.getenv('SEARXNG_INSTANCE', 'http://localhost:8080')
+# Search reads src.constants; re-export so this duplicate module cannot drift.
+from src.constants import SEARXNG_INSTANCE  # noqa: E402
 
 
 # Cleanup configuration

--- a/src/config.py
+++ b/src/config.py
@@ -54,7 +54,7 @@ class SearchConfig(BaseSettings):
     
     # Web search
     searxng_instance: str = Field(
-        default="http://localhost:8888",
+        default="http://localhost:8080",
         description="SearXNG instance URL (self-hosted)"
     )
     web_search_count: int = Field(default=10, description="Number of search results to retrieve")

--- a/src/constants.py
+++ b/src/constants.py
@@ -28,7 +28,8 @@ OPENAI_COMPAT_PATH = "/v1/chat/completions"
 DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")
 LLM_HOSTS = [h.strip() for h in os.getenv("LLM_HOSTS", "").split(",") if h.strip()]
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-SEARXNG_INSTANCE = os.getenv('SEARXNG_INSTANCE', 'http://localhost:8888')
+# Default matches docker-compose SearXNG (127.0.0.1:8080) and .env.example.
+SEARXNG_INSTANCE = os.getenv('SEARXNG_INSTANCE', 'http://localhost:8080')
 
 
 # Cleanup configuration

--- a/tests/test_searxng_default.py
+++ b/tests/test_searxng_default.py
@@ -1,0 +1,12 @@
+"""Pin the SearXNG env fallback to the bundled Compose port (8080)."""
+
+import importlib
+
+
+def test_searxng_instance_default_without_env(monkeypatch):
+    """Runtime search uses src.constants.SEARXNG_INSTANCE when settings.search_url is empty."""
+    monkeypatch.delenv("SEARXNG_INSTANCE", raising=False)
+    import src.constants
+
+    importlib.reload(src.constants)
+    assert src.constants.SEARXNG_INSTANCE == "http://localhost:8080"


### PR DESCRIPTION
Fixes inconsistent SearXNG defaults across the codebase.

Runtime search imports `SEARXNG_INSTANCE` from `src.constants`, so this was the fallback actually used when no per-user search URL or environment override was configured. That default was `http://localhost:8888`, while the bundled Docker Compose setup, `.env.example`, and documentation use port `8080`. Fresh installs that did not explicitly set `SEARXNG_INSTANCE` could therefore point search at the wrong port.

Changes:
- Updated the runtime fallback URL to `http://localhost:8080`
- Aligned `SearchConfig.searxng_instance` with the same default
- Re-exported `SEARXNG_INSTANCE` from `core.constants` to avoid duplicate constants drifting again
- Added a regression test for the unset-env fallback

Tested with:

`py -m pytest tests/test_searxng_default.py`

Result: `1 passed`