### PR TITLE
fix(setup): better local LLM endpoint URL setup when running in Docker

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -25,7 +25,6 @@ REQUEST_TIMEOUT = 20
 OPENAI_COMPAT_PATH = "/v1/chat/completions"
 
 # Environment variables with defaults
-DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")
 LLM_HOSTS = [h.strip() for h in os.getenv("LLM_HOSTS", "").split(",") if h.strip()]
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 SEARXNG_INSTANCE = os.getenv('SEARXNG_INSTANCE', 'http://localhost:8080')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
       # container, so persist its HuggingFace cache under ./data/huggingface.
       - ./data/huggingface:/app/.cache/huggingface
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file:
       - .env
     environment:

--- a/routes/diagnostics_routes.py
+++ b/routes/diagnostics_routes.py
@@ -6,7 +6,7 @@ from typing import Dict, Any
 from fastapi import APIRouter, HTTPException, Form
 
 from services.youtube.youtube_handler import extract_youtube_id, extract_transcript_async
-from core.constants import DEFAULT_HOST
+from src.constants import DEFAULT_HOST, SUGGESTED_LOCAL_LLM_URL, IS_DOCKER
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ def setup_diagnostics_routes(
     @router.post("/api/test-research")
     async def test_research(query: str = Form("What is machine learning?")) -> Dict[str, Any]:
         try:
-            endpoint = f"http://{DEFAULT_HOST}:8000/v1/chat/completions"
+            endpoint = SUGGESTED_LOCAL_LLM_URL.rstrip("/") + "/chat/completions"
             model = "gpt-oss-120b"
             result = await research_handler.call_research_service(query, endpoint, model)
             return {
@@ -67,5 +67,12 @@ def setup_diagnostics_routes(
             }
         except Exception as e:
             return {"status": "error", "error": str(e), "query": query}
+
+    @router.get("/api/system-info")
+    async def get_system_info() -> Dict[str, Any]:
+        return {
+            "docker": IS_DOCKER,
+            "suggested_local_url": SUGGESTED_LOCAL_LLM_URL,
+        }
 
     return router

--- a/src/constants.py
+++ b/src/constants.py
@@ -24,8 +24,26 @@ MAX_CONTEXT_MESSAGES = 90
 REQUEST_TIMEOUT = 20
 OPENAI_COMPAT_PATH = "/v1/chat/completions"
 
+def _is_running_in_docker() -> bool:
+    """Detect if we're running inside a Docker container."""
+    if os.path.exists("/.dockerenv"):
+        return True
+    try:
+        with open("/proc/1/cgroup", "r") as f:
+            return "docker" in f.read()
+    except Exception:
+        return False
+
+
+IS_DOCKER = _is_running_in_docker()
+
 # Environment variables with defaults
 DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")
+# When running inside Docker, suggest host.docker.internal for local LLM servers
+SUGGESTED_LOCAL_LLM_URL = os.getenv(
+    "SUGGESTED_LOCAL_LLM_URL",
+    "http://host.docker.internal:8000/v1" if IS_DOCKER else "http://localhost:8000/v1"
+)
 LLM_HOSTS = [h.strip() for h in os.getenv("LLM_HOSTS", "").split(",") if h.strip()]
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 SEARXNG_INSTANCE = os.getenv('SEARXNG_INSTANCE', 'http://localhost:8888')

--- a/static/app.js
+++ b/static/app.js
@@ -1081,6 +1081,20 @@ function initializeEventListeners() {
     userBarAdmin.addEventListener('click', () => adminModule.open());
   }
 
+  // Fetch system info (Docker detection, suggested local URL) — lightweight
+  fetch(`${API_BASE}/api/system-info`, { credentials: 'same-origin' })
+    .then(r => r.json())
+    .then(d => {
+      if (d.suggested_local_url) {
+        window._ODY_SUGGESTED_LOCAL_URL = d.suggested_local_url;
+        const localUrlInput = document.getElementById('adm-epLocalUrl');
+        if (localUrlInput && !localUrlInput.value) {
+          localUrlInput.placeholder = 'Paste an endpoint URL, e.g. ' + d.suggested_local_url;
+        }
+      }
+    })
+    .catch(() => {});
+
   // Fetch auth status — populate user bar and show admin button if admin
   fetch(`${API_BASE}/api/auth/status`, { credentials: 'same-origin' })
     .then(r => r.json())


### PR DESCRIPTION
When Odysseus runs in docker container, the suggested local LLM endpoint URL "localhost:8000/v1" points to a container port, rather than the host machine port.

To make it easier to setup access to LLM models running on the host machine:
- Added `host.docker.internal` in `docker-compose.yml`, so that network services running on the host machine are reliably accessible from within the container
- Updated the suggested local LLM endpoint URL to "http://host.docker.internal:8000/v1" when Odysseus runs in a docker container.

Also cleaned up `DEFAULT_HOST` from `core/constants.py`. There seems to be quite a duplication between `core/constants.py` and `src/constants.py`, which could use a further refactoring. Out of scope for this change though.

## Add Models UI testing:
Before:
<img width="734" height="622" alt="odysseus-sglang-offline" src="https://github.com/user-attachments/assets/1ea295c0-093b-4020-88d0-dc21c0ec3ce0" />
After:
<img width="912" height="703" alt="odysseus-docker-llm" src="https://github.com/user-attachments/assets/b100487e-bc48-4183-be43-d390865b9436" />
And a model discovered on the host machine after using the suggested URL:
<img width="638" height="349" alt="odysseus-local-model" src="https://github.com/user-attachments/assets/fe3b552e-7215-4d03-bae9-f23044e27d82" />
