### PR TITLE
Fix sidebar brand text clipping

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -546,11 +546,12 @@ body.bg-pattern-sparkles {
     .sidebar-brand-title {
       font-size: 1rem;
       font-weight: 600;
+      line-height: 1.35;
       color: var(--brand-color, var(--red));
       white-space: nowrap;
       user-select: none;
       position: relative;
-      top: 1px;
+      top: 0;
       left: -10px;
     }
     .sidebar-sep {


### PR DESCRIPTION
Fixes #355.

The sidebar brand text was using the browser's default line-height and had a tiny downward offset. That is easy to miss on macOS, but on Windows at 100% zoom it can put the top of the text right on a sub-pixel boundary and clip it.

This sets a stable line-height for the brand label and removes the 1px vertical nudge. It leaves the sidebar spacing and mobile override alone.

Checks:
- git diff --check
- node --check static/app.js
- node --check static/js/sidebar-layout.js
- python3 -m py_compile app.py
