### PR TITLE
Fix Windows startup compatibility issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,7 +600,7 @@ app.include_router(setup_contacts_routes())
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
     """Read an HTML file and inject the CSP nonce into inline <script> tags."""
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         html = f.read()
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -4,14 +4,19 @@ import asyncio
 import json
 import logging
 import os
-import pty
-import fcntl
 import shlex
 import shutil
 import uuid
 import tempfile
 from pathlib import Path
 from typing import Dict, Any
+
+try:
+    import fcntl
+    import pty
+except ImportError:
+    fcntl = None
+    pty = None
 
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import StreamingResponse
@@ -97,6 +102,11 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, An
 
 async def _generate_pty(cmd: str, timeout: int, request: Request):
     """Run command in a pseudo-TTY so tqdm/progress bars work natively."""
+    if pty is None or fcntl is None:
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': 'PTY streaming is not available on Windows'})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        return
+
     loop = asyncio.get_event_loop()
     master_fd, slave_fd = pty.openpty()
 


### PR DESCRIPTION
This fixes two Windows startup issues found during a fresh manual install smoke test:

1. `routes/shell_routes.py` imported Unix-only PTY modules at import time, which crashed app startup on Windows.
2. `app.py` read HTML files with the platform default encoding, which caused `UnicodeDecodeError` on Windows when serving `static/index.html`.

After these changes, the app starts and the login page loads successfully on Windows 10 with a manual Python setup.