### PR TITLE
Heal cross-OS HuggingFace embedding cache on native Windows

### DIFF
--- a/core/platform_compat.py
+++ b/core/platform_compat.py
@@ -41,6 +41,61 @@ def safe_chmod(path, mode: int) -> bool:
         return False
 
 
+# ── HuggingFace model-cache repair ───────────────────────────────────────────
+def _hf_model_root(path: str) -> Optional[str]:
+    """Walk up from a cached file to its enclosing ``models--*`` repo dir."""
+    root = path
+    while os.path.basename(root) and not os.path.basename(root).startswith("models--"):
+        parent = os.path.dirname(root)
+        if parent == root:
+            return None
+        root = parent
+    return root if os.path.basename(root).startswith("models--") else None
+
+
+def purge_unreadable_hf_cache(cache_dir, logger=None) -> List[str]:
+    """Drop HuggingFace ``models--*`` dirs whose model file is unreadable, so the
+    next download re-fetches real files. Returns the dirs removed.
+
+    The HF hub stores ``snapshots/<rev>/<file>`` as links into ``blobs/``. When
+    the cache was populated by a *different* OS — e.g. the Linux Docker container
+    writing into a bind-mounted ``data/`` dir that a native Windows run later
+    reads — those links are POSIX symlinks. Windows surfaces them as reparse
+    points carrying the WSL/Linux symlink tag (0xA000001D) that it cannot
+    follow: ``open()`` raises ``WinError 1920`` / ``OSError(22)`` and fastembed
+    loads a zero-byte model and dies. Crucially ``os.path.islink()`` returns
+    **False** for these, so a plain broken-symlink check misses them.
+
+    The reliable signal is *unresolvable*: present on disk (``lexists``) but not
+    resolvable (``not exists``). That covers both a dangling Windows symlink and
+    a foreign reparse point, while real files and working native symlinks (which
+    resolve fine) are left untouched. Best-effort: removal never raises.
+    """
+    import glob
+
+    removed: List[str] = []
+    if not cache_dir or not os.path.isdir(cache_dir):
+        return removed
+    for onnx in glob.glob(os.path.join(cache_dir, "**", "*.onnx"), recursive=True):
+        # os.path.exists() swallows the underlying OSError and returns False —
+        # exactly the "can't resolve this entry" signal we want.
+        if not (os.path.lexists(onnx) and not os.path.exists(onnx)):
+            continue
+        root = _hf_model_root(onnx)
+        if root and root not in removed:
+            removed.append(root)
+    for root in removed:
+        if logger is not None:
+            logger.warning(
+                "Embedding cache entry is unreadable on this OS (likely a "
+                "Linux/Docker-written symlink); clearing %s so fastembed "
+                "re-downloads real files",
+                root,
+            )
+        shutil.rmtree(root, ignore_errors=True)
+    return removed
+
+
 # ── Process detach / liveness / teardown ────────────────────────────────────
 def detached_popen_kwargs() -> dict:
     """Keyword args for :class:`subprocess.Popen` that fully detach a child so

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -121,34 +121,20 @@ class FastEmbedClient:
         )
         os.makedirs(cache_dir, exist_ok=True)
         # Windows self-heal: the HuggingFace-hub cache stores model files as
-        # symlinks (snapshots/<rev>/model.onnx -> ../../blobs/<hash>). On a
-        # network-share / UNC data dir Windows refuses to follow them
-        # ([WinError 1463] "symbolic link cannot be followed because its type is
-        # disabled"), and a cache copied between machines can carry dead symlinks
-        # too. Either way fastembed tries to load a broken symlink and fails
-        # *without* re-downloading, leaving semantic memory degraded. Detect a
-        # broken-symlink model in the cache and drop the contaminated hub dir so
-        # fastembed re-fetches (it falls back to its CDN tarball of real files,
-        # which load fine). Best-effort; only ever removes a verifiably dead link.
+        # symlinks (snapshots/<rev>/model.onnx -> ../../blobs/<hash>). A cache
+        # populated by another OS — e.g. the Linux Docker container writing into
+        # a bind-mounted data/ dir that a native Windows run then reads — leaves
+        # those as reparse points Windows can't follow ([WinError 1920]), and
+        # os.path.islink() does NOT report them, so fastembed would load a
+        # zero-byte model and die *without* re-downloading. Drop any such
+        # contaminated model dir so fastembed re-fetches real files. Centralized
+        # in platform_compat (see purge_unreadable_hf_cache's docstring).
         if os.name == "nt":
             try:
-                import glob, shutil
-                for _onnx in glob.glob(os.path.join(cache_dir, "**", "*.onnx"), recursive=True):
-                    if os.path.islink(_onnx) and not os.path.exists(_onnx):
-                        _root = _onnx
-                        while os.path.basename(_root) and not os.path.basename(_root).startswith("models--"):
-                            _parent = os.path.dirname(_root)
-                            if _parent == _root:
-                                break
-                            _root = _parent
-                        if os.path.basename(_root).startswith("models--"):
-                            logger.warning(
-                                "Embedding cache has a broken symlink (%s); clearing %s "
-                                "so fastembed re-downloads real files", _onnx, _root,
-                            )
-                            shutil.rmtree(_root, ignore_errors=True)
+                from core.platform_compat import purge_unreadable_hf_cache
+                purge_unreadable_hf_cache(cache_dir, logger=logger)
             except Exception as _e:
-                logger.debug("embedding cache symlink-heal skipped: %s", _e)
+                logger.debug("embedding cache self-heal skipped: %s", _e)
         kwargs = {"model_name": self.model, "cache_dir": cache_dir}
         self._embedding = TextEmbedding(**kwargs)
         self._dim: Optional[int] = None

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -1,0 +1,71 @@
+"""Windows embedding-cache repair.
+
+A HuggingFace model cache populated by a *different* OS — e.g. the Linux Docker
+container writing into a bind-mounted ``data/`` dir that a native Windows run
+later reads — stores ``snapshots/<rev>/<file>`` as POSIX symlinks into
+``blobs/``. Read back on Windows these surface as reparse points with the
+WSL/Linux symlink tag (0xA000001D) that Windows cannot follow: ``open()`` raises
+WinError 1920 / OSError(22) and fastembed loads a zero-byte model and dies.
+Crucially ``os.path.islink()`` returns **False** for them, so the original
+broken-symlink check (``islink and not exists``) never caught them.
+
+``purge_unreadable_hf_cache`` must key off *unresolvable* entries — present on
+disk (``lexists``) but not resolvable (``not exists``) — which covers both a
+dangling Windows symlink and a foreign reparse point, while leaving a healthy
+cache of real files (native copy mode) untouched.
+
+A dangling symlink reproduces the exact ``lexists and not exists`` code path on
+any OS, so these tests pin the behavior portably without needing a real
+LX-symlink reparse point.
+"""
+import os
+
+import pytest
+
+from core import platform_compat
+
+
+def _make_model_dir(cache_dir, repo="models--qdrant--all-MiniLM-L6-v2-onnx", rev="rev0"):
+    snap = os.path.join(cache_dir, repo, "snapshots", rev)
+    blobs = os.path.join(cache_dir, repo, "blobs")
+    os.makedirs(snap)
+    os.makedirs(blobs)
+    return snap, blobs, os.path.join(cache_dir, repo)
+
+
+def test_purge_removes_unresolvable_model_dir(tmp_path):
+    """A model whose .onnx is present-but-unresolvable gets its models-- dir dropped."""
+    cache = str(tmp_path)
+    snap, blobs, root = _make_model_dir(cache)
+    onnx = os.path.join(snap, "model.onnx")
+    try:
+        os.symlink(os.path.join(blobs, "missing-blob"), onnx)
+    except (OSError, NotImplementedError):
+        pytest.skip("creating symlinks is not permitted on this host")
+
+    # This is the exact state that fooled the old islink() check.
+    assert os.path.lexists(onnx) and not os.path.exists(onnx)
+    assert not os.path.islink(onnx) or True  # islink may be False (foreign reparse)
+
+    removed = platform_compat.purge_unreadable_hf_cache(cache)
+
+    assert removed == [root]
+    assert not os.path.exists(root)
+
+
+def test_purge_keeps_healthy_real_file_cache(tmp_path):
+    """A cache of real files (native copy mode) must never be cleared."""
+    cache = str(tmp_path)
+    snap, _blobs, root = _make_model_dir(cache)
+    with open(os.path.join(snap, "model.onnx"), "wb") as fh:
+        fh.write(b"\x00" * 32)
+
+    removed = platform_compat.purge_unreadable_hf_cache(cache)
+
+    assert removed == []
+    assert os.path.exists(root)
+
+
+def test_purge_missing_dir_is_noop(tmp_path):
+    """First-ever run (no cache dir yet) is a safe no-op."""
+    assert platform_compat.purge_unreadable_hf_cache(str(tmp_path / "nope")) == []

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -18,11 +18,24 @@ A dangling symlink reproduces the exact ``lexists and not exists`` code path on
 any OS, so these tests pin the behavior portably without needing a real
 LX-symlink reparse point.
 """
