### PR TITLE
fix: add vllm to cookbook install allowlist

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -616,7 +616,7 @@ def setup_shell_routes() -> APIRouter:
         known = {
             "rembg[gpu]", "hf_transfer", "llama-cpp-python[server]", "sglang[all]", "diffusers", "diffusers[torch]",
             "TTS", "bark", "faster-whisper", "playwright", "realesrgan", "gfpgan",
-            "insightface", "onnxruntime-gpu", "onnxruntime", "hdbscan",
+            "insightface", "onnxruntime-gpu", "onnxruntime", "hdbscan", "vllm",
         }
         if pip_name not in known:
             return {"ok": False, "error": f"Unknown package: {pip_name}"}


### PR DESCRIPTION
`vllm` is listed as an installable package in the cookbook UI but was missing from the allowlist in the install endpoint, so any attempt to install it returned `"Unknown package: vllm"`.

Added `"vllm"` to the known packages set so the install button actually works.