### PR TITLE
[codex] Fix calendar Escape handling guard

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -490,6 +490,15 @@ function initializeEventListeners() {
         return;
       }
 
+      // Calendar owns a few inner Escape layers (settings panel, event form,
+      // then the calendar modal itself). Let calendar.js handle those instead
+      // of falling through to unrelated page-level fallbacks like document
+      // panel minimize.
+      const calendarModal = document.getElementById('calendar-modal');
+      if (calendarModal && !calendarModal.classList.contains('hidden') && getComputedStyle(calendarModal).display !== 'none') {
+        return;
+      }
+
       // Close one modal at a time (last in DOM = topmost)
       // Map modal id → sidebar list-item id to clear active state
       const modalItemMap = {


### PR DESCRIPTION
## What changed

Added a small guard in the global Escape-key handler so that when the Calendar modal is visible, Calendar keeps ownership of Escape handling.

## Why

calendar.js already has layered Escape behavior for its own surfaces: close calendar settings, close an event form, then close the Calendar modal. The global Escape handler in static/app.js did not recognize calendar-modal as an active modal, so Escape could fall through to unrelated page-level behavior behind Calendar, such as minimizing the document panel.

This keeps Escape scoped to the visible Calendar window instead of affecting underlying UI.

## Validation

- 
ode --check static/app.js
- git diff --check

Manual test to confirm before marking ready:

1. Open the document panel.
2. Open Calendar.
3. Press Escape.
4. Calendar should handle Escape; the document panel should not minimize or close because of the same keypress.