+import importlib.util
 import os
 
 import pytest
 
-from core import platform_compat
+# Load the helper straight from its file rather than `from core import
+# platform_compat`. The latter executes core/__init__.py, which eagerly imports
+# src.llm_core, auth, database, ... and the SQLAlchemy stack — failing test
+# collection in checkouts where those heavy imports aren't available. The helper
+# under test is stdlib-only, so loading the module by path keeps this test pure.
+_PC_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "core",
+    "platform_compat.py",
+)
+_spec = importlib.util.spec_from_file_location("_odysseus_platform_compat_under_test", _PC_PATH)
+platform_compat = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(platform_compat)
 
 
 def _make_model_dir(cache_dir, repo="models--qdrant--all-MiniLM-L6-v2-onnx", rev="rev0"):


### PR DESCRIPTION
## What & why

On **native Windows**, semantic memory / RAG / tool-index start **DEGRADED** with a
`No embedding backend available` error, even though the local FastEmbed fallback is
installed. The underlying failure is a HuggingFace cache that was written by a
**different OS**:

```
fastembed ... _verify_files_from_metadata: [WinError 1920] ...\snapshots\<rev>\config.json
src.embeddings - ERROR - FastEmbed init failed: [ONNXRuntimeError] Load model ...\model.onnx failed
src.app_initializer - WARNING - MemoryVectorStore DEGRADED
```

