### PR TITLE
Add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.png binary
+*.jpg binary
+*.webm binary
+*.ico binary


### PR DESCRIPTION
On Windows, Git checks out *.sh with CRLF by default, which breaks the Docker entrypoint. Add .gitattributes to keep shell scripts as LF.