### PR TITLE
fix: don't cache calendar event ranges when the fetch fails

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -116,7 +116,10 @@ async function _fetchEvents(start, end, force) {
   const hasCache = Object.keys(_allEvents).length > 0;
   if (hasCache) _events = _filterPool(start, end);
   const fetchPromise = fetch(`${API_BASE}/api/calendar/events?start=${start}&end=${end}`, { credentials: 'same-origin' })
-    .then(r => r.json())
+    .then(r => {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
     .then(data => {
       // On first fetch after cache load, replace pool entirely to avoid
       // stale/duplicate UIDs from a previous backend (e.g. CalDAV → SQLite)
@@ -154,7 +157,10 @@ function _prefetchAdjacent() {
   for (const [s, e] of ranges) {
     if (_rangeIsCached(s, e)) continue;
     fetch(`${API_BASE}/api/calendar/events?start=${s}&end=${e}`, { credentials: 'same-origin' })
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
       .then(d => {
         (d.events || []).forEach(ev => { _allEvents[ev.uid] = ev; });
         _fetchedRanges.push([s, e]);


### PR DESCRIPTION
`_fetchEvents` and `_prefetchAdjacent` parsed the response with `.then(r => r.json())` and pushed the requested range into `_fetchedRanges` without checking `r.ok`. If `/api/calendar/events` returned a 500/503, the range still got marked as cached, so `_rangeIsCached` returned true on every subsequent visit and the calendar showed that month as permanently empty until a full page reload, even after the backend recovered. The failure was also silent.

Both fetch paths now check `r.ok` and throw on a non-OK status, so failed ranges are never added to the cache and will be retried on the next navigation. This matches the existing `r.ok` handling the create/update/delete flows already had (see the comment above `_createEvent`).