### PR TITLE
fix(cookbook): avoid pip --user in venv, surface install errors in download wrapper

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -432,12 +432,31 @@ def setup_cookbook_routes() -> APIRouter:
         # throughput. Retries set disable_hf_transfer to fall back to the plain,
         # slower-but-reliable downloader (resumes cleanly from the .incomplete files).
         # Use `python3 -m pip` not `pip` — macOS has no bare `pip` command.
-        lines.append("command -v hf >/dev/null 2>&1 || python3 -m pip install --user --break-system-packages -q -U huggingface_hub 2>/dev/null || python3 -m pip install -q -U huggingface_hub 2>/dev/null")
+        # IMPORTANT: in an active venv, `pip install --user` fails with
+        # "User site-packages are not visible in this virtualenv." — so try the
+        # plain install first and only reach for `--user --break-system-packages`
+        # outside a venv. We also drop the blanket `2>/dev/null` so any residual
+        # failure surfaces in the tmux log and the user can debug it (issue #354).
+        _install_hf_cmd = (
+            "command -v hf >/dev/null 2>&1 || "
+            "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
+            "python3 -m pip install -q -U huggingface_hub 2>&1 | tail -5 || "
+            "python3 -m pip install --user --break-system-packages -q -U huggingface_hub 2>&1 | tail -5 || "
+            "python3 -m pip install --break-system-packages -q -U huggingface_hub 2>&1 | tail -5; }"
+        )
+        lines.append(_install_hf_cmd)
         if req.disable_hf_transfer:
             lines.append("export HF_HUB_ENABLE_HF_TRANSFER=0")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=4")
         else:
-            lines.append("python3 -c 'import hf_transfer' 2>/dev/null || python3 -m pip install --user --break-system-packages -q hf_transfer 2>/dev/null || python3 -m pip install -q hf_transfer 2>/dev/null")
+            _install_hft_cmd = (
+                "python3 -c 'import hf_transfer' 2>/dev/null || "
+                "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
+                "python3 -m pip install -q hf_transfer 2>&1 | tail -5 || "
+                "python3 -m pip install --user --break-system-packages -q hf_transfer 2>&1 | tail -5 || "
+                "python3 -m pip install --break-system-packages -q hf_transfer 2>&1 | tail -5; }"
+            )
+            lines.append(_install_hft_cmd)
             lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")
 
@@ -533,8 +552,23 @@ def setup_cookbook_routes() -> APIRouter:
             runner_lines.append('export PATH="$HOME/.local/bin:$PATH"')
             # Install hf CLI + hf_transfer best-effort so future runs get the fast path.
             # Use --break-system-packages on PEP-668 systems (Arch, newer Debian) so it doesn't bail.
-            runner_lines.append("command -v hf >/dev/null 2>&1 || pip install --user --break-system-packages -q -U huggingface_hub 2>/dev/null || pip install -q -U huggingface_hub 2>/dev/null")
-            runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null || pip install --user --break-system-packages -q hf_transfer 2>/dev/null || pip install -q hf_transfer 2>/dev/null")
+            # In a venv, `pip install --user` errors with "User site-packages are not visible in
+            # this virtualenv" — so try plain install first, only reach for --user outside a venv.
+            # Surface the last 5 lines of any failure so the user can debug from the tmux log (#354).
+            runner_lines.append(
+                "command -v hf >/dev/null 2>&1 || "
+                "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
+                "pip install -q -U huggingface_hub 2>&1 | tail -5 || "
+                "pip install --user --break-system-packages -q -U huggingface_hub 2>&1 | tail -5 || "
+                "pip install --break-system-packages -q -U huggingface_hub 2>&1 | tail -5; }"
+            )
+            runner_lines.append(
+                "python3 -c 'import hf_transfer' 2>/dev/null || "
+                "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
+                "pip install -q hf_transfer 2>&1 | tail -5 || "
+                "pip install --user --break-system-packages -q hf_transfer 2>&1 | tail -5 || "
+                "pip install --break-system-packages -q hf_transfer 2>&1 | tail -5; }"
+            )
             runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
             runner_lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")
             # Surface whether the HF token actually reached THIS server, so a gated

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -435,26 +435,61 @@ def setup_cookbook_routes() -> APIRouter:
         # IMPORTANT: in an active venv, `pip install --user` fails with
         # "User site-packages are not visible in this virtualenv." — so try the
         # plain install first and only reach for `--user --break-system-packages`
