### PR TITLE
Feat: Add Token Usage Dashboard/Analytics

### DIFF
--- a/app.py
+++ b/app.py
@@ -552,6 +552,10 @@ app.include_router(setup_hwfit_routes())
 from routes.compare_routes import setup_compare_routes
 app.include_router(setup_compare_routes(session_manager))
 
+# Usage analytics
+from routes.usage_routes import setup_usage_routes
+app.include_router(setup_usage_routes())
+
 # User Preferences
 from routes.prefs_routes import setup_prefs_routes
 app.include_router(setup_prefs_routes())

--- a/routes/usage_routes.py
+++ b/routes/usage_routes.py
@@ -88,6 +88,19 @@ def _empty_daily_buckets(start: date, end: date) -> dict[str, dict]:
     }
 
 
+def _empty_user_daily_buckets(start: date, end: date) -> dict[str, dict]:
+    return {
+        day: {
+            "date": day,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "message_count": 0,
+        }
+        for day in _date_range(start, end)
+    }
+
+
 def _aggregate_usage_rows(
     rows: Iterable[tuple[datetime, Any, Optional[str], str]],
     *,
@@ -110,6 +123,7 @@ def _aggregate_usage_rows(
         "total_tokens": 0,
         "message_count": 0,
     })
+    daily_by_user: dict[str, dict[str, dict]] = defaultdict(lambda: _empty_user_daily_buckets(start, end))
 
     for timestamp, meta_data, owner, role in rows:
         if not timestamp:
@@ -122,6 +136,7 @@ def _aggregate_usage_rows(
         bucket["message_count"] += 1
         totals["message_count"] += 1
         by_user[owner_key]["message_count"] += 1
+        daily_by_user[owner_key][day]["message_count"] += 1
 
         if role != "assistant":
             continue
@@ -135,6 +150,10 @@ def _aggregate_usage_rows(
         bucket["input_tokens"] += input_tokens
         bucket["output_tokens"] += output_tokens
         bucket["total_tokens"] += total_tokens
+        user_bucket = daily_by_user[owner_key][day]
+        user_bucket["input_tokens"] += input_tokens
+        user_bucket["output_tokens"] += output_tokens
+        user_bucket["total_tokens"] += total_tokens
 
         source = metrics.get("usage_source")
         if source == "estimated":
@@ -158,6 +177,10 @@ def _aggregate_usage_rows(
         "by_user": [
             {"user": user, **values}
             for user, values in sorted(by_user.items(), key=lambda item: item[0])
+        ],
+        "daily_by_user": [
+            {"user": user, "daily": [values[day] for day in sorted(values)]}
+            for user, values in sorted(daily_by_user.items(), key=lambda item: item[0])
         ],
     }
 

--- a/routes/usage_routes.py
+++ b/routes/usage_routes.py
@@ -68,6 +68,7 @@ def _parse_message_metrics(meta_data: Any) -> Optional[dict]:
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
+        "model": str(meta.get("model") or "").strip(),
     }
 
 
@@ -97,6 +98,18 @@ def _empty_user_daily_buckets(start: date, end: date) -> dict[str, dict]:
     }
 
 
