### PR TITLE
feat(research): cite-based sources, inline citations, and favicon citation chips

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -197,13 +197,13 @@ Or with JSON for fresh news:
 ```web_search
 {"query": "<your query>", "time_filter": "day"}
 ```
-Search the web for a SINGLE quick fact/lookup mid-task. For news / "today" / "latest" queries, pass `time_filter` ("day", "week", "month", or "year"). NOT for "research X" / "do research on X" / "look into X" requests — those mean a multi-source DEEP RESEARCH job: use `trigger_research` instead (it runs in the Deep Research sidebar and produces a full report). web_search = one quick query; trigger_research = a researched report.""",
+Search the web for a SINGLE quick fact/lookup mid-task. For news / "today" / "latest" queries, pass `time_filter` ("day", "week", "month", or "year"). NOT for "research X" / "do research on X" / "look into X" requests — those mean a multi-source DEEP RESEARCH job: use `trigger_research` instead (it runs in the Deep Research sidebar and produces a full report). web_search = one quick query; trigger_research = a researched report. When you state a fact drawn from the results, cite it inline as a markdown link [source](url) using the result's URL.""",
 
     "web_fetch": """\
 ```web_fetch
 <url or domain>
 ```
-Fetch and read the text content of a SPECIFIC URL the user names (e.g. "check example.com", "what does this page say <url>"). A bare domain like `example.com` works (defaults to https). Use this when you already have a concrete URL. For open-ended lookups use `web_search`, and for "research X" jobs use `trigger_research`.""",
+Fetch and read the text content of a SPECIFIC URL the user names (e.g. "check example.com", "what does this page say <url>"). A bare domain like `example.com` works (defaults to https). Use this when you already have a concrete URL. For open-ended lookups use `web_search`, and for "research X" jobs use `trigger_research`. When you use what the page says, cite it inline as a markdown link [title](url).""",
 
     "read_file": """\
 ```read_file
@@ -2026,12 +2026,12 @@ async def stream_agent_loop(
                 )
             desc, result = await _tool_task
 
-            # Extract structured web sources from web_search tool output.
-            # web_search returns {"output": ..., "exit_code": 0}; check "output"
-            # first so the <!-- SOURCES:…--> marker is found and stripped even
-            # when the result doesn't carry a "results" or "stdout" key.
-            _src_text = result.get("output") or result.get("results") or result.get("stdout") or ""
-            if block.tool_type == "web_search" and _src_text:
+            # Extract structured web sources from web_search / web_fetch output.
+            # Track WHICH key holds the text so the stripped version is written
+            # back to the same key (avoids writing to a different field).
+            _src_key = next((k for k in ("output", "results", "stdout") if result.get(k)), None)
+            _src_text = result.get(_src_key) if _src_key else ""
+            if block.tool_type in ("web_search", "web_fetch") and _src_text:
                 _src_marker = "<!-- SOURCES:"
                 _src_idx = _src_text.find(_src_marker)
                 if _src_idx >= 0:
@@ -2041,13 +2041,7 @@ async def stream_agent_loop(
                             _extracted_sources = json.loads(_src_text[_src_idx + len(_src_marker):_src_end])
                             yield f'data: {json.dumps({"type": "web_sources", "data": _extracted_sources})}\n\n'
                             # Strip the marker from the result so it doesn't show in chat
-                            _clean = _src_text[:_src_idx].rstrip()
-                            if "output" in result:
-                                result["output"] = _clean
-                            elif "results" in result:
-                                result["results"] = _clean
-                            elif "stdout" in result:
-                                result["stdout"] = _clean
+                            result[_src_key] = _src_text[:_src_idx].rstrip()
                         except (json.JSONDecodeError, Exception):
                             pass
 

--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -119,7 +119,7 @@ Requirements:
 - Each section should have multiple detailed paragraphs, not just bullet points
 - Synthesize and analyze the information — explain WHY things matter, draw comparisons, provide context
 - Include specific data points, numbers, and statistics from the evidence
-- Include source URLs as inline citations [like this](url)
+- CITE AS YOU WRITE: every factual claim, statistic, or quote must be followed by an inline markdown citation in the form [Source name](url), using ONLY the exact source URLs that appear in the evidence above. Never invent or guess a URL. If a claim has no supporting source in the evidence, say so rather than fabricating a citation.
 - Note where sources agree and where they disagree
 - Add a brief executive summary at the top
 - End with a clear conclusion that directly answers the question

--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -119,7 +119,7 @@ Requirements:
 - Each section should have multiple detailed paragraphs, not just bullet points
 - Synthesize and analyze the information — explain WHY things matter, draw comparisons, provide context
 - Include specific data points, numbers, and statistics from the evidence
-- CITE AS YOU WRITE: every factual claim, statistic, or quote must be followed by an inline markdown citation in the form [Source name](url), using ONLY the exact source URLs that appear in the evidence above. Never invent or guess a URL. If a claim has no supporting source in the evidence, say so rather than fabricating a citation.
+- CITE KEY CLAIMS: support major claims and statistics with an inline markdown citation [Source name](url), placed at the END of the sentence. Use ONLY exact source URLs from the evidence above; never invent one. Do NOT over-cite: at most one citation per sentence, and do not repeat the same source multiple times in a paragraph (cite it once). If a claim has no supporting source, say so rather than fabricating a citation.
 - Note where sources agree and where they disagree
 - Add a brief executive summary at the top
 - End with a clear conclusion that directly answers the question

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -438,8 +438,15 @@ class ResearchHandler:
         return None
 
     @staticmethod
-    def _extract_sources(findings: list) -> list:
-        """Extract deduplicated [{url, title}] from findings, filtering low-quality ones."""
+    def _extract_sources(findings: list, report_text: str = "") -> list:
+        """Extract deduplicated [{url, title}] from findings, filtering low-quality ones.
+
+        When `report_text` is given and the report actually cites some of the
+        fetched URLs, return only the cited ones — this drops fetched-but-
+        irrelevant pages (e.g. junk search hits) that were never referenced.
+        Falls back to all non-low-quality findings when the report cites none,
+        so the sources list is never empty.
+        """
         seen = set()
         sources = []
         for f in findings:
@@ -453,6 +460,17 @@ class ResearchHandler:
                 if og_img:
                     entry["image"] = og_img
                 sources.append(entry)
+        if report_text:
+            import re as _re
+            # Match against the exact URLs present in the report (set
+            # membership), not a raw substring test — otherwise a root URL
+            # like https://site.com/ would falsely count as "cited" whenever
+            # it's a substring of a deeper cited URL on the same domain.
+            found = _re.findall(r'https?://[^\s)\]<>"\']+', report_text)
+            cited_set = {u.rstrip('/.,;:') for u in found}
+            cited = [s for s in sources if s["url"].rstrip('/.,;:') in cited_set]
+            if cited:
+                return cited
         return sources
 
     @staticmethod
@@ -516,7 +534,10 @@ class ResearchHandler:
             raw_findings = []
             researcher = entry.get("researcher")
             if researcher and researcher.findings:
-                sources = self._extract_sources(researcher.findings)
+                # Pass the report so sources can be narrowed to URLs the
+                # report actually cites (drops fetched-but-unused junk).
+                _report_text = entry.get("result") or entry.get("raw_report") or ""
+                sources = self._extract_sources(researcher.findings, _report_text)
                 raw_findings = self._extract_raw_findings(researcher.findings)
             entry["sources"] = sources
 

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -524,6 +524,9 @@ async def _direct_fallback(
             output = header + text
             if len(output) > MAX_OUTPUT_CHARS:
                 output = output[:MAX_OUTPUT_CHARS] + "\n\n[...truncated]"
+            # Emit the fetched page as a source so it shows in the chat
+            # sources box (parity with web_search). Stripped before display.
+            output += "\n\n<!-- SOURCES:" + _json.dumps([{"url": url, "title": title or url}]) + " -->"
             return {"output": output, "exit_code": 0}
 
         # manage_memory / generate_image still live as MCP servers

--- a/src/visual_report.py
+++ b/src/visual_report.py
@@ -56,12 +56,44 @@ def _md_to_html(md_text: str) -> str:
             "toc": {"marker": "", "toc_depth": "2-3"},
         },
     )
-    # Make external links open in new tab
-    result = re.sub(
-        r'<a href="(https?://)',
-        r'<a target="_blank" rel="noopener noreferrer" href="\1',
-        result,
-    )
+    # Render external links as favicon "citation chips" (source name in a
+    # rounded pill with the site's favicon), and open them in a new tab.
+    import html as _html
+    from urllib.parse import urlparse
+
+    def _citation_chip(m):
+        url = m.group(1)
+        # Strip any HTML tags markdown emitted inside the link text — the report
+        # is built from untrusted scraped content, so a crafted source could
+        # otherwise smuggle markup (e.g. <img onerror=...>) into the chip. The
+        # remaining text keeps markdown's entity-escaping (no double-encoding).
+        text = re.sub(r"<[^>]+>", "", m.group(2)).strip()
+        try:
+            domain = urlparse(url).netloc
+            if domain.startswith("www."):
+                domain = domain[4:]
+        except Exception:
+            domain = ""
+        label = text
+        # Keep the chip compact: short publisher names are kept as-is, but long
+        # descriptive citation text or bare URLs collapse to the domain so the
+        # chip stays small and reads inline after the text.
+        if not label or label.lower().startswith(("http://", "https://")) or len(label) > 28:
+            label = domain or label
+        url_attr = _html.escape(url, quote=True)
+        dom_attr = _html.escape(domain, quote=True)
+        fav = ""
+        if domain:
+            fav = (
+                f'<img class="cite-favicon" src="https://www.google.com/s2/favicons?domain={dom_attr}&sz=64" '
+                f'alt="" loading="lazy" referrerpolicy="no-referrer">'
+            )
+        return (
+            f'<a class="cite-chip" target="_blank" rel="noopener noreferrer" href="{url_attr}">'
+            f'{fav}<span>{label}</span></a>'
+        )
+
+    result = re.sub(r'<a href="(https?://[^"]+)">(.*?)</a>', _citation_chip, result, flags=re.S)
     return result
 
 
@@ -661,6 +693,36 @@ body::after {{
 .content a:hover {{
   text-decoration-color: var(--accent);
   color: var(--accent-light);
+}}
+/* Inline citation chips: source name in a rounded pill with favicon. */
+.content a.cite-chip {{
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.08em 0.6em 0.08em 0.45em;
+  margin: 0 0.12em;
+  border: 1px solid color-mix(in srgb, var(--text) 22%, transparent);
+  border-radius: 999px;
+  font-size: 0.8em;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--text) 72%, transparent);
+  text-decoration: none;
+  vertical-align: baseline;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}}
+.content a.cite-chip:hover {{
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: var(--accent);
+  color: var(--accent-light);
+}}
+.content a.cite-chip .cite-favicon {{
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  flex: 0 0 auto;
+  object-fit: cover;
+  background: color-mix(in srgb, var(--text) 12%, transparent);
 }}
 .content ul, .content ol {{ margin: 0 0 1.1rem 1.6rem; }}
 .content li {{ margin-bottom: 0.4rem; }}

--- a/src/visual_report.py
+++ b/src/visual_report.py
@@ -94,6 +94,29 @@ def _md_to_html(md_text: str) -> str:
         )
 
     result = re.sub(r'<a href="(https?://[^"]+)">(.*?)</a>', _citation_chip, result, flags=re.S)
+
+    # De-clutter: within each paragraph, keep only the first chip per source
+    # URL and drop later repeats (the model often re-cites the same source
+    # several times in one paragraph). Per-paragraph, so a source cited in
+    # different sections still shows in each.
+    def _dedupe_paragraph(pm):
+        seen = set()
+
+        def _drop_repeat(cm):
+            href = cm.group(1)
+            if href in seen:
+                return ""  # already cited in this paragraph
+            seen.add(href)
+            return cm.group(0)
+
+        return re.sub(
+            r'<a class="cite-chip"[^>]*?href="([^"]+)"[^>]*>.*?</a>',
+            _drop_repeat,
+            pm.group(0),
+            flags=re.S,
+        )
+
+    result = re.sub(r"<p>.*?</p>", _dedupe_paragraph, result, flags=re.S)
     return result
 
 


### PR DESCRIPTION
Hey again Pewds! 👋 I really love the Deep Research feature, but I kept wondering whether the AI was actually pulling from the web or just hallucinating, since the sources weren't always clear. So I figured proper citations would make it trustworthy: you can see exactly where each claim came from and click through to check.

This makes web sources actually useful: cleaner source lists, inline citations, and favicon citation chips in the research report.

## What this does

**1. web_fetch now contributes a source**
Previously only web_search fed the chat sources box. Now web_fetch emits the page it read as a source too (same `<!-- SOURCES -->` mechanism), so reading a URL in chat shows up as a source. Also fixed the extractor to read the `output` result key, which the native web tools actually use.

**2. Deep Research sources are now cite-based**
The source list used to be every URL fetched during the run, so irrelevant search hits (dictionary pages, unrelated brand sites, etc.) showed up as "sources" even when the report never referenced them. Now the list is narrowed to the URLs the report actually cites, falling back to all findings only if it cites none (so the box is never empty). In testing this took a run from "33 fetched, 9 listed (with junk)" down to "4 sources, all cited."

**3. Inline citations**
The agent is now nudged to cite inline as `[source](url)` in chat, and the Deep Research final-report prompt requires a `[Source](url)` citation after every factual claim, using only URLs that appear in the evidence (no invented links).

**4. Favicon citation chips in the report**
Inline citations in the visual report render as compact rounded pills with the site's favicon and a short source label (long descriptive link text collapses to the domain so chips stay small). Favicons come from a public favicon service, allowed by the report CSP. Link text is tag-stripped and URLs escaped before rendering, since report content is built from untrusted scraped pages.

## Notes
- Touches shared code: the source extractor and final-report prompt are also used by web_search and inline chat URL fetch, so those benefit too. Reports that already extracted full sources (cited >0 URLs) are unaffected by the cite-filter.
- Reports render fresh from saved markdown, so existing reports pick up the chips on refresh, no re-run needed.
- Chat citations render as plain links for now (favicon chips in chat need a same-origin favicon proxy, since the chat CSP blocks external images). Left as a follow-up.

## Screenshots

Inline citation chips in the research report (favicon + source, rendered after the text):

<img width="1512" height="755" alt="Screenshot 2026-06-01 at 17 01 41" src="https://github.com/user-attachments/assets/ce679172-960f-453f-9ede-89dc375226dd" />

## Testing
- web_fetch emits a valid source; extraction picks it up for both web tools.
- Cite-based source filtering drops uncited URLs and falls back safely; verified no substring false positives (a root URL is not falsely "cited" just because a deeper URL on the same domain is).
- Citation chips: short publisher names kept as-is, long descriptive text collapses to the domain, malicious HTML in link text is neutralized (no script execution), favicon URLs escaped.
- Full existing test suite passes (349 tests).

No new dependencies.
