### PR TITLE
  Fix Cookbook bash PATH export for POSIX interpreter paths on Windows hosts

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -3,6 +3,7 @@ Extracted from cookbook_routes.py; the routes module imports the symbols it need
 
 import logging
 import os
+import posixpath
 import re
 import shlex
 
@@ -112,7 +113,13 @@ def _local_tooling_path_export(executable: str) -> str:
     macOS, where the `pip --user` self-heal also misses (`pip` isn't a command,
     only `pip3`/`python3 -m pip`). Local runs only; meaningless over SSH.
     """
-    bin_dir = os.path.dirname(os.path.abspath(executable))
+    # This builds a bash snippet, so an explicit POSIX absolute path should keep
+    # POSIX semantics even when the app/tests run on Windows. Otherwise
+    # os.path.abspath("/opt/...") would incorrectly turn it into "D:\\opt\\...".
+    if executable.startswith("/"):
+        bin_dir = posixpath.dirname(executable)
+    else:
+        bin_dir = os.path.dirname(os.path.abspath(executable))
     # Escape for a double-quoted context: $PATH must still expand, but spaces
     # and shell metacharacters in the path must be preserved literally.
     esc = (


### PR DESCRIPTION
## Summary

  This fixes a small Cookbook path bug in routes/cookbook_helpers.py.

  _local_tooling_path_export() was using os.path.abspath() unconditionally.
  When the app/tests run on Windows, an explicit POSIX path such as
  /opt/venv/bin/python could be rewritten into a Windows-style path like
  D:\opt\venv\bin, which is invalid for the bash PATH export used by local
  Cookbook runners.

  ## Changed

  - Updated _local_tooling_path_export() to preserve POSIX absolute paths
    using POSIX path semantics.
  - Left the existing behavior unchanged for non-POSIX inputs.

  ## Why

  Cookbook builds bash runner scripts for local/tmux flows. Those scripts need a
  valid POSIX PATH entry so bundled tools like hf and python can be found.
  Rewriting POSIX paths with Windows path rules breaks that assumption.

  ## Files Changed

  - routes/cookbook_helpers.py

  ## Testing

  Ran: venv\Scripts\python.exe -m pytest -q tests\test_cookbook_helpers.py

  Result:
  - 8 passed

  Also verified Python syntax with an in-memory compile check for
  routes/cookbook_helpers.py.