### PR TITLE
Re-enable VectorRAG init — chromadb/pydantic compat issue resolved in current pins

### DIFF
--- a/app.py
+++ b/app.py
@@ -355,15 +355,26 @@ async def serve_generated_image(filename: str, request: Request):
 from services.youtube import init_youtube
 init_youtube()
 
-# ========= RAG (vector document RAG — DISABLED) =========
-# VectorRAG (ChromaDB-backed personal-document semantic search) is unused
-# (0 directories ever indexed) and its chromadb 1.4.1 / pydantic 2.12 client
-# can't even instantiate — it threw at init and cost ~30s of startup waiting on
-# the embedding probe. Disabled. All callers already guard on rag_available /
-# `if rag_manager`, so personal-doc routes degrade cleanly.
-rag_manager = None
-rag_available = False
-logger.info("Vector document RAG disabled (unused)")
+# ========= RAG (vector document RAG) =========
+# VectorRAG (ChromaDB-backed personal-document semantic search). Initialized
+# lazily via get_rag_manager() — returns None if ChromaDB isn't reachable
+# (no server running on the configured host:port), in which case personal-doc
+# routes return a clean 503 instead of busy-retrying every request.
+#
+# Note: this was previously hardcoded off because chromadb 1.4.1 / pydantic
+# 2.12 were mutually incompatible at the time. With the current pins
+# (chromadb 1.5.x + pydantic 2.13.x) the init works and Personal Docs
+# (POST /api/personal/add_directory etc.) is functional again.
+from src.rag_singleton import get_rag_manager
+rag_manager = get_rag_manager()
+rag_available = rag_manager is not None
+if rag_available:
+    logger.info("Vector document RAG initialized")
+else:
+    logger.info(
+        "Vector document RAG not available at startup "
+        "(ChromaDB may not be reachable yet — routes will retry lazily)"
+    )
 
 # ========= IMPORT CONFIG =========
 from src.config import config

--- a/src/rag_singleton.py
+++ b/src/rag_singleton.py
@@ -12,16 +12,21 @@ rag_instance = None
 _last_attempt = 0.0
 _RETRY_INTERVAL = 30  # seconds between re-init attempts
 
+
 def get_rag_manager():
-    """Disabled: vector document RAG (VectorRAG/ChromaDB) is unused and its
-    client is incompatible with the installed pydantic. Return None so personal-
-    doc routes fall back to non-vector behavior instead of re-attempting (and
-    re-hanging on) a broken ChromaDB init every 30s."""
-    return None
+    """Lazy ChromaDB-backed VectorRAG initializer.
 
+    Returns the VectorRAG instance on first successful init, None if ChromaDB
+    isn't reachable / available. Failed init attempts are throttled to once
+    per _RETRY_INTERVAL seconds so a missing ChromaDB doesn't busy-retry on
+    every request — callers (personal-doc routes etc.) get None back and
+    return a clean 503 to the user instead.
 
-def _get_rag_manager_legacy():
-    """Original lazy initializer, kept for reference / easy re-enable."""
+    Historical note: this used to be hardcoded to ``return None`` with a
+    comment about chromadb 1.4.1 / pydantic 2.12 being mutually incompatible.
+    That compat issue is resolved in current pinned versions
+    (chromadb 1.5.x + pydantic 2.13.x), so the real initializer is back.
+    """
     global rag_instance, _last_attempt
 
     if rag_instance is not None:
@@ -29,7 +34,7 @@ def _get_rag_manager_legacy():
 
     now = time.monotonic()
     if now - _last_attempt < _RETRY_INTERVAL:
-        return None  # too soon to retry
+        return None  # too soon to retry — last attempt failed
 
     _last_attempt = now
 


### PR DESCRIPTION
`get_rag_manager()` in `src/rag_singleton.py` is hardcoded to `return None`, and `app.py` mirrors it (`rag_manager = None; rag_available = False`). So `/api/personal/add_directory` and the rest of Personal Docs return 503 for every request.

The disable comment cites `chromadb 1.4.1` / `pydantic 2.12` being incompatible — that's fixed in the current pins (`chromadb-client 1.5.9` + `pydantic 2.13.4`). Verified by calling the still-present `_get_rag_manager_legacy()` against a live `chroma run` server:

```
>>> from src.rag_singleton import _get_rag_manager_legacy
>>> m = _get_rag_manager_legacy(); m, m.healthy
(<src.rag_vector.VectorRAG object at 0x...>, True)
```

Changes:

- `src/rag_singleton.py` — drop the hardcoded `return None`, restore the lazy init body (already kept as `_get_rag_manager_legacy`). The 30s retry-throttle stays, so a missing chroma doesn't busy-retry every request.
- `app.py` — replace the parallel `rag_manager = None` with a `get_rag_manager()` call. If chroma isn't reachable at startup, stays None and routes still 503 (no behavior change for that path); next request hits the retry-throttle and tries again.

No `requirements.txt` change. `chromadb-client` is enough for installs talking to a docker-compose'd or external chroma. Manual self-hosters who want Personal Docs need to install `chromadb` (full package) and run `chroma run` themselves — could add a README note as follow-up if you want.