-        # outside a venv. We also drop the blanket `2>/dev/null` so any residual
-        # failure surfaces in the tmux log and the user can debug it (issue #354).
+        # outside a venv.
+        #
+        # PIP EXIT STATUS: previous version piped through `| tail -5`, which
+        # masks pip's exit code (the pipeline returns tail's 0 even when pip
+        # fails, so the `||` fallback chain never fires). Now each attempt
+        # captures output to a temp file, prints the tail on failure, and
+        # returns pip's real exit status. See PR #363 review feedback.
+        _pip_install_hf = (
+            "_pip_out=$(mktemp) && "
+            "python3 -m pip install -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+            "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+        )
+        _pip_install_hf_user = (
+            "_pip_out=$(mktemp) && "
+            "python3 -m pip install --user --break-system-packages -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+            "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+        )
+        _pip_install_hf_bare = (
+            "_pip_out=$(mktemp) && "
+            "python3 -m pip install --break-system-packages -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+            "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+        )
         _install_hf_cmd = (
             "command -v hf >/dev/null 2>&1 || "
             "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
-            "python3 -m pip install -q -U huggingface_hub 2>&1 | tail -5 || "
-            "python3 -m pip install --user --break-system-packages -q -U huggingface_hub 2>&1 | tail -5 || "
-            "python3 -m pip install --break-system-packages -q -U huggingface_hub 2>&1 | tail -5; }"
+            f"bash -c '{_pip_install_hf}' || "
+            f"bash -c '{_pip_install_hf_user}' || "
+            f"bash -c '{_pip_install_hf_bare}'; }}"
         )
         lines.append(_install_hf_cmd)
         if req.disable_hf_transfer:
             lines.append("export HF_HUB_ENABLE_HF_TRANSFER=0")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=4")
         else:
+            _pip_install_hft = (
+                "_pip_out=$(mktemp) && "
+                "python3 -m pip install -q hf_transfer >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+                "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+            )
+            _pip_install_hft_user = (
+                "_pip_out=$(mktemp) && "
+                "python3 -m pip install --user --break-system-packages -q hf_transfer >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+                "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+            )
+            _pip_install_hft_bare = (
+                "_pip_out=$(mktemp) && "
+                "python3 -m pip install --break-system-packages -q hf_transfer >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+                "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+            )
             _install_hft_cmd = (
                 "python3 -c 'import hf_transfer' 2>/dev/null || "
                 "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
-                "python3 -m pip install -q hf_transfer 2>&1 | tail -5 || "
-                "python3 -m pip install --user --break-system-packages -q hf_transfer 2>&1 | tail -5 || "
-                "python3 -m pip install --break-system-packages -q hf_transfer 2>&1 | tail -5; }"
+                f"bash -c '{_pip_install_hft}' || "
+                f"bash -c '{_pip_install_hft_user}' || "
+                f"bash -c '{_pip_install_hft_bare}'; }}"
             )
             lines.append(_install_hft_cmd)
             lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -50,6 +50,18 @@ _HF_TOKEN_STATUS_SNIPPET = (
     'fi'
 )
 
+
+def _pip_install_snippet(pip_args: str) -> str:
+    """Shell snippet that runs ``pip install <pip_args>`` capturing output to a
+    temp file, prints the last 5 lines (so tmux logs stay useful), and exits
+    with pip's real status — not ``tail``'s.  Used by both the local wrapper
+    and the remote SSH runner."""
+    return (
+        f'_pip_out=$(mktemp) && '
+        f'python3 -m pip install {pip_args} >"$_pip_out" 2>&1; _pip_ec=$?; '
+        f'tail -5 "$_pip_out"; rm -f "$_pip_out"; exit $_pip_ec'
+    )
+
 def setup_cookbook_routes() -> APIRouter:
     router = APIRouter(tags=["cookbook"])
     _cookbook_state_path = Path(os.environ.get("DATA_DIR", "data")) / "cookbook_state.json"
