### PR TITLE
Fix startup crash on Python < 3.12 (backslash in f-string)

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -902,7 +902,8 @@ def setup_calendar_routes() -> APIRouter:
                     lines.append(f"DTSTART:{ev.dtstart.strftime('%Y%m%dT%H%M%S')}")
                     lines.append(f"DTEND:{ev.dtend.strftime('%Y%m%dT%H%M%S')}")
                 if ev.description:
-                    lines.append(f"DESCRIPTION:{ev.description.replace(chr(10), '\\n')}")
+                    escaped_desc = ev.description.replace(chr(10), "\\n")
+                    lines.append(f"DESCRIPTION:{escaped_desc}")
                 if ev.location:
                     lines.append(f"LOCATION:{ev.location}")
                 if ev.rrule:


### PR DESCRIPTION
On Python 3.11 the app won't start. `app.py` dies on import with:

    File "routes/calendar_routes.py", line 905
    SyntaxError: f-string expression part cannot include a backslash

That line builds the ICS calendar export with a backslash inside an f-string expression, which only became legal in 3.12 (PEP 701). On 3.11 (the minimum the README lists) the file won't parse, so nothing loads. It's the only file in the repo that fails to compile on 3.11.

The fix just moves the `replace()` into a variable so the f-string has no backslash. Same output, newlines still become a literal `\n`.

Tested on 3.11.5: the file compiles, the whole repo compiles clean, and the app boots (`Application startup complete`, `/api/health` returns 200).

Fixes #148.