### PR TITLE
build(docker): exclude docs/ and *.md from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,10 @@ build/
 .vscode/
 .idea/
 dev-docs/
+# Demo media + repo docs — landing page is GitHub Pages only, never served
+# at runtime (app mounts /static only), so keep ~18MB out of the image.
+docs/
+*.md
 *.db
 *.sqlite
 *.sqlite3


### PR DESCRIPTION
The Dockerfile's `COPY . .` pulled the entire docs/ directory (~18MB of demo GIFs/WebMs) into the build context and runtime image, but the app only mounts /static — docs/ is never served (the landing page is GitHub Pages only). Ignoring docs/ and *.md cuts the build context from 32.40MB to 14.7MB (~55%) at zero functional cost.

Closes #264