### PR TITLE
Fix NPX MCP server registration crashing event loop when subprocess fails to speak MCP

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -108,24 +108,51 @@ async def register_builtin_servers(mcp_manager):
     async def _start_npx_servers():
         await asyncio.sleep(3)  # let Python servers finish first
         for server_id, cfg in _BUILTIN_NPX_SERVERS.items():
+            logger.info(f"Starting NPX server: {cfg['name']} ({npx_path} {' '.join(cfg['args'])})")
+
+            # The MCP stdio client (mcp.client.stdio.stdio_client) opens an
+            # anyio.create_task_group() internally for its stdin/stdout
+            # reader tasks. If the wrapped subprocess never speaks MCP
+            # (npx fails to install Playwright, network issue, missing
+            # system deps, etc.), the only way to give up is to cancel the
+            # connect_server() coroutine — but a cancellation crossing
+            # anyio's task group from an outer asyncio.wait_for raises:
+            #
+            #   RuntimeError: Attempted to exit cancel scope in a different
+            #   task than it was entered in
+            #
+            # The error fires in a background task ("Task exception was
+            # never retrieved") AND cascades cancellations into other
+            # tasks in the event loop, including ones the rest of the
+            # app depends on. The original try/except BaseException here
+            # didn't catch it because the exception is in a sibling task.
+            #
+            # Fix: wrap the connect task in asyncio.shield so wait_for's
+            # cancellation can't reach it. On timeout we stop waiting and
+            # move on; the shielded task continues to run (or quietly fail)
+            # in the background, and its subprocess is cleaned up by
+            # stdio_client's own shutdown path when the event loop exits.
+            connect_task = asyncio.create_task(
+                mcp_manager.connect_server(
+                    server_id=server_id,
+                    name=cfg["name"],
+                    transport="stdio",
+                    command=npx_path,
+                    args=cfg["args"],
+                ),
+                name=f"mcp-npx-connect-{server_id}",
+            )
             try:
-                logger.info(f"Starting NPX server: {cfg['name']} ({npx_path} {' '.join(cfg['args'])})")
-                ok = await asyncio.wait_for(
-                    mcp_manager.connect_server(
-                        server_id=server_id,
-                        name=cfg["name"],
-                        transport="stdio",
-                        command=npx_path,
-                        args=cfg["args"],
-                    ),
-                    timeout=30,
-                )
+                ok = await asyncio.wait_for(asyncio.shield(connect_task), timeout=30)
                 if ok:
                     logger.info(f"Built-in NPX server registered: {cfg['name']}")
                 else:
                     logger.warning(f"Built-in NPX server failed to connect: {cfg['name']}")
             except asyncio.TimeoutError:
-                logger.warning(f"Built-in NPX server timed out: {cfg['name']}")
+                logger.warning(
+                    f"Built-in NPX server '{cfg['name']}' didn't connect within 30s; "
+                    f"continuing without it"
+                )
             except asyncio.CancelledError:
                 raise
             except BaseException as e:


### PR DESCRIPTION
The NPX server registration uses `asyncio.wait_for(mcp_manager.connect_server(...), timeout=30)`. When the subprocess fails to speak MCP in time (Playwright deps missing on a fresh install, network issue, etc.), the cancellation propagates into `mcp.client.stdio.stdio_client`'s internal anyio task group and raises:

```
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
```

The error fires in a sibling background task so the existing `except BaseException` here doesn't catch it, and the orphaned scope cascades cancellations into other tasks. Running requests start failing — Odysseus needs a restart.

Reproduces 100% on stock current versions (`starlette 1.2.1`, `anyio 4.13.0`, `mcp`, Python 3.14) — minimal repro, no Odysseus needed:

```python
import asyncio
from contextlib import AsyncExitStack
from mcp import ClientSession, StdioServerParameters
from mcp.client.stdio import stdio_client

async def connect():
    stack = AsyncExitStack()
    params = StdioServerParameters(command="/bin/sleep", args=["60"])
    r, w = await stack.enter_async_context(stdio_client(params))
    s = await stack.enter_async_context(ClientSession(r, w))
    await s.initialize()

async def main():
    try:
        await asyncio.wait_for(connect(), timeout=2)
    except asyncio.TimeoutError:
        pass
    await asyncio.sleep(8)  # gets cancelled by the orphan scope

asyncio.run(main())
```

Fix: wrap the connect task in `asyncio.shield` so `wait_for`'s cancellation can't reach `stdio_client`'s task group. On timeout we just stop waiting; the task drains in the background.

One wart — at uvicorn shutdown the still-pending `stdio_client`'s asyncgen close may print one `Attempted to exit cancel scope` ERROR as asyncio closes pending async generators. That's a limitation of `mcp.client.stdio.stdio_client` itself, not Odysseus. Cosmetic only — doesn't affect exit code or any other task.
