### PR TITLE
fix: prevent NOT NULL crash when delivering task results to a session (#326)

### DIFF
--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -1301,7 +1301,7 @@ class TaskScheduler:
                 id=session_id,
                 name=f"[Task] {task.name}",
                 endpoint_url=endpoint_url or "",
-                model=model_name,
+                model=model_name or "",
                 owner=task.owner,
                 created_at=datetime.utcnow(),
                 updated_at=datetime.utcnow(),

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -1300,7 +1300,7 @@ class TaskScheduler:
             sess = DbSession(
                 id=session_id,
                 name=f"[Task] {task.name}",
-                endpoint_url=endpoint_url,
+                endpoint_url=endpoint_url or "",
                 model=model_name,
                 owner=task.owner,
                 created_at=datetime.utcnow(),

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -1,0 +1,51 @@
+"""Regression tests for task-result delivery into chat sessions (issue #326)."""
+import asyncio
+import types as _types
+
+import pytest
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+if not isinstance(sqlalchemy, _types.ModuleType):
+    pytest.skip("sqlalchemy is stubbed in this environment", allow_module_level=True)
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import Base, Session as DbSession
+from src.task_scheduler import TaskScheduler
+
+
+def _make_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _make_task():
+    return _types.SimpleNamespace(
+        id="task-1",
+        name="Chat Sessions Tidy",
+        prompt="tidy",
+        output_target="session",
+        endpoint_url=None,
+        model=None,
+        session_id=None,
+        owner=None,
+        crew_member_id=None,
+    )
+
+
+def test_session_delivery_survives_empty_database():
+    """On a fresh/wiped database there is no session to inherit endpoint/model
+    from, so _resolve_defaults returns None. The delivery must still persist a
+    session instead of crashing on the NOT NULL constraint (issue #326)."""
+    db = _make_db()
+    scheduler = TaskScheduler.__new__(TaskScheduler)
+    scheduler._session_manager = None
+
+    asyncio.run(scheduler._deliver_task_result(_make_task(), "done", db))
+
+    sessions = db.query(DbSession).all()
+    assert len(sessions) == 1
+    assert sessions[0].endpoint_url == ""
+    assert sessions[0].model == ""


### PR DESCRIPTION
## Summary

Scheduled tasks that deliver their output to a chat session crash with `IntegrityError: NOT NULL constraint failed: sessions.endpoint_url` when no prior session exists to inherit an endpoint/model from — e.g. on a fresh install or after the admin "Wipe Chats" action. The "Chat Sessions Tidy" housekeeping task hits this reliably.

`_deliver_task_result` resolves the endpoint/model from the most recent session via `_resolve_defaults`, which returns `None, None` when the table is empty. Unlike the task *execution* path (which raises early when nothing resolves), the *delivery* path swallows that and inserts a `Session` row with `endpoint_url=None` / `model=None`, both of which are `NOT NULL` columns.

This coerces the two values to `""` at the insert, matching the existing convention already used for the default assistant session. The task output is still delivered; the session simply records an empty endpoint/model instead of crashing the scheduler.

## Changes
- `src/task_scheduler.py`: coerce `endpoint_url`/`model` to `""` when creating the delivery session.
- `tests/`: regression test delivering a result on an empty database.

Fixes #326