### PR TITLE
Fix/docker dependency in container

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -70,13 +70,14 @@ def _running_in_container(dockerenv_path="/.dockerenv", cgroup_path="/proc/1/cgr
     return any(token in contents for token in ("docker", "containerd", "kubepods"))
 
 
-DockerLocalStatus = namedtuple("DockerLocalStatus", ["applicable", "install_hint"])
+DockerRowStatus = namedtuple("DockerRowStatus", ["applicable", "install_hint"])
 
 
-def _local_docker_status(*, installed, in_container, default_hint):
-    if in_container and not installed:
-        return DockerLocalStatus(applicable=False, install_hint=DOCKER_IN_CONTAINER_HINT)
-    return DockerLocalStatus(applicable=True, install_hint=default_hint)
+def _docker_row_status(*, on_remote, in_container, installed, default_hint):
+    local_docker_unavailable = not on_remote and in_container and not installed
+    if local_docker_unavailable:
+        return DockerRowStatus(applicable=False, install_hint=DOCKER_IN_CONTAINER_HINT)
+    return DockerRowStatus(applicable=True, install_hint=default_hint)
 
 
 def _find_line_break(buf):
@@ -617,29 +618,29 @@ def setup_shell_routes() -> APIRouter:
                 pass
 
         for pkg in packages:
-            if host and pkg.get("target") == "remote":
+            on_remote = bool(host and pkg.get("target") == "remote")
+            if on_remote:
                 pkg["installed"] = bool(remote_status.get(pkg["name"], False))
-                continue
-            if pkg.get("kind") == "system":
-                installed = shutil.which(pkg["name"]) is not None
-                pkg["installed"] = installed
-                if pkg["name"] == "docker":
-                    status = _local_docker_status(
-                        installed=installed,
-                        in_container=_running_in_container(),
-                        default_hint=pkg.get("install_hint"),
-                    )
-                    pkg["applicable"] = status.applicable
-                    pkg["install_hint"] = status.install_hint
-                continue
-            try:
-                if pkg["name"] == "llama_cpp" and shutil.which("llama-server"):
-                    pkg["installed"] = True
-                    continue
-                importlib.import_module(pkg["name"])
+            elif pkg.get("kind") == "system":
+                pkg["installed"] = shutil.which(pkg["name"]) is not None
+            elif pkg["name"] == "llama_cpp" and shutil.which("llama-server"):
                 pkg["installed"] = True
-            except ImportError:
-                pkg["installed"] = False
+            else:
+                try:
+                    importlib.import_module(pkg["name"])
+                    pkg["installed"] = True
+                except ImportError:
+                    pkg["installed"] = False
+
+            if pkg["name"] == "docker":
+                status = _docker_row_status(
+                    on_remote=on_remote,
+                    in_container=_running_in_container() if not on_remote else False,
+                    installed=pkg["installed"],
+                    default_hint=pkg.get("install_hint"),
+                )
+                pkg["applicable"] = status.applicable
+                pkg["install_hint"] = status.install_hint
         return {"packages": packages}
 
     @router.post("/api/cookbook/packages/install")

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -8,6 +8,7 @@ import shlex
 import shutil
 import uuid
 import tempfile
+from collections import namedtuple
 from pathlib import Path
 from typing import Dict, Any
 
@@ -47,6 +48,35 @@ def _require_admin(request: Request):
 logger = logging.getLogger(__name__)
 
 PTY_SUPPORTED = pty is not None and fcntl is not None and hasattr(os, "setsid")
+
+
+DOCKER_IN_CONTAINER_HINT = (
+    "Not available inside the Odysseus container by design. The image ships no "
+    "docker CLI and no host socket is mounted. Run Docker-backed launches on a "
+    "remote server, where docker is checked over SSH. Mounting /var/run/docker.sock "
+    "into the container would grant it host-root access, so only do that if you "
+    "accept that risk."
+)
+
+
+def _running_in_container(dockerenv_path="/.dockerenv", cgroup_path="/proc/1/cgroup"):
+    if os.path.exists(dockerenv_path):
+        return True
+    try:
+        with open(cgroup_path, "r", encoding="utf-8") as fh:
+            contents = fh.read()
+    except OSError:
+        return False
+    return any(token in contents for token in ("docker", "containerd", "kubepods"))
+
+
+DockerLocalStatus = namedtuple("DockerLocalStatus", ["applicable", "install_hint"])
+
+
+def _local_docker_status(*, installed, in_container, default_hint):
+    if in_container and not installed:
+        return DockerLocalStatus(applicable=False, install_hint=DOCKER_IN_CONTAINER_HINT)
+    return DockerLocalStatus(applicable=True, install_hint=default_hint)
 
 
 def _find_line_break(buf):
@@ -591,7 +621,16 @@ def setup_shell_routes() -> APIRouter:
                 pkg["installed"] = bool(remote_status.get(pkg["name"], False))
                 continue
             if pkg.get("kind") == "system":
-                pkg["installed"] = shutil.which(pkg["name"]) is not None
+                installed = shutil.which(pkg["name"]) is not None
+                pkg["installed"] = installed
+                if pkg["name"] == "docker":
+                    status = _local_docker_status(
+                        installed=installed,
+                        in_container=_running_in_container(),
+                        default_hint=pkg.get("install_hint"),
+                    )
+                    pkg["applicable"] = status.applicable
+                    pkg["install_hint"] = status.install_hint
                 continue
             try:
                 if pkg["name"] == "llama_cpp" and shutil.which("llama-server"):

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -542,7 +542,11 @@ async function _fetchDependencies() {
       if (winBlocked) return `<span class="cookbook-dep-tag cookbook-dep-na">N/A</span>`;
       if (pkg.installed && isSystemDep) return `<span class="cookbook-dep-tag cookbook-dep-installed" title="Found on selected server">Installed</span>`;
       if (pkg.installed) return `<button class="cookbook-dep-tag cookbook-dep-installed cookbook-dep-installed-btn" title="Installed — click for actions"><span class="cookbook-dep-installed-label">Installed</span><span class="cookbook-dep-caret">&#9662;</span></button>`;
-      if (isSystemDep) return `<span class="cookbook-dep-tag cookbook-dep-na" title="${esc(pkg.install_hint || 'Install this OS package on the selected server.')}">Missing</span>`;
+      if (isSystemDep) {
+        const depTip = esc(pkg.install_hint || 'Install this OS package on the selected server.');
+        const depLabel = pkg.applicable === false ? 'N/A ?' : 'Missing';
+        return `<span class="cookbook-dep-tag cookbook-dep-na" title="${depTip}">${depLabel}</span>`;
+      }
       return `<button class="cookbook-dep-tag cookbook-dep-install" data-dep-pip="${esc(pkg.pip)}" data-dep-target="${isLocal ? 'local' : 'remote'}">Install</button>`;
     };
 

--- a/static/style.css
+++ b/static/style.css
@@ -18153,7 +18153,10 @@ body.gallery-selecting .gallery-dl-btn,
   border: 1px solid color-mix(in srgb, var(--green, #50fa7b) 35%, transparent);
 }
 .cookbook-dep-na {
-  color: color-mix(in srgb, var(--fg) 35%, transparent);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fg) 16%, transparent);
+  cursor: help;
 }
 .cookbook-dep-install {
   background: var(--accent, var(--red));

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from routes.shell_routes import (
     _find_line_break,
     _running_in_container,
-    _local_docker_status,
+    _docker_row_status,
     DOCKER_IN_CONTAINER_HINT,
 )
 
@@ -137,28 +137,42 @@ class TestRunningInContainer:
         ) is False
 
 
