### PR TITLE
Add a drop-in plugin system + plugin depot

### DIFF
--- a/app.py
+++ b/app.py
@@ -698,6 +698,11 @@ app.include_router(setup_contacts_routes())
 from companion import setup_companion_routes
 app.include_router(setup_companion_routes())
 
+# Plugin system — admin API for drop-in plugins (Settings -> Plugins). The
+# plugins themselves are loaded in the startup event (see load_plugins below).
+from routes.plugin_routes import setup_plugin_routes
+app.include_router(setup_plugin_routes())
+
 # ========= ROUTES (kept in app.py) =========
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
@@ -799,6 +804,14 @@ async def startup_event():
     global upload_cleanup_task
     logger.info("Application starting up...")
     webhook_manager.set_loop(asyncio.get_running_loop())
+    # Plugin system — load enabled drop-in plugins (they register routes / tools /
+    # background services via their setup(ctx)). Best-effort: a broken plugin is
+    # isolated and never blocks startup.
+    try:
+        from src.plugin_system import load_plugins
+        load_plugins(app)
+    except Exception as e:
+        logger.warning(f"Plugin system load skipped: {e}")
     # Wipe any leftover incognito sessions from previous process — they're
     # ephemeral by design and must not survive a restart.
     try:
@@ -1022,6 +1035,14 @@ async def startup_event():
 @app.on_event("shutdown")
 async def shutdown_event():
     logger.info("Application shutting down...")
+    # Tear down plugins so their background services (tunnels, etc.) stop.
+    try:
+        from src.plugin_system import get_manager
+        mgr = get_manager()
+        if mgr:
+            mgr.shutdown_all()
+    except Exception as e:
+        logger.warning(f"Plugin shutdown skipped: {e}")
     if upload_cleanup_task:
         upload_cleanup_task.cancel()
         try:

--- a/plugins/GUIDE.md
+++ b/plugins/GUIDE.md
@@ -65,6 +65,12 @@ route:
 - `LOCALHOST_BYPASS=true` lets same-machine clients skip auth at the middleware,
   **but `require_admin` does NOT honor it** (it needs a real admin session, the
   internal-tool token, or `AUTH_ENABLED=false`). Use a token for admin routes.
+- Your routes must be mounted under **`/api/plugins/<id>/`** (enforced by
+  `add_router`) — otherwise a plugin could shadow an auth-exempt path and expose
+  an unauthenticated endpoint.
+- The global gate only checks *logged-in*; the manifest **`permission` field is
+  advisory** (it controls who may toggle the plugin, not your routes). Gate any
+  admin-only route yourself with `require_admin`.
 - `/static` is auth-exempt, so the theme assets load on any page.
 
 ---

