### PR TITLE
Fix landing page GitHub links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -391,7 +391,7 @@
         <a href="#testimonials">Testimonials</a>
         <a href="#how">How it started</a>
         <a href="#start">Get started</a>
-        <a class="btn" href="https://github.com/odysseus-ui/odysseus" target="_blank">
+        <a class="btn" href="https://github.com/pewdiepie-archdaemon/odysseus" target="_blank">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
           GitHub
         </a>
@@ -419,7 +419,7 @@
       </p>
       <div class="hero-cta">
         <a class="btn primary" href="#start">Get started</a>
-        <a class="btn" href="https://github.com/odysseus-ui/odysseus" target="_blank">View on GitHub</a>
+        <a class="btn" href="https://github.com/pewdiepie-archdaemon/odysseus" target="_blank">View on GitHub</a>
       </div>
 
     </div>
@@ -660,9 +660,9 @@
         <div class="eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 17l6-5-6-5"/><path d="M12 19h8"/></svg>Get started</div>
         <h2 class="h" style="margin-bottom:6px;">Odysseus is yours.</h2>
         <p class="sub center" style="margin:0 auto;">It's open source and free. No sales team, no demo request, no Trojan horse.</p>
-        <div class="codeblock"><span class="prompt">$</span> git clone https://github.com/odysseus-ui/odysseus.git &amp;&amp; cd odysseus</div>
+        <div class="codeblock"><span class="prompt">$</span> git clone https://github.com/pewdiepie-archdaemon/odysseus.git &amp;&amp; cd odysseus</div>
         <div>
-          <a class="btn primary" href="https://github.com/odysseus-ui/odysseus" target="_blank" style="margin-top:14px;">View on GitHub</a>
+          <a class="btn primary" href="https://github.com/pewdiepie-archdaemon/odysseus" target="_blank" style="margin-top:14px;">View on GitHub</a>
         </div>
         <div class="pill-row">
           <span class="pill">Self-hosted</span>


### PR DESCRIPTION
Brother @pewdiepie-archdaemon, the links are broken.

P.S. Certainly was not on my 2026 bingo card that I would be contributing to a Pewdiepie OSS project.
Long time watcher and it's been super cool seeing you get into AI and coding!

## Summary
- Update all GitHub links on the landing page (`docs/index.html`) from `odysseus-ui/odysseus` to `pewdiepie-archdaemon/odysseus`
- Fix the get-started `git clone` command to use the correct repository URL

## Test plan
- [ ] Open `docs/index.html` locally and confirm header, hero, and footer GitHub buttons link to https://github.com/pewdiepie-archdaemon/odysseus
- [ ] Confirm the get-started clone command shows the correct repo URL


Made with [Cursor](https://cursor.com)