-class TestLocalDockerStatus:
-    """Status for a locally-checked docker row: applicability plus the hint."""
+class TestDockerRowStatus:
+    """Applicability plus install hint for the docker dependency row."""
 
     DEFAULT = "Install Docker on the selected server."
 
     def test_in_container_and_absent_is_not_applicable_with_safe_default_hint(self):
-        status = _local_docker_status(
-            installed=False, in_container=True, default_hint=self.DEFAULT,
+        status = _docker_row_status(
+            on_remote=False, in_container=True, installed=False, default_hint=self.DEFAULT,
         )
         assert status.applicable is False
         assert status.install_hint == DOCKER_IN_CONTAINER_HINT
 
     def test_in_container_but_present_is_applicable_with_default_hint(self):
-        status = _local_docker_status(
-            installed=True, in_container=True, default_hint=self.DEFAULT,
+        status = _docker_row_status(
+            on_remote=False, in_container=True, installed=True, default_hint=self.DEFAULT,
         )
         assert status.applicable is True
         assert status.install_hint == self.DEFAULT
 
     def test_on_host_and_absent_stays_applicable_with_default_hint(self):
-        status = _local_docker_status(
-            installed=False, in_container=False, default_hint=self.DEFAULT,
+        status = _docker_row_status(
+            on_remote=False, in_container=False, installed=False, default_hint=self.DEFAULT,
+        )
+        assert status.applicable is True
+        assert status.install_hint == self.DEFAULT
+
+    def test_remote_server_is_always_applicable_even_when_absent(self):
+        status = _docker_row_status(
+            on_remote=True, in_container=False, installed=False, default_hint=self.DEFAULT,
+        )
+        assert status.applicable is True
+        assert status.install_hint == self.DEFAULT
+
+    def test_remote_server_ignores_local_container_status(self):
+        status = _docker_row_status(
+            on_remote=True, in_container=True, installed=False, default_hint=self.DEFAULT,
         )
         assert status.applicable is True
         assert status.install_hint == self.DEFAULT

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -7,7 +7,12 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-from routes.shell_routes import _find_line_break
+from routes.shell_routes import (
+    _find_line_break,
+    _running_in_container,
+    _local_docker_status,
+    DOCKER_IN_CONTAINER_HINT,
+)
 
 
 def test_shell_routes_import_without_posix_pty_modules(monkeypatch):
@@ -99,3 +104,67 @@ class TestFindLineBreak:
     def test_newline_before_cr(self):
         """\\n comes before \\r — should return \\n."""
         assert _find_line_break(b"ab\ncd\r") == (2, 1)
+
+
+class TestRunningInContainer:
+    """Detect whether the Odysseus process itself runs inside a container."""
+
+    def test_dockerenv_marker_present(self, tmp_path):
+        marker = tmp_path / ".dockerenv"
+        marker.write_text("")
+        assert _running_in_container(
+            dockerenv_path=str(marker), cgroup_path=str(tmp_path / "missing"),
+        ) is True
+
+    def test_cgroup_names_a_container_runtime(self, tmp_path):
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("12:devices:/docker/abcdef0123456789\n")
+        assert _running_in_container(
+            dockerenv_path=str(tmp_path / "no-marker"), cgroup_path=str(cgroup),
+        ) is True
+
+    def test_bare_host_has_neither_signal(self, tmp_path):
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("0::/user.slice/session-1.scope\n")
+        assert _running_in_container(
+            dockerenv_path=str(tmp_path / "no-marker"), cgroup_path=str(cgroup),
+        ) is False
+
+    def test_missing_cgroup_file_is_not_a_container(self, tmp_path):
+        assert _running_in_container(
+            dockerenv_path=str(tmp_path / "no-marker"),
+            cgroup_path=str(tmp_path / "also-missing"),
+        ) is False
+
+
+class TestLocalDockerStatus:
+    """Status for a locally-checked docker row: applicability plus the hint."""
+
+    DEFAULT = "Install Docker on the selected server."
+
+    def test_in_container_and_absent_is_not_applicable_with_safe_default_hint(self):
+        status = _local_docker_status(
+            installed=False, in_container=True, default_hint=self.DEFAULT,
+        )
+        assert status.applicable is False
+        assert status.install_hint == DOCKER_IN_CONTAINER_HINT
+
+    def test_in_container_but_present_is_applicable_with_default_hint(self):
+        status = _local_docker_status(
+            installed=True, in_container=True, default_hint=self.DEFAULT,
+        )
+        assert status.applicable is True
+        assert status.install_hint == self.DEFAULT
+
+    def test_on_host_and_absent_stays_applicable_with_default_hint(self):
+        status = _local_docker_status(
+            installed=False, in_container=False, default_hint=self.DEFAULT,
+        )
+        assert status.applicable is True
+        assert status.install_hint == self.DEFAULT
+
+    def test_container_hint_steers_to_remote_and_warns_on_socket(self):
+        lowered = DOCKER_IN_CONTAINER_HINT.lower()
+        assert "remote" in lowered
+        assert "socket" in lowered
+        assert "host-root" in lowered or "host root" in lowered


### PR DESCRIPTION
Hey! Long-time viewer, first-time contributor : p

I've been poking around the project and ended up in the Cookbook, which I found a little confusing at first. The thing that actually nudged me to open an editor: the Dependencies panel listed Docker as missing  even though I'm running Odysseus through `docker compose`. After all, docker isn't really "missing" when the whole thing is running in docker.

I mean, it's technically true-ish (the image ships no docker CLI and the compose file doesn't mount the host socket, so from inside the container there's no docker to find), but "missing" reads like something is broken, when really it's working exactly as designed (I guess).

So here's my small contribution:

-   Detect when Odysseus is running inside a container and show docker as N/A instead of "Missing", with a hover `?` that explains what's going on and points docker-backed launches at a remote server (checked over SSH).
-   Deliberately not auto-mounting `/var/run/docker.sock` because that would hand the container host-root, so it stays opt-in with a warning rather than a default.

I tried to follow one of the contribution guides that are already separate PRs, so I hope it's going to be okay.

As a side note,  the target labels got me too. A row can say "GPU server" while the Server dropdown up top says "Local", and "Local" means two different things in those two places. I think that column is really about a dep's role (runs on your  box vs built into Odysseus) rather than location. 

I sprinkled some tests in and I tested it out in my own browser. Cheers!

Before:

<img width="752" height="48" alt="obraz" src="https://github.com/user-attachments/assets/62875ee6-e55f-470f-a309-a8d4d8c57c40" />


After:
<img width="745" height="63" alt="obraz" src="https://github.com/user-attachments/assets/200de975-626f-4d7b-aef2-befdc53ca8dd" />


