### PR TITLE
feat(ui): add first-run hints to empty notes, chats, and memory states

### DIFF
--- a/static/js/documentLibrary.js
+++ b/static/js/documentLibrary.js
@@ -1988,7 +1988,7 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
       if (!filtered.length) {
         // Sad-mouth smiley (downturn curve) for "nothing here yet".
         const _sadIco = '<span style="vertical-align:-3px;margin-left:6px;">' + uiModule.emptyStateIcon('sad') + '</span>';
-        grid.innerHTML = '<div class="doclib-empty">No chats' + _sadIco + '</div>';
+        grid.innerHTML = '<div class="doclib-empty">No chats yet' + _sadIco + '<span style="display:block;opacity:0.7;font-size:11px;margin-top:4px;">Your chats will show up here.</span></div>';
         _appendInlineLoadMore(grid, 0, _chatsVisibleLimit, () => {});
         return;
       }

--- a/static/js/memory.js
+++ b/static/js/memory.js
@@ -594,8 +594,9 @@ export function renderMemoryList() {
     } else {
       memoryList.innerHTML = `<div class="memory-empty" style="display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;">
         <span>No memories yet${_smiley}</span>
-        <span style="opacity:0.7;font-size:11px;display:block;">
-          <a href="#" data-mem-goto-add style="color:var(--accent,var(--red));text-decoration:underline;">Import in Add tab</a>
+        <span style="opacity:0.7;font-size:11px;display:block;max-width:240px;text-align:center;">
+          They build up automatically as you chat — or
+          <a href="#" data-mem-goto-add style="color:var(--accent,var(--red));text-decoration:underline;">import in the Add tab</a>.
         </span>
       </div>`;
       memoryList.querySelector('[data-mem-goto-add]')?.addEventListener('click', (e) => {

--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -1892,7 +1892,7 @@ function _renderNotes() {
     _renderLabelsInto(body);
     _renderQuickAdd(body);
     if (sorted.length === 0) {
-      body.insertAdjacentHTML('beforeend', '<div class="notes-empty-msg">No notes yet <span style="vertical-align:-3px;margin-left:4px;">' + uiModule.emptyStateIcon('smiley') + '</span></div>');
+      body.insertAdjacentHTML('beforeend', '<div class="notes-empty-msg">No notes yet <span style="vertical-align:-3px;margin-left:4px;">' + uiModule.emptyStateIcon('smiley') + '</span><span style="display:block;opacity:0.7;font-size:11px;margin-top:4px;">Add one above to get started.</span></div>');
     } else {
       body.insertAdjacentHTML('beforeend', html);
     }


### PR DESCRIPTION
## What & why

Three first-run empty states showed only a bare label, leaving a new user with no idea what to do next. This adds a short next-step hint to each — matching the pattern Odysseus already uses elsewhere (e.g. the Documents and Tasks empty states both say "…create one to get started"). Addresses the ROADMAP's "improve empty states … on fresh installs."

## Changes (text / HTML only)

- **Notes** (`static/js/notes.js`): `No notes yet` → adds *"Add one above to get started."* (the quick-add input is rendered directly above the message).
- **Chats library** (`static/js/documentLibrary.js`): `No chats` → `No chats yet` + *"Your chats will show up here."*
- **Memory** (`static/js/memory.js`): keeps the existing Import link, and explains how memories normally appear — *"They build up automatically as you chat — or import in the Add tab."* (`auto_memory` defaults to on; auto-extracted memories are saved with `source='auto'`).

## Testing

- `node --check` passes on all three changed modules.
- Confirmed the Memory empty-state's click handler still resolves its `[data-mem-goto-add]` anchor after the copy change.
- Static/HTML-only edits inside existing render paths — no logic changed, and no service-worker cache bump needed (these modules are network-first). Not run on a live instance here; a quick visual glance at the three empty states would confirm rendering.
