### PR TITLE
fix(ui): respect Text-only Emojis setting after mdToHtml svgify

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2553,14 +2553,23 @@ function initializeEventListeners() {
     });
   }
 
+  const _DEOJ_SKIP = '.sources-section, .thinking-toggle, .memory-used-pill';
+
   /** Walk all text nodes inside an element and replace emojis with text descriptions */
   function deEmojify(root) {
+    if (!root || !root.querySelectorAll) return;
+    // Monochrome SVG spans from svgifyEmoji — Unicode lives in aria-label only
+    root.querySelectorAll('.emoji[aria-label]').forEach((span) => {
+      if (span.closest(_DEOJ_SKIP)) return;
+      const label = span.getAttribute('aria-label') || '';
+      span.replaceWith(document.createTextNode(emojiToText(label)));
+    });
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     const nodes = [];
     while (walker.nextNode()) nodes.push(walker.currentNode);
     for (const node of nodes) {
       // Skip UI elements that use unicode symbols as functional icons
-      if (node.parentElement && node.parentElement.closest('.sources-section, .thinking-toggle, .memory-used-pill')) continue;
+      if (node.parentElement && node.parentElement.closest(_DEOJ_SKIP)) continue;
       if (EMOJI_RE.test(node.textContent)) {
         EMOJI_RE.lastIndex = 0; // reset regex state
         node.textContent = emojiToText(node.textContent);

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -233,8 +233,13 @@ function _svgifyText(text) {
   }
   return out;
 }
+/** When "Text-only Emojis" is on, keep Unicode in HTML so deEmojify() can strip them. */
+function _useSvgEmoji() {
+  return typeof document === 'undefined' || !document.body?.classList.contains('text-emojis');
+}
+
 export function svgifyEmoji(html) {
-  if (!html || !_EMOJI_RE.test(html)) return html;
+  if (!_useSvgEmoji() || !html || !_EMOJI_RE.test(html)) return html;
   const parts = html.split(/(<[^>]*>)/);   // odd indices = tags
   let codeDepth = 0;
   for (let i = 0; i < parts.length; i++) {
@@ -282,7 +287,7 @@ export function processWithThinking(text) {
     html += mdToHtml(content);
   }
 
-  return svgifyEmoji(html);
+  return _useSvgEmoji() ? svgifyEmoji(html) : html;
 }
 
 /**
@@ -539,7 +544,7 @@ export function mdToHtml(src) {
     s = s.replace(`___CODE_BLOCK_${index}___`, block);
   });
 
-  return svgifyEmoji(s);
+  return _useSvgEmoji() ? svgifyEmoji(s) : s;
 }
 
 /**


### PR DESCRIPTION
# fix(ui): respect Text-only Emojis setting after svgify in mdToHtml

I apologize for my previous Issue and PR for not testing it completely before proposing the fix.

Follow-up to #271 · Related to #270

## Summary

PR #271 moved emoji svgification into `mdToHtml()`. That change broke the **Text-only Emojis** chat setting (“Strip emojis from AI replies”), which converts emoji to `:description:` text via `deEmojify()`.

`deEmojify()` only walks **text nodes**. Svgified emoji live in `<span class="emoji" aria-label="…">` with no Unicode in the text, so stripping never ran.

This PR restores the setting while keeping #271’s behavior when Text-only Emojis is **off**.

## Changes

### `static/js/markdown.js`

- Add `_useSvgEmoji()` — returns `false` when `body` has class `text-emojis`.
- Skip `svgifyEmoji()` in `mdToHtml()`, `processWithThinking()`, and the `svgifyEmoji()` entry when Text-only Emojis is on (Unicode stays in the DOM for stripping).

### `static/app.js`

- Extend `deEmojify()` to replace existing `.emoji[aria-label]` spans with text descriptions (covers messages already rendered as SVG icons and toggling the setting on without reload).

## Test plan

- [x] **Text-only Emojis ON** (default): new AI replies show `:grinning:` / `:check mark:` text, not monochrome SVG icons.
- [x] **Text-only Emojis OFF**: new replies show monochrome line icons (regression check for #271).
- [x] Reload session with setting ON — emoji in history strip to text.
- [x] Toggle setting ON on a message that already has SVG emoji spans — converts to text without reload.
- [x] Code blocks: emoji inside fences stay literal; emoji outside still respect the setting.

## Related

- Merged fix: #271
- Original report: #270
