### PR TITLE
Add first-run onboarding for model and interface setup

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -43,6 +43,7 @@ import spinnerModule from './js/spinner.js';
 import { initKeyboardShortcuts } from './js/keyboard-shortcuts.js';
 import { initSidebarLayout, syncRailSide } from './js/sidebar-layout.js';
 import { initSectionCollapse, initSectionDrag } from './js/section-management.js';
+import { maybeShowOnboarding } from './js/onboarding.js';
 
 const API_BASE = window.location.origin;
 window.themeModule = themeModule;
@@ -3871,6 +3872,7 @@ function startOdysseusApp() {
           try { window._odysseusRouteOpener(); } catch (_) {}
           window._odysseusRouteOpener = null;
         }
+        maybeShowOnboarding().catch(e => console.warn('Onboarding failed:', e));
       });
   } else {
     console.error('Session module not loaded!');

--- a/static/js/onboarding.js
+++ b/static/js/onboarding.js
@@ -1,0 +1,1082 @@
+// static/js/onboarding.js
+// First-run welcome and setup flow for Odysseus.
+
+import themeModule, { THEMES } from './theme.js';
+
+const API_BASE = window.location.origin;
+const PREF_KEY = 'onboarding_complete';
+const TOTAL_STEPS = 4;
+
+const DEFAULT_THEME = 'dark';
+const DEFAULT_DENSITY = 'comfortable';
+const DEFAULT_FONT = 'mono';
+
+const THEME_DEFAULT_PATTERN = {
+  dark: 'none',
+  light: 'dots',
+  midnight: 'rain',
+  paper: 'dots',
+  cyberpunk: 'synapse',
+  retrowave: 'embers',
+  forest: 'petals',
+  ocean: 'constellations',
+  gpt: 'none',
+  claude: 'none',
+};
+
+const THEME_DEFAULT_EFFECT_COLOR = {
+  midnight: '#ffffff',
+};
+
+const THEME_DEFAULT_INTENSITY = {
+  midnight: 0.5,
+};
+
+const FEATURED_THEMES = [
+  'dark',
+  'midnight',
+  'gpt',
+  'claude',
+  'light',
+  'paper',
+  'ocean',
+  'forest',
+];
+
+const DENSITY_OPTIONS = [
+  { id: 'compact', label: 'Compact' },
+  { id: 'comfortable', label: 'Comfortable' },
+  { id: 'spacious', label: 'Spacious' },
+];
+
+const CLOUD_PROVIDERS = [
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    detail: 'GPT models',
+    baseUrl: 'https://api.openai.com/v1',
+    placeholder: 'sk-...',
+    keyRequired: true,
+    supportsTools: true,
+  },
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    detail: 'Claude models',
+    baseUrl: 'https://api.anthropic.com',
+    placeholder: 'sk-ant-...',
+    keyRequired: true,
+    supportsTools: true,
+  },
+  {
+    id: 'google',
+    name: 'Google AI',
+    detail: 'Gemini models',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    placeholder: 'AIza...',
+    keyRequired: true,
+    supportsTools: false,
+  },
+  {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    detail: 'Multi-provider routing',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    placeholder: 'sk-or-...',
+    keyRequired: true,
+    supportsTools: true,
+  },
+  {
+    id: 'custom',
+    name: 'Custom API',
+    detail: 'OpenAI-compatible',
+    baseUrl: '',
+    placeholder: 'Optional API key',
+    keyRequired: false,
+    supportsTools: '',
+  },
+];
+
+const LOCAL_PRESETS = [
+  {
+    id: 'ollama',
+    label: 'Ollama',
+    name: 'Ollama (local)',
+    url: 'http://localhost:11434/v1',
+  },
+  {
+    id: 'lmstudio',
+    label: 'LM Studio',
+    name: 'LM Studio',
+    url: 'http://localhost:1234/v1',
+  },
+  {
+    id: 'custom-local',
+    label: 'Custom',
+    name: 'Local model server',
+    url: 'http://localhost:8000/v1',
+  },
+];
+
+const FEATURE_CARDS = [
+  {
+    title: 'Chat',
+    body: 'Fast sessions with files, images, voice, and searchable history.',
+    icon: 'chat',
+  },
+  {
+    title: 'Agent',
+    body: 'Switch modes when a request needs tools, web work, or multiple steps.',
+    icon: 'agent',
+  },
+  {
+    title: 'Deep Research',
+    body: 'Plan, search, collect sources, and produce long-form reports.',
+    icon: 'search',
+  },
+  {
+    title: 'Library',
+    body: 'Keep chats, documents, research, notes, and exports organized.',
+    icon: 'library',
+  },
+  {
+    title: 'Memory',
+    body: 'Store durable context and keep control over what Odysseus remembers.',
+    icon: 'memory',
+  },
+  {
+    title: 'Compare',
+    body: 'Run models side by side when quality, speed, or cost matters.',
+    icon: 'compare',
+  },
+];
+
+const ICONS = {
+  boat: '<svg viewBox="0 0 32 32" aria-hidden="true"><path d="M16 4L16 22L6 22Z" fill="currentColor"/><path d="M16 8L16 22L24 22Z" fill="currentColor" opacity="0.55"/><path d="M4 24Q10 20 16 24Q22 28 28 24" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/></svg>',
+  spark: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2L4 14h7l-1 8 9-12h-7l1-8Z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/></svg>',
+  model: '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="14" rx="2.5" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M8 21h8M12 18v3M7 9h.01M10 9h7M7 13h.01M10 13h5" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>',
+  palette: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 0 0 0 18h1.5a2 2 0 0 0 1.4-3.4 1.7 1.7 0 0 1 1.2-2.9H18a6 6 0 0 0 0-12h-6Z" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="8.2" cy="10.2" r="1" fill="currentColor"/><circle cx="11.5" cy="7.7" r="1" fill="currentColor"/><circle cx="14.9" cy="10.3" r="1" fill="currentColor"/></svg>',
+  check: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  arrowRight: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  arrowLeft: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 12H5M11 6l-6 6 6 6" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  refresh: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 12a8 8 0 0 1-14 5.3M4 12a8 8 0 0 1 14-5.3M18 3v4h-4M6 21v-4h4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  cloud: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 18h10a4 4 0 0 0 .6-7.96A6 6 0 0 0 6.3 8.5 4.75 4.75 0 0 0 7 18Z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/></svg>',
+  server: '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="4" width="16" height="6" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><rect x="4" y="14" width="16" height="6" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="M8 7h.01M8 17h.01M12 7h4M12 17h4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>',
+  chat: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3h11A2.5 2.5 0 0 1 20 5.5v7a2.5 2.5 0 0 1-2.5 2.5H10l-5 5v-14.5Z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/></svg>',
+  agent: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v4M12 17v4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M3 12h4M17 12h4M5.6 18.4l2.8-2.8M15.6 8.4l2.8-2.8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="1.7"/></svg>',
+  search: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7" fill="none" stroke="currentColor" stroke-width="1.7"/><path d="m16 16 4 4" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/></svg>',
+  library: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4h5v16H5zM10 4h5v16h-5zM16 6l4 1-3 13-4-1 3-13Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>',
+  memory: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 17.5A7 7 0 1 1 17.8 8a5.2 5.2 0 0 1-.8 9.8V21H8v-3.5Z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/><path d="M9 10h6M9 13h4" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>',
+  compare: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5h12M8 12h12M8 19h12" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="4" cy="5" r="1.5" fill="currentColor"/><circle cx="4" cy="12" r="1.5" fill="currentColor"/><circle cx="4" cy="19" r="1.5" fill="currentColor"/></svg>',
+};
+
+let overlay = null;
+let currentStep = 0;
+let selectedProviderId = 'openai';
+let selectedTheme = getSavedThemeName();
+let selectedDensity = getSavedDensity();
+let modelCatalog = emptyCatalog();
+let previousFocus = null;
+let existingModelsLoaded = false;
+let scaleListenersAttached = false;
+
+function emptyCatalog() {
+  return { endpoints: [], models: [] };
+}
+
+function isComplete(value) {
+  return value === true || value === 'true' || value === 1 || value === '1' ||
+    Boolean(value && typeof value === 'object' && value.complete);
+}
+
+async function readError(res) {
+  try {
+    const data = await res.json();
+    if (data && data.detail) return String(data.detail);
+    if (data && data.error) return String(data.error);
+  } catch (_) {}
+  try {
+    const text = await res.text();
+    if (text) return text.slice(0, 180);
+  } catch (_) {}
+  return `HTTP ${res.status}`;
+}
+
+async function getPref(key) {
+  try {
+    const res = await fetch(`${API_BASE}/api/prefs/${encodeURIComponent(key)}`, {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.value;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function setPref(key, value) {
+  await fetch(`${API_BASE}/api/prefs/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ value }),
+  }).catch(() => {});
+}
+
+function parseModelCatalog(data) {
+  const items = Array.isArray(data?.items) ? data.items : (Array.isArray(data) ? data : []);
+  const models = [];
+
+  for (const item of items) {
+    const endpointId = item.endpoint_id || '';
+    const endpointName = item.endpoint_name || item.host || 'Endpoint';
+    const url = item.url || '';
+    const curated = Array.isArray(item.models) ? item.models : [];
+    const curatedDisplay = Array.isArray(item.models_display) ? item.models_display : [];
+    const extra = Array.isArray(item.models_extra) ? item.models_extra : [];
+    const extraDisplay = Array.isArray(item.models_extra_display) ? item.models_extra_display : [];
+
+    curated.forEach((model, index) => {
+      if (!model) return;
+      models.push({
+        model,
+        displayName: curatedDisplay[index] || model,
+        endpointId,
+        endpointName,
+        url,
+      });
+    });
+
+    extra.forEach((model, index) => {
+      if (!model) return;
+      models.push({
+        model,
+        displayName: extraDisplay[index] || model,
+        endpointId,
+        endpointName,
+        url,
+      });
+    });
+  }
+
+  const seen = new Set();
+  const uniqueModels = models.filter((entry) => {
+    const key = `${entry.endpointId}:${entry.model}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return { endpoints: items, models: uniqueModels };
+}
+
+async function fetchModelCatalog(refresh = false) {
+  const res = await fetch(`${API_BASE}/api/models${refresh ? '?refresh=true' : ''}`, {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return parseModelCatalog(await res.json());
+}
+
+function getSavedTheme() {
+  try {
+    return themeModule.getSaved?.() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getSavedThemeName() {
+  const saved = getSavedTheme();
+  if (saved?.name && THEMES[saved.name]) return saved.name;
+  return DEFAULT_THEME;
+}
+
+function getSavedDensity() {
+  const saved = getSavedTheme();
+  return saved?.density || DEFAULT_DENSITY;
+}
+
+function getThemeLabel(name) {
+  if (name === 'gpt') return 'GPT';
+  return String(name || '').replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function html(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderProviderCard(provider) {
+  return `
+    <button class="onboarding-provider${provider.id === selectedProviderId ? ' is-selected' : ''}" type="button" data-provider-id="${provider.id}">
+      <span class="onboarding-provider-icon">${provider.id === 'custom' ? ICONS.server : ICONS.cloud}</span>
+      <span>
+        <strong>${html(provider.name)}</strong>
+        <small>${html(provider.detail)}</small>
+      </span>
+    </button>
+  `;
+}
+
+function renderThemeSwatch(themeName) {
+  const theme = THEMES[themeName];
+  if (!theme) return '';
+  const active = themeName === selectedTheme ? ' is-selected' : '';
+  return `
+    <button class="onboarding-theme-swatch${active}" type="button" data-theme-id="${html(themeName)}">
+      <span class="onboarding-swatch-frame" aria-hidden="true" style="--ob-bg:${html(theme.bg)};--ob-panel:${html(theme.panel)};--ob-fg:${html(theme.fg)};--ob-accent:${html(theme.red)}">
+        <span></span><span></span><span></span>
+      </span>
+      <span>${html(getThemeLabel(themeName))}</span>
+    </button>
+  `;
+}
+
+function visibleThemeNames() {
+  const names = [selectedTheme, ...FEATURED_THEMES]
+    .filter((name, index, all) => name && THEMES[name] && all.indexOf(name) === index);
+  return names.slice(0, 8);
+}
+
+function renderDensityButton(option) {
+  return `
+    <button class="onboarding-density-btn${option.id === selectedDensity ? ' is-selected' : ''}" type="button" data-density="${option.id}">
+      ${html(option.label)}
+    </button>
+  `;
+}
+
+function renderFeatureCard(feature) {
+  return `
+    <article class="onboarding-feature-card">
+      <div class="onboarding-feature-icon">${ICONS[feature.icon] || ICONS.spark}</div>
+      <div>
+        <h3>${html(feature.title)}</h3>
+        <p>${html(feature.body)}</p>
+      </div>
+    </article>
+  `;
+}
+
+function buildOverlay() {
+  const el = document.createElement('div');
+  el.id = 'onboarding-overlay';
+  el.className = 'onboarding-overlay';
+  el.setAttribute('role', 'dialog');
+  el.setAttribute('aria-modal', 'true');
+  el.setAttribute('aria-labelledby', 'onboarding-title-0');
+
+  el.innerHTML = `
+    <div class="onboarding-scrim" aria-hidden="true"></div>
+    <div class="onboarding-shell" role="document">
+      <aside class="onboarding-aside">
+        <div class="onboarding-brand">
+          <div class="onboarding-brand-mark">${ICONS.boat}</div>
+          <div>
+            <strong>Odysseus</strong>
+            <span>First run</span>
+          </div>
+        </div>
+
+        <nav class="onboarding-step-list" aria-label="Setup progress">
+          <button class="onboarding-step-link is-active" type="button" data-step-link="0">
+            <span>01</span><strong>Welcome</strong><small>Start clean</small>
+          </button>
+          <button class="onboarding-step-link" type="button" data-step-link="1">
+            <span>02</span><strong>Model</strong><small>Connect intelligence</small>
+          </button>
+          <button class="onboarding-step-link" type="button" data-step-link="2">
+            <span>03</span><strong>Interface</strong><small>Tune the feel</small>
+          </button>
+          <button class="onboarding-step-link" type="button" data-step-link="3">
+            <span>04</span><strong>Features</strong><small>Know the map</small>
+          </button>
+        </nav>
+
+        <button class="onboarding-skip" type="button" data-onboarding-skip>Skip setup</button>
+      </aside>
+
+      <section class="onboarding-main">
+        <div class="onboarding-progress" aria-hidden="true">
+          <span class="is-active"></span><span></span><span></span><span></span>
+        </div>
+
+        <article class="onboarding-step is-active" data-step="0">
+          <div class="onboarding-kicker">${ICONS.spark}<span>Private AI workspace</span></div>
+          <h1 class="onboarding-title" id="onboarding-title-0" tabindex="-1">Welcome to Odysseus</h1>
+          <p class="onboarding-lede">Set the model, tune the interface, and get a quick map of the workspace. Four focused steps, then the dashboard stays out of your way.</p>
+          <div class="onboarding-value-grid">
+            <div><strong>Self-hosted</strong><span>Your data stays with your server.</span></div>
+            <div><strong>Model-flexible</strong><span>Use cloud APIs, local models, or both.</span></div>
+            <div><strong>Built for work</strong><span>Chat, research, files, memory, and tools.</span></div>
+          </div>
+          <div class="onboarding-actions">
+            <button class="onboarding-primary" type="button" data-onboarding-next>Get started ${ICONS.arrowRight}</button>
+          </div>
+        </article>
+
+        <article class="onboarding-step" data-step="1">
+          <div class="onboarding-kicker">${ICONS.model}<span>Model setup</span></div>
+          <h2 class="onboarding-title" id="onboarding-title-1" tabindex="-1">Connect a model</h2>
+          <p class="onboarding-lede">Add a provider now, point Odysseus at a local server, or keep the model setup that is already available.</p>
+
+          <div class="onboarding-model-summary" id="onboarding-model-summary">
+            <span class="onboarding-spinner" aria-hidden="true"></span>
+            <span>Checking configured models...</span>
+          </div>
+
+          <div class="onboarding-tabs" role="tablist" aria-label="Model setup options">
+            <button class="is-active" type="button" role="tab" aria-selected="true" data-model-tab="cloud">Cloud API</button>
+            <button type="button" role="tab" aria-selected="false" data-model-tab="local">Local endpoint</button>
+            <button type="button" role="tab" aria-selected="false" data-model-tab="existing">Current setup</button>
+          </div>
+
+          <div class="onboarding-tab-panel is-active" data-model-panel="cloud">
+            <div class="onboarding-provider-grid">
+              ${CLOUD_PROVIDERS.map(renderProviderCard).join('')}
+            </div>
+            <div class="onboarding-form-grid">
+              <label>
+                <span>Endpoint name</span>
+                <input class="onboarding-input" id="onboarding-cloud-name" autocomplete="off">
+              </label>
+              <label>
+                <span>Base URL</span>
+                <input class="onboarding-input" id="onboarding-cloud-url" autocomplete="off" spellcheck="false">
+              </label>
+              <label class="onboarding-form-wide">
+                <span>API key</span>
+                <input class="onboarding-input" id="onboarding-cloud-key" type="password" autocomplete="off" spellcheck="false">
+              </label>
+            </div>
+            <label class="onboarding-check">
+              <input id="onboarding-cloud-default" type="checkbox" checked>
+              <span>Make the first discovered chat model my default.</span>
+            </label>
+            <div class="onboarding-inline-actions">
+              <button class="onboarding-primary" id="onboarding-cloud-save" type="button">Save endpoint ${ICONS.check}</button>
+              <div class="onboarding-status" id="onboarding-cloud-status" role="status"></div>
+            </div>
+          </div>
+
+          <div class="onboarding-tab-panel" data-model-panel="local">
+            <div class="onboarding-local-presets">
+              ${LOCAL_PRESETS.map((preset) => `
+                <button type="button" data-local-preset="${preset.id}">
+                  ${ICONS.server}<span>${html(preset.label)}</span>
+                </button>
+              `).join('')}
+            </div>
+            <div class="onboarding-form-grid">
+              <label>
+                <span>Endpoint name</span>
+                <input class="onboarding-input" id="onboarding-local-name" autocomplete="off">
+              </label>
+              <label>
+                <span>Base URL</span>
+                <input class="onboarding-input" id="onboarding-local-url" autocomplete="off" spellcheck="false">
+              </label>
+            </div>
+            <label class="onboarding-check">
+              <input id="onboarding-local-default" type="checkbox" checked>
+              <span>Make the first discovered chat model my default.</span>
+            </label>
+            <div class="onboarding-inline-actions">
+              <button class="onboarding-primary" id="onboarding-local-save" type="button">Save local endpoint ${ICONS.check}</button>
+              <div class="onboarding-status" id="onboarding-local-status" role="status"></div>
+            </div>
+          </div>
+
+          <div class="onboarding-tab-panel" data-model-panel="existing">
+            <div class="onboarding-existing-head">
+              <div>
+                <strong>Available models</strong>
+                <span id="onboarding-existing-count">Checking...</span>
+              </div>
+              <button class="onboarding-icon-btn" id="onboarding-refresh-models" type="button" title="Refresh models" aria-label="Refresh models">${ICONS.refresh}</button>
+            </div>
+            <div class="onboarding-model-list" id="onboarding-existing-models"></div>
+            <div class="onboarding-inline-actions">
+              <button class="onboarding-secondary" id="onboarding-use-first-model" type="button">Use first available model</button>
+              <div class="onboarding-status" id="onboarding-existing-status" role="status"></div>
+            </div>
+          </div>
+
+          <div class="onboarding-actions">
+            <button class="onboarding-secondary" type="button" data-onboarding-back>${ICONS.arrowLeft} Back</button>
+            <button class="onboarding-primary" type="button" data-onboarding-next>Continue ${ICONS.arrowRight}</button>
+          </div>
+        </article>
+
+        <article class="onboarding-step" data-step="2">
+          <div class="onboarding-kicker">${ICONS.palette}<span>Application feel</span></div>
+          <h2 class="onboarding-title" id="onboarding-title-2" tabindex="-1">Make it yours</h2>
+          <p class="onboarding-lede">Pick a visual baseline and density. This saves into the same theme system as the rest of the app.</p>
+
+          <div class="onboarding-section-label">Theme</div>
+          <div class="onboarding-theme-grid">
+            ${visibleThemeNames().map(renderThemeSwatch).join('')}
+          </div>
+
+          <div class="onboarding-section-label">Density</div>
+          <div class="onboarding-density-group">
+            ${DENSITY_OPTIONS.map(renderDensityButton).join('')}
+          </div>
+
+          <div class="onboarding-actions">
+            <button class="onboarding-secondary" type="button" data-onboarding-back>${ICONS.arrowLeft} Back</button>
+            <button class="onboarding-primary" type="button" data-onboarding-next>Continue ${ICONS.arrowRight}</button>
+          </div>
+        </article>
+
+        <article class="onboarding-step" data-step="3">
+          <div class="onboarding-kicker">${ICONS.spark}<span>Workspace map</span></div>
+          <h2 class="onboarding-title" id="onboarding-title-3" tabindex="-1">You are ready</h2>
+          <p class="onboarding-lede">The dashboard opens into chat, but the sidebar is where Odysseus becomes a full workspace.</p>
+
+          <div class="onboarding-feature-grid">
+            ${FEATURE_CARDS.map(renderFeatureCard).join('')}
+          </div>
+
+          <div class="onboarding-actions">
+            <button class="onboarding-secondary" type="button" data-onboarding-back>${ICONS.arrowLeft} Back</button>
+            <button class="onboarding-primary" type="button" data-onboarding-finish>Start using Odysseus ${ICONS.arrowRight}</button>
+          </div>
+        </article>
+      </section>
+    </div>
+  `;
+
+  return el;
+}
+
+function setStatus(id, type, message) {
+  const el = overlay?.querySelector(`#${id}`);
+  if (!el) return;
+  el.className = `onboarding-status${type ? ` is-${type}` : ''}`;
+  el.textContent = message || '';
+}
+
+function setButtonBusy(button, busy, label) {
+  if (!button) return;
+  if (busy) {
+    button.dataset.originalHtml = button.innerHTML;
+    button.disabled = true;
+    button.textContent = label || 'Working...';
+    return;
+  }
+  button.disabled = false;
+  if (button.dataset.originalHtml) {
+    button.innerHTML = button.dataset.originalHtml;
+    delete button.dataset.originalHtml;
+  }
+}
+
+function selectProvider(providerId) {
+  const provider = CLOUD_PROVIDERS.find((item) => item.id === providerId) || CLOUD_PROVIDERS[0];
+  selectedProviderId = provider.id;
+
+  overlay?.querySelectorAll('.onboarding-provider').forEach((button) => {
+    const selected = button.dataset.providerId === provider.id;
+    button.classList.toggle('is-selected', selected);
+    button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+  });
+
+  const name = overlay?.querySelector('#onboarding-cloud-name');
+  const url = overlay?.querySelector('#onboarding-cloud-url');
+  const key = overlay?.querySelector('#onboarding-cloud-key');
+  const save = overlay?.querySelector('#onboarding-cloud-save');
+
+  if (name) name.value = provider.id === 'custom' ? 'Custom API' : provider.name;
+  if (url) {
+    url.value = provider.baseUrl;
+    url.placeholder = provider.id === 'custom' ? 'https://api.example.com/v1' : provider.baseUrl;
+  }
+  if (key) {
+    key.value = '';
+    key.placeholder = provider.placeholder;
+  }
+  if (save && !save.disabled) {
+    save.innerHTML = `Save ${html(provider.name)} endpoint ${ICONS.check}`;
+    delete save.dataset.originalHtml;
+  }
+  setStatus(
+    'onboarding-cloud-status',
+    'info',
+    `${provider.name} selected. ${provider.keyRequired ? 'Paste the API key, then save the endpoint.' : 'Confirm the URL, then save the endpoint.'}`
+  );
+}
+
+function selectLocalPreset(presetId) {
+  const preset = LOCAL_PRESETS.find((item) => item.id === presetId) || LOCAL_PRESETS[0];
+  overlay?.querySelectorAll('[data-local-preset]').forEach((button) => {
+    button.classList.toggle('is-selected', button.dataset.localPreset === preset.id);
+  });
+  const name = overlay?.querySelector('#onboarding-local-name');
+  const url = overlay?.querySelector('#onboarding-local-url');
+  if (name) name.value = preset.name;
+  if (url) url.value = preset.url;
+}
+
+function setModelTab(tab) {
+  overlay?.querySelectorAll('[data-model-tab]').forEach((button) => {
+    const active = button.dataset.modelTab === tab;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+  overlay?.querySelectorAll('[data-model-panel]').forEach((panel) => {
+    panel.classList.toggle('is-active', panel.dataset.modelPanel === tab);
+  });
+  if (tab === 'existing') refreshExistingModels(false);
+}
+
+function renderExistingModels() {
+  const summary = overlay?.querySelector('#onboarding-model-summary');
+  const count = overlay?.querySelector('#onboarding-existing-count');
+  const list = overlay?.querySelector('#onboarding-existing-models');
+  const useFirst = overlay?.querySelector('#onboarding-use-first-model');
+
+  const endpointCount = modelCatalog.endpoints.length;
+  const modelCount = modelCatalog.models.length;
+
+  if (summary) {
+    summary.innerHTML = modelCount
+      ? `${ICONS.check}<span>${modelCount} model${modelCount === 1 ? '' : 's'} available across ${endpointCount || 1} endpoint${endpointCount === 1 ? '' : 's'}.</span>`
+      : `${ICONS.model}<span>No chat model is available yet. Add one here or continue and configure it later.</span>`;
+    summary.classList.toggle('is-ready', modelCount > 0);
+  }
+
+  if (count) {
+    count.textContent = modelCount
+      ? `${modelCount} model${modelCount === 1 ? '' : 's'} found`
+      : 'No models found';
+  }
+
+  if (useFirst) useFirst.disabled = !modelCount;
+
+  if (!list) return;
+  if (!modelCount) {
+    list.innerHTML = '<div class="onboarding-empty">No models are visible from this account yet.</div>';
+    return;
+  }
+
+  list.innerHTML = modelCatalog.models.slice(0, 10).map((entry) => `
+    <div class="onboarding-model-chip">
+      <strong>${html(entry.displayName || entry.model)}</strong>
+      <span>${html(entry.endpointName || 'Endpoint')}</span>
+    </div>
+  `).join('') + (modelCount > 10 ? `<div class="onboarding-model-chip is-more">+${modelCount - 10} more</div>` : '');
+}
+
+async function refreshExistingModels(force = false) {
+  if (existingModelsLoaded && !force) {
+    renderExistingModels();
+    return;
+  }
+  const list = overlay?.querySelector('#onboarding-existing-models');
+  if (list) list.innerHTML = '<div class="onboarding-empty">Checking models...</div>';
+  try {
+    modelCatalog = await fetchModelCatalog(force);
+    existingModelsLoaded = true;
+  } catch (_) {
+    modelCatalog = emptyCatalog();
+  }
+  renderExistingModels();
+}
+
+function firstModelFromEndpointResult(result) {
+  const models = Array.isArray(result?.models) ? result.models : [];
+  return models.find((model) => model && !/embedding|whisper|tts|image|dall-e/i.test(model)) || models[0] || '';
+}
+
+async function createEndpoint({ name, baseUrl, apiKey, shared = false, supportsTools = '' }) {
+  const form = new FormData();
+  form.set('name', name);
+  form.set('base_url', baseUrl);
+  form.set('api_key', apiKey || '');
+  form.set('skip_probe', 'false');
+  form.set('require_models', 'false');
+  form.set('model_type', 'llm');
+  form.set('shared', shared ? 'true' : 'false');
+  if (supportsTools !== '') form.set('supports_tools', supportsTools ? 'true' : 'false');
+
+  const res = await fetch(`${API_BASE}/api/model-endpoints`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    body: form,
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return res.json();
+}
+
+async function saveDefaultModel(endpointId, model) {
+  if (!endpointId || !model) return false;
+
+  const payload = {
+    default_endpoint_id: endpointId,
+    default_model: model,
+    default_model_fallbacks: [],
+  };
+
+  const adminRes = await fetch(`${API_BASE}/api/auth/settings`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (adminRes.ok) return true;
+
+  if (adminRes.status !== 403) {
+    throw new Error(await readError(adminRes));
+  }
+
+  await Promise.all([
+    setPref('default_endpoint_id', endpointId),
+    setPref('default_model', model),
+    setPref('default_model_fallbacks', []),
+  ]);
+  return true;
+}
+
+async function saveCloudEndpoint() {
+  const provider = CLOUD_PROVIDERS.find((item) => item.id === selectedProviderId) || CLOUD_PROVIDERS[0];
+  const name = overlay?.querySelector('#onboarding-cloud-name')?.value.trim() || provider.name;
+  const baseUrl = overlay?.querySelector('#onboarding-cloud-url')?.value.trim() || provider.baseUrl;
+  const apiKey = overlay?.querySelector('#onboarding-cloud-key')?.value.trim() || '';
+  const setDefault = overlay?.querySelector('#onboarding-cloud-default')?.checked !== false;
+  const button = overlay?.querySelector('#onboarding-cloud-save');
+
+  if (!baseUrl) {
+    setStatus('onboarding-cloud-status', 'error', 'Enter the provider base URL.');
+    return;
+  }
+  if (provider.keyRequired && !apiKey) {
+    setStatus('onboarding-cloud-status', 'error', 'Enter the API key for this provider.');
+    return;
+  }
+
+  setButtonBusy(button, true, 'Saving...');
+  setStatus('onboarding-cloud-status', '', '');
+
+  try {
+    const result = await createEndpoint({
+      name,
+      baseUrl,
+      apiKey,
+      shared: false,
+      supportsTools: provider.supportsTools,
+    });
+    const model = firstModelFromEndpointResult(result);
+    if (setDefault && result.id && model) await saveDefaultModel(result.id, model);
+    existingModelsLoaded = false;
+    await refreshExistingModels(true);
+    const keyInput = overlay?.querySelector('#onboarding-cloud-key');
+    if (keyInput) keyInput.value = '';
+    setStatus(
+      'onboarding-cloud-status',
+      'success',
+      model && setDefault ? `Saved. Default model: ${model}` : 'Endpoint saved. Models will appear after refresh.'
+    );
+  } catch (err) {
+    const message = String(err?.message || err || 'Save failed');
+    setStatus(
+      'onboarding-cloud-status',
+      'error',
+      /admin/i.test(message) ? 'Admin access is required to add model endpoints.' : message
+    );
+  } finally {
+    setButtonBusy(button, false);
+  }
+}
+
+async function saveLocalEndpoint() {
+  const name = overlay?.querySelector('#onboarding-local-name')?.value.trim() || 'Local model server';
+  const baseUrl = overlay?.querySelector('#onboarding-local-url')?.value.trim() || '';
+  const setDefault = overlay?.querySelector('#onboarding-local-default')?.checked !== false;
+  const button = overlay?.querySelector('#onboarding-local-save');
+
+  if (!baseUrl) {
+    setStatus('onboarding-local-status', 'error', 'Enter the local endpoint URL.');
+    return;
+  }
+
+  setButtonBusy(button, true, 'Saving...');
+  setStatus('onboarding-local-status', '', '');
+
+  try {
+    const result = await createEndpoint({ name, baseUrl, apiKey: '', shared: false, supportsTools: '' });
+    const model = firstModelFromEndpointResult(result);
+    if (setDefault && result.id && model) await saveDefaultModel(result.id, model);
+    existingModelsLoaded = false;
+    await refreshExistingModels(true);
+    setStatus(
+      'onboarding-local-status',
+      'success',
+      model && setDefault ? `Saved. Default model: ${model}` : 'Endpoint saved. Start the server, then refresh models.'
+    );
+  } catch (err) {
+    const message = String(err?.message || err || 'Save failed');
+    setStatus(
+      'onboarding-local-status',
+      'error',
+      /admin/i.test(message) ? 'Admin access is required to add model endpoints.' : message
+    );
+  } finally {
+    setButtonBusy(button, false);
+  }
+}
+
+async function useFirstAvailableModel() {
+  const statusId = 'onboarding-existing-status';
+  const button = overlay?.querySelector('#onboarding-use-first-model');
+  const entry = modelCatalog.models[0];
+  if (!entry?.endpointId || !entry.model) {
+    setStatus(statusId, 'error', 'No configured model is available yet.');
+    return;
+  }
+
+  setButtonBusy(button, true, 'Saving...');
+  setStatus(statusId, '', '');
+
+  try {
+    await saveDefaultModel(entry.endpointId, entry.model);
+    setStatus(statusId, 'success', `Default model: ${entry.displayName || entry.model}`);
+  } catch (err) {
+    setStatus(statusId, 'error', String(err?.message || err || 'Could not set default model.'));
+  } finally {
+    setButtonBusy(button, false);
+  }
+}
+
+function applySelectedTheme(themeName) {
+  const colors = THEMES[themeName];
+  if (!colors) return;
+
+  selectedTheme = themeName;
+
+  const bgPattern = THEME_DEFAULT_PATTERN[themeName] || 'none';
+  const effectColor = THEME_DEFAULT_EFFECT_COLOR[themeName] || '';
+  const effectIntensity = THEME_DEFAULT_INTENSITY[themeName] ?? 1;
+
+  themeModule.applyColors(colors);
+  themeModule.applyFontDensity(DEFAULT_FONT, selectedDensity);
+  themeModule.applyBgEffectColor?.(effectColor);
+  themeModule.applyBgEffectIntensity?.(effectIntensity);
+  themeModule.applyBgEffectSize?.(1);
+  themeModule.applyFrostedGlass?.(false);
+  themeModule.applyBgPattern(bgPattern);
+  themeModule.save(themeName, colors, {
+    font: DEFAULT_FONT,
+    density: selectedDensity,
+    bgPattern,
+    bgEffectColor: effectColor,
+    bgEffectIntensity: effectIntensity,
+    bgEffectSize: 1,
+    frosted: false,
+  });
+
+  overlay?.querySelectorAll('.onboarding-theme-swatch').forEach((button) => {
+    button.classList.toggle('is-selected', button.dataset.themeId === themeName);
+  });
+  if (overlay) overlay.dataset.density = selectedDensity;
+}
+
+function applySelectedDensity(density) {
+  selectedDensity = density || DEFAULT_DENSITY;
+  const colors = THEMES[selectedTheme] || THEMES[DEFAULT_THEME];
+  const bgPattern = THEME_DEFAULT_PATTERN[selectedTheme] || 'none';
+  const effectColor = THEME_DEFAULT_EFFECT_COLOR[selectedTheme] || '';
+  const effectIntensity = THEME_DEFAULT_INTENSITY[selectedTheme] ?? 1;
+
+  themeModule.applyFontDensity(DEFAULT_FONT, selectedDensity);
+  themeModule.save(selectedTheme, colors, {
+    font: DEFAULT_FONT,
+    density: selectedDensity,
+    bgPattern,
+    bgEffectColor: effectColor,
+    bgEffectIntensity: effectIntensity,
+    bgEffectSize: 1,
+    frosted: false,
+  });
+
+  overlay?.querySelectorAll('.onboarding-density-btn').forEach((button) => {
+    button.classList.toggle('is-selected', button.dataset.density === selectedDensity);
+  });
+  if (overlay) overlay.dataset.density = selectedDensity;
+  syncOnboardingScale();
+}
+
+function syncOnboardingScale() {
+  if (!overlay) return;
+  if (window.matchMedia('(max-width: 760px)').matches) {
+    overlay.style.setProperty('--onboarding-scale', '1');
+    return;
+  }
+
+  const styles = getComputedStyle(overlay);
+  const designWidth = parseFloat(styles.getPropertyValue('--onboarding-design-width')) || 1040;
+  const designHeight = parseFloat(styles.getPropertyValue('--onboarding-design-height')) || 720;
+  const viewport = window.visualViewport || window;
+  const viewportWidth = Math.max(320, (viewport.width || window.innerWidth) - 32);
+  const viewportHeight = Math.max(320, (viewport.height || window.innerHeight) - 32);
+  const scale = Math.min(1, viewportWidth / designWidth, viewportHeight / designHeight);
+
+  overlay.style.setProperty('--onboarding-scale', Math.max(0.5, scale).toFixed(3));
+}
+
+function attachScaleListeners() {
+  if (scaleListenersAttached) return;
+  scaleListenersAttached = true;
+  window.addEventListener('resize', syncOnboardingScale, { passive: true });
+  window.visualViewport?.addEventListener('resize', syncOnboardingScale, { passive: true });
+}
+
+function detachScaleListeners() {
+  if (!scaleListenersAttached) return;
+  scaleListenersAttached = false;
+  window.removeEventListener('resize', syncOnboardingScale);
+  window.visualViewport?.removeEventListener('resize', syncOnboardingScale);
+}
+
+function goToStep(step) {
+  currentStep = Math.max(0, Math.min(TOTAL_STEPS - 1, step));
+
+  overlay?.querySelectorAll('.onboarding-step').forEach((panel) => {
+    panel.classList.toggle('is-active', Number(panel.dataset.step) === currentStep);
+  });
+  overlay?.querySelectorAll('.onboarding-step-link').forEach((link) => {
+    const linkStep = Number(link.dataset.stepLink);
+    link.classList.toggle('is-active', linkStep === currentStep);
+    link.classList.toggle('is-complete', linkStep < currentStep);
+  });
+  overlay?.querySelectorAll('.onboarding-progress span').forEach((dot, index) => {
+    dot.classList.toggle('is-active', index === currentStep);
+    dot.classList.toggle('is-complete', index < currentStep);
+  });
+
+  if (currentStep === 1) refreshExistingModels(false);
+
+  requestAnimationFrame(() => {
+    const title = overlay?.querySelector(`#onboarding-title-${currentStep}`);
+    if (title) title.focus({ preventScroll: true });
+  });
+}
+
+function focusableElements() {
+  return Array.from(overlay?.querySelectorAll(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  ) || []).filter((node) => node.offsetParent !== null);
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    dismiss();
+    return;
+  }
+
+  if (event.key !== 'Tab') return;
+  const nodes = focusableElements();
+  if (!nodes.length) return;
+  const first = nodes[0];
+  const last = nodes[nodes.length - 1];
+
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function wireOverlay() {
+  overlay.querySelectorAll('[data-onboarding-next]').forEach((button) => {
+    button.addEventListener('click', () => goToStep(currentStep + 1));
+  });
+  overlay.querySelectorAll('[data-onboarding-back]').forEach((button) => {
+    button.addEventListener('click', () => goToStep(currentStep - 1));
+  });
+  overlay.querySelector('[data-onboarding-finish]')?.addEventListener('click', dismiss);
+  overlay.querySelector('[data-onboarding-skip]')?.addEventListener('click', dismiss);
+  overlay.querySelectorAll('[data-step-link]').forEach((button) => {
+    button.addEventListener('click', () => goToStep(Number(button.dataset.stepLink) || 0));
+  });
+  overlay.querySelectorAll('[data-model-tab]').forEach((button) => {
+    button.addEventListener('click', () => setModelTab(button.dataset.modelTab));
+  });
+  overlay.querySelectorAll('[data-provider-id]').forEach((button) => {
+    button.addEventListener('click', () => selectProvider(button.dataset.providerId));
+  });
+  overlay.querySelectorAll('[data-local-preset]').forEach((button) => {
+    button.addEventListener('click', () => selectLocalPreset(button.dataset.localPreset));
+  });
+  overlay.querySelector('#onboarding-cloud-save')?.addEventListener('click', saveCloudEndpoint);
+  overlay.querySelector('#onboarding-local-save')?.addEventListener('click', saveLocalEndpoint);
+  overlay.querySelector('#onboarding-refresh-models')?.addEventListener('click', () => refreshExistingModels(true));
+  overlay.querySelector('#onboarding-use-first-model')?.addEventListener('click', useFirstAvailableModel);
+  overlay.querySelectorAll('[data-theme-id]').forEach((button) => {
+    button.addEventListener('click', () => applySelectedTheme(button.dataset.themeId));
+  });
+  overlay.querySelectorAll('[data-density]').forEach((button) => {
+    button.addEventListener('click', () => applySelectedDensity(button.dataset.density));
+  });
+  overlay.addEventListener('keydown', handleKeydown);
+
+  selectProvider(selectedProviderId);
+  selectLocalPreset('ollama');
+  renderExistingModels();
+}
+
+function cleanupOverlay() {
+  if (!overlay) return;
+  detachScaleListeners();
+  overlay.remove();
+  overlay = null;
+  document.body.classList.remove('onboarding-open');
+  if (previousFocus && typeof previousFocus.focus === 'function') {
+    try { previousFocus.focus({ preventScroll: true }); } catch (_) {}
+  }
+}
+
+async function dismiss() {
+  await setPref(PREF_KEY, true);
+  if (!overlay) return;
+  overlay.classList.add('is-leaving');
+  window.setTimeout(cleanupOverlay, 180);
+}
+
+async function showOnboarding() {
+  if (overlay) return;
+
+  previousFocus = document.activeElement;
+  existingModelsLoaded = false;
+  modelCatalog = await fetchModelCatalog(false).catch(() => emptyCatalog());
+  selectedTheme = getSavedThemeName();
+  selectedDensity = getSavedDensity();
+
+  overlay = buildOverlay();
+  overlay.dataset.density = selectedDensity;
+  document.body.appendChild(overlay);
+  document.body.classList.add('onboarding-open');
+  attachScaleListeners();
+  wireOverlay();
+  syncOnboardingScale();
+  goToStep(0);
+}
+
+export async function maybeShowOnboarding() {
+  const done = await getPref(PREF_KEY);
+  if (isComplete(done)) return;
+  await showOnboarding();
+}
+
+export default { maybeShowOnboarding };

--- a/static/style.css
+++ b/static/style.css
@@ -34069,3 +34069,1210 @@ body.theme-frosted .modal {
   background-color: color-mix(in srgb, var(--accent, var(--red)) 10%, transparent);
   transform: translateX(1px);
 }
+
+/* First-run onboarding */
+body.onboarding-open {
+  overflow: hidden;
+}
+
+.onboarding-overlay {
+  --onboarding-design-width: 1040px;
+  --onboarding-design-height: 720px;
+  --onboarding-scale: 1;
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: block;
+  padding: 16px;
+  color: var(--fg);
+  isolation: isolate;
+  animation: onboarding-fade-in 0.18s ease both;
+}
+
+.onboarding-overlay.is-leaving {
+  animation: onboarding-fade-out 0.18s ease both;
+}
+
+.onboarding-scrim {
+  position: absolute;
+  inset: 0;
+  background:
+    color-mix(in srgb, var(--bg) 84%, #000 16%);
+  backdrop-filter: blur(18px) saturate(130%);
+  -webkit-backdrop-filter: blur(18px) saturate(130%);
+}
+
+.onboarding-shell {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  width: var(--onboarding-design-width);
+  height: var(--onboarding-design-height);
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 292px minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 84%, var(--fg) 16%);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 92%, var(--bg) 8%);
+  box-shadow:
+    0 28px 90px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 color-mix(in srgb, var(--fg) 8%, transparent);
+  transform: translate(-50%, -50%) scale(var(--onboarding-scale));
+  transform-origin: center center;
+}
+
+.onboarding-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 24px;
+  border-right: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  background:
+    color-mix(in srgb, var(--bg) 42%, transparent);
+}
+
+.onboarding-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.onboarding-brand-mark {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  color: var(--accent, var(--red));
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 34%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 10%, transparent);
+}
+
+.onboarding-brand-mark svg {
+  width: 25px;
+  height: 25px;
+}
+
+.onboarding-brand strong {
+  display: block;
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
+.onboarding-brand span {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+}
+
+.onboarding-step-list {
+  display: grid;
+  gap: 8px;
+}
+
+.onboarding-step-link {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  grid-template-areas:
+    "num title"
+    "num detail";
+  column-gap: 12px;
+  row-gap: 2px;
+  width: 100%;
+  min-height: 58px;
+  padding: 10px 12px;
+  align-items: center;
+  text-align: left;
+  color: color-mix(in srgb, var(--fg) 64%, transparent);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease;
+}
+
+.onboarding-step-link:hover,
+.onboarding-step-link:focus-visible {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--border) 82%, var(--fg) 18%);
+  outline: none;
+}
+
+.onboarding-step-link.is-active {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 42%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 9%, transparent);
+}
+
+.onboarding-step-link.is-complete span {
+  color: var(--accent, var(--red));
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 40%, var(--border));
+}
+
+.onboarding-step-link span {
+  grid-area: num;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  align-self: center;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 6px;
+  font-size: 11px;
+}
+
+.onboarding-step-link strong {
+  grid-area: title;
+  align-self: end;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.15;
+}
+
+.onboarding-step-link small {
+  grid-area: detail;
+  align-self: start;
+  margin-top: 0;
+  font-size: 11px;
+  line-height: 1.2;
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+}
+
+.onboarding-skip {
+  margin-top: auto;
+  width: 100%;
+  min-height: 34px;
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease;
+}
+
+.onboarding-skip:hover,
+.onboarding-skip:focus-visible {
+  color: var(--fg);
+  border-color: var(--border);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  outline: none;
+}
+
+.onboarding-main {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.onboarding-progress {
+  position: absolute;
+  top: 22px;
+  right: 28px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.onboarding-progress span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg) 20%, transparent);
+  transition:
+    width 0.18s ease,
+    background-color 0.18s ease;
+}
+
+.onboarding-progress span.is-active {
+  width: 22px;
+  background: var(--accent, var(--red));
+}
+
+.onboarding-progress span.is-complete {
+  background: color-mix(in srgb, var(--accent, var(--red)) 62%, transparent);
+}
+
+.onboarding-step {
+  display: none;
+  height: 100%;
+  min-height: 0;
+  padding: 62px 44px 34px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.onboarding-step.is-active {
+  display: flex;
+  flex-direction: column;
+  animation: onboarding-step-in 0.2s ease both;
+}
+
+.onboarding-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  margin-bottom: 14px;
+  color: var(--accent, var(--red));
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.onboarding-kicker svg {
+  width: 17px;
+  height: 17px;
+}
+
+.onboarding-title {
+  max-width: 720px;
+  margin: 0;
+  color: var(--fg);
+  font-size: 36px;
+  line-height: 1.05;
+  font-weight: 760;
+  letter-spacing: 0;
+}
+
+.onboarding-title:focus {
+  outline: none;
+}
+
+.onboarding-lede {
+  max-width: 680px;
+  margin: 14px 0 0;
+  color: color-mix(in srgb, var(--fg) 68%, transparent);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.onboarding-value-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 30px;
+}
+
+.onboarding-value-grid div,
+.onboarding-feature-card,
+.onboarding-provider,
+.onboarding-model-chip {
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
+}
+
+.onboarding-value-grid div {
+  min-height: 106px;
+  padding: 15px;
+}
+
+.onboarding-value-grid strong,
+.onboarding-model-summary strong {
+  display: block;
+  font-size: 13px;
+}
+
+.onboarding-value-grid span {
+  display: block;
+  margin-top: 8px;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.onboarding-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: auto;
+  padding: 18px 0 2px;
+  background: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--panel) 94%, var(--bg) 6%) 0%,
+    color-mix(in srgb, var(--panel) 88%, transparent) 72%,
+    transparent 100%
+  );
+}
+
+.onboarding-primary,
+.onboarding-secondary,
+.onboarding-icon-btn {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  transition:
+    transform 0.15s ease,
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.onboarding-primary {
+  padding: 0 16px;
+  color: #fff;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 80%, var(--fg) 20%);
+  background: var(--accent, var(--red));
+}
+
+.onboarding-secondary,
+.onboarding-icon-btn {
+  color: var(--fg);
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+
+.onboarding-primary svg,
+.onboarding-secondary svg,
+.onboarding-icon-btn svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+
+.onboarding-primary:hover:not(:disabled),
+.onboarding-secondary:hover:not(:disabled),
+.onboarding-icon-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.onboarding-primary:disabled,
+.onboarding-secondary:disabled,
+.onboarding-icon-btn:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.onboarding-primary:focus-visible,
+.onboarding-secondary:focus-visible,
+.onboarding-icon-btn:focus-visible,
+.onboarding-tabs button:focus-visible,
+.onboarding-provider:focus-visible,
+.onboarding-theme-swatch:focus-visible,
+.onboarding-density-btn:focus-visible,
+.onboarding-local-presets button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent, var(--red)) 72%, transparent);
+  outline-offset: 2px;
+}
+
+.onboarding-model-summary {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 42px;
+  margin: 20px 0 16px;
+  padding: 10px 12px;
+  color: color-mix(in srgb, var(--fg) 68%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 16%, transparent);
+  font-size: 12px;
+}
+
+.onboarding-model-summary.is-ready {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 38%, var(--border));
+}
+
+.onboarding-model-summary svg {
+  width: 17px;
+  height: 17px;
+  color: var(--accent, var(--red));
+  flex: 0 0 auto;
+}
+
+.onboarding-spinner {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  border: 2px solid color-mix(in srgb, var(--fg) 18%, transparent);
+  border-top-color: var(--accent, var(--red));
+  border-radius: 999px;
+  animation: onboarding-spin 0.8s linear infinite;
+}
+
+.onboarding-tabs {
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
+}
+
+.onboarding-tabs button,
+.onboarding-density-btn {
+  min-height: 30px;
+  padding: 0 12px;
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+.onboarding-tabs button.is-active,
+.onboarding-density-btn.is-selected {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, var(--fg) 7%, transparent);
+}
+
+.onboarding-tab-panel {
+  display: none;
+  margin-top: 16px;
+}
+
+.onboarding-tab-panel.is-active {
+  display: block;
+}
+
+.onboarding-provider-grid,
+.onboarding-theme-grid,
+.onboarding-feature-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.onboarding-provider-grid {
+  grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));
+}
+
+.onboarding-provider {
+  min-width: 0;
+  min-height: 118px;
+  padding: 12px;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.onboarding-provider:hover,
+.onboarding-provider.is-selected {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 44%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+}
+
+.onboarding-provider:hover {
+  transform: translateY(-1px);
+}
+
+.onboarding-provider-icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 10px;
+  color: var(--accent, var(--red));
+}
+
+.onboarding-provider-icon svg {
+  width: 21px;
+  height: 21px;
+}
+
+.onboarding-provider > span:last-child {
+  min-width: 0;
+}
+
+.onboarding-provider strong,
+.onboarding-provider small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.onboarding-provider strong {
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.onboarding-provider small {
+  margin-top: 4px;
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: 11px;
+  line-height: 1.35;
+  white-space: normal;
+}
+
+.onboarding-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.onboarding-form-grid label,
+.onboarding-check {
+  min-width: 0;
+}
+
+.onboarding-form-grid label span,
+.onboarding-section-label {
+  display: block;
+  margin-bottom: 7px;
+  color: color-mix(in srgb, var(--fg) 56%, transparent);
+  font-size: 11px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.onboarding-form-wide {
+  grid-column: 1 / -1;
+}
+
+.onboarding-input {
+  width: 100%;
+  height: 36px;
+  min-width: 0;
+  padding: 0 11px;
+  color: var(--fg);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg) 26%, transparent);
+  font: inherit;
+  font-size: 12px;
+}
+
+.onboarding-input:focus {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 62%, var(--border));
+  outline: none;
+}
+
+.onboarding-check {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 12px;
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.onboarding-check input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent, var(--red));
+}
+
+.onboarding-inline-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 38px;
+  margin-top: 14px;
+}
+
+.onboarding-status {
+  min-width: 0;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.onboarding-status.is-success {
+  color: var(--color-success, #50fa7b);
+}
+
+.onboarding-status.is-info {
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+}
+
+.onboarding-status.is-error {
+  color: var(--red);
+}
+
+.onboarding-local-presets {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.onboarding-local-presets button {
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  color: color-mix(in srgb, var(--fg) 68%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+.onboarding-local-presets button.is-selected {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 44%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+}
+
+.onboarding-local-presets svg {
+  width: 18px;
+  height: 18px;
+  color: var(--accent, var(--red));
+  flex: 0 0 auto;
+}
+
+.onboarding-existing-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.onboarding-existing-head strong,
+.onboarding-existing-head span {
+  display: block;
+}
+
+.onboarding-existing-head strong {
+  font-size: 13px;
+}
+
+.onboarding-existing-head span {
+  margin-top: 3px;
+  color: color-mix(in srgb, var(--fg) 54%, transparent);
+  font-size: 12px;
+}
+
+.onboarding-icon-btn {
+  width: 34px;
+  min-width: 34px;
+  padding: 0;
+}
+
+.onboarding-model-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  min-height: 74px;
+}
+
+.onboarding-model-chip {
+  min-width: 0;
+  padding: 10px 12px;
+}
+
+.onboarding-model-chip strong,
+.onboarding-model-chip span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.onboarding-model-chip strong {
+  font-size: 12px;
+}
+
+.onboarding-model-chip span {
+  margin-top: 3px;
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size: 11px;
+}
+
+.onboarding-model-chip.is-more {
+  display: grid;
+  place-items: center;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  font-size: 12px;
+}
+
+.onboarding-empty {
+  grid-column: 1 / -1;
+  display: grid;
+  place-items: center;
+  min-height: 74px;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 8px;
+  font-size: 12px;
+}
+
+.onboarding-section-label {
+  margin-top: 26px;
+}
+
+.onboarding-theme-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.onboarding-theme-swatch {
+  min-height: 104px;
+  padding: 10px;
+  color: color-mix(in srgb, var(--fg) 66%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.onboarding-theme-swatch:hover,
+.onboarding-theme-swatch.is-selected {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 44%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+}
+
+.onboarding-theme-swatch:hover {
+  transform: translateY(-1px);
+}
+
+.onboarding-swatch-frame {
+  display: grid;
+  grid-template-rows: 16px 1fr;
+  gap: 7px;
+  height: 58px;
+  margin-bottom: 9px;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--ob-fg) 22%, transparent);
+  border-radius: 6px;
+  background: var(--ob-bg);
+}
+
+.onboarding-swatch-frame span:first-child {
+  width: 48%;
+  border-radius: 4px;
+  background: var(--ob-accent);
+}
+
+.onboarding-swatch-frame span:nth-child(2) {
+  border-radius: 4px;
+  background: var(--ob-panel);
+}
+
+.onboarding-swatch-frame span:nth-child(3) {
+  width: 28px;
+  height: 7px;
+  margin-top: -18px;
+  margin-left: auto;
+  border-radius: 999px;
+  background: var(--ob-fg);
+}
+
+.onboarding-density-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 18%, transparent);
+}
+
+.onboarding-feature-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 26px;
+}
+
+.onboarding-feature-card {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  gap: 12px;
+  min-height: 116px;
+  padding: 14px;
+}
+
+.onboarding-feature-icon {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  color: var(--accent, var(--red));
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 34%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+}
+
+.onboarding-feature-icon svg {
+  width: 19px;
+  height: 19px;
+}
+
+.onboarding-feature-card h3 {
+  margin: 1px 0 0;
+  font-size: 13px;
+}
+
+.onboarding-feature-card p {
+  margin: 6px 0 0;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.onboarding-overlay[data-density="compact"] {
+  --onboarding-design-width: 990px;
+  --onboarding-design-height: 660px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-aside {
+  gap: 20px;
+  padding: 20px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-step-link {
+  min-height: 50px;
+  padding: 8px 10px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-step-link span {
+  width: 31px;
+  height: 31px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-step {
+  padding: 50px 36px 28px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-title {
+  font-size: 32px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-lede {
+  margin-top: 10px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-value-grid,
+.onboarding-overlay[data-density="compact"] .onboarding-provider-grid,
+.onboarding-overlay[data-density="compact"] .onboarding-theme-grid,
+.onboarding-overlay[data-density="compact"] .onboarding-feature-grid {
+  gap: 8px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-value-grid div {
+  min-height: 88px;
+  padding: 12px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-provider {
+  min-height: 102px;
+  padding: 10px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-feature-card {
+  min-height: 100px;
+  padding: 12px;
+}
+
+.onboarding-overlay[data-density="compact"] .onboarding-input,
+.onboarding-overlay[data-density="compact"] .onboarding-primary,
+.onboarding-overlay[data-density="compact"] .onboarding-secondary,
+.onboarding-overlay[data-density="compact"] .onboarding-icon-btn {
+  min-height: 32px;
+}
+
+.onboarding-overlay[data-density="spacious"] {
+  --onboarding-design-width: 1120px;
+  --onboarding-design-height: 760px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-aside {
+  gap: 34px;
+  padding: 28px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-step-link {
+  min-height: 68px;
+  padding: 13px 14px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-step-link span {
+  width: 42px;
+  height: 42px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-step-link strong {
+  font-size: 13px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-step-link small {
+  font-size: 12px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-step {
+  padding: 72px 52px 42px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-title {
+  font-size: 40px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-lede {
+  margin-top: 16px;
+  font-size: 15px;
+  line-height: 1.62;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-value-grid,
+.onboarding-overlay[data-density="spacious"] .onboarding-provider-grid,
+.onboarding-overlay[data-density="spacious"] .onboarding-theme-grid,
+.onboarding-overlay[data-density="spacious"] .onboarding-feature-grid {
+  gap: 14px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-value-grid div {
+  min-height: 126px;
+  padding: 18px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-provider {
+  min-height: 136px;
+  padding: 15px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-provider strong,
+.onboarding-overlay[data-density="spacious"] .onboarding-value-grid strong,
+.onboarding-overlay[data-density="spacious"] .onboarding-feature-card h3 {
+  font-size: 14px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-provider small,
+.onboarding-overlay[data-density="spacious"] .onboarding-value-grid span,
+.onboarding-overlay[data-density="spacious"] .onboarding-feature-card p {
+  font-size: 13px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-feature-card {
+  min-height: 132px;
+  padding: 18px;
+}
+
+.onboarding-overlay[data-density="spacious"] .onboarding-input,
+.onboarding-overlay[data-density="spacious"] .onboarding-primary,
+.onboarding-overlay[data-density="spacious"] .onboarding-secondary,
+.onboarding-overlay[data-density="spacious"] .onboarding-icon-btn {
+  min-height: 40px;
+}
+
+@keyframes onboarding-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes onboarding-fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes onboarding-step-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes onboarding-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 980px) {
+  .onboarding-shell {
+    grid-template-columns: 238px minmax(0, 1fr);
+  }
+
+  .onboarding-provider-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .onboarding-theme-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .onboarding-overlay {
+    padding: 0;
+  }
+
+  .onboarding-shell {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100vw;
+    height: 100dvh;
+    min-height: 0;
+    transform: none;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    border: none;
+    border-radius: 0;
+  }
+
+  .onboarding-aside {
+    gap: 14px;
+    padding: 14px 14px 10px;
+    border-right: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  }
+
+  .onboarding-brand-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  .onboarding-step-list {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .onboarding-step-link {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "num"
+      "title";
+    justify-items: center;
+    padding: 8px 4px;
+  }
+
+  .onboarding-step-link small {
+    display: none;
+  }
+
+  .onboarding-step-link span {
+    width: 26px;
+    height: 24px;
+  }
+
+  .onboarding-step-link strong {
+    margin-top: 5px;
+    font-size: 10px;
+  }
+
+  .onboarding-skip {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    width: auto;
+    min-height: 30px;
+    padding: 0 10px;
+  }
+
+  .onboarding-progress {
+    top: 14px;
+    right: 14px;
+    display: none;
+  }
+
+  .onboarding-step {
+    padding: 28px 18px 24px;
+  }
+
+  .onboarding-title {
+    font-size: 29px;
+  }
+
+  .onboarding-value-grid,
+  .onboarding-provider-grid,
+  .onboarding-form-grid,
+  .onboarding-local-presets,
+  .onboarding-model-list,
+  .onboarding-feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .onboarding-provider {
+    min-height: 72px;
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr);
+    align-items: center;
+    column-gap: 8px;
+  }
+
+  .onboarding-provider-icon {
+    margin-bottom: 0;
+  }
+
+  .onboarding-theme-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .onboarding-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .onboarding-tabs button {
+    padding: 0 6px;
+  }
+
+  .onboarding-inline-actions,
+  .onboarding-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .onboarding-actions .onboarding-secondary,
+  .onboarding-actions .onboarding-primary,
+  .onboarding-inline-actions .onboarding-secondary,
+  .onboarding-inline-actions .onboarding-primary {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-overlay,
+  .onboarding-overlay.is-leaving,
+  .onboarding-step.is-active,
+  .onboarding-spinner {
+    animation: none;
+  }
+
+  .onboarding-primary,
+  .onboarding-secondary,
+  .onboarding-icon-btn,
+  .onboarding-provider,
+  .onboarding-theme-swatch {
+    transition: none;
+  }
+}

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v326';
+const CACHE_NAME = 'odysseus-v331';
 
 // Core shell precached on install so repeat opens are instant without any
 // network wait. Keep this list in sync with the <script type="module"> tags
@@ -60,6 +60,7 @@ const PRECACHE = [
   '/static/js/keyboard-shortcuts.js',
   '/static/js/sidebar-layout.js',
   '/static/js/section-management.js',
+  '/static/js/onboarding.js',
   '/static/lib/highlight.min.js',
 ];
 


### PR DESCRIPTION
## Summary

Adds a **first-run-only** onboarding overlay so a fresh Odysseus install guides the user through connecting a model, picking a theme/density, and seeing a short map of the workspace — instead of dropping them into a blank, model-less dashboard. It shows once (gated on the `onboarding_complete` pref via the existing prefs API), is fully skippable, and changes nothing about the dashboard layout.

## Linked Issue

Closes #2043

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start the app: `python -m uvicorn app:app --host 127.0.0.1 --port 7000` (or `docker compose up`).
2. Ensure the onboarding hasn't been completed for your user — clear it via the prefs API: `curl -X PUT http://localhost:7000/api/prefs/onboarding_complete -H 'Content-Type: application/json' --cookie <session> -d '{"value": false}'` (or test on a fresh user).
3. Load the dashboard. The onboarding overlay appears automatically on first run.
4. Walk the four steps (Welcome → Model → Interface → Features). Try: adding a cloud provider, pointing at a local endpoint (Ollama/LM Studio), switching theme + density (the swatches preview live), and **Skip setup**.
5. Finish or skip → overlay closes, `onboarding_complete` is persisted, and it does **not** reappear on reload.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuses existing CSS variables (`--fg` ×42, `--red` ×30, `--border` ×26, `--bg` ×11, `--panel`) — no new palette; raw `#fff`/`#000`/`rgba(0,0,0,…)` only where the rest of the stylesheet already does, and `var(--color-success, #50fa7b)` follows the existing var-with-fallback pattern.
  - Reuses existing button/input/card/border styling; px font-sizes match the codebase convention (no type-scale variable system exists).
  - **No Unicode emoji** — all icons are inline monochrome SVG matching `static/index.html`.
  - Monospaced `Fira Code` for primary UI text; dark theme default; theme selection is wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** The overlay reuses existing card/button/input idioms; theme + density apply through the existing theme system.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a single, scoped feature with a linked proposal issue (#2043), not a bulk auto-generated change.

### Scope

- `static/js/onboarding.js` — the module (overlay, steps, model/theme/density wiring).
- `static/style.css` — `.onboarding-*` styles only.
- `static/app.js` — one-line bootstrap hook (`maybeShowOnboarding()`), guarded with a `.catch`.
- `static/sw.js` — precache `onboarding.js` so the app shell stays available offline.

### Validation run

- `node --check static/js/onboarding.js`, `static/app.js`, `static/sw.js` — all pass.
- Booted `uvicorn app:app` and rendered all four onboarding steps in a real browser (screenshots below are from that run). Rebased onto current `main` and re-verified after resolving the `static/style.css` merge.

### Screenshots / clips

**Step 1 — Welcome**
![Welcome](https://github.com/user-attachments/assets/3b481070-7e24-4cb3-ba4d-9fd9a9f8edfb)

**Step 2 — Connect a model**
![Model setup](https://github.com/user-attachments/assets/56a892ce-4504-4db6-9ae5-aca99aa26c94)

**Step 3 — Interface (theme + density, live preview swatches)**
![Interface](https://github.com/user-attachments/assets/1bbc390f-9aaf-42bb-8daa-620427711541)

**Step 4 — Features map**
![Features](https://github.com/user-attachments/assets/d6c00e3b-0cc8-4d1c-98ef-b37db073c026)
