### PR TITLE
fix: create missing cache directory in Dockerfile to prevent permission error on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Create data directory (mount a volume here for persistence)
-RUN mkdir -p data logs
+RUN mkdir -p data logs services/cache/search
 
 # Entrypoint that drops to PUID/PGID (default 1000:1000) and repairs
 # ownership on the bind-mounted /app/data and /app/logs. Without this,


### PR DESCRIPTION
Description:
When deploying the application via Docker Compose on Windows 11 (Docker Desktop / WSL2), the main `odysseus` container enters a crash loop on startup. The application throws a `PermissionError: [Errno 13]` when attempting to dynamically create the `/app/services/cache/search` directory.

Cause:
Docker bind mounts from a Windows host do not automatically generate nested subdirectories with the correct internal Linux user permissions. When the application attempts to initialize the cache directory internally, it lacks the necessary privileges on the mounted volume, resulting in a fatal crash.

Solution:
Appended `services/cache/search` to the existing `RUN mkdir -p` command in the `Dockerfile`. This ensures the required directory structure is built into the image with the correct base ownership before the `entrypoint.sh` script drops root privileges.

Solved with the help of Gemini Pro 3.1.