### PR TITLE
fix(markdown): svgify emoji in mdToHtml output

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -539,7 +539,7 @@ export function mdToHtml(src) {
     s = s.replace(`___CODE_BLOCK_${index}___`, block);
   });
 
-  return s;
+  return svgifyEmoji(s);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #270

Monochrome emoji rendering was only applied in `processWithThinking()`, while several chat and preview paths call `mdToHtml()` directly. That caused emoji icons to disappear after streaming finished (especially on the live-reply finalization path when a thinking section is preserved).

Apply `svgifyEmoji()` at the end of `mdToHtml()` so every markdown render path consistently produces theme-tinted OpenMoji line icons.

## Changes

- `static/js/markdown.js`: return `svgifyEmoji(s)` from `mdToHtml()` instead of raw HTML

## Test plan

- [x] Chat with a model that uses thinking blocks; ask for a reply containing emoji (e.g. 😀 ✅)
- [x] Confirm emoji render during streaming **and** after the stream completes
- [x] Reload the session and confirm emoji still render from history
- [ ] Confirm emoji inside fenced code blocks remain literal (not converted)
- [ ] Spot-check document library chat preview if it includes emoji

## Tests

- Test 1

<img width="1920" height="1080" alt="02-emoji" src="https://github.com/user-attachments/assets/fece94d3-03dd-4a57-afcb-71bb28df4d76" />

