### PR TITLE
harden(skills): fail-closed confidence gate for teacher-escalation drafts

### DIFF
--- a/services/memory/skills.py
+++ b/services/memory/skills.py
@@ -577,6 +577,17 @@ class SkillsManager:
             def _passes(s):
                 if s.get("status") == "published":
                     return True
+                # Teacher-escalation drafts are auto-written from a (possibly
+                # untrusted) trace and injected as authoritative guidance, so they
+                # must EARN injection with an explicit, parseable confidence that
+                # clears the bar — fail closed on a missing/garbage value instead
+                # of treating it as 1.0. Hand-authored legacy drafts keep the
+                # lenient "unset → keep" behavior so they don't silently vanish.
+                if s.get("source") == "teacher-escalation":
+                    c = s.get("confidence")
+                    if c is None:
+                        return False
+                    return _to_float(c, 0.0) >= min_confidence  # unparseable → fail closed
                 c = s.get("confidence")
                 if c is None:
                     return True  # unset → don't filter (legacy)


### PR DESCRIPTION
## What

Follow-up to #275 (the one I flagged in that PR's description).

`get_relevant_skills()` treats a **missing or unparseable** `confidence` as `1.0`, so such a skill always clears the injection `min_confidence` threshold. For **teacher-escalation drafts** — which are auto-written from a (possibly untrusted) trace and then injected into the system prompt as authoritative guidance — that means a draft can be auto-injected *regardless* of the configured confidence bar.

## Change

In the draft confidence gate (`services/memory/skills.py`):
- **Teacher-escalation drafts** must carry an explicit, parseable `confidence` that meets `min_confidence` — **fail closed** on a missing/garbage value instead of treating it as `1.0`.
- **Hand-authored legacy drafts keep the lenient `unset → keep` behavior** (your deliberate "legacy skills shouldn't silently vanish" choice is preserved).
- **Published skills unaffected** (always pass).

Small and targeted — only the auto-generated lane is tightened.

## Tested

- `python -m py_compile services/memory/skills.py`
- `get_relevant_skills` unit check at `min_confidence=0.85`:
  - teacher drafts with `confidence` = `None` / `"garbage"` / `0.8` → **excluded**
  - teacher draft `0.9` → included
  - legacy draft (`source != teacher-escalation`) with no confidence → **still included**
  - published with no confidence → included
  - control: with the gate off (`min_confidence=0`) the teacher draft returns → disable path unchanged

Thanks again for the quick merge on #275.
