### PR TITLE
Add host.docker.internal mapping for Linux Ollama access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       chromadb:
         condition: service_started
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   chromadb:
     image: chromadb/chroma:latest


### PR DESCRIPTION
It's the fix I mentioned on the issue #164 

tldr
On Linux, host.docker.internal isn't defined by default, so Odysseus can't reach an Ollama instance running on the host. Adding extra_hosts with host-gateway fixes this. Should be harmless on Mac/Windows where the hostname already exists.