### PR TITLE
Fix Cookbook serve exit code reporting

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -214,6 +214,15 @@ def _validate_serve_cmd(v: str | None) -> str | None:
     return v
 
 
+def _append_serve_exit_code_lines(runner_lines: list[str], *, keep_shell_open: bool) -> None:
+    """Append serve-runner lines that preserve and report the command exit code."""
+    runner_lines.append('ODYSSEUS_CMD_EXIT=$?')
+    if keep_shell_open:
+        runner_lines.append('echo ""; echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="; exec "${SHELL:-/bin/bash}"')
+    else:
+        runner_lines.append('echo ""; echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="')
+
+
 class ModelDownloadRequest(BaseModel):
     repo_id: str
     include: str | None = None  # glob pattern e.g. "*Q4_K_M*"

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -36,7 +36,7 @@ from routes.cookbook_helpers import (
     _validate_repo_id, _validate_include, _validate_remote_host, _validate_token,
     _validate_local_dir, _validate_ssh_port, _validate_gpus, _shell_path,
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
-    _safe_env_prefix, _local_tooling_path_export,
+    _safe_env_prefix, _local_tooling_path_export, _append_serve_exit_code_lines,
     ModelDownloadRequest, ServeRequest,
 )
 
@@ -1057,10 +1057,10 @@ def setup_cookbook_routes() -> APIRouter:
             if local_windows:
                 # Detached background process — no interactive shell to keep open.
                 # Print the exit marker the status poller looks for, then stop.
-                runner_lines.append('echo ""; echo "=== Process exited with code $? ==="')
+                _append_serve_exit_code_lines(runner_lines, keep_shell_open=False)
             else:
                 # Keep shell open after exit so user can see errors
-                runner_lines.append('echo ""; echo "=== Process exited with code $? ==="; exec "${SHELL:-/bin/bash}"')
+                _append_serve_exit_code_lines(runner_lines, keep_shell_open=True)
 
             runner_path = TMUX_LOG_DIR / f"{session_id}_run.sh"
             runner_path.write_text("\n".join(runner_lines) + "\n", encoding="utf-8")

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi import HTTPException
 
 from routes.cookbook_helpers import (
+    _append_serve_exit_code_lines,
     _local_tooling_path_export,
     _safe_env_prefix,
     _validate_gpus,
@@ -58,3 +59,18 @@ def test_local_tooling_path_export_preserves_spaces_and_expands_path():
     line = _local_tooling_path_export("/Users/John Smith/.venv/bin/python3")
     assert line == 'export PATH="/Users/John Smith/.venv/bin:$PATH"'
     assert line.endswith(':$PATH"')  # $PATH stays expandable in double quotes
+
+
+def test_serve_runner_preserves_command_exit_code():
+    """The serve wrapper must capture `$?` before any echo resets it.
+
+    Otherwise a failed command can be reported as `Process exited with code 0`,
+    which hides the real failure from both the UI and diagnosis logic.
+    """
+    runner_lines = ["vllm serve Qwen/Qwen3.6-35B-A3B-NVFP4 --host 0.0.0.0 --port 8000"]
+    _append_serve_exit_code_lines(runner_lines, keep_shell_open=True)
+    script = "\n".join(runner_lines)
+
+    assert "ODYSSEUS_CMD_EXIT=$?" in script
+    assert 'echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="' in script
+    assert 'echo "=== Process exited with code $? ==="' not in script


### PR DESCRIPTION
## Summary

Cookbook serve runners currently append the process-exit marker with:

```bash
echo ""; echo "=== Process exited with code $? ==="
```

The first `echo` resets `$?` to `0`, so a failed serve command can be reported as `Process exited with code 0`.

This is easy to hit with llama.cpp fallback commands. For example, if `llama-server` fails and the `llama_cpp.server` fallback is also missing, the task log can show the real Python error followed by a successful-looking exit marker. That makes the Running tab and diagnosis logic less trustworthy.

## What changed

- Capture the serve command exit code immediately into `ODYSSEUS_CMD_EXIT` before printing any output.
- Use that stored value in the marker for both local detached and POSIX/tmux serve runners.
- Add a regression test that verifies the generated runner no longer uses `$?` after an `echo`.

## Verification

- `/tmp/odysseus-venv/bin/python -m pytest -q tests/test_cookbook_helpers.py`
- `/tmp/odysseus-venv/bin/python -m compileall -q routes/cookbook_routes.py routes/cookbook_helpers.py`
- `git diff --check origin/main..HEAD`

This complements #398, but is a separate, smaller fix: #398 keeps dependency preflight failures visible; this PR keeps the final command exit code accurate once the serve command itself runs.
