### PR TITLE
docker: persist /app/.local so Cookbook deps survive recreate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
       # container, so persist its HuggingFace cache under ./data/huggingface.
       - ./data/huggingface:/app/.cache/huggingface
+      # Persist `pip install --user` packages (vllm, llama-cpp-python,
+      # sglang, etc.) so Cookbook deps survive `docker compose down`.
+      - ./data/dot-local:/app/.local
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.


### PR DESCRIPTION
pip --user installs from Cookbook -> Dependencies land in /app/.local, which lives in the container's writable layer. Every `docker compose down` (or image rebuild) wipes ~10 GB of vllm/torch/cuda wheels and forces a re-download.

Bind-mount it next to the existing HF cache so it persists.