### PR TITLE
Allow custom Docker host port via ODYSSEUS_PORT (fixes #219)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@
 # Copy this file to .env and fill in your values.
 
 # ============================================================
+# Server / Deployment
+# ============================================================
+
+# Host-side port that Docker maps to Odysseus inside the container.
+# Default 7000. Change this if another service on your host already
+# uses 7000 — notably MacOS AirPlay Receiver (see issue #219).
+# Remember to update ALLOWED_ORIGINS below if you change this.
+# ODYSSEUS_PORT=7000
+
+# ============================================================
 # LLM Configuration
 # ============================================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ services:
   odysseus:
     build: .
     ports:
-      - "7000:7000"
+      # Host-side port is configurable via ODYSSEUS_PORT in .env.
+      # MacOS users may need to change this — port 7000 is used by the
+      # AirPlay Receiver by default. See issue #219.
+      - "${ODYSSEUS_PORT:-7000}:7000"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs


### PR DESCRIPTION
## Summary

- Parameterizes the Docker host-side port via a new optional `ODYSSEUS_PORT` env var, defaulting to `7000`
- Adds a documented `# ODYSSEUS_PORT=7000` block to `.env.example` under a new "Server / Deployment" section
- No behavior change for existing users — `${ODYSSEUS_PORT:-7000}:7000` keeps the same mapping when the var is unset

## Why

Closes #219. On MacOS, port 7000 is used by the AirPlay Receiver by default, so `docker compose up` fails on a clean install. Today the only workaround is editing tracked files (`docker-compose.yml`) which gets in the way of `git pull`. With this change MacOS users can just set `ODYSSEUS_PORT=7001` (or whatever) in their local `.env`.

## Test plan

- [x] `docker compose config` — default path, published port still `7000`
- [x] `ODYSSEUS_PORT=7001 docker compose config` — published port becomes `7001`, container target stays `7000`
- [ ] Maintainer: smoke `docker compose up -d --build` and hit `http://localhost:7000/` (default) and on a port-conflict host with `ODYSSEUS_PORT` set

In-container port stays at `7000` so `EXPOSE`, `ALLOWED_ORIGINS` defaults, and the uvicorn command line in the `Dockerfile` need no changes.