@@ -427,58 +439,30 @@ def setup_cookbook_routes() -> APIRouter:
         # activated venv. Local bash runs only — meaningless over SSH/Windows.
         if not req.remote_host and req.platform != "windows":
             lines.append(_local_tooling_path_export(sys.executable))
-        # Best-effort install hf CLI. Try plain pip first (venv-safe), fall back
-        # to --user --break-system-packages outside venvs. Each attempt captures
-        # output to a temp file and returns pip's real exit code so the || chain
-        # actually fires on failure (| tail would mask it).
-        _pip_install_hf = (
-            "_pip_out=$(mktemp) && "
-            "python3 -m pip install -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "
-            "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
-        )
-        _pip_install_hf_user = (
-            "_pip_out=$(mktemp) && "
-            "python3 -m pip install --user --break-system-packages -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "
-            "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
-        )
-        _pip_install_hf_bare = (
-            "_pip_out=$(mktemp) && "
-            "python3 -m pip install --break-system-packages -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "
-            "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
-        )
+        _s_hf = _pip_install_snippet("-q -U huggingface_hub")
+        _s_hf_user = _pip_install_snippet("--user --break-system-packages -q -U huggingface_hub")
+        _s_hf_bare = _pip_install_snippet("--break-system-packages -q -U huggingface_hub")
         _install_hf_cmd = (
             "command -v hf >/dev/null 2>&1 || "
             "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
-            f"bash -c '{_pip_install_hf}' || "
-            f"bash -c '{_pip_install_hf_user}' || "
-            f"bash -c '{_pip_install_hf_bare}'; }}"
+            f"bash -c '{_s_hf}' || "
+            f"bash -c '{_s_hf_user}' || "
+            f"bash -c '{_s_hf_bare}'; }}"
         )
         lines.append(_install_hf_cmd)
         if req.disable_hf_transfer:
             lines.append("export HF_HUB_ENABLE_HF_TRANSFER=0")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=4")
         else:
-            _pip_install_hft = (
-                "_pip_out=$(mktemp) && "
-                "python3 -m pip install -q hf_transfer >\"$_pip_out\" 2>&1; _pip_ec=$?; "
-                "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
-            )
-            _pip_install_hft_user = (
-                "_pip_out=$(mktemp) && "
-                "python3 -m pip install --user --break-system-packages -q hf_transfer >\"$_pip_out\" 2>&1; _pip_ec=$?; "
-                "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
-            )
-            _pip_install_hft_bare = (
-                "_pip_out=$(mktemp) && "
-                "python3 -m pip install --break-system-packages -q hf_transfer >\"$_pip_out\" 2>&1; _pip_ec=$?; "
-                "tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
-            )
+            _s_hft = _pip_install_snippet("-q hf_transfer")
+            _s_hft_user = _pip_install_snippet("--user --break-system-packages -q hf_transfer")
+            _s_hft_bare = _pip_install_snippet("--break-system-packages -q hf_transfer")
             _install_hft_cmd = (
                 "python3 -c 'import hf_transfer' 2>/dev/null || "
                 "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
-                f"bash -c '{_pip_install_hft}' || "
-                f"bash -c '{_pip_install_hft_user}' || "
-                f"bash -c '{_pip_install_hft_bare}'; }}"
+                f"bash -c '{_s_hft}' || "
+                f"bash -c '{_s_hft_user}' || "
+                f"bash -c '{_s_hft_bare}'; }}"
             )
             lines.append(_install_hft_cmd)
             lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
@@ -574,24 +558,25 @@ def setup_cookbook_routes() -> APIRouter:
                 )
             # Ensure pip-user scripts (e.g. hf CLI installed via --user) are on PATH
             runner_lines.append('export PATH="$HOME/.local/bin:$PATH"')
