### PR TITLE
Clarify first-run admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Defaults work out of the box: clone, run, then configure models/search/email
 inside **Settings**. Only edit `.env` for deployment-level overrides like
 `APP_PORT`, `AUTH_ENABLED`, `DATABASE_URL`, or a pre-seeded admin password.
 
+On first setup, Odysseus creates an admin account (`admin` unless
+`ODYSSEUS_ADMIN_USER` is set) and prints a temporary password in the terminal.
+For Docker installs, the same line is in `docker compose logs odysseus`.
+Use that for the first login, then change it in **Settings**.
+
 Contributing? See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and
 pull request guidelines.
 


### PR DESCRIPTION
Fixes #395.

Small README note for first login. The setup script already prints the temporary admin password, but it was easy to miss what username to use or where to find it again after starting with Docker.

This just spells out that the first user is `admin` by default, the temporary password is printed during setup, and Docker users can find it with `docker compose logs odysseus`.

Checked:
- git diff --check
