### PR TITLE
models: dedupe endpoints by base_url on create

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -909,6 +909,34 @@ def setup_model_routes(model_discovery):
         require_model_list = _truthy(require_models)
         should_probe = require_model_list or not _truthy(skip_probe)
 
+        # Dedupe: if an endpoint with the same base_url already exists and
+        # is reachable by the caller (shared or owned by them), return it
+        # instead of creating a duplicate row. Fixes "Scan for Servers"
+        # re-adding manually-added endpoints under their host:port name.
+        from src.auth_helpers import get_current_user as _gcu_dedup
+        _caller = _gcu_dedup(request) or None
+        _db_dedup = SessionLocal()
+        try:
+            existing = (
+                _db_dedup.query(ModelEndpoint)
+                .filter(ModelEndpoint.base_url == base_url)
+                .filter((ModelEndpoint.owner.is_(None)) | (ModelEndpoint.owner == _caller))
+                .order_by(ModelEndpoint.owner.desc())  # prefer owned over shared
+                .first()
+            )
+            if existing:
+                return {
+                    "id": existing.id,
+                    "name": existing.name,
+                    "base_url": existing.base_url,
+                    "models": json.loads(existing.cached_models) if existing.cached_models else [],
+                    "online": True,
+                    "status": "online",
+                    "existing": True,
+                }
+        finally:
+            _db_dedup.close()
+
         # Quick model list fetch (1s timeout — if endpoint is slow, it'll update on next refresh)
         _probe_timeout = 3 if (":11434" in base_url or "ollama" in base_url.lower()) else 1
         model_ids = _probe_endpoint(base_url, api_key.strip() or None, timeout=_probe_timeout) if should_probe else []

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -952,8 +952,10 @@ function initEndpointForm() {
           msg.textContent = 'No model servers found. Make sure vLLM, llama.cpp, SGLang, or Ollama is running. Docker users may need OLLAMA_HOST=0.0.0.0:11434.';
           msg.className = 'admin-error';
         } else {
-          // Auto-add each discovered endpoint
+          // Auto-add each discovered endpoint. Server dedupes on base_url
+          // and returns `existing: true` for already-registered ones.
           let added = 0;
+          let skipped = 0;
           for (const item of items) {
             const base = item.url.replace('/chat/completions', '').replace(/\/$/, '');
             const fd = new FormData();
@@ -961,12 +963,18 @@ function initEndpointForm() {
             fd.append('skip_probe', 'false');
             const r = await fetch('/api/model-endpoints', { method: 'POST', body: fd });
             if (r.ok) {
-              added++;
-              try { const dd = await r.json(); if (dd && dd.id) _recentlyAddedEpId = String(dd.id); } catch (_) {}
+              try {
+                const dd = await r.json();
+                if (dd && dd.existing) { skipped++; }
+                else { added++; if (dd && dd.id) _recentlyAddedEpId = String(dd.id); }
+              } catch (_) { added++; }
             }
           }
           const totalModels = items.reduce((n, i) => n + (i.models ? i.models.length : 0), 0);
-          msg.innerHTML = `Found ${items.length} server${items.length !== 1 ? 's' : ''} with ${totalModels} model${totalModels !== 1 ? 's' : ''}` + (added ? ` — added ${added} new` : ' (already added)');
+          const parts = [`Found ${items.length} server${items.length !== 1 ? 's' : ''} with ${totalModels} model${totalModels !== 1 ? 's' : ''}`];
+          if (added) parts.push(`added ${added} new`);
+          if (skipped) parts.push(`${skipped} already added`);
+          msg.innerHTML = parts.join(' — ');
           msg.className = 'admin-success';
           loadEndpoints();
         }


### PR DESCRIPTION
POST `/api/model-endpoints` always inserted a new row, so Settings → Add Models → **Scan for Servers** re-added any endpoint a user had already registered manually — once under its model name (from the earlier manual add) and again under its host:port (auto-generated when scan posts without a name). The success toast then misreported the result as *added N new*.

### Repro

1. Manually add `http://localhost:8000/v1` (vLLM serving Qwen2.5-Coder-14B-AWQ). Row shows up named `Qwen2.5-Coder-14B-Instruct-AWQ`.
2. Click **Scan for Servers**. Toast says *Found 1 server with 1 model — added 1 new*.
3. **Added Models** now lists two rows for the same URL: one named after the model, one named `localhost:8000`.

### Fix

Look up an existing endpoint with the same `base_url` accessible to the caller (shared or owned by them) before inserting. If found, return it with `existing: true` so the client can tell the difference between a real add and a dedupe hit. Prefers user-owned over shared when both match.

Updates the scan toast in `admin.js` to count `existing` separately, e.g. *Found 1 server with 1 model — 1 already added*.

### Tested

```
POST /api/model-endpoints  base_url=http://localhost:9999/v1  → id=b6ab34c9
POST /api/model-endpoints  base_url=http://localhost:9999/v1  → id=b6ab34c9 existing=true
POST /api/model-endpoints  base_url=http://localhost:9999/v1/ → id=b6ab34c9 existing=true   # trailing-slash variation normalized
GET  /api/model-endpoints                                     → 1 row
```

Manual paste path also benefits — re-pasting a URL no longer silently doubles it.