+def _empty_model_daily_buckets(start: date, end: date) -> dict[str, dict]:
+    return {
+        day: {
+            "date": day,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
+        for day in _date_range(start, end)
+    }
+
+
 def _aggregate_usage_rows(
     rows: Iterable[tuple[datetime, Any, Optional[str], str]],
     *,
@@ -112,6 +125,8 @@ def _aggregate_usage_rows(
         "message_count": 0,
     }
     daily_by_user: dict[str, dict[str, dict]] = defaultdict(lambda: _empty_user_daily_buckets(start, end))
+    daily_by_model: dict[str, dict[str, dict]] = defaultdict(lambda: _empty_model_daily_buckets(start, end))
+    by_model: dict[str, int] = defaultdict(int)
 
     for timestamp, meta_data, owner, role in rows:
         if not timestamp:
@@ -134,6 +149,7 @@ def _aggregate_usage_rows(
         input_tokens = metrics["input_tokens"]
         output_tokens = metrics["output_tokens"]
         total_tokens = input_tokens + output_tokens
+        model_key = metrics.get("model") or "unknown"
         bucket["input_tokens"] += input_tokens
         bucket["output_tokens"] += output_tokens
         bucket["total_tokens"] += total_tokens
@@ -141,10 +157,15 @@ def _aggregate_usage_rows(
         user_bucket["input_tokens"] += input_tokens
         user_bucket["output_tokens"] += output_tokens
         user_bucket["total_tokens"] += total_tokens
+        model_bucket = daily_by_model[model_key][day]
+        model_bucket["input_tokens"] += input_tokens
+        model_bucket["output_tokens"] += output_tokens
+        model_bucket["total_tokens"] += total_tokens
 
         totals["input_tokens"] += input_tokens
         totals["output_tokens"] += output_tokens
         totals["total_tokens"] += total_tokens
+        by_model[model_key] += total_tokens
 
     return {
         "daily": [daily[day] for day in sorted(daily)],
@@ -152,6 +173,15 @@ def _aggregate_usage_rows(
         "daily_by_user": [
             {"user": user, "daily": [values[day] for day in sorted(values)]}
             for user, values in sorted(daily_by_user.items(), key=lambda item: item[0])
+        ],
+        "daily_by_model": [
+            {"model": model, "daily": [values[day] for day in sorted(values)]}
+            for model, values in sorted(daily_by_model.items(), key=lambda item: item[0])
+        ],
+        "models": [
+            {"model": model, "total_tokens": total}
+            for model, total in sorted(by_model.items(), key=lambda item: (-item[1], item[0]))
+            if total > 0
         ],
     }
 

--- a/routes/usage_routes.py
+++ b/routes/usage_routes.py
@@ -68,8 +68,6 @@ def _parse_message_metrics(meta_data: Any) -> Optional[dict]:
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
-        "usage_source": meta.get("usage_source") or "unknown",
-        "model": meta.get("model") or "",
     }
 
 
@@ -81,8 +79,6 @@ def _empty_daily_buckets(start: date, end: date) -> dict[str, dict]:
             "output_tokens": 0,
             "total_tokens": 0,
             "message_count": 0,
-            "estimated_count": 0,
-            "real_count": 0,
         }
         for day in _date_range(start, end)
     }
@@ -114,15 +110,7 @@ def _aggregate_usage_rows(
         "output_tokens": 0,
         "total_tokens": 0,
         "message_count": 0,
-        "estimated_count": 0,
-        "real_count": 0,
     }
-    by_user: dict[str, dict[str, int]] = defaultdict(lambda: {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_tokens": 0,
-        "message_count": 0,
-    })
     daily_by_user: dict[str, dict[str, dict]] = defaultdict(lambda: _empty_user_daily_buckets(start, end))
 
     for timestamp, meta_data, owner, role in rows:
@@ -135,7 +123,6 @@ def _aggregate_usage_rows(
         bucket = daily[day]
         bucket["message_count"] += 1
         totals["message_count"] += 1
-        by_user[owner_key]["message_count"] += 1
         daily_by_user[owner_key][day]["message_count"] += 1
 
         if role != "assistant":
@@ -155,29 +142,13 @@ def _aggregate_usage_rows(
         user_bucket["output_tokens"] += output_tokens
         user_bucket["total_tokens"] += total_tokens
 
-        source = metrics.get("usage_source")
-        if source == "estimated":
-            bucket["estimated_count"] += 1
-            totals["estimated_count"] += 1
-        elif source == "real":
-            bucket["real_count"] += 1
-            totals["real_count"] += 1
-
         totals["input_tokens"] += input_tokens
         totals["output_tokens"] += output_tokens
         totals["total_tokens"] += total_tokens
 
-        by_user[owner_key]["input_tokens"] += input_tokens
-        by_user[owner_key]["output_tokens"] += output_tokens
-        by_user[owner_key]["total_tokens"] += total_tokens
-
     return {
         "daily": [daily[day] for day in sorted(daily)],
         "totals": totals,
-        "by_user": [
-            {"user": user, **values}
-            for user, values in sorted(by_user.items(), key=lambda item: item[0])
-        ],
         "daily_by_user": [
             {"user": user, "daily": [values[day] for day in sorted(values)]}
             for user, values in sorted(daily_by_user.items(), key=lambda item: item[0])

--- a/routes/usage_routes.py
+++ b/routes/usage_routes.py
@@ -1,0 +1,256 @@
+"""Usage analytics routes."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import date, datetime, time, timedelta
+from typing import Any, Dict, Iterable, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from core.database import ChatMessage as DbChatMessage
+from core.database import Session as DbSession
+from core.database import SessionLocal
+from src.auth_helpers import require_user
+
+
+ALL_USERS = "__all__"
+
+
+def _parse_ymd(value: str, field_name: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except Exception:
+        raise HTTPException(400, f"Invalid {field_name}; expected YYYY-MM-DD")
+
+
+def _date_range(start: date, end: date) -> list[str]:
+    days = (end - start).days
+    return [(start + timedelta(days=i)).isoformat() for i in range(days + 1)]
+
+
+def _local_bounds_to_utc(start: date, end: date, tz_offset_minutes: int) -> tuple[datetime, datetime]:
+    """Convert an inclusive local date range into UTC-naive DB bounds."""
+    offset = timedelta(minutes=tz_offset_minutes)
+    start_local = datetime.combine(start, time.min)
+    end_local_exclusive = datetime.combine(end + timedelta(days=1), time.min)
+    return start_local + offset, end_local_exclusive + offset
+
+
+def _timestamp_to_local_day(ts: datetime, tz_offset_minutes: int) -> str:
+    return (ts - timedelta(minutes=tz_offset_minutes)).date().isoformat()
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return max(int(value or 0), 0)
+    except Exception:
+        return 0
+
+
+def _parse_message_metrics(meta_data: Any) -> Optional[dict]:
+    if not meta_data:
+        return None
+    if isinstance(meta_data, str):
+        try:
+            meta = json.loads(meta_data)
+        except Exception:
+            return None
+    elif isinstance(meta_data, dict):
+        meta = meta_data
+    else:
+        return None
+    input_tokens = _coerce_int(meta.get("input_tokens"))
+    output_tokens = _coerce_int(meta.get("output_tokens"))
+    if not (input_tokens or output_tokens):
+        return None
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "usage_source": meta.get("usage_source") or "unknown",
+        "model": meta.get("model") or "",
+    }
+
+
+def _empty_daily_buckets(start: date, end: date) -> dict[str, dict]:
+    return {
+        day: {
+            "date": day,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "message_count": 0,
+            "estimated_count": 0,
+            "real_count": 0,
+        }
+        for day in _date_range(start, end)
+    }
+
+
+def _aggregate_usage_rows(
+    rows: Iterable[tuple[datetime, Any, Optional[str], str]],
+    *,
+    start: date,
+    end: date,
+    tz_offset_minutes: int,
+) -> dict:
+    daily = _empty_daily_buckets(start, end)
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "message_count": 0,
+        "estimated_count": 0,
+        "real_count": 0,
+    }
+    by_user: dict[str, dict[str, int]] = defaultdict(lambda: {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "message_count": 0,
+    })
+
+    for timestamp, meta_data, owner, role in rows:
+        if not timestamp:
+            continue
+        day = _timestamp_to_local_day(timestamp, tz_offset_minutes)
+        if day not in daily:
+            continue
+        owner_key = owner or "unassigned"
+        bucket = daily[day]
+        bucket["message_count"] += 1
+        totals["message_count"] += 1
+        by_user[owner_key]["message_count"] += 1
+
+        if role != "assistant":
+            continue
+        metrics = _parse_message_metrics(meta_data)
+        if not metrics:
+            continue
+
+        input_tokens = metrics["input_tokens"]
+        output_tokens = metrics["output_tokens"]
+        total_tokens = input_tokens + output_tokens
+        bucket["input_tokens"] += input_tokens
+        bucket["output_tokens"] += output_tokens
+        bucket["total_tokens"] += total_tokens
+
+        source = metrics.get("usage_source")
+        if source == "estimated":
+            bucket["estimated_count"] += 1
+            totals["estimated_count"] += 1
+        elif source == "real":
+            bucket["real_count"] += 1
+            totals["real_count"] += 1
+
+        totals["input_tokens"] += input_tokens
+        totals["output_tokens"] += output_tokens
+        totals["total_tokens"] += total_tokens
+
+        by_user[owner_key]["input_tokens"] += input_tokens
+        by_user[owner_key]["output_tokens"] += output_tokens
+        by_user[owner_key]["total_tokens"] += total_tokens
+
+    return {
+        "daily": [daily[day] for day in sorted(daily)],
+        "totals": totals,
+        "by_user": [
+            {"user": user, **values}
+            for user, values in sorted(by_user.items(), key=lambda item: item[0])
+        ],
+    }
+
+
+def _is_admin(request: Request, user: str) -> bool:
+    auth_mgr = getattr(request.app.state, "auth_manager", None)
+    if not user or not auth_mgr:
+        return False
+    try:
+        return bool(auth_mgr.is_admin(user))
+    except Exception:
+        return False
+
+
+def _user_options(request: Request, include: bool) -> list[dict]:
+    if not include:
+        return []
+    auth_mgr = getattr(request.app.state, "auth_manager", None)
+    if not auth_mgr:
+        return []
+    try:
+        return [
+            {"username": u.get("username"), "is_admin": bool(u.get("is_admin"))}
+            for u in auth_mgr.list_users()
+            if u.get("username")
+        ]
+    except Exception:
+        return []
+
+
+def _resolve_owner_scope(current_user: str, admin: bool, requested_user: Optional[str]) -> tuple[Optional[str], str]:
+    selected_user = (requested_user or "").strip()
+    if current_user:
+        if admin:
+            if selected_user and selected_user != ALL_USERS:
+                return selected_user, selected_user
+            return None, ALL_USERS
+        return current_user, current_user
+    return None, selected_user or ALL_USERS
+
+
+def setup_usage_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/usage", tags=["usage"])
+
+    @router.get("/tokens")
+    async def token_usage(
+        request: Request,
+        start: str = Query(..., description="Start date, YYYY-MM-DD, inclusive"),
+        end: str = Query(..., description="End date, YYYY-MM-DD, inclusive"),
+        user: Optional[str] = Query(None, description="Admin-only username filter"),
+        tz_offset_minutes: int = Query(0, ge=-840, le=840),
+    ) -> Dict[str, Any]:
+        current_user = require_user(request)
+        admin = _is_admin(request, current_user)
+
+        start_date = _parse_ymd(start, "start")
+        end_date = _parse_ymd(end, "end")
+        if end_date < start_date:
+            raise HTTPException(400, "end must be on or after start")
+        if (end_date - start_date).days > 370:
+            raise HTTPException(400, "Date range cannot exceed 371 days")
+
+        owner_scope, selected_user = _resolve_owner_scope(current_user, admin, user)
+
+        start_utc, end_utc = _local_bounds_to_utc(start_date, end_date, tz_offset_minutes)
+
+        db = SessionLocal()
+        try:
+            q = (
+                db.query(DbChatMessage.timestamp, DbChatMessage.meta_data, DbSession.owner, DbChatMessage.role)
+                .join(DbSession, DbChatMessage.session_id == DbSession.id)
+                .filter(DbChatMessage.timestamp >= start_utc)
+                .filter(DbChatMessage.timestamp < end_utc)
+            )
+            if owner_scope is not None:
+                q = q.filter(DbSession.owner == owner_scope)
+            rows = q.all()
+        finally:
+            db.close()
+
+        result = _aggregate_usage_rows(
+            rows,
+            start=start_date,
+            end=end_date,
+            tz_offset_minutes=tz_offset_minutes,
+        )
+        result.update({
+            "start": start_date.isoformat(),
+            "end": end_date.isoformat(),
+            "user": selected_user,
+            "is_admin": admin,
+            "users": _user_options(request, admin),
+        })
+        return result
+
+    return router

--- a/scripts/seed_usage_data.py
+++ b/scripts/seed_usage_data.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Seed local usage analytics data for dashboard demos.
+
+This writes synthetic sessions and chat_messages into data/app.db. Rows created
+by this script use a distinct ID prefix so they can be reset without touching
+real chats or older QA seed data.
+
+Usage:
+    python scripts/seed_usage_data.py
+    python scripts/seed_usage_data.py --reset
+    python scripts/seed_usage_data.py --days 120 --sessions-per-owner 18
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import sqlite3
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DB = REPO_ROOT / "data" / "app.db"
+SEED_PREFIX = "usage-seed-ext"
+SEED_NAME = "usage-seed-ext"
+DEFAULT_OWNERS = ["zapulam", "test", "brother"]
+DEFAULT_MODELS = [
+    "gpt-5.5-extra-high",
+    "claude-opus-4-8-thinking-high",
+    "composer-2.5",
+    "claude-4.6-sonnet-thinking",
+    "gemini-2.5-pro",
+    "deepseek-v3",
+    "composer-2.5-fast",
+]
+ENDPOINT_URL = "https://api.openai.com/v1/chat/completions"
+FOLDER = "Usage QA Seed"
+
+TOPICS = [
+    "usage dashboard validation",
+    "local model routing",
+    "calendar assistant polish",
+    "email triage workflow",
+    "document summarization",
+    "tool-call reliability",
+    "gallery metadata cleanup",
+    "agent memory review",
+    "scheduled task audit",
+    "chat renderer QA",
+]
+
+
+def _csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _dt(value: date, hour: int, minute: int = 0) -> datetime:
+    return datetime.combine(value, time(hour=hour, minute=minute))
+
+
+def _fmt(value: datetime) -> str:
+    return value.strftime("%Y-%m-%d %H:%M:%S.%f")
+
+
+def _session_dates(*, end: date, days: int, count: int, owner_index: int) -> list[date]:
+    """Evenly spread sessions across the date window, with a per-owner offset."""
+    if count <= 1:
+        return [end - timedelta(days=max(days - 1, 0))]
+
+    start = end - timedelta(days=max(days - 1, 0))
+    span = max(days - 1, 0)
+    dates: list[date] = []
+    for index in range(count):
+        day_offset = round(index * span / (count - 1))
+        # Stagger owners by a couple of days while keeping dates in bounds.
+        stagger = (owner_index * 2 + index % 3) % 5
+        seeded_day = min(start + timedelta(days=day_offset + stagger), end)
+        dates.append(seeded_day)
+    return dates
+
+
+def _turn_count(owner_index: int, session_index: int) -> int:
+    return 4 + ((owner_index + session_index) % 5)
+
+
+def _token_counts(owner_index: int, session_index: int, turn_index: int) -> tuple[int, int]:
+    base = 1200 + owner_index * 140 + session_index * 35
+    input_tokens = base + turn_index * 115 + (session_index % 4) * 45
+    output_tokens = 620 + owner_index * 80 + turn_index * 75 + (session_index % 5) * 30
+    return input_tokens, output_tokens
+
+
+def _model_for(models: list[str], owner_index: int, session_index: int) -> str:
+    # Owner offset makes every model appear across early/middle/late windows.
+    return models[(session_index + owner_index * 3) % len(models)]
+
+
+def _session_hour(owner_index: int, session_index: int) -> int:
+    return 9 + ((owner_index * 2 + session_index) % 8)
+
+
+def build_dataset(
+    *,
+    days: int,
+    end: date,
+    owners: list[str],
+    models: list[str],
+    sessions_per_owner: int,
+) -> tuple[list[dict], list[dict]]:
+    sessions: list[dict] = []
+    messages: list[dict] = []
+    rng = random.Random(522)
+
+    for owner_index, owner in enumerate(owners):
+        for session_index, session_day in enumerate(
+            _session_dates(end=end, days=days, count=sessions_per_owner, owner_index=owner_index)
+        ):
+            model = _model_for(models, owner_index, session_index)
+            topic = TOPICS[(session_index + owner_index) % len(TOPICS)]
+            session_id = f"{SEED_PREFIX}-{owner}-{session_index + 1:02d}"
+            started_at = _dt(session_day, _session_hour(owner_index, session_index), (owner_index * 7) % 45)
+            turns = _turn_count(owner_index, session_index)
+            total_input = 0
+            total_output = 0
+            last_message_at = started_at
+
+            for turn_index in range(turns):
+                user_ts = started_at + timedelta(minutes=turn_index * 11)
+                input_tokens, output_tokens = _token_counts(owner_index, session_index, turn_index)
+                assistant_ts = user_ts + timedelta(minutes=3 + (turn_index % 3))
+                user_id = f"{session_id}-t{turn_index + 1:02d}-user"
+                assistant_id = f"{session_id}-t{turn_index + 1:02d}-assistant"
+
+                messages.append(
+                    {
+                        "id": user_id,
+                        "session_id": session_id,
+                        "role": "user",
+                        "content": (
+                            f"Synthetic prompt {turn_index + 1} for {owner} about {topic} "
+                            f"on {session_day.isoformat()}."
+                        ),
+                        "metadata": None,
+                        "timestamp": _fmt(user_ts),
+                    }
+                )
+                messages.append(
+                    {
+                        "id": assistant_id,
+                        "session_id": session_id,
+                        "role": "assistant",
+                        "content": (
+                            "Synthetic assistant response for Usage dashboard validation. "
+                            f"Model: {model}. Topic: {topic}."
+                        ),
+                        "metadata": json.dumps(
+                            {
+                                "input_tokens": input_tokens,
+                                "output_tokens": output_tokens,
+                                "total_tokens": input_tokens + output_tokens,
+                                "usage_source": "real",
+                                "model": model,
+                                "seed": SEED_NAME,
+                            },
+                            separators=(",", ":"),
+                        ),
+                        "timestamp": _fmt(assistant_ts),
+                    }
+                )
+                total_input += input_tokens
+                total_output += output_tokens
+                last_message_at = assistant_ts
+
+            last_accessed = last_message_at + timedelta(minutes=rng.randint(5, 90))
+            sessions.append(
+                {
+                    "id": session_id,
+                    "name": f"Usage History {session_index + 1} - {owner}",
+                    "endpoint_url": ENDPOINT_URL,
+                    "model": model,
+                    "owner": owner,
+                    "rag": 0,
+                    "archived": 0,
+                    "folder": FOLDER,
+                    "headers": "{}",
+                    "last_accessed": _fmt(last_accessed),
+                    "last_message_at": _fmt(last_message_at),
+                    "is_important": 0,
+                    "message_count": turns * 2,
+                    "total_input_tokens": total_input,
+                    "total_output_tokens": total_output,
+                    "mode": "chat",
+                    "crew_member_id": None,
+                    "created_at": _fmt(started_at),
+                    "updated_at": _fmt(last_accessed),
+                }
+            )
+
+    return sessions, messages
+
+
+def reset_seed(con: sqlite3.Connection) -> tuple[int, int]:
+    session_ids = [row[0] for row in con.execute("SELECT id FROM sessions WHERE id LIKE ?", (f"{SEED_PREFIX}-%",))]
+    if not session_ids:
+        return 0, 0
+
+    placeholders = ",".join("?" for _ in session_ids)
+    message_count = con.execute(
+        f"SELECT COUNT(*) FROM chat_messages WHERE session_id IN ({placeholders})",
+        session_ids,
+    ).fetchone()[0]
+    con.execute(f"DELETE FROM chat_messages WHERE session_id IN ({placeholders})", session_ids)
+    con.execute(f"DELETE FROM sessions WHERE id IN ({placeholders})", session_ids)
+    return len(session_ids), int(message_count or 0)
+
+
+def insert_dataset(con: sqlite3.Connection, sessions: list[dict], messages: list[dict]) -> None:
+    con.executemany(
+        """
+        INSERT OR REPLACE INTO sessions (
+            id, name, endpoint_url, model, owner, rag, archived, folder, headers,
+            last_accessed, last_message_at, is_important, message_count,
+            total_input_tokens, total_output_tokens, mode, crew_member_id,
+            created_at, updated_at
+        ) VALUES (
+            :id, :name, :endpoint_url, :model, :owner, :rag, :archived, :folder, :headers,
+            :last_accessed, :last_message_at, :is_important, :message_count,
+            :total_input_tokens, :total_output_tokens, :mode, :crew_member_id,
+            :created_at, :updated_at
+        )
+        """,
+        sessions,
+    )
+    con.executemany(
+        """
+        INSERT OR REPLACE INTO chat_messages (
+            id, session_id, role, content, metadata, timestamp
+        ) VALUES (
+            :id, :session_id, :role, :content, :metadata, :timestamp
+        )
+        """,
+        messages,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Seed synthetic usage history into data/app.db")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="SQLite database path")
+    parser.add_argument("--days", type=int, default=90, help="Number of days to cover, ending at --end")
+    parser.add_argument("--end", type=date.fromisoformat, default=date.today(), help="End date, YYYY-MM-DD")
+    parser.add_argument("--owners", type=_csv, default=DEFAULT_OWNERS, help="Comma-separated owners")
+    parser.add_argument("--models", type=_csv, default=DEFAULT_MODELS, help="Comma-separated model names")
+    parser.add_argument(
+        "--sessions-per-owner",
+        type=int,
+        default=None,
+        help="Sessions per owner; default is roughly one session per week",
+    )
+    parser.add_argument("--reset", action="store_true", help="Delete this script's prior seed rows first")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.days < 1:
+        raise SystemExit("--days must be at least 1")
+    if not args.owners:
+        raise SystemExit("--owners must include at least one owner")
+    if not args.models:
+        raise SystemExit("--models must include at least one model")
+
+    sessions_per_owner = args.sessions_per_owner or math.ceil(args.days / 7)
+    if sessions_per_owner < 1:
+        raise SystemExit("--sessions-per-owner must be at least 1")
+    if not args.db.exists():
+        raise SystemExit(f"database not found: {args.db}")
+
+    sessions, messages = build_dataset(
+        days=args.days,
+        end=args.end,
+        owners=args.owners,
+        models=args.models,
+        sessions_per_owner=sessions_per_owner,
+    )
+
+    con = sqlite3.connect(str(args.db))
+    try:
+        removed_sessions = 0
+        removed_messages = 0
+        with con:
+            if args.reset:
+                removed_sessions, removed_messages = reset_seed(con)
+            insert_dataset(con, sessions, messages)
+        if args.reset:
+            print(f"removed {removed_sessions} session(s), {removed_messages} message(s) for prefix {SEED_PREFIX}-")
+        print(
+            f"seeded {len(sessions)} session(s), {len(messages)} message(s) "
+            f"from {(args.end - timedelta(days=args.days - 1)).isoformat()} to {args.end.isoformat()} "
+            f"using {len(args.models)} model(s)"
+        )
+        return 0
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/static/app.js
+++ b/static/app.js
@@ -23,6 +23,7 @@ import galleryModule from './js/gallery.js';
 import tasksModule from './js/tasks.js';
 import calendarModule from './js/calendar.js';
 import notesModule from './js/notes.js';
+import usageModule from './js/usage.js';
 import adminModule from './js/admin.js';
 import settingsModule from './js/settings.js';
 // Eagerly bind unified minimize/restore behavior across all tool modals.
@@ -1046,6 +1047,17 @@ function initializeEventListeners() {
     toolThemeBtn.addEventListener('click', () => {
       const tm = document.getElementById('theme-modal');
       if (tm) tm.classList.remove('hidden');
+    });
+  }
+
+  const toolUsageBtn = el('tool-usage-btn');
+  if (toolUsageBtn) {
+    toolUsageBtn.addEventListener('click', async () => {
+      if (!usageModule) return;
+      const Modals = await import('./js/modalManager.js');
+      if (!Modals.toggle('usage-modal')) {
+        usageModule.openUsage();
+      }
     });
   }
 
@@ -2341,6 +2353,7 @@ function initializeEventListeners() {
     'tool-notes':          '#tool-notes-btn',
     'tool-tasks':          '#tool-tasks-btn',
     'tool-theme':          '#tool-theme-btn',
+    'tool-usage':          '#tool-usage-btn',
     'user-bar':            '#user-bar-profile',
     'sidebar-settings-btn':'#user-bar-settings',
     'chat-meta':           '.chat-meta-overlay',

--- a/static/css/usage.css
+++ b/static/css/usage.css
@@ -19,7 +19,6 @@
   isolation:isolate;
   display:flex;
   flex-direction:column;
-  container:usage-modal / inline-size;
 }
 
 .usage-modal-content::after {
@@ -468,8 +467,6 @@
   opacity:0.82;
 }
 
-.usage-bar:hover .usage-bar-input,
-.usage-bar:hover .usage-bar-output,
 .usage-bar.active .usage-bar-input,
 .usage-bar.active .usage-bar-output {
   opacity:1;

--- a/static/css/usage.css
+++ b/static/css/usage.css
@@ -1,0 +1,488 @@
+/* Usage dashboard */
+.usage-modal-content {
+  width:min(960px, 94vw);
+  max-height:88vh;
+  background:var(--bg);
+  overflow:hidden;
+}
+
+.usage-body {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  overflow:hidden;
+  min-height:420px;
+  padding:0;
+}
+
+.usage-modal-content button:not(:disabled),
+.usage-modal-content select:not(:disabled) {
+  cursor:pointer;
+}
+
+.usage-toolbar {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  align-items:end;
+  justify-content:space-between;
+  flex-shrink:0;
+}
+
+.usage-filter-left,
+.usage-filter-right {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  align-items:end;
+}
+
+.usage-filter-left {
+  flex:1 1 auto;
+}
+
+.usage-filter-right {
+  flex:0 1 auto;
+  justify-content:flex-end;
+  margin-left:auto;
+}
+
+.usage-filter-left label,
+.usage-filter-right label {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:11px;
+  color:color-mix(in srgb, var(--fg) 62%, transparent);
+}
+
+.usage-select,
+#usage-user {
+  background:color-mix(in srgb, var(--fg) 5%, var(--bg));
+  color:var(--fg);
+  border:1px solid var(--border);
+  border-radius:5px;
+  padding:0 8px;
+  height:24px;
+  min-height:24px;
+  line-height:22px;
+  font:inherit;
+  font-size:11px;
+  box-sizing:border-box;
+  vertical-align:middle;
+  cursor:pointer;
+}
+
+#usage-preset option,
+#usage-preset option:hover {
+  cursor:pointer;
+}
+
+.usage-select:focus,
+#usage-user:focus,
+.usage-range-trigger:focus-visible {
+  outline:none;
+  border-color:var(--accent, var(--red));
+}
+
+.usage-range-wrap {
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  min-width:min(280px, 100%);
+}
+
+.usage-range-label {
+  font-size:11px;
+  color:color-mix(in srgb, var(--fg) 62%, transparent);
+}
+
+.usage-range-trigger {
+  background:color-mix(in srgb, var(--fg) 5%, var(--bg));
+  color:var(--fg);
+  border:1px solid var(--border);
+  border-radius:5px;
+  padding:0 8px;
+  height:24px;
+  line-height:22px;
+  min-width:250px;
+  font:inherit;
+  font-size:11px;
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  box-sizing:border-box;
+  margin-top:0;
+}
+
+.usage-range-trigger:hover {
+  background:color-mix(in srgb, var(--fg) 9%, var(--bg));
+}
+
+.usage-range-trigger svg {
+  color:var(--accent, var(--red));
+  flex-shrink:0;
+  opacity:0.85;
+}
+
+.usage-refresh {
+  background:color-mix(in srgb, var(--fg) 6%, transparent);
+  border:1px solid var(--border);
+  color:var(--fg);
+  border-radius:5px;
+  padding:0 8px;
+  width:auto;
+  height:24px;
+  line-height:22px;
+  cursor:pointer;
+  font-family:inherit;
+  font-size:11px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  box-sizing:border-box;
+  margin-top:0;
+  vertical-align:middle;
+}
+
+.usage-refresh:hover {
+  background:color-mix(in srgb, var(--fg) 12%, transparent);
+}
+
+.usage-refresh svg {
+  flex-shrink:0;
+}
+
+.usage-range-popover {
+  position:absolute;
+  top:calc(100% + 6px);
+  left:0;
+  z-index:20;
+  width:min(620px, calc(94vw - 32px));
+  background:var(--bg);
+  border:1px solid var(--border);
+  border-radius:10px;
+  box-shadow:0 14px 42px rgba(0,0,0,0.45);
+  padding:10px;
+}
+
+.usage-range-popover[hidden] {
+  display:none;
+}
+
+.usage-range-head {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  margin-bottom:8px;
+}
+
+.usage-range-head button,
+.usage-range-actions button {
+  background:color-mix(in srgb, var(--fg) 8%, transparent);
+  border:1px solid var(--border);
+  color:var(--fg);
+  border-radius:5px;
+  height:24px;
+  line-height:22px;
+  padding:0 8px;
+  font:inherit;
+  font-size:11px;
+  cursor:pointer;
+  margin-top:0;
+  box-sizing:border-box;
+  vertical-align:middle;
+}
+
+.usage-range-head button:hover,
+.usage-range-actions button:hover {
+  background:color-mix(in srgb, var(--fg) 14%, transparent);
+}
+
+.usage-range-title {
+  font-size:12px;
+  font-weight:600;
+  color:var(--fg);
+}
+
+.usage-range-months {
+  display:grid;
+  grid-template-columns:repeat(2, minmax(0, 1fr));
+  gap:12px;
+}
+
+.usage-range-month-title {
+  font-size:12px;
+  font-weight:600;
+  text-align:center;
+  margin:2px 0 8px;
+}
+
+.usage-range-weekdays,
+.usage-range-grid {
+  display:grid;
+  grid-template-columns:repeat(7, minmax(0, 1fr));
+}
+
+.usage-range-weekdays span {
+  text-align:center;
+  font-size:10px;
+  color:color-mix(in srgb, var(--fg) 55%, transparent);
+  padding-bottom:4px;
+}
+
+.usage-range-day {
+  height:24px;
+  line-height:22px;
+  border:none;
+  background:transparent;
+  color:var(--fg);
+  font:inherit;
+  font-size:11px;
+  cursor:pointer;
+  border-radius:0;
+  margin:0;
+  position:relative;
+}
+
+.usage-range-day:hover {
+  background:color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.usage-range-day.muted {
+  color:color-mix(in srgb, var(--fg) 32%, transparent);
+}
+
+.usage-range-day.in-range {
+  background:color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
+}
+
+.usage-range-day.selected {
+  background:var(--accent, var(--red));
+  color:var(--bg);
+  border-radius:999px;
+  font-weight:600;
+}
+
+.usage-range-actions {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  margin-top:10px;
+}
+
+.usage-range-hint {
+  font-size:11px;
+  color:color-mix(in srgb, var(--fg) 55%, transparent);
+}
+
+.usage-range-actions .usage-range-apply {
+  background:var(--accent, var(--red));
+  color:var(--bg);
+  border-color:var(--accent, var(--red));
+}
+
+.usage-summary {
+  display:grid;
+  grid-template-columns:repeat(4, minmax(0, 1fr));
+  gap:8px;
+  flex-shrink:0;
+}
+
+.usage-stat {
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:10px;
+  padding:10px;
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+  min-width:0;
+}
+
+.usage-stat span,
+.usage-stat small {
+  color:var(--color-muted, var(--fg));
+  opacity:0.72;
+  font-size:11px;
+}
+
+.usage-stat strong {
+  font-size:18px;
+  color:var(--fg);
+  line-height:1.1;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+.usage-chart-wrap {
+  position:relative;
+  flex:1;
+  min-height:280px;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:12px;
+  overflow:hidden;
+}
+
+.usage-chart-scroll {
+  position:relative;
+  height:100%;
+  min-height:280px;
+  overflow-x:auto;
+  overflow-y:hidden;
+  padding:8px;
+  box-sizing:border-box;
+}
+
+.usage-chart {
+  display:block;
+  width:100%;
+  min-width:720px;
+  height:100%;
+  min-height:280px;
+}
+
+.usage-grid-line {
+  stroke:var(--border);
+  stroke-width:1;
+  opacity:0.75;
+}
+
+.usage-axis-line {
+  stroke:var(--fg);
+  stroke-width:1;
+  opacity:0.3;
+}
+
+.usage-axis-label {
+  fill:var(--color-muted, var(--fg));
+  opacity:0.75;
+  font-size:11px;
+}
+
+.usage-x-label {
+  font-size:10px;
+}
+
+.usage-bar-input {
+  fill:var(--accent, #7aa2f7);
+  opacity:0.9;
+}
+
+.usage-bar-output {
+  fill:var(--red, #ff5555);
+  opacity:0.82;
+}
+
+.usage-bar:hover .usage-bar-input,
+.usage-bar:hover .usage-bar-output {
+  opacity:1;
+  filter:brightness(1.15);
+}
+
+.usage-tooltip {
+  position:absolute;
+  z-index:5;
+  min-width:150px;
+  pointer-events:none;
+  background:var(--bg);
+  border:1px solid var(--border);
+  border-radius:8px;
+  box-shadow:0 8px 24px rgba(0,0,0,0.35);
+  padding:8px;
+  font-size:12px;
+  display:flex;
+  flex-direction:column;
+  gap:3px;
+}
+
+.usage-tooltip strong {
+  color:var(--red);
+  margin-bottom:2px;
+}
+
+.usage-legend {
+  display:flex;
+  gap:16px;
+  align-items:center;
+  padding:8px 10px;
+  font-size:12px;
+  color:var(--color-muted, var(--fg));
+  border-top:1px solid var(--border);
+}
+
+.usage-legend span {
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+
+.usage-legend i {
+  width:10px;
+  height:10px;
+  border-radius:2px;
+  display:inline-block;
+}
+
+.usage-legend-input { background:var(--accent, #7aa2f7); }
+.usage-legend-output { background:var(--red, #ff5555); }
+
+.usage-loading,
+.usage-empty {
+  min-height:280px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:var(--color-muted, var(--fg));
+  opacity:0.75;
+  text-align:center;
+  padding:20px;
+}
+
+.usage-error {
+  color:var(--red);
+  opacity:1;
+}
+
+@media (max-width: 768px) {
+  .usage-modal-content {
+    width:100vw;
+    max-height:100vh;
+    height:100vh;
+    border-radius:0;
+  }
+
+  .usage-summary {
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+  }
+
+  .usage-body {
+    min-height:0;
+  }
+
+  .usage-range-trigger {
+    width:100%;
+    min-width:0;
+  }
+
+  .usage-range-popover {
+    position:fixed;
+    left:12px;
+    right:12px;
+    top:82px;
+    width:auto;
+    max-height:calc(100vh - 110px);
+    overflow:auto;
+  }
+
+  .usage-range-months {
+    grid-template-columns:1fr;
+  }
+}

--- a/static/css/usage.css
+++ b/static/css/usage.css
@@ -1,9 +1,60 @@
 /* Usage dashboard */
+@property --usage-orbit-angle {
+  syntax:'<angle>';
+  inherits:false;
+  initial-value:0deg;
+}
+
+@keyframes usage-border-orbit {
+  to { --usage-orbit-angle:360deg; }
+}
+
 .usage-modal-content {
   width:min(960px, 94vw);
+  height:min(760px, 88vh);
   max-height:88vh;
   background:var(--bg);
   overflow:hidden;
+  position:relative;
+  isolation:isolate;
+  display:flex;
+  flex-direction:column;
+  container:usage-modal / inline-size;
+}
+
+.usage-modal-content::after {
+  content:'';
+  position:absolute;
+  inset:0;
+  z-index:1;
+  pointer-events:none;
+  border-radius:inherit;
+  padding:2px;
+  background:conic-gradient(
+    from var(--usage-orbit-angle, 0deg),
+    transparent 0deg,
+    transparent 300deg,
+    color-mix(in srgb, var(--accent, var(--red)) 70%, transparent) 335deg,
+    var(--accent, var(--red)) 350deg,
+    color-mix(in srgb, var(--accent, var(--red)) 70%, transparent) 358deg,
+    transparent 360deg
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite:xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite:exclude;
+  animation:usage-border-orbit 24s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .usage-modal-content::after {
+    animation:none;
+    opacity:0.4;
+  }
 }
 
 .usage-body {
@@ -11,7 +62,8 @@
   flex-direction:column;
   gap:12px;
   overflow:hidden;
-  min-height:420px;
+  flex:1 1 auto;
+  min-height:0;
   padding:0;
 }
 
@@ -22,27 +74,30 @@
 
 .usage-toolbar {
   display:flex;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
   gap:6px;
   align-items:end;
   justify-content:space-between;
   flex-shrink:0;
+  min-width:0;
 }
 
 .usage-filter-left,
 .usage-filter-right {
   display:flex;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
   gap:6px;
   align-items:end;
+  min-width:0;
 }
 
 .usage-filter-left {
   flex:1 1 auto;
+  min-width:0;
 }
 
 .usage-filter-right {
-  flex:0 1 auto;
+  flex:0 0 auto;
   justify-content:flex-end;
   margin-left:auto;
 }
@@ -56,8 +111,7 @@
   color:color-mix(in srgb, var(--fg) 62%, transparent);
 }
 
-.usage-select,
-#usage-user {
+.usage-select {
   background:color-mix(in srgb, var(--fg) 5%, var(--bg));
   color:var(--fg);
   border:1px solid var(--border);
@@ -79,7 +133,6 @@
 }
 
 .usage-select:focus,
-#usage-user:focus,
 .usage-range-trigger:focus-visible {
   outline:none;
   border-color:var(--accent, var(--red));
@@ -90,7 +143,9 @@
   display:flex;
   flex-direction:column;
   gap:4px;
-  min-width:min(280px, 100%);
+  flex:1 1 auto;
+  min-width:0;
+  max-width:100%;
 }
 
 .usage-range-label {
@@ -106,7 +161,8 @@
   padding:0 8px;
   height:24px;
   line-height:22px;
-  min-width:250px;
+  width:100%;
+  min-width:0;
   font:inherit;
   font-size:11px;
   cursor:pointer;
@@ -116,6 +172,14 @@
   gap:10px;
   box-sizing:border-box;
   margin-top:0;
+  max-width:100%;
+}
+
+#usage-range-text {
+  min-width:0;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
 }
 
 .usage-range-trigger:hover {
@@ -157,16 +221,19 @@
 }
 
 .usage-range-popover {
-  position:absolute;
-  top:calc(100% + 6px);
+  position:fixed;
+  top:0;
   left:0;
-  z-index:20;
-  width:min(620px, calc(94vw - 32px));
+  z-index:2147483000;
+  width:min(620px, calc(100vw - 16px));
   background:var(--bg);
+  color:var(--fg);
   border:1px solid var(--border);
   border-radius:10px;
   box-shadow:0 14px 42px rgba(0,0,0,0.45);
   padding:10px;
+  font-family:'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  letter-spacing:-0.015em;
 }
 
 .usage-range-popover[hidden] {
@@ -257,6 +324,13 @@
   color:color-mix(in srgb, var(--fg) 32%, transparent);
 }
 
+.usage-range-day.future,
+.usage-range-day:disabled {
+  color:color-mix(in srgb, var(--fg) 20%, transparent);
+  cursor:not-allowed;
+  pointer-events:none;
+}
+
 .usage-range-day.in-range {
   background:color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
 }
@@ -323,52 +397,65 @@
 
 .usage-chart-wrap {
   position:relative;
-  flex:1;
-  min-height:280px;
+  flex:1 1 auto;
+  min-height:0;
   background:var(--panel);
   border:1px solid var(--border);
   border-radius:12px;
   overflow:hidden;
+  display:flex;
+  flex-direction:column;
 }
 
 .usage-chart-scroll {
   position:relative;
-  height:100%;
-  min-height:280px;
-  overflow-x:auto;
+  flex:1 1 0;
+  min-height:0;
+  overflow-x:hidden;
   overflow-y:hidden;
-  padding:8px;
+  padding:8px 8px 12px;
   box-sizing:border-box;
 }
 
 .usage-chart {
   display:block;
   width:100%;
-  min-width:720px;
+  min-width:0;
   height:100%;
-  min-height:280px;
+  min-height:0;
 }
 
 .usage-grid-line {
   stroke:var(--border);
   stroke-width:1;
-  opacity:0.75;
+  opacity:0.65;
 }
 
 .usage-axis-line {
   stroke:var(--fg);
-  stroke-width:1;
-  opacity:0.3;
+  stroke-width:1.5;
+  opacity:0.55;
 }
 
 .usage-axis-label {
-  fill:var(--color-muted, var(--fg));
-  opacity:0.75;
+  fill:var(--fg);
+  opacity:0.86;
   font-size:11px;
 }
 
 .usage-x-label {
-  font-size:10px;
+  font-size:11px;
+  font-weight:600;
+}
+
+.usage-hover-highlight {
+  fill:color-mix(in srgb, var(--fg) 7%, transparent);
+  opacity:0;
+  pointer-events:none;
+}
+
+.usage-hover-highlight.active {
+  opacity:1;
 }
 
 .usage-bar-input {
@@ -382,15 +469,32 @@
 }
 
 .usage-bar:hover .usage-bar-input,
-.usage-bar:hover .usage-bar-output {
+.usage-bar:hover .usage-bar-output,
+.usage-bar.active .usage-bar-input,
+.usage-bar.active .usage-bar-output {
   opacity:1;
   filter:brightness(1.15);
 }
 
+.usage-hover-target {
+  fill:transparent;
+  cursor:pointer;
+}
+
+.usage-ma-line {
+  fill:none;
+  stroke-width:2.0;
+  stroke-linecap:round;
+  stroke-linejoin:round;
+  opacity:0.75;
+  pointer-events:none;
+}
+
 .usage-tooltip {
   position:absolute;
-  z-index:5;
+  z-index:30;
   min-width:150px;
+  max-width:220px;
   pointer-events:none;
   background:var(--bg);
   border:1px solid var(--border);
@@ -403,6 +507,10 @@
   gap:3px;
 }
 
+.usage-tooltip[hidden] {
+  display:none;
+}
+
 .usage-tooltip strong {
   color:var(--red);
   margin-bottom:2px;
@@ -410,21 +518,46 @@
 
 .usage-legend {
   display:flex;
-  gap:16px;
+  flex-wrap:wrap;
+  gap:8px;
   align-items:center;
-  padding:8px 10px;
+  flex-shrink:0;
+  min-height:42px;
+  padding:9px 10px;
   font-size:12px;
   color:var(--color-muted, var(--fg));
   border-top:1px solid var(--border);
+  background:var(--panel);
 }
 
-.usage-legend span {
+.usage-legend-toggle {
+  background:transparent;
+  border:1px solid transparent;
+  border-radius:999px;
+  color:var(--color-muted, var(--fg));
+  cursor:pointer;
   display:inline-flex;
   align-items:center;
   gap:6px;
+  font:inherit;
+  font-size:12px;
+  padding:2px 8px;
+  opacity:0.48;
 }
 
-.usage-legend i {
+.usage-legend-toggle:hover,
+.usage-legend-toggle.active {
+  background:color-mix(in srgb, var(--fg) 6%, transparent);
+  border-color:color-mix(in srgb, var(--fg) 12%, transparent);
+  color:var(--fg);
+  opacity:1;
+}
+
+.usage-legend-toggle:not(.active) {
+  text-decoration:line-through;
+}
+
+.usage-legend-toggle i {
   width:10px;
   height:10px;
   border-radius:2px;
@@ -433,6 +566,12 @@
 
 .usage-legend-input { background:var(--accent, #7aa2f7); }
 .usage-legend-output { background:var(--red, #ff5555); }
+.usage-legend-average {
+  background:#f6c177;
+  height:2px;
+  border-radius:999px;
+}
+
 
 .usage-loading,
 .usage-empty {

--- a/static/css/usage.css
+++ b/static/css/usage.css
@@ -66,6 +66,52 @@
   padding:0;
 }
 
+.usage-tabs {
+  display:flex;
+  gap:0;
+  border-bottom:1px solid var(--border);
+  margin:-4px -4px 0;
+  padding:0 4px;
+  flex-shrink:0;
+}
+
+.usage-tab {
+  appearance:none;
+  background:transparent;
+  border:none;
+  border-bottom:2px solid transparent;
+  color:var(--fg);
+  cursor:pointer;
+  font:inherit;
+  font-size:12px;
+  opacity:0.5;
+  padding:8px 14px;
+  transition:opacity 0.15s, border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.usage-tab:hover {
+  opacity:0.8;
+  background:color-mix(in srgb, var(--fg) 5%, transparent);
+}
+
+.usage-tab.active {
+  opacity:1;
+  color:var(--red);
+  border-bottom-color:var(--red);
+}
+
+.usage-tab-panel {
+  display:flex;
+  flex:1 1 auto;
+  flex-direction:column;
+  min-height:0;
+  min-width:0;
+}
+
+.usage-tab-panel.hidden {
+  display:none;
+}
+
 .usage-modal-content button:not(:disabled),
 .usage-modal-content select:not(:disabled) {
   cursor:pointer;
@@ -132,7 +178,8 @@
 }
 
 .usage-select:focus,
-.usage-range-trigger:focus-visible {
+.usage-range-trigger:focus-visible,
+.usage-model-trigger:focus-visible {
   outline:none;
   border-color:var(--accent, var(--red));
 }
@@ -142,9 +189,18 @@
   display:flex;
   flex-direction:column;
   gap:4px;
-  flex:1 1 auto;
+  flex:1 1 100px;
   min-width:0;
   max-width:100%;
+  container-type:inline-size;
+}
+
+.usage-model-wrap {
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  flex:0 0 auto;
+  min-width:0;
 }
 
 .usage-range-label {
@@ -172,6 +228,49 @@
   box-sizing:border-box;
   margin-top:0;
   max-width:100%;
+}
+
+.usage-model-trigger {
+  background:color-mix(in srgb, var(--fg) 5%, var(--bg));
+  color:var(--fg);
+  border:1px solid var(--border);
+  border-radius:5px;
+  padding:0 8px;
+  width:132px;
+  min-width:132px;
+  height:24px;
+  line-height:22px;
+  font:inherit;
+  font-size:11px;
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  box-sizing:border-box;
+  margin-top:0;
+}
+
+.usage-model-trigger:hover {
+  background:color-mix(in srgb, var(--fg) 9%, var(--bg));
+}
+
+.usage-model-trigger svg {
+  color:var(--accent, var(--red));
+  flex-shrink:0;
+  opacity:0.85;
+}
+
+.usage-model-trigger:disabled {
+  opacity:0.55;
+  cursor:not-allowed;
+}
+
+#usage-model-text {
+  min-width:0;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
 }
 
 #usage-range-text {
@@ -219,6 +318,14 @@
   flex-shrink:0;
 }
 
+#usage-user-wrap {
+  min-width:132px;
+}
+
+#usage-user {
+  width:132px;
+}
+
 .usage-range-popover {
   position:fixed;
   top:0;
@@ -237,6 +344,95 @@
 
 .usage-range-popover[hidden] {
   display:none;
+}
+
+.usage-model-popover {
+  position:fixed;
+  top:0;
+  left:0;
+  z-index:2147483000;
+  width:min(360px, calc(100vw - 16px));
+  max-height:min(420px, calc(100vh - 24px));
+  overflow:auto;
+  background:var(--bg);
+  color:var(--fg);
+  border:1px solid var(--border);
+  border-radius:10px;
+  box-shadow:0 14px 42px rgba(0,0,0,0.45);
+  padding:10px;
+  font-family:'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  letter-spacing:-0.015em;
+}
+
+.usage-model-popover[hidden] {
+  display:none;
+}
+
+.usage-model-list {
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+}
+
+.usage-model-option {
+  display:flex;
+  align-items:center;
+  gap:7px;
+  min-height:24px;
+  padding:3px 6px;
+  border:1px solid transparent;
+  border-radius:6px;
+  background:transparent;
+  font:inherit;
+  font-size:11px;
+  color:var(--fg);
+  cursor:pointer;
+  box-sizing:border-box;
+}
+
+.usage-model-option:hover {
+  background:color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.usage-model-option input[type="checkbox"] {
+  width:13px;
+  height:13px;
+  margin:0;
+  flex:0 0 auto;
+  cursor:pointer;
+  accent-color:var(--accent, var(--red));
+}
+
+.usage-model-option span:not(.provider-logo) {
+  min-width:0;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  flex:1 1 auto;
+}
+
+.usage-model-option small {
+  color:color-mix(in srgb, var(--fg) 48%, transparent);
+  font-size:10px;
+  flex:0 0 auto;
+}
+
+.usage-model-all {
+  border-bottom:1px solid var(--border);
+  border-radius:6px 6px 0 0;
+  margin-bottom:6px;
+  padding-bottom:7px;
+}
+
+.usage-provider-logo {
+  flex:0 0 auto;
+  opacity:0.65;
+}
+
+.usage-empty-models {
+  color:color-mix(in srgb, var(--fg) 55%, transparent);
+  font-size:12px;
+  padding:8px 6px;
 }
 
 .usage-range-head {
@@ -424,6 +620,24 @@
   min-height:0;
 }
 
+.usage-model-chart-scroll {
+  position:relative;
+  flex:1 1 0;
+  height:100%;
+  min-height:0;
+  overflow-x:hidden;
+  overflow-y:auto;
+  padding:6px 8px 8px;
+  box-sizing:border-box;
+}
+
+.usage-model-chart {
+  display:block;
+  width:100%;
+  min-width:0;
+  min-height:100%;
+}
+
 .usage-grid-line {
   stroke:var(--border);
   stroke-width:1;
@@ -473,9 +687,96 @@
   filter:brightness(1.15);
 }
 
+.usage-model-segment-input {
+  opacity:0.95;
+}
+
+.usage-model-segment-output {
+  opacity:0.55;
+}
+
+.usage-bar.active .usage-model-segment {
+  opacity:1;
+  filter:brightness(1.12);
+}
+
 .usage-hover-target {
   fill:transparent;
   cursor:pointer;
+}
+
+.usage-model-row-highlight {
+  fill:color-mix(in srgb, var(--fg) 7%, transparent);
+  opacity:0;
+  pointer-events:none;
+}
+
+.usage-model-row-highlight.active {
+  opacity:1;
+}
+
+.usage-model-horizontal-segment {
+  transition:opacity 0.12s, filter 0.12s;
+}
+
+.usage-model-horizontal-bar.active .usage-model-horizontal-segment {
+  opacity:1;
+  filter:brightness(1.15);
+}
+
+.usage-model-hover-target {
+  fill:transparent;
+  cursor:pointer;
+}
+
+.usage-model-axis-label {
+  align-items:center;
+  color:var(--fg);
+  display:flex;
+  font-size:11px;
+  font-weight:600;
+  gap:6px;
+  height:24px;
+  line-height:1.2;
+  min-width:0;
+  overflow:hidden;
+  pointer-events:none;
+  white-space:nowrap;
+}
+
+.usage-model-axis-label.compact {
+  text-shadow:0 1px 2px var(--bg), 0 0 6px var(--bg);
+}
+
+.usage-model-axis-label span {
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+.usage-model-axis-label .usage-provider-logo {
+  width:12px !important;
+  height:12px !important;
+  opacity:0.85;
+}
+
+.usage-model-axis-label .usage-provider-logo svg {
+  width:12px;
+  height:12px;
+}
+
+.usage-model-total-label {
+  fill:var(--fg);
+  font-weight:600;
+  opacity:0.9;
+  paint-order:stroke;
+  stroke:var(--bg);
+  stroke-width:3px;
+}
+
+.usage-model-x-label {
+  font-size:10px;
+  opacity:0.72;
 }
 
 .usage-ma-line {
@@ -511,6 +812,18 @@
 .usage-tooltip strong {
   color:var(--red);
   margin-bottom:2px;
+}
+
+.usage-model-top-legend {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px 10px;
+  align-items:center;
+  flex-shrink:0;
+  min-height:30px;
+  padding:7px 10px;
+  border-bottom:1px solid var(--border);
+  background:var(--panel);
 }
 
 .usage-legend {
@@ -554,11 +867,19 @@
   text-decoration:line-through;
 }
 
+.usage-split-toggle {
+  margin-left:auto;
+}
+
 .usage-legend-toggle i {
   width:10px;
   height:10px;
   border-radius:2px;
   display:inline-block;
+}
+
+.usage-model-chart-legend {
+  min-height:38px;
 }
 
 .usage-legend-input { background:var(--accent, #7aa2f7); }
@@ -567,6 +888,54 @@
   background:#f6c177;
   height:2px;
   border-radius:999px;
+}
+
+.usage-model-swatches {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  align-items:center;
+  min-width:0;
+}
+
+.usage-model-swatch {
+  display:inline-flex;
+  align-items:center;
+  gap:4px;
+  max-width:190px;
+  color:color-mix(in srgb, var(--fg) 72%, transparent);
+  font-size:11px;
+}
+
+.usage-model-swatch i {
+  width:10px;
+  height:10px;
+  border-radius:2px;
+  flex:0 0 auto;
+}
+
+.usage-model-swatch .usage-provider-logo {
+  width:12px !important;
+  height:12px !important;
+  opacity:0.85;
+}
+
+.usage-model-swatch .usage-provider-logo svg {
+  width:12px;
+  height:12px;
+}
+
+.usage-model-swatch {
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+@container (max-width: 99px) {
+  .usage-range-label,
+  .usage-range-trigger {
+    display:none;
+  }
 }
 
 
@@ -608,6 +977,12 @@
     min-width:0;
   }
 
+  .usage-model-trigger,
+  #usage-user {
+    width:112px;
+    min-width:112px;
+  }
+
   .usage-range-popover {
     position:fixed;
     left:12px;
@@ -616,6 +991,11 @@
     width:auto;
     max-height:calc(100vh - 110px);
     overflow:auto;
+  }
+
+  .usage-model-popover {
+    width:min(360px, calc(100vw - 24px));
+    max-height:calc(100vh - 110px);
   }
 
   .usage-range-months {

--- a/static/index.html
+++ b/static/index.html
@@ -214,6 +214,7 @@
     })();
   </script>
   <link rel="stylesheet" href="/static/style.css">
+  <link rel="stylesheet" href="/static/css/usage.css">
   <link rel="modulepreload" href="/static/app.js">
   <link rel="modulepreload" href="/static/js/chat.js">
   <link rel="modulepreload" href="/static/js/ui.js">
@@ -906,6 +907,18 @@
             <circle cx="9" cy="15" r="1.5" fill="currentColor"/>
           </svg>
           <span class="grow">Theme</span>
+        </div>
+        <div class="list-item" id="tool-usage-btn">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            style="flex-shrink:0;opacity:0.5;">
+            <path d="M4 19V5"/>
+            <path d="M4 19h16"/>
+            <path d="M8 17V9"/>
+            <path d="M12 17V3"/>
+            <path d="M16 17v-6"/>
+          </svg>
+          <span class="grow">Usage</span>
         </div>
       </div>
     </div>
@@ -2239,6 +2252,7 @@
 <script type="module" src="/static/js/settings.js"></script>
 <script type="module" src="/static/js/admin.js"></script>
 <script type="module" src="/static/js/assistant.js"></script>
+<script type="module" src="/static/js/usage.js"></script>
 <script type="module" src="/static/app.js"></script>  <!-- app.js must be LAST -->
 <script type="module" src="/static/js/init.js"></script>
 <script nonce="{{CSP_NONCE}}">if('serviceWorker' in navigator){navigator.serviceWorker.register('/static/sw.js').catch(()=>{});}</script>

--- a/static/js/usage.js
+++ b/static/js/usage.js
@@ -4,29 +4,37 @@
 import uiModule from './ui.js';
 import * as Modals from './modalManager.js';
 import { makeWindowDraggable } from './windowDrag.js';
+import { providerLogo } from './providers.js';
 
 const MODAL_ID = 'usage-modal';
 const ALL_USERS = '__all__';
+const OTHER_MODELS = '__other__';
+const UNKNOWN_MODEL = 'unknown';
 const RANGE_KEY = 'ody-usage-range';
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 const AVG_COLORS = ['#f6c177', '#9ccfd8', '#c4a7e7', '#eb6f92', '#31748f', '#ea9a97'];
+const MODEL_COLORS = ['#7aa2f7', '#f6c177', '#9ccfd8', '#c4a7e7', '#eb6f92'];
 
 let modalEl = null;
 let chartResizeObserver = null;
 let chartResizeRaf = 0;
 let lastChartRenderWidth = 0;
 let lastChartRenderHeight = 0;
+let documentClickHandler = null;
 let state = {
+  tab: 'daily',
   range: 'last30',
   start: '',
   end: '',
   user: ALL_USERS,
+  models: [],
   data: null,
   loading: false,
   showInput: true,
   showOutput: true,
   showMovingAverage: false,
+  splitByModel: false,
 };
 
 let picker = {
@@ -34,6 +42,10 @@ let picker = {
   month: null,
   draftStart: '',
   draftEnd: '',
+};
+
+let modelPicker = {
+  open: false,
 };
 
 function esc(s) {
@@ -121,20 +133,21 @@ function movingAverage(values, windowSize = 7) {
 
 function movingAverageSeries(data) {
   if (!state.showMovingAverage) return [];
-  return (data?.daily_by_user || [])
-    .map((series, index) => {
-      const daily = series.daily || [];
-      const averages = movingAverage(daily.map(day => day.total_tokens || 0));
-      return {
-        user: series.user || 'unassigned',
-        color: AVG_COLORS[index % AVG_COLORS.length],
-        points: averages.map((value, pointIndex) => ({
-          date: daily[pointIndex]?.date || '',
-          value,
-        })),
-      };
-    })
-    .filter(series => series.points.length);
+  const daily = effectiveUsage(data).daily || [];
+  if (!daily.length) return [];
+  const visibleValues = daily.map(day => (
+    (state.showInput ? day.input_tokens || 0 : 0)
+    + (state.showOutput ? day.output_tokens || 0 : 0)
+  ));
+  const averages = movingAverage(visibleValues);
+  return [{
+    user: 'Visible usage',
+    color: AVG_COLORS[0],
+    points: averages.map((value, pointIndex) => ({
+      date: daily[pointIndex]?.date || '',
+      value,
+    })),
+  }];
 }
 
 function smoothPath(points) {
@@ -162,7 +175,13 @@ function closeUsage() {
   chartResizeRaf = 0;
   lastChartRenderWidth = 0;
   picker.open = false;
+  modelPicker.open = false;
   document.getElementById('usage-range-popover')?.remove();
+  document.getElementById('usage-model-popover')?.remove();
+  if (documentClickHandler) {
+    document.removeEventListener('click', documentClickHandler);
+    documentClickHandler = null;
+  }
   if (modalEl) modalEl.remove();
   modalEl = null;
   Modals.unregister(MODAL_ID);
@@ -170,6 +189,7 @@ function closeUsage() {
 
 function minimizeUsage() {
   closeRangePicker();
+  closeModelPicker();
   Modals.minimize(MODAL_ID);
 }
 
@@ -193,6 +213,142 @@ function saveRange() {
   } catch (_) {}
 }
 
+function modelDisplayName(model) {
+  if (!model || model === UNKNOWN_MODEL) return 'Unknown model';
+  return String(model);
+}
+
+function truncateModelLabel(label, max = 20) {
+  const text = String(label || '');
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function modelIcon(model) {
+  const logo = providerLogo(model);
+  return logo ? `<span class="provider-logo usage-provider-logo">${logo}</span>` : '';
+}
+
+function emptyTotals(messageCount = 0) {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+    message_count: messageCount,
+  };
+}
+
+function modelDailyLookup(data) {
+  const lookup = new Map();
+  (data?.daily_by_model || []).forEach(series => {
+    const byDate = new Map();
+    (series.daily || []).forEach(day => {
+      byDate.set(day.date, day);
+    });
+    lookup.set(series.model, byDate);
+  });
+  return lookup;
+}
+
+function availableModelIds(data = state.data) {
+  return new Set((data?.models || []).map(model => model.model));
+}
+
+function pruneSelectedModels(data = state.data) {
+  if (!state.models.length) return;
+  const available = availableModelIds(data);
+  state.models = state.models.filter(model => available.has(model));
+}
+
+function effectiveModelTotals(data) {
+  const models = data?.models || [];
+  if (!state.models.length) return models;
+  const selected = new Set(state.models);
+  return models.filter(model => selected.has(model.model));
+}
+
+function effectiveUsage(data) {
+  const baseDaily = data?.daily || [];
+  const baseTotals = data?.totals || emptyTotals();
+  if (!state.models.length) {
+    return {
+      daily: baseDaily,
+      totals: baseTotals,
+      modelTotals: data?.models || [],
+    };
+  }
+
+  const selected = new Set(state.models);
+  const lookup = modelDailyLookup(data);
+  const totals = emptyTotals(baseTotals.message_count || 0);
+  const daily = baseDaily.map(base => {
+    const row = {
+      date: base.date,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      message_count: base.message_count || 0,
+    };
+    selected.forEach(model => {
+      const modelDay = lookup.get(model)?.get(base.date);
+      if (!modelDay) return;
+      row.input_tokens += modelDay.input_tokens || 0;
+      row.output_tokens += modelDay.output_tokens || 0;
+      row.total_tokens += modelDay.total_tokens || 0;
+    });
+    totals.input_tokens += row.input_tokens;
+    totals.output_tokens += row.output_tokens;
+    totals.total_tokens += row.total_tokens;
+    return row;
+  });
+
+  return {
+    daily,
+    totals,
+    modelTotals: effectiveModelTotals(data),
+  };
+}
+
+function modelPeriodTotals(data) {
+  return (data?.daily_by_model || [])
+    .map(series => {
+      const totals = (series.daily || []).reduce((sum, day) => {
+        sum.input_tokens += day.input_tokens || 0;
+        sum.output_tokens += day.output_tokens || 0;
+        sum.total_tokens += day.total_tokens || 0;
+        return sum;
+      }, { input_tokens: 0, output_tokens: 0, total_tokens: 0 });
+      return {
+        model: series.model || UNKNOWN_MODEL,
+        ...totals,
+      };
+    })
+    .filter(model => (model.total_tokens || 0) > 0)
+    .sort((a, b) => (b.total_tokens || 0) - (a.total_tokens || 0) || String(a.model).localeCompare(String(b.model)));
+}
+
+function splitModelGroups(data) {
+  const modelTotals = effectiveModelTotals(data)
+    .filter(model => (model.total_tokens || 0) > 0)
+    .sort((a, b) => (b.total_tokens || 0) - (a.total_tokens || 0) || String(a.model).localeCompare(String(b.model)));
+  const top = modelTotals.slice(0, 4);
+  const rest = modelTotals.slice(4);
+  const groups = top.map((model, index) => ({
+    id: model.model,
+    label: modelDisplayName(model.model),
+    models: [model.model],
+    color: MODEL_COLORS[index % MODEL_COLORS.length],
+  }));
+  if (rest.length) {
+    groups.push({
+      id: OTHER_MODELS,
+      label: 'Other',
+      models: rest.map(model => model.model),
+      color: MODEL_COLORS[4],
+    });
+  }
+  return groups;
+}
+
 function renderSkeleton() {
   return `
     <div class="modal-content usage-modal-content">
@@ -202,6 +358,14 @@ function renderSkeleton() {
         <button type="button" class="modal-close" id="usage-close-btn" title="Close">×</button>
       </div>
       <div class="modal-body usage-body">
+        <div class="usage-tabs" role="tablist" aria-label="Usage views">
+          <button type="button" class="usage-tab active" data-usage-tab="daily" role="tab" aria-selected="true">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px;margin-right:5px"><path d="M3 19h18"/><path d="M3 5v14"/><polyline points="5 15 9 11 13 14 20 7"/></svg>Daily
+          </button>
+          <button type="button" class="usage-tab" data-usage-tab="models" role="tab" aria-selected="false">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="vertical-align:-2px;margin-right:5px"><rect x="3" y="5" width="18" height="4" rx="1"/><rect x="3" y="10" width="14" height="4" rx="1"/><rect x="3" y="15" width="10" height="4" rx="1"/></svg>Models
+          </button>
+        </div>
         <div class="usage-toolbar">
           <div class="usage-filter-left">
             <label>Period
@@ -230,6 +394,16 @@ function renderSkeleton() {
             </div>
           </div>
           <div class="usage-filter-right">
+            <div class="usage-model-wrap" id="usage-model-wrap">
+              <span class="usage-range-label">Models</span>
+              <button type="button" class="usage-model-trigger" id="usage-model-trigger" aria-haspopup="listbox" aria-expanded="false">
+                <span id="usage-model-text">All models</span>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+              </button>
+              <div class="usage-model-popover" id="usage-model-popover" hidden></div>
+            </div>
             <label id="usage-user-wrap" style="display:none;">Users <select id="usage-user" class="usage-select"></select></label>
             <button type="button" class="usage-refresh" id="usage-refresh" title="Refresh from database" aria-label="Refresh from database">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 4v6h6"/><path d="M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
@@ -237,12 +411,41 @@ function renderSkeleton() {
           </div>
         </div>
         <div class="usage-summary" id="usage-summary"></div>
-        <div class="usage-chart-wrap" id="usage-chart-wrap">
-          <div class="usage-loading">Loading usage...</div>
+        <div class="usage-tab-panel" data-usage-panel="daily" role="tabpanel">
+          <div class="usage-chart-wrap" id="usage-chart-wrap">
+            <div class="usage-loading">Loading usage...</div>
+          </div>
+        </div>
+        <div class="usage-tab-panel hidden" data-usage-panel="models" role="tabpanel">
+          <div class="usage-chart-wrap" id="usage-model-chart-wrap">
+            <div class="usage-loading">Loading usage...</div>
+          </div>
         </div>
       </div>
     </div>
   `;
+}
+
+function syncTabUI({ closePopovers = false } = {}) {
+  if (!modalEl) return;
+  const showModelsTab = state.tab === 'models';
+  if (closePopovers) picker.open = false;
+  if (closePopovers || showModelsTab) modelPicker.open = false;
+
+  modalEl.querySelectorAll('.usage-tab[data-usage-tab]').forEach(tab => {
+    const active = tab.dataset.usageTab === state.tab;
+    tab.classList.toggle('active', active);
+    tab.setAttribute('aria-selected', String(active));
+  });
+  modalEl.querySelectorAll('.usage-tab-panel[data-usage-panel]').forEach(panel => {
+    panel.classList.toggle('hidden', panel.dataset.usagePanel !== state.tab);
+  });
+
+  const modelWrap = modalEl.querySelector('#usage-model-wrap');
+  if (modelWrap) modelWrap.style.display = showModelsTab ? 'none' : '';
+
+  renderRangePicker();
+  renderModelPicker();
 }
 
 function syncControls() {
@@ -251,11 +454,13 @@ function syncControls() {
   if (preset) preset.value = state.range;
   const rangeText = modalEl.querySelector('#usage-range-text');
   if (rangeText) rangeText.textContent = rangeLabel(state.start, state.end);
-  renderRangePicker();
+  syncTabUI();
 }
 
 function renderSummary(data) {
-  const totals = data?.totals || {};
+  const totals = state.tab === 'models'
+    ? data?.totals || emptyTotals()
+    : effectiveUsage(data).totals || {};
   const summary = modalEl?.querySelector('#usage-summary');
   if (!summary) return;
   summary.innerHTML = `
@@ -280,6 +485,112 @@ function renderUserSelect(data) {
     .concat(users.map(u => `<option value="${esc(u.username)}">${esc(u.username)}${u.is_admin ? ' (admin)' : ''}</option>`));
   select.innerHTML = options.join('');
   select.value = state.user || ALL_USERS;
+}
+
+function renderModelPicker(data = state.data) {
+  const trigger = modalEl?.querySelector('#usage-model-trigger');
+  const text = modalEl?.querySelector('#usage-model-text');
+  const popover = document.getElementById('usage-model-popover');
+  if (!trigger || !text || !popover) return;
+
+  pruneSelectedModels(data);
+  const models = data?.models || [];
+  trigger.disabled = !models.length;
+  trigger.setAttribute('aria-expanded', String(modelPicker.open));
+  text.textContent = state.models.length ? `${state.models.length} model${state.models.length === 1 ? '' : 's'}` : 'All models';
+
+  popover.hidden = !modelPicker.open;
+  if (!modelPicker.open) {
+    popover.innerHTML = '';
+    return;
+  }
+  if (popover.parentElement !== document.body) {
+    document.body.appendChild(popover);
+  }
+
+  const selected = new Set(state.models);
+  const modelRows = models.length
+    ? models.map(({ model, total_tokens }) => `
+        <label class="usage-model-option" title="${esc(modelDisplayName(model))}">
+          <input type="checkbox" data-usage-model="${esc(model)}" ${selected.has(model) ? 'checked' : ''}>
+          ${modelIcon(model)}
+          <span>${esc(modelDisplayName(model))}</span>
+          <small>${fmtCompact(total_tokens || 0)}</small>
+        </label>
+      `).join('')
+    : '<div class="usage-empty-models">No model usage in this range.</div>';
+
+  popover.innerHTML = `
+    <label class="usage-model-option usage-model-all">
+      <input type="checkbox" data-usage-model-all ${state.models.length ? '' : 'checked'}>
+      <span>All models</span>
+    </label>
+    <div class="usage-model-list">${modelRows}</div>
+  `;
+
+  popover.querySelector('[data-usage-model-all]')?.addEventListener('change', e => {
+    e.stopPropagation();
+    state.models = [];
+    renderModelPicker(data);
+    renderSummary(state.data);
+    renderActiveChart(state.data);
+  });
+
+  popover.querySelectorAll('[data-usage-model]').forEach(input => {
+    input.addEventListener('change', e => {
+      e.stopPropagation();
+      const model = input.dataset.usageModel;
+      if (!model) return;
+      const next = new Set(state.models);
+      if (input.checked) next.add(model);
+      else next.delete(model);
+      state.models = Array.from(next);
+      // Selecting specific models implies a per-model breakdown, so turn the
+      // split-by-model view on automatically.
+      if (state.models.length) state.splitByModel = true;
+      renderModelPicker(data);
+      renderSummary(state.data);
+      renderActiveChart(state.data);
+    });
+  });
+
+  clampModelPopover(popover);
+}
+
+function openModelPicker() {
+  modelPicker.open = true;
+  renderModelPicker();
+}
+
+function closeModelPicker() {
+  modelPicker.open = false;
+  renderModelPicker();
+}
+
+function clampModelPopover(popover) {
+  const trigger = modalEl?.querySelector('#usage-model-trigger');
+  if (!trigger) return;
+  popover.style.right = 'auto';
+  if (!modelPicker.open) return;
+  const margin = 8;
+  const triggerRect = trigger.getBoundingClientRect();
+  const popRect = popover.getBoundingClientRect();
+  const popW = popRect.width;
+  const popH = popRect.height;
+
+  let left = triggerRect.left;
+  const maxLeft = window.innerWidth - margin - popW;
+  left = Math.min(left, maxLeft);
+  left = Math.max(margin, left);
+
+  let top = triggerRect.bottom + 6;
+  if (top + popH > window.innerHeight - margin) {
+    const above = triggerRect.top - 6 - popH;
+    top = above >= margin ? above : Math.max(margin, window.innerHeight - margin - popH);
+  }
+
+  popover.style.left = `${Math.round(left)}px`;
+  popover.style.top = `${Math.round(top)}px`;
 }
 
 function monthGrid(baseDate) {
@@ -445,7 +756,8 @@ function clampRangePopover(popover) {
 }
 
 function chartInnerSvg(data, width, height) {
-  const daily = data?.daily || [];
+  const effective = effectiveUsage(data);
+  const daily = effective.daily || [];
   const avgSeries = movingAverageSeries(data);
   const visibleTotal = d => (state.showInput ? d.input_tokens || 0 : 0) + (state.showOutput ? d.output_tokens || 0 : 0);
   const maxVisibleTotal = Math.max(0, ...daily.map(visibleTotal));
@@ -467,30 +779,64 @@ function chartInnerSvg(data, width, height) {
   const yFor = val => top + plotH - (val / maxTotal) * plotH;
   const ticks = [0, 0.25, 0.5, 0.75, 1].map(p => Math.round(maxTotal * p));
   const every = Math.max(1, Math.ceil(daily.length / 10));
+  const splitGroups = state.splitByModel ? splitModelGroups(data) : [];
+  const modelLookup = modelDailyLookup(data);
 
   const grid = ticks.map(t => {
     const y = yFor(t);
     return `<g><line x1="${left}" y1="${y}" x2="${width - right}" y2="${y}" class="usage-grid-line"></line><text x="${left - 8}" y="${y + 4}" class="usage-axis-label" text-anchor="end">${fmtCompact(t)}</text></g>`;
   }).join('');
 
+  const modelTokensForDay = (group, date) => group.models.reduce((sum, model) => {
+    const row = modelLookup.get(model)?.get(date);
+    sum.input_tokens += row?.input_tokens || 0;
+    sum.output_tokens += row?.output_tokens || 0;
+    return sum;
+  }, { input_tokens: 0, output_tokens: 0 });
+
   const bars = daily.map((d, i) => {
     const laneX = left + i * slotW;
     const x = laneX + barGap / 2;
     const rawInput = d.input_tokens || 0;
     const rawOutput = d.output_tokens || 0;
-    const input = state.showInput ? rawInput : 0;
-    const output = state.showOutput ? rawOutput : 0;
-    const inputH = (input / maxTotal) * plotH;
-    const outputH = (output / maxTotal) * plotH;
-    const inputY = top + plotH - inputH;
-    const outputY = inputY - outputH;
     const centerX = laneX + slotW / 2;
     const label = i % every === 0 ? `<text x="${centerX}" y="${height - 24}" class="usage-axis-label usage-x-label" text-anchor="middle">${d.date.slice(5)}</text>` : '';
+    let barRects = '';
+
+    if (state.splitByModel && splitGroups.length) {
+      let cursorY = top + plotH;
+      splitGroups.forEach(group => {
+        const values = modelTokensForDay(group, d.date);
+        const input = state.showInput ? values.input_tokens : 0;
+        const output = state.showOutput ? values.output_tokens : 0;
+        const inputH = (input / maxTotal) * plotH;
+        const outputH = (output / maxTotal) * plotH;
+        if (inputH > 0) {
+          cursorY -= inputH;
+          barRects += `<rect x="${x}" y="${cursorY}" width="${Math.max(barW, 1)}" height="${inputH}" class="usage-model-segment usage-model-segment-input" fill="${esc(group.color)}"><title>${esc(group.label)} input</title></rect>`;
+        }
+        if (outputH > 0) {
+          cursorY -= outputH;
+          barRects += `<rect x="${x}" y="${cursorY}" width="${Math.max(barW, 1)}" height="${outputH}" class="usage-model-segment usage-model-segment-output" fill="${esc(group.color)}"><title>${esc(group.label)} output</title></rect>`;
+        }
+      });
+    } else {
+      const input = state.showInput ? rawInput : 0;
+      const output = state.showOutput ? rawOutput : 0;
+      const inputH = (input / maxTotal) * plotH;
+      const outputH = (output / maxTotal) * plotH;
+      const inputY = top + plotH - inputH;
+      const outputY = inputY - outputH;
+      barRects = `
+        <rect x="${x}" y="${outputY}" width="${Math.max(barW, 1)}" height="${outputH}" class="usage-bar-output"></rect>
+        <rect x="${x}" y="${inputY}" width="${Math.max(barW, 1)}" height="${inputH}" class="usage-bar-input"></rect>
+      `;
+    }
+
     return `
       <rect x="${laneX}" y="${top}" width="${slotW}" height="${plotH}" class="usage-hover-highlight" data-highlight-date="${esc(d.date)}"></rect>
       <g class="usage-bar" data-bar-date="${esc(d.date)}">
-        <rect x="${x}" y="${outputY}" width="${Math.max(barW, 1)}" height="${outputH}" class="usage-bar-output"></rect>
-        <rect x="${x}" y="${inputY}" width="${Math.max(barW, 1)}" height="${inputH}" class="usage-bar-input"></rect>
+        ${barRects}
         ${label}
       </g>
       <rect x="${laneX}" y="${top}" width="${slotW}" height="${plotH}" class="usage-hover-target" data-date="${esc(d.date)}" data-input="${rawInput}" data-output="${rawOutput}" data-total="${d.total_tokens || 0}" data-messages="${d.message_count || 0}"></rect>
@@ -524,8 +870,19 @@ function chartInnerSvg(data, width, height) {
   `;
 }
 
-function chartShell() {
+function chartShell(data) {
+  const topLegend = state.splitByModel
+    ? splitModelGroups(data).map(group => {
+        const icon = group.id === OTHER_MODELS ? '' : modelIcon(group.id);
+        return `
+        <span class="usage-model-swatch" title="${esc(group.label)}">
+          <i style="background:${esc(group.color)}"></i>${icon}${esc(truncateModelLabel(group.label))}
+        </span>
+      `;
+      }).join('')
+    : '';
   return `
+    ${topLegend ? `<div class="usage-model-top-legend">${topLegend}</div>` : ''}
     <div class="usage-chart-scroll"></div>
     <div class="usage-tooltip" id="usage-tooltip" hidden></div>
     <div class="usage-legend">
@@ -538,8 +895,195 @@ function chartShell() {
       <button type="button" class="usage-legend-toggle${state.showMovingAverage ? ' active' : ''}" data-usage-series="average" aria-pressed="${state.showMovingAverage}">
         <i class="usage-legend-average"></i>7-day average
       </button>
+      <button type="button" class="usage-legend-toggle usage-split-toggle${state.splitByModel ? ' active' : ''}" data-usage-series="split" aria-pressed="${state.splitByModel}">
+        Split by model
+      </button>
     </div>
   `;
+}
+
+function modelChartInnerSvg(data, width, minHeight = 0) {
+  const rows = modelPeriodTotals(data);
+  if (!rows.length) {
+    return '<div class="usage-empty">No model usage found for this range.</div>';
+  }
+
+  const left = 8;
+  const right = 8;
+  const compactLabels = width < 640;
+  const top = 10;
+  const bottom = 30;
+  const minRowH = compactLabels ? 30 : 44;
+  const plotH = Math.max(1, Math.max(minHeight - top - bottom, rows.length * minRowH));
+  const rowH = plotH / rows.length;
+  const labelH = compactLabels ? 0 : 18;
+  const barH = compactLabels
+    ? Math.max(18, Math.min(56, rowH * 0.72))
+    : Math.max(18, Math.min(58, (rowH - labelH - 6) * 0.88));
+  const height = top + bottom + plotH;
+  const plotW = Math.max(1, width - left - right);
+  const visibleTotal = row => (
+    (state.showInput ? row.input_tokens || 0 : 0)
+    + (state.showOutput ? row.output_tokens || 0 : 0)
+  );
+  const maxTotal = Math.max(1, ...rows.map(visibleTotal));
+  const periodTotal = Math.max(1, data?.totals?.total_tokens || 0);
+  const ticks = [0, 0.25, 0.5, 0.75, 1];
+
+  const grid = ticks.map(p => {
+    const x = left + p * plotW;
+    const value = Math.round(maxTotal * p);
+    return `
+      <g>
+        <line x1="${x}" y1="${top}" x2="${x}" y2="${height - bottom}" class="usage-grid-line"></line>
+        <text x="${x}" y="${height - 12}" class="usage-axis-label usage-model-x-label" text-anchor="${p === 0 ? 'start' : p === 1 ? 'end' : 'middle'}">${fmtCompact(value)}</text>
+      </g>
+    `;
+  }).join('');
+
+  const bars = rows.map((row, index) => {
+    const rowTop = top + index * rowH;
+    const centerY = rowTop + rowH / 2;
+    const barY = compactLabels
+      ? centerY - barH / 2
+      : rowTop + labelH + Math.max(3, (rowH - labelH - barH) / 2);
+    const input = state.showInput ? row.input_tokens || 0 : 0;
+    const output = state.showOutput ? row.output_tokens || 0 : 0;
+    const inputW = (input / maxTotal) * plotW;
+    const outputW = (output / maxTotal) * plotW;
+    const rowVisibleTotal = input + output;
+    const label = modelDisplayName(row.model);
+    const labelText = truncateModelLabel(label, 32);
+    const share = ((row.total_tokens || 0) / periodTotal) * 100;
+    const labelW = Math.min(Math.max(width * 0.34, 160), Math.max(160, width - 116));
+    const labelY = compactLabels ? barY + barH / 2 - 12 : rowTop + Math.max(1, (labelH - 14) / 2);
+
+    return `
+      <rect x="0" y="${centerY - rowH / 2 + 2}" width="${width}" height="${rowH - 4}" class="usage-model-row-highlight" data-model-row="${index}"></rect>
+      <g class="usage-model-horizontal-bar" data-model-bar="${index}">
+        <rect x="${left}" y="${barY}" width="${Math.max(inputW, 0)}" height="${barH}" rx="3" class="usage-bar-input usage-model-horizontal-segment"></rect>
+        <rect x="${left + inputW}" y="${barY}" width="${Math.max(outputW, 0)}" height="${barH}" rx="3" class="usage-bar-output usage-model-horizontal-segment"></rect>
+        <foreignObject x="${left + 8}" y="${labelY}" width="${labelW}" height="24">
+          <div xmlns="http://www.w3.org/1999/xhtml" class="usage-model-axis-label${compactLabels ? ' compact' : ''}" title="${esc(label)}">
+            ${modelIcon(row.model)}<span>${esc(labelText)}</span>
+          </div>
+        </foreignObject>
+        <text x="${left + plotW - 8}" y="${barY + barH / 2 + 4}" class="usage-axis-label usage-model-total-label" text-anchor="end">${fmtCompact(rowVisibleTotal)}</text>
+      </g>
+      <rect x="0" y="${centerY - rowH / 2}" width="${width}" height="${rowH}" class="usage-model-hover-target" data-model-index="${index}" data-display="${esc(label)}" data-input="${row.input_tokens || 0}" data-output="${row.output_tokens || 0}" data-total="${row.total_tokens || 0}" data-share="${share.toFixed(1)}"></rect>
+    `;
+  }).join('');
+
+  return `
+    <svg class="usage-model-chart" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="Model token usage chart">
+      ${grid}
+      <line x1="${left}" y1="${height - bottom}" x2="${left + plotW}" y2="${height - bottom}" class="usage-axis-line"></line>
+      ${bars}
+    </svg>
+  `;
+}
+
+function modelChartShell() {
+  return `
+    <div class="usage-model-chart-scroll"></div>
+    <div class="usage-tooltip" id="usage-model-tooltip" hidden></div>
+    <div class="usage-legend usage-model-chart-legend">
+      <button type="button" class="usage-legend-toggle${state.showInput ? ' active' : ''}" data-usage-series="input" aria-pressed="${state.showInput}">
+        <i class="usage-legend-input"></i>Input tokens
+      </button>
+      <button type="button" class="usage-legend-toggle${state.showOutput ? ' active' : ''}" data-usage-series="output" aria-pressed="${state.showOutput}">
+        <i class="usage-legend-output"></i>Output tokens
+      </button>
+    </div>
+  `;
+}
+
+function wireModelChartTooltips() {
+  const wrap = modalEl?.querySelector('#usage-model-chart-wrap');
+  const scroll = modalEl?.querySelector('.usage-model-chart-scroll');
+  const tip = modalEl?.querySelector('#usage-model-tooltip');
+  if (!wrap || !tip) return;
+
+  const clearActive = () => {
+    wrap.querySelectorAll('.usage-model-row-highlight.active, .usage-model-horizontal-bar.active').forEach(el => {
+      el.classList.remove('active');
+    });
+  };
+  const hideTooltip = () => {
+    clearActive();
+    tip.hidden = true;
+  };
+  const positionTooltip = e => {
+    const rect = wrap.getBoundingClientRect();
+    const padding = 8;
+    const preferredLeft = e.clientX - rect.left + 12;
+    const preferredTop = e.clientY - rect.top + 12;
+    const maxLeft = Math.max(padding, wrap.clientWidth - tip.offsetWidth - padding);
+    const maxTop = Math.max(padding, wrap.clientHeight - tip.offsetHeight - padding);
+    tip.style.left = `${Math.max(padding, Math.min(preferredLeft, maxLeft))}px`;
+    tip.style.top = `${Math.max(padding, Math.min(preferredTop, maxTop))}px`;
+  };
+
+  wrap.querySelectorAll('.usage-model-hover-target').forEach(target => {
+    target.addEventListener('mousemove', e => {
+      clearActive();
+      const index = target.dataset.modelIndex;
+      wrap.querySelector(`[data-model-row="${index}"]`)?.classList.add('active');
+      wrap.querySelector(`[data-model-bar="${index}"]`)?.classList.add('active');
+      tip.hidden = false;
+      tip.innerHTML = `
+        <strong>${esc(target.dataset.display)}</strong>
+        <span>Total: ${fmtNum(target.dataset.total)} tokens</span>
+        <span>Input: ${fmtNum(target.dataset.input)}</span>
+        <span>Output: ${fmtNum(target.dataset.output)}</span>
+        <span>Share: ${esc(target.dataset.share)}%</span>
+      `;
+      positionTooltip(e);
+    });
+  });
+
+  scroll?.addEventListener('mouseleave', hideTooltip);
+  wrap.addEventListener('mouseleave', hideTooltip);
+  wrap.querySelectorAll('[data-usage-series]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const series = btn.dataset.usageSeries;
+      if (series === 'input') state.showInput = !state.showInput;
+      if (series === 'output') state.showOutput = !state.showOutput;
+      renderModelChart(state.data);
+    });
+  });
+}
+
+function renderModelChart(data) {
+  const wrap = modalEl?.querySelector('#usage-model-chart-wrap');
+  if (!wrap) return;
+  if (state.loading && data) return;
+  if (state.loading) {
+    wrap.innerHTML = '<div class="usage-loading">Loading usage...</div>';
+    return;
+  }
+  lastChartRenderWidth = Math.round(wrap.clientWidth);
+  lastChartRenderHeight = Math.round(wrap.clientHeight);
+  wrap.innerHTML = modelChartShell();
+  const scroll = wrap.querySelector('.usage-model-chart-scroll');
+  if (scroll) {
+    const cs = getComputedStyle(scroll);
+    const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
+    const padY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+    const w = Math.max(1, Math.floor(scroll.clientWidth - padX));
+    const h = Math.max(1, Math.floor(scroll.clientHeight - padY));
+    scroll.innerHTML = modelChartInnerSvg(data, w, h);
+  }
+  wireModelChartTooltips();
+}
+
+function activeChartWrap() {
+  return modalEl?.querySelector(state.tab === 'models' ? '#usage-model-chart-wrap' : '#usage-chart-wrap');
+}
+
+function renderActiveChart(data) {
+  if (state.tab === 'models') renderModelChart(data);
+  else renderChart(data);
 }
 
 function wireChartTooltips() {
@@ -590,6 +1134,7 @@ function wireChartTooltips() {
       if (series === 'input') state.showInput = !state.showInput;
       if (series === 'output') state.showOutput = !state.showOutput;
       if (series === 'average') state.showMovingAverage = !state.showMovingAverage;
+      if (series === 'split') state.splitByModel = !state.splitByModel;
       renderChart(state.data);
     });
   });
@@ -605,7 +1150,7 @@ function renderChart(data) {
   }
   lastChartRenderWidth = Math.round(wrap.clientWidth);
   lastChartRenderHeight = Math.round(wrap.clientHeight);
-  wrap.innerHTML = chartShell();
+  wrap.innerHTML = chartShell(data);
   const scroll = wrap.querySelector('.usage-chart-scroll');
   if (scroll) {
     const cs = getComputedStyle(scroll);
@@ -619,26 +1164,28 @@ function renderChart(data) {
 }
 
 function watchChartSize() {
-  const wrap = modalEl?.querySelector('#usage-chart-wrap');
-  if (!wrap || chartResizeObserver) return;
+  const wraps = modalEl ? Array.from(modalEl.querySelectorAll('#usage-chart-wrap, #usage-model-chart-wrap')) : [];
+  if (!wraps.length || chartResizeObserver) return;
   chartResizeObserver = new ResizeObserver(() => {
     if (!state.data || state.loading) return;
     if (chartResizeRaf) cancelAnimationFrame(chartResizeRaf);
     chartResizeRaf = requestAnimationFrame(() => {
       chartResizeRaf = 0;
+      const wrap = activeChartWrap();
+      if (!wrap || wrap.clientWidth <= 0 || wrap.clientHeight <= 0) return;
       const nextWidth = Math.round(wrap.clientWidth);
       const nextHeight = Math.round(wrap.clientHeight);
       if (Math.abs(nextWidth - lastChartRenderWidth) < 2 && Math.abs(nextHeight - lastChartRenderHeight) < 2) return;
-      renderChart(state.data);
+      renderActiveChart(state.data);
     });
   });
-  chartResizeObserver.observe(wrap);
+  wraps.forEach(wrap => chartResizeObserver.observe(wrap));
 }
 
 async function loadUsage() {
   if (!modalEl) return;
   state.loading = true;
-  renderChart(state.data);
+  renderActiveChart(state.data);
   saveRange();
   const params = new URLSearchParams({
     start: state.start,
@@ -652,12 +1199,14 @@ async function loadUsage() {
     const data = await res.json();
     state.data = data;
     state.loading = false;
+    pruneSelectedModels(data);
     renderUserSelect(data);
+    renderModelPicker(data);
     renderSummary(data);
-    renderChart(data);
+    renderActiveChart(data);
   } catch (err) {
     state.loading = false;
-    const wrap = modalEl.querySelector('#usage-chart-wrap');
+    const wrap = activeChartWrap();
     if (wrap) wrap.innerHTML = `<div class="usage-empty usage-error">Failed to load usage: ${esc(err.message || err)}</div>`;
   }
 }
@@ -666,6 +1215,18 @@ function wireControls() {
   modalEl.querySelector('#usage-close-btn')?.addEventListener('click', closeUsage);
   modalEl.querySelector('#usage-minimize-btn')?.addEventListener('click', minimizeUsage);
   modalEl.querySelector('#usage-refresh')?.addEventListener('click', loadUsage);
+  modalEl.querySelectorAll('.usage-tab[data-usage-tab]').forEach(tab => {
+    tab.addEventListener('click', () => {
+      const next = tab.dataset.usageTab || 'daily';
+      if (next === state.tab) return;
+      state.tab = next;
+      lastChartRenderWidth = 0;
+      lastChartRenderHeight = 0;
+      syncTabUI({ closePopovers: true });
+      renderSummary(state.data);
+      renderActiveChart(state.data);
+    });
+  });
   modalEl.querySelector('#usage-preset')?.addEventListener('change', e => {
     const next = e.target.value;
     state.range = next;
@@ -682,8 +1243,16 @@ function wireControls() {
   modalEl.querySelector('#usage-range-trigger')?.addEventListener('click', e => {
     e.stopPropagation();
     e.preventDefault();
+    closeModelPicker();
     if (picker.open) closeRangePicker();
     else openRangePicker();
+  });
+  modalEl.querySelector('#usage-model-trigger')?.addEventListener('click', e => {
+    e.stopPropagation();
+    e.preventDefault();
+    closeRangePicker();
+    if (modelPicker.open) closeModelPicker();
+    else openModelPicker();
   });
   modalEl.querySelector('#usage-user')?.addEventListener('change', e => {
     state.user = e.target.value || ALL_USERS;
@@ -692,7 +1261,17 @@ function wireControls() {
   modalEl.addEventListener('click', e => {
     if (e.target === modalEl) closeUsage();
     else if (picker.open && !e.target.closest('#usage-range-wrap')) closeRangePicker();
+    else if (modelPicker.open && !e.target.closest('#usage-model-wrap')) closeModelPicker();
   });
+  documentClickHandler = e => {
+    if (picker.open && !e.target.closest('#usage-range-wrap') && !e.target.closest('#usage-range-popover')) {
+      closeRangePicker();
+    }
+    if (modelPicker.open && !e.target.closest('#usage-model-wrap') && !e.target.closest('#usage-model-popover')) {
+      closeModelPicker();
+    }
+  };
+  document.addEventListener('click', documentClickHandler);
 }
 
 export function openUsage() {

--- a/static/js/usage.js
+++ b/static/js/usage.js
@@ -1,0 +1,527 @@
+// static/js/usage.js
+// Usage dashboard: token analytics by day.
+
+import uiModule from './ui.js';
+import * as Modals from './modalManager.js';
+import { makeWindowDraggable } from './windowDrag.js';
+
+const MODAL_ID = 'usage-modal';
+const ALL_USERS = '__all__';
+const RANGE_KEY = 'ody-usage-range';
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+let modalEl = null;
+let state = {
+  range: 'month',
+  start: '',
+  end: '',
+  user: ALL_USERS,
+  data: null,
+  loading: false,
+};
+
+let picker = {
+  open: false,
+  month: null,
+  draftStart: '',
+  draftEnd: '',
+};
+
+function esc(s) {
+  return uiModule && uiModule.esc ? uiModule.esc(String(s ?? '')) : String(s ?? '');
+}
+
+function pad(n) {
+  return String(n).padStart(2, '0');
+}
+
+function ymd(d) {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function parseYmd(s) {
+  const [y, m, d] = String(s || '').split('-').map(Number);
+  if (!y || !m || !d) return new Date();
+  return new Date(y, m - 1, d);
+}
+
+function addDays(d, days) {
+  const out = new Date(d);
+  out.setDate(out.getDate() + days);
+  return out;
+}
+
+function addMonths(d, months) {
+  return new Date(d.getFullYear(), d.getMonth() + months, 1);
+}
+
+function rangeFor(key) {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  let start = today;
+  if (key === 'week') {
+    start = addDays(today, -today.getDay());
+  } else if (key === 'month') {
+    start = new Date(today.getFullYear(), today.getMonth(), 1);
+  } else if (key === 'year') {
+    start = new Date(today.getFullYear(), 0, 1);
+  } else if (key === 'last7') {
+    start = addDays(today, -6);
+  } else if (key === 'last14') {
+    start = addDays(today, -13);
+  } else if (key === 'last30') {
+    start = addDays(today, -29);
+  }
+  return { start: ymd(start), end: ymd(today) };
+}
+
+function fmtNum(n) {
+  return Number(n || 0).toLocaleString();
+}
+
+function fmtCompact(n) {
+  n = Number(n || 0);
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`;
+  return String(n);
+}
+
+function fmtDate(value) {
+  return parseYmd(value).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function rangeLabel(start, end) {
+  if (!start || !end) return 'Choose date range';
+  return `${fmtDate(start)} - ${fmtDate(end)}`;
+}
+
+function sortedRange(start, end) {
+  if (!start) return { start: '', end: '' };
+  if (!end) return { start, end: start };
+  return start <= end ? { start, end } : { start: end, end: start };
+}
+
+function closeUsage() {
+  if (modalEl) modalEl.remove();
+  modalEl = null;
+  Modals.unregister(MODAL_ID);
+}
+
+function minimizeUsage() {
+  Modals.minimize(MODAL_ID);
+}
+
+function restoreUsage() {
+  if (!modalEl) return;
+  modalEl.classList.remove('hidden', 'modal-minimized');
+}
+
+function ensureDefaults() {
+  if (state.start && state.end) return;
+  const saved = (() => {
+    try { return JSON.parse(localStorage.getItem(RANGE_KEY) || '{}'); } catch (_) { return {}; }
+  })();
+  if (saved.user) state.user = saved.user;
+  state = { ...state, range: 'month', ...rangeFor('month') };
+}
+
+function saveRange() {
+  try {
+    localStorage.setItem(RANGE_KEY, JSON.stringify({
+      range: state.range,
+      start: state.start,
+      end: state.end,
+      user: state.user,
+    }));
+  } catch (_) {}
+}
+
+function renderSkeleton() {
+  return `
+    <div class="modal-content usage-modal-content">
+      <div class="modal-header">
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M4 19V5"/><path d="M4 19h16"/><path d="M8 17V9"/><path d="M12 17V3"/><path d="M16 17v-6"/></svg>Usage</h4>
+        <button type="button" class="minimize-btn" id="usage-minimize-btn" title="Minimize">_</button>
+        <button type="button" class="modal-close" id="usage-close-btn" title="Close">×</button>
+      </div>
+      <div class="modal-body usage-body">
+        <div class="usage-toolbar">
+          <div class="usage-filter-left">
+            <label>Period
+              <select id="usage-preset" class="usage-select">
+                <option value="week">Week to date</option>
+                <option value="month">Month to date</option>
+                <option value="year">Year to date</option>
+                <option value="last7">Last 7 days</option>
+                <option value="last14">Last 14 days</option>
+                <option value="last30">Last 30 days</option>
+                <option value="custom" hidden>Custom range</option>
+              </select>
+            </label>
+            <div class="usage-range-wrap" id="usage-range-wrap">
+              <span class="usage-range-label">Date range</span>
+              <button type="button" class="usage-range-trigger" id="usage-range-trigger">
+                <span id="usage-range-text"></span>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <rect x="3" y="4" width="18" height="18" rx="2"></rect>
+                  <line x1="16" y1="2" x2="16" y2="6"></line>
+                  <line x1="8" y1="2" x2="8" y2="6"></line>
+                  <line x1="3" y1="10" x2="21" y2="10"></line>
+                </svg>
+              </button>
+              <div class="usage-range-popover" id="usage-range-popover" hidden></div>
+            </div>
+          </div>
+          <div class="usage-filter-right">
+            <label id="usage-user-wrap" style="display:none;">Users <select id="usage-user"></select></label>
+            <button type="button" class="usage-refresh" id="usage-refresh" title="Refresh from database" aria-label="Refresh from database">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 4v6h6"/><path d="M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="usage-summary" id="usage-summary"></div>
+        <div class="usage-chart-wrap" id="usage-chart-wrap">
+          <div class="usage-loading">Loading usage...</div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function syncControls() {
+  if (!modalEl) return;
+  const preset = modalEl.querySelector('#usage-preset');
+  if (preset) preset.value = state.range;
+  const rangeText = modalEl.querySelector('#usage-range-text');
+  if (rangeText) rangeText.textContent = rangeLabel(state.start, state.end);
+  renderRangePicker();
+}
+
+function renderSummary(data) {
+  const totals = data?.totals || {};
+  const summary = modalEl?.querySelector('#usage-summary');
+  if (!summary) return;
+  summary.innerHTML = `
+    <div class="usage-stat"><span>Total</span><strong>${fmtNum(totals.total_tokens)}</strong><small>tokens</small></div>
+    <div class="usage-stat"><span>Input</span><strong>${fmtNum(totals.input_tokens)}</strong><small>tokens</small></div>
+    <div class="usage-stat"><span>Output</span><strong>${fmtNum(totals.output_tokens)}</strong><small>tokens</small></div>
+    <div class="usage-stat"><span>Messages</span><strong>${fmtNum(totals.message_count)}</strong><small>messages</small></div>
+  `;
+}
+
+function renderUserSelect(data) {
+  const wrap = modalEl?.querySelector('#usage-user-wrap');
+  const select = modalEl?.querySelector('#usage-user');
+  if (!wrap || !select) return;
+  if (!data?.is_admin) {
+    wrap.style.display = 'none';
+    return;
+  }
+  wrap.style.display = '';
+  const users = data.users || [];
+  const options = [`<option value="${ALL_USERS}">All users</option>`]
+    .concat(users.map(u => `<option value="${esc(u.username)}">${esc(u.username)}${u.is_admin ? ' (admin)' : ''}</option>`));
+  select.innerHTML = options.join('');
+  select.value = state.user || ALL_USERS;
+}
+
+function monthGrid(baseDate) {
+  const first = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1);
+  const start = addDays(first, -first.getDay());
+  const selected = sortedRange(picker.draftStart, picker.draftEnd);
+  let days = '';
+  for (let i = 0; i < 42; i++) {
+    const d = addDays(start, i);
+    const day = ymd(d);
+    const muted = d.getMonth() !== baseDate.getMonth();
+    const inRange = selected.start && selected.end && day > selected.start && day < selected.end;
+    const isSelected = day === selected.start || day === selected.end;
+    days += `<button type="button" class="usage-range-day${muted ? ' muted' : ''}${inRange ? ' in-range' : ''}${isSelected ? ' selected' : ''}" data-day="${day}">${d.getDate()}</button>`;
+  }
+  return `
+    <div class="usage-range-month">
+      <div class="usage-range-month-title">${MONTHS[baseDate.getMonth()]} ${baseDate.getFullYear()}</div>
+      <div class="usage-range-weekdays">${WEEKDAYS.map(d => `<span>${d}</span>`).join('')}</div>
+      <div class="usage-range-grid">${days}</div>
+    </div>
+  `;
+}
+
+function openRangePicker() {
+  picker.open = true;
+  picker.draftStart = state.start;
+  picker.draftEnd = state.end;
+  const startDate = parseYmd(state.start);
+  picker.month = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+  renderRangePicker();
+}
+
+function closeRangePicker() {
+  picker.open = false;
+  renderRangePicker();
+}
+
+function applyRangePicker() {
+  const selected = sortedRange(picker.draftStart, picker.draftEnd);
+  if (!selected.start) return;
+  state.start = selected.start;
+  state.end = selected.end;
+  state.range = 'custom';
+  picker.open = false;
+  syncControls();
+  loadUsage();
+}
+
+function renderRangePicker() {
+  const popover = modalEl?.querySelector('#usage-range-popover');
+  if (!popover) return;
+  popover.hidden = !picker.open;
+  if (!picker.open) {
+    popover.innerHTML = '';
+    return;
+  }
+  if (!picker.month) {
+    const startDate = parseYmd(state.start);
+    picker.month = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+  }
+  const nextMonth = addMonths(picker.month, 1);
+  const selected = sortedRange(picker.draftStart, picker.draftEnd);
+  popover.innerHTML = `
+    <div class="usage-range-head">
+      <button type="button" data-usage-cal-nav="-1" aria-label="Previous month">‹</button>
+      <div class="usage-range-title">${selected.start ? rangeLabel(selected.start, selected.end) : 'Choose date range'}</div>
+      <button type="button" data-usage-cal-nav="1" aria-label="Next month">›</button>
+    </div>
+    <div class="usage-range-months">
+      ${monthGrid(picker.month)}
+      ${monthGrid(nextMonth)}
+    </div>
+    <div class="usage-range-actions">
+      <span class="usage-range-hint">${picker.draftStart && !picker.draftEnd ? 'Choose an end date' : 'Choose start and end dates'}</span>
+      <div>
+        <button type="button" data-usage-range-cancel>Cancel</button>
+        <button type="button" class="usage-range-apply" data-usage-range-apply>Apply</button>
+      </div>
+    </div>
+  `;
+  popover.querySelectorAll('[data-usage-cal-nav]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      picker.month = addMonths(picker.month, Number(btn.dataset.usageCalNav || 0));
+      renderRangePicker();
+    });
+  });
+  popover.querySelectorAll('[data-day]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const day = btn.dataset.day;
+      if (!picker.draftStart || (picker.draftStart && picker.draftEnd)) {
+        picker.draftStart = day;
+        picker.draftEnd = '';
+      } else if (day < picker.draftStart) {
+        picker.draftEnd = picker.draftStart;
+        picker.draftStart = day;
+      } else {
+        picker.draftEnd = day;
+      }
+      renderRangePicker();
+    });
+  });
+  popover.querySelector('[data-usage-range-cancel]')?.addEventListener('click', e => {
+    e.stopPropagation();
+    closeRangePicker();
+  });
+  popover.querySelector('[data-usage-range-apply]')?.addEventListener('click', e => {
+    e.stopPropagation();
+    applyRangePicker();
+  });
+}
+
+function chartSvg(data) {
+  const daily = data?.daily || [];
+  const maxTotal = Math.max(0, ...daily.map(d => d.total_tokens || 0));
+  if (!daily.length || maxTotal === 0) {
+    return '<div class="usage-empty">No token usage found for this range.</div>';
+  }
+
+  const width = Math.max(720, daily.length * 18);
+  const height = 320;
+  const left = 54;
+  const top = 18;
+  const bottom = 42;
+  const right = 12;
+  const plotW = width - left - right;
+  const plotH = height - top - bottom;
+  const barW = plotW / daily.length;
+  const yFor = val => top + plotH - (val / maxTotal) * plotH;
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map(p => Math.round(maxTotal * p));
+  const every = Math.max(1, Math.ceil(daily.length / 10));
+
+  const grid = ticks.map(t => {
+    const y = yFor(t);
+    return `<g><line x1="${left}" y1="${y}" x2="${width - right}" y2="${y}" class="usage-grid-line"></line><text x="${left - 8}" y="${y + 4}" class="usage-axis-label" text-anchor="end">${fmtCompact(t)}</text></g>`;
+  }).join('');
+
+  const bars = daily.map((d, i) => {
+    const x = left + i * barW;
+    const input = d.input_tokens || 0;
+    const output = d.output_tokens || 0;
+    const inputH = (input / maxTotal) * plotH;
+    const outputH = (output / maxTotal) * plotH;
+    const inputY = top + plotH - inputH;
+    const outputY = inputY - outputH;
+    const label = i % every === 0 ? `<text x="${x + barW / 2}" y="${height - 18}" class="usage-axis-label usage-x-label" text-anchor="middle">${d.date.slice(5)}</text>` : '';
+    return `
+      <g class="usage-bar" data-date="${esc(d.date)}" data-input="${input}" data-output="${output}" data-total="${d.total_tokens || 0}" data-messages="${d.message_count || 0}">
+        <rect x="${x}" y="${outputY}" width="${Math.max(barW, 1)}" height="${outputH}" class="usage-bar-output"></rect>
+        <rect x="${x}" y="${inputY}" width="${Math.max(barW, 1)}" height="${inputH}" class="usage-bar-input"></rect>
+        ${label}
+      </g>
+    `;
+  }).join('');
+
+  return `
+    <div class="usage-chart-scroll">
+      <svg class="usage-chart" viewBox="0 0 ${width} ${height}" role="img" aria-label="Daily token usage chart">
+        ${grid}
+        <line x1="${left}" y1="${top + plotH}" x2="${width - right}" y2="${top + plotH}" class="usage-axis-line"></line>
+        ${bars}
+      </svg>
+      <div class="usage-tooltip" id="usage-tooltip" hidden></div>
+    </div>
+    <div class="usage-legend">
+      <span><i class="usage-legend-input"></i>Input tokens</span>
+      <span><i class="usage-legend-output"></i>Output tokens</span>
+    </div>
+  `;
+}
+
+function wireChartTooltips() {
+  const wrap = modalEl?.querySelector('#usage-chart-wrap');
+  const tip = modalEl?.querySelector('#usage-tooltip');
+  if (!wrap || !tip) return;
+  wrap.querySelectorAll('.usage-bar').forEach(bar => {
+    bar.addEventListener('mousemove', e => {
+      tip.hidden = false;
+      tip.innerHTML = `
+        <strong>${esc(bar.dataset.date)}</strong>
+        <span>Total: ${fmtNum(bar.dataset.total)} tokens</span>
+        <span>Input: ${fmtNum(bar.dataset.input)}</span>
+        <span>Output: ${fmtNum(bar.dataset.output)}</span>
+        <span>Messages: ${fmtNum(bar.dataset.messages)}</span>
+      `;
+      const rect = wrap.getBoundingClientRect();
+      tip.style.left = `${e.clientX - rect.left + 12}px`;
+      tip.style.top = `${e.clientY - rect.top + 12}px`;
+    });
+    bar.addEventListener('mouseleave', () => { tip.hidden = true; });
+  });
+}
+
+function renderChart(data) {
+  const wrap = modalEl?.querySelector('#usage-chart-wrap');
+  if (!wrap) return;
+  wrap.innerHTML = state.loading
+    ? '<div class="usage-loading">Loading usage...</div>'
+    : chartSvg(data);
+  wireChartTooltips();
+}
+
+async function loadUsage() {
+  if (!modalEl) return;
+  state.loading = true;
+  renderChart(state.data);
+  saveRange();
+  const params = new URLSearchParams({
+    start: state.start,
+    end: state.end,
+    tz_offset_minutes: String(new Date().getTimezoneOffset()),
+  });
+  if (state.user) params.set('user', state.user);
+  try {
+    const res = await fetch(`/api/usage/tokens?${params}`, { credentials: 'same-origin' });
+    if (!res.ok) throw new Error(await res.text());
+    const data = await res.json();
+    state.data = data;
+    state.loading = false;
+    renderUserSelect(data);
+    renderSummary(data);
+    renderChart(data);
+  } catch (err) {
+    state.loading = false;
+    const wrap = modalEl.querySelector('#usage-chart-wrap');
+    if (wrap) wrap.innerHTML = `<div class="usage-empty usage-error">Failed to load usage: ${esc(err.message || err)}</div>`;
+  }
+}
+
+function wireControls() {
+  modalEl.querySelector('#usage-close-btn')?.addEventListener('click', closeUsage);
+  modalEl.querySelector('#usage-minimize-btn')?.addEventListener('click', minimizeUsage);
+  modalEl.querySelector('#usage-refresh')?.addEventListener('click', loadUsage);
+  modalEl.querySelector('#usage-preset')?.addEventListener('change', e => {
+    const next = e.target.value;
+    state.range = next;
+    if (next === 'custom') {
+      syncControls();
+      openRangePicker();
+      return;
+    }
+    Object.assign(state, rangeFor(next));
+    closeRangePicker();
+    syncControls();
+    loadUsage();
+  });
+  modalEl.querySelector('#usage-range-trigger')?.addEventListener('click', e => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (picker.open) closeRangePicker();
+    else openRangePicker();
+  });
+  modalEl.querySelector('#usage-user')?.addEventListener('change', e => {
+    state.user = e.target.value || ALL_USERS;
+    loadUsage();
+  });
+  modalEl.addEventListener('click', e => {
+    if (e.target === modalEl) closeUsage();
+    else if (picker.open && !e.target.closest('#usage-range-wrap')) closeRangePicker();
+  });
+}
+
+export function openUsage() {
+  ensureDefaults();
+  if (modalEl) {
+    if (Modals.isMinimized(MODAL_ID)) Modals.restore(MODAL_ID);
+    else modalEl.classList.remove('hidden');
+    return;
+  }
+  modalEl = document.createElement('div');
+  modalEl.className = 'modal usage-modal';
+  modalEl.id = MODAL_ID;
+  modalEl.innerHTML = renderSkeleton();
+  document.body.appendChild(modalEl);
+  makeWindowDraggable(modalEl, {
+    content: modalEl.querySelector('.modal-content'),
+    header: modalEl.querySelector('.modal-header'),
+  });
+  Modals.register(MODAL_ID, {
+    restoreFn: restoreUsage,
+    closeFn: closeUsage,
+    sidebarBtnId: 'tool-usage-btn',
+    label: 'Usage',
+    icon: 'M4 19V5M4 19h16M8 17V9M12 17V3M16 17v-6',
+  });
+  syncControls();
+  wireControls();
+  loadUsage();
+}
+
+export function isUsageOpen() {
+  return !!modalEl && !modalEl.classList.contains('hidden');
+}
+
+export default {
+  openUsage,
+  closeUsage,
+  isUsageOpen,
+};

--- a/static/js/usage.js
+++ b/static/js/usage.js
@@ -10,15 +10,23 @@ const ALL_USERS = '__all__';
 const RANGE_KEY = 'ody-usage-range';
 const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const AVG_COLORS = ['#f6c177', '#9ccfd8', '#c4a7e7', '#eb6f92', '#31748f', '#ea9a97'];
 
 let modalEl = null;
+let chartResizeObserver = null;
+let chartResizeRaf = 0;
+let lastChartRenderWidth = 0;
+let lastChartRenderHeight = 0;
 let state = {
-  range: 'month',
+  range: 'last30',
   start: '',
   end: '',
   user: ALL_USERS,
   data: null,
   loading: false,
+  showInput: true,
+  showOutput: true,
+  showMovingAverage: false,
 };
 
 let picker = {
@@ -102,13 +110,66 @@ function sortedRange(start, end) {
   return start <= end ? { start, end } : { start: end, end: start };
 }
 
+function movingAverage(values, windowSize = 7) {
+  return values.map((_, index) => {
+    const start = Math.max(0, index - windowSize + 1);
+    const window = values.slice(start, index + 1);
+    const total = window.reduce((sum, value) => sum + Number(value || 0), 0);
+    return total / window.length;
+  });
+}
+
+function movingAverageSeries(data) {
+  if (!state.showMovingAverage) return [];
+  return (data?.daily_by_user || [])
+    .map((series, index) => {
+      const daily = series.daily || [];
+      const averages = movingAverage(daily.map(day => day.total_tokens || 0));
+      return {
+        user: series.user || 'unassigned',
+        color: AVG_COLORS[index % AVG_COLORS.length],
+        points: averages.map((value, pointIndex) => ({
+          date: daily[pointIndex]?.date || '',
+          value,
+        })),
+      };
+    })
+    .filter(series => series.points.length);
+}
+
+function smoothPath(points) {
+  if (!points.length) return '';
+  if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
+  const d = [`M ${points[0].x} ${points[0].y}`];
+  for (let i = 0; i < points.length - 1; i++) {
+    const previous = points[i - 1] || points[i];
+    const current = points[i];
+    const next = points[i + 1];
+    const following = points[i + 2] || next;
+    const cp1x = current.x + (next.x - previous.x) / 6;
+    const cp1y = current.y + (next.y - previous.y) / 6;
+    const cp2x = next.x - (following.x - current.x) / 6;
+    const cp2y = next.y - (following.y - current.y) / 6;
+    d.push(`C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${next.x} ${next.y}`);
+  }
+  return d.join(' ');
+}
+
 function closeUsage() {
+  if (chartResizeObserver) chartResizeObserver.disconnect();
+  chartResizeObserver = null;
+  if (chartResizeRaf) cancelAnimationFrame(chartResizeRaf);
+  chartResizeRaf = 0;
+  lastChartRenderWidth = 0;
+  picker.open = false;
+  document.getElementById('usage-range-popover')?.remove();
   if (modalEl) modalEl.remove();
   modalEl = null;
   Modals.unregister(MODAL_ID);
 }
 
 function minimizeUsage() {
+  closeRangePicker();
   Modals.minimize(MODAL_ID);
 }
 
@@ -123,7 +184,7 @@ function ensureDefaults() {
     try { return JSON.parse(localStorage.getItem(RANGE_KEY) || '{}'); } catch (_) { return {}; }
   })();
   if (saved.user) state.user = saved.user;
-  state = { ...state, range: 'month', ...rangeFor('month') };
+  state = { ...state, range: 'last30', ...rangeFor('last30') };
 }
 
 function saveRange() {
@@ -174,7 +235,7 @@ function renderSkeleton() {
             </div>
           </div>
           <div class="usage-filter-right">
-            <label id="usage-user-wrap" style="display:none;">Users <select id="usage-user"></select></label>
+            <label id="usage-user-wrap" style="display:none;">Users <select id="usage-user" class="usage-select"></select></label>
             <button type="button" class="usage-refresh" id="usage-refresh" title="Refresh from database" aria-label="Refresh from database">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 4v6h6"/><path d="M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
             </button>
@@ -230,14 +291,16 @@ function monthGrid(baseDate) {
   const first = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1);
   const start = addDays(first, -first.getDay());
   const selected = sortedRange(picker.draftStart, picker.draftEnd);
+  const todayStr = ymd(new Date());
   let days = '';
   for (let i = 0; i < 42; i++) {
     const d = addDays(start, i);
     const day = ymd(d);
     const muted = d.getMonth() !== baseDate.getMonth();
+    const future = day > todayStr;
     const inRange = selected.start && selected.end && day > selected.start && day < selected.end;
     const isSelected = day === selected.start || day === selected.end;
-    days += `<button type="button" class="usage-range-day${muted ? ' muted' : ''}${inRange ? ' in-range' : ''}${isSelected ? ' selected' : ''}" data-day="${day}">${d.getDate()}</button>`;
+    days += `<button type="button" class="usage-range-day${muted ? ' muted' : ''}${future ? ' future' : ''}${inRange ? ' in-range' : ''}${isSelected ? ' selected' : ''}" data-day="${day}"${future ? ' disabled' : ''}>${d.getDate()}</button>`;
   }
   return `
     <div class="usage-range-month">
@@ -274,12 +337,19 @@ function applyRangePicker() {
 }
 
 function renderRangePicker() {
-  const popover = modalEl?.querySelector('#usage-range-popover');
+  const popover = document.getElementById('usage-range-popover');
   if (!popover) return;
   popover.hidden = !picker.open;
   if (!picker.open) {
     popover.innerHTML = '';
     return;
+  }
+  // Portal the popover to <body> so it isn't clipped by the modal's
+  // overflow:hidden, nor re-anchored as a fixed element by the modal's
+  // (animation-held) transform. This keeps it visible and correctly
+  // positioned even when the modal is narrow.
+  if (popover.parentElement !== document.body) {
+    document.body.appendChild(popover);
   }
   if (!picker.month) {
     const startDate = parseYmd(state.start);
@@ -308,7 +378,10 @@ function renderRangePicker() {
   popover.querySelectorAll('[data-usage-cal-nav]').forEach(btn => {
     btn.addEventListener('click', e => {
       e.stopPropagation();
-      picker.month = addMonths(picker.month, Number(btn.dataset.usageCalNav || 0));
+      const next = addMonths(picker.month, Number(btn.dataset.usageCalNav || 0));
+      const now = new Date();
+      const maxMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      picker.month = next > maxMonth ? maxMonth : next;
       renderRangePicker();
     });
   });
@@ -336,24 +409,66 @@ function renderRangePicker() {
     e.stopPropagation();
     applyRangePicker();
   });
+  clampRangePopover(popover);
 }
 
-function chartSvg(data) {
+function clampRangePopover(popover) {
+  // On mobile the stylesheet pins the popover with fixed positioning; leave it
+  // alone there and let CSS handle it.
+  if (window.matchMedia && window.matchMedia('(max-width: 768px)').matches) {
+    popover.style.left = '';
+    popover.style.right = '';
+    popover.style.top = '';
+    return;
+  }
+  // The popover is position:fixed so it can spill outside the (overflow:hidden)
+  // modal when it's narrow. Anchor it to the trigger in viewport coordinates and
+  // clamp to the viewport so it never runs off-screen.
+  const trigger = modalEl?.querySelector('#usage-range-trigger');
+  if (!trigger) return;
+  popover.style.right = 'auto';
+  if (!picker.open) return;
+  const margin = 8;
+  const triggerRect = trigger.getBoundingClientRect();
+  const popRect = popover.getBoundingClientRect();
+  const popW = popRect.width;
+  const popH = popRect.height;
+
+  let left = triggerRect.left;
+  const maxLeft = window.innerWidth - margin - popW;
+  left = Math.min(left, maxLeft);
+  left = Math.max(margin, left);
+
+  let top = triggerRect.bottom + 6;
+  if (top + popH > window.innerHeight - margin) {
+    const above = triggerRect.top - 6 - popH;
+    top = above >= margin ? above : Math.max(margin, window.innerHeight - margin - popH);
+  }
+
+  popover.style.left = `${Math.round(left)}px`;
+  popover.style.top = `${Math.round(top)}px`;
+}
+
+function chartInnerSvg(data, width, height) {
   const daily = data?.daily || [];
-  const maxTotal = Math.max(0, ...daily.map(d => d.total_tokens || 0));
-  if (!daily.length || maxTotal === 0) {
+  const avgSeries = movingAverageSeries(data);
+  const visibleTotal = d => (state.showInput ? d.input_tokens || 0 : 0) + (state.showOutput ? d.output_tokens || 0 : 0);
+  const maxVisibleTotal = Math.max(0, ...daily.map(visibleTotal));
+  const maxAverageTotal = Math.max(0, ...avgSeries.flatMap(series => series.points.map(point => point.value || 0)));
+  const maxTotal = Math.max(maxVisibleTotal, maxAverageTotal, 1);
+  if (!daily.length) {
     return '<div class="usage-empty">No token usage found for this range.</div>';
   }
 
-  const width = Math.max(720, daily.length * 18);
-  const height = 320;
   const left = 54;
   const top = 18;
-  const bottom = 42;
+  const bottom = 56;
   const right = 12;
   const plotW = width - left - right;
   const plotH = height - top - bottom;
-  const barW = plotW / daily.length;
+  const slotW = plotW / daily.length;
+  const barGap = Math.min(Math.max(slotW * 0.18, 4), 10);
+  const barW = Math.max(slotW - barGap, 1);
   const yFor = val => top + plotH - (val / maxTotal) * plotH;
   const ticks = [0, 0.25, 0.5, 0.75, 1].map(p => Math.round(maxTotal * p));
   const every = Math.max(1, Math.ceil(daily.length / 10));
@@ -364,68 +479,165 @@ function chartSvg(data) {
   }).join('');
 
   const bars = daily.map((d, i) => {
-    const x = left + i * barW;
-    const input = d.input_tokens || 0;
-    const output = d.output_tokens || 0;
+    const laneX = left + i * slotW;
+    const x = laneX + barGap / 2;
+    const rawInput = d.input_tokens || 0;
+    const rawOutput = d.output_tokens || 0;
+    const input = state.showInput ? rawInput : 0;
+    const output = state.showOutput ? rawOutput : 0;
     const inputH = (input / maxTotal) * plotH;
     const outputH = (output / maxTotal) * plotH;
     const inputY = top + plotH - inputH;
     const outputY = inputY - outputH;
-    const label = i % every === 0 ? `<text x="${x + barW / 2}" y="${height - 18}" class="usage-axis-label usage-x-label" text-anchor="middle">${d.date.slice(5)}</text>` : '';
+    const centerX = laneX + slotW / 2;
+    const label = i % every === 0 ? `<text x="${centerX}" y="${height - 24}" class="usage-axis-label usage-x-label" text-anchor="middle">${d.date.slice(5)}</text>` : '';
     return `
-      <g class="usage-bar" data-date="${esc(d.date)}" data-input="${input}" data-output="${output}" data-total="${d.total_tokens || 0}" data-messages="${d.message_count || 0}">
+      <rect x="${laneX}" y="${top}" width="${slotW}" height="${plotH}" class="usage-hover-highlight" data-highlight-date="${esc(d.date)}"></rect>
+      <g class="usage-bar" data-bar-date="${esc(d.date)}">
         <rect x="${x}" y="${outputY}" width="${Math.max(barW, 1)}" height="${outputH}" class="usage-bar-output"></rect>
         <rect x="${x}" y="${inputY}" width="${Math.max(barW, 1)}" height="${inputH}" class="usage-bar-input"></rect>
         ${label}
       </g>
+      <rect x="${laneX}" y="${top}" width="${slotW}" height="${plotH}" class="usage-hover-target" data-date="${esc(d.date)}" data-input="${rawInput}" data-output="${rawOutput}" data-total="${d.total_tokens || 0}" data-messages="${d.message_count || 0}"></rect>
     `;
   }).join('');
 
+  const leftEdge = left;
+  const rightEdge = width - right;
+  const avgLines = avgSeries.map(series => {
+    const points = series.points.map((point, i) => {
+      const x = left + i * slotW + slotW / 2;
+      return { x, y: yFor(point.value || 0) };
+    });
+    // Stretch the line out to the chart edges instead of stopping at the
+    // centers of the first/last bars.
+    if (points.length) {
+      if (points[0].x > leftEdge) points.unshift({ x: leftEdge, y: points[0].y });
+      const lastPoint = points[points.length - 1];
+      if (lastPoint.x < rightEdge) points.push({ x: rightEdge, y: lastPoint.y });
+    }
+    return `<path class="usage-ma-line" d="${smoothPath(points)}" stroke="${esc(series.color)}" fill="none" vector-effect="non-scaling-stroke"><title>${esc(series.user)} 7-day average</title></path>`;
+  }).join('');
+
   return `
-    <div class="usage-chart-scroll">
-      <svg class="usage-chart" viewBox="0 0 ${width} ${height}" role="img" aria-label="Daily token usage chart">
-        ${grid}
-        <line x1="${left}" y1="${top + plotH}" x2="${width - right}" y2="${top + plotH}" class="usage-axis-line"></line>
-        ${bars}
-      </svg>
-      <div class="usage-tooltip" id="usage-tooltip" hidden></div>
-    </div>
+    <svg class="usage-chart" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" role="img" aria-label="Daily token usage chart">
+      ${grid}
+      <line x1="${left}" y1="${top + plotH}" x2="${width - right}" y2="${top + plotH}" class="usage-axis-line"></line>
+      ${bars}
+      ${avgLines}
+    </svg>
+  `;
+}
+
+function chartShell() {
+  return `
+    <div class="usage-chart-scroll"></div>
+    <div class="usage-tooltip" id="usage-tooltip" hidden></div>
     <div class="usage-legend">
-      <span><i class="usage-legend-input"></i>Input tokens</span>
-      <span><i class="usage-legend-output"></i>Output tokens</span>
+      <button type="button" class="usage-legend-toggle${state.showInput ? ' active' : ''}" data-usage-series="input" aria-pressed="${state.showInput}">
+        <i class="usage-legend-input"></i>Input tokens
+      </button>
+      <button type="button" class="usage-legend-toggle${state.showOutput ? ' active' : ''}" data-usage-series="output" aria-pressed="${state.showOutput}">
+        <i class="usage-legend-output"></i>Output tokens
+      </button>
+      <button type="button" class="usage-legend-toggle${state.showMovingAverage ? ' active' : ''}" data-usage-series="average" aria-pressed="${state.showMovingAverage}">
+        <i class="usage-legend-average"></i>7-day average
+      </button>
     </div>
   `;
 }
 
 function wireChartTooltips() {
   const wrap = modalEl?.querySelector('#usage-chart-wrap');
+  const scroll = modalEl?.querySelector('.usage-chart-scroll');
   const tip = modalEl?.querySelector('#usage-tooltip');
   if (!wrap || !tip) return;
-  wrap.querySelectorAll('.usage-bar').forEach(bar => {
-    bar.addEventListener('mousemove', e => {
+  const clearActive = () => {
+    wrap.querySelectorAll('.usage-hover-highlight.active, .usage-bar.active').forEach(el => {
+      el.classList.remove('active');
+    });
+  };
+  const hideTooltip = () => {
+    clearActive();
+    tip.hidden = true;
+  };
+  const positionTooltip = e => {
+    const rect = wrap.getBoundingClientRect();
+    const padding = 8;
+    const preferredLeft = e.clientX - rect.left + 12;
+    const preferredTop = e.clientY - rect.top + 12;
+    const maxLeft = Math.max(padding, wrap.clientWidth - tip.offsetWidth - padding);
+    const maxTop = Math.max(padding, wrap.clientHeight - tip.offsetHeight - padding);
+    tip.style.left = `${Math.max(padding, Math.min(preferredLeft, maxLeft))}px`;
+    tip.style.top = `${Math.max(padding, Math.min(preferredTop, maxTop))}px`;
+  };
+  wrap.querySelectorAll('.usage-hover-target').forEach(target => {
+    target.addEventListener('mousemove', e => {
+      clearActive();
+      wrap.querySelector(`[data-highlight-date="${target.dataset.date}"]`)?.classList.add('active');
+      wrap.querySelector(`[data-bar-date="${target.dataset.date}"]`)?.classList.add('active');
       tip.hidden = false;
       tip.innerHTML = `
-        <strong>${esc(bar.dataset.date)}</strong>
-        <span>Total: ${fmtNum(bar.dataset.total)} tokens</span>
-        <span>Input: ${fmtNum(bar.dataset.input)}</span>
-        <span>Output: ${fmtNum(bar.dataset.output)}</span>
-        <span>Messages: ${fmtNum(bar.dataset.messages)}</span>
+        <strong>${esc(target.dataset.date)}</strong>
+        <span>Total: ${fmtNum(target.dataset.total)} tokens</span>
+        <span>Input: ${fmtNum(target.dataset.input)}</span>
+        <span>Output: ${fmtNum(target.dataset.output)}</span>
+        <span>Messages: ${fmtNum(target.dataset.messages)}</span>
       `;
-      const rect = wrap.getBoundingClientRect();
-      tip.style.left = `${e.clientX - rect.left + 12}px`;
-      tip.style.top = `${e.clientY - rect.top + 12}px`;
+      positionTooltip(e);
     });
-    bar.addEventListener('mouseleave', () => { tip.hidden = true; });
+  });
+  scroll?.addEventListener('mouseleave', hideTooltip);
+  wrap.addEventListener('mouseleave', hideTooltip);
+  wrap.querySelectorAll('[data-usage-series]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const series = btn.dataset.usageSeries;
+      if (series === 'input') state.showInput = !state.showInput;
+      if (series === 'output') state.showOutput = !state.showOutput;
+      if (series === 'average') state.showMovingAverage = !state.showMovingAverage;
+      renderChart(state.data);
+    });
   });
 }
 
 function renderChart(data) {
   const wrap = modalEl?.querySelector('#usage-chart-wrap');
   if (!wrap) return;
-  wrap.innerHTML = state.loading
-    ? '<div class="usage-loading">Loading usage...</div>'
-    : chartSvg(data);
+  if (state.loading && data) return;
+  if (state.loading) {
+    wrap.innerHTML = '<div class="usage-loading">Loading usage...</div>';
+    return;
+  }
+  lastChartRenderWidth = Math.round(wrap.clientWidth);
+  lastChartRenderHeight = Math.round(wrap.clientHeight);
+  wrap.innerHTML = chartShell();
+  const scroll = wrap.querySelector('.usage-chart-scroll');
+  if (scroll) {
+    const cs = getComputedStyle(scroll);
+    const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
+    const padY = (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0);
+    const w = Math.max(1, Math.floor(scroll.clientWidth - padX));
+    const h = Math.max(1, Math.floor(scroll.clientHeight - padY));
+    scroll.innerHTML = chartInnerSvg(data, w, h);
+  }
   wireChartTooltips();
+}
+
+function watchChartSize() {
+  const wrap = modalEl?.querySelector('#usage-chart-wrap');
+  if (!wrap || chartResizeObserver) return;
+  chartResizeObserver = new ResizeObserver(() => {
+    if (!state.data || state.loading) return;
+    if (chartResizeRaf) cancelAnimationFrame(chartResizeRaf);
+    chartResizeRaf = requestAnimationFrame(() => {
+      chartResizeRaf = 0;
+      const nextWidth = Math.round(wrap.clientWidth);
+      const nextHeight = Math.round(wrap.clientHeight);
+      if (Math.abs(nextWidth - lastChartRenderWidth) < 2 && Math.abs(nextHeight - lastChartRenderHeight) < 2) return;
+      renderChart(state.data);
+    });
+  });
+  chartResizeObserver.observe(wrap);
 }
 
 async function loadUsage() {
@@ -513,6 +725,7 @@ export function openUsage() {
   });
   syncControls();
   wireControls();
+  watchChartSize();
   loadUsage();
 }
 

--- a/static/js/usage.js
+++ b/static/js/usage.js
@@ -189,12 +189,7 @@ function ensureDefaults() {
 
 function saveRange() {
   try {
-    localStorage.setItem(RANGE_KEY, JSON.stringify({
-      range: state.range,
-      start: state.start,
-      end: state.end,
-      user: state.user,
-    }));
+    localStorage.setItem(RANGE_KEY, JSON.stringify({ user: state.user }));
   } catch (_) {}
 }
 
@@ -729,12 +724,6 @@ export function openUsage() {
   loadUsage();
 }
 
-export function isUsageOpen() {
-  return !!modalEl && !modalEl.classList.contains('hidden');
-}
-
 export default {
   openUsage,
-  closeUsage,
-  isUsageOpen,
 };

--- a/static/style.css
+++ b/static/style.css
@@ -4693,6 +4693,7 @@ body.bg-pattern-sparkles {
     .modal-dock-close:hover { color:var(--red); opacity:1; }
     .modal-body { flex:1; overflow-y:auto; }
     .modal-body button { margin-top:6px; }
+
     /* Styled confirm dialog — keeps backdrop */
     #styled-confirm-overlay {
       background:rgba(0,0,0,0.5);

--- a/tests/test_usage_routes.py
+++ b/tests/test_usage_routes.py
@@ -39,8 +39,6 @@ def test_aggregate_usage_rows_buckets_stacked_tokens_by_local_day():
     assert by_day["2026-06-01"]["message_count"] == 4
     assert result["totals"]["total_tokens"] == 265
     assert result["totals"]["message_count"] == 5
-    assert result["totals"]["real_count"] == 2
-    assert result["totals"]["estimated_count"] == 1
     by_user_daily = {row["user"]: row["daily"] for row in result["daily_by_user"]}
     alice_daily = {row["date"]: row for row in by_user_daily["alice"]}
     bob_daily = {row["date"]: row for row in by_user_daily["bob"]}

--- a/tests/test_usage_routes.py
+++ b/tests/test_usage_routes.py
@@ -1,0 +1,61 @@
+from datetime import date, datetime
+
+from routes.usage_routes import (
+    ALL_USERS,
+    _aggregate_usage_rows,
+    _parse_message_metrics,
+    _resolve_owner_scope,
+)
+
+
+def test_parse_message_metrics_ignores_missing_or_zero_tokens():
+    assert _parse_message_metrics(None) is None
+    assert _parse_message_metrics("{}") is None
+    assert _parse_message_metrics('{"input_tokens": 0, "output_tokens": 0}') is None
+
+
+def test_aggregate_usage_rows_buckets_stacked_tokens_by_local_day():
+    rows = [
+        (datetime(2026, 6, 1, 4, 30), '{"input_tokens": 100, "output_tokens": 25, "usage_source": "real"}', "alice", "assistant"),
+        (datetime(2026, 6, 1, 18, 0), '{"input_tokens": 50, "output_tokens": 75, "usage_source": "estimated"}', "alice", "assistant"),
+        (datetime(2026, 6, 2, 2, 0), '{"input_tokens": 10, "output_tokens": 5, "usage_source": "real"}', "bob", "assistant"),
+        (datetime(2026, 6, 2, 3, 0), '{"not_tokens": true}', "bob", "assistant"),
+        (datetime(2026, 6, 2, 4, 0), '{"input_tokens": 999, "output_tokens": 999}', "bob", "user"),
+    ]
+
+    result = _aggregate_usage_rows(
+        rows,
+        start=date(2026, 5, 31),
+        end=date(2026, 6, 1),
+        tz_offset_minutes=300,
+    )
+
+    by_day = {row["date"]: row for row in result["daily"]}
+    assert by_day["2026-05-31"]["input_tokens"] == 100
+    assert by_day["2026-05-31"]["output_tokens"] == 25
+    assert by_day["2026-05-31"]["message_count"] == 1
+    assert by_day["2026-06-01"]["input_tokens"] == 60
+    assert by_day["2026-06-01"]["output_tokens"] == 80
+    assert by_day["2026-06-01"]["message_count"] == 4
+    assert result["totals"]["total_tokens"] == 265
+    assert result["totals"]["message_count"] == 5
+    assert result["totals"]["real_count"] == 2
+    assert result["totals"]["estimated_count"] == 1
+
+
+def test_resolve_owner_scope_admin_all_users():
+    owner_scope, selected_user = _resolve_owner_scope("admin", True, ALL_USERS)
+    assert owner_scope is None
+    assert selected_user == ALL_USERS
+
+
+def test_resolve_owner_scope_admin_single_user():
+    owner_scope, selected_user = _resolve_owner_scope("admin", True, "alice")
+    assert owner_scope == "alice"
+    assert selected_user == "alice"
+
+
+def test_resolve_owner_scope_non_admin_forces_own_user():
+    owner_scope, selected_user = _resolve_owner_scope("alice", False, "bob")
+    assert owner_scope == "alice"
+    assert selected_user == "alice"

--- a/tests/test_usage_routes.py
+++ b/tests/test_usage_routes.py
@@ -16,9 +16,9 @@ def test_parse_message_metrics_ignores_missing_or_zero_tokens():
 
 def test_aggregate_usage_rows_buckets_stacked_tokens_by_local_day():
     rows = [
-        (datetime(2026, 6, 1, 4, 30), '{"input_tokens": 100, "output_tokens": 25, "usage_source": "real"}', "alice", "assistant"),
-        (datetime(2026, 6, 1, 18, 0), '{"input_tokens": 50, "output_tokens": 75, "usage_source": "estimated"}', "alice", "assistant"),
-        (datetime(2026, 6, 2, 2, 0), '{"input_tokens": 10, "output_tokens": 5, "usage_source": "real"}', "bob", "assistant"),
+        (datetime(2026, 6, 1, 4, 30), '{"input_tokens": 100, "output_tokens": 25, "usage_source": "real", "model": "gpt-4o"}', "alice", "assistant"),
+        (datetime(2026, 6, 1, 18, 0), '{"input_tokens": 50, "output_tokens": 75, "usage_source": "estimated", "model": "claude-3-5-sonnet"}', "alice", "assistant"),
+        (datetime(2026, 6, 2, 2, 0), '{"input_tokens": 10, "output_tokens": 5, "usage_source": "real", "model": "gpt-4o"}', "bob", "assistant"),
         (datetime(2026, 6, 2, 3, 0), '{"not_tokens": true}', "bob", "assistant"),
         (datetime(2026, 6, 2, 4, 0), '{"input_tokens": 999, "output_tokens": 999}', "bob", "user"),
     ]
@@ -46,6 +46,17 @@ def test_aggregate_usage_rows_buckets_stacked_tokens_by_local_day():
     assert alice_daily["2026-06-01"]["total_tokens"] == 125
     assert bob_daily["2026-06-01"]["total_tokens"] == 15
     assert bob_daily["2026-06-01"]["message_count"] == 3
+    assert result["models"] == [
+        {"model": "gpt-4o", "total_tokens": 140},
+        {"model": "claude-3-5-sonnet", "total_tokens": 125},
+    ]
+    by_model_daily = {row["model"]: row["daily"] for row in result["daily_by_model"]}
+    gpt_daily = {row["date"]: row for row in by_model_daily["gpt-4o"]}
+    claude_daily = {row["date"]: row for row in by_model_daily["claude-3-5-sonnet"]}
+    assert gpt_daily["2026-05-31"]["total_tokens"] == 125
+    assert gpt_daily["2026-06-01"]["total_tokens"] == 15
+    assert claude_daily["2026-06-01"]["input_tokens"] == 50
+    assert claude_daily["2026-06-01"]["output_tokens"] == 75
 
 
 def test_resolve_owner_scope_admin_all_users():

--- a/tests/test_usage_routes.py
+++ b/tests/test_usage_routes.py
@@ -41,6 +41,13 @@ def test_aggregate_usage_rows_buckets_stacked_tokens_by_local_day():
     assert result["totals"]["message_count"] == 5
     assert result["totals"]["real_count"] == 2
     assert result["totals"]["estimated_count"] == 1
+    by_user_daily = {row["user"]: row["daily"] for row in result["daily_by_user"]}
+    alice_daily = {row["date"]: row for row in by_user_daily["alice"]}
+    bob_daily = {row["date"]: row for row in by_user_daily["bob"]}
+    assert alice_daily["2026-05-31"]["total_tokens"] == 125
+    assert alice_daily["2026-06-01"]["total_tokens"] == 125
+    assert bob_daily["2026-06-01"]["total_tokens"] == 15
+    assert bob_daily["2026-06-01"]["message_count"] == 3
 
 
 def test_resolve_owner_scope_admin_all_users():


### PR DESCRIPTION
Hey Felix,
I added a token usage dashboard, by day and by model, figured this would be pretty useful for those curious on token consumption. Added it as a new button on the side nav under the "Theme" button which opens a new modal. I seeded some older messages to make it usable. Spend would also be cool to track for non-hosting folks, just gets a bit weird to get the actual cost nailed down with cached tokens (different providers do it a bit differently I think), but its doable.


https://github.com/user-attachments/assets/f8e81adb-8c1e-48d2-a3a0-cbd3d69a07cc

https://github.com/user-attachments/assets/7cffea5c-9400-436b-bedf-cf77f30a08f6

https://github.com/user-attachments/assets/352ce4eb-9984-4bd0-afed-faa22efed668


## Changed Areas
- `routes/usage_routes.py`
  - Adds `/api/usage/tokens` aggregation for daily token/message usage.
  - Supports admin user filtering and timezone-aware date bucketing.
  - Returns per-user daily data for moving average overlays.
- `static/js/usage.js`
  - Adds the Usage modal, chart rendering, date range picker, user filtering, tooltips, legend toggles, and responsive behavior.
  - Prevents future date selection.
  - Keeps the date picker visible outside narrow modal bounds.
- `static/css/usage.css`
  - Adds dedicated styling for the Usage modal, toolbar, summary cards, chart, tooltip, legend, and range picker.
- `static/index.html` / `static/app.js`
  - Adds the Usage SideNav entry and wires it to the modal.
- `tests/test_usage_routes.py`
  - Adds/updates coverage for usage aggregation, message counts, token bucketing, user scoping, and admin filtering behavior.
## Testing
Automated checks run:
- `python -m pytest tests/test_usage_routes.py -q`
  - `5 passed`
  - One existing SQLAlchemy deprecation warning from `core/database.py`.
- `node --check static/js/usage.js`
  - Passed.
- Linter diagnostics for edited usage files
  - No errors found.

Manual UI checks performed:
- Opened Usage from the SideNav.
- Verified default range is Last 30 days.
- Verified preset range changes reload the chart.
- Verified custom date range picker opens, clamps to the viewport, and does not allow dates after today.
- Verified admin user dropdown filters usage by user.
- Verified Input/Output legend toggles hide and show bars.
- Verified 7-day average toggle renders the moving average line across the chart.
- Verified chart hover highlights the full date column and shows tooltip details.
- Verified narrow modal/window behavior keeps controls usable and prevents chart horizontal scrolling.