### PR TITLE
feat: render :shortcode: emoji in chat (#345)

### DIFF
--- a/static/js/emoji/shortcodes.js
+++ b/static/js/emoji/shortcodes.js
@@ -24,11 +24,29 @@ export const EMOJI_SHORTCODES = {
 
 const _SHORTCODE_RE = /:([a-z0-9_+-]+):/gi;
 
-export function replaceEmojiShortcodes(text) {
-  if (!text) return text;
+function _replaceInText(text) {
   return text.replace(_SHORTCODE_RE, (match, name) =>
     Object.prototype.hasOwnProperty.call(EMOJI_SHORTCODES, name.toLowerCase())
       ? EMOJI_SHORTCODES[name.toLowerCase()]
       : match,
   );
+}
+
+// Operates on rendered HTML: only rewrites text outside tags and skips the
+// contents of <code>/<pre> so shortcodes shown inside code samples stay
+// literal (e.g. a `:rocket:` in a snippet must not turn into 🚀).
+export function replaceEmojiShortcodes(html) {
+  if (!html || html.indexOf(':') === -1) return html;
+  const parts = html.split(/(<[^>]*>)/); // odd indices = tags
+  let codeDepth = 0;
+  for (let i = 0; i < parts.length; i++) {
+    if (i % 2 === 1) {
+      const t = parts[i].toLowerCase();
+      if (/^<(pre|code)[\s>]/.test(t)) codeDepth++;
+      else if (/^<\/(pre|code)\s*>/.test(t)) codeDepth = Math.max(0, codeDepth - 1);
+      continue;
+    }
+    if (codeDepth === 0) parts[i] = _replaceInText(parts[i]);
+  }
+  return parts.join('');
 }

--- a/static/js/emoji/shortcodes.js
+++ b/static/js/emoji/shortcodes.js
@@ -1,0 +1,34 @@
+// static/js/emoji/shortcodes.js
+//
+// Convert `:shortcode:` emoji (the ":blush:", ":rocket:" style that many LLMs
+// emit) into the Unicode emoji, so chat renders 😊 instead of literal text.
+// Pure — no DOM, no fetch — so it can be unit-tested under node.
+
+export const EMOJI_SHORTCODES = {
+  smile: '😄', smiley: '😃', grin: '😁', laughing: '😆', joy: '😂',
+  rofl: '🤣', blush: '😊', wink: '😉', heart_eyes: '😍', smirk: '😏',
+  thinking: '🤔', neutral_face: '😐', expressionless: '😑', sweat_smile: '😅',
+  sob: '😭', cry: '😢', disappointed: '😞', confused: '😕', flushed: '😳',
+  sunglasses: '😎', heart: '❤️', broken_heart: '💔', sparkling_heart: '💖',
+  thumbsup: '👍', '+1': '👍', thumbsdown: '👎', '-1': '👎', ok_hand: '👌',
+  clap: '👏', wave: '👋', pray: '🙏', muscle: '💪', point_right: '👉',
+  fire: '🔥', tada: '🎉', sparkles: '✨', star: '⭐', star2: '🌟',
+  zap: '⚡', boom: '💥', rocket: '🚀', bulb: '💡', warning: '⚠️',
+  white_check_mark: '✅', heavy_check_mark: '✔️', x: '❌', no_entry: '⛔',
+  question: '❓', exclamation: '❗', eyes: '👀', tongue: '👅',
+  microphone: '🎤', mag: '🔍', lock: '🔒', key: '🔑', gear: '⚙️',
+  hourglass: '⏳', alarm_clock: '⏰', calendar: '📅', email: '📧',
+  pencil: '✏️', memo: '📝', book: '📖', books: '📚', package: '📦',
+  computer: '💻', bug: '🐛', wrench: '🔧', hammer: '🔨', chart_with_upwards_trend: '📈',
+};
+
+const _SHORTCODE_RE = /:([a-z0-9_+-]+):/gi;
+
+export function replaceEmojiShortcodes(text) {
+  if (!text) return text;
+  return text.replace(_SHORTCODE_RE, (match, name) =>
+    Object.prototype.hasOwnProperty.call(EMOJI_SHORTCODES, name.toLowerCase())
+      ? EMOJI_SHORTCODES[name.toLowerCase()]
+      : match,
+  );
+}

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -5,6 +5,7 @@
  */
 
 import uiModule from './ui.js';
+import { replaceEmojiShortcodes } from './emoji/shortcodes.js';
 
 var escapeHtml = uiModule.esc;
 
@@ -544,6 +545,7 @@ export function mdToHtml(src) {
     s = s.replace(`___CODE_BLOCK_${index}___`, block);
   });
 
+  s = replaceEmojiShortcodes(s);
   return _useSvgEmoji() ? svgifyEmoji(s) : s;
 }
 

--- a/tests/test_emoji_shortcodes_js.py
+++ b/tests/test_emoji_shortcodes_js.py
@@ -1,0 +1,51 @@
+"""Pin the pure emoji-shortcode helper in emoji/shortcodes.js.
+
+Driven through `node --input-type=module` (same approach as test_compare_js.py);
+skips when `node` is not installed rather than failing.
+
+Regression for issue #345: `:blush:` style shortcodes emitted by models were
+shown as literal text instead of the Unicode emoji.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "emoji" / "shortcodes.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _run(js: str) -> str:
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _call(html: str) -> str:
+    js = f"""
+    import {{ replaceEmojiShortcodes }} from '{_HELPER.as_posix()}';
+    console.log(JSON.stringify(replaceEmojiShortcodes({json.dumps(html)})));
+    """
+    return json.loads(_run(js))
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_known_shortcodes_become_unicode():
+    assert _call("nice work :rocket: :blush:") == "nice work 🚀 😊"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_unknown_shortcode_left_untouched():
+    assert _call("ping :not_an_emoji: pong") == "ping :not_an_emoji: pong"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_shortcodes_inside_code_are_preserved():
+    html = "say <code>:rocket:</code> then :rocket:"
+    assert _call(html) == "say <code>:rocket:</code> then 🚀"


### PR DESCRIPTION
## Summary

Models frequently emit emoji as `:shortcode:` text (`:blush:`, `:rocket:`, `:fire:`). The renderer only handled Unicode emoji, so these showed up literally in chat instead of as the emoji.

This adds a small, code-aware pass over rendered markdown that converts known shortcodes to the Unicode emoji, which then flows through the existing emoji pipeline (svgify / text-only handling). Unknown shortcodes are left untouched, and shortcodes inside `<code>`/`<pre>` are preserved so code samples are never rewritten.

## Changes
- `static/js/emoji/shortcodes.js`: new pure module — shortcode→emoji map and a code-aware `replaceEmojiShortcodes`.
- `static/js/markdown.js`: apply it at the end of `mdToHtml`.
- `tests/test_emoji_shortcodes_js.py`: node-driven regression tests (conversion, unknown left alone, code spans preserved).

Fixes #345