### PR TITLE
ci: add secret scanning with gitleaks

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,60 @@
+# Secret scanning
+#
+# Purpose: stop credentials (API keys, tokens, passwords, private keys) from
+# ever living in the Git history. Odysseus deliberately keeps real secrets in
+# files that are gitignored (.env, data/), but a slip in a future commit -- or a
+# malicious pull request that sneaks one in -- would otherwise go unnoticed.
+# This job reads the repository and the full commit history and fails if it
+# finds anything that looks like a secret.
+#
+# It runs the official gitleaks BINARY directly (pinned to an exact version and
+# verified against the project's published SHA-256 checksum) rather than the
+# gitleaks GitHub Action, because the Action asks for a paid license on
+# organization-owned repos. The binary is free and behaves identically.
+
+name: Secret scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Start with zero permissions; the single job opts back in to read-only.
+permissions: {}
+
+concurrency:
+  group: secret-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so a secret committed in an earlier commit (and later
+          # deleted) is still caught -- deletion does not remove it from Git.
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Pinned version + checksum so a tampered release binary cannot run here.
+      # Bump VERSION/SHA256 together; the checksum comes from the matching
+      # gitleaks_<version>_checksums.txt on the GitHub release.
+      - name: Run gitleaks (pinned, checksum-verified)
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL -o "${TARBALL}" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}"
+          echo "${GITLEAKS_SHA256}  ${TARBALL}" | sha256sum -c -
+          tar -xzf "${TARBALL}" gitleaks
+          # Scan the whole history. Findings print to the log and fail the job.
+          ./gitleaks git --no-banner --redact --verbose .


### PR DESCRIPTION
## Secret scanning (gitleaks)

**What it does:** scans the whole Git history on every pull request and push to `main` for committed credentials (API keys, tokens, private keys).

**What it prevents:** a secret being committed by mistake, or slipped in by a malicious PR. Complements the already-gitignored `.env` and `data/`.

**What you'll see:** a `gitleaks` check in the PR's Checks tab. Green = clean.

**If it fails:** a real credential was likely committed. Treat it as leaked, rotate (regenerate) the key, then remove it from the file.

**Cost/noise:** runs in ~10s, no secrets or paid license required (uses the gitleaks binary directly, pinned + checksum-verified), free on public repos. **Blocking.**

