### PR TITLE
Pin pydantic to v2 so install doesn't crash on import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ uvicorn
 python-multipart
 python-dotenv
 httpx
-pydantic
-pydantic-settings
+pydantic>=2.0
+pydantic-settings>=2.0
 SQLAlchemy
 pypdf
 beautifulsoup4


### PR DESCRIPTION
Rebased on current main and trimmed this down. When I went through it against main, most of what I'd bundled here is already handled:

- the calendar f-string fix is already in (same change)
- the host.docker.internal / Ollama note is already in the README
- the clone placeholders are already replaced with the real URL

So the only thing still missing is the pydantic pin, which is what this PR is now. Unpinned, pip can resolve v1 which has no pydantic-core and the app dies on import.

Dropped the Intel GPU detection from here. jaitaiwan's point about integrated Arc/Xe (the 140V etc.) using unified memory is right, my version hardcoded that to false. I'll redo it as its own PR with the unified-memory case handled properly.
