### PR TITLE
fix: Require document privilege for PDF imports

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -137,7 +137,8 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         from src.document_processor import _process_pdf
         import os
 
-        user = get_current_user(request)
+        from src.auth_helpers import require_privilege
+        user = require_privilege(request, "can_use_documents")
 
         # session_id is optional — a library import isn't tied to a chat. When
         # given, validate it; otherwise the PDF becomes a session-less library


### PR DESCRIPTION
### Why needed:
Normal document creation already checks can_use_documents, but PDF import went through a separate route and only identified the current user. That meant an account with Documents disabled could still import a PDF through /api/documents/import-pdf, saving the upload and creating a document despite the intended permission setting.

### Risk:
Low. This only aligns PDF import authorization with existing document creation behavior. Users who can use Documents are unaffected; users without that privilege are now blocked consistently.