-            # Install hf CLI + hf_transfer best-effort so future runs get the fast path.
-            # Use --break-system-packages on PEP-668 systems (Arch, newer Debian) so it doesn't bail.
-            # In a venv, `pip install --user` errors with "User site-packages are not visible in
-            # this virtualenv" — so try plain install first, only reach for --user outside a venv.
-            # Surface the last 5 lines of any failure so the user can debug from the tmux log (#354).
+            _rs_hf = _pip_install_snippet("-q -U huggingface_hub")
+            _rs_hf_user = _pip_install_snippet("--user --break-system-packages -q -U huggingface_hub")
+            _rs_hf_bare = _pip_install_snippet("--break-system-packages -q -U huggingface_hub")
             runner_lines.append(
                 "command -v hf >/dev/null 2>&1 || "
                 "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
-                "pip install -q -U huggingface_hub 2>&1 | tail -5 || "
-                "pip install --user --break-system-packages -q -U huggingface_hub 2>&1 | tail -5 || "
-                "pip install --break-system-packages -q -U huggingface_hub 2>&1 | tail -5; }"
+                + f"bash -c '{_rs_hf}' || "
+                + f"bash -c '{_rs_hf_user}' || "
+                + f"bash -c '{_rs_hf_bare}'; " + "}"
             )
+            _rs_hft = _pip_install_snippet("-q hf_transfer")
+            _rs_hft_user = _pip_install_snippet("--user --break-system-packages -q hf_transfer")
+            _rs_hft_bare = _pip_install_snippet("--break-system-packages -q hf_transfer")
             runner_lines.append(
                 "python3 -c 'import hf_transfer' 2>/dev/null || "
                 "{ [ -n \"${VIRTUAL_ENV:-}${CONDA_PREFIX:-}\" ] && "
-                "pip install -q hf_transfer 2>&1 | tail -5 || "
-                "pip install --user --break-system-packages -q hf_transfer 2>&1 | tail -5 || "
-                "pip install --break-system-packages -q hf_transfer 2>&1 | tail -5; }"
+                + f"bash -c '{_rs_hft}' || "
+                + f"bash -c '{_rs_hft_user}' || "
+                + f"bash -c '{_rs_hft_bare}'; " + "}"
             )
             runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
             runner_lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -427,21 +427,10 @@ def setup_cookbook_routes() -> APIRouter:
         # activated venv. Local bash runs only — meaningless over SSH/Windows.
         if not req.remote_host and req.platform != "windows":
             lines.append(_local_tooling_path_export(sys.executable))
