### PR TITLE
Render common emoji shortcodes in chat

### DIFF
--- a/static/js/emojiShortcodes.js
+++ b/static/js/emojiShortcodes.js
@@ -1,0 +1,74 @@
+// Convert common chat-style emoji shortcodes (:blush:, :microphone:) into
+// Unicode before markdown's existing monochrome emoji pass runs.
+
+const SHORTCODE_TO_EMOJI = Object.freeze({
+  blush: '\u{1f60a}',
+  blushes: '\u{1f60a}',
+  smile: '\u{1f604}',
+  smiling: '\u{1f604}',
+  grin: '\u{1f601}',
+  joy: '\u{1f602}',
+  laugh: '\u{1f602}',
+  laughing: '\u{1f602}',
+  wink: '\u{1f609}',
+  heart: '\u{2764}\u{fe0f}',
+  red_heart: '\u{2764}\u{fe0f}',
+  thumbs_up: '\u{1f44d}',
+  thumbsup: '\u{1f44d}',
+  '+1': '\u{1f44d}',
+  thumbs_down: '\u{1f44e}',
+  '-1': '\u{1f44e}',
+  ok_hand: '\u{1f44c}',
+  clap: '\u{1f44f}',
+  fire: '\u{1f525}',
+  tada: '\u{1f389}',
+  eyes: '\u{1f440}',
+  thinking: '\u{1f914}',
+  rocket: '\u{1f680}',
+  microphone: '\u{1f3a4}',
+  mic: '\u{1f3a4}',
+  music: '\u{1f3b5}',
+  musical_note: '\u{1f3b5}',
+  notes: '\u{1f3b6}',
+  emoji: '\u{1f642}',
+});
+
+const SHORTCODE_RE = /:([a-z0-9_+-]+):/gi;
+
+function _lookupShortcode(name) {
+  const normalized = String(name || '').toLowerCase().replace(/-/g, '_');
+  return SHORTCODE_TO_EMOJI[normalized] || null;
+}
+
+export function expandEmojiShortcodesInText(text) {
+  if (!text || !String(text).includes(':')) return text;
+  return String(text).replace(SHORTCODE_RE, (match, name) => {
+    return _lookupShortcode(name) || match;
+  });
+}
+
+export function expandEmojiShortcodesInHtml(html) {
+  if (!html || !String(html).includes(':')) return html;
+
+  const parts = String(html).split(/(<[^>]*>)/);
+  let codeDepth = 0;
+
+  for (let i = 0; i < parts.length; i += 1) {
+    if (i % 2 === 1) {
+      const tag = parts[i].toLowerCase();
+      if (/^<(pre|code)[\s>]/.test(tag)) codeDepth += 1;
+      else if (/^<\/(pre|code)\s*>/.test(tag)) codeDepth = Math.max(0, codeDepth - 1);
+      continue;
+    }
+    if (codeDepth === 0 && parts[i].includes(':')) {
+      parts[i] = expandEmojiShortcodesInText(parts[i]);
+    }
+  }
+
+  return parts.join('');
+}
+
+export default {
+  expandEmojiShortcodesInText,
+  expandEmojiShortcodesInHtml,
+};

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -6,6 +6,7 @@
 
 import uiModule from './ui.js';
 import { splitTableRow } from './markdown/tableRow.js';
+import { expandEmojiShortcodesInHtml } from './emojiShortcodes.js';
 
 var escapeHtml = uiModule.esc;
 
@@ -628,6 +629,7 @@ export function mdToHtml(src) {
     s = s.replace(`___CODE_BLOCK_${index}___`, block);
   });
 
+  s = expandEmojiShortcodesInHtml(s);
   return _useSvgEmoji() ? svgifyEmoji(s) : s;
 }
 

--- a/tests/test_emoji_shortcodes_js.py
+++ b/tests/test_emoji_shortcodes_js.py
@@ -1,0 +1,62 @@
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _run_node(script: str) -> dict:
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO,
+        capture_output=True,
+        timeout=15,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.splitlines()[-1])
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_expands_common_model_emoji_shortcodes():
+    script = textwrap.dedent(
+        """
+        const { expandEmojiShortcodesInText } = await import('./static/js/emojiShortcodes.js');
+        const out = expandEmojiShortcodesInText('hello :blush: sing :microphone: **:emoji:**');
+        console.log(JSON.stringify({
+          has_blush: out.includes('\\u{1f60a}'),
+          has_microphone: out.includes('\\u{1f3a4}'),
+          has_generic: out.includes('\\u{1f642}'),
+          keeps_text: out.includes('hello') && out.includes('sing'),
+        }));
+        """
+    )
+    assert _run_node(script) == {
+        "has_blush": True,
+        "has_microphone": True,
+        "has_generic": True,
+        "keeps_text": True,
+    }
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_does_not_expand_shortcodes_inside_code_blocks():
+    script = textwrap.dedent(
+        """
+        const { expandEmojiShortcodesInHtml } = await import('./static/js/emojiShortcodes.js');
+        const out = expandEmojiShortcodesInHtml('<p>:blush:</p><pre><code>:microphone:</code></pre>');
+        console.log(JSON.stringify({
+          expanded_paragraph: out.includes('\\u{1f60a}'),
+          kept_code: out.includes('<code>:microphone:</code>'),
+        }));
+        """
+    )
+    assert _run_node(script) == {
+        "expanded_paragraph": True,
+        "kept_code": True,
+    }


### PR DESCRIPTION
Some model replies include chat-style emoji names like `:blush:` or `:microphone:`. Right now those show up as plain text.

This adds a small frontend helper that expands common shortcodes before the existing emoji rendering pass runs. It skips `<code>` and `<pre>` content so examples/snippets stay unchanged.

Fixes #345.

Tested:
- `venv/bin/python -m pytest -q tests/test_emoji_shortcodes_js.py`
- `node --check static/js/emojiShortcodes.js`
- `node --check static/js/markdown.js`
- `git diff --check`