### PR TITLE
Treat host.docker.internal as a local (free) endpoint

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -660,6 +660,7 @@ export function isLocalEndpoint(url) {
   try { host = new URL(url).hostname; } catch (_e) { return true; }
   if (!host) return true;
   if (host === 'localhost' || host === '0.0.0.0' || host.endsWith('.local')) return true;
+  if (host === 'host.docker.internal') return true;  // Docker Desktop (Mac/Windows) → host machine; a model served there (e.g. Ollama) is local → free
   if (typeof window !== 'undefined' && window.location && host === window.location.hostname) return true;
   if (/^127\./.test(host)) return true;
   if (/^10\./.test(host)) return true;


### PR DESCRIPTION
## Problem

When Odysseus runs in Docker and is pointed at a model server on the **host** — e.g. Ollama running on the Mac/Windows host, reached via `host.docker.internal:11434` — the message-stats cost estimator bills those tokens at **cloud rates**.

`isLocalEndpoint()` in `static/js/chatRenderer.js` already exempts local models from billing, but it only recognized `localhost`, `*.local`, private LAN ranges (10/172.16-31/192.168), and the Tailscale CGNAT range. It did **not** recognize `host.docker.internal`, the hostname Docker Desktop injects so a container can reach the host.

Because cost lookup matches the model name by substring (e.g. `qwen3:8b` → `qwen`), a free local model ends up displaying a non-zero cost and inflating the session total. This is the standard, documented way to run a local LLM with a Dockerized Odysseus, so it affects every Docker Desktop user on Mac and Windows.

## Fix

Add `host.docker.internal` to the local-host checks in `isLocalEndpoint()`. Models served on the host now correctly report **$0 / free**.

```js
if (host === 'host.docker.internal') return true;
```

## Testing

- Dockerized Odysseus + Ollama on the host via `LLM_HOST=host.docker.internal`.
- Before: chat with `qwen3:8b` shows e.g. `Cost $0.0009`.
- After (hard refresh): same chat shows free / $0; cloud endpoints still priced normally.