### PR TITLE
Fix vision attachment timeout and stale cache

### DIFF
--- a/src/chat_handler.py
+++ b/src/chat_handler.py
@@ -223,19 +223,22 @@ class ChatHandler:
                         if os.path.exists(_vcache):
                             try:
                                 with open(_vcache) as _vf:
-                                    vl_desc = _vf.read()
+                                    cached_desc = _vf.read().strip()
+                                if cached_desc and not cached_desc.startswith("["):
+                                    vl_desc = cached_desc
                             except Exception:
                                 vl_desc = None
                         if not vl_desc:
                             vl_result = analyze_image_with_vl_result(file_info["path"])
                             vl_desc = vl_result.get("text", "")
                             vl_model = vl_result.get("model", "")
-                            try:
-                                os.makedirs(os.path.join(UPLOAD_DIR, ".vision"), exist_ok=True)
-                                with open(_vcache, "w") as _vf:
-                                    _vf.write(vl_desc or "")
-                            except Exception:
-                                pass
+                            if vl_desc and not vl_desc.startswith("["):
+                                try:
+                                    os.makedirs(os.path.join(UPLOAD_DIR, ".vision"), exist_ok=True)
+                                    with open(_vcache, "w") as _vf:
+                                        _vf.write(vl_desc)
+                                except Exception:
+                                    pass
                         enhanced_message = f"{enhanced_message}\n\n[Image: {file_info['name']}]\n{vl_desc}"
                         # Surface the description to the client live so it renders as a
                         # collapsible "image description" on the user bubble (not just

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -230,7 +230,7 @@ def analyze_image_with_vl_result(image_path: str) -> dict:
         last_err = None
         for i, (_url, _model, _headers) in enumerate([c for c in _vl_candidates if c and c[0] and c[1]]):
             try:
-                description = llm_call(_url, _model, vl_messages, headers=_headers, timeout=30)
+                description = llm_call(_url, _model, vl_messages, headers=_headers, timeout=120)
                 logger.info("VL analysis complete with model %s", _model)
                 return {"text": description, "model": _model}
             except Exception as e:


### PR DESCRIPTION
## Summary
- Increase the vision attachment analysis timeout so local VL models have enough time to cold-load and process images.
- Avoid reusing or writing transient bracketed failure placeholders as cached vision descriptions.

Closes #202.

## Test plan
- Reproduced with Docker Compose, Ollama on `host.docker.internal:11434`, default chat model `qwen3:14b`, and Vision model `qwen2.5vl:7b`.
- Verified `analyze_image_with_vl_result()` returns a real `qwen2.5vl:7b` image description after rebuilding the Odysseus container.
- Checked edited files with Cursor diagnostics; no linter errors found.

<img width="1512" height="909" alt="image" src="https://github.com/user-attachments/assets/58e1f8e2-f1fb-484c-9aa3-993c37260b58" />