--- a/plugins/GUIDE.md
+++ b/plugins/GUIDE.md
@@ -1,0 +1,141 @@
+# Plugin developer guide
+
+A companion to **`plugins/README.md`** (the reference for the manifest + `ctx`
+API). This covers the conventions and gotchas for building a plugin that looks
+and behaves like a native part of Odysseus.
+
+Copy **`plugins/example/`** as your starting point — it's a working scaffold with
+a route, a background service, and a themed UI page.
+
+---
+
+## 1. Give your plugin a UI (the `ui` manifest field)
+
+A plugin's hook into the frontend is the **`ui`** manifest entry:
+
+```python
+PLUGIN = { ..., "ui": {"open": "/api/plugins/<your-id>/app", "label": "Open"} }
+```
+
+This renders an **Open** button on the plugin's card in **Settings → Plugins**
+(next to the enable toggle) that opens your page in a new tab. Serve the page
+from a route; serve any of your own static files from a `/web/{asset}` route, and
+validate the name (`^[A-Za-z0-9_.-]+$`, reject leading `.`) to block traversal.
+
+---
+
+## 2. Visual parity + user theme
+
+Odysseus themes via CSS variables (`--bg --fg --panel --border --red` + advanced
+`--input-bg --send-btn-bg --brand-color …`) and persists the active theme to
+`localStorage['odysseus-theme']` (+ `/api/prefs/theme`). A **shared theme layer**
+ships as a core static asset — link it from your page `<head>`:
+
+```html
+<link rel="stylesheet" href="/static/plugin-theme.css">
+<script src="/static/js/plugin-theme.js"></script>   <!-- blocking in <head> = no flash -->
+```
+
+- `plugin-theme.js` applies the user's colors/font/density **before first paint**
+  (reads the same `localStorage` the theme picker writes; `/api/prefs/theme`
+  fallback; live-follows changes via the `storage` event).
+- `plugin-theme.css` gives you `od-wrap`, `od-card`, `od-btn` (`.ghost`),
+  `od-input`, `od-header` (the "‹ Odysseus" back bar), `badge`, `bar`, `muted`,
+  `ok`/`warn` — all on the theme vars, so your page recolors with any preset *or*
+  custom theme automatically.
+
+Always include the **`od-header`** (or a link to `/`) so users can return to the
+main interface — your page opens in a new tab.
+
+> A plugin shipped in its own repo can either link `/static/plugin-theme.css`
+> (recommended — it installs into an Odysseus that has it) or vendor a copy under
+> its `web/` for full self-containment.
+
+---
+
+## 3. Auth model
+
+Every `/api/*` request passes the global auth middleware before reaching your
+route:
+
+- In routes, call `require_admin(request)` for admin-only endpoints; omit it for
+  any-logged-in-user endpoints. Don't roll your own auth.
+- External clients authenticate with an **Odysseus API token**:
+  `Authorization: Bearer ody_…` (Settings → API Tokens).
+- `LOCALHOST_BYPASS=true` lets same-machine clients skip auth at the middleware,
+  **but `require_admin` does NOT honor it** (it needs a real admin session, the
+  internal-tool token, or `AUTH_ENABLED=false`). Use a token for admin routes.
+- `/static` is auth-exempt, so the theme assets load on any page.
+
+---
+
+## 4. Heavy deps & external binaries
+
+- **Never import heavy deps at module top.** Discovery parses the manifest via AST
+  (no import), but *loading* runs `setup` + top-level imports — a missing
+  top-level `import torch` turns the plugin into an error card. Import lazily
+  inside handlers and degrade with a clear message when absent.
+- **Don't bundle large models/weights.** Point users at the source and download
+  on demand into `ctx.data_dir` (verify a sha256 when you can).
+- **External CLIs may be off the server's PATH** (e.g. a `pip install --user`
+  Scripts dir). Resolve robustly: an env override, then PATH, then probe the
+  interpreter's Scripts dir + `site.getuserbase()`. Shelling out also decouples
+  you from the server's Python version.
+
+---
+
+## 5. CSP for plugin pages
+
+Odysseus ships a strict Content-Security-Policy:
+
+- **Scripts:** `'self'`, `https://cdn.jsdelivr.net`, or inline-with-nonce
+  (`<script nonce="{request.state.csp_nonce}">`). No other inline script.
+- **No blob/data web workers** — `worker-src` falls back to `default-src 'self'`,
+  so libraries that spawn workers from `blob:` URLs are blocked. Serve a worker
+  from a same-origin URL, or go worker-free.
+- Inline `<style>`/`style=""` is allowed; fetch/XHR is same-origin only.
+- Pages are framed-denied (`frame-ancestors 'none'`) — open in a new tab rather
+  than embedding a plugin page in an in-app iframe.
+
+---
+
+## 6. Gotcha: import order when reusing the tool subsystem
+
+If your plugin imports from `src.tool_schemas` / `src.tool_execution` /
+`src.tool_implementations`, **import `src.agent_tools` first** (the facade) —
+importing `src.tool_schemas` directly triggers a `tool_schemas ↔ agent_tools`
+circular import. Note `ctx.register_tool` is a no-op in builds without
+`src/tool_registry.py` (logs a warning and skips) — expose functionality via
+routes unless you've confirmed the registry is present.
+
+---
+
+## 7. Test without booting the whole app
+
+Use the real `PluginManager` + FastAPI `TestClient` against a temp dir (see
+`tests/test_plugin_system.py`):
+
+```python
+os.environ["ODYSSEUS_PLUGINS_DIR"] = "<dir with your plugin>"
+os.environ["ODYSSEUS_DATA_DIR"]   = "<temp>"
+os.environ["AUTH_ENABLED"]        = "false"   # require_admin() passes → routes reachable
+mgr = PluginManager(app=FastAPI(), directory=...); mgr.load_enabled(app)
+```
+
+`DATABASE_URL` defaults to cwd-relative `./data/app.db` — run from a checkout
+with a `data/` dir or set `DATABASE_URL=sqlite:///<temp>/app.db`. Run and state
+the checks: `python -m py_compile plugin.py`, `node --check web/*.js`.
+
+---
+
+## 8. Distribution
+
+A plugin is a folder, so it ships as its **own git repo** (the
+[Cloudflare Tunnel](https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel),
+[MCP Server](https://github.com/kanaru-dev/odysseus-plugin-mcp-server), and
+[Image → Splat](https://github.com/kanaru-dev/odysseus-plugin-image-splat)
+plugins are the references). Publish a release zip (files at the archive root)
+with its `sha256`, then open a PR adding an entry to
+[`plugins/registry.json`](registry.json). Users then install it in one click from
+**Settings → Plugins → Browse**. Keep secrets out of the plugin — read them from
+`ctx.data_dir` config or Odysseus settings.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,256 @@
+# Writing Odysseus Plugins
+
+Add a feature to Odysseus by dropping a **folder** in `plugins/` — no core edits.
+A plugin can register agent tools, mount HTTP routes, and run background
+services, and it can be **enabled/disabled live** from **Settings → Plugins**
+(no restart). Plugins can live in their own git repos and be shared.
+
+- [Why plugins?](#why-plugins)
+- [Quick start](#quick-start)
+- [Anatomy](#anatomy)
+- [Manifest reference](#manifest-reference)
+- [The `ctx` (PluginContext)](#the-ctx-plugincontext)
+- [Worked examples](#worked-examples) — route, background service, agent tool
+- [Lifecycle & enable/disable](#lifecycle--enabledisable)
+- [Per-plugin storage](#per-plugin-storage)
+- [Auth & permissions](#auth--permissions)
+- [Managing plugins (UI + HTTP API)](#managing-plugins)
+- [Distributing a plugin](#distributing-a-plugin)
+- [Troubleshooting](#troubleshooting)
+
+## Why plugins?
+
+The plugin system exists so Odysseus can grow **without growing the core**:
+
+- **Less churn in main source.** A feature lives in its own folder instead of
+  threading edits through core modules — smaller diffs, easier review, fewer
+  merge conflicts, and a core that stays focused and maintainable.
+- **Users choose what they run.** Nothing is forced on. Enable only the features
+  you want — a leaner install, a smaller attack surface, and no paying (in load
+  time, deps, or risk) for things you don't use.
+- **A real ecosystem.** Anyone can build and share a feature as a drop-in folder /
+  separate repo, without touching core or waiting on an upstream merge. Third-party
+  plugins evolve on their own cadence.
+- **Bundle-by-default, still modular.** Odysseus can ship selected plugins enabled
+  out of the box (so they "just work") while keeping them isolated and toggleable —
+  the default experience is rich, but every piece can be turned off.
+- **Safe by construction.** A broken plugin is isolated (it can't crash startup),
+  each one tears down cleanly, and a plugin is easy to test on its own — so adding
+  or removing a feature is low-risk.
+
+In short: keep the core small and stable, push optional/experimental/niche
+functionality to the edges, and let users (and the community) compose the Odysseus
+they want.
+
+## Quick start
+
+Copy `plugins/example/` to `plugins/my_plugin/`, edit the `PLUGIN` manifest and
+`setup(ctx)`, then either restart Odysseus or hit **Settings → Plugins → Rescan**.
+Your plugin appears in the panel with an on/off toggle.
+
+## Anatomy
+
+A plugin is discovered as either:
+
+```
+plugins/<id>/plugin.py          # a folder with a plugin.py  (preferred)
+plugins/<id>_plugin.py          # …or a single file
+```
+
+`<id>` (the folder/file name) is the plugin's stable id. The module exposes:
+
+```python
+PLUGIN = { ... }                 # a manifest dict (see below)
+
+def setup(ctx):                  # like Blender's register() — wire everything here
+    ...
+
+def teardown(ctx):               # OPTIONAL — like unregister(); usually unneeded,
+    ...                          #   because add_service(stop=)/on_teardown() cover cleanup
+```
+
+## Manifest reference
+
+`PLUGIN` is read at discovery **without executing your module** (parsed from the
+AST), so keep it a plain literal dict.
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Human-readable name shown in the panel. |
+| `version` | rec. | e.g. `"1.0.0"`. |
+| `author` | no | Shown in the panel. |
+| `description` | rec. | One line; shown under the name. |
+| `category` | no | Grouping label (e.g. `Networking`, `Tools`). Default `General`. |
+| `permission` | no | Who may toggle it: `"admin"` (default) or `"user"`. |
+| `requires` | no | Informational list of pip packages / external binaries. |
+
+## The `ctx` (PluginContext)
+
+`setup(ctx)` / `teardown(ctx)` receive a `PluginContext`. **Prefer its helpers**
+over touching `ctx.app` directly — the manager *tracks* what you register so it
+can undo it cleanly when the plugin is disabled.
+
+| Helper | What it does |
+|---|---|
+| `ctx.add_router(router)` | Mount a FastAPI `APIRouter`. Its routes are removed on disable. |
+| `ctx.add_service(start=, stop=)` | Run `start()` now; run `stop()` on disable/shutdown. |
+| `ctx.register_tool(spec)` | Register an agent tool (`ToolSpec`), if the tool registry is present. |
+| `ctx.on_teardown(fn)` | Register any extra cleanup callable. |
+| `ctx.app` | The FastAPI app (escape hatch — usually not needed). |
+| `ctx.data_dir` | A per-plugin writable directory (created for you). |
+| `ctx.logger` | Logger namespaced `plugin.<id>`. |
+
+## Worked examples
+
+### 1. A route (HTTP endpoint)
+
+```python
+from fastapi import APIRouter, Request
+
+PLUGIN = {"name": "Echo", "version": "1.0.0", "category": "Examples"}
+
+def setup(ctx):
+    router = APIRouter(prefix="/api/plugins/echo", tags=["plugin:echo"])
+
+    @router.post("/say")
+    async def say(request: Request):
+        body = await request.json()
+        return {"echo": body.get("text", "")}
+
+    ctx.add_router(router)   # auto-removed when disabled
+```
+
+The route is behind Odysseus auth (a logged-in session). Add admin-only gating
+with `from core.middleware import require_admin; require_admin(request)`.
+
+### 2. A background service
+
+```python
+import threading, time
+
+PLUGIN = {"name": "Heartbeat", "version": "1.0.0", "category": "Examples"}
+
+def setup(ctx):
+    stop = threading.Event()
+    def run():
+        while not stop.is_set():
+            ctx.logger.info("tick"); stop.wait(30)
+    t = threading.Thread(target=run, daemon=True)
+    ctx.add_service(start=t.start, stop=stop.set)   # started now; stopped on disable
+```
+
+### 3. An agent tool
+
+```python
+from src.tool_registry import ToolSpec   # available when the tool registry is installed
+
+PLUGIN = {"name": "Word Count", "version": "1.0.0", "category": "Tools"}
+
+async def _run(args):
+    return {"output": str(len((args.get("text") or "").split())), "exit_code": 0}
+
+def setup(ctx):
+    ctx.register_tool(ToolSpec(
+        name="word_count",
+        description="Count the words in some text.",
+        parameters={"type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"]},
+        execute=_run,
+        permission="user",
+    ))
+```
+
+A plugin can do **any combination** of the above in one `setup(ctx)`.
+
+## Lifecycle & enable/disable
+
+- **Discovery** reads the manifest via AST (no code execution), so even a plugin
+  that would fail to load still appears in the panel.
+- **Enabled** plugins are loaded at startup (their `setup(ctx)` runs). Disabled
+  ones are not.
+- Toggling in the UI calls `setup`/`teardown` **immediately** — routes appear/
+  disappear and services start/stop without a restart.
+- A **broken** plugin (raises on import or in `setup`) is recorded with its
+  traceback, its partial `setup` is rolled back, and startup continues. The panel
+  shows the error.
+- Enable state persists in `<data>/plugins.json`; a newly dropped-in plugin
+  defaults to **enabled**.
+
+## Per-plugin storage
+
+`ctx.data_dir` is a writable folder unique to your plugin
+(`<data>/plugins/<id>/`) — use it for downloaded binaries, caches, or config:
+
+```python
+import os, json
+def setup(ctx):
+    cfg = os.path.join(ctx.data_dir, "config.json")
+    state = json.load(open(cfg)) if os.path.exists(cfg) else {}
+```
+
+## Auth & permissions
+
+Routes you mount go through Odysseus's normal auth: they require a logged-in
+session, and `require_admin(request)` makes them admin-only. They are **not**
+reachable without credentials — including over a Cloudflare tunnel. The manifest
+`permission` field controls who may *toggle* the plugin from the panel.
+
+## Managing plugins
+
+**UI:** Settings → **Plugins** (admin) — list, enable/disable, Rescan.
+
+**HTTP API** (admin-only), for tooling/automation:
+
+| Method & path | Action |
+|---|---|
+| `GET /api/plugins` | List plugins with manifest + status. |
+| `POST /api/plugins/<id>/enable` | Enable + load live. |
+| `POST /api/plugins/<id>/disable` | Disable + unload live. |
+| `POST /api/plugins/<id>/reload` | Re-read + reload. |
+| `POST /api/plugins/rescan` | Pick up newly added plugins. |
+
+Set `ODYSSEUS_PLUGINS_DIR` to load plugins from a custom directory.
+
+## Distributing a plugin
+
+A plugin is just a folder, so it ships as its **own git repo** (the
+[Cloudflare Tunnel plugin](https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel)
+is the reference — DokuWiki-InfoBox style). Core stays small; you release on your
+own cadence without waiting on an upstream merge.
+
+**Publish a release.** Zip the plugin's files *at the archive root* (`plugin.py`
++ assets — no wrapping folder, though a single top-level dir is auto-flattened on
+install) and attach it to a tagged GitHub release, with its `sha256`:
+
+```sh
+zip -j my_plugin-1.0.0.zip plugin.py README.md LICENSE
+sha256sum my_plugin-1.0.0.zip
+gh release create v1.0.0 my_plugin-1.0.0.zip
+```
+
+**List it in the depot.** Open a PR to the main repo adding an entry to
+[`plugins/registry.json`](registry.json) — `id`, `name`, `version`, `download`
+(the release URL), and `sha256` (verified before install). Once merged, anyone
+sees it under **Settings → Plugins → Browse** and installs with one click
+(download → verify → extract into `plugins/<id>/` → enable).
+
+**Other install paths.** Users can also **Add registry…** in the Browse tab to
+point at your own `registry.json` (https, or http to loopback), **Install from
+URL…** with a direct release zip, or just drop the folder into `plugins/` by hand.
+
+Declare external needs in `requires` (for humans); if you import a pip package,
+document it in your README. Keep secrets out of the plugin; read them from
+`ctx.data_dir` config or Odysseus settings.
+
+## Troubleshooting
+
+- **Plugin not listed?** It needs `plugins/<id>/plugin.py` (or `<id>_plugin.py`).
+  Hit **Rescan**.
+- **Status “error”?** The panel shows the traceback tail; full traceback is in the
+  server log (`plugin.<id>` logger). Common causes: a bad import or an exception in
+  `setup`.
+- **Route 401/redirect?** That's expected — routes require login. Use a session
+  cookie / API token, and `require_admin` only where intended.
+- **Disable didn't remove my route?** Mount routers via `ctx.add_router` (not
+  `ctx.app.include_router`) so the manager can track + remove them.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -5,12 +5,16 @@ A plugin can register agent tools, mount HTTP routes, and run background
 services, and it can be **enabled/disabled live** from **Settings → Plugins**
 (no restart). Plugins can live in their own git repos and be shared.
 
+New here? Copy `plugins/example/` and skim **[GUIDE.md](GUIDE.md)** for theming,
+auth, CSP, heavy-deps, and distribution conventions.
+
 - [Why plugins?](#why-plugins)
 - [Quick start](#quick-start)
 - [Anatomy](#anatomy)
 - [Manifest reference](#manifest-reference)
 - [The `ctx` (PluginContext)](#the-ctx-plugincontext)
 - [Worked examples](#worked-examples) — route, background service, agent tool
+- [UI pages & theming](#ui-pages--theming)
 - [Lifecycle & enable/disable](#lifecycle--enabledisable)
 - [Per-plugin storage](#per-plugin-storage)
 - [Auth & permissions](#auth--permissions)
@@ -83,6 +87,7 @@ AST), so keep it a plain literal dict.
 | `category` | no | Grouping label (e.g. `Networking`, `Tools`). Default `General`. |
 | `permission` | no | Who may toggle it: `"admin"` (default) or `"user"`. |
 | `requires` | no | Informational list of pip packages / external binaries. |
+| `ui` | no | `{"open": "/api/plugins/<id>/page", "label": "Open"}` — adds an **Open** button on the plugin's Settings → Plugins card, linking to a page your plugin serves. |
 
 ## The `ctx` (PluginContext)
 
@@ -162,6 +167,25 @@ def setup(ctx):
 ```
 
 A plugin can do **any combination** of the above in one `setup(ctx)`.
+
+## UI pages & theming
+
+A plugin can serve a page that matches the interface. Add a `ui` entry to the
+manifest (above) for an **Open** button, serve the page from a route, and link
+the shared theme layer so it picks up the user's active theme + customization
+(with no flash):
+
+```html
+<link rel="stylesheet" href="/static/plugin-theme.css">
+<script src="/static/js/plugin-theme.js"></script>
+```
+
+That gives you `od-wrap` / `od-card` / `od-btn` / `od-input` / `od-header`
+components built on the app's theme variables, so the page recolors with any
+preset or custom theme. Include the `od-header` (or a link to `/`) so users can
+get back to the main interface — plugin pages open in a new tab. See
+[`plugins/example/`](example/plugin.py) for a working page and
+**[GUIDE.md](GUIDE.md)** (theming, auth, CSP, heavy deps, distribution).
 
 ## Lifecycle & enable/disable
 

--- a/plugins/example/plugin.py
+++ b/plugins/example/plugin.py
@@ -1,0 +1,50 @@
+"""Example Odysseus plugin — a minimal, copy-me template.
+
+Shows the two things a feature plugin commonly does: mount an HTTP route and run
+a background service that's cleaned up on disable. Delete what you don't need.
+
+Drop this folder in `plugins/`, restart (or hit Settings -> Plugins -> Rescan),
+and it appears with a toggle.
+"""
+from fastapi import APIRouter, Request
+
+PLUGIN = {
+    "name": "Example",
+    "version": "1.0.0",
+    "author": "Odysseus",
+    "description": "Minimal plugin template: a route + a background service.",
+    "category": "Examples",
+    "permission": "admin",
+}
+
+
+def setup(ctx):
+    # 1) Mount a route. It's auto-removed when the plugin is disabled.
+    router = APIRouter(prefix="/api/plugins/example", tags=["plugin:example"])
+
+    @router.get("/hello")
+    async def hello(request: Request):
+        # Requires a logged-in session (Odysseus auth). Add
+        #   from core.middleware import require_admin; require_admin(request)
+        # to make it admin-only.
+        return {"plugin": "example", "message": "Hello from a drop-in plugin!"}
+
+    ctx.add_router(router)
+
+    # 2) Register a background service. start() runs now; stop() runs on
+    #    disable/shutdown. Replace with real work (a thread, a poller, …).
+    def start():
+        ctx.logger.info("example service started")
+
+    def stop():
+        ctx.logger.info("example service stopped")
+
+    ctx.add_service(start=start, stop=stop)
+
+    ctx.logger.info("example plugin ready  ->  GET /api/plugins/example/hello")
+
+
+# Optional. Most plugins don't need this — add_service(stop=) and on_teardown()
+# already cover cleanup. Defined here just to show the hook exists.
+def teardown(ctx):
+    ctx.logger.info("example plugin torn down")

--- a/plugins/example/plugin.py
+++ b/plugins/example/plugin.py
@@ -1,21 +1,64 @@
-"""Example Odysseus plugin — a minimal, copy-me template.
+"""Example Odysseus plugin — a copy-me template.
 
-Shows the two things a feature plugin commonly does: mount an HTTP route and run
-a background service that's cleaned up on disable. Delete what you don't need.
+Shows what a feature plugin commonly does: mount an HTTP route, run a background
+service that's cleaned up on disable, and serve a small UI page that matches the
+interface (via the `ui` manifest field + the shared theme layer). Delete what you
+don't need.
 
 Drop this folder in `plugins/`, restart (or hit Settings -> Plugins -> Rescan),
-and it appears with a toggle.
+and it appears with a toggle (and an "Open" button, thanks to `ui`). See
+`plugins/GUIDE.md` for conventions, theming, and gotchas.
 """
 from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
 
 PLUGIN = {
     "name": "Example",
     "version": "1.0.0",
     "author": "Odysseus",
-    "description": "Minimal plugin template: a route + a background service.",
+    "description": "Copy-me template: a route, a background service, and a themed UI page.",
     "category": "Examples",
     "permission": "admin",
+    # `ui.open` gives the plugin an "Open" button on its Settings -> Plugins card.
+    "ui": {"open": "/api/plugins/example/app", "label": "Open"},
 }
+
+# Back-to-the-interface chevron for the themed header.
+_CHEVRON = ('<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" '
+            'stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>')
+
+
+def _app_html(nonce: str) -> str:
+    # Link the shared theme layer (served from /static) so the page picks up the
+    # user's active theme + customization before first paint — no flash. Then use
+    # the od-* component classes. Inline scripts need the request CSP nonce.
+    return f"""<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Example</title>
+<link rel="stylesheet" href="/static/plugin-theme.css">
+<script src="/static/js/plugin-theme.js"></script>
+</head><body>
+<header class="od-header">
+  <a class="brand" href="/" title="Back to Odysseus">{_CHEVRON}<span>Odysseus</span></a>
+  <span class="od-title">Example</span>
+</header>
+<div class="od-wrap">
+  <h1>Example plugin</h1>
+  <div class="od-card">
+    <button id="hi" class="od-btn">Say hello</button>
+    <div id="out" class="muted" style="margin-top:10px">click the button…</div>
+  </div>
+</div>
+<script nonce="{nonce}">
+document.getElementById("hi").onclick = async () => {{
+  const out = document.getElementById("out");
+  try {{
+    const r = await fetch("/api/plugins/example/hello", {{ credentials: "same-origin" }});
+    out.textContent = (await r.json()).message;
+  }} catch (e) {{ out.innerHTML = '<span class="warn">' + e.message + '</span>'; }}
+}};
+</script>
+</body></html>"""
 
 
 def setup(ctx):
@@ -29,9 +72,14 @@ def setup(ctx):
         # to make it admin-only.
         return {"plugin": "example", "message": "Hello from a drop-in plugin!"}
 
+    # 2) A themed UI page (the "Open" button targets this).
+    @router.get("/app")
+    async def app_page(request: Request):
+        return HTMLResponse(_app_html(getattr(request.state, "csp_nonce", "")))
+
     ctx.add_router(router)
 
-    # 2) Register a background service. start() runs now; stop() runs on
+    # 3) Register a background service. start() runs now; stop() runs on
     #    disable/shutdown. Replace with real work (a thread, a poller, …).
     def start():
         ctx.logger.info("example service started")
@@ -41,7 +89,7 @@ def setup(ctx):
 
     ctx.add_service(start=start, stop=stop)
 
-    ctx.logger.info("example plugin ready  ->  GET /api/plugins/example/hello")
+    ctx.logger.info("example plugin ready  ->  /api/plugins/example/app")
 
 
 # Optional. Most plugins don't need this — add_service(stop=) and on_teardown()

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -12,6 +12,28 @@
       "homepage": "https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel",
       "download": "https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel/releases/download/v1.0.1/cloudflare_tunnel-1.0.1.zip",
       "sha256": "4dbce57eb8f8ea360de09696e4e44749952b09660a691c8bce78b414440f507b"
+    },
+    {
+      "id": "mcp_server",
+      "name": "MCP Server",
+      "version": "1.0.0",
+      "author": "kanaru-dev",
+      "category": "Integrations",
+      "description": "Expose Odysseus to external MCP clients (Claude Code, Cursor, …) over Streamable HTTP so they can run its tools. Reuses Odysseus auth (API token).",
+      "homepage": "https://github.com/kanaru-dev/odysseus-plugin-mcp-server",
+      "download": "https://github.com/kanaru-dev/odysseus-plugin-mcp-server/releases/download/v1.0.0/mcp_server-1.0.0.zip",
+      "sha256": "cdf6e00b647efbdd356e7672551f28cb1a9fc1b26a2ac0eb31d0beb9a0099fdc"
+    },
+    {
+      "id": "image_splat",
+      "name": "Image → Splat",
+      "version": "1.0.0",
+      "author": "kanaru-dev",
+      "category": "Media",
+      "description": "Turn a gallery image into a 3D Gaussian Splat with Apple SHARP, with a built-in WebGL viewer. Model downloaded on demand (not bundled).",
+      "homepage": "https://github.com/kanaru-dev/odysseus-plugin-image-splat",
+      "download": "https://github.com/kanaru-dev/odysseus-plugin-image-splat/releases/download/v1.0.0/image_splat-1.0.0.zip",
+      "sha256": "d840cad42327104cbd03348ffd46764d18a96d6ce333d1eb527001c1e448b842"
     }
   ]
 }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Official Odysseus plugin registry. Submit a plugin by opening a PR that adds an entry here. Each plugin lives in its own repo (DokuWiki-InfoBox model); `download` is an https zip whose root contains the plugin's files (plugin.py + assets) and `sha256` of that zip is verified before install. The in-app Plugins -> Browse tab reads this file. Add more sources in the UI, or override the base with ODYSSEUS_PLUGIN_REGISTRY (comma-separated) for a fork/private registry. The bundled plugins/example is an in-tree template, not listed here.",
+  "version": 1,
+  "plugins": [
+    {
+      "id": "cloudflare_tunnel",
+      "name": "Cloudflare Tunnel",
+      "version": "1.0.1",
+      "author": "kanaru-dev",
+      "category": "Networking",
+      "description": "Expose Odysseus remotely over a Cloudflare tunnel (quick or named). Login is still required to reach the app.",
+      "homepage": "https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel",
+      "download": "https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel/releases/download/v1.0.1/cloudflare_tunnel-1.0.1.zip",
+      "sha256": "4dbce57eb8f8ea360de09696e4e44749952b09660a691c8bce78b414440f507b"
+    }
+  ]
+}

--- a/routes/plugin_routes.py
+++ b/routes/plugin_routes.py
@@ -1,0 +1,123 @@
+"""Admin API for the plugin system — list / enable / disable / reload.
+
+Backs the Settings → Plugins panel. All endpoints are admin-only.
+"""
+from fastapi import APIRouter, Request, HTTPException
+
+from core.middleware import require_admin
+
+
+def setup_plugin_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/plugins", tags=["plugins"])
+
+    def _mgr():
+        from src.plugin_system import get_manager
+        m = get_manager()
+        if m is None:
+            raise HTTPException(503, "Plugin system not initialized")
+        return m
+
+    @router.get("")
+    async def list_plugins(request: Request):
+        require_admin(request)
+        return {"plugins": _mgr().list()}
+
+    @router.post("/{plugin_id}/enable")
+    async def enable_plugin(plugin_id: str, request: Request):
+        require_admin(request)
+        try:
+            return _mgr().enable(plugin_id)
+        except KeyError:
+            raise HTTPException(404, "Plugin not found")
+
+    @router.post("/{plugin_id}/disable")
+    async def disable_plugin(plugin_id: str, request: Request):
+        require_admin(request)
+        try:
+            return _mgr().disable(plugin_id)
+        except KeyError:
+            raise HTTPException(404, "Plugin not found")
+
+    @router.post("/{plugin_id}/reload")
+    async def reload_plugin(plugin_id: str, request: Request):
+        require_admin(request)
+        try:
+            return _mgr().reload(plugin_id)
+        except KeyError:
+            raise HTTPException(404, "Plugin not found")
+
+    @router.post("/rescan")
+    async def rescan(request: Request):
+        """Re-scan the plugins directory (pick up newly dropped-in plugins)."""
+        require_admin(request)
+        _mgr().load_enabled()
+        return {"plugins": _mgr().list()}
+
+    # ---- Registry / depot (browse + install from a curated index) ----------
+    @router.get("/registry")
+    async def registry(request: Request):
+        """Available plugins aggregated across all registries, with install state.
+        Returns {"plugins": [...], "sources": [{url, ok, count/error}]}."""
+        require_admin(request)
+        from src import plugin_registry as reg
+        return reg.available()
+
+    @router.get("/registries")
+    async def registries(request: Request):
+        """The configured registry source URLs (base + user-added)."""
+        require_admin(request)
+        from src import plugin_registry as reg
+        return {"registries": reg.get_registries(), "custom": reg._load_custom()}
+
+    @router.post("/registries")
+    async def add_registry(request: Request):
+        """Add a custom registry source URL."""
+        require_admin(request)
+        from src import plugin_registry as reg
+        body = await request.json()
+        try:
+            return {"registries": reg.add_registry((body.get("url") or "").strip())}
+        except Exception as e:
+            raise HTTPException(400, str(e))
+
+    @router.delete("/registries")
+    async def del_registry(request: Request):
+        """Remove a custom registry source URL."""
+        require_admin(request)
+        from src import plugin_registry as reg
+        body = await request.json()
+        return {"registries": reg.remove_registry((body.get("url") or "").strip())}
+
+    @router.post("/install")
+    async def install(request: Request):
+        """Install a plugin by registry id ({"id": ...}) or a direct zip
+        ({"url": ..., "id": ..., "sha256": ...})."""
+        require_admin(request)
+        from src import plugin_registry as reg
+        body = await request.json()
+        try:
+            if body.get("url"):
+                return reg.install(url=body["url"], plugin_id=body.get("id") or body.get("plugin_id"),
+                                   sha256=body.get("sha256"))
+            entry = reg.find_entry(body.get("id"))
+            if not entry:
+                raise HTTPException(404, "plugin id not in any registry")
+            return reg.install(entry=entry)
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(400, f"Install failed: {e}")
+
+    @router.post("/{plugin_id}/uninstall")
+    async def uninstall(plugin_id: str, request: Request):
+        """Disable + delete a plugin's folder."""
+        require_admin(request)
+        from src import plugin_registry as reg
+        try:
+            return reg.uninstall(plugin_id)
+        except KeyError:
+            raise HTTPException(404, "Plugin not found")
+        except Exception as e:
+            raise HTTPException(400, f"Uninstall failed: {e}")
+
+    return router

--- a/src/plugin_registry.py
+++ b/src/plugin_registry.py
@@ -38,9 +38,12 @@ import hashlib
 import io
 import json
 import os
+import re
 import shutil
+import urllib.error
 import urllib.request
 import zipfile
+from urllib.parse import urlsplit
 from typing import Any, Dict, List, Optional
 
 from src.plugin_system import plugins_dir, get_manager
@@ -49,17 +52,49 @@ DEFAULT_REGISTRY = (
     "https://raw.githubusercontent.com/pewdiepie-archdaemon/odysseus/main/plugins/registry.json"
 )
 
+# Resource caps — guard against zip bombs / oversized downloads (DoS).
+MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024        # compressed download
+MAX_TOTAL_UNCOMPRESSED = 256 * 1024 * 1024   # sum of extracted bytes
+MAX_REGISTRY_BYTES = 4 * 1024 * 1024         # registry index JSON
+
 
 def _allowed_url(url: str) -> bool:
-    """Allow https anywhere, or http only to loopback (local/LAN registries +
-    testing). Blocks plaintext http to arbitrary hosts (MITM risk)."""
-    u = (url or "").lower()
-    if u.startswith("https://"):
-        return True
-    if u.startswith("http://"):
-        host = u[len("http://"):].split("/", 1)[0].split(":", 1)[0]
-        return host in ("127.0.0.1", "localhost", "[::1]", "::1")
+    """Allow https to any host, or http only to loopback (local/LAN registries +
+    testing). Parses with urlsplit and rejects userinfo/whitespace so the host we
+    validate is the host urllib actually connects to — blocks tricks like
+    ``http://127.0.0.1:1@evil.com`` and plaintext http to arbitrary hosts."""
+    if not isinstance(url, str) or url != url.strip() or any(c in url for c in " \t\r\n"):
+        return False
+    try:
+        u = urlsplit(url)
+    except Exception:
+        return False
+    if u.username or u.password or "@" in (u.netloc or ""):
+        return False
+    host = (u.hostname or "").lower()
+    if u.scheme == "https":
+        return bool(host)
+    if u.scheme == "http":
+        return host in ("127.0.0.1", "localhost", "::1")
     return False
+
+
+class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Re-apply ``_allowed_url`` to every redirect hop so an https URL can't 302
+    to http://internal-host / cloud-metadata (SSRF) and bypass the policy."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if not _allowed_url(newurl):
+            raise urllib.error.HTTPError(newurl, code, "redirect to a disallowed URL blocked", headers, fp)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_OPENER = urllib.request.build_opener(_ValidatingRedirectHandler())
+
+
+def _urlopen(url: str, timeout: int):
+    """urlopen via an opener that re-validates redirect targets."""
+    return _OPENER.open(url, timeout=timeout)
 
 
 def _data_root() -> str:
@@ -88,8 +123,10 @@ def _load_custom() -> List[str]:
 def _save_custom(urls: List[str]) -> None:
     path = _custom_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump(urls, f, indent=2)
+    os.replace(tmp, path)   # atomic write — no truncation on crash mid-write
 
 
 def get_registries() -> List[str]:
@@ -143,8 +180,11 @@ def fetch_registry(url: Optional[str] = None, timeout: int = 15) -> List[Dict[st
     url = url or registry_url()
     if not _allowed_url(url):
         raise ValueError("registry URL must be https (or http to loopback)")
-    with urllib.request.urlopen(url, timeout=timeout) as r:  # nosec - admin-configured
-        data = json.loads(r.read().decode("utf-8"))
+    with _urlopen(url, timeout) as r:  # redirect-validated; admin-configured
+        raw = r.read(MAX_REGISTRY_BYTES + 1)
+    if len(raw) > MAX_REGISTRY_BYTES:
+        raise ValueError("registry index too large")
+    data = json.loads(raw.decode("utf-8"))
     if isinstance(data, dict) and isinstance(data.get("plugins"), list):
         data = data["plugins"]
     if not isinstance(data, list):
@@ -208,8 +248,10 @@ def _ver(v: str):
 
 def _safe_extract(zf: zipfile.ZipFile, dest: str) -> None:
     """Extract ``zf`` into ``dest``, rejecting zip-slip (absolute paths / ``..``
-    that escape dest) and symlinks."""
+    that escape dest) and symlinks, and capping the total uncompressed size to
+    guard against zip bombs."""
     dest_real = os.path.realpath(dest)
+    budget = MAX_TOTAL_UNCOMPRESSED
     for member in zf.infolist():
         name = member.filename
         if name.endswith("/"):
@@ -222,8 +264,17 @@ def _safe_extract(zf: zipfile.ZipFile, dest: str) -> None:
         if mode == 0o120000:
             raise ValueError(f"symlink not allowed in archive: {name}")
         os.makedirs(os.path.dirname(target), exist_ok=True)
+        # Bounded copy — enforce the ACTUAL decompressed size (member.file_size
+        # can lie), so a crafted archive can't exhaust the disk.
         with zf.open(member) as src, open(target, "wb") as out:
-            shutil.copyfileobj(src, out)
+            while True:
+                chunk = src.read(65536)
+                if not chunk:
+                    break
+                budget -= len(chunk)
+                if budget < 0:
+                    raise ValueError("archive exceeds the uncompressed size limit")
+                out.write(chunk)
 
 
 def install(entry: Optional[Dict[str, Any]] = None, *, url: Optional[str] = None,
@@ -243,13 +294,19 @@ def install(entry: Optional[Dict[str, Any]] = None, *, url: Optional[str] = None
         raise ValueError("download URL must be https (or http to loopback)")
     if not _is_safe_id(plugin_id):
         raise ValueError("invalid plugin id")
+    # Require a verified digest — installing runs third-party code, so never
+    # install an unverified blob (covers registry entries AND install-from-URL).
+    digest = (sha256 or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ValueError("a valid sha256 digest is required to install (integrity check)")
 
-    with urllib.request.urlopen(url, timeout=timeout) as r:  # nosec - admin action
-        blob = r.read()
-    if sha256:
-        got = hashlib.sha256(blob).hexdigest()
-        if got.lower() != sha256.lower():
-            raise ValueError(f"sha256 mismatch (expected {sha256}, got {got})")
+    with _urlopen(url, timeout) as r:  # redirect-validated; admin action
+        blob = r.read(MAX_DOWNLOAD_BYTES + 1)
+    if len(blob) > MAX_DOWNLOAD_BYTES:
+        raise ValueError(f"download exceeds the {MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB limit")
+    got = hashlib.sha256(blob).hexdigest()
+    if got != digest:
+        raise ValueError(f"sha256 mismatch (expected {digest}, got {got})")
 
     target = os.path.join(plugins_dir(), plugin_id)
     staging = target + ".incoming"
@@ -269,11 +326,17 @@ def install(entry: Optional[Dict[str, Any]] = None, *, url: Optional[str] = None
 
     mgr = get_manager()
     if mgr:
-        mgr.load_enabled()            # rescan picks up the new folder
-        try:
-            return mgr.enable(plugin_id)
-        except KeyError:
-            pass
+        # Atomic w.r.t. other manager mutations (RLock, reentrant) so a concurrent
+        # uninstall of the same id can't slip between discover() and reload().
+        with mgr._lock:
+            mgr.discover()              # pick up the new folder + fresh manifest
+            rec = mgr.records.get(plugin_id)
+            if rec is not None:
+                rec.enabled = True      # installing (re)enables it
+                mgr._save_state()
+                # reload() tears down any previously-running version and
+                # re-imports the just-written code (enable() would keep the old).
+                return mgr.reload(plugin_id)
     return {"id": plugin_id, "installed": True}
 
 

--- a/src/plugin_registry.py
+++ b/src/plugin_registry.py
@@ -1,0 +1,320 @@
+"""Plugin registry / depot — discover and install plugins from a curated index.
+
+Like DokuWiki's Extension Manager or Blender's "Get Extensions": a JSON index
+lists available plugins with metadata + a download URL; the admin browses it and
+installs with one click (download -> verify -> extract into ``plugins/<id>/``).
+
+The default registry is the **upstream** project's, served straight from the main
+repo (no server to run):
+
+    https://raw.githubusercontent.com/pewdiepie-archdaemon/odysseus/main/plugins/registry.json
+
+Override with ``ODYSSEUS_PLUGIN_REGISTRY`` (env) or the ``plugin_registry`` app
+setting — e.g. to point at a fork while testing, or a private/org registry.
+
+index.json schema (a list of):
+    {
+      "id": "cloudflare_tunnel",
+      "name": "Cloudflare Tunnel",
+      "version": "1.0.0",
+      "author": "...",
+      "category": "Networking",
+      "description": "...",
+      "download": "https://github.com/<owner>/<repo>/releases/download/v1.0.0/cloudflare_tunnel.zip",
+      "sha256": "<hex>",          # optional but recommended; verified before install
+      "min_odysseus": "1.0",      # optional
+      "homepage": "https://...",  # optional
+      "screenshot": "https://..." # optional
+    }
+
+The zip must contain the plugin's files at its root (it is extracted into
+``plugins/<id>/``). Extraction is hardened against zip-slip / absolute paths.
+
+Security: installing a plugin runs third-party code. These functions are wired to
+admin-only routes; downloads are HTTPS-only and sha256-verified when a digest is
+provided. Keep the default (curated) registry as the trusted source.
+"""
+import hashlib
+import io
+import json
+import os
+import shutil
+import urllib.request
+import zipfile
+from typing import Any, Dict, List, Optional
+
+from src.plugin_system import plugins_dir, get_manager
+
+DEFAULT_REGISTRY = (
+    "https://raw.githubusercontent.com/pewdiepie-archdaemon/odysseus/main/plugins/registry.json"
+)
+
+
+def _allowed_url(url: str) -> bool:
+    """Allow https anywhere, or http only to loopback (local/LAN registries +
+    testing). Blocks plaintext http to arbitrary hosts (MITM risk)."""
+    u = (url or "").lower()
+    if u.startswith("https://"):
+        return True
+    if u.startswith("http://"):
+        host = u[len("http://"):].split("/", 1)[0].split(":", 1)[0]
+        return host in ("127.0.0.1", "localhost", "[::1]", "::1")
+    return False
+
+
+def _data_root() -> str:
+    root = os.environ.get("ODYSSEUS_DATA_DIR")
+    if root:
+        return root
+    try:
+        from core.constants import DATA_DIR
+        return DATA_DIR
+    except Exception:
+        return os.path.join(os.path.dirname(plugins_dir()), "data")
+
+
+def _custom_path() -> str:
+    return os.path.join(_data_root(), "plugin_registries.json")
+
+
+def _load_custom() -> List[str]:
+    try:
+        with open(_custom_path(), encoding="utf-8") as f:
+            return [u for u in json.load(f) if isinstance(u, str)]
+    except Exception:
+        return []
+
+
+def _save_custom(urls: List[str]) -> None:
+    path = _custom_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(urls, f, indent=2)
+
+
+def get_registries() -> List[str]:
+    """Ordered, de-duplicated registry URLs to aggregate. Base = the env override
+    (comma-separated) or the ``plugin_registry`` setting or the upstream default;
+    user-added custom registries (managed in the UI) are appended."""
+    out: List[str] = []
+    env = (os.environ.get("ODYSSEUS_PLUGIN_REGISTRY") or "").strip()
+    if env:
+        out += [u.strip() for u in env.split(",") if u.strip()]
+    else:
+        try:
+            from src.settings import get_setting
+            out += [u.strip() for u in (get_setting("plugin_registry", "") or "").split(",") if u.strip()]
+        except Exception:
+            pass
+        if not out:
+            out.append(DEFAULT_REGISTRY)
+    out += _load_custom()
+    seen, result = set(), []
+    for u in out:
+        if u and u not in seen and _allowed_url(u):
+            seen.add(u)
+            result.append(u)
+    return result
+
+
+def registry_url() -> str:
+    """The primary registry (first source) — used for display."""
+    regs = get_registries()
+    return regs[0] if regs else DEFAULT_REGISTRY
+
+
+def add_registry(url: str) -> List[str]:
+    if not _allowed_url(url):
+        raise ValueError("registry URL must be https (or http to loopback)")
+    custom = _load_custom()
+    if url not in custom:
+        custom.append(url)
+        _save_custom(custom)
+    return get_registries()
+
+
+def remove_registry(url: str) -> List[str]:
+    _save_custom([u for u in _load_custom() if u != url])
+    return get_registries()
+
+
+def fetch_registry(url: Optional[str] = None, timeout: int = 15) -> List[Dict[str, Any]]:
+    """Fetch + parse a single registry index. Raises on network/parse error."""
+    url = url or registry_url()
+    if not _allowed_url(url):
+        raise ValueError("registry URL must be https (or http to loopback)")
+    with urllib.request.urlopen(url, timeout=timeout) as r:  # nosec - admin-configured
+        data = json.loads(r.read().decode("utf-8"))
+    if isinstance(data, dict) and isinstance(data.get("plugins"), list):
+        data = data["plugins"]
+    if not isinstance(data, list):
+        raise ValueError("registry must be a JSON list (or {\"plugins\": [...]})")
+    return data
+
+
+def find_entry(plugin_id: str) -> Optional[Dict[str, Any]]:
+    """Find a plugin's entry across all registries (first match wins)."""
+    for url in get_registries():
+        try:
+            for e in fetch_registry(url):
+                if e.get("id") == plugin_id:
+                    return e
+        except Exception:
+            continue
+    return None
+
+
+def available() -> Dict[str, Any]:
+    """Aggregate entries across all registries, annotated with install state.
+    Returns ``{"plugins": [...], "sources": [{"url", "ok", "count"/"error"}]}``."""
+    mgr = get_manager()
+    installed = {p["id"]: p for p in (mgr.list() if mgr else [])}
+    seen, plugins, sources = set(), [], []
+    for url in get_registries():
+        try:
+            entries = fetch_registry(url)
+            sources.append({"url": url, "ok": True, "count": len(entries)})
+        except Exception as e:
+            sources.append({"url": url, "ok": False, "error": str(e)})
+            continue
+        for e in entries:
+            pid = e.get("id")
+            if not pid or pid in seen:
+                continue
+            seen.add(pid)
+            e = dict(e)
+            e["_source"] = url
+            cur = installed.get(pid)
+            if cur:
+                e["installed"] = True
+                e["installed_version"] = cur.get("version", "")
+                e["update_available"] = bool(e.get("version") and cur.get("version") and
+                                              _ver(e["version"]) > _ver(cur["version"]))
+            else:
+                e["installed"] = False
+            plugins.append(e)
+    return {"plugins": plugins, "sources": sources}
+
+
+def _ver(v: str):
+    parts = []
+    for p in str(v).split("."):
+        try:
+            parts.append(int(p))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def _safe_extract(zf: zipfile.ZipFile, dest: str) -> None:
+    """Extract ``zf`` into ``dest``, rejecting zip-slip (absolute paths / ``..``
+    that escape dest) and symlinks."""
+    dest_real = os.path.realpath(dest)
+    for member in zf.infolist():
+        name = member.filename
+        if name.endswith("/"):
+            continue
+        target = os.path.realpath(os.path.join(dest, name))
+        if target != dest_real and not target.startswith(dest_real + os.sep):
+            raise ValueError(f"unsafe path in archive: {name}")
+        # block symlinks (high bits of external_attr encode the unix mode)
+        mode = (member.external_attr >> 16) & 0o170000
+        if mode == 0o120000:
+            raise ValueError(f"symlink not allowed in archive: {name}")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with zf.open(member) as src, open(target, "wb") as out:
+            shutil.copyfileobj(src, out)
+
+
+def install(entry: Optional[Dict[str, Any]] = None, *, url: Optional[str] = None,
+            plugin_id: Optional[str] = None, sha256: Optional[str] = None,
+            timeout: int = 60) -> Dict[str, Any]:
+    """Install a plugin from the registry (pass ``entry``) or a direct zip URL
+    (pass ``url`` + ``plugin_id``). Downloads, verifies sha256 (if given), and
+    extracts into ``plugins/<id>/`` (replacing any existing copy), then rescans +
+    enables. Returns the manager's record for the plugin."""
+    if entry:
+        url = entry.get("download")
+        plugin_id = entry.get("id")
+        sha256 = entry.get("sha256") or sha256
+    if not url or not plugin_id:
+        raise ValueError("need a download url + plugin id")
+    if not _allowed_url(url):
+        raise ValueError("download URL must be https (or http to loopback)")
+    if not _is_safe_id(plugin_id):
+        raise ValueError("invalid plugin id")
+
+    with urllib.request.urlopen(url, timeout=timeout) as r:  # nosec - admin action
+        blob = r.read()
+    if sha256:
+        got = hashlib.sha256(blob).hexdigest()
+        if got.lower() != sha256.lower():
+            raise ValueError(f"sha256 mismatch (expected {sha256}, got {got})")
+
+    target = os.path.join(plugins_dir(), plugin_id)
+    staging = target + ".incoming"
+    shutil.rmtree(staging, ignore_errors=True)
+    os.makedirs(staging, exist_ok=True)
+    try:
+        with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+            _safe_extract(zf, staging)
+        # a zip that wraps everything in a single top dir → flatten it
+        _flatten_single_root(staging)
+        if not _has_plugin_entry(staging):
+            raise ValueError("archive has no plugin.py / *_plugin.py")
+        shutil.rmtree(target, ignore_errors=True)
+        os.replace(staging, target)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    mgr = get_manager()
+    if mgr:
+        mgr.load_enabled()            # rescan picks up the new folder
+        try:
+            return mgr.enable(plugin_id)
+        except KeyError:
+            pass
+    return {"id": plugin_id, "installed": True}
+
+
+def uninstall(plugin_id: str) -> Dict[str, Any]:
+    """Disable + delete a plugin's folder. Admin-only at the route layer."""
+    if not _is_safe_id(plugin_id):
+        raise ValueError("invalid plugin id")
+    mgr = get_manager()
+    if mgr:
+        try:
+            mgr.disable(plugin_id)
+        except KeyError:
+            pass
+    folder = os.path.join(plugins_dir(), plugin_id)
+    single = os.path.join(plugins_dir(), plugin_id + "_plugin.py")
+    if os.path.isdir(folder):
+        shutil.rmtree(folder, ignore_errors=True)
+    elif os.path.isfile(single):
+        os.remove(single)
+    else:
+        raise KeyError(plugin_id)
+    if mgr:
+        mgr.discover()
+    return {"id": plugin_id, "removed": True}
+
+
+def _is_safe_id(pid: str) -> bool:
+    import re
+    return bool(pid) and re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_-]{0,63}", pid) is not None
+
+
+def _has_plugin_entry(folder: str) -> bool:
+    if os.path.isfile(os.path.join(folder, "plugin.py")):
+        return True
+    return any(n.endswith("_plugin.py") for n in os.listdir(folder))
+
+
+def _flatten_single_root(folder: str) -> None:
+    entries = os.listdir(folder)
+    if len(entries) == 1 and os.path.isdir(os.path.join(folder, entries[0])):
+        inner = os.path.join(folder, entries[0])
+        for n in os.listdir(inner):
+            shutil.move(os.path.join(inner, n), os.path.join(folder, n))
+        os.rmdir(inner)

--- a/src/plugin_system.py
+++ b/src/plugin_system.py
@@ -144,6 +144,10 @@ class PluginRecord:
             "category": m.get("category", "General"),
             "permission": m.get("permission", "admin"),
             "requires": m.get("requires", []),
+            # Optional UI contribution: {"open": "/api/.../page", "label": "Open"}.
+            # The Plugins panel renders an "Open" button for enabled plugins that
+            # declare it — a plugin's only hook into the frontend.
+            "ui": m.get("ui"),
             "enabled": self.enabled,
             "status": self.status,
             "error": self.error,

--- a/src/plugin_system.py
+++ b/src/plugin_system.py
@@ -1,0 +1,392 @@
+"""Odysseus plugin system — a Blender-style, drop-in plugin architecture.
+
+Goal: adding a feature to Odysseus should be as easy as dropping a folder in
+``plugins/`` — no editing core. A plugin can register agent tools, mount HTTP
+routes, run background services, and add UI, and can be enabled/disabled at
+runtime without a restart.
+
+A plugin is a folder ``plugins/<id>/plugin.py`` (or a single-file
+``plugins/<id>_plugin.py``) exposing:
+
+    PLUGIN = {                       # manifest — like Blender's bl_info
+        "name": "Human Name",
+        "version": "1.0.0",
+        "author": "you",
+        "description": "What it does.",
+        "category": "Networking",     # optional grouping for the UI
+        "requires": [],               # optional: pip pkgs / external bins (informational)
+        "permission": "admin",        # who may toggle/use it: "admin" (default) or "user"
+    }
+
+    def setup(ctx):    ...            # like register(): wire routes/services/tools
+    def teardown(ctx): ...            # like unregister(): undo setup (optional)
+
+``ctx`` is a :class:`PluginContext`. Use its helpers (``add_router``,
+``add_service``, ``register_tool``) rather than touching ``ctx.app`` directly so
+the manager can TRACK what you registered and tear it down cleanly on disable.
+
+Design notes for contributors
+-----------------------------
+* **Isolation** — a plugin that raises during import or ``setup`` is recorded
+  with its traceback and skipped; it never crashes app startup.
+* **State** — which plugins are enabled persists in ``<data>/plugins.json``.
+  A newly-discovered plugin defaults to enabled (drop-in just works); an admin
+  can disable it from the Plugins panel.
+* **Live toggle** — ``add_router``/``add_service``/``register_tool`` are
+  reversible, so enable/disable take effect immediately (best-effort for routes;
+  the OpenAPI schema is rebuilt on next access).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import os
+import threading
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def plugins_dir() -> str:
+    return os.environ.get(
+        "ODYSSEUS_PLUGINS_DIR",
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "plugins"),
+    )
+
+
+def _data_root() -> str:
+    """Writable data root: ODYSSEUS_DATA_DIR if set, else the app's DATA_DIR."""
+    root = os.environ.get("ODYSSEUS_DATA_DIR")
+    if root:
+        return root
+    try:
+        from core.constants import DATA_DIR
+        return DATA_DIR
+    except Exception:
+        return os.path.join(os.path.dirname(plugins_dir()), "data")
+
+
+def _state_path() -> str:
+    return os.path.join(_data_root(), "plugins.json")
+
+
+# ---------------------------------------------------------------------------
+# PluginContext — the controlled surface a plugin's setup(ctx) receives
+# ---------------------------------------------------------------------------
+@dataclass
+class PluginContext:
+    """Handed to ``setup(ctx)`` / ``teardown(ctx)``. Prefer its helpers over
+    poking ``app`` directly so the manager can undo everything on disable."""
+    plugin_id: str
+    app: Any
+    data_dir: str
+    logger: logging.Logger
+    # internal teardown tracking
+    _routes: List[Any] = field(default_factory=list)
+    _services: List["tuple[Optional[Callable], Optional[Callable]]"] = field(default_factory=list)
+    _tools: List[str] = field(default_factory=list)
+    _cleanups: List[Callable[[], None]] = field(default_factory=list)
+
+    # -- routes -------------------------------------------------------------
+    def add_router(self, router, **include_kwargs) -> None:
+        """Mount a FastAPI APIRouter; its routes are tracked for clean removal."""
+        before = len(self.app.router.routes)
+        self.app.include_router(router, **include_kwargs)
+        self._routes.extend(self.app.router.routes[before:])
+
+    # -- background services -----------------------------------------------
+    def add_service(self, start: Optional[Callable] = None,
+                    stop: Optional[Callable] = None) -> None:
+        """Register a background service. ``start`` runs now; ``stop`` runs on
+        teardown/disable. Both are plain callables (sync)."""
+        self._services.append((start, stop))
+        if start:
+            start()
+
+    # -- agent tools (optional; needs the tool registry) -------------------
+    def register_tool(self, spec) -> None:
+        """Register an agent tool via the ToolSpec registry, if present."""
+        try:
+            from src.tool_registry import register_tool as _rt
+        except Exception as e:  # tool registry not installed in this build
+            self.logger.warning("register_tool unavailable (%s); skipping %r", e, getattr(spec, "name", spec))
+            return
+        _rt(spec)
+        self._tools.append(getattr(spec, "name", str(spec)))
+
+    def on_teardown(self, fn: Callable[[], None]) -> None:
+        """Register an arbitrary cleanup callable run on teardown."""
+        self._cleanups.append(fn)
+
+
+@dataclass
+class PluginRecord:
+    plugin_id: str
+    path: str
+    manifest: Dict[str, Any] = field(default_factory=dict)
+    enabled: bool = True
+    status: str = "discovered"          # discovered | loaded | disabled | error
+    error: Optional[str] = None
+    module: Any = None
+    ctx: Optional[PluginContext] = None
+
+    def public(self) -> Dict[str, Any]:
+        m = self.manifest or {}
+        return {
+            "id": self.plugin_id,
+            "name": m.get("name", self.plugin_id),
+            "version": m.get("version", ""),
+            "author": m.get("author", ""),
+            "description": m.get("description", ""),
+            "category": m.get("category", "General"),
+            "permission": m.get("permission", "admin"),
+            "requires": m.get("requires", []),
+            "enabled": self.enabled,
+            "status": self.status,
+            "error": self.error,
+        }
+
+
+# ---------------------------------------------------------------------------
+# PluginManager
+# ---------------------------------------------------------------------------
+class PluginManager:
+    def __init__(self, app: Any = None, directory: Optional[str] = None):
+        self.app = app
+        self.directory = directory or plugins_dir()
+        self.records: Dict[str, PluginRecord] = {}
+        self._lock = threading.RLock()
+
+    # -- persisted enable/disable state ------------------------------------
+    def _load_state(self) -> Dict[str, Dict[str, Any]]:
+        try:
+            with open(_state_path(), "r", encoding="utf-8") as f:
+                return json.load(f) or {}
+        except Exception:
+            return {}
+
+    def _save_state(self) -> None:
+        path = _state_path()
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            state = {pid: {"enabled": r.enabled} for pid, r in self.records.items()}
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(state, f, indent=2)
+        except Exception as e:
+            logger.warning("Could not persist plugin state: %s", e)
+
+    # -- discovery ----------------------------------------------------------
+    def discover(self) -> None:
+        """Scan the plugins dir, read manifests, apply persisted enable state.
+        Does not import/run plugin code — that's `setup`/`load`."""
+        with self._lock:
+            state = self._load_state()
+            found: Dict[str, PluginRecord] = {}
+            if not os.path.isdir(self.directory):
+                self.records = found
+                return
+            for entry in sorted(os.listdir(self.directory)):
+                full = os.path.join(self.directory, entry)
+                if os.path.isdir(full) and os.path.isfile(os.path.join(full, "plugin.py")):
+                    pid, path = entry, os.path.join(full, "plugin.py")
+                elif entry.endswith("_plugin.py"):
+                    pid, path = entry[:-len("_plugin.py")], full
+                else:
+                    continue
+                rec = self.records.get(pid) or PluginRecord(plugin_id=pid, path=path)
+                rec.path = path
+                rec.manifest = _read_manifest(path) or rec.manifest
+                rec.enabled = state.get(pid, {}).get("enabled", True)
+                found[pid] = rec
+            self.records = found
+
+    # -- load / unload ------------------------------------------------------
+    def load_enabled(self, app: Any = None) -> int:
+        """Discover, then `setup` every enabled plugin. Returns count loaded."""
+        if app is not None:
+            self.app = app
+        self.discover()
+        loaded = 0
+        for rec in self.records.values():
+            if rec.enabled and self._setup(rec):
+                loaded += 1
+        if self.records:
+            logger.info("Plugin system: %d/%d plugin(s) active", loaded, len(self.records))
+        return loaded
+
+    def _import(self, rec: PluginRecord) -> bool:
+        try:
+            mod_name = "odysseus_plugin_" + rec.plugin_id
+            spec = importlib.util.spec_from_file_location(mod_name, rec.path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            rec.module = module
+            if not rec.manifest:
+                rec.manifest = getattr(module, "PLUGIN", {}) or {}
+            return True
+        except Exception:
+            rec.status, rec.error = "error", traceback.format_exc(limit=6)
+            logger.error("Plugin %s failed to import:\n%s", rec.plugin_id, rec.error)
+            return False
+
+    def _setup(self, rec: PluginRecord) -> bool:
+        with self._lock:
+            if rec.status == "loaded":
+                return True
+            if rec.module is None and not self._import(rec):
+                return False
+            ctx = PluginContext(
+                plugin_id=rec.plugin_id,
+                app=self.app,
+                data_dir=self._data_dir(rec.plugin_id),
+                logger=logging.getLogger("plugin." + rec.plugin_id),
+            )
+            try:
+                setup = getattr(rec.module, "setup", None)
+                if callable(setup):
+                    setup(ctx)
+                rec.ctx, rec.status, rec.error = ctx, "loaded", None
+                logger.info("Plugin loaded: %s", rec.plugin_id)
+                return True
+            except Exception:
+                rec.status, rec.error = "error", traceback.format_exc(limit=6)
+                logger.error("Plugin %s setup() failed:\n%s", rec.plugin_id, rec.error)
+                self._teardown(rec)  # roll back partial registration
+                return False
+
+    def _teardown(self, rec: PluginRecord) -> None:
+        ctx = rec.ctx
+        if not ctx:
+            return
+        # services
+        for _start, stop in reversed(ctx._services):
+            if stop:
+                try:
+                    stop()
+                except Exception as e:
+                    logger.warning("Plugin %s service stop failed: %s", rec.plugin_id, e)
+        # custom cleanups
+        for fn in reversed(ctx._cleanups):
+            try:
+                fn()
+            except Exception as e:
+                logger.warning("Plugin %s cleanup failed: %s", rec.plugin_id, e)
+        # routes
+        for route in ctx._routes:
+            try:
+                self.app.router.routes.remove(route)
+            except ValueError:
+                pass
+        # tools
+        if ctx._tools:
+            try:
+                from src.tool_registry import unregister_tool as _ut
+                for name in ctx._tools:
+                    _ut(name)
+            except Exception:
+                pass
+        # plugin-level teardown hook
+        try:
+            td = getattr(rec.module, "teardown", None)
+            if callable(td):
+                td(ctx)
+        except Exception as e:
+            logger.warning("Plugin %s teardown() failed: %s", rec.plugin_id, e)
+        rec.ctx = None
+        try:
+            self.app.openapi_schema = None  # force schema rebuild after route change
+        except Exception:
+            pass
+
+    # -- public toggle API --------------------------------------------------
+    def enable(self, plugin_id: str) -> Dict[str, Any]:
+        with self._lock:
+            rec = self.records.get(plugin_id)
+            if not rec:
+                raise KeyError(plugin_id)
+            rec.enabled = True
+            self._save_state()
+            self._setup(rec)
+            return rec.public()
+
+    def disable(self, plugin_id: str) -> Dict[str, Any]:
+        with self._lock:
+            rec = self.records.get(plugin_id)
+            if not rec:
+                raise KeyError(plugin_id)
+            self._teardown(rec)
+            rec.enabled = False
+            rec.status = "disabled"
+            self._save_state()
+            return rec.public()
+
+    def reload(self, plugin_id: str) -> Dict[str, Any]:
+        with self._lock:
+            rec = self.records.get(plugin_id)
+            if not rec:
+                raise KeyError(plugin_id)
+            self._teardown(rec)
+            rec.module = None
+            rec.manifest = _read_manifest(rec.path) or {}
+            if rec.enabled:
+                self._setup(rec)
+            return rec.public()
+
+    def list(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [r.public() for r in sorted(self.records.values(), key=lambda r: r.plugin_id)]
+
+    def shutdown_all(self) -> None:
+        """Tear down every loaded plugin (stop services, remove routes). Called
+        on app shutdown so background services (tunnels, etc.) don't linger."""
+        with self._lock:
+            for rec in self.records.values():
+                if rec.ctx:
+                    self._teardown(rec)
+
+    def _data_dir(self, plugin_id: str) -> str:
+        d = os.path.join(_data_root(), "plugins", plugin_id)
+        os.makedirs(d, exist_ok=True)
+        return d
+
+
+def _read_manifest(path: str) -> Dict[str, Any]:
+    """Extract the PLUGIN dict WITHOUT executing the module — parse the AST so
+    discovery is cheap and a broken plugin body can't break the listing."""
+    import ast
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=path)
+    except Exception:
+        return {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "PLUGIN":
+                    try:
+                        return ast.literal_eval(node.value)
+                    except Exception:
+                        return {}
+    return {}
+
+
+# Module-level singleton + entry point used by app.py.
+MANAGER: Optional[PluginManager] = None
+
+
+def load_plugins(app: Any) -> PluginManager:
+    """Build the manager (if needed) and load all enabled plugins. Idempotent."""
+    global MANAGER
+    if MANAGER is None:
+        MANAGER = PluginManager(app=app)
+    else:
+        MANAGER.app = app
+    MANAGER.load_enabled(app)
+    return MANAGER
+
+
+def get_manager() -> Optional[PluginManager]:
+    return MANAGER

--- a/src/plugin_system.py
+++ b/src/plugin_system.py
@@ -42,12 +42,16 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import threading
 import traceback
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# A safe plugin id: used as a filesystem path component AND a Python import name.
+_ID_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$")
 
 
 def plugins_dir() -> str:
@@ -92,10 +96,26 @@ class PluginContext:
 
     # -- routes -------------------------------------------------------------
     def add_router(self, router, **include_kwargs) -> None:
-        """Mount a FastAPI APIRouter; its routes are tracked for clean removal."""
+        """Mount a FastAPI APIRouter; its routes are tracked for clean removal.
+
+        Routes MUST live under ``/api/plugins/`` — otherwise a plugin could mount
+        under an auth-exempt prefix (``/static``, ``/api/auth``, ``/api/health``)
+        and expose an UNAUTHENTICATED endpoint, since the auth middleware gates by
+        path. Off-namespace routes are rolled back and rejected."""
         before = len(self.app.router.routes)
         self.app.include_router(router, **include_kwargs)
-        self._routes.extend(self.app.router.routes[before:])
+        added = self.app.router.routes[before:]
+        bad = [r for r in added if not str(getattr(r, "path", "")).startswith("/api/plugins/")]
+        if bad:
+            for r in added:
+                try:
+                    self.app.router.routes.remove(r)
+                except ValueError:
+                    pass
+            raise ValueError(
+                "plugin routes must be mounted under /api/plugins/<id>/ "
+                f"(rejected: {[getattr(r, 'path', '?') for r in bad][:3]})")
+        self._routes.extend(added)
 
     # -- background services -----------------------------------------------
     def add_service(self, start: Optional[Callable] = None,
@@ -145,9 +165,9 @@ class PluginRecord:
             "permission": m.get("permission", "admin"),
             "requires": m.get("requires", []),
             # Optional UI contribution: {"open": "/api/.../page", "label": "Open"}.
-            # The Plugins panel renders an "Open" button for enabled plugins that
-            # declare it — a plugin's only hook into the frontend.
-            "ui": m.get("ui"),
+            # Sanitized (see _safe_ui) so `open` must be a same-origin path — the
+            # Plugins panel renders it as a link, so block javascript:/`//evil`.
+            "ui": _safe_ui(m),
             "enabled": self.enabled,
             "status": self.status,
             "error": self.error,
@@ -177,8 +197,10 @@ class PluginManager:
         try:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             state = {pid: {"enabled": r.enabled} for pid, r in self.records.items()}
-            with open(path, "w", encoding="utf-8") as f:
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
                 json.dump(state, f, indent=2)
+            os.replace(tmp, path)   # atomic — a crash mid-write can't truncate the file
         except Exception as e:
             logger.warning("Could not persist plugin state: %s", e)
 
@@ -194,17 +216,28 @@ class PluginManager:
                 return
             for entry in sorted(os.listdir(self.directory)):
                 full = os.path.join(self.directory, entry)
+                if os.path.islink(full):
+                    continue   # don't load a symlinked entry (could point outside the dir)
                 if os.path.isdir(full) and os.path.isfile(os.path.join(full, "plugin.py")):
                     pid, path = entry, os.path.join(full, "plugin.py")
                 elif entry.endswith("_plugin.py"):
                     pid, path = entry[:-len("_plugin.py")], full
                 else:
                     continue
+                # id is used as a filesystem path + an import name, and the entry
+                # file must not be a symlink to code outside the plugins dir.
+                if not _ID_RE.match(pid) or os.path.islink(path):
+                    continue
                 rec = self.records.get(pid) or PluginRecord(plugin_id=pid, path=path)
                 rec.path = path
                 rec.manifest = _read_manifest(path) or rec.manifest
                 rec.enabled = state.get(pid, {}).get("enabled", True)
                 found[pid] = rec
+            # Tear down any previously-loaded plugin whose folder vanished from
+            # disk, so its routes/services don't linger (orphaned otherwise).
+            for pid, rec in self.records.items():
+                if pid not in found and rec.ctx is not None:
+                    self._teardown(rec)
             self.records = found
 
     # -- load / unload ------------------------------------------------------
@@ -334,6 +367,7 @@ class PluginManager:
                 raise KeyError(plugin_id)
             self._teardown(rec)
             rec.module = None
+            rec.status = "discovered"   # force _setup to re-import the (possibly new) code
             rec.manifest = _read_manifest(rec.path) or {}
             if rec.enabled:
                 self._setup(rec)
@@ -355,6 +389,21 @@ class PluginManager:
         d = os.path.join(_data_root(), "plugins", plugin_id)
         os.makedirs(d, exist_ok=True)
         return d
+
+
+def _safe_ui(manifest: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Sanitize the manifest ``ui`` entry for the Plugins panel. ``open`` must be
+    a same-origin path (a single leading ``/``) so the rendered Open button can't
+    become a ``javascript:`` or protocol-relative (``//evil``) link. Returns None
+    if absent or unsafe."""
+    ui = manifest.get("ui")
+    if not isinstance(ui, dict):
+        return None
+    open_ = ui.get("open")
+    if not (isinstance(open_, str) and open_.startswith("/") and not open_.startswith("//")):
+        return None
+    label = ui.get("label")
+    return {"open": open_, "label": label if isinstance(label, str) and label else "Open"}
 
 
 def _read_manifest(path: str) -> Dict[str, Any]:

--- a/static/app.js
+++ b/static/app.js
@@ -1058,6 +1058,11 @@ function initializeEventListeners() {
     });
   }
 
+  const toolPluginsBtn = el('tool-plugins-btn');
+  if (toolPluginsBtn) {
+    toolPluginsBtn.addEventListener('click', () => settingsModule.open('plugins'));
+  }
+
   // Sidebar toggle
   const toggleSidebarOption = el('toggle-sidebar-option');
   if (toggleSidebarOption) {
@@ -1090,6 +1095,11 @@ function initializeEventListeners() {
     .then(d => {
       window._isAdmin = !!d.is_admin;
       if (d.is_admin && userBarAdmin) userBarAdmin.style.display = '';
+      // Plugins entries (sidebar + rail) are admin-only — reveal for admins
+      ['tool-plugins-btn', 'rail-plugins'].forEach(id => {
+        const e = el(id);
+        if (e) e.style.display = d.is_admin ? '' : 'none';
+      });
       const userBarName = el('user-bar-name');
       const userBarAvatar = el('user-bar-avatar');
       if (userBarName && d.username) {
@@ -3450,6 +3460,7 @@ function startOdysseusApp() {
     'rail-notes':     'tool-notes-btn',
     'rail-memory':    'tool-memory-btn',
     'rail-theme':     'tool-theme-btn',
+    'rail-plugins':   'tool-plugins-btn',
     'rail-email':     'email-section-title',
   };
   Object.entries(_railToolMap).forEach(([railId, toolId]) => {

--- a/static/index.html
+++ b/static/index.html
@@ -664,6 +664,7 @@
     <button class="icon-rail-btn" id="rail-notes" title="Notes"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 3h10l4 4v14H5z"/><path d="M15 3v5h5"/><path d="M8 17.5 15.5 10l2.5 2.5L10.5 20H8z"/></svg></button>
     <button class="icon-rail-btn" id="rail-tasks" title="Tasks"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><path d="M9 16l2 2 4-4"/></svg></button>
     <button class="icon-rail-btn" id="rail-theme" title="Theme"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a10 10 0 0 0 0 20 5 5 0 0 0 5-5 3 3 0 0 0-3-3h-2a3 3 0 0 1-3-3 5 5 0 0 1 5-5"/></svg></button>
+    <button class="icon-rail-btn admin-only" id="rail-plugins" title="Plugins" style="display:none"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg></button>
     <div style="flex:1"></div>
     <!-- Static: bottom -->
     <button class="icon-rail-btn" id="rail-settings" title="Settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
@@ -905,6 +906,18 @@
             <circle cx="9" cy="15" r="1.5" fill="currentColor"/>
           </svg>
           <span class="grow">Theme</span>
+        </div>
+
+        <div class="list-item admin-only" id="tool-plugins-btn" style="display:none">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            style="flex-shrink:0;opacity:0.5;">
+            <path d="M12 22v-5"/>
+            <path d="M9 8V2"/>
+            <path d="M15 8V2"/>
+            <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/>
+          </svg>
+          <span class="grow">Plugins</span>
         </div>
       </div>
     </div>
@@ -1369,6 +1382,10 @@
           <button class="settings-nav-item admin-only" data-settings-tab="system">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
             <span>System</span>
+          </button>
+          <button class="settings-nav-item admin-only" data-settings-tab="plugins">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg>
+            <span>Plugins</span>
           </button>
         </div>
         <div class="settings-panels">
@@ -2127,6 +2144,17 @@
         </div>
 
         <!-- ═══ SYSTEM TAB ═══ -->
+        <div data-settings-panel="plugins" class="hidden">
+          <div class="admin-card">
+            <h2 style="display:flex;align-items:center;gap:8px;">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg>
+              Plugins
+              <button class="admin-btn-sm" id="plugins-rescan-btn" style="margin-left:auto;">Rescan</button>
+            </h2>
+            <div class="admin-toggle-sub" style="margin-bottom:10px">Drop-in plugins extend Odysseus without editing core. Toggle one off to unload it live. Plugins live in the <code>plugins/</code> folder.</div>
+            <div id="plugins-list"><div class="adm-ep-inline-msg">Loading…</div></div>
+          </div>
+        </div>
         <div data-settings-panel="system" class="hidden">
 
           <div class="admin-card">

--- a/static/js/plugin-theme.js
+++ b/static/js/plugin-theme.js
@@ -1,0 +1,74 @@
+/* Plugin theme bridge — applies the user's active Odysseus theme to plugin pages.
+ *
+ * Plugin pages are same-origin, so this reads the SAME localStorage the main
+ * app's theme.js writes ('odysseus-theme'), and falls back to /api/prefs/theme.
+ * Loaded as a blocking <script> in <head> → vars are set before first paint
+ * (no flash). Mirrors core theme.js applyColors()/computeAdvancedDefaults() for
+ * the variables the plugin components use.
+ */
+(function () {
+  var FONT_MAP = {
+    mono: "'Fira Code', monospace",
+    sans: "system-ui, -apple-system, 'Segoe UI', sans-serif",
+    serif: "Georgia, 'Times New Roman', serif",
+  };
+  var DARK = { bg: '#282c34', fg: '#9cdef2', panel: '#111111', border: '#355a66', red: '#e06c75' };
+  // advanced override key (camelCase, as stored) → CSS var
+  var ADV = {
+    userBubbleBg: '--user-bubble-bg', aiBubbleBg: '--ai-bubble-bg', bubbleBorder: '--bubble-border',
+    sidebarBg: '--sidebar-bg', brandColor: '--brand-color', hamburgerColor: '--hamburger-color',
+    inputBg: '--input-bg', inputBorder: '--input-border', sendBtnBg: '--send-btn-bg',
+    sendBtnHover: '--send-btn-hover', codeBg: '--code-bg', codeFg: '--code-fg', toggleActive: '--toggle-active',
+  };
+  function defaults(c) {
+    var red = c.red || '#e06c75';
+    return {
+      '--user-bubble-bg': c.bg, '--ai-bubble-bg': c.panel, '--bubble-border': c.border,
+      '--sidebar-bg': c.panel, '--brand-color': red, '--hamburger-color': c.fg,
+      '--input-bg': c.panel, '--input-border': c.border, '--send-btn-bg': red, '--send-btn-hover': red,
+      '--code-bg': c.panel, '--code-fg': c.fg, '--toggle-active': red,
+    };
+  }
+  function apply(c, font, density) {
+    if (!c || !c.bg) return;
+    var s = document.documentElement.style;
+    s.setProperty('--bg', c.bg); s.setProperty('--fg', c.fg);
+    s.setProperty('--panel', c.panel); s.setProperty('--border', c.border);
+    if (c.red) s.setProperty('--red', c.red);
+    var def = defaults(c);
+    for (var v in def) s.setProperty(v, def[v]);
+    var o = c.advanced || {};
+    for (var k in o) if (ADV[k] && o[k]) s.setProperty(ADV[k], o[k]);
+    s.setProperty('--font-family', FONT_MAP[font] || FONT_MAP.mono);
+    var de = document.documentElement;
+    de.classList.remove('density-compact', 'density-spacious');
+    if (density === 'compact') de.classList.add('density-compact');
+    else if (density === 'spacious') de.classList.add('density-spacious');
+  }
+  window.__applyOdysseusTheme = apply;
+
+  var saved = null;
+  try {
+    var raw = localStorage.getItem('odysseus-theme');
+    if (raw) { var o = JSON.parse(raw); if (o && o.colors) saved = o; }
+  } catch (e) {}
+  if (saved) {
+    apply(saved.colors, saved.font, saved.density);
+  } else {
+    apply(DARK, 'mono', 'comfortable');
+    try {
+      fetch('/api/prefs/theme', { credentials: 'same-origin' })
+        .then(function (r) { return r.json(); })
+        .then(function (d) { if (d && d.value && d.value.colors) apply(d.value.colors, d.value.font, d.value.density); })
+        .catch(function () {});
+    } catch (e) {}
+  }
+
+  // Live-follow theme/customization changes made in other tabs (e.g. the main
+  // app's theme picker) — the storage event fires across same-origin tabs.
+  window.addEventListener('storage', function (e) {
+    if (e.key === 'odysseus-theme' && e.newValue) {
+      try { var o = JSON.parse(e.newValue); if (o && o.colors) apply(o.colors, o.font, o.density); } catch (_) {}
+    }
+  });
+})();

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -34,8 +34,235 @@ function initTabs() {
       document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
       syncAppearanceOpacity(tab === 'appearance');
       if (tab === 'ai') refreshAiModelEndpoints();
+      if (tab === 'plugins') loadPlugins();
     });
   });
+}
+
+/* ── Plugins panel (drop-in plugin manager) ── */
+async function loadPlugins() {
+  const host = document.getElementById('plugins-list');
+  if (!host) return;
+  const rescan = document.getElementById('plugins-rescan-btn');
+  if (rescan && !rescan._wired) {
+    rescan._wired = true;
+    rescan.addEventListener('click', async () => {
+      rescan.disabled = true;
+      try { await fetch('/api/plugins/rescan', { method: 'POST', credentials: 'same-origin' }); } catch (_) {}
+      rescan.disabled = false; loadPlugins();
+    });
+  }
+  host.innerHTML = '<div class="adm-ep-inline-msg">Loading…</div>';
+  let plugins;
+  try {
+    const r = await fetch('/api/plugins', { credentials: 'same-origin' });
+    plugins = (await r.json()).plugins || [];
+  } catch (_) { host.innerHTML = '<div class="adm-ep-inline-msg">Failed to load plugins.</div>'; return; }
+  host.innerHTML = '';
+  host.appendChild(_pluginsToolbar('installed'));
+  if (!plugins.length) {
+    const m = document.createElement('div');
+    m.className = 'adm-ep-inline-msg';
+    m.innerHTML = 'No plugins installed. Drop a folder in <code>plugins/</code> and Rescan, or Browse the depot.';
+    host.appendChild(m);
+    return;
+  }
+  for (const p of plugins) host.appendChild(_pluginCard(p));
+}
+
+function _pluginsToolbar(active) {
+  const bar = document.createElement('div');
+  bar.style.cssText = 'display:flex;gap:6px;margin-bottom:10px;';
+  const on = 'background:var(--accent,#3a6);color:#fff;';
+  bar.innerHTML = `
+    <button class="admin-btn-sm" data-view="installed" style="${active === 'installed' ? on : ''}">Installed</button>
+    <button class="admin-btn-sm" data-view="browse" style="${active === 'browse' ? on : ''}">Browse depot</button>`;
+  bar.querySelector('[data-view="installed"]').addEventListener('click', loadPlugins);
+  bar.querySelector('[data-view="browse"]').addEventListener('click', loadBrowse);
+  return bar;
+}
+
+async function loadBrowse() {
+  const host = document.getElementById('plugins-list');
+  if (!host) return;
+  host.innerHTML = '';
+  host.appendChild(_pluginsToolbar('browse'));
+  const loading = document.createElement('div');
+  loading.className = 'adm-ep-inline-msg';
+  loading.textContent = 'Loading depot…';
+  host.appendChild(loading);
+  let data;
+  try { data = await fetch('/api/plugins/registry', { credentials: 'same-origin' }).then(r => r.json()); }
+  catch (_) { loading.textContent = 'Could not reach the plugin registry.'; return; }
+  if (!data || !data.plugins) { loading.textContent = (data && data.detail) || 'Registry unavailable.'; return; }
+  loading.remove();
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display:flex;gap:6px;margin-bottom:8px;';
+  actions.innerHTML = `
+    <button class="admin-btn-sm" id="depot-install-url">Install from URL…</button>
+    <button class="admin-btn-sm" id="depot-add-source">Add registry…</button>`;
+  actions.querySelector('#depot-install-url').addEventListener('click', _installFromUrlPrompt);
+  actions.querySelector('#depot-add-source').addEventListener('click', _addSourcePrompt);
+  host.appendChild(actions);
+  if (!data.plugins.length) {
+    const m = document.createElement('div'); m.className = 'adm-ep-inline-msg';
+    m.textContent = 'No plugins available from the configured registries.'; host.appendChild(m);
+  } else {
+    for (const e of data.plugins) host.appendChild(_browseCard(e));
+  }
+  host.appendChild(_sourcesFooter(data.sources || []));
+}
+
+function _sourcesFooter(sources) {
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+  const box = document.createElement('div');
+  box.style.cssText = 'margin-top:12px;border-top:1px solid var(--border,#333);padding-top:8px;';
+  box.innerHTML = '<div class="admin-toggle-sub" style="margin-bottom:4px;">Registry sources</div>';
+  for (const s of sources) {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:8px;font-size:.8em;opacity:.9;margin:2px 0;';
+    const status = s.ok
+      ? `<span style="color:var(--accent,#3a6);white-space:nowrap;">✓ ${s.count} plugin(s)</span>`
+      : `<span style="color:var(--red,#e66);white-space:nowrap;">✗ ${esc(s.error || 'unreachable')}</span>`;
+    row.innerHTML = `<code style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${esc(s.url)}</code>${status}<button class="admin-btn-sm depot-rm-source" style="padding:1px 6px;">Remove</button>`;
+    row.querySelector('.depot-rm-source').addEventListener('click', () => _removeSource(s.url));
+    box.appendChild(row);
+  }
+  return box;
+}
+
+async function _addSourcePrompt() {
+  const url = prompt('Registry URL (https, or http to localhost):');
+  if (!url) return;
+  try {
+    const r = await fetch('/api/plugins/registries', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.trim() }) });
+    if (!r.ok) { const d = await r.json().catch(() => ({})); alert(d.detail || 'Could not add source'); return; }
+  } catch (_) {}
+  loadBrowse();
+}
+
+async function _removeSource(url) {
+  await fetch('/api/plugins/registries', { method: 'DELETE', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url }) }).catch(() => {});
+  loadBrowse();
+}
+
+async function _installFromUrlPrompt() {
+  const url = prompt('Plugin zip URL (https):');
+  if (!url) return;
+  const id = prompt('Install as plugin id (folder name):');
+  if (!id) return;
+  try {
+    const r = await fetch('/api/plugins/install', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.trim(), id: id.trim() }) });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok) { alert(d.detail || 'Install failed'); return; }
+    alert('Installed: ' + (d.id || id));
+    loadBrowse();
+  } catch (e) { alert('Install failed: ' + e.message); }
+}
+
+function _browseCard(e) {
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+  const card = document.createElement('div');
+  card.className = 'admin-card';
+  card.style.cssText = 'margin-bottom:10px;padding:12px 14px;';
+  let action;
+  if (e.installed && e.update_available) action = `<button class="admin-btn-sm depot-install" data-id="${esc(e.id)}" style="background:var(--accent,#3a6);color:#fff;">Update</button>`;
+  else if (e.installed) action = `<button class="admin-btn-sm" disabled style="opacity:.6;">Installed</button>`;
+  else action = `<button class="admin-btn-sm depot-install" data-id="${esc(e.id)}" style="background:var(--accent,#3a6);color:#fff;">Install</button>`;
+  card.innerHTML = `
+    <div style="display:flex;align-items:center;gap:10px;">
+      <div style="flex:1;min-width:0;">
+        <div style="font-weight:600;">${esc(e.name || e.id)} <span style="opacity:.5;font-weight:normal;font-size:.85em;">v${esc(e.version || '')}</span>
+          <span style="opacity:.5;font-weight:normal;font-size:.8em;border:1px solid var(--border,#444);border-radius:6px;padding:1px 6px;margin-left:6px;">${esc(e.category || 'General')}</span></div>
+        <div class="admin-toggle-sub" style="margin-top:2px;">${esc(e.description || '')}${e.author ? (' — by ' + esc(e.author)) : ''}</div>
+        ${e.homepage ? `<div style="margin-top:5px;"><a href="${esc(e.homepage)}" target="_blank" rel="noopener" style="font-size:.82em;color:var(--accent,#6af);text-decoration:none;">${/github\.com/i.test(e.homepage) ? 'View on GitHub' : 'Learn more'} ↗</a></div>` : ''}
+      </div>${action}
+    </div>
+    <div class="depot-msg" style="margin-top:6px;font-size:.85em;"></div>`;
+  const btn = card.querySelector('.depot-install');
+  if (btn) btn.addEventListener('click', () => _installFromRegistry(e.id, card));
+  return card;
+}
+
+async function _installFromRegistry(id, card) {
+  const btn = card.querySelector('.depot-install');
+  const msg = card.querySelector('.depot-msg');
+  if (btn) { btn.disabled = true; btn.textContent = 'Installing…'; }
+  try {
+    const r = await fetch('/api/plugins/install', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id }),
+    });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(d.detail || d.error || ('HTTP ' + r.status));
+    if (msg) { msg.style.color = 'var(--accent,#3a6)'; msg.textContent = 'Installed ✓ — opening Installed…'; }
+    setTimeout(loadPlugins, 700);   // jump to the Installed view so controls (e.g. Start tunnel) show without a manual Rescan
+  } catch (e) {
+    if (msg) { msg.style.color = 'var(--red,#e66)'; msg.textContent = String(e.message || e); }
+    if (btn) { btn.disabled = false; btn.textContent = 'Install'; }
+  }
+}
+
+function _pluginCard(p) {
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+  const card = document.createElement('div');
+  card.className = 'admin-card';
+  card.style.cssText = 'margin-bottom:10px;padding:12px 14px;';
+  const err = p.status === 'error' ? `<div class="adm-ep-inline-msg" style="color:var(--red,#e66);margin-top:6px;">Failed to load: ${esc(p.error || '').split('\n').pop()}</div>` : '';
+  card.innerHTML = `
+    <div style="display:flex;align-items:center;gap:10px;">
+      <div style="flex:1;min-width:0;">
+        <div style="font-weight:600;">${esc(p.name)} <span style="opacity:.5;font-weight:normal;font-size:.85em;">v${esc(p.version)}</span>
+          <span style="opacity:.5;font-weight:normal;font-size:.8em;border:1px solid var(--border,#444);border-radius:6px;padding:1px 6px;margin-left:6px;">${esc(p.category)}</span></div>
+        <div class="admin-toggle-sub" style="margin-top:2px;">${esc(p.description)}${p.author ? ' — by ' + esc(p.author) : ''}</div>
+      </div>
+      <button class="admin-btn-sm plugin-toggle" data-id="${esc(p.id)}" data-enabled="${p.enabled ? '1' : '0'}"
+        style="min-width:78px;${p.enabled ? 'background:var(--accent,#3a6);color:#fff;' : ''}">${p.enabled ? 'Enabled' : 'Disabled'}</button>
+    </div>${err}
+    <div class="plugin-controls" data-id="${esc(p.id)}" style="margin-top:8px;"></div>`;
+  card.querySelector('.plugin-toggle').addEventListener('click', (e) => _togglePlugin(e.currentTarget));
+  // Per-plugin control surface (e.g. the Cloudflare tunnel's start/stop/URL).
+  if (p.id === 'cloudflare_tunnel' && p.enabled && p.status === 'loaded') {
+    _renderTunnelControls(card.querySelector('.plugin-controls'));
+  }
+  return card;
+}
+
+async function _togglePlugin(btn) {
+  const id = btn.dataset.id, on = btn.dataset.enabled === '1';
+  btn.disabled = true;
+  try {
+    await fetch(`/api/plugins/${encodeURIComponent(id)}/${on ? 'disable' : 'enable'}`, { method: 'POST', credentials: 'same-origin' });
+  } catch (_) {}
+  btn.disabled = false;
+  loadPlugins();
+}
+
+async function _renderTunnelControls(host) {
+  if (!host) return;
+  host.innerHTML = '<div class="adm-ep-inline-msg">Checking tunnel…</div>';
+  const get = async () => (await fetch('/api/plugins/cloudflare-tunnel/status', { credentials: 'same-origin' }).then(r => r.json()).catch(() => ({})));
+  const paint = (s) => {
+    const running = s && s.running;
+    host.innerHTML = `
+      <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
+        <button class="admin-btn-sm" id="tunnel-toggle" style="${running ? 'background:var(--red,#c44);color:#fff;' : 'background:var(--accent,#3a6);color:#fff;'}">${running ? 'Stop tunnel' : 'Start tunnel'}</button>
+        <span style="font-size:.85em;opacity:.85;">
+          ${running && s.url ? `Public URL: <a href="${s.url}" target="_blank" rel="noopener" style="color:var(--accent,#6ab7ff);font-weight:600;">${s.url}</a> <span style="opacity:.55;">(may take a few seconds to come online)</span>`
+            : running ? (s && s.provisioning ? 'almost ready… (bringing the tunnel online)' : 'starting… (fetching public URL)')
+            : (s && s.error ? '<span style="color:var(--red,#e66)">' + String(s.error) + '</span>' : 'stopped — auth still required when started')}
+        </span>
+      </div>`;
+    host.querySelector('#tunnel-toggle').addEventListener('click', async (e) => {
+      const _t = e.currentTarget;
+      _t.disabled = true; _t.style.opacity = '0.6'; _t.textContent = running ? 'Stopping…' : 'Starting…';
+      const _port = Number(location.port) || (location.protocol === 'https:' ? 443 : 80);
+      await fetch(`/api/plugins/cloudflare-tunnel/${running ? 'stop' : 'start'}`, { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ port: _port }) }).catch(() => {});
+      // poll a few times so the URL shows up after starting
+      for (let i = 0; i < 32; i++) { await new Promise(r => setTimeout(r, 2000)); const s2 = await get(); if (s2.url || s2.error || (!running && !s2.running)) { paint(s2); break; } paint(s2); }
+    });
+  };
+  paint(await get());
 }
 
 /* ── Dragging ── */
@@ -4343,6 +4570,7 @@ export function open(tab) {
   document.body.classList.toggle('settings-appearance-open', activeTab === 'appearance');
   syncAppearanceOpacity(activeTab === 'appearance');
   if (activeTab === 'ai') refreshAiModelEndpoints();
+  if (activeTab === 'plugins') loadPlugins();
   if (ADMIN_TABS.has(activeTab) && window.adminModule && !window.adminModule._initialized) {
     window.adminModule._initData();
   }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -216,6 +216,10 @@ function _pluginCard(p) {
           <span style="opacity:.5;font-weight:normal;font-size:.8em;border:1px solid var(--border,#444);border-radius:6px;padding:1px 6px;margin-left:6px;">${esc(p.category)}</span></div>
         <div class="admin-toggle-sub" style="margin-top:2px;">${esc(p.description)}${p.author ? ' — by ' + esc(p.author) : ''}</div>
       </div>
+      ${(p.ui && p.ui.open && p.enabled && p.status === 'loaded')
+        ? `<a class="admin-btn-sm" href="${esc(p.ui.open)}" target="_blank" rel="noopener"
+             style="text-decoration:none;display:inline-flex;align-items:center;gap:4px;">${esc(p.ui.label || 'Open')} ↗</a>`
+        : ''}
       <button class="admin-btn-sm plugin-toggle" data-id="${esc(p.id)}" data-enabled="${p.enabled ? '1' : '0'}"
         style="min-width:78px;${p.enabled ? 'background:var(--accent,#3a6);color:#fff;' : ''}">${p.enabled ? 'Enabled' : 'Disabled'}</button>
     </div>${err}

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -151,8 +151,11 @@ async function _installFromUrlPrompt() {
   if (!url) return;
   const id = prompt('Install as plugin id (folder name):');
   if (!id) return;
+  const sha = prompt('SHA-256 of the zip (64 hex chars — required for integrity):');
+  if (!sha) return;
+  if (!/^[0-9a-f]{64}$/i.test(sha.trim())) { alert('That is not a valid 64-char SHA-256.'); return; }
   try {
-    const r = await fetch('/api/plugins/install', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.trim(), id: id.trim() }) });
+    const r = await fetch('/api/plugins/install', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.trim(), id: id.trim(), sha256: sha.trim() }) });
     const d = await r.json().catch(() => ({}));
     if (!r.ok) { alert(d.detail || 'Install failed'); return; }
     alert('Installed: ' + (d.id || id));
@@ -175,7 +178,7 @@ function _browseCard(e) {
         <div style="font-weight:600;">${esc(e.name || e.id)} <span style="opacity:.5;font-weight:normal;font-size:.85em;">v${esc(e.version || '')}</span>
           <span style="opacity:.5;font-weight:normal;font-size:.8em;border:1px solid var(--border,#444);border-radius:6px;padding:1px 6px;margin-left:6px;">${esc(e.category || 'General')}</span></div>
         <div class="admin-toggle-sub" style="margin-top:2px;">${esc(e.description || '')}${e.author ? (' — by ' + esc(e.author)) : ''}</div>
-        ${e.homepage ? `<div style="margin-top:5px;"><a href="${esc(e.homepage)}" target="_blank" rel="noopener" style="font-size:.82em;color:var(--accent,#6af);text-decoration:none;">${/github\.com/i.test(e.homepage) ? 'View on GitHub' : 'Learn more'} ↗</a></div>` : ''}
+        ${(e.homepage && /^https?:\/\//i.test(e.homepage)) ? `<div style="margin-top:5px;"><a href="${esc(e.homepage)}" target="_blank" rel="noopener" style="font-size:.82em;color:var(--accent,#6af);text-decoration:none;">${/github\.com/i.test(e.homepage) ? 'View on GitHub' : 'Learn more'} ↗</a></div>` : ''}
       </div>${action}
     </div>
     <div class="depot-msg" style="margin-top:6px;font-size:.85em;"></div>`;
@@ -209,6 +212,9 @@ function _pluginCard(p) {
   card.className = 'admin-card';
   card.style.cssText = 'margin-bottom:10px;padding:12px 14px;';
   const err = p.status === 'error' ? `<div class="adm-ep-inline-msg" style="color:var(--red,#e66);margin-top:6px;">Failed to load: ${esc(p.error || '').split('\n').pop()}</div>` : '';
+  // Render the Open link only if ui.open is a same-origin path (defense in depth
+  // — the server sanitizes this too; blocks javascript:/`//evil` links).
+  const safeOpen = (p.ui && typeof p.ui.open === 'string' && /^\/(?!\/)/.test(p.ui.open)) ? p.ui.open : null;
   card.innerHTML = `
     <div style="display:flex;align-items:center;gap:10px;">
       <div style="flex:1;min-width:0;">
@@ -216,8 +222,8 @@ function _pluginCard(p) {
           <span style="opacity:.5;font-weight:normal;font-size:.8em;border:1px solid var(--border,#444);border-radius:6px;padding:1px 6px;margin-left:6px;">${esc(p.category)}</span></div>
         <div class="admin-toggle-sub" style="margin-top:2px;">${esc(p.description)}${p.author ? ' — by ' + esc(p.author) : ''}</div>
       </div>
-      ${(p.ui && p.ui.open && p.enabled && p.status === 'loaded')
-        ? `<a class="admin-btn-sm" href="${esc(p.ui.open)}" target="_blank" rel="noopener"
+      ${(safeOpen && p.enabled && p.status === 'loaded')
+        ? `<a class="admin-btn-sm" href="${esc(safeOpen)}" target="_blank" rel="noopener"
              style="text-decoration:none;display:inline-flex;align-items:center;gap:4px;">${esc(p.ui.label || 'Open')} ↗</a>`
         : ''}
       <button class="admin-btn-sm plugin-toggle" data-id="${esc(p.id)}" data-enabled="${p.enabled ? '1' : '0'}"
@@ -254,7 +260,7 @@ async function _renderTunnelControls(host) {
         <span style="font-size:.85em;opacity:.85;">
           ${running && s.url ? `Public URL: <a href="${s.url}" target="_blank" rel="noopener" style="color:var(--accent,#6ab7ff);font-weight:600;">${s.url}</a> <span style="opacity:.55;">(may take a few seconds to come online)</span>`
             : running ? (s && s.provisioning ? 'almost ready… (bringing the tunnel online)' : 'starting… (fetching public URL)')
-            : (s && s.error ? '<span style="color:var(--red,#e66)">' + String(s.error) + '</span>' : 'stopped — auth still required when started')}
+            : (s && s.error ? '<span style="color:var(--red,#e66)">' + String(s.error).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])) + '</span>' : 'stopped — auth still required when started')}
         </span>
       </div>`;
     host.querySelector('#tunnel-toggle').addEventListener('click', async (e) => {

--- a/static/plugin-theme.css
+++ b/static/plugin-theme.css
@@ -1,0 +1,52 @@
+/* Plugin theme layer — components built on the main Odysseus CSS variables so
+ * plugin pages match the active theme + user customization. Defaults below are
+ * the built-in "dark" theme; theme.js overrides them with the user's actual
+ * theme before first paint. */
+:root {
+  --bg: #282c34; --fg: #9cdef2; --panel: #111111; --border: #355a66; --red: #e06c75;
+  --input-bg: #111111; --input-border: #355a66; --send-btn-bg: #e06c75; --send-btn-hover: #e06c75;
+  --brand-color: #e06c75; --toggle-active: #e06c75; --code-bg: #0c0c0c; --code-fg: #9cdef2;
+  --font-family: 'Fira Code', monospace;
+  --od-radius: 12px; --od-gap: 12px;
+}
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body { margin: 0; background: var(--bg); color: var(--fg); font-family: var(--font-family); font-size: 14px; line-height: 1.5; }
+.od-wrap { max-width: 920px; margin: 0 auto; padding: 24px; }
+h1 { font-size: 18px; margin: 0 0 4px; }
+h2 { font-size: 14px; margin: 18px 0 8px; opacity: .9; }
+a { color: var(--brand-color); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.muted { opacity: .65; }
+.od-card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--od-radius); padding: 14px; margin: var(--od-gap) 0; }
+.od-btn { font: inherit; display: inline-flex; align-items: center; gap: 6px; background: var(--send-btn-bg); color: #fff; border: 1px solid var(--send-btn-bg); border-radius: 8px; padding: 8px 14px; cursor: pointer; }
+.od-btn:hover { background: var(--send-btn-hover); border-color: var(--send-btn-hover); }
+.od-btn:disabled { opacity: .5; cursor: default; }
+.od-btn.ghost { background: transparent; color: var(--fg); border-color: var(--border); }
+.od-btn.ghost:hover { background: color-mix(in srgb, var(--fg) 10%, transparent); }
+.od-input { font: inherit; background: var(--input-bg); border: 1px solid var(--input-border); color: var(--fg); border-radius: 8px; padding: 8px; }
+.od-input::placeholder { color: var(--fg); opacity: .45; }
+.od-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+pre, code { background: var(--code-bg); color: var(--code-fg); border: 1px solid var(--border); border-radius: 8px; }
+pre { padding: 12px; overflow: auto; white-space: pre-wrap; }
+code { padding: 2px 6px; }
+.badge { font-size: .78em; border: 1px solid var(--border); border-radius: 6px; padding: 1px 6px; opacity: .85; }
+.bar { height: 6px; background: color-mix(in srgb, var(--fg) 12%, transparent); border-radius: 4px; overflow: hidden; margin-top: 6px; }
+.bar > i { display: block; height: 100%; width: 0; background: var(--send-btn-bg); transition: width .3s; }
+.ok { color: #7fd69a; } .warn { color: #e6c07a; }
+.density-compact .od-card { padding: 10px; }
+.density-spacious .od-card { padding: 18px; }
+
+/* Themed top bar with a "back to the main interface" brand link. */
+.od-header { display: flex; align-items: center; gap: 12px; padding: 10px 16px;
+  background: var(--sidebar-bg); border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 10; }
+.od-header .brand { display: inline-flex; align-items: center; gap: 6px; color: var(--brand-color);
+  font-weight: 600; text-decoration: none; }
+.od-header .brand:hover { opacity: .85; text-decoration: none; }
+.od-header .brand svg { width: 16px; height: 16px; }
+.od-header .od-title { opacity: .7; font-size: 13px; }
+.od-header .spacer { flex: 1; }
+.od-backpill { display: inline-flex; align-items: center; gap: 5px; background: var(--panel);
+  border: 1px solid var(--border); border-radius: 8px; padding: 4px 9px; color: var(--brand-color);
+  text-decoration: none; font-size: 12px; }
+.od-backpill:hover { text-decoration: none; opacity: .85; }

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,114 @@
+"""Tests for the plugin registry / installer.
+
+Focus on the security-critical bits: zip-slip and symlink rejection during
+extract, sha256 verification, id validation — plus a happy-path install/uninstall
+with the network mocked (no real download).
+"""
+import hashlib
+import io
+import os
+import zipfile
+
+import pytest
+
+from src import plugin_registry as reg
+
+
+def _zip(files):
+    """Build an in-memory zip from {arcname: bytes|str}."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content if isinstance(content, (bytes, str)) else "")
+    return buf.getvalue()
+
+
+def _mock_download(monkeypatch, blob):
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return blob
+    monkeypatch.setattr(reg.urllib.request, "urlopen", lambda *a, **k: _Resp())
+
+
+@pytest.fixture
+def pdir(tmp_path, monkeypatch):
+    d = tmp_path / "plugins"; d.mkdir()
+    monkeypatch.setenv("ODYSSEUS_PLUGINS_DIR", str(d))
+    monkeypatch.setattr(reg, "get_manager", lambda: None)   # no live manager in unit tests
+    return str(d)
+
+
+# -- security -----------------------------------------------------------------
+
+def test_safe_extract_blocks_zip_slip(tmp_path):
+    dest = tmp_path / "dest"; dest.mkdir()
+    blob = _zip({"../escape.py": "x = 1"})
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        with pytest.raises(ValueError):
+            reg._safe_extract(zf, str(dest))
+    assert not (tmp_path / "escape.py").exists()
+
+
+def test_safe_extract_blocks_absolute_path(tmp_path):
+    dest = tmp_path / "dest"; dest.mkdir()
+    # zip with an absolute-ish member
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("/etc/evil", "x")
+    with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
+        with pytest.raises(ValueError):
+            reg._safe_extract(zf, str(dest))
+
+
+def test_install_rejects_non_https(pdir):
+    with pytest.raises(ValueError):
+        reg.install(url="http://example.com/p.zip", plugin_id="p")
+
+
+def test_install_rejects_bad_id(pdir, monkeypatch):
+    _mock_download(monkeypatch, _zip({"plugin.py": "PLUGIN={}"}))
+    with pytest.raises(ValueError):
+        reg.install(url="https://x/p.zip", plugin_id="../evil")
+
+
+def test_sha256_mismatch_raises(pdir, monkeypatch):
+    blob = _zip({"plugin.py": "PLUGIN={'name':'P'}"})
+    _mock_download(monkeypatch, blob)
+    with pytest.raises(ValueError):
+        reg.install(url="https://x/p.zip", plugin_id="p", sha256="deadbeef")
+
+
+# -- happy path ---------------------------------------------------------------
+
+def test_install_extracts_and_verifies(pdir, monkeypatch):
+    blob = _zip({"plugin.py": "PLUGIN = {'name': 'Demo'}\n",
+                 "data/notes.txt": "hi"})
+    _mock_download(monkeypatch, blob)
+    digest = hashlib.sha256(blob).hexdigest()
+    reg.install(url="https://x/demo.zip", plugin_id="demo", sha256=digest)
+    assert os.path.isfile(os.path.join(pdir, "demo", "plugin.py"))
+    assert os.path.isfile(os.path.join(pdir, "demo", "data", "notes.txt"))
+
+
+def test_install_flattens_single_root_dir(pdir, monkeypatch):
+    # a zip that wraps everything under one top folder (common GitHub archive shape)
+    blob = _zip({"demo-1.0/plugin.py": "PLUGIN={'name':'D'}"})
+    _mock_download(monkeypatch, blob)
+    reg.install(url="https://x/demo.zip", plugin_id="demo")
+    assert os.path.isfile(os.path.join(pdir, "demo", "plugin.py"))
+
+
+def test_install_requires_a_plugin_entry(pdir, monkeypatch):
+    _mock_download(monkeypatch, _zip({"readme.txt": "no plugin here"}))
+    with pytest.raises(ValueError):
+        reg.install(url="https://x/demo.zip", plugin_id="demo")
+    assert not os.path.isdir(os.path.join(pdir, "demo"))
+
+
+def test_uninstall_removes_folder(pdir, monkeypatch):
+    _mock_download(monkeypatch, _zip({"plugin.py": "PLUGIN={'name':'D'}"}))
+    reg.install(url="https://x/demo.zip", plugin_id="demo")
+    assert os.path.isdir(os.path.join(pdir, "demo"))
+    reg.uninstall("demo")
+    assert not os.path.isdir(os.path.join(pdir, "demo"))

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -27,8 +27,8 @@ def _mock_download(monkeypatch, blob):
     class _Resp:
         def __enter__(self): return self
         def __exit__(self, *a): return False
-        def read(self): return blob
-    monkeypatch.setattr(reg.urllib.request, "urlopen", lambda *a, **k: _Resp())
+        def read(self, *a): return blob   # real responses accept a size arg
+    monkeypatch.setattr(reg, "_urlopen", lambda *a, **k: _Resp())
 
 
 @pytest.fixture
@@ -75,8 +75,25 @@ def test_install_rejects_bad_id(pdir, monkeypatch):
 def test_sha256_mismatch_raises(pdir, monkeypatch):
     blob = _zip({"plugin.py": "PLUGIN={'name':'P'}"})
     _mock_download(monkeypatch, blob)
-    with pytest.raises(ValueError):
-        reg.install(url="https://x/p.zip", plugin_id="p", sha256="deadbeef")
+    with pytest.raises(ValueError):   # valid 64-hex format, wrong value → mismatch
+        reg.install(url="https://x/p.zip", plugin_id="p", sha256="0" * 64)
+
+
+def test_install_requires_sha256(pdir, monkeypatch):
+    blob = _zip({"plugin.py": "PLUGIN={'name':'P'}"})
+    _mock_download(monkeypatch, blob)
+    for bad in (None, "", "abc", "g" * 64):   # missing / malformed digests are rejected
+        with pytest.raises(ValueError):
+            reg.install(url="https://x/p.zip", plugin_id="p", sha256=bad)
+
+
+def test_safe_extract_rejects_oversized(tmp_path, monkeypatch):
+    dest = tmp_path / "dest"; dest.mkdir()
+    monkeypatch.setattr(reg, "MAX_TOTAL_UNCOMPRESSED", 1000)
+    blob = _zip({"big.bin": b"x" * 5000})
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        with pytest.raises(ValueError):
+            reg._safe_extract(zf, str(dest))
 
 
 # -- happy path ---------------------------------------------------------------
@@ -95,20 +112,67 @@ def test_install_flattens_single_root_dir(pdir, monkeypatch):
     # a zip that wraps everything under one top folder (common GitHub archive shape)
     blob = _zip({"demo-1.0/plugin.py": "PLUGIN={'name':'D'}"})
     _mock_download(monkeypatch, blob)
-    reg.install(url="https://x/demo.zip", plugin_id="demo")
+    reg.install(url="https://x/demo.zip", plugin_id="demo", sha256=hashlib.sha256(blob).hexdigest())
     assert os.path.isfile(os.path.join(pdir, "demo", "plugin.py"))
 
 
 def test_install_requires_a_plugin_entry(pdir, monkeypatch):
-    _mock_download(monkeypatch, _zip({"readme.txt": "no plugin here"}))
-    with pytest.raises(ValueError):
-        reg.install(url="https://x/demo.zip", plugin_id="demo")
+    blob = _zip({"readme.txt": "no plugin here"})
+    _mock_download(monkeypatch, blob)
+    with pytest.raises(ValueError):   # valid digest → reaches (and fails) the no-plugin-entry check
+        reg.install(url="https://x/demo.zip", plugin_id="demo", sha256=hashlib.sha256(blob).hexdigest())
     assert not os.path.isdir(os.path.join(pdir, "demo"))
+
+
+def test_allowed_url_hardening():
+    assert reg._allowed_url("https://example.com/x.zip")
+    assert reg._allowed_url("http://127.0.0.1:7000/r.json")
+    assert reg._allowed_url("http://localhost/r.json")
+    assert not reg._allowed_url("http://evil.com/x")              # http to non-loopback
+    assert not reg._allowed_url("http://127.0.0.1:1@evil.com/x")  # userinfo trick → real host evil.com
+    assert not reg._allowed_url("https://127.0.0.1@evil.com/x")   # userinfo
+    assert not reg._allowed_url("ftp://127.0.0.1/x")
+    assert not reg._allowed_url("file:///etc/passwd")
+    assert not reg._allowed_url(" https://example.com")           # leading whitespace
+    assert not reg._allowed_url("https://exa\tmple.com")          # embedded whitespace
 
 
 def test_uninstall_removes_folder(pdir, monkeypatch):
-    _mock_download(monkeypatch, _zip({"plugin.py": "PLUGIN={'name':'D'}"}))
-    reg.install(url="https://x/demo.zip", plugin_id="demo")
+    blob = _zip({"plugin.py": "PLUGIN={'name':'D'}"})
+    _mock_download(monkeypatch, blob)
+    reg.install(url="https://x/demo.zip", plugin_id="demo", sha256=hashlib.sha256(blob).hexdigest())
     assert os.path.isdir(os.path.join(pdir, "demo"))
     reg.uninstall("demo")
     assert not os.path.isdir(os.path.join(pdir, "demo"))
+
+
+def test_install_update_reimports_new_code(tmp_path, monkeypatch):
+    """Updating an installed plugin must run the NEW code, not the stale module."""
+    import src.plugin_system as ps
+    from fastapi import FastAPI
+    pdir = tmp_path / "plugins"; pdir.mkdir()
+    data = tmp_path / "data"; data.mkdir()
+    monkeypatch.setenv("ODYSSEUS_PLUGINS_DIR", str(pdir))
+    monkeypatch.setenv("ODYSSEUS_DATA_DIR", str(data))
+    mgr = ps.PluginManager(app=FastAPI(), directory=str(pdir))
+    monkeypatch.setattr(reg, "get_manager", lambda: mgr)
+
+    def _src(v):
+        return ("PLUGIN = {'name': 'U', 'version': '%s'}\n" % v +
+                "def setup(ctx):\n"
+                "    from fastapi import APIRouter\n"
+                "    r = APIRouter()\n"
+                "    @r.get('/api/plugins/u/ver')\n"
+                "    async def ver(): return {'v': '%s'}\n" % v +
+                "    ctx.add_router(r)\n")
+
+    b1 = _zip({"plugin.py": _src("1")})
+    _mock_download(monkeypatch, b1)
+    reg.install(url="https://x/u.zip", plugin_id="u", sha256=hashlib.sha256(b1).hexdigest())
+    assert mgr.records["u"].status == "loaded"
+    assert mgr.records["u"].module.PLUGIN["version"] == "1"
+
+    b2 = _zip({"plugin.py": _src("2")})
+    _mock_download(monkeypatch, b2)
+    reg.install(url="https://x/u.zip", plugin_id="u", sha256=hashlib.sha256(b2).hexdigest())
+    assert mgr.records["u"].module.PLUGIN["version"] == "2"   # NEW code re-imported, not stale

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -1,0 +1,134 @@
+"""Tests for the drop-in plugin system: manifest discovery, setup/teardown
+lifecycle, live enable/disable (routes + services), persistence, and isolation
+of a broken plugin.
+
+Uses self-contained demo plugins written to a temp dir, so nothing here depends
+on Odysseus internals.
+"""
+import json
+import os
+import textwrap
+
+import pytest
+from fastapi import FastAPI
+
+from src.plugin_system import PluginManager
+
+
+def _write(pdir, pid, body):
+    d = os.path.join(pdir, pid)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "plugin.py"), "w", encoding="utf-8") as f:
+        f.write(textwrap.dedent(body))
+
+
+DEMO = '''
+    PLUGIN = {"name": "Demo", "version": "0.2.0", "author": "t",
+              "description": "demo", "category": "Test"}
+    counters = {"start": 0, "stop": 0}
+    def setup(ctx):
+        from fastapi import APIRouter
+        r = APIRouter()
+        @r.get("/api/plugins/demo/ping")
+        async def ping():
+            return {"ok": True}
+        ctx.add_router(r)
+        ctx.add_service(start=lambda: counters.__setitem__("start", counters["start"] + 1),
+                        stop=lambda: counters.__setitem__("stop", counters["stop"] + 1))
+'''
+
+BROKEN = '''
+    PLUGIN = {"name": "Broken", "version": "1.0.0"}
+    def setup(ctx):
+        raise RuntimeError("boom")
+'''
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    pdir = tmp_path / "plugins"; pdir.mkdir()
+    data = tmp_path / "data"; data.mkdir()
+    monkeypatch.setenv("ODYSSEUS_PLUGINS_DIR", str(pdir))
+    monkeypatch.setenv("ODYSSEUS_DATA_DIR", str(data))
+    monkeypatch.setenv("DATA_DIR", str(data))
+    return str(pdir), str(data)
+
+
+def _routes(app):
+    return [r.path for r in app.router.routes if getattr(r, "path", "").startswith("/api/plugins/demo")]
+
+
+def test_manifest_read_without_executing(env):
+    pdir, _ = env
+    _write(pdir, "demo", DEMO)
+    mgr = PluginManager(app=FastAPI(), directory=pdir)
+    mgr.discover()                       # discovery must NOT import/run the module
+    rec = mgr.list()[0]
+    assert rec["id"] == "demo" and rec["name"] == "Demo" and rec["version"] == "0.2.0"
+    assert rec["status"] == "discovered"
+
+
+def test_load_mounts_route_and_starts_service(env):
+    pdir, _ = env
+    _write(pdir, "demo", DEMO)
+    app = FastAPI()
+    mgr = PluginManager(app=app, directory=pdir)
+    assert mgr.load_enabled(app) == 1
+    assert _routes(app) == ["/api/plugins/demo/ping"]
+    assert mgr.list()[0]["status"] == "loaded"
+
+
+def test_disable_then_enable_toggles_routes_and_services(env):
+    pdir, _ = env
+    _write(pdir, "demo", DEMO)
+    app = FastAPI()
+    mgr = PluginManager(app=app, directory=pdir)
+    mgr.load_enabled(app)
+    counters = mgr.records["demo"].module.counters
+    assert counters["start"] == 1 and _routes(app)
+
+    mgr.disable("demo")
+    assert _routes(app) == [] and counters["stop"] == 1
+    assert mgr.list()[0]["enabled"] is False and mgr.list()[0]["status"] == "disabled"
+
+    mgr.enable("demo")
+    assert _routes(app) == ["/api/plugins/demo/ping"] and counters["start"] == 2
+
+
+def test_disabled_state_persists(env):
+    pdir, data = env
+    _write(pdir, "demo", DEMO)
+    mgr = PluginManager(app=FastAPI(), directory=pdir)
+    mgr.load_enabled()
+    mgr.disable("demo")
+    with open(os.path.join(data, "plugins.json"), encoding="utf-8") as f:
+        assert json.load(f)["demo"]["enabled"] is False
+    # a fresh manager respects the persisted state — does not load it
+    app2 = FastAPI()
+    mgr2 = PluginManager(app=app2, directory=pdir)
+    assert mgr2.load_enabled(app2) == 0
+    assert mgr2.list()[0]["enabled"] is False
+
+
+def test_broken_plugin_is_isolated(env):
+    pdir, _ = env
+    _write(pdir, "demo", DEMO)
+    _write(pdir, "broken", BROKEN)
+    app = FastAPI()
+    mgr = PluginManager(app=app, directory=pdir)
+    loaded = mgr.load_enabled(app)            # must not raise
+    assert loaded == 1                        # demo loads; broken fails
+    by_id = {p["id"]: p for p in mgr.list()}
+    assert by_id["demo"]["status"] == "loaded"
+    assert by_id["broken"]["status"] == "error" and by_id["broken"]["error"]
+    assert _routes(app) == ["/api/plugins/demo/ping"]   # broken left nothing behind
+
+
+def test_shutdown_all_stops_services(env):
+    pdir, _ = env
+    _write(pdir, "demo", DEMO)
+    app = FastAPI()
+    mgr = PluginManager(app=app, directory=pdir)
+    mgr.load_enabled(app)
+    mgr.shutdown_all()
+    assert mgr.records["demo"].module.counters["stop"] == 1 and _routes(app) == []

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -132,3 +132,35 @@ def test_shutdown_all_stops_services(env):
     mgr.load_enabled(app)
     mgr.shutdown_all()
     assert mgr.records["demo"].module.counters["stop"] == 1 and _routes(app) == []
+
+
+OFF_NAMESPACE = '''
+    PLUGIN = {"name": "OffNs", "version": "1.0.0"}
+    def setup(ctx):
+        from fastapi import APIRouter
+        r = APIRouter()
+        @r.get("/static/evil")          # auth-exempt prefix → must be rejected
+        async def evil(): return {"x": 1}
+        ctx.add_router(r)
+'''
+
+
+def test_add_router_rejects_off_namespace_routes(env):
+    pdir, _ = env
+    _write(pdir, "offns", OFF_NAMESPACE)
+    app = FastAPI()
+    mgr = PluginManager(app=app, directory=pdir)
+    assert mgr.load_enabled(app) == 0                       # plugin fails to load
+    assert mgr.list()[0]["status"] == "error"
+    assert not any(getattr(r, "path", "") == "/static/evil" for r in app.router.routes)
+
+
+def test_ui_field_sanitized():
+    """public()'s `ui.open` must be a same-origin path — blocks javascript:/`//evil`."""
+    from src.plugin_system import _safe_ui
+    assert _safe_ui({"ui": {"open": "/api/plugins/x/app"}}) == {"open": "/api/plugins/x/app", "label": "Open"}
+    assert _safe_ui({"ui": {"open": "/api/x", "label": "Go"}})["label"] == "Go"
+    assert _safe_ui({"ui": {"open": "javascript:alert(1)"}}) is None
+    assert _safe_ui({"ui": {"open": "//evil.com/x"}}) is None
+    assert _safe_ui({"ui": {"open": 123}}) is None
+    assert _safe_ui({}) is None


### PR DESCRIPTION
Adds a drop-in plugin system + depot so capabilities can ship as plugins (in their own repos) instead of core changes.

Fixes #415.

## What's included

- **`src/plugin_system.py`** — discover `plugins/<id>/plugin.py` via an AST manifest read (no exec at discovery); `PluginContext` (`add_router` / `add_service` / `register_tool`, per-plugin `data_dir`, `logger`) with tracked teardown for live enable/disable; persisted enabled-state; honors `ODYSSEUS_PLUGINS_DIR` / `ODYSSEUS_DATA_DIR`.
- **`routes/plugin_routes.py`** — admin API: list / enable / disable / reload / rescan, registry browse, install (by id or `{url}`), uninstall, registry-source management.
- **`src/plugin_registry.py`** — depot: aggregate multiple registries; install = download → sha256-verify → hardened extract (rejects zip-slip / absolute paths / symlinks) → flatten → enable; https-only (loopback http allowed); uninstall.
- **`app.py`** — load plugins on startup, stop them on shutdown.
- **UI** (Settings → Plugins, admin-only): Installed / Browse-depot views, per-source status, Install-from-URL, Add-registry; a Plugins entry under Theme in the expanded sidebar + the collapsed icon rail.
- **`plugins/example/`** template, **`plugins/registry.json`** index (points at plugins' own repos), **`plugins/README.md`** authoring guide.
- **Tests:** `tests/test_plugin_system.py`, `tests/test_plugin_registry.py`.

The Cloudflare Tunnel reference plugin lives at https://github.com/kanaru-dev/odysseus-plugin-cloudflare-tunnel and installs from the depot.

## Security

No code execution at discovery (manifest read with `ast`). Installs are https-only (loopback http allowed for local registries), sha256-verified, and extraction rejects zip-slip / absolute paths / symlinks. Plugin routes use normal auth; `permission: admin` gates admin-only plugins.

## Testing

- `python -m pytest tests/test_plugin_system.py tests/test_plugin_registry.py` → **15 passed**.
- `python -m pytest` (full) → **336 passed, 13 failed, 1 skipped, 1 collection error**. The failures/error are pre-existing on `main` (calendar-recurrence import, shell pty on Windows, review-regressions, task-scheduler) — verified by running the same files at the base commit without this change; none are plugin-related.
- `python -m py_compile app.py routes/plugin_routes.py src/plugin_system.py src/plugin_registry.py plugins/example/plugin.py` → OK.
- `node --check static/app.js static/js/settings.js` → OK.
- App boots; `/api/plugins` returns 401 unauthenticated (admin-gated). Installed the tunnel from the depot end-to-end (download → sha256 → extract → enable → start tunnel).

## Screenshots

Plugins entry under Theme in the sidebar:

![Plugins in the sidebar](https://raw.githubusercontent.com/kanaru-dev/odysseus/pr-assets/sidebar.png)

Settings → Plugins → Browse depot (install + registry-source status):

![Browse the depot](https://raw.githubusercontent.com/kanaru-dev/odysseus/pr-assets/depot.png)

Installed — Cloudflare Tunnel running with its public URL (auth still required):

![Running tunnel](https://raw.githubusercontent.com/kanaru-dev/odysseus/pr-assets/tunnel.png)
