### PR TITLE
Normalize setup admin usernames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def create_default_admin():
         import bcrypt
         import json
 
-        username = os.getenv("ODYSSEUS_ADMIN_USER", "admin").strip() or "admin"
+        username = os.getenv("ODYSSEUS_ADMIN_USER", "admin").strip().lower() or "admin"
         password = os.getenv("ODYSSEUS_ADMIN_PASSWORD") or __import__("secrets").token_urlsafe(18)
         hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
         auth_data = {

--- a/tests/test_setup_admin_user.py
+++ b/tests/test_setup_admin_user.py
@@ -1,0 +1,25 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_setup_module():
+    spec = importlib.util.spec_from_file_location("odysseus_setup_under_test", Path("setup.py"))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_create_default_admin_normalizes_env_username(tmp_path, monkeypatch):
+    setup_module = _load_setup_module()
+    monkeypatch.setattr(setup_module, "DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ODYSSEUS_ADMIN_USER", " AdminUser ")
+    monkeypatch.setenv("ODYSSEUS_ADMIN_PASSWORD", "temporary-password")
+
+    assert setup_module.create_default_admin() == "created"
+
+    auth_path = tmp_path / "auth.json"
+    data = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert "adminuser" in data["users"]
+    assert "AdminUser" not in data["users"]


### PR DESCRIPTION
`setup.py` let `ODYSSEUS_ADMIN_USER` be written exactly as provided, but the auth manager lowercases usernames when it checks passwords and creates sessions. That means a generated `AdminUser` account is stored under `AdminUser`, then login looks for `adminuser` and misses it.

This normalizes the setup-created username the same way the auth code does. It may not explain every case in #423, but it fixes a real mismatch in the generated-admin path.

Checked:
- `venv/bin/python -m py_compile setup.py tests/test_setup_admin_user.py`
- `venv/bin/python -m pytest -q tests/test_setup_admin_user.py`
- `git diff --check origin/main...normalize-setup-admin-user`