### PR TITLE
Add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pewdiepie-archdaemon/odysseus.git"
+  },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.3.2"
   },


### PR DESCRIPTION
This is so that it is as easy as running `npm repo` to open the github page for this project.