### PR TITLE
Fix sidebar text clipping on Windows

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1598,7 +1598,7 @@ body.bg-pattern-sparkles {
       margin: 0;
       border-radius: 4px;
       border: none;
-      line-height: 1;
+      line-height: 1.3;
       font-size: 13px;
       background: transparent;
       transition: background 0.08s;


### PR DESCRIPTION
Fix sidebar text clipping on Windows.

`line-height: 1` cut off descenders on the sidebar text input on Windows. Bumped to `1.3` for proper vertical space.

Tested visually on Windows via the native launcher.

Before
------
<img width="240" height="467" alt="image" src="https://github.com/user-attachments/assets/e797d162-0309-48e6-837e-8cdb03573055" />

After
------
<img width="239" height="475" alt="image" src="https://github.com/user-attachments/assets/91a1e4df-0e7f-4f52-a3e6-0f1463c3feaf" />
