### PR TITLE
Remove duplicate index_builtin_tools call from startup warmup

### DIFF
--- a/app.py
+++ b/app.py
@@ -817,7 +817,6 @@ async def startup_event():
             from src.tool_index import get_tool_index
             idx = await asyncio.to_thread(get_tool_index)
             if idx:
-                await asyncio.to_thread(idx.index_builtin_tools)
                 await asyncio.to_thread(idx.get_tools_for_query, "warmup", 8)
                 logger.info("[startup] Tool index pre-warmed")
         except Exception as e:


### PR DESCRIPTION
`get_tool_index()` calls `index_builtin_tools()` on first init (`src/tool_index.py:469-470`), and `_warmup_tool_index` then calls it explicitly right after. Every cold boot embeds all 58 built-in tools twice and double-upserts them into the ChromaDB collection.

Visible in the boot log as two `Indexed N built-in tools` lines about 600ms apart. Roughly 15 CPU-seconds of redundant FastEmbed work per boot on my machine, plus the duplicated ChromaDB roundtrips.

The remaining `get_tools_for_query` call still pre-warms the query path, so the warmup still does what it set out to do without re-doing what `get_tool_index()` already did.