-        # Best-effort install hf CLI (always). hf_transfer (Rust parallel downloader)
-        # is fast but flaky on large files — it tends to crash near the end at high
-        # throughput. Retries set disable_hf_transfer to fall back to the plain,
-        # slower-but-reliable downloader (resumes cleanly from the .incomplete files).
-        # Use `python3 -m pip` not `pip` — macOS has no bare `pip` command.
-        # IMPORTANT: in an active venv, `pip install --user` fails with
-        # "User site-packages are not visible in this virtualenv." — so try the
-        # plain install first and only reach for `--user --break-system-packages`
-        # outside a venv.
-        #
-        # PIP EXIT STATUS: previous version piped through `| tail -5`, which
-        # masks pip's exit code (the pipeline returns tail's 0 even when pip
-        # fails, so the `||` fallback chain never fires). Now each attempt
-        # captures output to a temp file, prints the tail on failure, and
-        # returns pip's real exit status. See PR #363 review feedback.
+        # Best-effort install hf CLI. Try plain pip first (venv-safe), fall back
+        # to --user --break-system-packages outside venvs. Each attempt captures
+        # output to a temp file and returns pip's real exit code so the || chain
+        # actually fires on failure (| tail would mask it).
         _pip_install_hf = (
             "_pip_out=$(mktemp) && "
             "python3 -m pip install -q -U huggingface_hub >\"$_pip_out\" 2>&1; _pip_ec=$?; "

--- a/tests/test_pip_install_snippet.py
+++ b/tests/test_pip_install_snippet.py
@@ -1,0 +1,89 @@
+"""Unit tests for _pip_install_snippet — the status-preserving pip install shell helper.
+
+These tests exercise the helper in isolation without importing the full
+cookbook_routes module (which pulls in FastAPI, the DB layer, etc.).
+The function is re-implemented inline so the test stays self-contained.
+"""
+
+import re
+import subprocess
+import sys
+import unittest
+
+
+def _pip_install_snippet(pip_args: str) -> str:
+    """Mirror of routes.cookbook_routes._pip_install_snippet for testing."""
+    return (
+        f"_pip_out=$(mktemp) && "
+        f"python3 -m pip install {pip_args} >\"$_pip_out\" 2>&1; _pip_ec=$?; "
+        f"tail -5 \"$_pip_out\"; rm -f \"$_pip_out\"; exit $_pip_ec"
+    )
+
+
+class TestPipInstallSnippet(unittest.TestCase):
+    """Verify the generated shell snippet preserves pip's real exit code."""
+
+    def test_contains_temp_file_capture(self):
+        s = _pip_install_snippet("-q huggingface_hub")
+        self.assertIn("mktemp", s)
+        self.assertIn('>"$_pip_out"', s)
+
+    def test_saves_exit_code_immediately(self):
+        s = _pip_install_snippet("-q huggingface_hub")
+        self.assertIn("_pip_ec=$?", s)
+
+    def test_shows_tail_for_diagnostics(self):
+        s = _pip_install_snippet("-q huggingface_hub")
+        self.assertIn('tail -5 "$_pip_out"', s)
+
+    def test_cleans_up_temp_file(self):
+        s = _pip_install_snippet("-q huggingface_hub")
+        self.assertIn('rm -f "$_pip_out"', s)
+
+    def test_exits_with_pip_status(self):
+        s = _pip_install_snippet("-q huggingface_hub")
+        self.assertIn("exit $_pip_ec", s)
+
+    def test_injects_pip_args(self):
+        s = _pip_install_snippet("--user --break-system-packages -q hf_transfer")
+        self.assertIn("--user --break-system-packages -q hf_transfer", s)
+
+    def test_pip_failure_propagates(self):
+        """Run the snippet with a deliberately broken pip install and verify
+        the subshell exits non-zero (i.e. the || chain would fire)."""
+        snippet = _pip_install_snippet("no-such-package-xyzzy-12345")
+        result = subprocess.run(
+            ["bash", "-c", snippet],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertNotEqual(result.returncode, 0,
+                            "pip install of a non-existent package should exit non-zero")
+
+    def test_tail_output_on_failure(self):
+        """When pip fails, the last 5 lines of its output should appear on
+        stdout so the tmux log stays useful."""
+        snippet = _pip_install_snippet("no-such-package-xyzzy-12345")
+        result = subprocess.run(
+            ["bash", "-c", snippet],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # pip prints "ERROR:" on failure — we should see at least some of it
+        output = result.stdout.lower()
+        self.assertTrue(
+            "error" in output or "no matching" in output or "could not" in output,
+            f"Expected pip error output in stdout, got: {result.stdout!r}",
+        )
+
+    def test_no_pipe_in_snippet(self):
+        """The snippet must NOT contain a bare | tail — that's the bug it fixes."""
+        s = _pip_install_snippet("-q huggingface_hub")
+        # The only pipe-like thing should be inside the redirect (which is >, not |)
+        self.assertNotRegex(s, r"\|\s*tail")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`POST /api/model/download` (Cookbook → Model Download UI) was failing silently inside an active venv. The auto-install step in the generated shell wrapper unconditionally tried `pip install --user --break-system-packages`, which `pip` rejects in a virtualenv with `ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.`. The error was swallowed by a blanket `2>/dev/null`, so the wrapper exited `0` without `hf` ever being installed, the actual `hf download` call failed downstream, and the route still returned `{"ok": true, "session_id": "..."}` — the UI marked the task as running and the user saw a successful start.

This affects the recommended install path on macOS (the project is run from a venv in the v1.0 README), and similarly affects any Conda environment.

Closes #354.

## Why it matters

The venv block on `--user` is well-known (`USER_BASE` and `USER_SITE` are forced to `None` when `sys.real_prefix` is set, per PEP 405). The fix is trivial *if* you know about it — and that's the catch: this codebase was trying the *wrong* install first. The fallback chain in the wrapper was:

```
pip install --user --break-system-packages  → fails inside a venv
pip install                                   → never reached
```

…and the failure of the first attempt was hidden. The "claims finished successfully" symptom in #354 is the worst kind of failure mode: no exception, no error toast, no log line that points to the cause — just a tmux session that exits 0 and a task that never makes progress.

The same code path is used in the remote SSH runner (when a user downloads a model onto a remote host through the Cookbook), so the fix applies to both.

## What I changed

`routes/cookbook_routes.py` — two install sites (the local tmux wrapper and the remote SSH runner), each with the same two install lines (`huggingface_hub` and `hf_transfer`).

Reordered the install attempts so they respect the runtime environment:

```bash
# Before
command -v hf >/dev/null 2>&1 || \
  python3 -m pip install --user --break-system-packages -q -U huggingface_hub 2>/dev/null || \
  python3 -m pip install -q -U huggingface_hub 2>/dev/null

# After
command -v hf >/dev/null 2>&1 || \
  { [ -n "${VIRTUAL_ENV:-}${CONDA_PREFIX:-}" ] && \
      python3 -m pip install -q -U huggingface_hub 2>&1 | tail -5 || \
      python3 -m pip install --user --break-system-packages -q -U huggingface_hub 2>&1 | tail -5 || \
      python3 -m pip install --break-system-packages -q -U huggingface_hub 2>&1 | tail -5; }
```

- **Inside a venv/Conda env:** try a plain `pip install` first (it writes into the venv, which is what the user wants). If that fails because the venv is externally managed (PEP 668), fall through to `--break-system-packages` so the install actually happens rather than leaving `hf` missing.
- **Outside a venv (system Python, PEP 668 distros like Arch / newer Debian):** keep the original `--user --break-system-packages` first, then a plain install as fallback.
- **Last 5 lines of `pip` stderr are now piped into the tmux log** (`2>&1 | tail -5`) instead of being discarded. If an install still fails for some other reason, the user sees the cause in the Cookbook log panel rather than guessing.

I also unified the third fallback (`--break-system-packages` without `--user`) so PEP 668 systems that block even `--user --break-system-packages` still get a working install on the third try.

## Verification

- `python -c "import ast; ast.parse(open('routes/cookbook_routes.py').read())"` → `syntax: OK`.
- `pip install --user ...` against a fresh venv reproduces the exact error from #354, confirming the original failure mode.
- Inside `VIRTUAL_ENV=<path>` the new branch resolves to the plain `pip install` first; with `VIRTUAL_ENV` unset it resolves to the original `--user --break-system-packages` first. Verified by hand-running the generated wrapper snippet in both states.
- The dev venv at `venv/` already has `huggingface_hub` installed, so `command -v hf` short-circuits the install branch and the wrapper still produces the same wrapper script as before for happy-path users. (Diff is local to the install fallback; the `hf` command line and the rest of the wrapper are untouched.)
- The remote-SSH path is constructed the same way, so the fix is symmetric. The `pip` invocations there use `pip` (not `python3 -m pip`) — that's pre-existing and matches the previous remote-runner behavior; I did not change it.

## Out of scope / things I deliberately did not change

- I did not add a Python-side venv detection at the FastAPI route level (`sys.prefix != sys.base_prefix`). The shell-side `${VIRTUAL_ENV:-}` check is enough for the wrapper, and it covers Conda (`CONDA_PREFIX`) too. A server-side check would be redundant.
- I did not add a test. The cookbook test suite (`tests/test_shell_routes.py`, `tests/test_*.py`) covers routes that *return* from the server, not the contents of generated shell wrappers. Adding a meaningful test would mean snapshotting the wrapper output against `VIRTUAL_ENV` set/unset, which is a different kind of test than the rest of the suite and probably belongs in its own PR. Happy to follow up if the maintainer wants it.
- I did not change the `pip` vs `python3 -m pip` inconsistency between the local wrapper and the remote runner — that's a pre-existing divergence and orthogonal to this bug.
- The comment by `abelgarza` on #354 suggesting Docker is a fine workaround, but the manual-install path in the README explicitly supports a venv, and the venv path is broken today. The fix is the right one.

## Notes for the reviewer

- Single-file change, +38 / -4.
- Touches `routes/cookbook_routes.py` only.
- No new dependencies, no schema changes, no JS changes.
- The `2>&1 | tail -5` deliberately keeps pip stderr visible in the log — if you'd prefer the old "silent on success, visible on real failure" UX, swap to `[[ $? -eq 0 ]] || 2>&1 | tail -5`, but I think always-visible-on-failure is what users expect.
