### PR TITLE
Fix NPX MCP server crash (shield + lifecycle, per #242 review)

### DIFF
--- a/app.py
+++ b/app.py
@@ -947,6 +947,15 @@ async def shutdown_event():
         await webhook_manager.close()
     except Exception as e:
         logger.warning(f"Webhook manager shutdown error: {e}")
+    # Drain any pending NPX MCP connect tasks before disconnecting servers,
+    # so their shielded tasks have a chance to finish cleanly rather than
+    # being force-cancelled by asyncio's shutdown_asyncgens (which would
+    # trip the cancel-scope issue inside mcp.client.stdio's task group).
+    try:
+        from src.builtin_mcp import drain_pending_npx_tasks
+        await drain_pending_npx_tasks()
+    except Exception as e:
+        logger.warning(f"NPX MCP drain error: {e}")
     # Disconnect all MCP servers
     try:
         await mcp_manager.disconnect_all()

--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -10,8 +10,56 @@ import os
 import shutil
 import sys
 import asyncio
+from typing import Set
 
 logger = logging.getLogger(__name__)
+
+# In-flight NPX connect tasks. wait_for in _start_npx_servers shields these
+# from cancellation (cancelling mid-handshake triggers a cancel-scope crash
+# inside mcp.client.stdio's anyio task group — see _start_npx_servers and
+# _drain_pending_npx_tasks for full context). We track them so we can
+# consume their exceptions and drain them at shutdown rather than leaking
+# tasks and subprocesses.
+_pending_npx_tasks: Set[asyncio.Task] = set()
+
+
+def _npx_task_done(task: asyncio.Task) -> None:
+    """done_callback for shielded NPX connect tasks. Removes from the
+    pending set and consumes any exception so we don't get a noisy
+    'Task exception was never retrieved' at shutdown."""
+    _pending_npx_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning(
+            f"NPX MCP connect task '{task.get_name()}' finished with error: "
+            f"{type(exc).__name__}: {exc}"
+        )
+
+
+async def drain_pending_npx_tasks(timeout_s: float = 5.0) -> None:
+    """Drain any still-pending NPX connect tasks at app shutdown.
+
+    Called from app.py's on_event('shutdown') handler. Gives shielded
+    NPX connect tasks a brief chance to finish on their own (the
+    subprocess may exit, the handshake may complete) before the event
+    loop closes. Tasks that don't finish are left to be cleaned up by
+    asyncio's shutdown_asyncgens — they may emit one cosmetic
+    'Attempted to exit cancel scope' ERROR line per remaining task as
+    mcp.client.stdio's async generator is force-closed, but that's a
+    library-level limitation and doesn't affect exit code or behavior.
+    """
+    pending = list(_pending_npx_tasks)
+    if not pending:
+        return
+    logger.info(f"Draining {len(pending)} pending NPX MCP connect task(s)...")
+    done, still_pending = await asyncio.wait(pending, timeout=timeout_s)
+    if still_pending:
+        logger.warning(
+            f"{len(still_pending)} NPX MCP task(s) didn't finish in {timeout_s}s "
+            f"at shutdown; their async generators will be force-closed."
+        )
 
 
 def _find_npx() -> str:
@@ -108,24 +156,47 @@ async def register_builtin_servers(mcp_manager):
     async def _start_npx_servers():
         await asyncio.sleep(3)  # let Python servers finish first
         for server_id, cfg in _BUILTIN_NPX_SERVERS.items():
+            logger.info(f"Starting NPX server: {cfg['name']} ({npx_path} {' '.join(cfg['args'])})")
+
+            # mcp.client.stdio.stdio_client opens an anyio task group
+            # internally. If wait_for cancels the connect mid-handshake,
+            # that task group can't be exited from a different task and
+            # anyio raises "Attempted to exit cancel scope in a different
+            # task than it was entered in" in a sibling task. The error
+            # isn't caught by the surrounding except BaseException (wrong
+            # task), and the orphaned cancel scope cascades cancellations
+            # into the rest of the event loop and downs the app.
+            #
+            # Fix: wrap the connect task in asyncio.shield so wait_for's
+            # cancellation can't reach it. Track the task in
+            # _pending_npx_tasks with a done_callback that consumes its
+            # eventual exception, and drain still-pending tasks at
+            # shutdown (see drain_pending_npx_tasks, hooked from app.py's
+            # on_event('shutdown')).
+            connect_task = asyncio.create_task(
+                mcp_manager.connect_server(
+                    server_id=server_id,
+                    name=cfg["name"],
+                    transport="stdio",
+                    command=npx_path,
+                    args=cfg["args"],
+                ),
+                name=f"mcp-npx-connect-{server_id}",
+            )
+            _pending_npx_tasks.add(connect_task)
+            connect_task.add_done_callback(_npx_task_done)
+
             try:
-                logger.info(f"Starting NPX server: {cfg['name']} ({npx_path} {' '.join(cfg['args'])})")
-                ok = await asyncio.wait_for(
-                    mcp_manager.connect_server(
-                        server_id=server_id,
-                        name=cfg["name"],
-                        transport="stdio",
-                        command=npx_path,
-                        args=cfg["args"],
-                    ),
-                    timeout=30,
-                )
+                ok = await asyncio.wait_for(asyncio.shield(connect_task), timeout=30)
                 if ok:
                     logger.info(f"Built-in NPX server registered: {cfg['name']}")
                 else:
                     logger.warning(f"Built-in NPX server failed to connect: {cfg['name']}")
             except asyncio.TimeoutError:
-                logger.warning(f"Built-in NPX server timed out: {cfg['name']}")
+                logger.warning(
+                    f"Built-in NPX server '{cfg['name']}' didn't connect within 30s; "
+                    f"continuing without it (task drained at shutdown)"
+                )
             except asyncio.CancelledError:
                 raise
             except BaseException as e:


### PR DESCRIPTION
Following up on #242 with the lifecycle-management shape you asked for in the review.

Changes:

- `src/builtin_mcp.py`: wrap each NPX connect task in `asyncio.shield` so `wait_for`'s cancellation can't reach `mcp.client.stdio.stdio_client`'s task group. Track shielded tasks in a module-level set with an `add_done_callback` that reads `task.exception()`, so there's no "Task exception was never retrieved" at shutdown. Expose `drain_pending_npx_tasks()` for the shutdown handler.
- `app.py`: call `drain_pending_npx_tasks()` in the existing `on_event('shutdown')` handler, before `mcp_manager.disconnect_all()`.

Verified end to end with the `/bin/sleep`-as-NPX-server harness from #242:

- Main loop is uncancelled when the connect times out (cascade is shielded out)
- `done_callback` fires and logs the exception cleanly, no "never retrieved" warning
- Drain runs at shutdown, gives pending tasks 5s to finish before giving up

Known remaining shutdown noise: if a connect task is still pending when the event loop closes (subprocess never exited, handshake never completed), asyncio's `shutdown_asyncgens` force-closes `mcp.client.stdio`'s async generator, which logs one "Attempted to exit cancel scope" ERROR per remaining task. That's a limitation in `mcp.client.stdio` itself: its anyio task group can't tolerate any external cancellation, including from the loop closer. Cosmetic only, doesn't affect exit code or behavior. Properly fixing would need a change in the `mcp` library.

---

I also opened **#253** (a different shape that removes the failure class entirely by detecting whether the npx package is cached before invoking `connect_server`, instead of timing out around it). No shield, no task tracking, no shutdown noise. Posted both so you can pick whichever fits your preference. Happy to close this one if you'd rather have the other shape, or vice versa.
