### PR TITLE
security: fix app_api administrative bypass and RCE

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -167,6 +167,7 @@ async def _run_subprocess_streaming(
     )
 
 _ADMIN_TOOLS = {
+    "app_api",
     "manage_endpoints",
     "manage_mcp",
     "manage_webhooks",

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2585,6 +2585,11 @@ _APP_API_BLOCKLIST_PREFIXES = (
     "/api/tokens/",        # api token mgmt
     "/api/admin/",         # admin one-shots (wipe etc.)
     "/api/backup/restore", # destructive restore
+    "/api/shell/",         # RCE vector (exec/stream)
+    "/api/cookbook/",      # setup/kill-pid/packages/etc.
+    "/api/settings/",      # system settings
+    "/api/prefs/",         # security prefs
+    "/api/email/accounts", # owner-filtered bypass
 )
 
 # (method, prefix) pairs to refuse specifically. Used for endpoints
@@ -2637,6 +2642,7 @@ async def do_app_api(content: str, owner: Optional[str] = None) -> Dict:
     refuses auth/user/admin paths to keep blast radius bounded.
     """
     import httpx
+    import posixpath
     try:
         args = _parse_tool_args(content) if content.strip() else {}
     except ValueError:
@@ -2661,12 +2667,14 @@ async def do_app_api(content: str, owner: Optional[str] = None) -> Dict:
         for path, methods in (data.get("paths") or {}).items():
             if not isinstance(methods, dict):
                 continue
-            if any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
+            # Normalize path before checking blocklist
+            clean_p = posixpath.normpath("/" + path.lstrip("/"))
+            if any(clean_p.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
                 continue
             for method, op in methods.items():
                 if method.lower() not in ("get", "post", "put", "patch", "delete"):
                     continue
-                if any(method.upper() == m and path.startswith(p) for m, p in _APP_API_BLOCKLIST_METHOD_PATH):
+                if any(method.upper() == m and clean_p.startswith(p) for m, p in _APP_API_BLOCKLIST_METHOD_PATH):
                     continue
                 summary = (op or {}).get("summary") or (op or {}).get("description") or ""
                 if isinstance(summary, str):
@@ -2691,15 +2699,18 @@ async def do_app_api(content: str, owner: Optional[str] = None) -> Dict:
     path = args.get("path") or ""
     if not path:
         return {"error": "path is required (e.g. '/api/cookbook/gpus')", "exit_code": 1}
-    if not path.startswith("/"):
-        path = "/" + path
-    if any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
+    
+    # Normalize path to prevent double-slash bypasses (//api/admin)
+    # and directory traversal.
+    clean_path = posixpath.normpath("/" + path.lstrip("/"))
+
+    if any(clean_path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
         return {"error": f"Path blocked for safety: {path}. Auth/user/admin endpoints are off-limits via app_api.", "exit_code": 1}
 
     method = (args.get("method") or "GET").upper()
     if method not in ("GET", "POST", "PUT", "PATCH", "DELETE"):
         return {"error": f"Unsupported method: {method}", "exit_code": 1}
-    if any(method == m and path.startswith(p) for m, p in _APP_API_BLOCKLIST_METHOD_PATH):
+    if any(method == m and clean_path.startswith(p) for m, p in _APP_API_BLOCKLIST_METHOD_PATH):
         if "/api/email/accounts" in path:
             return {"error": "Don't use /api/email/accounts via app_api — it is owner-filtered in tool context and may return empty. Use the `list_email_accounts` email tool, then pass `account` to list_emails/read_email.", "exit_code": 1}
         if "/api/model/download" in path:

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -382,3 +382,34 @@ def test_mcp_config_listing_is_admin_gated():
     assert "def list_servers(request: Request):" in src
     assert "def list_tools(request: Request):" in src
     assert "def list_server_tools(server_id: str, request: Request):" in src
+
+# ── app_api security ──────────────────────────────────────────
+
+def test_app_api_blocklist_normalization():
+    """Verify that app_api correctly normalizes paths to prevent double-slash bypasses."""
+    from src.tool_implementations import app_api
+    import asyncio
+    
+    async def run_test():
+        # Double-slash bypass attempt
+        res = await app_api('{"action": "call", "path": "//api/admin/wipe/chats"}')
+        assert res["exit_code"] == 1
+        assert "Path blocked for safety" in res["error"]
+        
+        # Omitted sensitive endpoint
+        res = await app_api('{"action": "call", "path": "/api/shell/exec"}')
+        assert res["exit_code"] == 1
+        assert "Path blocked for safety" in res["error"]
+        
+        # Traversal attempt
+        res = await app_api('{"action": "call", "path": "/api/chat/../../api/admin/wipe/chats"}')
+        assert res["exit_code"] == 1
+        assert "Path blocked for safety" in res["error"]
+
+    asyncio.run(run_test())
+
+
+def test_app_api_is_admin_tool():
+    """Verify that app_api is restricted to admins."""
+    from src.tool_execution import _ADMIN_TOOLS
+    assert "app_api" in _ADMIN_TOOLS


### PR DESCRIPTION
This PR fixes several critical security vulnerabilities in the app_api tool:

1.  **Administrative Bypass**: Implemented path normalization in `app_api` to prevent blocklist bypasses using double slashes (e.g., `//api/admin/`).
2.  **RCE Protection**: Added `/api/shell/`, `/api/cookbook/`, and other sensitive endpoints to the `app_api` blocklist.
3.  **Privilege Escalation**: Restricted the `app_api` tool to administrative users only by adding it to `_ADMIN_TOOLS`.
4.  **Regression Tests**: Added tests to ensure these bypasses remain blocked.