### Root cause (confirmed on disk)

The native run reuses the same cache the Docker container populates: compose mounts
`./data:/app/data`, and FastEmbed's cache defaults to `<repo>/data/fastembed_cache`,
so the **Linux** container writes the model there first. The HF hub stores
`snapshots/<rev>/<file>` as POSIX symlinks into `blobs/`. Read back on Windows those
entries are reparse points carrying the WSL/Linux symlink tag `0xA000001D`, which
Windows cannot follow — `open()` raises `WinError 1920` / `OSError(22)` and fastembed
loads a zero-byte `model.onnx`.

The existing Windows self-heal only dropped `os.path.islink()` "broken" links — but
**`os.path.islink()` returns `False` for these foreign reparse points**, so the
contaminated model dir was never cleared. Verified directly:

```
os.path.islink  -> False
os.path.lexists -> True
os.path.exists  -> False
st_reparse_tag  -> 0xa000001d   # IO_REPARSE_TAG_LX_SYMLINK
are_symlinks_supported(cache) -> False   # so a fresh native download correctly COPIES
```

## The fix

Key off **present-but-unresolvable** (`os.path.lexists` and `not os.path.exists`)
instead of `islink`. That catches both a dangling Windows symlink and a foreign
reparse point, while leaving real files and working native symlinks untouched. The
contaminated `models--*` dir is removed so fastembed re-downloads real files (copies,
since symlinks aren't supported without Developer Mode).

Per `platform_compat`'s own rule ("import from here instead of sprinkling
`os.name == 'nt'` checks"), the logic moves into a tested
`purge_unreadable_hf_cache()` helper; `src/embeddings.py` just calls it.

## Files changed
- `core/platform_compat.py` — new `purge_unreadable_hf_cache()` (+ `_hf_model_root`).
- `src/embeddings.py` — route the Windows self-heal to the helper (replaces the
  `islink`-only inline check).
- `tests/test_platform_compat.py` — new tests.

## Tests run
- `python -m pytest tests/test_platform_compat.py` → **2 passed, 1 skipped** (the
  skip is the real-symlink case, which needs Developer Mode to create a symlink on
  the test host; it runs on CI/Linux).
- `python -m py_compile core/platform_compat.py src/embeddings.py app.py` → OK.
- **End-to-end on the real reparse-point cache:** cleared on first init, fastembed
  re-downloaded real files and loaded (`dim 384`); `0` reparse points remained; the
  native server then logs `FastEmbed loaded` / `Embedding dimension: 384` with no
  `WinError`.
- Full suite: `python -m pytest` shows the same **9 pre-existing failures that are
  already present on unmodified `main`** (Windows-only test-ordering / MagicMock-stub
  issues, unrelated to this change — CONTRIBUTING notes Windows isn't actively
  tested). This change adds no new failures.

## Scope
Embedding-backend repair only. Full vector memory additionally needs a reachable
ChromaDB (`localhost:8100`); that's unchanged and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
