### PR TITLE
Fix fresh checkout test failures

### DIFF
--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 for mod in [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
-    'src.database', 'src.endpoint_resolver',
+    'src.database',
     'src.agent_tools',
     'core.models', 'core.database',
 ]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,10 +32,13 @@ class TestAppStructure:
         src_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src")
         assert os.path.exists(src_path), "src directory should exist"
 
-    def test_env_file_exists(self):
-        """Test that .env file exists"""
-        env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
-        assert os.path.exists(env_path), ".env file should exist"
+    def test_env_file_is_optional_and_ignored(self):
+        """A fresh checkout should not require a private .env file."""
+        root = os.path.dirname(os.path.dirname(__file__))
+        gitignore_path = os.path.join(root, ".gitignore")
+        with open(gitignore_path, encoding="utf-8") as fh:
+            ignored = {line.strip() for line in fh}
+        assert ".env" in ignored, ".env should stay local and ignored"
 
     def test_env_example_exists(self):
         """Test that .env.example exists"""

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 for mod in [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
-    'src.database', 'src.endpoint_resolver',
+    'src.database',
     'core.models', 'core.database',
 ]:
     if mod not in sys.modules:

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -6,6 +6,13 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+_endpoint_resolver = sys.modules.get("src.endpoint_resolver")
+if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
+    # Other tests stub this module during collection. These helper tests need
+    # the real URL normalization helpers so Anthropic /v1 handling is covered.
+    sys.modules.pop("src.endpoint_resolver", None)
+    sys.modules.pop("routes.model_routes", None)
+
 if "core.database" not in sys.modules:
     _core_db = types.ModuleType("core.database")
     for _name in [


### PR DESCRIPTION
## Summary
- remove the test requirement for a private `.env` file in fresh checkouts
- keep `.env.example` as the committed configuration template and verify `.env` remains ignored
- prevent endpoint resolver test stubs from leaking into model route helper tests

## Why
A clean checkout currently fails the test suite because `.env` is intentionally ignored and optional. The full suite can also fail the Anthropic model route test when an earlier test leaves a stubbed `src.endpoint_resolver` module in `sys.modules`.

## Validation
- `.venv/bin/python -m pytest -q`
- Result: 262 passed, 4 existing deprecation warnings