### PR TITLE
Fix Windows startup crash in shell routes

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -4,8 +4,6 @@ import asyncio
 import json
 import logging
 import os
-import pty
-import fcntl
 import shlex
 import shutil
 import uuid
@@ -37,6 +35,18 @@ def _require_admin(request: Request):
         raise HTTPException(403, "Admin only")
 
 logger = logging.getLogger(__name__)
+
+try:
+    import fcntl
+    import pty
+except ImportError as exc:
+    fcntl = None
+    pty = None
+    _PTY_IMPORT_ERROR = exc
+else:
+    _PTY_IMPORT_ERROR = None
+
+PTY_SUPPORTED = pty is not None and fcntl is not None and hasattr(os, "setsid")
 
 
 def _find_line_break(buf):
@@ -97,6 +107,14 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, An
 
 async def _generate_pty(cmd: str, timeout: int, request: Request):
     """Run command in a pseudo-TTY so tqdm/progress bars work natively."""
+    if not PTY_SUPPORTED:
+        msg = "PTY streaming is not supported on this platform"
+        if _PTY_IMPORT_ERROR:
+            msg += f": {_PTY_IMPORT_ERROR}"
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': msg})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        return
+
     loop = asyncio.get_event_loop()
     master_fd, slave_fd = pty.openpty()
 

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -68,6 +68,7 @@ EXEC_TIMEOUT = 30  # seconds — shorter than agent's 60s
 STREAM_TIMEOUT = 120  # default for short commands
 MAX_OUTPUT = 200_000  # truncate limit
 TMUX_LOG_DIR = Path(tempfile.gettempdir()) / "odysseus-tmux"
+PTY_UNSUPPORTED_ERROR = "pty_unsupported"
 
 
 class ShellExecRequest(BaseModel):
@@ -111,8 +112,8 @@ async def _generate_pty(cmd: str, timeout: int, request: Request):
         msg = "PTY streaming is not supported on this platform"
         if _PTY_IMPORT_ERROR:
             msg += f": {_PTY_IMPORT_ERROR}"
-        yield f"data: {json.dumps({'stream': 'stderr', 'data': msg})}\n\n"
-        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': msg, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
         return
 
     loop = asyncio.get_event_loop()

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -1,7 +1,35 @@
-"""Tests for shell_routes.py — _find_line_break helper.
-Imports the function directly since it has no app dependencies."""
+"""Tests for shell_routes.py helpers."""
+
+import builtins
+import importlib.util
+import sys
+from pathlib import Path
 
 from routes.shell_routes import _find_line_break
+
+
+def test_shell_routes_import_without_posix_pty_modules(monkeypatch):
+    """Native Windows has no fcntl/termios; importing routes must still work."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"fcntl", "pty"}:
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module_path = Path(__file__).resolve().parents[1] / "routes" / "shell_routes.py"
+    spec = importlib.util.spec_from_file_location("_shell_routes_without_pty", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+
+    assert module.PTY_SUPPORTED is False
+    assert module._find_line_break(b"ok\n") == (2, 1)
 
 
 class TestFindLineBreak:

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -1,8 +1,10 @@
 """Tests for shell_routes.py helpers."""
 
+import json
 import builtins
 import importlib.util
 import sys
+from types import SimpleNamespace
 from pathlib import Path
 
 from routes.shell_routes import _find_line_break
@@ -18,6 +20,7 @@ def test_shell_routes_import_without_posix_pty_modules(monkeypatch):
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
+    cached_modules = {name: sys.modules.pop(name, None) for name in ("fcntl", "pty")}
 
     module_path = Path(__file__).resolve().parents[1] / "routes" / "shell_routes.py"
     spec = importlib.util.spec_from_file_location("_shell_routes_without_pty", module_path)
@@ -27,9 +30,35 @@ def test_shell_routes_import_without_posix_pty_modules(monkeypatch):
         spec.loader.exec_module(module)
     finally:
         sys.modules.pop(spec.name, None)
+        for name, cached_module in cached_modules.items():
+            if cached_module is not None:
+                sys.modules[name] = cached_module
 
     assert module.PTY_SUPPORTED is False
     assert module._find_line_break(b"ok\n") == (2, 1)
+
+
+async def test_generate_pty_reports_explicit_unsupported_error(monkeypatch):
+    """Clients can distinguish unsupported PTY mode from process failures."""
+    import routes.shell_routes as shell_routes
+
+    monkeypatch.setattr(shell_routes, "PTY_SUPPORTED", False)
+    monkeypatch.setattr(shell_routes, "_PTY_IMPORT_ERROR", ImportError("No module named 'termios'"))
+
+    request = SimpleNamespace(is_disconnected=lambda: False)
+    events = [
+        json.loads(chunk.removeprefix("data: ").strip())
+        async for chunk in shell_routes._generate_pty("echo hi", 5, request)
+    ]
+
+    assert events == [
+        {
+            "stream": "stderr",
+            "data": "PTY streaming is not supported on this platform: No module named 'termios'",
+            "error": shell_routes.PTY_UNSUPPORTED_ERROR,
+        },
+        {"exit_code": -1, "error": shell_routes.PTY_UNSUPPORTED_ERROR},
+    ]
 
 
 class TestFindLineBreak:


### PR DESCRIPTION
## Summary
- make POSIX-only PTY imports optional in `routes/shell_routes.py`
- return a clear unsupported-platform stream error when PTY mode is requested without PTY support
- add a regression test that imports shell routes without `pty`/`fcntl` available

## Why
Native Windows crashes during app startup because `routes/shell_routes.py` imports `pty`, which eventually imports the Unix-only `termios` module. Moving those imports behind a platform-safe guard lets the app import on Windows while keeping PTY behavior on POSIX systems.

## Validation
- `.venv/bin/python -m pytest tests/test_shell_routes.py -q`
- Full suite still has the existing upstream fresh-checkout failures unrelated to this change: missing `.env` expectation and endpoint-resolver test isolation.