### PR TITLE
adjust the compose stack to avoid blindly making services public.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,15 +70,10 @@ SEARXNG_INSTANCE=http://localhost:8080
 # CHROMADB_HOST=localhost
 # CHROMADB_PORT=8100
 
-# Docker Compose host-port bind addresses for bundled services.
-# Defaults are loopback-only for safety. To expose ntfy only on Tailscale,
-# set NTFY_BIND to your host's Tailscale IP and update NTFY_BASE_URL.
-# CHROMADB_BIND=127.0.0.1
-# NTFY_BIND=127.0.0.1
-# NTFY_BASE_URL=http://localhost:8091
-# Example:
-# NTFY_BIND=100.x.y.z
-# NTFY_BASE_URL=http://100.x.y.z:8091
+# ntfy base URL — used by Odysseus to build notification links.
+# In Docker Compose, ntfy is on the internal network only; set this to a
+# publicly reachable URL if you front ntfy with a reverse proxy.
+# NTFY_BASE_URL=http://ntfy
 
 # ============================================================
 # RAG / Embeddings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       # Find yours with:  id -u  /  id -g
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+    networks:
+      - internal
+      - public
     depends_on:
       searxng:
         condition: service_healthy
@@ -41,12 +44,12 @@ services:
 
   chromadb:
     image: chromadb/chroma:latest
-    ports:
-      - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
     volumes:
       - chromadb-data:/chroma/chroma
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
+    networks:
+      - internal
     restart: unless-stopped
 
   searxng:
@@ -64,14 +67,14 @@ services:
           sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
         fi
         exec /usr/local/searxng/entrypoint.sh
-    ports:
-      - "127.0.0.1:8080:8080"
     volumes:
       - searxng-data:/etc/searxng
       - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro
     environment:
       - SEARXNG_BASE_URL=http://localhost:8080/
       - SEARXNG_SECRET=${SEARXNG_SECRET:-}
+    networks:
+      - internal
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
       interval: 5s
@@ -83,13 +86,18 @@ services:
   ntfy:
     image: binwiederhier/ntfy
     command: serve
-    ports:
-      - "${NTFY_BIND:-127.0.0.1}:8091:80"
     volumes:
       - ntfy-cache:/var/cache/ntfy
     environment:
       - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+    networks:
+      - internal
     restart: unless-stopped
+
+networks:
+  internal:
+    internal: true
+  public:
 
 volumes:
   searxng-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
     volumes:
       - ntfy-cache:/var/cache/ntfy
     environment:
-      - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+      - NTFY_BASE_URL=${NTFY_BASE_URL:-http://ntfy}
     networks:
       - internal
     restart: unless-stopped
@@ -98,6 +98,7 @@ networks:
   internal:
     internal: true
   public:
+    driver: bridge
 
 volumes:
   searxng-data:


### PR DESCRIPTION
Just adjusts the compose stack to only expose odysseus, this reduces possible attack vectors if someone hosts this on a VPS as well as local network security. Only exposing odysseus is just overall better in my opinion.  