### PR TITLE
fix: quote and sanitize export filename in Content-Disposition header

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -32,6 +32,18 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["sessions"])
 
+
+def _content_disposition(out_name: str) -> str:
+    """Build a safe Content-Disposition header value for a download.
+
+    The export filename can come from a user-supplied query param, so strip
+    control characters (header-injection guard) and double quotes, then wrap
+    the result in quotes so spaces and other special characters survive per
+    RFC 6266 instead of truncating the name in the browser."""
+    safe = re.sub(r'[\r\n"]', "", out_name or "").strip() or "download"
+    return f'attachment; filename="{safe}"'
+
+
 def _pick_endpoint_for_sort():
     """Pick model endpoint for auto-sort LLM call — uses utility endpoint setting, falls back to default."""
     from src.endpoint_resolver import resolve_endpoint
@@ -570,7 +582,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             return Response(
                 content=_json.dumps(data, indent=2, ensure_ascii=False),
                 media_type="application/json",
-                headers={"Content-Disposition": f"attachment; filename={out_name}"},
+                headers={"Content-Disposition": _content_disposition(out_name)},
             )
 
         if fmt == "txt":
@@ -583,7 +595,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             return Response(
                 content="\n".join(lines),
                 media_type="text/plain",
-                headers={"Content-Disposition": f"attachment; filename={out_name}"},
+                headers={"Content-Disposition": _content_disposition(out_name)},
             )
 
         if fmt == "html":
@@ -607,7 +619,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             return Response(
                 content="\n".join(html_parts),
                 media_type="text/html",
-                headers={"Content-Disposition": f"attachment; filename={out_name}"},
+                headers={"Content-Disposition": _content_disposition(out_name)},
             )
 
         # Default: markdown
@@ -628,7 +640,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         return Response(
             content="\n".join(markdown_lines),
             media_type="text/markdown",
-            headers={"Content-Disposition": f"attachment; filename={out_name}"},
+            headers={"Content-Disposition": _content_disposition(out_name)},
         )
     
     @router.post("/sessions/save")


### PR DESCRIPTION
`GET /api/session/{sid}/export` accepts a `filename` query parameter and dropped it straight into `Content-Disposition: attachment; filename={out_name}` unquoted across all four export formats (json/txt/html/md).

Two problems:
- A filename with spaces or special characters (e.g. `My export.md`) gets truncated by browsers, since an unquoted value stops at the first space.
- The value is user-controlled and went into a response header without stripping control characters.

Added a small `_content_disposition` helper that strips CR/LF and double quotes, then wraps the name in quotes per RFC 6266. This matches how the other export endpoints in the codebase (calendar, contacts, gallery, documents) already build the header.