### PR TITLE
Gate Cookbook "Run" on the model being downloaded

### DIFF
--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -887,7 +887,30 @@ export function _expandModelRow(row, modelData) {
   const quickRunBtn = panel.querySelector('.hwfit-quickrun-btn');
   if (quickRunBtn) {
     quickRunBtn.addEventListener('click', async () => {
-      _syncHostFromScanDropdown();
+      const _qrHost = _syncHostFromScanDropdown();
+
+      // Don't serve a model that isn't downloaded yet. vLLM/SGLang would
+      // background-pull at launch, so the serve task shows up as "running" in
+      // the Running tab while nothing is actually served (and llama.cpp just
+      // errors "No GGUF found"). The Configure button and the Serve tab already
+      // gate on the cached-model list — mirror that here. When the model isn't
+      // present, honor the button's "Download" half by kicking off the download
+      // instead, then the user can Run again to serve once it finishes.
+      const _short = modelData.name.split('/').pop();
+      const _downloaded = _cachedModelIds && (
+        _cachedModelIds.has(modelData.name)
+        || [..._cachedModelIds].some(id => id === modelData.name || id.endsWith('/' + _short))
+      );
+      if (_cachedModelIds && !_downloaded) {
+        uiModule.showToast('Model not downloaded yet — starting download. Run again to serve once it finishes.');
+        if (backend === 'ollama') {
+          _runPanelCmd(panel, _buildDownloadCmd(modelData, backend), { timeout: 0 });
+        } else {
+          _runModelDownload(panel, modelData, backend, _qrHost);
+        }
+        return;
+      }
+
       quickRunBtn.disabled = true;
       quickRunBtn.textContent = 'Starting...';
 


### PR DESCRIPTION
## What was broken

The **Run** button in the Cookbook's **What Fits?** tab was basically lying. The tooltip said "Download + launch with smart defaults" but it never downloaded anything. It just fired a serve command immediately, whether or not the model was on disk.

So the model would show up in the **Running** tab looking fine, while in reality:
- vLLM/SGLang were quietly pulling weights in the background, or
- llama.cpp was immediately failing with `No GGUF found on this host`

Every other path in the UI already handles this correctly. The **Configure** button and the **Serve** tab both check `_cachedModelIds` before doing anything. Quick-Run was just the one place that slipped through.

## What I changed

Quick-Run now checks the same gate. If the model isn't cached locally, it starts a **download** instead of a fake serve, and toasts the user to hit Run again once it finishes. If the model is already downloaded, nothing changes.

Only one file touched: `static/js/cookbook-hwfit.js`. No backend changes.

## How to test

1. Cookbook -> **What Fits?**, expand a model you haven't downloaded
2. Click **Run**
   - **Before:** serve task appears in Running and does nothing useful
   - **After:** download starts, toast tells you to Run again when done
3. Let it finish, click **Run** again -> actually serves, Running tab shows a real task
4. Try with an already-downloaded model -> serves immediately, no regression

## Checks
- `node --check static/js/cookbook-hwfit.js` passes
- No Python touched

## Related

Related to the symptoms in #312 and #191 but goes the other direction (undownloaded -> fake running). Not a direct fix for either.