### PR TITLE
refactor(ai_interaction): maintainability overhaul + tests + SonarLint cleanup (behavior-preserving)

### DIFF
--- a/scripts/smoke_ai_interaction.py
+++ b/scripts/smoke_ai_interaction.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+"""
+Integration smoke test for src/ai_interaction.dispatch_ai_tool.
+
+Drives the REAL dispatcher -> real do_* handlers -> real SessionManager,
+MemoryManager and a throwaway SQLite database. Only the I/O boundary is
+mocked: the LLM call (llm_call_async), model resolution (_resolve_model) and
+endpoint model-listing (_fetch_endpoint_model_ids) — there is no live LLM
+endpoint in this environment.
+
+Run:  python scripts/smoke_ai_interaction.py
+Exits non-zero if any step fails.
+
+NOT a pytest test on purpose: tests/conftest.py stubs core.database/src.database
+with MagicMocks, which would defeat the point of exercising the real stack.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+
+# ── Point the DB at a throwaway file BEFORE importing core.database ──────────
+_TMP = tempfile.mkdtemp(prefix="odysseus_smoke_")
+os.environ["DATABASE_URL"] = f"sqlite:///{os.path.join(_TMP, 'smoke.db')}"
+
+# Make the repo root importable when run from anywhere
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.database import init_db, SessionLocal, ModelEndpoint  # noqa: E402
+from core.session_manager import SessionManager  # noqa: E402
+from core.models import set_session_manager as set_core_sm  # noqa: E402
+from src.memory import MemoryManager  # noqa: E402
+import src.ai_interaction as ai  # noqa: E402
+
+
+# ── Counters / assertion helper ─────────────────────────────────────────────
+_passed = 0
+_failed = 0
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if condition:
+        _passed += 1
+        print(f"  PASS  {label}")
+    else:
+        _failed += 1
+        print(f"  FAIL  {label}   {detail}")
+
+
+# ── Environment setup ───────────────────────────────────────────────────────
+def setup():
+    init_db()  # create schema in the throwaway DB
+
+    # Seed one enabled endpoint so DB-backed tools have something to find
+    db = SessionLocal()
+    try:
+        db.add(ModelEndpoint(
+            id="smoke-ep",
+            name="Smoke Endpoint",
+            base_url="http://fake-host/v1",
+            api_key=None,
+            is_enabled=True,
+            model_type="llm",
+            owner="smoke-user",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+    # Real managers backed by the temp dir
+    memory_manager = MemoryManager(_TMP)
+    session_manager = SessionManager(os.path.join(_TMP, "sessions.json"))
+    set_core_sm(session_manager)  # enable Session.add_message persistence
+
+    # Wire the real managers into ai_interaction (same calls app.py makes)
+    ai.set_session_manager(session_manager)
+    ai.set_memory_manager(memory_manager, None)
+    ai.set_rag_manager(None, None)
+
+    # Mock ONLY the I/O boundary
+    async def _fake_llm(*args, **kwargs):
+        return "FAKE-LLM-RESPONSE"
+
+    ai.llm_call_async = _fake_llm
+    ai._resolve_model = lambda spec: ("http://fake-host/v1/chat/completions", "fake-model", {})
+    ai._fetch_endpoint_model_ids = lambda base, headers, provider, anth: ["fake-model"]
+
+    return session_manager, memory_manager
+
+
+# ── The smoke scenarios ─────────────────────────────────────────────────────
+async def run(session_manager, memory_manager):
+    OWNER = "smoke-user"
+
+    async def dispatch(tool, content):
+        return await ai.dispatch_ai_tool(tool, content, session_id=None, owner=OWNER)
+
+    # 1) ui_control: toggle (sync handler through await-agnostic dispatcher)
+    desc, res = await dispatch("ui_control", "toggle shell on")
+    check("ui_control toggle: alias shell->bash", res.get("toggle_name") == "bash", str(res))
+    check("ui_control toggle: state on", res.get("state") is True, str(res))
+    check("ui_control desc derived", desc.startswith("ui_control"), desc)
+
+    # 2) ui_control: set_theme
+    _, res = await dispatch("ui_control", "set_theme dark")
+    check("ui_control set_theme dark", res.get("theme_name") == "dark", str(res))
+    _, res = await dispatch("ui_control", "set_theme not_a_real_theme")
+    check("ui_control unknown theme -> error", "error" in res, str(res))
+
+    # 3) manage_memory: add -> list -> search (real MemoryManager + temp files)
+    _, res = await dispatch("manage_memory", "add\nUser prefers dark mode and Python\npreference")
+    check("manage_memory add returns id", bool(res.get("memory_id")), str(res))
+    _, res = await dispatch("manage_memory", "list")
+    check("manage_memory list shows entry", "dark mode" in res.get("results", ""), str(res))
+    _, res = await dispatch("manage_memory", "search\nPython")
+    check("manage_memory search finds entry", "Python" in res.get("results", ""), str(res))
+
+    # 4) create_session -> list_sessions -> manage_session rename -> delete
+    _, res = await dispatch("create_session", "Smoke Chat\nfake-model")
+    sid = res.get("session_id")
+    check("create_session returns id", bool(sid), str(res))
+    check("create_session persisted to manager", session_manager.get_session(sid) is not None)
+
+    _, res = await dispatch("list_sessions", "")
+    check("list_sessions shows new session", sid in res.get("results", ""), str(res)[:200])
+
+    _, res = await dispatch("manage_session", f"rename\n{sid}\nRenamed Smoke Chat")
+    check("manage_session rename ok", res.get("action") == "rename", str(res))
+    check("rename reflected in manager",
+          session_manager.get_session(sid).name == "Renamed Smoke Chat")
+
+    _, res = await dispatch("manage_session", "list")
+    check("manage_session list delegates", "Renamed Smoke Chat" in res.get("results", ""), str(res)[:200])
+
+    _, res = await dispatch("manage_session", f"delete\n{sid}")
+    check("manage_session delete ok", res.get("action") == "delete", str(res))
+    # get_session raises KeyError once a session is gone — absence from the
+    # user's session map is the reliable "deleted" signal.
+    check("session actually deleted", sid not in session_manager.get_sessions_for_user(OWNER))
+
+    # 5) list_models (mocked endpoint listing, real formatting)
+    _, res = await dispatch("list_models", "")
+    check("list_models lists fake-model", "fake-model" in res.get("results", ""), str(res)[:200])
+
+    # 6) chat_with_model (mocked llm, real truncation/result shaping)
+    _, res = await dispatch("chat_with_model", "fake-model\nHello there")
+    check("chat_with_model returns response", res.get("response") == "FAKE-LLM-RESPONSE", str(res))
+
+    # 7) pipeline (mocked llm, real step chaining)
+    _, res = await dispatch("pipeline", "fake-model | draft\nfake-model | refine")
+    check("pipeline runs 2 steps", len(res.get("steps", [])) == 2, str(res)[:200])
+
+    # 8) unknown tool -> graceful error
+    _, res = await dispatch("does_not_exist", "")
+    check("unknown tool -> error dict", "error" in res, str(res))
+
+
+def main():
+    print(f"Smoke DB: {os.environ['DATABASE_URL']}")
+    sm, mm = setup()
+    asyncio.run(run(sm, mm))
+    print(f"\nSmoke result: {_passed} passed, {_failed} failed")
+    sys.exit(1 if _failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -626,40 +626,18 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
             provider = _detect_provider(base)
             headers = build_headers(ep.api_key, base)
 
-            if provider == "anthropic":
-                # Anthropic: match against hardcoded model list
-                matched = None
-                for am in ANTHROPIC_MODELS:
-                    if model_name.lower() in am.lower() or am.lower() in model_name.lower():
-                        matched = am
-                        break
-                if matched:
-                    return build_chat_url(base), matched, headers
-            else:
-                # OpenAI-compatible and native Ollama: probe the provider's model list.
-                try:
-                    r = httpx.get(build_models_url(base), headers=headers, timeout=HTTP_TIMEOUT_MODEL_LIST)
-                    r.raise_for_status()
-                    data = r.json()
-                    model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
-                    if not model_ids:
-                        model_ids = [
-                            m.get("name") or m.get("model")
-                            for m in (data.get("models") or [])
-                            if m.get("name") or m.get("model")
-                        ]
-                except Exception:
-                    model_ids = []
+            model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
 
-                # Exact match first
-                for mid in model_ids:
-                    if mid.lower() == model_name.lower():
-                        return build_chat_url(base), mid, headers
+            # Filter out the offline sentinel so we don't match it
+            model_ids = [m for m in model_ids if m != "(endpoint offline)"]
 
-                # Partial match
-                for mid in model_ids:
-                    if model_name.lower() in mid.lower() or mid.lower() in model_name.lower():
-                        return build_chat_url(base), mid, headers
+            # Exact match first, then partial match
+            for mid in model_ids:
+                if mid.lower() == model_name.lower():
+                    return build_chat_url(base), mid, headers
+            for mid in model_ids:
+                if model_name.lower() in mid.lower() or mid.lower() in model_name.lower():
+                    return build_chat_url(base), mid, headers
 
         raise ValueError(f"Model '{spec}' not found on any configured endpoint")
     finally:
@@ -1599,14 +1577,15 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
     Content = optional filter keyword.
     """
     import httpx
-    from src.database import SessionLocal, ModelEndpoint
+    from src.database import ModelEndpoint
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
 
     keyword = content.strip().lower() if content.strip() else None
 
-    db = SessionLocal()
     try:
-        endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+        with get_db_session() as db:
+            endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+
         if not endpoints:
             return {"results": "No enabled model endpoints configured."}
 
@@ -1618,26 +1597,13 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
             provider = _detect_provider(base)
             headers = build_headers(ep.api_key, base)
 
-            model_ids = []
-            if provider == "anthropic":
-                model_ids = list(ANTHROPIC_MODELS)
-            else:
-                try:
-                    r = httpx.get(build_models_url(base), headers=headers, timeout=HTTP_TIMEOUT_MODEL_LIST)
-                    r.raise_for_status()
-                    data = r.json()
-                    model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
-                    if not model_ids:
-                        model_ids = [
-                            m.get("name") or m.get("model")
-                            for m in (data.get("models") or [])
-                            if m.get("name") or m.get("model")
-                        ]
-                except Exception:
-                    model_ids = ["(endpoint offline)"]
+            model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
 
             if keyword:
-                model_ids = [m for m in model_ids if keyword in m.lower() or keyword in (ep.name or "").lower()]
+                model_ids = [
+                    m for m in model_ids
+                    if keyword in m.lower() or keyword in (ep.name or "").lower()
+                ]
 
             if model_ids:
                 result_lines.append(f"\n**{ep.name or base}** ({provider}):")
@@ -1648,13 +1614,37 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
         if not result_lines:
             return {"results": "No models found" + (f" matching '{keyword}'" if keyword else "") + "."}
 
-        header = f"Available models ({total_models} total):"
-        return {"results": header + "\n".join(result_lines)}
+        return {"results": f"Available models ({total_models} total):" + "\n".join(result_lines)}
+
     except Exception as e:
         logger.error(f"list_models failed: {e}")
         return {"error": str(e)}
-    finally:
-        db.close()
+
+
+def _fetch_endpoint_model_ids(base: str, headers: Dict, provider: str, anthropic_models) -> list:
+    """Probe an endpoint and return its model IDs.
+
+    Returns a list of model ID strings, or ["(endpoint offline)"] on failure.
+    """
+    import httpx
+
+    if provider == "anthropic":
+        return list(anthropic_models)
+
+    try:
+        r = httpx.get(build_models_url(base), headers=headers, timeout=HTTP_TIMEOUT_MODEL_LIST)
+        r.raise_for_status()
+        data = r.json()
+        model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
+        if not model_ids:
+            model_ids = [
+                m.get("name") or m.get("model")
+                for m in (data.get("models") or [])
+                if m.get("name") or m.get("model")
+            ]
+        return model_ids or ["(endpoint offline)"]
+    except Exception:
+        return ["(endpoint offline)"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -299,7 +299,7 @@ def is_valid_hex_color(value: str) -> bool:
     return bool(re.match(r'^#[0-9a-fA-F]{6}$', value))
 
 
-async def resolve_model_safe(model_spec: str) -> Tuple[Optional[str], Optional[str], Optional[Dict], Optional[Dict]]:
+def resolve_model_safe(model_spec: str) -> Tuple[Optional[str], Optional[str], Optional[Dict], Optional[Dict]]:
     """Resolve model spec or return error dict.
 
     Wraps _resolve_model with error handling.
@@ -477,7 +477,7 @@ def _image_save_to_gallery(
         return ""
 
 
-async def _image_save_b64(
+def _image_save_b64(
     b64_data: str, prompt: str, model_id: str, size: str, quality: str,
     session_id: Optional[str], owner: Optional[str],
 ) -> tuple:
@@ -677,7 +677,7 @@ def _match_model_id(model_name: str, model_ids: List[str]) -> Optional[str]:
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_chat_with_model(content: str) -> Dict:
     """Send a message to a specific model and return its response.
 
     Content format:
@@ -716,7 +716,7 @@ async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> 
 _TEACHER_SYSTEM_PROMPT = TEACHER_SYSTEM_PROMPT
 
 
-async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_ask_teacher(content: str) -> Dict:
     """Ask a more capable model for help.
 
     Content format:
@@ -878,7 +878,7 @@ async def _second_opinion_unify(sess, context_text: str, reviewer_model: str, re
         return original_model, f"(Failed to get unified response: {e})"
 
 
-async def do_create_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
+def do_create_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Create a new chat session.
 
     Content format:
@@ -929,7 +929,7 @@ async def do_create_session(content: str, session_id: Optional[str] = None, owne
         return {"error": f"Failed to create session: {e}"}
 
 
-async def do_list_sessions(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
+def do_list_sessions(content: str, owner: Optional[str] = None) -> Dict:
     """List sessions sorted by most-recently-active first.
 
     Output includes a relative "last active" timestamp per row so the
@@ -1108,7 +1108,7 @@ async def stream_ai_tool(tool: str, content: str, session_id: Optional[str] = No
     yield {"_final": True, "desc": desc, "result": result}
 
 
-async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_pipeline(content: str) -> Dict:
     """Execute a multi-step pipeline where each model's output feeds the next.
 
     Content format (JSON):
@@ -1192,7 +1192,7 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
 # Session management tool
 # ---------------------------------------------------------------------------
 
-async def do_manage_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
+def do_manage_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Manage sessions: list, switch, rename, archive, unarchive, delete, important, truncate, fork.
 
     Accepts both JSON format ({action, session_id, value}) and line format:
@@ -1209,7 +1209,7 @@ async def do_manage_session(content: str, session_id: Optional[str] = None, owne
         return {"error": "Missing action (rename|archive|delete|important|truncate|fork|list|switch)"}
 
     if action == "list":
-        return await do_list_sessions(list_filter, session_id, owner=owner)
+        return do_list_sessions(list_filter, owner=owner)
 
     if not target_sid:
         return {"error": "Need a session_id (or 'current' for the active chat)"}
@@ -1218,7 +1218,7 @@ async def do_manage_session(content: str, session_id: Optional[str] = None, owne
         target_sid = session_id
 
     try:
-        return await _dispatch_session_action(action, target_sid, value, session_id, owner)
+        return _dispatch_session_action(action, target_sid, value, session_id, owner)
     except Exception as e:
         logger.error(f"manage_session failed: {e}")
         return {"error": str(e)}
@@ -1279,7 +1279,7 @@ def _parse_session_lines(raw: str) -> Tuple[str, str, Optional[str], str]:
     return action, target_sid, value, list_filter
 
 
-async def _dispatch_session_action(
+def _dispatch_session_action(
     action: str,
     target_sid: str,
     value: Optional[str],
@@ -1322,7 +1322,7 @@ async def _dispatch_session_action(
             return _session_action_truncate(db_sess, target_sid, value)
 
         if action == "fork":
-            return await _session_action_fork(db_sess, target_sid, value, owner)
+            return _session_action_fork(db_sess, target_sid, value, owner)
 
         return {"error": f"Unknown action '{action}'. Use: {_VALID}"}
 
@@ -1426,7 +1426,7 @@ def _session_action_truncate(db_sess, target_sid: str, value: Optional[str]) -> 
     return {"error": f"Failed to truncate session '{target_sid}'"}
 
 
-async def _session_action_fork(db_sess, target_sid: str, value: Optional[str], owner: Optional[str]) -> Dict:
+def _session_action_fork(db_sess, target_sid: str, value: Optional[str], owner: Optional[str]) -> Dict:
     """Fork a session, copying messages into a new session."""
     if not db_sess:
         return _session_not_found_error(target_sid)
@@ -1478,7 +1478,7 @@ async def _session_action_fork(db_sess, target_sid: str, value: Optional[str], o
 # Memory management tool
 # ---------------------------------------------------------------------------
 
-async def do_manage_memory(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
+def do_manage_memory(content: str, owner: Optional[str] = None) -> Dict:
     """Manage memories: list, add, edit, delete, search.
 
     Content format:
@@ -1671,7 +1671,7 @@ def _fire_memory_event(event: str, owner: Optional[str]) -> None:
 # List models tool
 # ---------------------------------------------------------------------------
 
-async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict:
+def do_list_models(content: str) -> Dict:
     """List all available models across configured endpoints.
 
     Content = optional filter keyword.
@@ -1764,7 +1764,7 @@ def _fetch_endpoint_model_ids(base: str, headers: Dict, provider: str, anthropic
 # RAG management tool
 # ---------------------------------------------------------------------------
 
-async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
+def do_manage_rag(content: str) -> Dict:
     """Manage RAG indexed documents: list, add_directory, remove_directory.
 
     Content format:
@@ -1871,7 +1871,7 @@ def _rag_action_remove_directory(lines: list) -> Dict:
 # UI control tool (returns events for frontend to apply)
 # ---------------------------------------------------------------------------
 
-async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
+def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
     """Control frontend UI: toggle settings, switch model, change theme.
 
     Content format:
@@ -1914,7 +1914,7 @@ async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
     }
 
     if action == "switch_model":
-        return await _ui_handle_switch_model(parts, lines, session_id)
+        return _ui_handle_switch_model(parts, lines, session_id)
 
     handler = _HANDLERS.get(action)
     if handler:
@@ -1957,7 +1957,7 @@ def _ui_handle_set_mode(parts: list, lines: list) -> Dict:
     }
 
 
-async def _ui_handle_switch_model(parts: list, lines: list, session_id: Optional[str]) -> Dict:
+def _ui_handle_switch_model(parts: list, lines: list, session_id: Optional[str]) -> Dict:
     """Handle switch_model — validate and apply a model change to the current session."""
     model_spec = " ".join(parts[1:]) if len(parts) > 1 else ""
     if not model_spec:
@@ -2289,7 +2289,7 @@ async def _image_persist_result(
 ) -> Dict:
     """Persist a returned image (b64 or url) and build the tool result dict."""
     if img.get("b64_json"):
-        image_url, image_id = await _image_save_b64(
+        image_url, image_id = _image_save_b64(
             img["b64_json"], prompt, model_id, size, quality, session_id, owner
         )
     elif img.get("url"):
@@ -2320,19 +2320,20 @@ async def dispatch_ai_tool(
 ) -> Tuple[str, Dict]:
     """Dispatch an AI interaction tool. Returns (description, result_dict).
 
-    Each entry in _TOOL_REGISTRY is:
-        tool_name -> (handler_coro, desc_fn)
-    where desc_fn(content) produces the human-readable description string.
+    Each entry in _TOOL_REGISTRY maps a tool name to
+    ``(handler_factory, description_factory)``. Handlers may be sync or async;
+    the result is awaited only when it is actually awaitable, so handlers that
+    do no I/O can stay plain functions.
     """
-    # Registry: tool name → (coroutine_factory, description_factory)
-    # desc_fn receives raw content and returns a short label for the UI.
+    import inspect
+
     _TOOL_REGISTRY = {
         "chat_with_model": (
-            lambda c: do_chat_with_model(c, session_id),
+            lambda c: do_chat_with_model(c),
             lambda c: f"chat_with_model: {get_first_line(c, 60)}",
         ),
         "ask_teacher": (
-            lambda c: do_ask_teacher(c, session_id),
+            lambda c: do_ask_teacher(c),
             lambda c: f"ask_teacher: {get_first_line(c, 60)}",
         ),
         "second_opinion": (
@@ -2344,7 +2345,7 @@ async def dispatch_ai_tool(
             lambda c: f"create_session: {get_first_line(c, 60)}",
         ),
         "list_sessions": (
-            lambda c: do_list_sessions(c, session_id, owner=owner),
+            lambda c: do_list_sessions(c, owner=owner),
             lambda c: f"list_sessions{': ' + c.strip()[:40] if c.strip() else ''}",
         ),
         "send_to_session": (
@@ -2356,15 +2357,15 @@ async def dispatch_ai_tool(
             lambda c: f"manage_session: {get_action_from_content(c)}",
         ),
         "pipeline": (
-            lambda c: do_pipeline(c, session_id),
+            lambda c: do_pipeline(c),
             lambda c: "pipeline: running steps",
         ),
         "manage_memory": (
-            lambda c: do_manage_memory(c, session_id, owner=owner),
+            lambda c: do_manage_memory(c, owner=owner),
             lambda c: f"manage_memory: {get_action_from_content(c)}",
         ),
         "list_models": (
-            lambda c: do_list_models(c, session_id),
+            lambda c: do_list_models(c),
             lambda c: f"list_models{': ' + c.strip()[:40] if c.strip() else ''}",
         ),
         "ui_control": (
@@ -2382,5 +2383,7 @@ async def dispatch_ai_tool(
 
     handler_factory, desc_factory = _TOOL_REGISTRY[tool]
     desc = desc_factory(content)
-    result = await handler_factory(content)
+    result = handler_factory(content)
+    if inspect.isawaitable(result):
+        result = await result
     return desc, result

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -925,15 +925,7 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
                     f"(showing first {SESSION_LIST_DISPLAY_LIMIT})"
                 )
                 break
-            safe_name = (sess.name or "Untitled").replace("[", "\\[").replace("]", "\\]")
-            msg_count = getattr(sess, "message_count", 0) or 0
-            model = getattr(sess, "model", "unknown")
-            marker = " ← most recent" if i == 0 else ""
-            lines.append(
-                f"- **[{safe_name}](#session-{sid})** "
-                f"(id: `{sid}`, model: {model}, {msg_count} msgs, "
-                f"last active {_session_relative_time(ts)}){marker}"
-            )
+            lines.append(_format_session_row(i, ts, sid, sess))
 
         if not lines:
             suffix = f" matching '{keyword}'" if keyword else ""
@@ -960,6 +952,19 @@ def _session_best_timestamp(db_row) -> Optional[object]:
         getattr(db_row, "last_accessed", None)
         or getattr(db_row, "updated_at", None)
         or getattr(db_row, "created_at", None)
+    )
+
+
+def _format_session_row(index: int, ts, sid: str, sess) -> str:
+    """Format a single session as a markdown list row for list_sessions."""
+    safe_name = (sess.name or "Untitled").replace("[", "\\[").replace("]", "\\]")
+    msg_count = getattr(sess, "message_count", 0) or 0
+    model = getattr(sess, "model", "unknown")
+    marker = " ← most recent" if index == 0 else ""
+    return (
+        f"- **[{safe_name}](#session-{sid})** "
+        f"(id: `{sid}`, model: {model}, {msg_count} msgs, "
+        f"last active {_session_relative_time(ts)}){marker}"
     )
 
 
@@ -1179,29 +1184,46 @@ def _parse_manage_session_input(content: str) -> Tuple[str, str, Optional[str], 
     """Parse do_manage_session content from JSON or line format.
 
     Returns:
-        Tuple of (action, target_sid, value, list_filter) — all str or None.
+        Tuple of (action, target_sid, value, list_filter).
     """
     raw = (content or "").strip()
 
     if raw.startswith("{"):
-        try:
-            parsed = json.loads(raw)
-        except Exception:
-            parsed = None
+        parsed = _parse_session_json(raw)
+        if parsed is not None:
+            return parsed
 
-        if isinstance(parsed, dict):
-            action = str(parsed.get("action") or "").strip().lower()
-            target_sid = str(
-                parsed.get("session_id") or parsed.get("session") or parsed.get("id") or ""
-            ).strip()
-            v = parsed.get("value")
-            if v is None:
-                v = (parsed.get("name") or parsed.get("new_name")
-                     or parsed.get("title") or parsed.get("keep_count"))
-            value = None if v is None else str(v).strip()
-            list_filter = str(parsed.get("filter") or "").strip()
-            return action, target_sid, value, list_filter
+    return _parse_session_lines(raw)
 
+
+def _parse_session_json(raw: str) -> Optional[Tuple[str, str, Optional[str], str]]:
+    """Parse the structured JSON form of a manage_session command.
+
+    Returns the parsed 4-tuple, or None if the text is not a JSON object.
+    """
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+
+    action = str(parsed.get("action") or "").strip().lower()
+    target_sid = str(
+        parsed.get("session_id") or parsed.get("session") or parsed.get("id") or ""
+    ).strip()
+    v = parsed.get("value")
+    if v is None:
+        v = (parsed.get("name") or parsed.get("new_name")
+             or parsed.get("title") or parsed.get("keep_count"))
+    value = None if v is None else str(v).strip()
+    list_filter = str(parsed.get("filter") or "").strip()
+    return action, target_sid, value, list_filter
+
+
+def _parse_session_lines(raw: str) -> Tuple[str, str, Optional[str], str]:
+    """Parse the legacy line-based form of a manage_session command."""
     lines = raw.split("\n")
     if not lines or not lines[0].strip():
         return "", "", None, ""
@@ -1611,7 +1633,7 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
     Content = optional filter keyword.
     """
     from src.database import ModelEndpoint
-    from src.llm_core import _detect_provider, ANTHROPIC_MODELS
+    from src.llm_core import ANTHROPIC_MODELS
 
     keyword = content.strip().lower() if content.strip() else None
 
@@ -1626,23 +1648,9 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
         total_models = 0
 
         for ep in endpoints:
-            base = _normalize_base(ep.base_url)
-            provider = _detect_provider(base)
-            headers = build_headers(ep.api_key, base)
-
-            model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
-
-            if keyword:
-                model_ids = [
-                    m for m in model_ids
-                    if keyword in m.lower() or keyword in (ep.name or "").lower()
-                ]
-
-            if model_ids:
-                result_lines.append(f"\n**{ep.name or base}** ({provider}):")
-                for mid in model_ids:
-                    result_lines.append(f"  - `{mid}`")
-                    total_models += 1
+            ep_lines, count = _format_endpoint_models(ep, keyword, ANTHROPIC_MODELS)
+            result_lines.extend(ep_lines)
+            total_models += count
 
         if not result_lines:
             return {"results": "No models found" + (f" matching '{keyword}'" if keyword else "") + "."}
@@ -1652,6 +1660,34 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
     except Exception as e:
         logger.error(f"list_models failed: {e}")
         return {"error": str(e)}
+
+
+def _format_endpoint_models(ep, keyword: Optional[str], anthropic_models) -> Tuple[List[str], int]:
+    """Build the markdown lines + model count for a single endpoint.
+
+    Returns:
+        (lines, count) — empty list and 0 when the endpoint has no matching models.
+    """
+    from src.llm_core import _detect_provider
+
+    base = _normalize_base(ep.base_url)
+    provider = _detect_provider(base)
+    headers = build_headers(ep.api_key, base)
+
+    model_ids = _fetch_endpoint_model_ids(base, headers, provider, anthropic_models)
+
+    if keyword:
+        model_ids = [
+            m for m in model_ids
+            if keyword in m.lower() or keyword in (ep.name or "").lower()
+        ]
+
+    if not model_ids:
+        return [], 0
+
+    lines = [f"\n**{ep.name or base}** ({provider}):"]
+    lines.extend(f"  - `{mid}`" for mid in model_ids)
+    return lines, len(model_ids)
 
 
 def _fetch_endpoint_model_ids(base: str, headers: Dict, provider: str, anthropic_models) -> list:
@@ -2088,18 +2124,16 @@ def _ui_handle_get_toggles(parts: list, lines: list) -> Dict:
 # Image generation
 # ---------------------------------------------------------------------------
 
-async def do_generate_image(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
-    """Generate an image using an image-capable model (e.g. gpt-image-1).
+def _image_parse_request(content: str):
+    """Parse a generate_image request: prompt, model, size, quality.
 
-    Content format:
-      Line 1: prompt describing the image
-      Line 2: model name (optional, auto-detects if omitted)
-      Line 3: size (optional, defaults to 1024x1024)
-      Line 4: quality (optional: low, medium, high, auto — defaults to medium)
+    Applies admin-configured defaults and auto-detects a model when omitted.
+
+    Returns:
+        (prompt, model_spec, size, quality) tuple on success,
+        or an error dict if the prompt is missing or no model is available.
     """
-    import httpx
-
-    lines = content.strip().split(chr(10)) if content.strip() else []
+    lines = content.strip().split("\n") if content.strip() else []
     prompt = lines[0].strip() if lines else ""
     if not prompt:
         return {"error": "Image prompt is required (line 1)"}
@@ -2108,7 +2142,6 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     size = lines[2].strip() if len(lines) > 2 and lines[2].strip() else _DEFAULT_IMAGE_SIZE
     quality = lines[3].strip() if len(lines) > 3 and lines[3].strip() else "medium"
 
-    # Apply admin-configured defaults when caller did not specify
     try:
         from src.settings import load_settings
         settings = load_settings()
@@ -2120,11 +2153,41 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     if quality == "medium" and settings.get("image_quality"):
         quality = settings["image_quality"]
 
-    # Auto-detect the best available image model
     if not model_spec:
         model_spec = _image_auto_detect_model_spec()
     if not model_spec:
         return {"error": "No image model found. Configure one in Admin → Image Generation."}
+
+    return prompt, model_spec, size, quality
+
+
+def _image_extract_api_error(resp) -> str:
+    """Extract a human-readable error message from a failed image API response."""
+    error_text = resp.text[:ERROR_TEXT_DISPLAY_LIMIT]
+    try:
+        err_obj = resp.json().get("error", error_text)
+        if isinstance(err_obj, dict):
+            return err_obj.get("message", error_text)
+        return str(err_obj)
+    except Exception:
+        return error_text
+
+
+async def do_generate_image(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
+    """Generate an image using an image-capable model (e.g. gpt-image-1).
+
+    Content format:
+      Line 1: prompt describing the image
+      Line 2: model name (optional, auto-detects if omitted)
+      Line 3: size (optional, defaults to 1024x1024)
+      Line 4: quality (optional: low, medium, high, auto — defaults to medium)
+    """
+    import httpx
+
+    parsed = _image_parse_request(content)
+    if isinstance(parsed, dict):  # error
+        return parsed
+    prompt, model_spec, size, quality = parsed
 
     try:
         url, model_id, headers = _resolve_model(model_spec)
@@ -2151,45 +2214,47 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
             resp = await client.post(images_url, json=payload, headers=headers)
 
         if resp.status_code != 200:
-            error_text = resp.text[:ERROR_TEXT_DISPLAY_LIMIT]
-            try:
-                err_obj = resp.json().get("error", error_text)
-                error_text = err_obj.get("message", error_text) if isinstance(err_obj, dict) else str(err_obj)
-            except Exception:
-                pass
-            return {"error": f"Image generation failed ({resp.status_code}): {error_text}"}
+            return {"error": f"Image generation failed ({resp.status_code}): {_image_extract_api_error(resp)}"}
 
         images = resp.json().get("data", [])
         if not images:
             return {"error": "No images returned from API"}
 
-        img = images[0]
-
-        if img.get("b64_json"):
-            image_url, image_id = await _image_save_b64(
-                img["b64_json"], prompt, model_id, size, effective_quality, session_id, owner
-            )
-        elif img.get("url"):
-            image_url, image_id = await _image_download_and_save(
-                img["url"], prompt, model_id, size, effective_quality, session_id, owner
-            )
-        else:
-            return {"error": "Image API returned unexpected format (no b64_json or url)"}
-
-        return {
-            "results": f"Generated image for: {prompt[:100]}",
-            "image_url": image_url,
-            "image_id": image_id,
-            "image_prompt": prompt,
-            "image_model": model_id,
-            "image_size": size,
-            "image_quality": effective_quality,
-        }
+        return await _image_persist_result(
+            images[0], prompt, model_id, size, effective_quality, session_id, owner
+        )
 
     except httpx.TimeoutException:
         return {"error": "Image generation timed out (300s). The model may be overloaded — try again or use quality=low."}
     except Exception as e:
         return {"error": f"Image generation error: {str(e)}"}
+
+
+async def _image_persist_result(
+    img: Dict, prompt: str, model_id: str, size: str, quality: str,
+    session_id: Optional[str], owner: Optional[str],
+) -> Dict:
+    """Persist a returned image (b64 or url) and build the tool result dict."""
+    if img.get("b64_json"):
+        image_url, image_id = await _image_save_b64(
+            img["b64_json"], prompt, model_id, size, quality, session_id, owner
+        )
+    elif img.get("url"):
+        image_url, image_id = await _image_download_and_save(
+            img["url"], prompt, model_id, size, quality, session_id, owner
+        )
+    else:
+        return {"error": "Image API returned unexpected format (no b64_json or url)"}
+
+    return {
+        "results": f"Generated image for: {prompt[:100]}",
+        "image_url": image_url,
+        "image_id": image_id,
+        "image_prompt": prompt,
+        "image_model": model_id,
+        "image_size": size,
+        "image_quality": quality,
+    }
 
 
 

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -36,6 +36,12 @@ CONTEXT_MESSAGE_TEXT_LIMIT = 2000       # Max chars per message in context
 SESSION_LIST_DISPLAY_LIMIT = 50         # Max sessions to show in list_sessions
 SESSION_TRUNCATE_DEFAULT_KEEP = 10      # Default messages to keep when truncating
 
+# ─ Reused Error / Event Strings ───────────────────────────────────────
+ERR_NO_SESSION_MANAGER = "Session manager not available"
+ERR_NO_ACTION = "No action specified"
+ENDPOINT_OFFLINE = "(endpoint offline)"
+EVENT_SESSION_CREATED = "session_created"
+
 # ─ ID & Display Limits ────────────────────────────────────────────────
 UUID_SHORT_ID_LENGTH = 8                # Length of short session/memory IDs
 MEMORY_LIST_DISPLAY_LIMIT = 100         # Max memories to show in list
@@ -417,7 +423,7 @@ def _image_auto_detect_model_spec() -> str:
         _idb = _ISL()
         try:
             eps = _idb.query(_IME).filter(
-                _IME.is_enabled == True,
+                _IME.is_enabled.is_(True),
                 _IME.model_type == "image",
             ).all()
             for ep in eps:
@@ -446,7 +452,7 @@ def _image_save_to_gallery(
 ) -> str:
     """Insert a GalleryImage row and return the new UUID (or '' on failure)."""
     try:
-        from src.database import SessionLocal as _GSL, GalleryImage
+        from src.database import GalleryImage
         new_id = str(uuid.uuid4())
         with get_db_session() as db:
             db.add(GalleryImage(
@@ -533,8 +539,7 @@ def _pipeline_parse_steps(content: str) -> Tuple[Optional[List[Dict]], Optional[
     steps = None
     if stripped.startswith(("{", "[")):
         try:
-            import json as _json
-            data = _json.loads(stripped)
+            data = json.loads(stripped)
             steps = data.get("steps") if isinstance(data, dict) else data
         except (ValueError, TypeError):
             pass
@@ -596,8 +601,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
 
     Raises ValueError if model not found.
     """
-    import httpx
-    from src.database import SessionLocal, ModelEndpoint
+    from src.database import ModelEndpoint
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
 
     spec = spec.strip()
@@ -611,7 +615,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
         model_name = spec
 
     with get_db_session() as db:
-        query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled.is_(True))
         if target_endpoint_name:
             query = query.filter(ModelEndpoint.name.ilike(f"%{target_endpoint_name}%"))
         endpoints = query.all()
@@ -628,7 +632,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
         headers = build_headers(ep.api_key, base)
 
         model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
-        model_ids = [m for m in model_ids if m != "(endpoint offline)"]
+        model_ids = [m for m in model_ids if m != ENDPOINT_OFFLINE]
 
         for mid in model_ids:
             if mid.lower() == model_name.lower():
@@ -838,7 +842,7 @@ async def do_create_session(content: str, session_id: Optional[str] = None, owne
       Line 2: model_name (or model_name@endpoint_name)
     """
     if not _session_manager:
-        return {"error": "Session manager not available"}
+        return {"error": ERR_NO_SESSION_MANAGER}
 
     lines = content.strip().split("\n")
     if len(lines) < 2:
@@ -871,7 +875,7 @@ async def do_create_session(content: str, session_id: Optional[str] = None, owne
             sess.headers = headers
         try:
             from src.event_bus import fire_event
-            fire_event("session_created", owner)
+            fire_event(EVENT_SESSION_CREATED, owner)
         except Exception:
             logger.debug("session_created event dispatch failed", exc_info=True)
 
@@ -890,7 +894,7 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
     Content = optional filter keyword (matches session name).
     """
     if not _session_manager:
-        return {"error": "Session manager not available"}
+        return {"error": ERR_NO_SESSION_MANAGER}
 
     keyword = content.strip().lower() if content.strip() else None
 
@@ -1006,7 +1010,7 @@ async def do_send_to_session(content: str, session_id: Optional[str] = None) -> 
     from core.models import ChatMessage
 
     if not _session_manager:
-        return {"error": "Session manager not available"}
+        return {"error": ERR_NO_SESSION_MANAGER}
 
     lines = content.strip().split("\n", 1)
     if len(lines) < 2:
@@ -1148,7 +1152,7 @@ async def do_manage_session(content: str, session_id: Optional[str] = None, owne
       Line 3+: action-specific value (new name for rename, keep_count for truncate)
     """
     if not _session_manager:
-        return {"error": "Session manager not available"}
+        return {"error": ERR_NO_SESSION_MANAGER}
 
     action, target_sid, value, list_filter = _parse_manage_session_input(content)
 
@@ -1257,12 +1261,22 @@ async def _dispatch_session_action(
         return {"error": f"Unknown action '{action}'. Use: {_VALID}"}
 
 
+def _session_not_found_error(sid: str) -> Dict:
+    """Standard error dict for an unknown session id."""
+    return {"error": f"Session '{sid}' not found. Use list_sessions and pass the exact id it returned."}
+
+
+def _memory_not_found_error(mid: str) -> Dict:
+    """Standard error dict for an unknown memory id."""
+    return {"error": f"Memory '{mid}' not found"}
+
+
 def _session_action_view(target_sid: str, query_fn, action: str) -> Dict:
     """Return a clickable link so the user can navigate to the session."""
     with get_db_session() as db:
         db_sess = query_fn(db).first()
         if not db_sess:
-            return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+            return _session_not_found_error(target_sid)
         name = db_sess.name or target_sid
     return {
         "action": action,
@@ -1277,7 +1291,7 @@ def _session_action_rename(db, db_sess, target_sid: str, value: Optional[str]) -
     if not value:
         return {"error": "rename needs a new name (the `value` arg, or line 3 in the legacy format)"}
     if not db_sess:
-        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+        return _session_not_found_error(target_sid)
     db_sess.name = value
     db.commit()
     _session_manager.update_session_name(target_sid, value)
@@ -1289,7 +1303,7 @@ def _session_action_set_archived(db, db_sess, target_sid: str, archived: bool) -
     """Archive or unarchive a session."""
     action_word = "archive" if archived else "unarchive"
     if not db_sess:
-        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+        return _session_not_found_error(target_sid)
     db_sess.archived = archived
     db.commit()
     past = "archived" if archived else "unarchived"
@@ -1318,7 +1332,7 @@ def _session_action_delete(db_sess, target_sid: str, current_session_id: Optiona
 def _session_action_set_important(db, db_sess, target_sid: str, is_important: bool) -> Dict:
     """Star or unstar a session."""
     if not db_sess:
-        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+        return _session_not_found_error(target_sid)
     if not is_important and db_sess.is_important:
         return {"error": f"Session '{db_sess.name}' is starred by the user. Only the user can unstar sessions manually."}
     db_sess.is_important = is_important
@@ -1332,7 +1346,7 @@ def _session_action_set_important(db, db_sess, target_sid: str, is_important: bo
 def _session_action_truncate(db_sess, target_sid: str, value: Optional[str]) -> Dict:
     """Truncate a session to the last N messages."""
     if not db_sess:
-        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+        return _session_not_found_error(target_sid)
     keep_count = SESSION_TRUNCATE_DEFAULT_KEEP
     if value:
         try:
@@ -1349,7 +1363,7 @@ def _session_action_truncate(db_sess, target_sid: str, value: Optional[str]) -> 
 async def _session_action_fork(db_sess, target_sid: str, value: Optional[str], owner: Optional[str]) -> Dict:
     """Fork a session, copying messages into a new session."""
     if not db_sess:
-        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+        return _session_not_found_error(target_sid)
     keep_count = 0
     if value:
         try:
@@ -1381,7 +1395,7 @@ async def _session_action_fork(db_sess, target_sid: str, value: Optional[str], o
 
     try:
         from src.event_bus import fire_event
-        fire_event("session_created", owner)
+        fire_event(EVENT_SESSION_CREATED, owner)
     except Exception:
         logger.debug("session_created event dispatch failed", exc_info=True)
 
@@ -1491,14 +1505,14 @@ def _memory_action_edit(lines: list, owner: Optional[str]) -> Dict:
     for m in memories:
         if m.get("id", "").startswith(memory_id):
             if owner and m.get("owner") != owner:
-                return {"error": f"Memory '{memory_id}' not found"}
+                return _memory_not_found_error(memory_id)
             m["text"] = new_text
             m["timestamp"] = int(time.time())
             full_id = m["id"]
             break
 
     if not full_id:
-        return {"error": f"Memory '{memory_id}' not found"}
+        return _memory_not_found_error(memory_id)
 
     _memory_manager.save(memories)
     _memory_vector_add(full_id, new_text)
@@ -1519,13 +1533,13 @@ def _memory_action_delete(lines: list, owner: Optional[str]) -> Dict:
     for m in memories:
         if m.get("id", "").startswith(memory_id):
             if owner and m.get("owner") != owner:
-                return {"error": f"Memory '{memory_id}' not found"}
+                return _memory_not_found_error(memory_id)
             full_id = m["id"]
             break
 
     memories = [m for m in memories if m.get("id") != full_id]
     if len(memories) == original_len:
-        return {"error": f"Memory '{memory_id}' not found"}
+        return _memory_not_found_error(memory_id)
 
     _memory_manager.save(memories)
     _memory_vector_remove(full_id)
@@ -1596,7 +1610,6 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
 
     Content = optional filter keyword.
     """
-    import httpx
     from src.database import ModelEndpoint
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
 
@@ -1604,7 +1617,7 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
 
     try:
         with get_db_session() as db:
-            endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+            endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled.is_(True)).all()
 
         if not endpoints:
             return {"results": "No enabled model endpoints configured."}
@@ -1662,9 +1675,9 @@ def _fetch_endpoint_model_ids(base: str, headers: Dict, provider: str, anthropic
                 for m in (data.get("models") or [])
                 if m.get("name") or m.get("model")
             ]
-        return model_ids or ["(endpoint offline)"]
+        return model_ids or [ENDPOINT_OFFLINE]
     except Exception:
-        return ["(endpoint offline)"]
+        return [ENDPOINT_OFFLINE]
 
 
 # ---------------------------------------------------------------------------
@@ -1680,7 +1693,7 @@ async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
     """
     lines = content.strip().split("\n") if content.strip() else []
     if not lines:
-        return {"error": "No action specified"}
+        return {"error": ERR_NO_ACTION}
 
     action = lines[0].strip().lower()
 
@@ -1799,12 +1812,12 @@ async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
     """
     stripped = content.strip()
     if not stripped:
-        return {"error": "No action specified"}
+        return {"error": ERR_NO_ACTION}
 
     lines = stripped.split("\n")
     parts = lines[0].strip().split(None, 2)
     if not parts:
-        return {"error": "No action specified"}
+        return {"error": ERR_NO_ACTION}
 
     action = parts[0].lower()
 
@@ -1878,7 +1891,7 @@ async def _ui_handle_switch_model(parts: list, lines: list, session_id: Optional
         return {"error": str(e)}
 
     if session_id and _session_manager:
-        from src.database import SessionLocal as _SL, Session as _DbSess
+        from src.database import Session as _DbSess
         with get_db_session() as db:
             db_s = db.query(_DbSess).filter(_DbSess.id == session_id).first()
             if db_s:

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -1206,159 +1206,185 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
       Line 2+: action-specific params
 
     Actions:
-      list                    — list all memories (optional line 2: category filter)
-      add                     — line 2: text, optional line 3: category (fact|event|contact|preference)
-      edit                    — line 2: memory_id, line 3: new text
-      delete                  — line 2: memory_id
-      search                  — line 2: query
+      list   [category]      — list memories, optionally filtered by category
+      add    <text> [cat]    — add a memory; cat defaults to 'fact'
+      edit   <id> <new_text> — update memory text
+      delete <id>            — remove a memory
+      search <query>         — full-text or vector search
     """
     if not _memory_manager:
         return {"error": "Memory manager not available"}
 
-    lines = content.strip().split("\n")
+    lines = content.strip().split("\n") if content.strip() else []
     if not lines:
         return {"error": "Need at least 1 line: action"}
 
     action = lines[0].strip().lower()
 
-    if action == "list":
-        category_filter = lines[1].strip().lower() if len(lines) > 1 and lines[1].strip() else None
-        memories = _memory_manager.load(owner=owner)
-        if category_filter:
-            memories = [m for m in memories if m.get("category", "").lower() == category_filter]
-        if not memories:
-            return {"results": "No memories found" + (f" in category '{category_filter}'" if category_filter else "") + "."}
-        result_lines = [f"Found {len(memories)} memory entries:\n"]
-        for m in memories[:MEMORY_LIST_DISPLAY_LIMIT]:
-            cat = m.get("category", "fact")
-            mid = m.get("id", "?")[:8]
-            text = m.get("text", "")
-            if len(text) > MEMORY_TEXT_PREVIEW_LIMIT:
-                text = text[:MEMORY_TEXT_PREVIEW_LIMIT] + "..."
-            result_lines.append(f"- [{cat}] `{mid}` — {text}")
-        if len(memories) > MEMORY_LIST_DISPLAY_LIMIT:
-            result_lines.append(f"... and {len(memories) - MEMORY_LIST_DISPLAY_LIMIT} more")  # noqa
-        return {"results": "\n".join(result_lines)}
+    _HANDLERS = {
+        "list": _memory_action_list,
+        "add": _memory_action_add,
+        "edit": _memory_action_edit,
+        "delete": _memory_action_delete,
+        "search": _memory_action_search,
+    }
 
-    elif action == "add":
-        if len(lines) < 2:
-            return {"error": "Add needs line 2: memory text"}
-        text = lines[1].strip()
-        category = lines[2].strip().lower() if len(lines) > 2 and lines[2].strip() else "fact"
-        if not text:
-            return {"error": "Memory text cannot be empty"}
+    handler = _HANDLERS.get(action)
+    if not handler:
+        valid = ", ".join(sorted(_HANDLERS))
+        return {"error": f"Unknown action '{action}'. Use: {valid}"}
 
-        entry = _memory_manager.add_entry(text, source="ai_agent", category=category, owner=owner)
-        memories = _memory_manager.load_all()
-        memories.append(entry)
-        _memory_manager.save(memories)
+    return handler(lines, owner)
 
-        # Update vector index if available
-        if _memory_vector and hasattr(_memory_vector, 'healthy') and _memory_vector.healthy:
-            try:
-                _memory_vector.add(entry["id"], text)
-            except Exception:
-                pass
-        try:
-            from src.event_bus import fire_event
-            fire_event("memory_added", owner)
-        except Exception:
-            logger.debug("memory_added event dispatch failed", exc_info=True)
 
-        return {"action": "add", "memory_id": entry["id"],
-                "results": f"Memory added: [{category}] {text}"}
+def _memory_action_list(lines: list, owner: Optional[str]) -> Dict:
+    """List memories, optionally filtered by category."""
+    category_filter = lines[1].strip().lower() if len(lines) > 1 and lines[1].strip() else None
+    memories = _memory_manager.load(owner=owner)
+    if category_filter:
+        memories = [m for m in memories if m.get("category", "").lower() == category_filter]
+    if not memories:
+        suffix = f" in category '{category_filter}'" if category_filter else ""
+        return {"results": f"No memories found{suffix}."}
 
-    elif action == "edit":
-        if len(lines) < 3:
-            return {"error": "Edit needs line 2: memory_id, line 3: new text"}
-        memory_id = lines[1].strip()
-        new_text = lines[2].strip()
-        if not new_text:
-            return {"error": "New text cannot be empty"}
+    result_lines = [f"Found {len(memories)} memory entries:\n"]
+    for m in memories[:MEMORY_LIST_DISPLAY_LIMIT]:
+        cat = m.get("category", "fact")
+        mid = m.get("id", "?")[:UUID_SHORT_ID_LENGTH]
+        text = m.get("text", "")
+        if len(text) > MEMORY_TEXT_PREVIEW_LIMIT:
+            text = text[:MEMORY_TEXT_PREVIEW_LIMIT] + "..."
+        result_lines.append(f"- [{cat}] `{mid}` — {text}")
+    if len(memories) > MEMORY_LIST_DISPLAY_LIMIT:
+        result_lines.append(f"... and {len(memories) - MEMORY_LIST_DISPLAY_LIMIT} more")
+    return {"results": "\n".join(result_lines)}
 
-        memories = _memory_manager.load_all()
-        found = False
-        for m in memories:
-            if m.get("id", "").startswith(memory_id):
-                # Verify ownership
-                if owner and m.get("owner") != owner:
-                    return {"error": f"Memory '{memory_id}' not found"}
-                m["text"] = new_text
-                m["timestamp"] = int(time.time())
-                found = True
-                full_id = m["id"]
-                break
-        if not found:
-            return {"error": f"Memory '{memory_id}' not found"}
-        _memory_manager.save(memories)
 
-        # Update vector index
-        if _memory_vector and hasattr(_memory_vector, 'healthy') and _memory_vector.healthy:
-            try:
-                _memory_vector.add(full_id, new_text)
-            except Exception:
-                pass
+def _memory_action_add(lines: list, owner: Optional[str]) -> Dict:
+    """Add a new memory entry."""
+    if len(lines) < 2 or not lines[1].strip():
+        return {"error": "Add needs line 2: memory text"}
+    text = lines[1].strip()
+    category = lines[2].strip().lower() if len(lines) > 2 and lines[2].strip() else "fact"
 
-        return {"action": "edit", "memory_id": memory_id,
-                "results": f"Memory updated: {new_text}"}
+    entry = _memory_manager.add_entry(text, source="ai_agent", category=category, owner=owner)
+    memories = _memory_manager.load_all()
+    memories.append(entry)
+    _memory_manager.save(memories)
 
-    elif action == "delete":
-        if len(lines) < 2:
-            return {"error": "Delete needs line 2: memory_id"}
-        memory_id = lines[1].strip()
+    _memory_vector_add(entry["id"], text)
+    _fire_memory_event("memory_added", owner)
 
-        memories = _memory_manager.load_all()
-        original_len = len(memories)
-        full_id = None
-        delete_id = None
-        for m in memories:
-            if m.get("id", "").startswith(memory_id):
-                # Verify ownership
-                if owner and m.get("owner") != owner:
-                    return {"error": f"Memory '{memory_id}' not found"}
-                full_id = m["id"]
-                delete_id = m["id"]
-                break
-        memories = [m for m in memories if m.get("id") != delete_id]
-        if len(memories) == original_len:
-            return {"error": f"Memory '{memory_id}' not found"}
-        _memory_manager.save(memories)
+    return {"action": "add", "memory_id": entry["id"],
+            "results": f"Memory added: [{category}] {text}"}
 
-        # Remove from vector index
-        if _memory_vector and full_id and hasattr(_memory_vector, 'healthy') and _memory_vector.healthy:
-            try:
-                _memory_vector.remove(full_id)
-            except Exception:
-                pass
 
-        return {"action": "delete", "memory_id": memory_id,
-                "results": f"Memory '{memory_id}' deleted"}
+def _memory_action_edit(lines: list, owner: Optional[str]) -> Dict:
+    """Edit an existing memory by (partial) ID."""
+    if len(lines) < 3 or not lines[2].strip():
+        return {"error": "Edit needs line 2: memory_id, line 3: new text"}
+    memory_id = lines[1].strip()
+    new_text = lines[2].strip()
 
-    elif action == "search":
-        if len(lines) < 2:
-            return {"error": "Search needs line 2: query"}
-        query = lines[1].strip()
-        memories = _memory_manager.load(owner=owner)
+    memories = _memory_manager.load_all()
+    full_id = None
+    for m in memories:
+        if m.get("id", "").startswith(memory_id):
+            if owner and m.get("owner") != owner:
+                return {"error": f"Memory '{memory_id}' not found"}
+            m["text"] = new_text
+            m["timestamp"] = int(time.time())
+            full_id = m["id"]
+            break
 
-        if hasattr(_memory_manager, 'get_relevant_memories'):
-            results = _memory_manager.get_relevant_memories(query, memories, threshold=0.05, max_items=MEMORY_SEARCH_RESULT_LIMIT)
-        else:
-            # Fallback: simple text search
-            query_lower = query.lower()
-            results = [m for m in memories if query_lower in m.get("text", "").lower()][:MEMORY_SEARCH_RESULT_LIMIT]
+    if not full_id:
+        return {"error": f"Memory '{memory_id}' not found"}
 
-        if not results:
-            return {"results": f"No memories found matching '{query}'."}
-        result_lines = [f"Found {len(results)} matching memories:\n"]
-        for m in results:
-            cat = m.get("category", "fact")
-            mid = m.get("id", "?")[:8]
-            text = m.get("text", "")
-            result_lines.append(f"- [{cat}] `{mid}` — {text}")
-        return {"results": "\n".join(result_lines)}
+    _memory_manager.save(memories)
+    _memory_vector_add(full_id, new_text)
+    return {"action": "edit", "memory_id": memory_id,
+            "results": f"Memory updated: {new_text}"}
 
+
+def _memory_action_delete(lines: list, owner: Optional[str]) -> Dict:
+    """Delete a memory by (partial) ID."""
+    if len(lines) < 2 or not lines[1].strip():
+        return {"error": "Delete needs line 2: memory_id"}
+    memory_id = lines[1].strip()
+
+    memories = _memory_manager.load_all()
+    original_len = len(memories)
+    full_id = None
+
+    for m in memories:
+        if m.get("id", "").startswith(memory_id):
+            if owner and m.get("owner") != owner:
+                return {"error": f"Memory '{memory_id}' not found"}
+            full_id = m["id"]
+            break
+
+    memories = [m for m in memories if m.get("id") != full_id]
+    if len(memories) == original_len:
+        return {"error": f"Memory '{memory_id}' not found"}
+
+    _memory_manager.save(memories)
+    _memory_vector_remove(full_id)
+    return {"action": "delete", "memory_id": memory_id,
+            "results": f"Memory '{memory_id}' deleted"}
+
+
+def _memory_action_search(lines: list, owner: Optional[str]) -> Dict:
+    """Search memories by text or vector similarity."""
+    if len(lines) < 2 or not lines[1].strip():
+        return {"error": "Search needs line 2: query"}
+    query = lines[1].strip()
+    memories = _memory_manager.load(owner=owner)
+
+    if hasattr(_memory_manager, "get_relevant_memories"):
+        results = _memory_manager.get_relevant_memories(
+            query, memories, threshold=0.05, max_items=MEMORY_SEARCH_RESULT_LIMIT
+        )
     else:
-        return {"error": f"Unknown action '{action}'. Use: list, add, edit, delete, search"}
+        query_lower = query.lower()
+        results = [m for m in memories if query_lower in m.get("text", "").lower()][:MEMORY_SEARCH_RESULT_LIMIT]
+
+    if not results:
+        return {"results": f"No memories found matching '{query}'."}
+
+    result_lines = [f"Found {len(results)} matching memories:\n"]
+    for m in results:
+        cat = m.get("category", "fact")
+        mid = m.get("id", "?")[:UUID_SHORT_ID_LENGTH]
+        text = m.get("text", "")
+        result_lines.append(f"- [{cat}] `{mid}` — {text}")
+    return {"results": "\n".join(result_lines)}
+
+
+def _memory_vector_add(memory_id: str, text: str) -> None:
+    """Add or update an entry in the memory vector index (best-effort)."""
+    if _memory_vector and hasattr(_memory_vector, "healthy") and _memory_vector.healthy:
+        try:
+            _memory_vector.add(memory_id, text)
+        except Exception:
+            pass
+
+
+def _memory_vector_remove(memory_id: Optional[str]) -> None:
+    """Remove an entry from the memory vector index (best-effort)."""
+    if memory_id and _memory_vector and hasattr(_memory_vector, "healthy") and _memory_vector.healthy:
+        try:
+            _memory_vector.remove(memory_id)
+        except Exception:
+            pass
+
+
+def _fire_memory_event(event: str, owner: Optional[str]) -> None:
+    """Emit an event on the event bus (best-effort, non-blocking)."""
+    try:
+        from src.event_bus import fire_event
+        fire_event(event, owner)
+    except Exception:
+        logger.debug("memory event dispatch failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -2033,59 +2059,69 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
 async def dispatch_ai_tool(
     tool: str, content: str, session_id: Optional[str] = None, owner: Optional[str] = None
 ) -> Tuple[str, Dict]:
-    """Dispatch an AI interaction tool. Returns (description, result_dict)."""
+    """Dispatch an AI interaction tool. Returns (description, result_dict).
 
-    if tool == "chat_with_model":
-        model_spec = content.split("\n")[0].strip()[:60]
-        desc = f"chat_with_model: {model_spec}"
-        result = await do_chat_with_model(content, session_id)
+    Each entry in _TOOL_REGISTRY is:
+        tool_name -> (handler_coro, desc_fn)
+    where desc_fn(content) produces the human-readable description string.
+    """
+    # Registry: tool name → (coroutine_factory, description_factory)
+    # desc_fn receives raw content and returns a short label for the UI.
+    _TOOL_REGISTRY = {
+        "chat_with_model": (
+            lambda c: do_chat_with_model(c, session_id),
+            lambda c: f"chat_with_model: {get_first_line(c, 60)}",
+        ),
+        "ask_teacher": (
+            lambda c: do_ask_teacher(c, session_id),
+            lambda c: f"ask_teacher: {get_first_line(c, 60)}",
+        ),
+        "second_opinion": (
+            lambda c: do_second_opinion(c, session_id),
+            lambda c: f"second_opinion: {get_first_line(c, 60)}",
+        ),
+        "create_session": (
+            lambda c: do_create_session(c, session_id, owner=owner),
+            lambda c: f"create_session: {get_first_line(c, 60)}",
+        ),
+        "list_sessions": (
+            lambda c: do_list_sessions(c, session_id, owner=owner),
+            lambda c: f"list_sessions{': ' + c.strip()[:40] if c.strip() else ''}",
+        ),
+        "send_to_session": (
+            lambda c: do_send_to_session(c, session_id),
+            lambda c: f"send_to_session: {get_first_line(c, 20)}",
+        ),
+        "manage_session": (
+            lambda c: do_manage_session(c, session_id, owner=owner),
+            lambda c: f"manage_session: {get_action_from_content(c)}",
+        ),
+        "pipeline": (
+            lambda c: do_pipeline(c, session_id),
+            lambda c: "pipeline: running steps",
+        ),
+        "manage_memory": (
+            lambda c: do_manage_memory(c, session_id, owner=owner),
+            lambda c: f"manage_memory: {get_action_from_content(c)}",
+        ),
+        "list_models": (
+            lambda c: do_list_models(c, session_id),
+            lambda c: f"list_models{': ' + c.strip()[:40] if c.strip() else ''}",
+        ),
+        "ui_control": (
+            lambda c: do_ui_control(c, session_id),
+            lambda c: f"ui_control: {get_first_line(c, 60)}",
+        ),
+        "generate_image": (
+            lambda c: do_generate_image(c, session_id, owner=owner),
+            lambda c: f"generate_image: {get_first_line(c, 60)}",
+        ),
+    }
 
-    elif tool == "create_session":
-        name = content.split("\n")[0].strip()[:60]
-        desc = f"create_session: {name}"
-        result = await do_create_session(content, session_id, owner=owner)
+    if tool not in _TOOL_REGISTRY:
+        return f"unknown ai tool: {tool}", {"error": f"Unknown AI interaction tool: {tool}"}
 
-    elif tool == "list_sessions":
-        keyword = content.strip()[:40]
-        desc = f"list_sessions{': ' + keyword if keyword else ''}"
-        result = await do_list_sessions(content, session_id, owner=owner)
-
-    elif tool == "send_to_session":
-        sid = content.split("\n")[0].strip()[:20]
-        desc = f"send_to_session: {sid}"
-        result = await do_send_to_session(content, session_id)
-
-    elif tool == "pipeline":
-        desc = "pipeline: running steps"
-        result = await do_pipeline(content, session_id)
-
-    elif tool == "manage_session":
-        action = content.split("\n")[0].strip()[:40]
-        desc = f"manage_session: {action}"
-        result = await do_manage_session(content, session_id, owner=owner)
-
-    elif tool == "manage_memory":
-        action = content.split("\n")[0].strip()[:40]
-        desc = f"manage_memory: {action}"
-        result = await do_manage_memory(content, session_id, owner=owner)
-
-    elif tool == "list_models":
-        keyword = content.strip()[:40]
-        desc = f"list_models{': ' + keyword if keyword else ''}"
-        result = await do_list_models(content, session_id)
-
-    elif tool == "ui_control":
-        action = content.split("\n")[0].strip()[:60]
-        desc = f"ui_control: {action}"
-        result = await do_ui_control(content, session_id)
-
-    elif tool == "ask_teacher":
-        problem = content.split("\n", 1)[-1].strip()[:60]
-        desc = f"ask_teacher: {problem}"
-        result = await do_ask_teacher(content, session_id)
-
-    else:
-        desc = f"unknown ai tool: {tool}"
-        result = {"error": f"Unknown AI interaction tool: {tool}"}
-
+    handler_factory, desc_factory = _TOOL_REGISTRY[tool]
+    desc = desc_factory(content)
+    result = await handler_factory(content)
     return desc, result

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -12,7 +12,7 @@ import json
 import logging
 import uuid
 import time
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +238,7 @@ def get_model_spec_from_content(content: str) -> str:
     return get_first_line(content, 60)
 
 
-def resolve_panel(name: str) -> Optional[str]:
+def resolve_panel(name: Optional[str]) -> Optional[str]:
     """Resolve panel alias to canonical name.
 
     Args:
@@ -259,7 +259,7 @@ def resolve_panel(name: str) -> Optional[str]:
     return None
 
 
-def resolve_toggle(name: str) -> Optional[str]:
+def resolve_toggle(name: Optional[str]) -> Optional[str]:
     """Resolve toggle alias to canonical name.
 
     Args:
@@ -519,7 +519,7 @@ async def _image_download_and_save(
 # Pipeline helpers
 # ---------------------------------------------------------------------------
 
-def _pipeline_parse_steps(content: str):
+def _pipeline_parse_steps(content: str) -> Tuple[Optional[List[Dict]], Optional[Dict]]:
     """Parse pipeline steps from JSON or pipe-delimited line format.
 
     Returns:
@@ -610,38 +610,34 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
     else:
         model_name = spec
 
-    db = SessionLocal()
-    try:
+    with get_db_session() as db:
         query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
         if target_endpoint_name:
             query = query.filter(ModelEndpoint.name.ilike(f"%{target_endpoint_name}%"))
         endpoints = query.all()
 
-        if not endpoints:
-            raise ValueError("No enabled endpoints found" +
-                             (f" matching '{target_endpoint_name}'" if target_endpoint_name else ""))
+    if not endpoints:
+        raise ValueError(
+            "No enabled endpoints found"
+            + (f" matching '{target_endpoint_name}'" if target_endpoint_name else "")
+        )
 
-        for ep in endpoints:
-            base = _normalize_base(ep.base_url)
-            provider = _detect_provider(base)
-            headers = build_headers(ep.api_key, base)
+    for ep in endpoints:
+        base = _normalize_base(ep.base_url)
+        provider = _detect_provider(base)
+        headers = build_headers(ep.api_key, base)
 
-            model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
+        model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
+        model_ids = [m for m in model_ids if m != "(endpoint offline)"]
 
-            # Filter out the offline sentinel so we don't match it
-            model_ids = [m for m in model_ids if m != "(endpoint offline)"]
+        for mid in model_ids:
+            if mid.lower() == model_name.lower():
+                return build_chat_url(base), mid, headers
+        for mid in model_ids:
+            if model_name.lower() in mid.lower() or mid.lower() in model_name.lower():
+                return build_chat_url(base), mid, headers
 
-            # Exact match first, then partial match
-            for mid in model_ids:
-                if mid.lower() == model_name.lower():
-                    return build_chat_url(base), mid, headers
-            for mid in model_ids:
-                if model_name.lower() in mid.lower() or mid.lower() in model_name.lower():
-                    return build_chat_url(base), mid, headers
-
-        raise ValueError(f"Model '{spec}' not found on any configured endpoint")
-    finally:
-        db.close()
+    raise ValueError(f"Model '{spec}' not found on any configured endpoint")
 
 
 # ---------------------------------------------------------------------------
@@ -890,7 +886,6 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
 
     Output includes a relative "last active" timestamp per row so the
     agent can answer "open my last chat" without guessing from titles.
-    The most-recent session is always first in the list.
 
     Content = optional filter keyword (matches session name).
     """
@@ -900,76 +895,105 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
     keyword = content.strip().lower() if content.strip() else None
 
     try:
-        from core.database import SessionLocal, Session as DbSession
-        from datetime import datetime, timezone
+        from core.database import Session as DbSession
+        from datetime import datetime
 
-        # Pull every session's last_accessed from the DB so we can sort
-        # by recency. In-memory sessions hold name + model + msg_count;
-        # the DB row holds the timestamps.
-        db = SessionLocal()
-        try:
+        with get_db_session() as db:
             db_rows = {r.id: r for r in db.query(DbSession).all()}
-        finally:
-            db.close()
 
-        # SECURITY: scope to the caller's sessions. Passing None returned
-        # every user's sessions, which the agent tool then exposed via the
-        # "list my chats" reply.
+        # SECURITY: scope to the caller's sessions only
         sessions = _session_manager.get_sessions_for_user(owner)
         rows = []
         for sid, sess in sessions.items():
             if keyword and keyword not in (sess.name or "").lower():
                 continue
             db_row = db_rows.get(sid)
-            # Prefer last_accessed; fall back to updated_at, then created_at.
-            ts = None
-            if db_row:
-                ts = getattr(db_row, 'last_accessed', None) or getattr(db_row, 'updated_at', None) or getattr(db_row, 'created_at', None)
+            ts = _session_best_timestamp(db_row)
             rows.append((ts, sid, sess))
 
-        # Sort by timestamp DESC; rows without a timestamp sink to the bottom.
         rows.sort(key=lambda r: r[0] or datetime.min, reverse=True)
-
-        def _rel(ts):
-            if not ts:
-                return 'never'
-            now = datetime.utcnow()
-            try:
-                if ts.tzinfo is not None:
-                    now = datetime.now(timezone.utc)
-                diff = (now - ts).total_seconds()
-            except Exception:
-                return 'unknown'
-            if diff < 60: return 'just now'
-            if diff < 3600: return f'{int(diff / 60)}m ago'
-            if diff < 86400: return f'{int(diff / 3600)}h ago'
-            if diff < 86400 * 7: return f'{int(diff / 86400)}d ago'
-            return ts.strftime('%Y-%m-%d')
 
         lines = []
         for i, (ts, sid, sess) in enumerate(rows):
             if i >= SESSION_LIST_DISPLAY_LIMIT:
-                lines.append(f"... and {len(rows) - SESSION_LIST_DISPLAY_LIMIT} more (showing first {SESSION_LIST_DISPLAY_LIMIT})")
+                lines.append(
+                    f"... and {len(rows) - SESSION_LIST_DISPLAY_LIMIT} more "
+                    f"(showing first {SESSION_LIST_DISPLAY_LIMIT})"
+                )
                 break
             safe_name = (sess.name or "Untitled").replace("[", "\\[").replace("]", "\\]")
             msg_count = getattr(sess, "message_count", 0) or 0
             model = getattr(sess, "model", "unknown")
             marker = " ← most recent" if i == 0 else ""
-            lines.append(f"- **[{safe_name}](#session-{sid})** (id: `{sid}`, model: {model}, {msg_count} msgs, last active {_rel(ts)}){marker}")
+            lines.append(
+                f"- **[{safe_name}](#session-{sid})** "
+                f"(id: `{sid}`, model: {model}, {msg_count} msgs, "
+                f"last active {_session_relative_time(ts)}){marker}"
+            )
 
         if not lines:
-            return {"results": "No sessions found" + (f" matching '{keyword}'" if keyword else "") + "."}
+            suffix = f" matching '{keyword}'" if keyword else ""
+            return {"results": f"No sessions found{suffix}."}
 
         return {
             "results": (
                 f"Found {len(rows)} session(s), sorted most-recent first:\n"
                 + "\n".join(lines)
-                + "\n\nAssistant: when replying to the user, preserve the chat-title markdown links exactly as shown, e.g. `[Chat](#session-id)`. Do not rewrite this as a plain, non-clickable table."
+                + "\n\nAssistant: when replying to the user, preserve the chat-title markdown links "
+                "exactly as shown, e.g. `[Chat](#session-id)`. Do not rewrite as a plain table."
             )
         }
     except Exception as e:
         logger.error(f"list_sessions failed: {e}")
         return {"error": str(e)}
+
+
+def _session_best_timestamp(db_row) -> Optional[object]:
+    """Return the most informative timestamp from a DB session row, or None."""
+    if not db_row:
+        return None
+    return (
+        getattr(db_row, "last_accessed", None)
+        or getattr(db_row, "updated_at", None)
+        or getattr(db_row, "created_at", None)
+    )
+
+
+def _session_relative_time(ts) -> str:
+    """Convert a datetime to a human-readable relative string (e.g. '5m ago').
+
+    Args:
+        ts: datetime object (naive or tz-aware), or None
+
+    Returns:
+        Relative string like 'just now', '5m ago', '2h ago', '3d ago',
+        a date string for older entries, or 'never' if ts is None.
+    """
+    from datetime import datetime, timezone
+
+    if ts is None:
+        return "never"
+
+    try:
+        # Always use tz-aware comparison; make naive datetimes UTC-aware
+        if getattr(ts, "tzinfo", None) is not None:
+            now = datetime.now(timezone.utc)
+        else:
+            ts = ts.replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
+        diff = (now - ts).total_seconds()
+    except Exception:
+        return "unknown"
+
+    if diff < 60:
+        return "just now"
+    if diff < 3600:
+        return f"{int(diff / 60)}m ago"
+    if diff < 86400:
+        return f"{int(diff / 3600)}h ago"
+    if diff < 86400 * 7:
+        return f"{int(diff / 86400)}d ago"
+    return ts.strftime("%Y-%m-%d")
 
 
 async def do_send_to_session(content: str, session_id: Optional[str] = None) -> Dict:
@@ -1147,7 +1171,7 @@ async def do_manage_session(content: str, session_id: Optional[str] = None, owne
         return {"error": str(e)}
 
 
-def _parse_manage_session_input(content: str):
+def _parse_manage_session_input(content: str) -> Tuple[str, str, Optional[str], str]:
     """Parse do_manage_session content from JSON or line format.
 
     Returns:
@@ -1235,15 +1259,11 @@ async def _dispatch_session_action(
 
 def _session_action_view(target_sid: str, query_fn, action: str) -> Dict:
     """Return a clickable link so the user can navigate to the session."""
-    from src.database import SessionLocal
-    db = SessionLocal()
-    try:
+    with get_db_session() as db:
         db_sess = query_fn(db).first()
         if not db_sess:
             return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
         name = db_sess.name or target_sid
-    finally:
-        db.close()
     return {
         "action": action,
         "session_id": target_sid,
@@ -1658,82 +1678,100 @@ async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
       Line 1: action (list|add_directory|remove_directory)
       Line 2: directory path (for add/remove)
     """
-    lines = content.strip().split("\n")
+    lines = content.strip().split("\n") if content.strip() else []
     if not lines:
         return {"error": "No action specified"}
+
     action = lines[0].strip().lower()
 
-    if action == "list":
-        if not _personal_docs_manager:
-            return {"results": "Personal docs manager not available. RAG may not be configured."}
-        try:
-            files = []
-            if hasattr(_personal_docs_manager, 'index'):
-                files = _personal_docs_manager.index or []
-            dirs = []
-            if hasattr(_personal_docs_manager, 'get_indexed_directories'):
-                dirs = _personal_docs_manager.get_indexed_directories()
+    _HANDLERS = {
+        "list": _rag_action_list,
+        "add_directory": _rag_action_add_directory,
+        "remove_directory": _rag_action_remove_directory,
+    }
 
-            result_lines = []
-            if dirs:
-                result_lines.append(f"**Indexed directories ({len(dirs)}):**")
-                for d in dirs:
-                    result_lines.append(f"  - `{d}`")
-            if files:
-                result_lines.append(f"\n**Indexed files ({len(files)}):**")
-                for f in files[:50]:
-                    name = f.get("name", str(f)) if isinstance(f, dict) else str(f)
-                    result_lines.append(f"  - {name}")
-                if len(files) > 50:
-                    result_lines.append(f"  ... and {len(files) - 50} more")
+    handler = _HANDLERS.get(action)
+    if not handler:
+        valid = ", ".join(sorted(_HANDLERS))
+        return {"error": f"Unknown action '{action}'. Use: {valid}"}
 
-            if not result_lines:
-                return {"results": "No files or directories indexed in RAG."}
-            return {"results": "\n".join(result_lines)}
-        except Exception as e:
-            return {"error": str(e)}
+    return handler(lines)
 
-    elif action == "add_directory":
-        if len(lines) < 2:
-            return {"error": "add_directory needs line 2: directory path"}
-        directory = lines[1].strip()
 
-        import os
-        directory = os.path.expanduser(directory)
-        if not os.path.isdir(directory):
-            return {"error": f"Directory not found: {directory}"}
+def _rag_action_list(lines: list) -> Dict:
+    """List all indexed RAG files and directories."""
+    if not _personal_docs_manager:
+        return {"results": "Personal docs manager not available. RAG may not be configured."}
+    try:
+        files = getattr(_personal_docs_manager, "index", None) or []
+        dirs = []
+        if hasattr(_personal_docs_manager, "get_indexed_directories"):
+            dirs = _personal_docs_manager.get_indexed_directories()
 
-        if not _rag_manager:
-            return {"error": "RAG manager not available"}
+        result_lines = []
+        if dirs:
+            result_lines.append(f"**Indexed directories ({len(dirs)}):**")
+            result_lines.extend(f"  - `{d}`" for d in dirs)
+        if files:
+            result_lines.append(f"\n**Indexed files ({len(files)}):**")
+            for f in files[:50]:
+                name = f.get("name", str(f)) if isinstance(f, dict) else str(f)
+                result_lines.append(f"  - {name}")
+            if len(files) > 50:
+                result_lines.append(f"  ... and {len(files) - 50} more")
 
-        try:
-            result = _rag_manager.index_personal_documents(directory)
-            indexed = result.get("indexed", 0) if isinstance(result, dict) else 0
-            return {"action": "add_directory", "directory": directory,
-                    "results": f"Directory '{directory}' added to RAG index ({indexed} files indexed)"}
-        except Exception as e:
-            return {"error": f"Failed to index directory: {e}"}
+        if not result_lines:
+            return {"results": "No files or directories indexed in RAG."}
+        return {"results": "\n".join(result_lines)}
+    except Exception as e:
+        return {"error": str(e)}
 
-    elif action == "remove_directory":
-        if len(lines) < 2:
-            return {"error": "remove_directory needs line 2: directory path"}
-        directory = lines[1].strip()
 
-        if not _personal_docs_manager:
-            return {"error": "Personal docs manager not available"}
+def _rag_action_add_directory(lines: list) -> Dict:
+    """Index a directory into RAG."""
+    import os
 
-        try:
-            if hasattr(_personal_docs_manager, 'remove_directory'):
-                _personal_docs_manager.remove_directory(directory)
-            if _rag_manager and hasattr(_rag_manager, 'rebuild_index'):
-                _rag_manager.rebuild_index()
-            return {"action": "remove_directory", "directory": directory,
-                    "results": f"Directory '{directory}' removed from RAG index"}
-        except Exception as e:
-            return {"error": f"Failed to remove directory: {e}"}
+    if len(lines) < 2 or not lines[1].strip():
+        return {"error": "add_directory needs line 2: directory path"}
+    directory = os.path.expanduser(lines[1].strip())
 
-    else:
-        return {"error": f"Unknown action '{action}'. Use: list, add_directory, remove_directory"}
+    if not os.path.isdir(directory):
+        return {"error": f"Directory not found: {directory}"}
+    if not _rag_manager:
+        return {"error": "RAG manager not available"}
+
+    try:
+        result = _rag_manager.index_personal_documents(directory)
+        indexed = result.get("indexed", 0) if isinstance(result, dict) else 0
+        return {
+            "action": "add_directory",
+            "directory": directory,
+            "results": f"Directory '{directory}' added to RAG index ({indexed} files indexed)",
+        }
+    except Exception as e:
+        return {"error": f"Failed to index directory: {e}"}
+
+
+def _rag_action_remove_directory(lines: list) -> Dict:
+    """Remove a directory from the RAG index and rebuild."""
+    if len(lines) < 2 or not lines[1].strip():
+        return {"error": "remove_directory needs line 2: directory path"}
+    if not _personal_docs_manager:
+        return {"error": "Personal docs manager not available"}
+
+    directory = lines[1].strip()
+    try:
+        if hasattr(_personal_docs_manager, "remove_directory"):
+            _personal_docs_manager.remove_directory(directory)
+        if _rag_manager and hasattr(_rag_manager, "rebuild_index"):
+            _rag_manager.rebuild_index()
+        return {
+            "action": "remove_directory",
+            "directory": directory,
+            "results": f"Directory '{directory}' removed from RAG index",
+        }
+    except Exception as e:
+        return {"error": f"Failed to remove directory: {e}"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -391,7 +391,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
             else:
                 # OpenAI-compatible and native Ollama: probe the provider's model list.
                 try:
-                    r = httpx.get(build_models_url(base), headers=headers, timeout=5)
+                    r = httpx.get(build_models_url(base), headers=headers, timeout=HTTP_TIMEOUT_MODEL_LIST)
                     r.raise_for_status()
                     data = r.json()
                     model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
@@ -453,23 +453,14 @@ async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> 
             headers=headers,
             timeout=AI_CHAT_TIMEOUT,
         )
-        # Truncate very long responses
-        if len(response) > 10000:
-            response = response[:10000] + "\n... (truncated)"
-        return {"model": model, "response": response}
+        return {"model": model, "response": truncate_response(response)}
     except Exception as e:
         logger.error(f"chat_with_model failed: {e}")
         return {"error": f"Failed to get response from {model_spec}: {e}"}
 
 
-_TEACHER_SYSTEM_PROMPT = (
-    "You are a senior AI mentor. A less capable model is stuck on a problem and asking for help. "
-    "Provide clear, actionable guidance:\n"
-    "1. Brief analysis of the problem\n"
-    "2. Recommended approach (step by step)\n"
-    "3. Key things to watch out for\n\n"
-    "Be concise and practical. No preamble."
-)
+# Backward-compat alias for modules that import _TEACHER_SYSTEM_PROMPT directly
+_TEACHER_SYSTEM_PROMPT = TEACHER_SYSTEM_PROMPT
 
 
 async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict:
@@ -503,15 +494,13 @@ async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict
         response = await llm_call_async(
             url, model,
             [
-                {"role": "system", "content": _TEACHER_SYSTEM_PROMPT},
+                {"role": "system", "content": TEACHER_SYSTEM_PROMPT},
                 {"role": "user", "content": f"Problem:\n{problem}"},
             ],
             headers=headers,
             timeout=AI_CHAT_TIMEOUT,
         )
-        if len(response) > 8000:
-            response = response[:8000] + "\n... (truncated)"
-        return {"model": model, "response": response, "teacher": True}
+        return {"model": model, "response": truncate_for_teacher(response), "teacher": True}
     except Exception as e:
         logger.error(f"ask_teacher failed: {e}")
         return {"error": f"Teacher call failed ({model_spec}): {e}"}
@@ -552,7 +541,7 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
         sess = _session_manager.get_session(session_id)
         if sess:
             messages = sess.get_context_messages()
-            recent = messages[-15:] if len(messages) > 15 else messages
+            recent = messages[-SESSION_CONTEXT_WINDOW:] if len(messages) > SESSION_CONTEXT_WINDOW else messages
             parts = []
             for m in recent:
                 role = m.get("role", "unknown").upper()
@@ -562,26 +551,13 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
                         p.get("text", "") for p in text if isinstance(p, dict)
                     )
                 if text:
-                    parts.append(f"[{role}]: {text[:2000]}")
+                    parts.append(f"[{role}]: {text[:CONTEXT_MESSAGE_TEXT_LIMIT]}")
             context_text = "\n\n".join(parts)
 
     if not context_text:
         return {"error": "No conversation context found to review"}
 
     # ── Step 1: Get the reviewer's feedback ──
-    reviewer_system = (
-        "You are giving a second opinion on a conversation between a user and an AI assistant. "
-        "Your job is to be genuinely helpful and honest — not a yes-man, but not a contrarian either.\n\n"
-        "Guidelines:\n"
-        "- If the plan/idea is solid, say so clearly. Don't manufacture problems that aren't there.\n"
-        "- If you spot a real flaw, blind spot, or simpler approach — call it out directly.\n"
-        "- Be practical. Don't over-engineer or over-analyze. Real-world tradeoffs matter.\n"
-        "- If there's a meaningfully better way to do something, suggest it concretely.\n"
-        "- Give credit where it's due — highlight what's working well.\n"
-        "- Keep it concise and actionable. No fluff.\n"
-        "- You're a second pair of eyes, not a professor grading a paper."
-    )
-
     reviewer_message = f"Here's the conversation so far:\n\n{context_text}"
     if focus:
         reviewer_message += f"\n\n---\nSpecifically, I want your take on: {focus}"
@@ -592,14 +568,13 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
         review = await llm_call_async(
             reviewer_url, reviewer_model,
             [
-                {"role": "system", "content": reviewer_system},
+                {"role": "system", "content": SECOND_OPINION_REVIEWER_SYSTEM},
                 {"role": "user", "content": reviewer_message},
             ],
             headers=reviewer_headers,
             timeout=AI_CHAT_TIMEOUT,
         )
-        if len(review) > 8000:
-            review = review[:8000] + "\n... (truncated)"
+        review = truncate_for_teacher(review)
     except Exception as e:
         logger.error(f"second_opinion reviewer call failed: {e}")
         return {"error": f"Failed to get second opinion from {model_spec}: {e}"}
@@ -611,17 +586,6 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
         original_url = sess.endpoint_url
         original_model = sess.model
         original_headers = getattr(sess, "headers", None) or {}
-
-        unify_system = (
-            "Another AI model just reviewed the conversation you've been having with the user. "
-            "Read their feedback carefully, then respond with:\n\n"
-            "1. **What you agree with** — acknowledge valid points honestly.\n"
-            "2. **What you disagree with** — explain why, briefly.\n"
-            "3. **Unified version** — produce an updated/refined version of whatever was being discussed, "
-            "incorporating the feedback you found valid. Don't accept every note blindly — "
-            "use your judgment on what actually improves things vs what's unnecessary.\n\n"
-            "Be concise and practical. The user wants a better result, not a meta-discussion."
-        )
 
         unify_message = (
             f"Here's the conversation context:\n\n{context_text}\n\n"
@@ -635,14 +599,13 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
             unified = await llm_call_async(
                 original_url, original_model,
                 [
-                    {"role": "system", "content": unify_system},
+                    {"role": "system", "content": SECOND_OPINION_UNIFIER_SYSTEM},
                     {"role": "user", "content": unify_message},
                 ],
                 headers=original_headers,
                 timeout=AI_CHAT_TIMEOUT,
             )
-            if len(unified) > 10000:
-                unified = unified[:10000] + "\n... (truncated)"
+            unified = truncate_response(unified)
         except Exception as e:
             logger.error(f"second_opinion unify call failed: {e}")
             unified = f"(Failed to get unified response: {e})"
@@ -775,8 +738,8 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
 
         lines = []
         for i, (ts, sid, sess) in enumerate(rows):
-            if i >= 50:
-                lines.append(f"... and {len(rows) - 50} more (showing first 50)")
+            if i >= SESSION_LIST_DISPLAY_LIMIT:
+                lines.append(f"... and {len(rows) - SESSION_LIST_DISPLAY_LIMIT} more (showing first {SESSION_LIST_DISPLAY_LIMIT})")
                 break
             safe_name = (sess.name or "Untitled").replace("[", "\\[").replace("]", "\\]")
             msg_count = getattr(sess, "message_count", 0) or 0
@@ -842,13 +805,10 @@ async def do_send_to_session(content: str, session_id: Optional[str] = None) -> 
         sess.add_message(ChatMessage("assistant", response))
 
         # Truncate for tool output
-        if len(response) > 10000:
-            response = response[:10000] + "\n... (truncated)"
-
         return {
             "session_id": target_sid,
             "session_name": sess.name,
-            "response": response,
+            "response": truncate_response(response),
         }
     except Exception as e:
         logger.error(f"send_to_session failed: {e}")
@@ -948,7 +908,7 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
                 "step": i + 1,
                 "model": model,
                 "instruction": instruction,
-                "output": response[:5000] if len(response) > 5000 else response,
+                "output": truncate_for_pipeline(response),
             })
 
             previous_output = response
@@ -976,226 +936,262 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
 # ---------------------------------------------------------------------------
 
 async def do_manage_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
-    """Manage sessions: rename, archive, delete, important, truncate, fork.
+    """Manage sessions: list, switch, rename, archive, unarchive, delete, important, truncate, fork.
 
-    Content format:
-      Line 1: action (rename|archive|unarchive|delete|important|unimportant|truncate|fork)
-      Line 2: target session_id (or "current" to use the active session)
-      Line 3+: action-specific params (e.g. new name for rename, keep_count for truncate)
+    Accepts both JSON format ({action, session_id, value}) and line format:
+      Line 1: action
+      Line 2: target session_id  (or "current" for the active session)
+      Line 3+: action-specific value (new name for rename, keep_count for truncate)
     """
     if not _session_manager:
         return {"error": "Session manager not available"}
 
-    from src.database import SessionLocal, Session as DbSession
-
-    # Accept BOTH the structured JSON args the tool schema advertises
-    # ({action, session_id, value}) AND the legacy line-based format
-    # (line1=action, line2=session_id, line3=value). Native function-calling
-    # models send JSON; fenced-block callers send lines. Previously only the
-    # line format was parsed, so a model that followed the schema (JSON) got
-    # "Need at least 2 lines" / "Rename needs line 3" and couldn't drive it.
-    _raw = (content or "").strip()
-    action = ""
-    target_sid = ""
-    value = None      # the action param: new name (rename) / keep_count (truncate, fork)
-    _list_filter = ""
-    _parsed = None
-    if _raw.startswith("{"):
-        try:
-            _parsed = json.loads(_raw)
-        except Exception:
-            _parsed = None
-    if isinstance(_parsed, dict):
-        action = str(_parsed.get("action") or "").strip().lower()
-        target_sid = str(_parsed.get("session_id") or _parsed.get("session") or _parsed.get("id") or "").strip()
-        _v = _parsed.get("value")
-        if _v is None:
-            _v = (_parsed.get("name") or _parsed.get("new_name")
-                  or _parsed.get("title") or _parsed.get("keep_count"))
-        value = None if _v is None else str(_v).strip()
-        _list_filter = str(_parsed.get("filter") or "").strip()
-    else:
-        lines = _raw.split("\n")
-        if not lines or not lines[0].strip():
-            return {"error": "Missing action (rename|archive|delete|important|truncate|fork|list|switch)"}
-        action = lines[0].strip().lower()
-        target_sid = lines[1].strip() if len(lines) >= 2 else ""
-        value = lines[2].strip() if len(lines) >= 3 else None
-        _list_filter = "\n".join(lines[1:]).strip()
+    action, target_sid, value, list_filter = _parse_manage_session_input(content)
 
     if not action:
         return {"error": "Missing action (rename|archive|delete|important|truncate|fork|list|switch)"}
 
-    # `list` alias — dispatch to do_list_sessions so the agent's natural
-    # first guess (every other manage_* tool has a `list` action) works.
     if action == "list":
-        return await do_list_sessions(_list_filter, session_id, owner=owner)
+        return await do_list_sessions(list_filter, session_id, owner=owner)
 
     if not target_sid:
         return {"error": "Need a session_id (or 'current' for the active chat)"}
 
-    # Allow "current" to refer to the active session
     if target_sid.lower() == "current" and session_id:
         target_sid = session_id
 
-    # `switch` / `open` / `select` / `view` — the agent reaches for
-    # these when the user asks to "open" or "switch to" a session.
-    # There's no server-side way to make the browser navigate, so we
-    # just return a clickable anchor link the user can click. The
-    # frontend's chat-history click delegate routes `#session-<id>`
-    # to selectSession(). The agent's reply naturally embeds this
-    # result so the user sees a single clickable line.
-    def _session_query(db):
-        query = db.query(DbSession).filter(DbSession.id == target_sid)
-        if owner is not None:
-            query = query.filter(DbSession.owner == owner)
-        return query
-
-    if action in ("switch", "open", "select", "view"):
-        db = SessionLocal()
-        try:
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            name = db_sess.name or target_sid
-        finally:
-            db.close()
-        return {
-            "action": action,
-            "session_id": target_sid,
-            "name": name,
-            "results": f"[{name}](#session-{target_sid}) — click to open.",
-        }
-
-    db = SessionLocal()
     try:
-        if action == "rename":
-            if not value:
-                return {"error": "rename needs a new name (the `value` arg, or line 3 in the legacy format)"}
-            new_name = value
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            db_sess.name = new_name
-            db.commit()
-            _session_manager.update_session_name(target_sid, new_name)
-            return {"action": "rename", "session_id": target_sid, "name": new_name,
-                    "results": f"Session renamed to '{new_name}'"}
-
-        elif action == "archive":
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            db_sess.archived = True
-            db.commit()
-            return {"action": "archive", "session_id": target_sid,
-                    "results": f"Session '{db_sess.name}' archived"}
-
-        elif action == "unarchive":
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            db_sess.archived = False
-            db.commit()
-            return {"action": "unarchive", "session_id": target_sid,
-                    "results": f"Session '{db_sess.name}' unarchived"}
-
-        elif action == "delete":
-            if target_sid == session_id:
-                return {"error": "Cannot delete the current session while chatting in it. Delete other sessions first."}
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Refusing to delete an unknown chat id; use the exact id from list_sessions."}
-            if db_sess and db_sess.is_important:
-                return {"error": f"Session '{db_sess.name}' is starred/favorited. Unstar it first before deleting."}
-            try:
-                ok = _session_manager.delete_session(target_sid)
-                if not ok:
-                    return {"error": f"Session '{target_sid}' was not deleted because it no longer exists."}
-                return {"action": "delete", "session_id": target_sid,
-                        "results": f"Session '{db_sess.name or target_sid}' deleted"}
-            except Exception as e:
-                return {"error": f"Failed to delete session: {e}"}
-
-        elif action in ("important", "unimportant"):
-            is_important = action == "important"
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            # Prevent AI from unstarring sessions — only the user can do that manually
-            if not is_important and db_sess.is_important:
-                return {"error": f"Session '{db_sess.name}' is starred by the user. Only the user can unstar sessions manually."}
-            db_sess.is_important = is_important
-            db.commit()
-            status = "marked as important" if is_important else "unmarked as important"
-            return {"action": action, "session_id": target_sid,
-                    "results": f"Session '{db_sess.name}' {status}"}
-
-        elif action == "truncate":
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            keep_count = 10
-            if value:
-                try:
-                    keep_count = int(value)
-                except ValueError:
-                    pass
-            success = _session_manager.truncate_messages(target_sid, keep_count)
-            if success:
-                return {"action": "truncate", "session_id": target_sid,
-                        "results": f"Session truncated to last {keep_count} messages"}
-            return {"error": f"Failed to truncate session '{target_sid}'"}
-
-        elif action == "fork":
-            db_sess = _session_query(db).first()
-            if not db_sess:
-                return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
-            keep_count = 0  # 0 = all messages
-            if value:
-                try:
-                    keep_count = int(value)
-                except ValueError:
-                    pass
-
-            source = _session_manager.get_session(target_sid)
-            if not source:
-                return {"error": f"Session '{target_sid}' not found"}
-
-            new_sid = str(uuid.uuid4())[:8]
-            _session_manager.create_session(
-                session_id=new_sid,
-                name=f"Fork: {source.name}",
-                endpoint_url=source.endpoint_url,
-                model=source.model,
-                rag=False,
-                owner=owner,
-            )
-            # Copy messages
-            history = source.get_context_messages()
-            if keep_count > 0:
-                history = history[:keep_count]
-            from core.models import ChatMessage as InMemoryMsg
-            new_sess = _session_manager.get_session(new_sid)
-            for msg in history:
-                new_sess.add_message(InMemoryMsg(msg["role"], msg["content"]))
-            try:
-                from src.event_bus import fire_event
-                fire_event("session_created", owner)
-            except Exception:
-                logger.debug("session_created event dispatch failed", exc_info=True)
-
-            return {"action": "fork", "session_id": new_sid,
-                    "source_session": target_sid, "messages_copied": len(history),
-                    "results": f"Forked session '{source.name}' -> new session {new_sid} ({len(history)} messages)"}
-
-        else:
-            return {"error": f"Unknown action '{action}'. Use: list, switch, rename, archive, unarchive, delete, important, unimportant, truncate, fork"}
+        return await _dispatch_session_action(action, target_sid, value, session_id, owner)
     except Exception as e:
         logger.error(f"manage_session failed: {e}")
         return {"error": str(e)}
+
+
+def _parse_manage_session_input(content: str):
+    """Parse do_manage_session content from JSON or line format.
+
+    Returns:
+        Tuple of (action, target_sid, value, list_filter) — all str or None.
+    """
+    raw = (content or "").strip()
+
+    if raw.startswith("{"):
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            parsed = None
+
+        if isinstance(parsed, dict):
+            action = str(parsed.get("action") or "").strip().lower()
+            target_sid = str(
+                parsed.get("session_id") or parsed.get("session") or parsed.get("id") or ""
+            ).strip()
+            v = parsed.get("value")
+            if v is None:
+                v = (parsed.get("name") or parsed.get("new_name")
+                     or parsed.get("title") or parsed.get("keep_count"))
+            value = None if v is None else str(v).strip()
+            list_filter = str(parsed.get("filter") or "").strip()
+            return action, target_sid, value, list_filter
+
+    lines = raw.split("\n")
+    if not lines or not lines[0].strip():
+        return "", "", None, ""
+
+    action = lines[0].strip().lower()
+    target_sid = lines[1].strip() if len(lines) >= 2 else ""
+    value = lines[2].strip() if len(lines) >= 3 else None
+    list_filter = "\n".join(lines[1:]).strip()
+    return action, target_sid, value, list_filter
+
+
+async def _dispatch_session_action(
+    action: str,
+    target_sid: str,
+    value: Optional[str],
+    current_session_id: Optional[str],
+    owner: Optional[str],
+) -> Dict:
+    """Route a validated manage_session action to its handler.
+
+    Raises on unexpected errors; callers should catch Exception.
+    """
+    def _query(db):
+        from src.database import Session as DbSession
+        q = db.query(DbSession).filter(DbSession.id == target_sid)
+        if owner is not None:
+            q = q.filter(DbSession.owner == owner)
+        return q
+
+    VIEW_ACTIONS = ("switch", "open", "select", "view")
+    if action in VIEW_ACTIONS:
+        return _session_action_view(target_sid, _query, action)
+
+    _VALID = "list, switch, rename, archive, unarchive, delete, important, unimportant, truncate, fork"
+
+    with get_db_session() as db:
+        db_sess = _query(db).first()
+
+        if action == "rename":
+            return _session_action_rename(db, db_sess, target_sid, value)
+
+        if action in ("archive", "unarchive"):
+            return _session_action_set_archived(db, db_sess, target_sid, action == "archive")
+
+        if action == "delete":
+            return _session_action_delete(db_sess, target_sid, current_session_id)
+
+        if action in ("important", "unimportant"):
+            return _session_action_set_important(db, db_sess, target_sid, action == "important")
+
+        if action == "truncate":
+            return _session_action_truncate(db_sess, target_sid, value)
+
+        if action == "fork":
+            return await _session_action_fork(db_sess, target_sid, value, owner)
+
+        return {"error": f"Unknown action '{action}'. Use: {_VALID}"}
+
+
+def _session_action_view(target_sid: str, query_fn, action: str) -> Dict:
+    """Return a clickable link so the user can navigate to the session."""
+    from src.database import SessionLocal
+    db = SessionLocal()
+    try:
+        db_sess = query_fn(db).first()
+        if not db_sess:
+            return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+        name = db_sess.name or target_sid
     finally:
         db.close()
+    return {
+        "action": action,
+        "session_id": target_sid,
+        "name": name,
+        "results": f"[{name}](#session-{target_sid}) — click to open.",
+    }
+
+
+def _session_action_rename(db, db_sess, target_sid: str, value: Optional[str]) -> Dict:
+    """Rename a session and update the in-memory manager."""
+    if not value:
+        return {"error": "rename needs a new name (the `value` arg, or line 3 in the legacy format)"}
+    if not db_sess:
+        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+    db_sess.name = value
+    db.commit()
+    _session_manager.update_session_name(target_sid, value)
+    return {"action": "rename", "session_id": target_sid, "name": value,
+            "results": f"Session renamed to '{value}'"}
+
+
+def _session_action_set_archived(db, db_sess, target_sid: str, archived: bool) -> Dict:
+    """Archive or unarchive a session."""
+    action_word = "archive" if archived else "unarchive"
+    if not db_sess:
+        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+    db_sess.archived = archived
+    db.commit()
+    past = "archived" if archived else "unarchived"
+    return {"action": action_word, "session_id": target_sid,
+            "results": f"Session '{db_sess.name}' {past}"}
+
+
+def _session_action_delete(db_sess, target_sid: str, current_session_id: Optional[str]) -> Dict:
+    """Delete a session with safety guards."""
+    if target_sid == current_session_id:
+        return {"error": "Cannot delete the current session while chatting in it. Delete other sessions first."}
+    if not db_sess:
+        return {"error": f"Session '{target_sid}' not found. Refusing to delete an unknown chat id; use the exact id from list_sessions."}
+    if db_sess.is_important:
+        return {"error": f"Session '{db_sess.name}' is starred/favorited. Unstar it first before deleting."}
+    try:
+        ok = _session_manager.delete_session(target_sid)
+        if not ok:
+            return {"error": f"Session '{target_sid}' was not deleted because it no longer exists."}
+        return {"action": "delete", "session_id": target_sid,
+                "results": f"Session '{db_sess.name or target_sid}' deleted"}
+    except Exception as e:
+        return {"error": f"Failed to delete session: {e}"}
+
+
+def _session_action_set_important(db, db_sess, target_sid: str, is_important: bool) -> Dict:
+    """Star or unstar a session."""
+    if not db_sess:
+        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+    if not is_important and db_sess.is_important:
+        return {"error": f"Session '{db_sess.name}' is starred by the user. Only the user can unstar sessions manually."}
+    db_sess.is_important = is_important
+    db.commit()
+    action_word = "important" if is_important else "unimportant"
+    status = "marked as important" if is_important else "unmarked as important"
+    return {"action": action_word, "session_id": target_sid,
+            "results": f"Session '{db_sess.name}' {status}"}
+
+
+def _session_action_truncate(db_sess, target_sid: str, value: Optional[str]) -> Dict:
+    """Truncate a session to the last N messages."""
+    if not db_sess:
+        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+    keep_count = SESSION_TRUNCATE_DEFAULT_KEEP
+    if value:
+        try:
+            keep_count = int(value)
+        except ValueError:
+            pass
+    success = _session_manager.truncate_messages(target_sid, keep_count)
+    if success:
+        return {"action": "truncate", "session_id": target_sid,
+                "results": f"Session truncated to last {keep_count} messages"}
+    return {"error": f"Failed to truncate session '{target_sid}'"}
+
+
+async def _session_action_fork(db_sess, target_sid: str, value: Optional[str], owner: Optional[str]) -> Dict:
+    """Fork a session, copying messages into a new session."""
+    if not db_sess:
+        return {"error": f"Session '{target_sid}' not found. Use list_sessions and pass the exact id it returned."}
+    keep_count = 0
+    if value:
+        try:
+            keep_count = int(value)
+        except ValueError:
+            pass
+
+    source = _session_manager.get_session(target_sid)
+    if not source:
+        return {"error": f"Session '{target_sid}' not found"}
+
+    new_sid = str(uuid.uuid4())[:UUID_SHORT_ID_LENGTH]
+    _session_manager.create_session(
+        session_id=new_sid,
+        name=f"Fork: {source.name}",
+        endpoint_url=source.endpoint_url,
+        model=source.model,
+        rag=False,
+        owner=owner,
+    )
+    history = source.get_context_messages()
+    if keep_count > 0:
+        history = history[:keep_count]
+
+    from core.models import ChatMessage as InMemoryMsg
+    new_sess = _session_manager.get_session(new_sid)
+    for msg in history:
+        new_sess.add_message(InMemoryMsg(msg["role"], msg["content"]))
+
+    try:
+        from src.event_bus import fire_event
+        fire_event("session_created", owner)
+    except Exception:
+        logger.debug("session_created event dispatch failed", exc_info=True)
+
+    return {
+        "action": "fork",
+        "session_id": new_sid,
+        "source_session": target_sid,
+        "messages_copied": len(history),
+        "results": f"Forked session '{source.name}' -> new session {new_sid} ({len(history)} messages)",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1233,15 +1229,15 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
         if not memories:
             return {"results": "No memories found" + (f" in category '{category_filter}'" if category_filter else "") + "."}
         result_lines = [f"Found {len(memories)} memory entries:\n"]
-        for m in memories[:100]:
+        for m in memories[:MEMORY_LIST_DISPLAY_LIMIT]:
             cat = m.get("category", "fact")
             mid = m.get("id", "?")[:8]
             text = m.get("text", "")
-            if len(text) > 150:
-                text = text[:150] + "..."
+            if len(text) > MEMORY_TEXT_PREVIEW_LIMIT:
+                text = text[:MEMORY_TEXT_PREVIEW_LIMIT] + "..."
             result_lines.append(f"- [{cat}] `{mid}` — {text}")
-        if len(memories) > 100:
-            result_lines.append(f"... and {len(memories) - 100} more")
+        if len(memories) > MEMORY_LIST_DISPLAY_LIMIT:
+            result_lines.append(f"... and {len(memories) - MEMORY_LIST_DISPLAY_LIMIT} more")  # noqa
         return {"results": "\n".join(result_lines)}
 
     elif action == "add":
@@ -1345,11 +1341,11 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
         memories = _memory_manager.load(owner=owner)
 
         if hasattr(_memory_manager, 'get_relevant_memories'):
-            results = _memory_manager.get_relevant_memories(query, memories, threshold=0.05, max_items=20)
+            results = _memory_manager.get_relevant_memories(query, memories, threshold=0.05, max_items=MEMORY_SEARCH_RESULT_LIMIT)
         else:
             # Fallback: simple text search
             query_lower = query.lower()
-            results = [m for m in memories if query_lower in m.get("text", "").lower()][:20]
+            results = [m for m in memories if query_lower in m.get("text", "").lower()][:MEMORY_SEARCH_RESULT_LIMIT]
 
         if not results:
             return {"results": f"No memories found matching '{query}'."}
@@ -1399,7 +1395,7 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
                 model_ids = list(ANTHROPIC_MODELS)
             else:
                 try:
-                    r = httpx.get(build_models_url(base), headers=headers, timeout=5)
+                    r = httpx.get(build_models_url(base), headers=headers, timeout=HTTP_TIMEOUT_MODEL_LIST)
                     r.raise_for_status()
                     data = r.json()
                     model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
@@ -1534,283 +1530,289 @@ async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
       Line 2+: action-specific params
 
     Actions:
-      toggle <name> <on|off>  — Toggle a setting (web, bash, rag, research, incognito, document_editor)
+      toggle <name> <on|off>  — Toggle a setting (web, bash, research, incognito, document_editor)
       set_mode <agent|chat>   — Switch between agent and chat mode
       switch_model <model>    — Change the model for the current session
-      set_theme <preset>      — Apply a theme preset (dark, light, paper, nord, dracula, gruvbox, gpt, claude, lavender, etc.)
-      create_theme <name> <bg> <fg> <panel> <border> <accent> [key=val ...] — Create custom theme. Optional key=val: advanced color overrides AND background effects: bgPattern=<none|dots|synapse|rain|constellations|perlin-flow|petals|sparkles|embers>, bgEffectColor=#RRGGBB, bgEffectIntensity=<num>, bgEffectSize=<num>, frosted=true|false
-      open_panel <name>       — Open a panel (documents, gallery, email, sessions, notes, memories, skills, settings, cookbook)
-      open_email_reply <uid> [folder] [reply|reply-all|ai-reply] — Open a reply draft document for an email; does not send
-      get_toggles             — Return current toggle states (server-side knowledge)
+      set_theme <preset>      — Apply a theme preset (dark, light, paper, cyberpunk, etc.)
+      create_theme <name> <bg> <fg> <panel> <border> <accent> [key=val ...]
+      open_panel <name>       — Open a panel (documents, gallery, email, sessions, notes, etc.)
+      open_email_reply <uid> [folder] [reply|reply-all|ai-reply]
+      highlight <selector> [label] — Highlight a UI element
+      clear_highlight         — Clear all highlights
+      get_toggles             — Return info about available toggles
     """
-    lines = content.strip().split("\n")
-    if not lines:
+    stripped = content.strip()
+    if not stripped:
         return {"error": "No action specified"}
 
+    lines = stripped.split("\n")
     parts = lines[0].strip().split(None, 2)
+    if not parts:
+        return {"error": "No action specified"}
+
     action = parts[0].lower()
 
-    if action == "toggle":
-        if len(parts) < 3:
-            return {"error": "toggle needs: toggle <name> <on|off>"}
-        toggle_name = parts[1].lower()
-        state = parts[2].lower() in ("on", "true", "1", "yes", "enable", "enabled")
-        # Friendly aliases — users say "shell" / "search" naturally.
-        _toggle_aliases = {
-            "shell": "bash",
-            "terminal": "bash",
-            "search": "web",
-            "websearch": "web",
-            "web_search": "web",
-            "deepresearch": "research",
-            "deep_research": "research",
-            "documents": "document_editor",
-            "doc": "document_editor",
-            "docs": "document_editor",
-            "private": "incognito",
-        }
-        toggle_name = _toggle_aliases.get(toggle_name, toggle_name)
-        valid_toggles = {"web", "bash", "research", "incognito", "document_editor"}
-        if toggle_name not in valid_toggles:
-            return {"error": f"Unknown toggle '{toggle_name}'. Valid: {', '.join(sorted(valid_toggles))}"}
-        return {
-            "ui_event": "toggle",
-            "toggle_name": toggle_name,
-            "state": state,
-            "results": f"Toggle '{toggle_name}' set to {'on' if state else 'off'}",
-        }
+    _HANDLERS = {
+        "toggle": _ui_handle_toggle,
+        "set_mode": _ui_handle_set_mode,
+        "set_theme": _ui_handle_set_theme,
+        "create_theme": _ui_handle_create_theme,
+        "highlight": _ui_handle_highlight,
+        "clear_highlight": _ui_handle_clear_highlight,
+        "open_panel": _ui_handle_open_panel,
+        "open_email_reply": _ui_handle_open_email_reply,
+        "get_toggles": _ui_handle_get_toggles,
+    }
 
-    elif action == "set_mode":
-        if len(parts) < 2:
-            return {"error": "set_mode needs: set_mode <agent|chat>"}
-        mode = parts[1].lower()
-        if mode not in ("agent", "chat"):
-            return {"error": f"Invalid mode '{mode}'. Use: agent, chat"}
-        return {
-            "ui_event": "set_mode",
-            "mode": mode,
-            "results": f"Mode changed to '{mode}'",
-        }
+    if action == "switch_model":
+        return await _ui_handle_switch_model(parts, lines, session_id)
 
-    elif action == "switch_model":
-        model_spec = " ".join(parts[1:]) if len(parts) > 1 else ""
-        if not model_spec:
-            model_spec = lines[1].strip() if len(lines) > 1 else ""
-        if not model_spec:
-            return {"error": "switch_model needs a model name"}
+    handler = _HANDLERS.get(action)
+    if handler:
+        return handler(parts, lines)
 
-        # Resolve the model to validate it exists
+    valid = sorted(_HANDLERS.keys()) + ["switch_model"]
+    return {"error": f"Unknown action '{action}'. Use: {', '.join(valid)}"}
+
+
+def _ui_handle_toggle(parts: list, lines: list) -> Dict:
+    """Handle the toggle action — enable/disable a UI feature."""
+    if len(parts) < 3:
+        return {"error": "toggle needs: toggle <name> <on|off>"}
+
+    raw_name = parts[1].lower()
+    toggle_name = resolve_toggle(raw_name)
+    if not toggle_name or toggle_name not in CANONICAL_TOGGLES:
+        return {"error": f"Unknown toggle '{raw_name}'. Valid: {', '.join(sorted(CANONICAL_TOGGLES))}"}
+
+    state = parts[2].lower() in ("on", "true", "1", "yes", "enable", "enabled")
+    return {
+        "ui_event": "toggle",
+        "toggle_name": toggle_name,
+        "state": state,
+        "results": f"Toggle '{toggle_name}' set to {'on' if state else 'off'}",
+    }
+
+
+def _ui_handle_set_mode(parts: list, lines: list) -> Dict:
+    """Handle the set_mode action — switch between agent and chat mode."""
+    if len(parts) < 2:
+        return {"error": "set_mode needs: set_mode <agent|chat>"}
+    mode = parts[1].lower()
+    if mode not in ("agent", "chat"):
+        return {"error": f"Invalid mode '{mode}'. Use: agent, chat"}
+    return {
+        "ui_event": "set_mode",
+        "mode": mode,
+        "results": f"Mode changed to '{mode}'",
+    }
+
+
+async def _ui_handle_switch_model(parts: list, lines: list, session_id: Optional[str]) -> Dict:
+    """Handle switch_model — validate and apply a model change to the current session."""
+    model_spec = " ".join(parts[1:]) if len(parts) > 1 else ""
+    if not model_spec:
+        model_spec = lines[1].strip() if len(lines) > 1 else ""
+    if not model_spec:
+        return {"error": "switch_model needs a model name"}
+
+    try:
+        url, model_id, headers = _resolve_model(model_spec)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    if session_id and _session_manager:
+        from src.database import SessionLocal as _SL, Session as _DbSess
+        with get_db_session() as db:
+            db_s = db.query(_DbSess).filter(_DbSess.id == session_id).first()
+            if db_s:
+                db_s.endpoint_url = url
+                db_s.model = model_id
+                db.commit()
+
+        sess = _session_manager.get_session(session_id)
+        if sess:
+            sess.endpoint_url = url
+            sess.model = model_id
+            if headers:
+                sess.headers = headers
+
+    return {
+        "ui_event": "switch_model",
+        "model": model_id,
+        "endpoint_url": url,
+        "results": f"Model switched to '{model_id}'",
+    }
+
+
+def _ui_handle_set_theme(parts: list, lines: list) -> Dict:
+    """Handle set_theme — apply a named theme preset or custom theme."""
+    theme_name = parts[1].lower() if len(parts) > 1 else ""
+    if not theme_name:
+        return {"error": "set_theme needs a theme name"}
+
+    custom_themes = {}
+    try:
+        from routes.prefs_routes import _load as _load_prefs
+        custom_themes = _load_prefs().get("custom-themes", {}) or {}
+    except Exception:
+        pass
+
+    all_known = THEME_PRESETS | set(custom_themes.keys())
+    if theme_name not in all_known:
+        custom_label = f" | Custom: {', '.join(sorted(custom_themes.keys()))}" if custom_themes else ""
+        return {"error": f"Unknown theme '{theme_name}'. Available: {', '.join(sorted(THEME_PRESETS))}{custom_label}"}
+
+    return {
+        "ui_event": "set_theme",
+        "theme_name": theme_name,
+        "results": f"Theme changed to '{theme_name}'",
+    }
+
+
+def _ui_handle_create_theme(parts: list, lines: list) -> Dict:
+    """Handle create_theme — create a custom named theme with colors and optional effects."""
+    all_parts = lines[0].strip().split()
+    if len(all_parts) < 7:
+        return {"error": (
+            "create_theme needs: create_theme <name> <bg> <fg> <panel> <border> <accent> "
+            "(all hex colors). Optional advanced color key=value pairs and background EFFECTS: "
+            f"bgPattern=<{'|'.join(sorted(BACKGROUND_PATTERNS))}>, "
+            "bgEffectColor=#RRGGBB, bgEffectIntensity=<num>, bgEffectSize=<num>, frosted=true|false"
+        )}
+
+    name = all_parts[1].lower().replace(" ", "-")
+    base_color_keys = ("bg", "fg", "panel", "border", "red")
+    colors = dict(zip(base_color_keys, all_parts[2:7]))
+
+    for key, val in colors.items():
+        if not is_valid_hex_color(val):
+            return {"error": f"Invalid hex color for {key}: '{val}'. Use format #RRGGBB"}
+
+    advanced, bg = {}, {}
+    for token in all_parts[7:]:
+        if "=" not in token:
+            continue
+        key, val = token.split("=", 1)
+        err = _ui_parse_theme_token(key, val, advanced, bg)
+        if err:
+            return err
+
+    if advanced:
+        colors["advanced"] = advanced
+
+    effect_label = bg.get("pattern", "frosted" if bg.get("frosted") else "custom") if bg else None
+    return {
+        "ui_event": "create_theme",
+        "theme_name": name,
+        "colors": colors,
+        "bg": bg or None,
+        "results": (
+            f"Custom theme '{name}' created and applied"
+            + (f" with {len(advanced)} advanced overrides" if advanced else "")
+            + (f" + background effect ({effect_label})" if bg else "")
+        ),
+    }
+
+
+def _ui_parse_theme_token(key: str, val: str, advanced: dict, bg: dict) -> Optional[Dict]:
+    """Parse one key=value token from create_theme. Mutates advanced/bg dicts.
+
+    Returns an error dict if invalid, or None if the token was consumed correctly.
+    """
+    if key in ADVANCED_COLOR_KEYS:
+        if not is_valid_hex_color(val):
+            return {"error": f"Invalid hex color for advanced key {key}: '{val}'. Use format #RRGGBB"}
+        advanced[key] = val
+
+    elif key == "bgPattern":
+        if val not in BACKGROUND_PATTERNS:
+            return {"error": f"Invalid bgPattern '{val}'. Use one of: {', '.join(sorted(BACKGROUND_PATTERNS))}"}
+        bg["pattern"] = val
+
+    elif key == "bgEffectColor":
+        if not is_valid_hex_color(val):
+            return {"error": f"Invalid hex color for bgEffectColor: '{val}'. Use format #RRGGBB"}
+        bg["effectColor"] = val
+
+    elif key in ("bgEffectIntensity", "bgEffectSize"):
         try:
-            url, model_id, headers = _resolve_model(model_spec)
-        except ValueError as e:
-            return {"error": str(e)}
+            dest = "effectIntensity" if key == "bgEffectIntensity" else "effectSize"
+            bg[dest] = float(val)
+        except ValueError:
+            return {"error": f"Invalid number for {key}: '{val}'"}
 
-        # Update current session's model if we have a session
-        if session_id and _session_manager:
-            from src.database import SessionLocal as SL2, Session as DbSess2
-            db2 = SL2()
-            try:
-                db_s = db2.query(DbSess2).filter(DbSess2.id == session_id).first()
-                if db_s:
-                    db_s.endpoint_url = url
-                    db_s.model = model_id
-                    db2.commit()
-            finally:
-                db2.close()
+    elif key == "frosted":
+        bg["frosted"] = val.lower() in ("true", "1", "yes", "on")
 
-            sess = _session_manager.get_session(session_id)
-            if sess:
-                sess.endpoint_url = url
-                sess.model = model_id
-                if headers:
-                    sess.headers = headers
+    return None
 
-        return {
-            "ui_event": "switch_model",
-            "model": model_id,
-            "endpoint_url": url,
-            "results": f"Model switched to '{model_id}'",
-        }
 
-    elif action == "set_theme":
-        theme_name = parts[1].lower() if len(parts) > 1 else ""
-        # Theme colors are defined in static/js/theme.js on the frontend.
-        # We pass the name; the frontend looks it up from presets + custom themes.
-        # Also check user's custom themes stored in prefs.
-        # Must match the THEMES keys in static/js/theme.js.
-        known_presets = [
-            "dark", "light", "midnight", "paper", "cyberpunk", "retrowave",
-            "forest", "ocean", "ume", "copper", "terminal", "organs",
-            "lavender", "gpt", "claude", "cute",
-        ]
-        custom_themes = {}
-        try:
-            from routes.prefs_routes import _load as _load_prefs
-            custom_themes = _load_prefs().get("custom-themes", {}) or {}
-        except Exception:
-            pass
-        all_known = set(known_presets) | set(custom_themes.keys())
-        if theme_name not in all_known:
-            custom_label = f" | Custom: {', '.join(sorted(custom_themes.keys()))}" if custom_themes else ""
-            return {"error": f"Unknown theme '{theme_name}'. Available: {', '.join(sorted(known_presets))}{custom_label}"}
-        return {
-            "ui_event": "set_theme",
-            "theme_name": theme_name,
-            "results": f"Theme changed to '{theme_name}'",
-        }
+def _ui_handle_highlight(parts: list, lines: list) -> Dict:
+    """Handle highlight — mark a CSS selector for visual emphasis."""
+    selector = parts[1] if len(parts) > 1 else ""
+    label = " ".join(parts[2:]) if len(parts) > 2 else ""
+    if not selector:
+        return {"error": "highlight needs: highlight <css-selector> [label]"}
+    return {
+        "ui_event": "highlight",
+        "selector": selector,
+        "label": label,
+        "results": f"Highlighting '{selector}'",
+    }
 
-    elif action == "create_theme":
-        # Re-split without limit to get all parts
-        parts = lines[0].strip().split()
-        # create_theme <name> <bg> <fg> <panel> <border> <accent> [key=value ...]
-        if len(parts) < 7:
-            return {"error": "create_theme needs: create_theme <name> <bg> <fg> <panel> <border> <accent> (all hex colors). Optional advanced color key=value pairs (userBubbleBg, aiBubbleBg, bubbleBorder, sidebarBg, sectionAccent, brandColor, inputBg, inputBorder, sendBtnBg, sendBtnHover, codeBg, codeFg, toggleBg, toggleActive, accentPrimary, accentError). Optional background EFFECTS: bgPattern=<none|dots|synapse|rain|constellations|perlin-flow|petals|sparkles|embers>, bgEffectColor=#RRGGBB, bgEffectIntensity=<num e.g. 1>, bgEffectSize=<num e.g. 1>, frosted=true|false"}
-        name = parts[1].lower().replace(" ", "-")
-        colors = {"bg": parts[2], "fg": parts[3], "panel": parts[4], "border": parts[5], "red": parts[6]}
-        # Validate base hex colors
-        import re as _re
-        for k, v in colors.items():
-            if not _re.match(r'^#[0-9a-fA-F]{6}$', v):
-                return {"error": f"Invalid hex color for {k}: '{v}'. Use format #RRGGBB"}
-        # Parse optional advanced key=value pairs
-        adv_keys = {
-            "userBubbleBg", "aiBubbleBg", "bubbleBorder", "sidebarBg",
-            "sectionAccent", "brandColor", "inputBg", "inputBorder",
-            "sendBtnBg", "sendBtnHover", "codeBg", "codeFg",
-            "toggleBg", "toggleActive", "accentPrimary", "accentError",
-        }
-        advanced = {}
-        # Background-effect fields (animated pattern + frosted glass). Different
-        # value types than the hex-only advanced keys, so parse separately.
-        _BG_PATTERNS = {"none", "dots", "synapse", "rain", "constellations",
-                        "perlin-flow", "petals", "sparkles", "embers"}
-        bg = {}
-        for part in parts[7:]:
-            if "=" not in part:
-                continue
-            ak, av = part.split("=", 1)
-            if ak in adv_keys:
-                if not _re.match(r'^#[0-9a-fA-F]{6}$', av):
-                    return {"error": f"Invalid hex color for advanced key {ak}: '{av}'. Use format #RRGGBB"}
-                advanced[ak] = av
-            elif ak == "bgPattern":
-                if av not in _BG_PATTERNS:
-                    return {"error": f"Invalid bgPattern '{av}'. Use one of: {', '.join(sorted(_BG_PATTERNS))}"}
-                bg["pattern"] = av
-            elif ak == "bgEffectColor":
-                if not _re.match(r'^#[0-9a-fA-F]{6}$', av):
-                    return {"error": f"Invalid hex color for bgEffectColor: '{av}'. Use format #RRGGBB"}
-                bg["effectColor"] = av
-            elif ak in ("bgEffectIntensity", "bgEffectSize"):
-                try:
-                    bg["effectIntensity" if ak == "bgEffectIntensity" else "effectSize"] = float(av)
-                except ValueError:
-                    return {"error": f"Invalid number for {ak}: '{av}'"}
-            elif ak == "frosted":
-                bg["frosted"] = av.lower() in ("true", "1", "yes", "on")
-        if advanced:
-            colors["advanced"] = advanced
-        return {
-            "ui_event": "create_theme",
-            "theme_name": name,
-            "colors": colors,
-            "bg": bg or None,
-            "results": f"Custom theme '{name}' created and applied"
-                       + (f" with {len(advanced)} advanced overrides" if advanced else "")
-                       + (f" + background effect ({bg.get('pattern', 'frosted' if bg.get('frosted') else 'custom')})" if bg else ""),
-        }
 
-    elif action == "highlight":
-        selector = parts[1] if len(parts) > 1 else ""
-        label = " ".join(parts[2:]) if len(parts) > 2 else ""
-        if not selector:
-            return {"error": "highlight needs: highlight <css-selector> [label]"}
-        return {
-            "ui_event": "highlight",
-            "selector": selector,
-            "label": label,
-            "results": f"Highlighting '{selector}'",
-        }
+def _ui_handle_clear_highlight(parts: list, lines: list) -> Dict:
+    """Handle clear_highlight — remove all visual highlights."""
+    return {
+        "ui_event": "clear_highlight",
+        "results": "Highlights cleared",
+    }
 
-    elif action == "clear_highlight":
-        return {
-            "ui_event": "clear_highlight",
-            "results": "Highlights cleared",
-        }
 
-    elif action == "open_panel":
-        # Open a top-level panel/modal: documents/library, gallery,
-        # email, sessions, notes, memories, skills, settings, cookbook.
-        panel = parts[1].lower() if len(parts) > 1 else ""
-        _panel_aliases = {
-            "documents": "documents",
-            "document": "documents",
-            "doc": "documents",
-            "docs": "documents",
-            "library": "documents",
-            "doclib": "documents",
-            "gallery": "gallery",
-            "images": "gallery",
-            "email": "email",
-            "emails": "email",
-            "inbox": "email",
-            "mail": "email",
-            "sessions": "sessions",
-            "chats": "sessions",
-            "history": "sessions",
-            "notes": "notes",
-            "note": "notes",
-            "todo": "notes",
-            "todos": "notes",
-            "memories": "memories",
-            "memory": "memories",
-            "brain": "memories",
-            "skills": "skills",
-            "settings": "settings",
-            "preferences": "settings",
-            "cookbook": "cookbook",
-            "models": "cookbook",
-            "llm": "cookbook",
-            "serve": "cookbook",
-            "serving": "cookbook",
-        }
-        target = _panel_aliases.get(panel)
-        if not target:
-            return {"error": f"Unknown panel '{panel}'. Valid: documents, gallery, email, sessions, notes, memories, skills, settings, cookbook."}
-        return {
-            "ui_event": "open_panel",
-            "panel": target,
-            "results": f"Opening {target} panel",
-        }
+def _ui_handle_open_panel(parts: list, lines: list) -> Dict:
+    """Handle open_panel — navigate to a top-level panel in the UI."""
+    raw = parts[1].lower() if len(parts) > 1 else ""
+    target = resolve_panel(raw)
+    if not target:
+        return {"error": f"Unknown panel '{raw}'. Valid: {', '.join(sorted(CANONICAL_PANELS))}."}
+    return {
+        "ui_event": "open_panel",
+        "panel": target,
+        "results": f"Opening {target} panel",
+    }
 
-    elif action == "open_email_reply":
-        reply_parts = lines[0].strip().split()
-        uid = reply_parts[1].strip() if len(reply_parts) > 1 else ""
-        folder = reply_parts[2].strip() if len(reply_parts) > 2 else "INBOX"
-        mode = reply_parts[3].strip().lower() if len(reply_parts) > 3 else "reply"
-        if not uid:
-            return {"error": "open_email_reply needs: open_email_reply <uid> [folder] [reply|reply-all|ai-reply]"}
-        if mode not in ("reply", "reply-all", "ai-reply"):
-            mode = "reply"
-        return {
-            "ui_event": "open_email_reply",
-            "uid": uid,
-            "folder": folder or "INBOX",
-            "mode": mode,
-            "results": f"Opening reply draft for email UID {uid}",
-        }
 
-    elif action == "get_toggles":
-        return {
-            "results": (
-                "Toggle states are managed client-side in localStorage. "
-                "Available toggles: web, bash, rag, research, incognito, document_editor. "
-                "Use 'toggle <name> <on|off>' to change them."
-            )
-        }
+def _ui_handle_open_email_reply(parts: list, lines: list) -> Dict:
+    """Handle open_email_reply — open a pre-populated reply draft for an email."""
+    tokens = lines[0].strip().split()
+    uid = tokens[1].strip() if len(tokens) > 1 else ""
+    folder = tokens[2].strip() if len(tokens) > 2 else "INBOX"
+    mode = tokens[3].strip().lower() if len(tokens) > 3 else "reply"
 
-    else:
-        return {"error": f"Unknown action '{action}'. Use: toggle, set_mode, switch_model, set_theme, highlight, clear_highlight, get_toggles"}
+    if not uid:
+        return {"error": "open_email_reply needs: open_email_reply <uid> [folder] [reply|reply-all|ai-reply]"}
+    if mode not in ("reply", "reply-all", "ai-reply"):
+        mode = "reply"
+
+    return {
+        "ui_event": "open_email_reply",
+        "uid": uid,
+        "folder": folder or "INBOX",
+        "mode": mode,
+        "results": f"Opening reply draft for email UID {uid}",
+    }
+
+
+def _ui_handle_get_toggles(parts: list, lines: list) -> Dict:
+    """Handle get_toggles — return info about available UI toggles."""
+    return {
+        "results": (
+            "Toggle states are managed client-side in localStorage. "
+            f"Available toggles: {', '.join(sorted(CANONICAL_TOGGLES))}. "
+            "Use 'toggle <name> <on|off>' to change them."
+        )
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1877,7 +1879,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                         if not _ibase.endswith("/v1"):
                             _ibase += "/v1"
                         try:
-                            _r = _req.get(_ibase + "/models", timeout=3)
+                            _r = _req.get(_ibase + "/models", timeout=HTTP_TIMEOUT_IMAGE_ENDPOINT)
                             _r.raise_for_status()
                             _mids = [m.get("id") for m in (_r.json().get("data") or []) if m.get("id")]
                             if _mids:
@@ -1930,7 +1932,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
         else:
             payload["quality"] = "medium"
 
-    logger.info(f"Image generation: model={model_id}, size={size}, quality={quality}, prompt={prompt[:80]}")
+    logger.info(f"Image generation: model={model_id}, size={size}, quality={quality}, prompt={prompt[:IMAGE_PROMPT_LOG_LIMIT]}")
 
     try:
         # GPT image models can take 30-120s+ depending on quality
@@ -1938,7 +1940,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
             resp = await client.post(images_url, json=payload, headers=headers)
 
             if resp.status_code != 200:
-                error_text = resp.text[:500]
+                error_text = resp.text[:ERROR_TEXT_DISPLAY_LIMIT]
                 try:
                     err_json = resp.json()
                     error_text = err_json.get("error", {}).get("message", error_text) if isinstance(err_json.get("error"), dict) else str(err_json.get("error", error_text))
@@ -1991,7 +1993,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
             elif img.get("url"):
                 # Download external URL and save locally (DALL-E returns temp URLs)
                 try:
-                    dl_resp = httpx.get(img["url"], timeout=60)
+                    dl_resp = httpx.get(img["url"], timeout=HTTP_TIMEOUT_IMAGE_DOWNLOAD)
                     if dl_resp.status_code == 200:
                         img_dir = Path("data/generated_images")
                         img_dir.mkdir(parents=True, exist_ok=True)

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -480,7 +480,7 @@ def _image_save_to_gallery(
 def _image_save_b64(
     b64_data: str, prompt: str, model_id: str, size: str, quality: str,
     session_id: Optional[str], owner: Optional[str],
-) -> tuple:
+) -> Tuple[str, str]:
     """Decode a base64 image, save to disk, persist gallery record.
 
     Returns:
@@ -501,7 +501,7 @@ def _image_save_b64(
 async def _image_download_and_save(
     remote_url: str, prompt: str, model_id: str, size: str, quality: str,
     session_id: Optional[str], owner: Optional[str],
-) -> tuple:
+) -> Tuple[str, str]:
     """Download an external image URL, save locally, persist gallery record.
 
     Returns:
@@ -903,7 +903,7 @@ def do_create_session(content: str, session_id: Optional[str] = None, owner: Opt
     except ValueError as e:
         return {"error": str(e)}
 
-    sid = str(uuid.uuid4())[:8]
+    sid = str(uuid.uuid4())[:UUID_SHORT_ID_LENGTH]
     try:
         _session_manager.create_session(
             session_id=sid,

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -382,10 +382,15 @@ def _image_build_payload(
     quality: str,
     *,
     is_gpt_image: bool,
-    is_dalle: bool,
     is_local_diffusion: bool,
+    **_kind: bool,  # absorbs is_dalle from the classify-model dict
 ) -> Dict:
-    """Build the images/generations API request payload."""
+    """Build the images/generations API request payload.
+
+    DALL-E 3 rejects a quality field, so only GPT-image and local-diffusion
+    models receive one. ``is_dalle`` is therefore not needed here; it is
+    accepted via ``**_kind`` only so the caller can splat the classify dict.
+    """
     payload: Dict = {
         "model": model_id,
         "prompt": prompt,
@@ -506,7 +511,8 @@ async def _image_download_and_save(
     from pathlib import Path
 
     try:
-        dl = httpx.get(remote_url, timeout=HTTP_TIMEOUT_IMAGE_DOWNLOAD)
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_IMAGE_DOWNLOAD) as client:
+            dl = await client.get(remote_url)
         if dl.status_code == 200:
             img_dir = Path("data/generated_images")
             img_dir.mkdir(parents=True, exist_ok=True)
@@ -525,6 +531,34 @@ async def _image_download_and_save(
 # Pipeline helpers
 # ---------------------------------------------------------------------------
 
+def _pipeline_steps_from_json(stripped: str) -> Optional[List[Dict]]:
+    """Parse pipeline steps from a JSON object/array, or None if not JSON."""
+    if not stripped.startswith(("{", "[")):
+        return None
+    try:
+        data = json.loads(stripped)
+    except (ValueError, TypeError):
+        return None
+    return data.get("steps") if isinstance(data, dict) else data
+
+
+def _pipeline_steps_from_lines(stripped: str) -> Tuple[List[Dict], Optional[Dict]]:
+    """Parse 'model | instruction' lines into steps.
+
+    Returns (steps, error_dict); error_dict is None on success.
+    """
+    steps: List[Dict] = []
+    for line in stripped.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        if "|" not in line:
+            return [], {"error": "Each line must be: model | instruction (or use JSON format)"}
+        model_part, instruction_part = line.split("|", 1)
+        steps.append({"model": model_part.strip(), "instruction": instruction_part.strip()})
+    return steps, None
+
+
 def _pipeline_parse_steps(content: str) -> Tuple[Optional[List[Dict]], Optional[Dict]]:
     """Parse pipeline steps from JSON or pipe-delimited line format.
 
@@ -535,26 +569,11 @@ def _pipeline_parse_steps(content: str) -> Tuple[Optional[List[Dict]], Optional[
     if not stripped:
         return None, {"error": "No pipeline steps provided"}
 
-    # Try JSON first
-    steps = None
-    if stripped.startswith(("{", "[")):
-        try:
-            data = json.loads(stripped)
-            steps = data.get("steps") if isinstance(data, dict) else data
-        except (ValueError, TypeError):
-            pass
-
-    # Fall back to line-based format: model | instruction
+    steps = _pipeline_steps_from_json(stripped)
     if steps is None:
-        steps = []
-        for line in stripped.split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            if "|" not in line:
-                return None, {"error": "Each line must be: model | instruction (or use JSON format)"}
-            model_part, instruction_part = line.split("|", 1)
-            steps.append({"model": model_part.strip(), "instruction": instruction_part.strip()})
+        steps, error = _pipeline_steps_from_lines(stripped)
+        if error:
+            return None, error
 
     if not steps:
         return None, {"error": "No pipeline steps provided"}
@@ -605,14 +624,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
 
     spec = spec.strip()
-    target_endpoint_name = None
-
-    if "@" in spec:
-        model_name, target_endpoint_name = spec.rsplit("@", 1)
-        model_name = model_name.strip()
-        target_endpoint_name = target_endpoint_name.strip()
-    else:
-        model_name = spec
+    model_name, target_endpoint_name = _parse_model_spec(spec)
 
     with get_db_session() as db:
         query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled.is_(True))
@@ -634,14 +646,31 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
         model_ids = _fetch_endpoint_model_ids(base, headers, provider, ANTHROPIC_MODELS)
         model_ids = [m for m in model_ids if m != ENDPOINT_OFFLINE]
 
-        for mid in model_ids:
-            if mid.lower() == model_name.lower():
-                return build_chat_url(base), mid, headers
-        for mid in model_ids:
-            if model_name.lower() in mid.lower() or mid.lower() in model_name.lower():
-                return build_chat_url(base), mid, headers
+        matched = _match_model_id(model_name, model_ids)
+        if matched:
+            return build_chat_url(base), matched, headers
 
     raise ValueError(f"Model '{spec}' not found on any configured endpoint")
+
+
+def _parse_model_spec(spec: str) -> Tuple[str, Optional[str]]:
+    """Split a 'model@endpoint' spec into (model_name, endpoint_name | None)."""
+    if "@" in spec:
+        model_name, endpoint_name = spec.rsplit("@", 1)
+        return model_name.strip(), endpoint_name.strip()
+    return spec, None
+
+
+def _match_model_id(model_name: str, model_ids: List[str]) -> Optional[str]:
+    """Find the best matching model id: exact match first, then substring."""
+    target = model_name.lower()
+    for mid in model_ids:
+        if mid.lower() == target:
+            return mid
+    for mid in model_ids:
+        if target in mid.lower() or mid.lower() in target:
+            return mid
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -768,59 +797,17 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
         return {"error": "No conversation context found to review"}
 
     # ── Step 1: Get the reviewer's feedback ──
-    reviewer_message = f"Here's the conversation so far:\n\n{context_text}"
-    if focus:
-        reviewer_message += f"\n\n---\nSpecifically, I want your take on: {focus}"
-    else:
-        reviewer_message += "\n\n---\nGive me your honest second opinion on what's being discussed."
-
     try:
-        review = await llm_call_async(
-            reviewer_url, reviewer_model,
-            [
-                {"role": "system", "content": SECOND_OPINION_REVIEWER_SYSTEM},
-                {"role": "user", "content": reviewer_message},
-            ],
-            headers=reviewer_headers,
-            timeout=AI_CHAT_TIMEOUT,
+        review = await _second_opinion_review(
+            reviewer_url, reviewer_model, reviewer_headers, context_text, focus
         )
-        review = truncate_for_teacher(review)
     except Exception as e:
         logger.error(f"second_opinion reviewer call failed: {e}")
         return {"error": f"Failed to get second opinion from {model_spec}: {e}"}
 
     # ── Step 2: Send review back to session's own model for evaluation ──
-    unified = ""
-    original_model = "unknown"
-    if sess:
-        original_url = sess.endpoint_url
-        original_model = sess.model
-        original_headers = getattr(sess, "headers", None) or {}
+    original_model, unified = await _second_opinion_unify(sess, context_text, reviewer_model, review)
 
-        unify_message = (
-            f"Here's the conversation context:\n\n{context_text}\n\n"
-            f"---\n\n"
-            f"**Review from {reviewer_model}:**\n\n{review}\n\n"
-            f"---\n\n"
-            f"Evaluate this feedback and produce a unified improved version."
-        )
-
-        try:
-            unified = await llm_call_async(
-                original_url, original_model,
-                [
-                    {"role": "system", "content": SECOND_OPINION_UNIFIER_SYSTEM},
-                    {"role": "user", "content": unify_message},
-                ],
-                headers=original_headers,
-                timeout=AI_CHAT_TIMEOUT,
-            )
-            unified = truncate_response(unified)
-        except Exception as e:
-            logger.error(f"second_opinion unify call failed: {e}")
-            unified = f"(Failed to get unified response: {e})"
-
-    # Build combined result
     combined = (
         f"## Second Opinion from {reviewer_model}\n\n{review}"
         f"\n\n---\n\n"
@@ -832,6 +819,63 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
         "response": combined,
         "instruction": "Present these results to the user exactly as they are. Do NOT call second_opinion again. The user can continue the conversation from here.",
     }
+
+
+async def _second_opinion_review(
+    reviewer_url: str, reviewer_model: str, reviewer_headers: Dict,
+    context_text: str, focus: str,
+) -> str:
+    """Ask the reviewer model for honest feedback on the conversation."""
+    reviewer_message = f"Here's the conversation so far:\n\n{context_text}"
+    if focus:
+        reviewer_message += f"\n\n---\nSpecifically, I want your take on: {focus}"
+    else:
+        reviewer_message += "\n\n---\nGive me your honest second opinion on what's being discussed."
+
+    review = await llm_call_async(
+        reviewer_url, reviewer_model,
+        [
+            {"role": "system", "content": SECOND_OPINION_REVIEWER_SYSTEM},
+            {"role": "user", "content": reviewer_message},
+        ],
+        headers=reviewer_headers,
+        timeout=AI_CHAT_TIMEOUT,
+    )
+    return truncate_for_teacher(review)
+
+
+async def _second_opinion_unify(sess, context_text: str, reviewer_model: str, review: str) -> Tuple[str, str]:
+    """Have the session's own model evaluate the review and produce a unified result.
+
+    Returns (original_model_name, unified_text). When there is no session, returns
+    ("unknown", "").
+    """
+    if not sess:
+        return "unknown", ""
+
+    original_model = sess.model
+    unify_message = (
+        f"Here's the conversation context:\n\n{context_text}\n\n"
+        f"---\n\n"
+        f"**Review from {reviewer_model}:**\n\n{review}\n\n"
+        f"---\n\n"
+        f"Evaluate this feedback and produce a unified improved version."
+    )
+
+    try:
+        unified = await llm_call_async(
+            sess.endpoint_url, original_model,
+            [
+                {"role": "system", "content": SECOND_OPINION_UNIFIER_SYSTEM},
+                {"role": "user", "content": unify_message},
+            ],
+            headers=getattr(sess, "headers", None) or {},
+            timeout=AI_CHAT_TIMEOUT,
+        )
+        return original_model, truncate_response(unified)
+    except Exception as e:
+        logger.error(f"second_opinion unify call failed: {e}")
+        return original_model, f"(Failed to get unified response: {e})"
 
 
 async def do_create_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
@@ -1975,6 +2019,15 @@ def _ui_handle_set_theme(parts: list, lines: list) -> Dict:
     }
 
 
+def _theme_effect_label(bg: Dict) -> Optional[str]:
+    """Return a short label describing a theme's background effect, or None."""
+    if not bg:
+        return None
+    if bg.get("pattern"):
+        return bg["pattern"]
+    return "frosted" if bg.get("frosted") else "custom"
+
+
 def _ui_handle_create_theme(parts: list, lines: list) -> Dict:
     """Handle create_theme — create a custom named theme with colors and optional effects."""
     all_parts = lines[0].strip().split()
@@ -2006,7 +2059,7 @@ def _ui_handle_create_theme(parts: list, lines: list) -> Dict:
     if advanced:
         colors["advanced"] = advanced
 
-    effect_label = bg.get("pattern", "frosted" if bg.get("frosted") else "custom") if bg else None
+    effect_label = _theme_effect_label(bg)
     return {
         "ui_event": "create_theme",
         "theme_name": name,

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -334,10 +334,257 @@ def get_db_session():
 
 
 # ---------------------------------------------------------------------------
+# Image generation helpers
+# ---------------------------------------------------------------------------
+
+def _image_classify_model(model_id: str) -> Dict:
+    """Classify a model as gpt-image, dall-e, or local diffusion.
+
+    Returns:
+        Dict with boolean flags: is_gpt_image, is_dalle, is_local_diffusion
+    """
+    is_gpt_image = "gpt-image" in model_id.lower()
+    is_dalle = "dall-e" in model_id.lower()
+    return {
+        "is_gpt_image": is_gpt_image,
+        "is_dalle": is_dalle,
+        "is_local_diffusion": not is_gpt_image and not is_dalle,
+    }
+
+
+_VALID_GPT_SIZES = {"1024x1024", "1024x1536", "1536x1024", "auto"}
+_VALID_DALLE3_SIZES = {"1024x1024", "1024x1792", "1792x1024"}
+_DEFAULT_IMAGE_SIZE = "1024x1024"
+
+
+def _image_clamp_size(size: str, *, is_gpt_image: bool, is_dalle: bool) -> str:
+    """Clamp size to the allowed values for the given model family.
+
+    Local diffusion models accept any WxH string.
+    """
+    if is_gpt_image and size not in _VALID_GPT_SIZES:
+        return _DEFAULT_IMAGE_SIZE
+    if is_dalle and size not in _VALID_DALLE3_SIZES:
+        return _DEFAULT_IMAGE_SIZE
+    return size
+
+
+def _image_build_payload(
+    model_id: str,
+    prompt: str,
+    size: str,
+    quality: str,
+    *,
+    is_gpt_image: bool,
+    is_dalle: bool,
+    is_local_diffusion: bool,
+) -> Dict:
+    """Build the images/generations API request payload."""
+    payload: Dict = {
+        "model": model_id,
+        "prompt": prompt,
+        "n": 1,
+        "size": size,
+    }
+    # DALL-E 3 does not accept a quality field; others do
+    if is_gpt_image or is_local_diffusion:
+        payload["quality"] = quality if quality in ("low", "medium", "high", "auto") else "medium"
+    return payload
+
+
+def _image_derive_generations_url(chat_url: str) -> str:
+    """Derive the images/generations endpoint URL from the chat completions URL."""
+    base = chat_url.replace("/chat/completions", "").replace("/v1/messages", "").rstrip("/")
+    return base + "/images/generations"
+
+
+def _image_auto_detect_model_spec() -> str:
+    """Probe configured endpoints and return the first usable image model spec.
+
+    Returns empty string if nothing is found.
+    """
+    for candidate in ("gpt-image-1.5", "gpt-image-1", "dall-e-3"):
+        try:
+            _resolve_model(candidate)
+            return candidate
+        except ValueError:
+            continue
+
+    # Fallback: scan image-type endpoints registered in the database
+    try:
+        import httpx as _req
+        from src.database import SessionLocal as _ISL, ModelEndpoint as _IME
+        _idb = _ISL()
+        try:
+            eps = _idb.query(_IME).filter(
+                _IME.is_enabled == True,
+                _IME.model_type == "image",
+            ).all()
+            for ep in eps:
+                base = ep.base_url.rstrip("/")
+                if not base.endswith("/v1"):
+                    base += "/v1"
+                try:
+                    r = _req.get(base + "/models", timeout=HTTP_TIMEOUT_IMAGE_ENDPOINT)
+                    r.raise_for_status()
+                    model_ids = [m.get("id") for m in (r.json().get("data") or []) if m.get("id")]
+                    if model_ids:
+                        return model_ids[0]
+                except Exception:
+                    continue
+        finally:
+            _idb.close()
+    except Exception:
+        pass
+
+    return ""
+
+
+def _image_save_to_gallery(
+    filename: str, prompt: str, model_id: str, size: str, quality: str,
+    session_id: Optional[str], owner: Optional[str],
+) -> str:
+    """Insert a GalleryImage row and return the new UUID (or '' on failure)."""
+    try:
+        from src.database import SessionLocal as _GSL, GalleryImage
+        new_id = str(uuid.uuid4())
+        with get_db_session() as db:
+            db.add(GalleryImage(
+                id=new_id,
+                filename=filename,
+                prompt=prompt,
+                model=model_id,
+                size=size,
+                quality=quality,
+                session_id=session_id,
+                owner=owner,
+            ))
+            db.commit()
+        return new_id
+    except Exception as exc:
+        logger.warning(f"Failed to save gallery record: {exc}")
+        return ""
+
+
+async def _image_save_b64(
+    b64_data: str, prompt: str, model_id: str, size: str, quality: str,
+    session_id: Optional[str], owner: Optional[str],
+) -> tuple:
+    """Decode a base64 image, save to disk, persist gallery record.
+
+    Returns:
+        (image_url, image_id)
+    """
+    import base64
+    from pathlib import Path
+
+    img_dir = Path("data/generated_images")
+    img_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{uuid.uuid4().hex[:12]}.png"
+    (img_dir / filename).write_bytes(base64.b64decode(b64_data))
+    image_url = f"/api/generated-image/{filename}"
+    image_id = _image_save_to_gallery(filename, prompt, model_id, size, quality, session_id, owner)
+    return image_url, image_id
+
+
+async def _image_download_and_save(
+    remote_url: str, prompt: str, model_id: str, size: str, quality: str,
+    session_id: Optional[str], owner: Optional[str],
+) -> tuple:
+    """Download an external image URL, save locally, persist gallery record.
+
+    Returns:
+        (image_url, image_id) — falls back to remote_url if download fails.
+    """
+    import httpx
+    from pathlib import Path
+
+    try:
+        dl = httpx.get(remote_url, timeout=HTTP_TIMEOUT_IMAGE_DOWNLOAD)
+        if dl.status_code == 200:
+            img_dir = Path("data/generated_images")
+            img_dir.mkdir(parents=True, exist_ok=True)
+            filename = f"{uuid.uuid4().hex[:12]}.png"
+            (img_dir / filename).write_bytes(dl.content)
+            image_url = f"/api/generated-image/{filename}"
+            image_id = _image_save_to_gallery(filename, prompt, model_id, size, quality, session_id, owner)
+            return image_url, image_id
+    except Exception as exc:
+        logger.warning(f"Failed to download image: {exc}")
+
+    return remote_url, ""  # Fallback to external URL
+
+
+# ---------------------------------------------------------------------------
+# Pipeline helpers
+# ---------------------------------------------------------------------------
+
+def _pipeline_parse_steps(content: str):
+    """Parse pipeline steps from JSON or pipe-delimited line format.
+
+    Returns:
+        (steps, error_dict) — exactly one of them is None.
+    """
+    stripped = content.strip()
+    if not stripped:
+        return None, {"error": "No pipeline steps provided"}
+
+    # Try JSON first
+    steps = None
+    if stripped.startswith(("{", "[")):
+        try:
+            import json as _json
+            data = _json.loads(stripped)
+            steps = data.get("steps") if isinstance(data, dict) else data
+        except (ValueError, TypeError):
+            pass
+
+    # Fall back to line-based format: model | instruction
+    if steps is None:
+        steps = []
+        for line in stripped.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            if "|" not in line:
+                return None, {"error": "Each line must be: model | instruction (or use JSON format)"}
+            model_part, instruction_part = line.split("|", 1)
+            steps.append({"model": model_part.strip(), "instruction": instruction_part.strip()})
+
+    if not steps:
+        return None, {"error": "No pipeline steps provided"}
+
+    return steps, None
+
+
+# ---------------------------------------------------------------------------
+# Second-opinion helpers
+# ---------------------------------------------------------------------------
+
+def _second_opinion_build_context(messages: list) -> str:
+    """Build a readable context string from the most recent session messages.
+
+    Returns:
+        Formatted string with [ROLE]: text lines, or '' if nothing to show.
+    """
+    recent = messages[-SESSION_CONTEXT_WINDOW:] if len(messages) > SESSION_CONTEXT_WINDOW else messages
+    parts = []
+    for m in recent:
+        role = m.get("role", "unknown").upper()
+        text = m.get("content", "")
+        if isinstance(text, list):
+            text = " ".join(p.get("text", "") for p in text if isinstance(p, dict))
+        if text:
+            parts.append(f"[{role}]: {text[:CONTEXT_MESSAGE_TEXT_LIMIT]}")
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
 # Model resolution
 # ---------------------------------------------------------------------------
 
 from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url, build_headers, build_models_url
+from src.llm_core import llm_call_async
 
 
 def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
@@ -430,7 +677,6 @@ async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> 
       Line 1: model_name (or model_name@endpoint_name)
       Line 2+: the message to send
     """
-    from src.llm_core import llm_call_async
 
     lines = content.strip().split("\n", 1)
     if not lines or not lines[0].strip():
@@ -470,7 +716,6 @@ async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict
       Line 1: model_name (or 'auto')
       Line 2+: the problem description
     """
-    from src.llm_core import llm_call_async
     from src.settings import get_setting
 
     lines = content.strip().split("\n", 1)
@@ -520,7 +765,6 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
       3. Send feedback back to the session's own model → evaluate & unify
       4. Return both the review and the unified response
     """
-    from src.llm_core import llm_call_async
 
     lines = content.strip().split("\n", 1)
     if not lines or not lines[0].strip():
@@ -534,25 +778,13 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
     except ValueError as e:
         return {"error": str(e)}
 
-    # Pull recent conversation context from current session
+    # Pull recent conversation context from the active session
     context_text = ""
     sess = None
     if session_id and _session_manager:
         sess = _session_manager.get_session(session_id)
         if sess:
-            messages = sess.get_context_messages()
-            recent = messages[-SESSION_CONTEXT_WINDOW:] if len(messages) > SESSION_CONTEXT_WINDOW else messages
-            parts = []
-            for m in recent:
-                role = m.get("role", "unknown").upper()
-                text = m.get("content", "")
-                if isinstance(text, list):
-                    text = " ".join(
-                        p.get("text", "") for p in text if isinstance(p, dict)
-                    )
-                if text:
-                    parts.append(f"[{role}]: {text[:CONTEXT_MESSAGE_TEXT_LIMIT]}")
-            context_text = "\n\n".join(parts)
+            context_text = _second_opinion_build_context(sess.get_context_messages())
 
     if not context_text:
         return {"error": "No conversation context found to review"}
@@ -769,7 +1001,6 @@ async def do_send_to_session(content: str, session_id: Optional[str] = None) -> 
       Line 1: session_id
       Line 2+: message
     """
-    from src.llm_core import llm_call_async
     from core.models import ChatMessage
 
     if not _session_manager:
@@ -832,43 +1063,18 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
         {"model": "model_a", "instruction": "Revise based on this critique"}
       ]}
 
-    Or line format:
-      Line 1: step1_model | step1_instruction
-      Line 2: step2_model | step2_instruction
-      ...
+    Or pipe-delimited line format:
+      model_a | Draft an essay about X
+      model_b | Critique the following draft
     """
-    from src.llm_core import llm_call_async
+    steps, parse_error = _pipeline_parse_steps(content)
+    if parse_error:
+        return parse_error
 
-    # Try JSON parse first
-    steps = None
-    try:
-        data = json.loads(content.strip())
-        if isinstance(data, dict) and "steps" in data:
-            steps = data["steps"]
-        elif isinstance(data, list):
-            steps = data
-    except (json.JSONDecodeError, TypeError):
-        pass
-
-    # Fall back to line format: model | instruction
-    if not steps:
-        steps = []
-        for line in content.strip().split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            if "|" in line:
-                parts = line.split("|", 1)
-                steps.append({"model": parts[0].strip(), "instruction": parts[1].strip()})
-            else:
-                return {"error": "Each line must be: model | instruction (or use JSON format)"}
-
-    if not steps:
-        return {"error": "No pipeline steps provided"}
     if len(steps) > MAX_PIPELINE_STEPS:
         return {"error": f"Maximum {MAX_PIPELINE_STEPS} steps allowed"}
 
-    # Resolve all models first (fail fast)
+    # Resolve all models first so we fail fast before executing anything
     resolved = []
     for i, step in enumerate(steps):
         model_spec = step.get("model", "").strip()
@@ -881,20 +1087,16 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
         except ValueError as e:
             return {"error": f"Step {i + 1}: {e}"}
 
-    # Execute pipeline
+    # Execute the pipeline, chaining each step's output into the next
     step_outputs = []
     previous_output = None
 
     try:
         for i, (url, model, headers, instruction) in enumerate(resolved):
-            if previous_output:
-                user_content = (
-                    f"Previous step's output:\n\n{previous_output}\n\n"
-                    f"Your task: {instruction}"
-                )
-            else:
-                user_content = instruction
-
+            user_content = (
+                f"Previous step's output:\n\n{previous_output}\n\nYour task: {instruction}"
+                if previous_output else instruction
+            )
             messages = [
                 {"role": "system", "content": f"You are step {i + 1} in a processing pipeline. {instruction}"},
                 {"role": "user", "content": user_content},
@@ -1850,206 +2052,104 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
 
     Content format:
       Line 1: prompt describing the image
-      Line 2: model name (optional, default auto-detects: prefers gpt-image-1.5 > gpt-image-1)
+      Line 2: model name (optional, auto-detects if omitted)
       Line 3: size (optional, defaults to 1024x1024)
-      Line 4: quality (optional, defaults to medium — options: low, medium, high, auto)
+      Line 4: quality (optional: low, medium, high, auto — defaults to medium)
     """
-    import base64
     import httpx
-    from pathlib import Path
 
-    lines = content.strip().split("\n")
+    lines = content.strip().split(chr(10)) if content.strip() else []
     prompt = lines[0].strip() if lines else ""
-    model_spec = lines[1].strip() if len(lines) > 1 and lines[1].strip() else ""
-    size = lines[2].strip() if len(lines) > 2 and lines[2].strip() else "1024x1024"
-    quality = lines[3].strip() if len(lines) > 3 and lines[3].strip() else "medium"
-
     if not prompt:
         return {"error": "Image prompt is required (line 1)"}
 
-    # Load admin settings for defaults
+    model_spec = lines[1].strip() if len(lines) > 1 and lines[1].strip() else ""
+    size = lines[2].strip() if len(lines) > 2 and lines[2].strip() else _DEFAULT_IMAGE_SIZE
+    quality = lines[3].strip() if len(lines) > 3 and lines[3].strip() else "medium"
+
+    # Apply admin-configured defaults when caller did not specify
     try:
         from src.settings import load_settings
-        _settings = load_settings()
+        settings = load_settings()
     except Exception:
-        _settings = {}
+        settings = {}
 
-    # Use admin-configured model/quality if not specified by the tool call
     if not model_spec:
-        model_spec = _settings.get("image_model", "")
-    if quality == "medium" and _settings.get("image_quality"):
-        quality = _settings["image_quality"]
+        model_spec = settings.get("image_model", "")
+    if quality == "medium" and settings.get("image_quality"):
+        quality = settings["image_quality"]
 
-    # Auto-detect best available image model if still not set
+    # Auto-detect the best available image model
     if not model_spec:
-        for candidate in ("gpt-image-1.5", "gpt-image-1", "dall-e-3"):
-            try:
-                _resolve_model(candidate)
-                model_spec = candidate
-                break
-            except ValueError:
-                continue
-        # Fallback: find any locally registered image-type endpoint
-        if not model_spec:
-            try:
-                from src.database import SessionLocal, ModelEndpoint
-                import httpx as _req
-                _idb = SessionLocal()
-                try:
-                    _img_eps = _idb.query(ModelEndpoint).filter(
-                        ModelEndpoint.is_enabled == True,
-                        ModelEndpoint.model_type == "image",
-                    ).all()
-                    for _iep in _img_eps:
-                        _ibase = _iep.base_url.rstrip("/")
-                        if not _ibase.endswith("/v1"):
-                            _ibase += "/v1"
-                        try:
-                            _r = _req.get(_ibase + "/models", timeout=HTTP_TIMEOUT_IMAGE_ENDPOINT)
-                            _r.raise_for_status()
-                            _mids = [m.get("id") for m in (_r.json().get("data") or []) if m.get("id")]
-                            if _mids:
-                                model_spec = _mids[0]
-                                break
-                        except Exception:
-                            continue
-                finally:
-                    _idb.close()
-            except Exception:
-                pass
-        if not model_spec:
-            return {"error": "No image model found. Configure one in Admin → Image Generation."}
+        model_spec = _image_auto_detect_model_spec()
+    if not model_spec:
+        return {"error": "No image model found. Configure one in Admin → Image Generation."}
 
-    # Resolve the model to find the right endpoint
     try:
         url, model_id, headers = _resolve_model(model_spec)
     except ValueError:
         return {"error": f"No endpoint found with image model '{model_spec}'. "
                 "Configure an OpenAI-compatible endpoint with image generation support."}
 
-    # Detect if this is a GPT image model vs DALL-E vs local diffusion
-    is_gpt_image = "gpt-image" in model_id.lower()
-    is_dalle = "dall-e" in model_id.lower()
-    is_local_diffusion = not is_gpt_image and not is_dalle
+    model_kind = _image_classify_model(model_id)
+    size = _image_clamp_size(size, **{k: model_kind[k] for k in ("is_gpt_image", "is_dalle")})
+    payload = _image_build_payload(model_id, prompt, size, quality, **model_kind)
+    images_url = _image_derive_generations_url(url)
+    effective_quality = payload.get("quality", "medium")
 
-    # Build the images endpoint URL from the chat completions URL
-    base_url = url.replace("/chat/completions", "").replace("/v1/messages", "").rstrip("/")
-    images_url = base_url + "/images/generations"
-
-    # Validate size for cloud image models (local diffusion accepts any WxH)
-    valid_gpt_sizes = {"1024x1024", "1024x1536", "1536x1024", "auto"}
-    valid_dalle3_sizes = {"1024x1024", "1024x1792", "1792x1024"}
-    if is_gpt_image and size not in valid_gpt_sizes:
-        size = "1024x1024"
-    elif is_dalle and size not in valid_dalle3_sizes:
-        size = "1024x1024"
-
-    payload = {
-        "model": model_id,
-        "prompt": prompt,
-        "n": 1,
-        "size": size,
-    }
-
-    # GPT image models and local diffusion support quality; DALL-E does not
-    if is_gpt_image or is_local_diffusion:
-        if quality in ("low", "medium", "high", "auto"):
-            payload["quality"] = quality
-        else:
-            payload["quality"] = "medium"
-
-    logger.info(f"Image generation: model={model_id}, size={size}, quality={quality}, prompt={prompt[:IMAGE_PROMPT_LOG_LIMIT]}")
+    logger.info(
+        f"Image generation: model={model_id}, size={size}, quality={quality}, "
+        f"prompt={prompt[:IMAGE_PROMPT_LOG_LIMIT]}"
+    )
 
     try:
-        # GPT image models can take 30-120s+ depending on quality
-        async with httpx.AsyncClient(timeout=httpx.Timeout(connect=30.0, read=300.0, write=30.0, pool=30.0)) as client:
+        # GPT image models can take 30-120s+
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=30.0, read=300.0, write=30.0, pool=30.0)
+        ) as client:
             resp = await client.post(images_url, json=payload, headers=headers)
 
-            if resp.status_code != 200:
-                error_text = resp.text[:ERROR_TEXT_DISPLAY_LIMIT]
-                try:
-                    err_json = resp.json()
-                    error_text = err_json.get("error", {}).get("message", error_text) if isinstance(err_json.get("error"), dict) else str(err_json.get("error", error_text))
-                except Exception:
-                    pass
-                return {"error": f"Image generation failed ({resp.status_code}): {error_text}"}
+        if resp.status_code != 200:
+            error_text = resp.text[:ERROR_TEXT_DISPLAY_LIMIT]
+            try:
+                err_obj = resp.json().get("error", error_text)
+                error_text = err_obj.get("message", error_text) if isinstance(err_obj, dict) else str(err_obj)
+            except Exception:
+                pass
+            return {"error": f"Image generation failed ({resp.status_code}): {error_text}"}
 
-            data = resp.json()
-            images = data.get("data", [])
-            if not images:
-                return {"error": "No images returned from API"}
+        images = resp.json().get("data", [])
+        if not images:
+            return {"error": "No images returned from API"}
 
-            img = images[0]
-            image_url = None
-            image_id = None
+        img = images[0]
 
-            def _save_to_gallery(filename: str) -> str:
-                """Insert a GalleryImage row and return the new id (or '')."""
-                try:
-                    from src.database import SessionLocal as _GallerySL, GalleryImage
-                    new_id = str(uuid.uuid4())
-                    _gdb = _GallerySL()
-                    _gdb.add(GalleryImage(
-                        id=new_id,
-                        filename=filename,
-                        prompt=prompt,
-                        model=model_id,
-                        size=size,
-                        quality=payload.get("quality", "medium"),
-                        session_id=session_id,
-                        owner=owner,
-                    ))
-                    _gdb.commit()
-                    _gdb.close()
-                    return new_id
-                except Exception as _ge:
-                    logger.warning(f"Failed to save gallery record: {_ge}")
-                    return ""
+        if img.get("b64_json"):
+            image_url, image_id = await _image_save_b64(
+                img["b64_json"], prompt, model_id, size, effective_quality, session_id, owner
+            )
+        elif img.get("url"):
+            image_url, image_id = await _image_download_and_save(
+                img["url"], prompt, model_id, size, effective_quality, session_id, owner
+            )
+        else:
+            return {"error": "Image API returned unexpected format (no b64_json or url)"}
 
-            # GPT image models always return b64_json; DALL-E may return url
-            if img.get("b64_json"):
-                img_dir = Path("data/generated_images")
-                img_dir.mkdir(parents=True, exist_ok=True)
-                filename = f"{uuid.uuid4().hex[:12]}.png"
-                img_path = img_dir / filename
-                img_path.write_bytes(base64.b64decode(img.get("b64_json")))
-                image_url = f"/api/generated-image/{filename}"
-                image_id = _save_to_gallery(filename)
-
-            elif img.get("url"):
-                # Download external URL and save locally (DALL-E returns temp URLs)
-                try:
-                    dl_resp = httpx.get(img["url"], timeout=HTTP_TIMEOUT_IMAGE_DOWNLOAD)
-                    if dl_resp.status_code == 200:
-                        img_dir = Path("data/generated_images")
-                        img_dir.mkdir(parents=True, exist_ok=True)
-                        filename = f"{uuid.uuid4().hex[:12]}.png"
-                        img_path = img_dir / filename
-                        img_path.write_bytes(dl_resp.content)
-                        image_url = f"/api/generated-image/{filename}"
-                        image_id = _save_to_gallery(filename)
-                    else:
-                        image_url = img["url"]  # fallback to external URL
-                except Exception as _dl_e:
-                    logger.warning(f"Failed to download DALL-E image: {_dl_e}")
-                    image_url = img["url"]  # fallback to external URL
-            else:
-                return {"error": "Image API returned unexpected format (no b64_json or url)"}
-
-            return {
-                "results": f"Generated image for: {prompt[:100]}",
-                "image_url": image_url,
-                "image_id": image_id,
-                "image_prompt": prompt,
-                "image_model": model_id,
-                "image_size": size,
-                "image_quality": payload.get("quality", "medium"),
-            }
+        return {
+            "results": f"Generated image for: {prompt[:100]}",
+            "image_url": image_url,
+            "image_id": image_id,
+            "image_prompt": prompt,
+            "image_model": model_id,
+            "image_size": size,
+            "image_quality": effective_quality,
+        }
 
     except httpx.TimeoutException:
         return {"error": "Image generation timed out (300s). The model may be overloaded — try again or use quality=low."}
     except Exception as e:
         return {"error": f"Image generation error: {str(e)}"}
+
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -20,6 +20,138 @@ AI_CHAT_TIMEOUT = 120  # seconds for a single LLM call
 MAX_DEBATE_ROUNDS = 5
 MAX_PIPELINE_STEPS = 10
 
+# ─ Timeouts (seconds) ──────────────────────────────────────────────────
+HTTP_TIMEOUT_MODEL_LIST = 5        # Fetching model list from endpoint
+HTTP_TIMEOUT_IMAGE_ENDPOINT = 3    # Checking image endpoint availability
+HTTP_TIMEOUT_IMAGE_DOWNLOAD = 60   # Downloading DALL-E temp images
+
+# ─ Response Truncation Limits (characters) ────────────────────────────
+RESPONSE_TRUNCATE_LIMIT = 10000        # chat_with_model, send_to_session, second_opinion unified
+RESPONSE_TRUNCATE_TEACHER = 8000       # ask_teacher, second_opinion review
+RESPONSE_TRUNCATE_PIPELINE = 5000      # pipeline step output
+
+# ─ Session & Message Management ───────────────────────────────────────
+SESSION_CONTEXT_WINDOW = 15             # Recent messages to include in second_opinion
+CONTEXT_MESSAGE_TEXT_LIMIT = 2000       # Max chars per message in context
+SESSION_LIST_DISPLAY_LIMIT = 50         # Max sessions to show in list_sessions
+SESSION_TRUNCATE_DEFAULT_KEEP = 10      # Default messages to keep when truncating
+
+# ─ ID & Display Limits ────────────────────────────────────────────────
+UUID_SHORT_ID_LENGTH = 8                # Length of short session/memory IDs
+MEMORY_LIST_DISPLAY_LIMIT = 100         # Max memories to show in list
+MEMORY_TEXT_PREVIEW_LIMIT = 150         # Max chars for memory text preview
+MEMORY_SEARCH_RESULT_LIMIT = 20         # Max search results to return
+IMAGE_PROMPT_LOG_LIMIT = 80             # Max chars of image prompt in logs
+ERROR_TEXT_DISPLAY_LIMIT = 500          # Max chars of error details to show
+
+# ─ UI Panel Aliases ───────────────────────────────────────────────────
+PANEL_ALIASES = {
+    "documents": "documents",
+    "document": "documents",
+    "doc": "documents",
+    "docs": "documents",
+    "library": "documents",
+    "doclib": "documents",
+    "gallery": "gallery",
+    "images": "gallery",
+    "email": "email",
+    "emails": "email",
+    "inbox": "email",
+    "mail": "email",
+    "sessions": "sessions",
+    "chats": "sessions",
+    "history": "sessions",
+    "notes": "notes",
+    "note": "notes",
+    "todo": "notes",
+    "todos": "notes",
+    "memories": "memories",
+    "memory": "memories",
+    "brain": "memories",
+    "skills": "skills",
+    "settings": "settings",
+    "preferences": "settings",
+    "cookbook": "cookbook",
+    "models": "cookbook",
+    "llm": "cookbook",
+    "serve": "cookbook",
+    "serving": "cookbook",
+}
+
+CANONICAL_PANELS = set(PANEL_ALIASES.values())
+
+# ─ UI Toggle Aliases ──────────────────────────────────────────────────
+TOGGLE_ALIASES = {
+    "shell": "bash",
+    "terminal": "bash",
+    "search": "web",
+    "websearch": "web",
+    "web_search": "web",
+    "deepresearch": "research",
+    "deep_research": "research",
+    "documents": "document_editor",
+    "doc": "document_editor",
+    "docs": "document_editor",
+    "private": "incognito",
+}
+
+CANONICAL_TOGGLES = {"web", "bash", "research", "incognito", "document_editor"}
+
+# ─ Theme Presets ──────────────────────────────────────────────────────
+THEME_PRESETS = {
+    "dark", "light", "midnight", "paper", "cyberpunk", "retrowave",
+    "forest", "ocean", "ume", "copper", "terminal", "organs",
+    "lavender", "gpt", "claude", "cute",
+}
+
+# ─ Background Pattern Options ─────────────────────────────────────────
+BACKGROUND_PATTERNS = {
+    "none", "dots", "synapse", "rain", "constellations",
+    "perlin-flow", "petals", "sparkles", "embers"
+}
+
+# ─ Color Keys for Theme Customization ─────────────────────────────────
+ADVANCED_COLOR_KEYS = {
+    "userBubbleBg", "aiBubbleBg", "bubbleBorder", "sidebarBg",
+    "sectionAccent", "brandColor", "inputBg", "inputBorder",
+    "sendBtnBg", "sendBtnHover", "codeBg", "codeFg",
+    "toggleBg", "toggleActive", "accentPrimary", "accentError",
+}
+
+# ─ System Prompts ─────────────────────────────────────────────────────
+TEACHER_SYSTEM_PROMPT = (
+    "You are a senior AI mentor. A less capable model is stuck on a problem and asking for help. "
+    "Provide clear, actionable guidance:\n"
+    "1. Brief analysis of the problem\n"
+    "2. Recommended approach (step by step)\n"
+    "3. Key things to watch out for\n\n"
+    "Be concise and practical. No preamble."
+)
+
+SECOND_OPINION_REVIEWER_SYSTEM = (
+    "You are giving a second opinion on a conversation between a user and an AI assistant. "
+    "Your job is to be genuinely helpful and honest — not a yes-man, but not a contrarian either.\n\n"
+    "Guidelines:\n"
+    "- If the plan/idea is solid, say so clearly. Don't manufacture problems that aren't there.\n"
+    "- If you spot a real flaw, blind spot, or simpler approach — call it out directly.\n"
+    "- Be practical. Don't over-engineer or over-analyze. Real-world tradeoffs matter.\n"
+    "- If there's a meaningfully better way to do something, suggest it concretely.\n"
+    "- Give credit where it's due — highlight what's working well.\n"
+    "- Keep it concise and actionable. No fluff.\n"
+    "- You're a second pair of eyes, not a professor grading a paper."
+)
+
+SECOND_OPINION_UNIFIER_SYSTEM = (
+    "Another AI model just reviewed the conversation you've been having with the user. "
+    "Read their feedback carefully, then respond with:\n\n"
+    "1. **What you agree with** — acknowledge valid points honestly.\n"
+    "2. **What you disagree with** — explain why, briefly.\n"
+    "3. **Unified version** — produce an updated/refined version of whatever was being discussed, "
+    "incorporating the feedback you found valid. Don't accept every note blindly — "
+    "use your judgment on what actually improves things vs what's unnecessary.\n\n"
+    "Be concise and practical. The user wants a better result, not a meta-discussion."
+)
+
 # ---------------------------------------------------------------------------
 # Global managers (set from app.py, same pattern as _mcp_manager)
 # ---------------------------------------------------------------------------
@@ -49,6 +181,156 @@ def set_rag_manager(rag_mgr, personal_docs_mgr=None):
     global _rag_manager, _personal_docs_manager
     _rag_manager = rag_mgr
     _personal_docs_manager = personal_docs_mgr
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def truncate_response(text: str, limit: int = RESPONSE_TRUNCATE_LIMIT) -> str:
+    """Truncate text to limit, append '... (truncated)' if needed.
+
+    Args:
+        text: The text to potentially truncate
+        limit: Character limit (default: RESPONSE_TRUNCATE_LIMIT)
+
+    Returns:
+        Truncated text with notice, or original if under limit
+    """
+    if len(text) > limit:
+        return text[:limit] + "\n... (truncated)"
+    return text
+
+
+def truncate_for_teacher(text: str) -> str:
+    """Truncate response to teacher-specific limit (8000 chars)."""
+    return truncate_response(text, RESPONSE_TRUNCATE_TEACHER)
+
+
+def truncate_for_pipeline(text: str) -> str:
+    """Truncate response to pipeline-specific limit (5000 chars)."""
+    return truncate_response(text, RESPONSE_TRUNCATE_PIPELINE)
+
+
+def get_first_line(content: str, max_len: Optional[int] = None) -> str:
+    """Extract first line from content, optionally limit length.
+
+    Used for extracting model specs, action names, etc. from multi-line content.
+
+    Args:
+        content: The content to parse
+        max_len: Optional character limit for the result
+
+    Returns:
+        First line of content, stripped, optionally truncated
+    """
+    line = content.strip().split("\n")[0].strip() if content.strip() else ""
+    return line[:max_len] if max_len else line
+
+
+def get_action_from_content(content: str) -> str:
+    """Extract action name (first line) from content."""
+    return get_first_line(content, 40)
+
+
+def get_model_spec_from_content(content: str) -> str:
+    """Extract model spec (first line) from content."""
+    return get_first_line(content, 60)
+
+
+def resolve_panel(name: str) -> Optional[str]:
+    """Resolve panel alias to canonical name.
+
+    Args:
+        name: Panel name or alias (case-insensitive)
+
+    Returns:
+        Canonical panel name or None if not found
+    """
+    if not name:
+        return None
+    name_lower = name.lower()
+    # Check if it's an alias first
+    if name_lower in PANEL_ALIASES:
+        return PANEL_ALIASES[name_lower]
+    # Check if it's already canonical
+    if name_lower in CANONICAL_PANELS:
+        return name_lower
+    return None
+
+
+def resolve_toggle(name: str) -> Optional[str]:
+    """Resolve toggle alias to canonical name.
+
+    Args:
+        name: Toggle name or alias (case-insensitive)
+
+    Returns:
+        Canonical toggle name or None if not found
+    """
+    if not name:
+        return None
+    name_lower = name.lower()
+    # Check if it's an alias first
+    if name_lower in TOGGLE_ALIASES:
+        return TOGGLE_ALIASES[name_lower]
+    # Check if it's already canonical
+    if name_lower in CANONICAL_TOGGLES:
+        return name_lower
+    return None
+
+
+def is_valid_hex_color(value: str) -> bool:
+    """Validate hex color #RRGGBB format.
+
+    Args:
+        value: Color string to validate
+
+    Returns:
+        True if valid hex color, False otherwise
+    """
+    import re
+    return bool(re.match(r'^#[0-9a-fA-F]{6}$', value))
+
+
+async def resolve_model_safe(model_spec: str) -> Tuple[Optional[str], Optional[str], Optional[Dict], Optional[Dict]]:
+    """Resolve model spec or return error dict.
+
+    Wraps _resolve_model with error handling.
+
+    Args:
+        model_spec: Model name or "name@endpoint"
+
+    Returns:
+        Tuple of (url, model_id, headers, error_dict)
+        On success: (url, model, headers, None)
+        On error: (None, None, None, {"error": "message"})
+    """
+    try:
+        url, model, headers = _resolve_model(model_spec)
+        return url, model, headers, None
+    except ValueError as e:
+        return None, None, None, {"error": str(e)}
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def get_db_session():
+    """Context manager for database session.
+
+    Usage:
+        with get_db_session() as db:
+            # use db
+            pass
+    """
+    from src.database import SessionLocal
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,13 @@ if "src.database" not in sys.modules:
     _db.GalleryImage = MagicMock()
     sys.modules["src.database"] = _db
 
-# Also stub core.database so tests don't try to open the real SQLite file.
-# do_list_sessions imports Session from core.database at call time.
-if "core.database" not in sys.modules:
+# Stub core.database ONLY when the real package can't be imported (e.g. deps
+# missing). When it is importable we must NOT shadow it: tests such as
+# test_session_mode_helpers monkeypatch the real module's SessionLocal and call
+# its get/set_session_mode helpers. do_list_sessions only imports the Session
+# model class (cheap) and patches get_db_session in its own tests, so the real
+# module is safe to use here.
+if "core.database" not in sys.modules and not _has_module("core.database"):
     _coredb = types.ModuleType("core.database")
     _coredb.SessionLocal = MagicMock()
     _coredb.Session = MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,12 @@ if "src.database" not in sys.modules:
     _db.Session = MagicMock()
     _db.GalleryImage = MagicMock()
     sys.modules["src.database"] = _db
+
+# Also stub core.database so tests don't try to open the real SQLite file.
+# do_list_sessions imports Session from core.database at call time.
+if "core.database" not in sys.modules:
+    _coredb = types.ModuleType("core.database")
+    _coredb.SessionLocal = MagicMock()
+    _coredb.Session = MagicMock()
+    _coredb.Base = MagicMock()
+    sys.modules["core.database"] = _coredb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,4 +31,6 @@ if "src.database" not in sys.modules:
     _db = types.ModuleType("src.database")
     _db.SessionLocal = MagicMock()
     _db.ModelEndpoint = MagicMock()
+    _db.Session = MagicMock()
+    _db.GalleryImage = MagicMock()
     sys.modules["src.database"] = _db

--- a/tests/test_ai_interaction_constants.py
+++ b/tests/test_ai_interaction_constants.py
@@ -1,0 +1,285 @@
+"""
+Tests for ai_interaction.py constants.
+
+Ensures all configuration values are properly defined and valid.
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+
+
+class TestTimeoutConstants:
+    """Test timeout configuration constants."""
+
+    def test_ai_chat_timeout_defined(self) -> None:
+        """Verify AI_CHAT_TIMEOUT constant exists and is valid."""
+        from src.ai_interaction import AI_CHAT_TIMEOUT
+
+        assert isinstance(AI_CHAT_TIMEOUT, int), "AI_CHAT_TIMEOUT must be int"
+        assert AI_CHAT_TIMEOUT > 0, "AI_CHAT_TIMEOUT must be positive"
+        assert AI_CHAT_TIMEOUT == 120, "AI_CHAT_TIMEOUT should be 120 seconds"
+
+    def test_http_timeout_model_list_defined(self) -> None:
+        """Verify HTTP_TIMEOUT_MODEL_LIST is defined and valid."""
+        from src.ai_interaction import HTTP_TIMEOUT_MODEL_LIST
+
+        assert isinstance(HTTP_TIMEOUT_MODEL_LIST, int), "HTTP_TIMEOUT_MODEL_LIST must be int"
+        assert HTTP_TIMEOUT_MODEL_LIST > 0, "HTTP_TIMEOUT_MODEL_LIST must be positive"
+
+    def test_http_timeout_image_endpoint_defined(self) -> None:
+        """Verify HTTP_TIMEOUT_IMAGE_ENDPOINT is defined and valid."""
+        from src.ai_interaction import HTTP_TIMEOUT_IMAGE_ENDPOINT
+
+        assert isinstance(HTTP_TIMEOUT_IMAGE_ENDPOINT, int), "HTTP_TIMEOUT_IMAGE_ENDPOINT must be int"
+        assert HTTP_TIMEOUT_IMAGE_ENDPOINT > 0, "HTTP_TIMEOUT_IMAGE_ENDPOINT must be positive"
+
+    def test_http_timeout_image_download_defined(self) -> None:
+        """Verify HTTP_TIMEOUT_IMAGE_DOWNLOAD is defined and valid."""
+        from src.ai_interaction import HTTP_TIMEOUT_IMAGE_DOWNLOAD
+
+        assert isinstance(HTTP_TIMEOUT_IMAGE_DOWNLOAD, int), "HTTP_TIMEOUT_IMAGE_DOWNLOAD must be int"
+        assert HTTP_TIMEOUT_IMAGE_DOWNLOAD > 0, "HTTP_TIMEOUT_IMAGE_DOWNLOAD must be positive"
+
+
+class TestTruncationConstants:
+    """Test response truncation limit constants."""
+
+    def test_response_truncate_limit_defined(self) -> None:
+        """Verify RESPONSE_TRUNCATE_LIMIT is defined and valid."""
+        from src.ai_interaction import RESPONSE_TRUNCATE_LIMIT
+
+        assert isinstance(RESPONSE_TRUNCATE_LIMIT, int), "RESPONSE_TRUNCATE_LIMIT must be int"
+        assert RESPONSE_TRUNCATE_LIMIT > 1000, "RESPONSE_TRUNCATE_LIMIT should be > 1000 chars"
+
+    def test_response_truncate_teacher_defined(self) -> None:
+        """Verify RESPONSE_TRUNCATE_TEACHER is defined and valid."""
+        from src.ai_interaction import RESPONSE_TRUNCATE_TEACHER
+
+        assert isinstance(RESPONSE_TRUNCATE_TEACHER, int), "RESPONSE_TRUNCATE_TEACHER must be int"
+        assert RESPONSE_TRUNCATE_TEACHER > 1000, "RESPONSE_TRUNCATE_TEACHER should be > 1000 chars"
+
+    def test_response_truncate_pipeline_defined(self) -> None:
+        """Verify RESPONSE_TRUNCATE_PIPELINE is defined and valid."""
+        from src.ai_interaction import RESPONSE_TRUNCATE_PIPELINE
+
+        assert isinstance(RESPONSE_TRUNCATE_PIPELINE, int), "RESPONSE_TRUNCATE_PIPELINE must be int"
+        assert RESPONSE_TRUNCATE_PIPELINE > 1000, "RESPONSE_TRUNCATE_PIPELINE should be > 1000 chars"
+
+    def test_truncation_limits_reasonable(self) -> None:
+        """Verify truncation limits are in reasonable order."""
+        from src.ai_interaction import (
+            RESPONSE_TRUNCATE_LIMIT,
+            RESPONSE_TRUNCATE_TEACHER,
+            RESPONSE_TRUNCATE_PIPELINE,
+        )
+
+        # All should be different but reasonable
+        assert RESPONSE_TRUNCATE_LIMIT > RESPONSE_TRUNCATE_TEACHER
+        assert RESPONSE_TRUNCATE_TEACHER > RESPONSE_TRUNCATE_PIPELINE
+
+
+class TestSessionConstants:
+    """Test session management constants."""
+
+    def test_session_context_window_defined(self) -> None:
+        """Verify SESSION_CONTEXT_WINDOW is defined and valid."""
+        from src.ai_interaction import SESSION_CONTEXT_WINDOW
+
+        assert isinstance(SESSION_CONTEXT_WINDOW, int), "SESSION_CONTEXT_WINDOW must be int"
+        assert SESSION_CONTEXT_WINDOW > 0, "SESSION_CONTEXT_WINDOW must be positive"
+
+    def test_context_message_text_limit_defined(self) -> None:
+        """Verify CONTEXT_MESSAGE_TEXT_LIMIT is defined and valid."""
+        from src.ai_interaction import CONTEXT_MESSAGE_TEXT_LIMIT
+
+        assert isinstance(CONTEXT_MESSAGE_TEXT_LIMIT, int)
+        assert CONTEXT_MESSAGE_TEXT_LIMIT > 0, "CONTEXT_MESSAGE_TEXT_LIMIT must be positive"
+
+    def test_session_list_display_limit_defined(self) -> None:
+        """Verify SESSION_LIST_DISPLAY_LIMIT is defined and valid."""
+        from src.ai_interaction import SESSION_LIST_DISPLAY_LIMIT
+
+        assert isinstance(SESSION_LIST_DISPLAY_LIMIT, int)
+        assert SESSION_LIST_DISPLAY_LIMIT > 0, "SESSION_LIST_DISPLAY_LIMIT must be positive"
+
+    def test_uuid_short_id_length_defined(self) -> None:
+        """Verify UUID_SHORT_ID_LENGTH is defined and valid."""
+        from src.ai_interaction import UUID_SHORT_ID_LENGTH
+
+        assert isinstance(UUID_SHORT_ID_LENGTH, int)
+        assert 4 <= UUID_SHORT_ID_LENGTH <= 16, "UUID_SHORT_ID_LENGTH should be 4-16 chars"
+
+
+class TestMemoryConstants:
+    """Test memory management constants."""
+
+    def test_memory_list_display_limit_defined(self) -> None:
+        """Verify MEMORY_LIST_DISPLAY_LIMIT is defined and valid."""
+        from src.ai_interaction import MEMORY_LIST_DISPLAY_LIMIT
+
+        assert isinstance(MEMORY_LIST_DISPLAY_LIMIT, int)
+        assert MEMORY_LIST_DISPLAY_LIMIT > 0
+
+    def test_memory_text_preview_limit_defined(self) -> None:
+        """Verify MEMORY_TEXT_PREVIEW_LIMIT is defined and valid."""
+        from src.ai_interaction import MEMORY_TEXT_PREVIEW_LIMIT
+
+        assert isinstance(MEMORY_TEXT_PREVIEW_LIMIT, int)
+        assert MEMORY_TEXT_PREVIEW_LIMIT > 0
+
+    def test_memory_search_result_limit_defined(self) -> None:
+        """Verify MEMORY_SEARCH_RESULT_LIMIT is defined and valid."""
+        from src.ai_interaction import MEMORY_SEARCH_RESULT_LIMIT
+
+        assert isinstance(MEMORY_SEARCH_RESULT_LIMIT, int)
+        assert MEMORY_SEARCH_RESULT_LIMIT > 0
+
+
+class TestPipelineConstants:
+    """Test pipeline configuration constants."""
+
+    def test_max_pipeline_steps_defined(self) -> None:
+        """Verify MAX_PIPELINE_STEPS is defined and valid."""
+        from src.ai_interaction import MAX_PIPELINE_STEPS
+
+        assert isinstance(MAX_PIPELINE_STEPS, int)
+        assert MAX_PIPELINE_STEPS > 0, "MAX_PIPELINE_STEPS must be positive"
+        assert MAX_PIPELINE_STEPS >= 5, "MAX_PIPELINE_STEPS should allow at least 5 steps"
+
+    def test_max_debate_rounds_defined(self) -> None:
+        """Verify MAX_DEBATE_ROUNDS is defined and valid."""
+        from src.ai_interaction import MAX_DEBATE_ROUNDS
+
+        assert isinstance(MAX_DEBATE_ROUNDS, int)
+        assert MAX_DEBATE_ROUNDS > 0, "MAX_DEBATE_ROUNDS must be positive"
+
+
+class TestUIPanelConstants:
+    """Test UI panel alias constants."""
+
+    def test_panel_aliases_is_dict(self) -> None:
+        """Verify PANEL_ALIASES is a non-empty dict."""
+        from src.ai_interaction import PANEL_ALIASES
+
+        assert isinstance(PANEL_ALIASES, dict), "PANEL_ALIASES must be a dict"
+        assert len(PANEL_ALIASES) > 0, "PANEL_ALIASES must not be empty"
+
+    def test_panel_aliases_have_canonical_targets(self) -> None:
+        """Verify all PANEL_ALIASES map to valid canonical panels."""
+        from src.ai_interaction import PANEL_ALIASES, CANONICAL_PANELS
+
+        for alias, canonical in PANEL_ALIASES.items():
+            assert isinstance(alias, str), f"Alias key must be str, got {type(alias)}"
+            assert isinstance(canonical, str), f"Canonical value must be str, got {type(canonical)}"
+            assert canonical in CANONICAL_PANELS, f"'{canonical}' not in CANONICAL_PANELS"
+
+    def test_canonical_panels_not_empty(self) -> None:
+        """Verify CANONICAL_PANELS is defined and not empty."""
+        from src.ai_interaction import CANONICAL_PANELS
+
+        assert isinstance(CANONICAL_PANELS, (set, frozenset)), "CANONICAL_PANELS must be a set"
+        assert len(CANONICAL_PANELS) > 0, "CANONICAL_PANELS must not be empty"
+
+
+class TestUIToggleConstants:
+    """Test UI toggle alias constants."""
+
+    def test_toggle_aliases_is_dict(self) -> None:
+        """Verify TOGGLE_ALIASES is a non-empty dict."""
+        from src.ai_interaction import TOGGLE_ALIASES
+
+        assert isinstance(TOGGLE_ALIASES, dict), "TOGGLE_ALIASES must be a dict"
+        assert len(TOGGLE_ALIASES) > 0, "TOGGLE_ALIASES must not be empty"
+
+    def test_toggle_aliases_have_canonical_targets(self) -> None:
+        """Verify all TOGGLE_ALIASES map to valid canonical toggles."""
+        from src.ai_interaction import TOGGLE_ALIASES, CANONICAL_TOGGLES
+
+        for alias, canonical in TOGGLE_ALIASES.items():
+            assert isinstance(alias, str), f"Alias key must be str, got {type(alias)}"
+            assert isinstance(canonical, str), f"Canonical value must be str, got {type(canonical)}"
+            assert canonical in CANONICAL_TOGGLES, f"'{canonical}' not in CANONICAL_TOGGLES"
+
+    def test_canonical_toggles_not_empty(self) -> None:
+        """Verify CANONICAL_TOGGLES is defined and not empty."""
+        from src.ai_interaction import CANONICAL_TOGGLES
+
+        assert isinstance(CANONICAL_TOGGLES, (set, frozenset)), "CANONICAL_TOGGLES must be a set"
+        assert len(CANONICAL_TOGGLES) > 0, "CANONICAL_TOGGLES must not be empty"
+
+
+class TestThemeConstants:
+    """Test theme configuration constants."""
+
+    def test_theme_presets_is_set(self) -> None:
+        """Verify THEME_PRESETS is a non-empty set."""
+        from src.ai_interaction import THEME_PRESETS
+
+        assert isinstance(THEME_PRESETS, (set, frozenset)), "THEME_PRESETS must be a set"
+        assert len(THEME_PRESETS) > 0, "THEME_PRESETS must not be empty"
+
+    def test_theme_presets_all_strings(self) -> None:
+        """Verify all THEME_PRESETS entries are strings."""
+        from src.ai_interaction import THEME_PRESETS
+
+        for preset in THEME_PRESETS:
+            assert isinstance(preset, str), f"Theme preset must be str, got {type(preset)}"
+
+
+class TestBackgroundPatternConstants:
+    """Test background pattern constants."""
+
+    def test_background_patterns_is_set(self) -> None:
+        """Verify BACKGROUND_PATTERNS is a non-empty set."""
+        from src.ai_interaction import BACKGROUND_PATTERNS
+
+        assert isinstance(BACKGROUND_PATTERNS, (set, frozenset))
+        assert len(BACKGROUND_PATTERNS) > 0
+
+    def test_background_patterns_all_strings(self) -> None:
+        """Verify all BACKGROUND_PATTERNS entries are strings."""
+        from src.ai_interaction import BACKGROUND_PATTERNS
+
+        for pattern in BACKGROUND_PATTERNS:
+            assert isinstance(pattern, str), f"Pattern must be str, got {type(pattern)}"
+
+
+class TestSystemPromptConstants:
+    """Test system prompt constants."""
+
+    def test_teacher_system_prompt_not_empty(self) -> None:
+        """Verify TEACHER_SYSTEM_PROMPT is defined and not empty."""
+        from src.ai_interaction import TEACHER_SYSTEM_PROMPT
+
+        assert isinstance(TEACHER_SYSTEM_PROMPT, str), "TEACHER_SYSTEM_PROMPT must be str"
+        assert len(TEACHER_SYSTEM_PROMPT) > 20, "TEACHER_SYSTEM_PROMPT should not be trivial"
+
+    def test_second_opinion_reviewer_system_not_empty(self) -> None:
+        """Verify SECOND_OPINION_REVIEWER_SYSTEM is defined and not empty."""
+        from src.ai_interaction import SECOND_OPINION_REVIEWER_SYSTEM
+
+        assert isinstance(SECOND_OPINION_REVIEWER_SYSTEM, str)
+        assert len(SECOND_OPINION_REVIEWER_SYSTEM) > 20
+
+    def test_second_opinion_unifier_system_not_empty(self) -> None:
+        """Verify SECOND_OPINION_UNIFIER_SYSTEM is defined and not empty."""
+        from src.ai_interaction import SECOND_OPINION_UNIFIER_SYSTEM
+
+        assert isinstance(SECOND_OPINION_UNIFIER_SYSTEM, str)
+        assert len(SECOND_OPINION_UNIFIER_SYSTEM) > 20
+
+    def test_system_prompts_differ(self) -> None:
+        """Verify system prompts are different from each other."""
+        from src.ai_interaction import (
+            TEACHER_SYSTEM_PROMPT,
+            SECOND_OPINION_REVIEWER_SYSTEM,
+            SECOND_OPINION_UNIFIER_SYSTEM,
+        )
+
+        prompts = [
+            TEACHER_SYSTEM_PROMPT,
+            SECOND_OPINION_REVIEWER_SYSTEM,
+            SECOND_OPINION_UNIFIER_SYSTEM,
+        ]
+        # All should be unique
+        assert len(set(prompts)) == 3, "System prompts should all be different"

--- a/tests/test_ai_interaction_dispatch.py
+++ b/tests/test_ai_interaction_dispatch.py
@@ -1,0 +1,187 @@
+"""
+Tests for dispatch_ai_tool() — the public entry point.
+
+Verifies that every tool name routes to the correct handler and that
+the return format (description, result_dict) is always correct.
+
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from typing import Dict, Tuple
+
+
+async def _dispatch(tool: str, content: str = "", session_id: str = "s1", owner: str = "u1") -> Tuple:
+    from src.ai_interaction import dispatch_ai_tool
+    return await dispatch_ai_tool(tool, content, session_id=session_id, owner=owner)
+
+
+# ---------------------------------------------------------------------------
+# Return format contract
+# ---------------------------------------------------------------------------
+
+class TestDispatchReturnFormat:
+    """Verify dispatch_ai_tool always returns (str, dict)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_tuple(self) -> None:
+        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "ok"}
+            result = await _dispatch("list_sessions")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_description_is_string(self) -> None:
+        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "ok"}
+            desc, _ = await _dispatch("list_sessions")
+        assert isinstance(desc, str)
+
+    @pytest.mark.asyncio
+    async def test_result_is_dict(self) -> None:
+        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "ok"}
+            _, result = await _dispatch("list_sessions")
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error_dict(self) -> None:
+        desc, result = await _dispatch("totally_unknown_tool_xyz")
+        assert "error" in result
+        assert isinstance(desc, str)
+
+
+# ---------------------------------------------------------------------------
+# Routing — each tool reaches its handler
+# ---------------------------------------------------------------------------
+
+class TestDispatchRouting:
+    """Verify each tool name dispatches to the correct do_* function."""
+
+    @pytest.mark.asyncio
+    async def test_chat_with_model_routes(self) -> None:
+        with patch("src.ai_interaction.do_chat_with_model", new_callable=AsyncMock) as m:
+            m.return_value = {"response": "hi"}
+            desc, _ = await _dispatch("chat_with_model", "model_name\nHello")
+        m.assert_called_once()
+        assert "chat_with_model" in desc
+
+    @pytest.mark.asyncio
+    async def test_create_session_routes(self) -> None:
+        with patch("src.ai_interaction.do_create_session", new_callable=AsyncMock) as m:
+            m.return_value = {"session_id": "abc"}
+            desc, _ = await _dispatch("create_session", "My session\nmodel_name")
+        m.assert_called_once()
+        assert "create_session" in desc
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_routes(self) -> None:
+        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "sessions"}
+            desc, _ = await _dispatch("list_sessions")
+        m.assert_called_once()
+        assert "list_sessions" in desc
+
+    @pytest.mark.asyncio
+    async def test_send_to_session_routes(self) -> None:
+        with patch("src.ai_interaction.do_send_to_session", new_callable=AsyncMock) as m:
+            m.return_value = {"response": "hi"}
+            desc, _ = await _dispatch("send_to_session", "session_id\nHello")
+        m.assert_called_once()
+        assert "send_to_session" in desc
+
+    @pytest.mark.asyncio
+    async def test_pipeline_routes(self) -> None:
+        with patch("src.ai_interaction.do_pipeline", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "done"}
+            desc, _ = await _dispatch("pipeline", "model | do something")
+        m.assert_called_once()
+        assert "pipeline" in desc
+
+    @pytest.mark.asyncio
+    async def test_manage_session_routes(self) -> None:
+        with patch("src.ai_interaction.do_manage_session", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "ok"}
+            desc, _ = await _dispatch("manage_session", "list")
+        m.assert_called_once()
+        assert "manage_session" in desc
+
+    @pytest.mark.asyncio
+    async def test_manage_memory_routes(self) -> None:
+        with patch("src.ai_interaction.do_manage_memory", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "ok"}
+            desc, _ = await _dispatch("manage_memory", "list")
+        m.assert_called_once()
+        assert "manage_memory" in desc
+
+    @pytest.mark.asyncio
+    async def test_list_models_routes(self) -> None:
+        with patch("src.ai_interaction.do_list_models", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "models"}
+            desc, _ = await _dispatch("list_models")
+        m.assert_called_once()
+        assert "list_models" in desc
+
+    @pytest.mark.asyncio
+    async def test_ui_control_routes(self) -> None:
+        with patch("src.ai_interaction.do_ui_control", new_callable=AsyncMock) as m:
+            m.return_value = {"ui_event": "toggle"}
+            desc, _ = await _dispatch("ui_control", "toggle bash on")
+        m.assert_called_once()
+        assert "ui_control" in desc
+
+    @pytest.mark.asyncio
+    async def test_ask_teacher_routes(self) -> None:
+        with patch("src.ai_interaction.do_ask_teacher", new_callable=AsyncMock) as m:
+            m.return_value = {"response": "guidance"}
+            desc, _ = await _dispatch("ask_teacher", "auto\nMy problem")
+        m.assert_called_once()
+        assert "ask_teacher" in desc
+
+    @pytest.mark.asyncio
+    async def test_second_opinion_routes(self) -> None:
+        with patch("src.ai_interaction.do_second_opinion", new_callable=AsyncMock) as m:
+            m.return_value = {"response": "opinion"}
+            desc, _ = await _dispatch("second_opinion", "model_name")
+        m.assert_called_once()
+        assert "second_opinion" in desc
+
+
+# ---------------------------------------------------------------------------
+# Description uses content helpers (not raw split)
+# ---------------------------------------------------------------------------
+
+class TestDispatchDescriptions:
+    """Verify descriptions are derived from content correctly."""
+
+    @pytest.mark.asyncio
+    async def test_chat_description_uses_model_spec(self) -> None:
+        with patch("src.ai_interaction.do_chat_with_model", new_callable=AsyncMock) as m:
+            m.return_value = {}
+            desc, _ = await _dispatch("chat_with_model", "gpt-4\nHello there")
+        assert "gpt-4" in desc
+
+    @pytest.mark.asyncio
+    async def test_description_truncates_long_content(self) -> None:
+        very_long = "x" * 200
+        with patch("src.ai_interaction.do_chat_with_model", new_callable=AsyncMock) as m:
+            m.return_value = {}
+            desc, _ = await _dispatch("chat_with_model", f"{very_long}\nHello")
+        # Description should not be excessively long
+        assert len(desc) < 100
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_with_keyword_in_description(self) -> None:
+        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as m:
+            m.return_value = {"results": "ok"}
+            desc, _ = await _dispatch("list_sessions", "python projects")
+        assert "python projects" in desc
+
+    @pytest.mark.asyncio
+    async def test_manage_session_action_in_description(self) -> None:
+        with patch("src.ai_interaction.do_manage_session", new_callable=AsyncMock) as m:
+            m.return_value = {}
+            desc, _ = await _dispatch("manage_session", "rename\nsome_id\nnew name")
+        assert "rename" in desc

--- a/tests/test_ai_interaction_generate_image.py
+++ b/tests/test_ai_interaction_generate_image.py
@@ -213,3 +213,96 @@ class TestGenerateImageEndToEnd:
 
             result = await _gen("A sunset")
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# _image_parse_request — input parsing + settings defaults + auto-detect
+# ---------------------------------------------------------------------------
+
+class TestImageParseRequest:
+
+    def test_missing_prompt_returns_error_dict(self) -> None:
+        from src.ai_interaction import _image_parse_request
+        result = _image_parse_request("")
+        assert isinstance(result, dict)
+        assert "error" in result
+
+    def test_returns_tuple_on_success(self) -> None:
+        from src.ai_interaction import _image_parse_request
+        with patch("src.ai_interaction._image_auto_detect_model_spec", return_value="gpt-image-1"):
+            result = _image_parse_request("A sunset")
+        assert isinstance(result, tuple)
+        prompt, model_spec, size, quality = result
+        assert prompt == "A sunset"
+
+    def test_defaults_size_and_quality(self) -> None:
+        from src.ai_interaction import _image_parse_request, _DEFAULT_IMAGE_SIZE
+        with patch("src.ai_interaction._image_auto_detect_model_spec", return_value="gpt-image-1"):
+            _, _, size, quality = _image_parse_request("A cat")
+        assert size == _DEFAULT_IMAGE_SIZE
+        assert quality == "medium"
+
+    def test_explicit_model_size_quality(self) -> None:
+        from src.ai_interaction import _image_parse_request
+        content = "A dog\ndall-e-3\n1024x1792\nhigh"
+        prompt, model_spec, size, quality = _image_parse_request(content)
+        assert prompt == "A dog"
+        assert model_spec == "dall-e-3"
+        assert size == "1024x1792"
+        assert quality == "high"
+
+    def test_admin_settings_model_fallback(self) -> None:
+        from src.ai_interaction import _image_parse_request
+        with patch("src.settings.load_settings", return_value={"image_model": "admin-model"}):
+            _, model_spec, _, _ = _image_parse_request("A bird")
+        assert model_spec == "admin-model"
+
+    def test_admin_settings_quality_fallback(self) -> None:
+        from src.ai_interaction import _image_parse_request
+        with patch("src.settings.load_settings", return_value={"image_model": "m", "image_quality": "high"}):
+            _, _, _, quality = _image_parse_request("A bird")
+        assert quality == "high"
+
+    def test_no_model_found_returns_error(self) -> None:
+        from src.ai_interaction import _image_parse_request
+        with patch("src.ai_interaction._image_auto_detect_model_spec", return_value=""), \
+             patch("src.settings.load_settings", return_value={}):
+            result = _image_parse_request("A bird")
+        assert isinstance(result, dict)
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# _image_extract_api_error — error-body parsing
+# ---------------------------------------------------------------------------
+
+class TestImageExtractApiError:
+
+    def test_dict_error_with_message(self) -> None:
+        from src.ai_interaction import _image_extract_api_error
+        resp = MagicMock()
+        resp.text = "raw body"
+        resp.json.return_value = {"error": {"message": "Bad prompt"}}
+        assert _image_extract_api_error(resp) == "Bad prompt"
+
+    def test_string_error(self) -> None:
+        from src.ai_interaction import _image_extract_api_error
+        resp = MagicMock()
+        resp.text = "raw body"
+        resp.json.return_value = {"error": "simple error"}
+        assert _image_extract_api_error(resp) == "simple error"
+
+    def test_non_json_body_falls_back_to_text(self) -> None:
+        from src.ai_interaction import _image_extract_api_error
+        resp = MagicMock()
+        resp.text = "plain text error body"
+        resp.json.side_effect = Exception("not json")
+        assert "plain text error body" in _image_extract_api_error(resp)
+
+    def test_truncates_long_body(self) -> None:
+        from src.ai_interaction import _image_extract_api_error, ERROR_TEXT_DISPLAY_LIMIT
+        resp = MagicMock()
+        resp.text = "x" * (ERROR_TEXT_DISPLAY_LIMIT + 100)
+        resp.json.side_effect = Exception("not json")
+        result = _image_extract_api_error(resp)
+        assert len(result) <= ERROR_TEXT_DISPLAY_LIMIT

--- a/tests/test_ai_interaction_generate_image.py
+++ b/tests/test_ai_interaction_generate_image.py
@@ -1,0 +1,215 @@
+"""
+Tests for do_generate_image() and its extracted sub-functions.
+
+Uses mocks for httpx, _resolve_model, and database to stay unit-level.
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict
+
+
+async def _gen(content: str, session_id: str = "s1", owner: str = "u1") -> Dict:
+    from src.ai_interaction import do_generate_image
+    return await do_generate_image(content, session_id=session_id, owner=owner)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestGenerateImageInput:
+
+    @pytest.mark.asyncio
+    async def test_missing_prompt_returns_error(self) -> None:
+        result = await _gen("")
+        assert "error" in result
+        assert "prompt" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_prompt_returns_error(self) -> None:
+        result = await _gen("   \n   ")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Image model type detection helpers
+# ---------------------------------------------------------------------------
+
+class TestImageModelTypeDetection:
+
+    def test_detect_gpt_image(self) -> None:
+        from src.ai_interaction import _image_classify_model
+        assert _image_classify_model("gpt-image-1")["is_gpt_image"] is True
+        assert _image_classify_model("gpt-image-1.5")["is_gpt_image"] is True
+
+    def test_detect_dalle(self) -> None:
+        from src.ai_interaction import _image_classify_model
+        assert _image_classify_model("dall-e-3")["is_dalle"] is True
+
+    def test_detect_local_diffusion(self) -> None:
+        from src.ai_interaction import _image_classify_model
+        result = _image_classify_model("stable-diffusion-xl")
+        assert result["is_local_diffusion"] is True
+        assert result["is_gpt_image"] is False
+        assert result["is_dalle"] is False
+
+
+# ---------------------------------------------------------------------------
+# Size validation helpers
+# ---------------------------------------------------------------------------
+
+class TestImageSizeValidation:
+
+    def test_gpt_image_valid_size_unchanged(self) -> None:
+        from src.ai_interaction import _image_clamp_size
+        assert _image_clamp_size("1024x1024", is_gpt_image=True, is_dalle=False) == "1024x1024"
+
+    def test_gpt_image_invalid_size_clamped(self) -> None:
+        from src.ai_interaction import _image_clamp_size
+        assert _image_clamp_size("9999x9999", is_gpt_image=True, is_dalle=False) == "1024x1024"
+
+    def test_dalle_valid_size_unchanged(self) -> None:
+        from src.ai_interaction import _image_clamp_size
+        assert _image_clamp_size("1024x1792", is_gpt_image=False, is_dalle=True) == "1024x1792"
+
+    def test_dalle_invalid_size_clamped(self) -> None:
+        from src.ai_interaction import _image_clamp_size
+        assert _image_clamp_size("512x512", is_gpt_image=False, is_dalle=True) == "1024x1024"
+
+    def test_local_diffusion_any_size_accepted(self) -> None:
+        from src.ai_interaction import _image_clamp_size
+        assert _image_clamp_size("512x512", is_gpt_image=False, is_dalle=False) == "512x512"
+        assert _image_clamp_size("768x1152", is_gpt_image=False, is_dalle=False) == "768x1152"
+
+
+# ---------------------------------------------------------------------------
+# Payload building helper
+# ---------------------------------------------------------------------------
+
+class TestImagePayloadBuilding:
+
+    def test_gpt_image_includes_quality(self) -> None:
+        from src.ai_interaction import _image_build_payload
+        payload = _image_build_payload("gpt-image-1", "a cat", "1024x1024", "high",
+                                       is_gpt_image=True, is_dalle=False, is_local_diffusion=False)
+        assert payload["quality"] == "high"
+
+    def test_dalle_excludes_quality(self) -> None:
+        from src.ai_interaction import _image_build_payload
+        payload = _image_build_payload("dall-e-3", "a cat", "1024x1024", "high",
+                                       is_gpt_image=False, is_dalle=True, is_local_diffusion=False)
+        assert "quality" not in payload
+
+    def test_local_diffusion_includes_quality(self) -> None:
+        from src.ai_interaction import _image_build_payload
+        payload = _image_build_payload("sd-xl", "a cat", "512x512", "low",
+                                       is_gpt_image=False, is_dalle=False, is_local_diffusion=True)
+        assert payload["quality"] == "low"
+
+    def test_invalid_quality_defaults_to_medium(self) -> None:
+        from src.ai_interaction import _image_build_payload
+        payload = _image_build_payload("gpt-image-1", "a cat", "1024x1024", "ultra",
+                                       is_gpt_image=True, is_dalle=False, is_local_diffusion=False)
+        assert payload["quality"] == "medium"
+
+    def test_payload_contains_required_fields(self) -> None:
+        from src.ai_interaction import _image_build_payload
+        payload = _image_build_payload("gpt-image-1", "a cat", "1024x1024", "medium",
+                                       is_gpt_image=True, is_dalle=False, is_local_diffusion=False)
+        assert payload["model"] == "gpt-image-1"
+        assert payload["prompt"] == "a cat"
+        assert payload["n"] == 1
+        assert payload["size"] == "1024x1024"
+
+
+# ---------------------------------------------------------------------------
+# Images URL derivation
+# ---------------------------------------------------------------------------
+
+class TestImageUrlDerivation:
+
+    def test_derives_from_chat_completions_url(self) -> None:
+        from src.ai_interaction import _image_derive_generations_url
+        url = _image_derive_generations_url("https://api.openai.com/v1/chat/completions")
+        assert url == "https://api.openai.com/v1/images/generations"
+
+    def test_derives_from_anthropic_messages_url(self) -> None:
+        from src.ai_interaction import _image_derive_generations_url
+        url = _image_derive_generations_url("https://api.anthropic.com/v1/messages")
+        # /v1/messages is stripped, leaving base + /images/generations
+        assert url.endswith("/images/generations")
+        assert "anthropic.com" in url
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with mocked HTTP
+# ---------------------------------------------------------------------------
+
+class TestGenerateImageEndToEnd:
+
+    @pytest.mark.asyncio
+    async def test_no_model_found_returns_error(self) -> None:
+        with patch("src.ai_interaction._resolve_model", side_effect=ValueError("not found")), \
+             patch("src.ai_interaction._image_auto_detect_model_spec", return_value=""):
+            result = await _gen("A sunset over mountains")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_http_timeout_returns_error(self) -> None:
+        import httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"b64_json": ""}]}
+
+        with patch("src.ai_interaction._resolve_model", return_value=("http://url", "gpt-image-1", {})), \
+             patch("src.ai_interaction._image_auto_detect_model_spec", return_value="gpt-image-1"), \
+             patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+            mock_client_cls.return_value = mock_client
+
+            result = await _gen("A sunset")
+        assert "error" in result
+        assert "timed out" in result["error"].lower() or "timeout" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_api_error_status_returns_error(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "Bad request"
+        mock_resp.json.side_effect = Exception("no json")
+
+        with patch("src.ai_interaction._resolve_model", return_value=("http://url", "gpt-image-1", {})), \
+             patch("src.ai_interaction._image_auto_detect_model_spec", return_value="gpt-image-1"), \
+             patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            result = await _gen("A sunset")
+        assert "error" in result
+        assert "400" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_data_list_returns_error(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": []}
+
+        with patch("src.ai_interaction._resolve_model", return_value=("http://url", "gpt-image-1", {})), \
+             patch("src.ai_interaction._image_auto_detect_model_spec", return_value="gpt-image-1"), \
+             patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            result = await _gen("A sunset")
+        assert "error" in result

--- a/tests/test_ai_interaction_helpers.py
+++ b/tests/test_ai_interaction_helpers.py
@@ -314,13 +314,12 @@ class TestColorValidation:
 class TestModelResolution:
     """Test model resolution error handling."""
 
-    @pytest.mark.asyncio
-    async def test_resolve_model_safe_error_handling(self) -> None:
+    def test_resolve_model_safe_error_handling(self) -> None:
         """Verify resolve_model_safe returns error dict on failure."""
         from src.ai_interaction import resolve_model_safe
 
         # Use a clearly invalid model spec
-        url, model, headers, error = await resolve_model_safe("nonexistent_model_xyz_not_real_12345")
+        url, model, headers, error = resolve_model_safe("nonexistent_model_xyz_not_real_12345")
 
         assert url is None, "URL should be None on error"
         assert model is None, "Model should be None on error"
@@ -329,12 +328,11 @@ class TestModelResolution:
         assert "error" in error, "Error dict should have 'error' key"
         assert isinstance(error["error"], str), "Error message should be string"
 
-    @pytest.mark.asyncio
-    async def test_resolve_model_safe_returns_all_none_on_error(self) -> None:
+    def test_resolve_model_safe_returns_all_none_on_error(self) -> None:
         """Verify resolve_model_safe returns (None, None, None, error_dict) on error."""
         from src.ai_interaction import resolve_model_safe
 
-        result = await resolve_model_safe("invalid_model")
+        result = resolve_model_safe("invalid_model")
 
         assert isinstance(result, tuple), "Should return tuple"
         assert len(result) == 4, "Should return 4-tuple"

--- a/tests/test_ai_interaction_helpers.py
+++ b/tests/test_ai_interaction_helpers.py
@@ -1,0 +1,366 @@
+"""
+Tests for ai_interaction.py helper functions.
+
+Tests extraction and truncation helpers, content parsing, UI resolution,
+and model resolution error handling.
+
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from typing import Optional, Dict, Tuple
+
+
+class TestResponseTruncation:
+    """Test response truncation helper functions."""
+
+    def test_truncate_response_under_limit(self) -> None:
+        """Verify truncate_response doesn't modify text under limit."""
+        from src.ai_interaction import truncate_response, RESPONSE_TRUNCATE_LIMIT
+
+        short_text = "Short response"
+        result = truncate_response(short_text)
+
+        assert result == short_text, "Text under limit should not be modified"
+
+    def test_truncate_response_at_limit(self) -> None:
+        """Verify truncate_response doesn't modify text at exact limit."""
+        from src.ai_interaction import truncate_response, RESPONSE_TRUNCATE_LIMIT
+
+        text_at_limit = "x" * RESPONSE_TRUNCATE_LIMIT
+        result = truncate_response(text_at_limit)
+
+        assert result == text_at_limit, "Text at limit should not be truncated"
+
+    def test_truncate_response_over_limit(self) -> None:
+        """Verify truncate_response truncates text over limit."""
+        from src.ai_interaction import truncate_response, RESPONSE_TRUNCATE_LIMIT
+
+        long_text = "x" * (RESPONSE_TRUNCATE_LIMIT + 100)
+        result = truncate_response(long_text)
+
+        assert len(result) <= RESPONSE_TRUNCATE_LIMIT + 30, "Result should be <= limit + notice"
+        assert "truncated" in result.lower(), "Result should indicate truncation"
+
+    def test_truncate_response_with_custom_limit(self) -> None:
+        """Verify truncate_response respects custom limit."""
+        custom_limit = 50
+        long_text = "x" * 100
+
+        result_func = pytest.importorskip("src.ai_interaction").truncate_response
+        result = result_func(long_text, custom_limit)
+
+        assert len(result) <= custom_limit + 30, "Should respect custom limit"
+        assert "truncated" in result.lower()
+
+    def test_truncate_response_preserves_content_under_limit(self) -> None:
+        """Verify truncate_response preserves text content when under limit."""
+        from src.ai_interaction import truncate_response
+
+        text = "This is important content."
+        result = truncate_response(text)
+
+        assert text in result, "Important content should be preserved"
+        assert "truncated" not in result.lower(), "Should not indicate truncation"
+
+    def test_truncate_for_teacher(self) -> None:
+        """Verify truncate_for_teacher uses teacher-specific limit."""
+        from src.ai_interaction import (
+            truncate_for_teacher,
+            RESPONSE_TRUNCATE_TEACHER,
+        )
+
+        long_text = "x" * (RESPONSE_TRUNCATE_TEACHER + 100)
+        result = truncate_for_teacher(long_text)
+
+        assert len(result) <= RESPONSE_TRUNCATE_TEACHER + 30
+        assert "truncated" in result.lower()
+
+    def test_truncate_for_pipeline(self) -> None:
+        """Verify truncate_for_pipeline uses pipeline-specific limit."""
+        from src.ai_interaction import (
+            truncate_for_pipeline,
+            RESPONSE_TRUNCATE_PIPELINE,
+        )
+
+        long_text = "x" * (RESPONSE_TRUNCATE_PIPELINE + 100)
+        result = truncate_for_pipeline(long_text)
+
+        assert len(result) <= RESPONSE_TRUNCATE_PIPELINE + 30
+        assert "truncated" in result.lower()
+
+
+class TestContentParsing:
+    """Test content parsing helper functions."""
+
+    def test_get_first_line_simple(self) -> None:
+        """Verify get_first_line extracts first line."""
+        from src.ai_interaction import get_first_line
+
+        content = "model_name\nrest of content\nmore lines"
+        result = get_first_line(content)
+
+        assert result == "model_name", "Should extract first line"
+
+    def test_get_first_line_with_whitespace(self) -> None:
+        """Verify get_first_line strips whitespace."""
+        from src.ai_interaction import get_first_line
+
+        content = "  model_name  \nrest"
+        result = get_first_line(content)
+
+        assert result == "model_name", "Should strip whitespace from first line"
+
+    def test_get_first_line_with_max_len(self) -> None:
+        """Verify get_first_line respects max_len parameter."""
+        from src.ai_interaction import get_first_line
+
+        content = "very_long_model_name_that_is_too_long\nrest"
+        result = get_first_line(content, 10)
+
+        assert len(result) == 10, "Result should be limited to max_len"
+        assert result == "very_long_", "Should truncate to specified length"
+
+    def test_get_first_line_empty_content(self) -> None:
+        """Verify get_first_line handles empty content."""
+        from src.ai_interaction import get_first_line
+
+        result = get_first_line("")
+        assert result == "", "Empty content should return empty string"
+
+    def test_get_first_line_whitespace_only(self) -> None:
+        """Verify get_first_line handles whitespace-only content."""
+        from src.ai_interaction import get_first_line
+
+        result = get_first_line("   \n   \n   ")
+        assert result == "", "Whitespace-only content should return empty string"
+
+    def test_get_first_line_no_max_len(self) -> None:
+        """Verify get_first_line doesn't truncate when max_len is None."""
+        from src.ai_interaction import get_first_line
+
+        long_line = "x" * 200
+        content = f"{long_line}\nrest"
+        result = get_first_line(content, max_len=None)
+
+        assert result == long_line, "Should not truncate when max_len=None"
+
+    def test_get_action_from_content(self) -> None:
+        """Verify get_action_from_content extracts action name."""
+        from src.ai_interaction import get_action_from_content
+
+        content = "rename\nsession_id\nnew_name"
+        result = get_action_from_content(content)
+
+        assert result == "rename", "Should extract action from first line"
+        assert len(result) <= 40, "Should limit to action max length"
+
+    def test_get_model_spec_from_content(self) -> None:
+        """Verify get_model_spec_from_content extracts model spec."""
+        from src.ai_interaction import get_model_spec_from_content
+
+        content = "claude@anthropic\nPlease analyze this..."
+        result = get_model_spec_from_content(content)
+
+        assert result == "claude@anthropic", "Should extract model spec"
+        assert len(result) <= 60, "Should limit to model spec max length"
+
+
+class TestUIResolution:
+    """Test UI string resolution helper functions."""
+
+    def test_resolve_panel_direct_match(self) -> None:
+        """Verify resolve_panel returns canonical name for direct match."""
+        from src.ai_interaction import resolve_panel
+
+        result = resolve_panel("documents")
+        assert result == "documents", "Should return canonical name for direct match"
+
+    def test_resolve_panel_alias(self) -> None:
+        """Verify resolve_panel resolves aliases."""
+        from src.ai_interaction import resolve_panel
+
+        # Common aliases
+        assert resolve_panel("doc") == "documents"
+        assert resolve_panel("docs") == "documents"
+        assert resolve_panel("doclib") == "documents"
+
+    def test_resolve_panel_case_insensitive(self) -> None:
+        """Verify resolve_panel is case-insensitive."""
+        from src.ai_interaction import resolve_panel
+
+        assert resolve_panel("DOCUMENTS") == "documents"
+        assert resolve_panel("Documents") == "documents"
+        assert resolve_panel("DOC") == "documents"
+
+    def test_resolve_panel_unknown(self) -> None:
+        """Verify resolve_panel returns None for unknown panel."""
+        from src.ai_interaction import resolve_panel
+
+        result = resolve_panel("unknown_panel_xyz")
+        assert result is None, "Should return None for unknown panel"
+
+    def test_resolve_panel_none_input(self) -> None:
+        """Verify resolve_panel handles None input."""
+        from src.ai_interaction import resolve_panel
+
+        result = resolve_panel(None)
+        assert result is None, "Should handle None input gracefully"
+
+    def test_resolve_toggle_direct_match(self) -> None:
+        """Verify resolve_toggle returns canonical name for direct match."""
+        from src.ai_interaction import resolve_toggle
+
+        result = resolve_toggle("bash")
+        assert result == "bash", "Should return canonical name for direct match"
+
+    def test_resolve_toggle_alias(self) -> None:
+        """Verify resolve_toggle resolves aliases."""
+        from src.ai_interaction import resolve_toggle
+
+        # Common aliases
+        assert resolve_toggle("shell") == "bash"
+        assert resolve_toggle("terminal") == "bash"
+        assert resolve_toggle("search") == "web"
+        assert resolve_toggle("web") == "web"
+
+    def test_resolve_toggle_case_insensitive(self) -> None:
+        """Verify resolve_toggle is case-insensitive."""
+        from src.ai_interaction import resolve_toggle
+
+        assert resolve_toggle("SHELL") == "bash"
+        assert resolve_toggle("Shell") == "bash"
+        assert resolve_toggle("WEB") == "web"
+
+    def test_resolve_toggle_unknown(self) -> None:
+        """Verify resolve_toggle returns None for unknown toggle."""
+        from src.ai_interaction import resolve_toggle
+
+        result = resolve_toggle("unknown_toggle_xyz")
+        assert result is None, "Should return None for unknown toggle"
+
+    def test_resolve_toggle_none_input(self) -> None:
+        """Verify resolve_toggle handles None input."""
+        from src.ai_interaction import resolve_toggle
+
+        result = resolve_toggle(None)
+        assert result is None, "Should handle None input gracefully"
+
+
+class TestColorValidation:
+    """Test color validation helper functions."""
+
+    def test_is_valid_hex_color_valid_lowercase(self) -> None:
+        """Verify is_valid_hex_color accepts valid lowercase hex."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("#ffffff") is True
+        assert is_valid_hex_color("#000000") is True
+        assert is_valid_hex_color("#abcdef") is True
+
+    def test_is_valid_hex_color_valid_uppercase(self) -> None:
+        """Verify is_valid_hex_color accepts valid uppercase hex."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("#FFFFFF") is True
+        assert is_valid_hex_color("#ABCDEF") is True
+
+    def test_is_valid_hex_color_valid_mixed_case(self) -> None:
+        """Verify is_valid_hex_color accepts valid mixed-case hex."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("#FfFfFf") is True
+        assert is_valid_hex_color("#aAbBcC") is True
+
+    def test_is_valid_hex_color_invalid_letters(self) -> None:
+        """Verify is_valid_hex_color rejects invalid hex letters."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("#GGGGGG") is False
+        assert is_valid_hex_color("#gggggg") is False
+        assert is_valid_hex_color("#zzzzzz") is False
+
+    def test_is_valid_hex_color_wrong_length(self) -> None:
+        """Verify is_valid_hex_color rejects wrong length."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("#fff") is False  # Too short
+        assert is_valid_hex_color("#fffffff") is False  # Too long
+        assert is_valid_hex_color("ffffff") is False  # Missing #
+
+    def test_is_valid_hex_color_no_hash(self) -> None:
+        """Verify is_valid_hex_color requires # prefix."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("ffffff") is False
+        assert is_valid_hex_color("000000") is False
+
+    def test_is_valid_hex_color_with_spaces(self) -> None:
+        """Verify is_valid_hex_color rejects colors with spaces."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("# ffffff") is False
+        assert is_valid_hex_color("#fff fff") is False
+
+    def test_is_valid_hex_color_named_colors(self) -> None:
+        """Verify is_valid_hex_color rejects named colors."""
+        from src.ai_interaction import is_valid_hex_color
+
+        assert is_valid_hex_color("#white") is False
+        assert is_valid_hex_color("#red") is False
+        assert is_valid_hex_color("#blue") is False
+
+
+class TestModelResolution:
+    """Test model resolution error handling."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_model_safe_error_handling(self) -> None:
+        """Verify resolve_model_safe returns error dict on failure."""
+        from src.ai_interaction import resolve_model_safe
+
+        # Use a clearly invalid model spec
+        url, model, headers, error = await resolve_model_safe("nonexistent_model_xyz_not_real_12345")
+
+        assert url is None, "URL should be None on error"
+        assert model is None, "Model should be None on error"
+        assert headers is None, "Headers should be None on error"
+        assert error is not None, "Error should be a dict"
+        assert "error" in error, "Error dict should have 'error' key"
+        assert isinstance(error["error"], str), "Error message should be string"
+
+    @pytest.mark.asyncio
+    async def test_resolve_model_safe_returns_all_none_on_error(self) -> None:
+        """Verify resolve_model_safe returns (None, None, None, error_dict) on error."""
+        from src.ai_interaction import resolve_model_safe
+
+        result = await resolve_model_safe("invalid_model")
+
+        assert isinstance(result, tuple), "Should return tuple"
+        assert len(result) == 4, "Should return 4-tuple"
+        assert result[0] is None, "First element should be None"
+        assert result[1] is None, "Second element should be None"
+        assert result[2] is None, "Third element should be None"
+        assert result[3] is not None, "Fourth element should be error dict"
+
+
+class TestDatabaseContextManager:
+    """Test database session context manager."""
+
+    def test_get_db_session_context_manager(self) -> None:
+        """Verify get_db_session returns a context manager."""
+        from src.ai_interaction import get_db_session
+
+        ctx = get_db_session()
+
+        assert hasattr(ctx, "__enter__"), "Should be context manager"
+        assert hasattr(ctx, "__exit__"), "Should be context manager"
+
+    def test_get_db_session_cleanup(self) -> None:
+        """Verify get_db_session cleans up on exit."""
+        from src.ai_interaction import get_db_session
+
+        with get_db_session() as db:
+            assert db is not None, "Context should yield database session"
+            # Session is open here
+        # Session should be closed after exiting context

--- a/tests/test_ai_interaction_list_sessions.py
+++ b/tests/test_ai_interaction_list_sessions.py
@@ -1,0 +1,177 @@
+"""
+Tests for do_list_sessions() and its extracted helpers.
+
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+from typing import Dict
+
+
+# ---------------------------------------------------------------------------
+# Relative-time helper
+# ---------------------------------------------------------------------------
+
+class TestSessionRelativeTime:
+    """Tests for the _session_relative_time() helper."""
+
+    def test_none_returns_never(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        assert _session_relative_time(None) == "never"
+
+    def test_just_now(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        ts = datetime.now(timezone.utc) - timedelta(seconds=30)
+        assert _session_relative_time(ts) == "just now"
+
+    def test_minutes_ago(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        ts = datetime.now(timezone.utc) - timedelta(minutes=5)
+        result = _session_relative_time(ts)
+        assert "m ago" in result
+        assert "5" in result
+
+    def test_hours_ago(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        ts = datetime.now(timezone.utc) - timedelta(hours=3)
+        result = _session_relative_time(ts)
+        assert "h ago" in result
+        assert "3" in result
+
+    def test_days_ago(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        ts = datetime.now(timezone.utc) - timedelta(days=2)
+        result = _session_relative_time(ts)
+        assert "d ago" in result
+        assert "2" in result
+
+    def test_old_date_returns_formatted(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        ts = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        result = _session_relative_time(ts)
+        assert "2024-01-15" in result
+
+    def test_naive_datetime_works(self) -> None:
+        from src.ai_interaction import _session_relative_time
+        # Naive datetime (no tzinfo) — treated as UTC internally
+        ts = datetime(2024, 1, 1, 0, 0, 0)  # old fixed date, no tzinfo
+        result = _session_relative_time(ts)
+        # Should return a date string (more than 7 days ago)
+        assert "2024-01-01" in result
+
+
+# ---------------------------------------------------------------------------
+# do_list_sessions
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_session_manager(monkeypatch):
+    mgr = MagicMock()
+    mgr.get_sessions_for_user.return_value = {}
+    monkeypatch.setattr("src.ai_interaction._session_manager", mgr)
+    return mgr
+
+
+async def _list(content: str = "", owner: str = "user1") -> Dict:
+    from src.ai_interaction import do_list_sessions
+    return await do_list_sessions(content, owner=owner)
+
+
+class TestListSessions:
+
+    @pytest.mark.asyncio
+    async def test_no_manager_returns_error(self, monkeypatch) -> None:
+        monkeypatch.setattr("src.ai_interaction._session_manager", None)
+        result = await _list()
+        assert "error" in result
+
+    def _make_ctx(self, db_rows=None):
+        """Build a get_db_session context manager mock returning the given rows."""
+        from contextlib import contextmanager
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = db_rows or []
+
+        @contextmanager
+        def _ctx():
+            yield mock_db
+
+        return _ctx
+
+    @pytest.mark.asyncio
+    async def test_no_sessions_returns_results(self, mock_session_manager) -> None:
+        mock_session_manager.get_sessions_for_user.return_value = {}
+        with patch("src.ai_interaction.get_db_session", self._make_ctx()):
+            result = await _list()
+        assert "results" in result
+        assert "No sessions" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_sessions_sorted_most_recent_first(self, mock_session_manager) -> None:
+        older_ts = datetime.now(timezone.utc) - timedelta(hours=2)
+        newer_ts = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+        sess_old = MagicMock()
+        sess_old.name = "Old Chat"
+        sess_old.model = "gpt-4"
+        sess_old.message_count = 5
+
+        sess_new = MagicMock()
+        sess_new.name = "New Chat"
+        sess_new.model = "gpt-4"
+        sess_new.message_count = 3
+
+        mock_session_manager.get_sessions_for_user.return_value = {
+            "old_id": sess_old,
+            "new_id": sess_new,
+        }
+
+        db_old = MagicMock(id="old_id", last_accessed=older_ts, updated_at=None, created_at=None)
+        db_new = MagicMock(id="new_id", last_accessed=newer_ts, updated_at=None, created_at=None)
+
+        with patch("src.ai_interaction.get_db_session", self._make_ctx([db_old, db_new])):
+            result = await _list()
+
+        assert "results" in result
+        new_pos = result["results"].find("New Chat")
+        old_pos = result["results"].find("Old Chat")
+        assert new_pos < old_pos, "Most-recent session should appear first"
+        assert "← most recent" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_keyword_filter_applied(self, mock_session_manager) -> None:
+        sess_python = MagicMock()
+        sess_python.name = "Python Help"
+        sess_python.model = "gpt-4"
+        sess_python.message_count = 2
+
+        sess_js = MagicMock()
+        sess_js.name = "JavaScript Tips"
+        sess_js.model = "gpt-4"
+        sess_js.message_count = 1
+
+        mock_session_manager.get_sessions_for_user.return_value = {
+            "s1": sess_python,
+            "s2": sess_js,
+        }
+
+        with patch("src.ai_interaction.get_db_session", self._make_ctx()):
+            result = await _list("python")
+
+        assert "Python Help" in result["results"]
+        assert "JavaScript Tips" not in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_result_contains_clickable_links(self, mock_session_manager) -> None:
+        sess = MagicMock()
+        sess.name = "My Chat"
+        sess.model = "gpt-4"
+        sess.message_count = 10
+
+        mock_session_manager.get_sessions_for_user.return_value = {"abc123": sess}
+
+        with patch("src.ai_interaction.get_db_session", self._make_ctx()):
+            result = await _list()
+
+        assert "#session-abc123" in result["results"]

--- a/tests/test_ai_interaction_list_sessions.py
+++ b/tests/test_ai_interaction_list_sessions.py
@@ -76,7 +76,7 @@ def mock_session_manager(monkeypatch):
 
 async def _list(content: str = "", owner: str = "user1") -> Dict:
     from src.ai_interaction import do_list_sessions
-    return await do_list_sessions(content, owner=owner)
+    return do_list_sessions(content, owner=owner)
 
 
 class TestListSessions:

--- a/tests/test_ai_interaction_manage_memory.py
+++ b/tests/test_ai_interaction_manage_memory.py
@@ -1,0 +1,278 @@
+"""
+Tests for do_manage_memory() and its extracted action handlers.
+
+Covers: list, add, edit, delete, search actions.
+
+Uses mocks for memory_manager and memory_vector to stay unit-level.
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from typing import Dict
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_memory_manager(monkeypatch):
+    """Inject a mock memory manager into ai_interaction module."""
+    mgr = MagicMock()
+    mgr.load.return_value = []
+    mgr.load_all.return_value = []
+    monkeypatch.setattr("src.ai_interaction._memory_manager", mgr)
+    return mgr
+
+
+async def _memory(content: str, owner: str = "user1") -> Dict:
+    from src.ai_interaction import do_manage_memory
+    return await do_manage_memory(content, owner=owner)
+
+
+# ---------------------------------------------------------------------------
+# No manager
+# ---------------------------------------------------------------------------
+
+class TestManageMemoryNoManager:
+    @pytest.mark.asyncio
+    async def test_no_manager_returns_error(self, monkeypatch) -> None:
+        monkeypatch.setattr("src.ai_interaction._memory_manager", None)
+        result = await _memory("list")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# list action
+# ---------------------------------------------------------------------------
+
+class TestManageMemoryList:
+    @pytest.mark.asyncio
+    async def test_list_no_memories(self, mock_memory_manager) -> None:
+        mock_memory_manager.load.return_value = []
+        result = await _memory("list")
+        assert "results" in result
+        assert "No memories" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_list_returns_memories(self, mock_memory_manager) -> None:
+        mock_memory_manager.load.return_value = [
+            {"id": "abc12345", "category": "fact", "text": "Python is great"},
+            {"id": "def67890", "category": "preference", "text": "Likes dark mode"},
+        ]
+        result = await _memory("list")
+        assert "results" in result
+        assert "Python is great" in result["results"]
+        assert "Likes dark mode" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_list_with_category_filter(self, mock_memory_manager) -> None:
+        mock_memory_manager.load.return_value = [
+            {"id": "abc12345", "category": "fact", "text": "Python is great"},
+            {"id": "def67890", "category": "preference", "text": "Likes dark mode"},
+        ]
+        result = await _memory("list\nfact")
+        assert "results" in result
+        assert "Python is great" in result["results"]
+        assert "Likes dark mode" not in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_list_truncates_long_text(self, mock_memory_manager) -> None:
+        from src.ai_interaction import MEMORY_TEXT_PREVIEW_LIMIT
+        long_text = "x" * (MEMORY_TEXT_PREVIEW_LIMIT + 50)
+        mock_memory_manager.load.return_value = [
+            {"id": "abc12345", "category": "fact", "text": long_text},
+        ]
+        result = await _memory("list")
+        assert "..." in result["results"]
+
+
+# ---------------------------------------------------------------------------
+# add action
+# ---------------------------------------------------------------------------
+
+class TestManageMemoryAdd:
+    @pytest.mark.asyncio
+    async def test_add_missing_text_returns_error(self) -> None:
+        result = await _memory("add")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_add_success(self, mock_memory_manager) -> None:
+        entry = {"id": "abc12345", "text": "New fact", "category": "fact"}
+        mock_memory_manager.add_entry.return_value = entry
+        mock_memory_manager.load_all.return_value = []
+
+        result = await _memory("add\nNew fact")
+        assert result.get("action") == "add"
+        assert "memory_id" in result
+
+    @pytest.mark.asyncio
+    async def test_add_with_category(self, mock_memory_manager) -> None:
+        entry = {"id": "abc12345", "text": "Prefers Python", "category": "preference"}
+        mock_memory_manager.add_entry.return_value = entry
+        mock_memory_manager.load_all.return_value = []
+
+        await _memory("add\nPrefers Python\npreference")
+        mock_memory_manager.add_entry.assert_called_once_with(
+            "Prefers Python", source="ai_agent", category="preference", owner="user1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_default_category_is_fact(self, mock_memory_manager) -> None:
+        entry = {"id": "abc12345", "text": "Some fact", "category": "fact"}
+        mock_memory_manager.add_entry.return_value = entry
+        mock_memory_manager.load_all.return_value = []
+
+        await _memory("add\nSome fact")
+        mock_memory_manager.add_entry.assert_called_once_with(
+            "Some fact", source="ai_agent", category="fact", owner="user1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_updates_vector_index_if_available(self, mock_memory_manager, monkeypatch) -> None:
+        entry = {"id": "abc12345", "text": "New fact", "category": "fact"}
+        mock_memory_manager.add_entry.return_value = entry
+        mock_memory_manager.load_all.return_value = []
+
+        mock_vector = MagicMock()
+        mock_vector.healthy = True
+        monkeypatch.setattr("src.ai_interaction._memory_vector", mock_vector)
+
+        await _memory("add\nNew fact")
+        mock_vector.add.assert_called_once_with("abc12345", "New fact")
+
+
+# ---------------------------------------------------------------------------
+# edit action
+# ---------------------------------------------------------------------------
+
+class TestManageMemoryEdit:
+    @pytest.mark.asyncio
+    async def test_edit_missing_args_returns_error(self) -> None:
+        result = await _memory("edit\nsome_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_edit_unknown_id_returns_error(self, mock_memory_manager) -> None:
+        mock_memory_manager.load_all.return_value = [
+            {"id": "other_id", "text": "Some text", "owner": "user1"}
+        ]
+        result = await _memory("edit\nunknown_id\nnew text")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_edit_success(self, mock_memory_manager) -> None:
+        mock_memory_manager.load_all.return_value = [
+            {"id": "abc12345", "text": "Old text", "owner": "user1"}
+        ]
+        result = await _memory("edit\nabc1\nnew text")
+        assert result.get("action") == "edit"
+        mock_memory_manager.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_edit_respects_owner(self, mock_memory_manager) -> None:
+        """Cannot edit another user's memory."""
+        mock_memory_manager.load_all.return_value = [
+            {"id": "abc12345", "text": "Secret", "owner": "other_user"}
+        ]
+        result = await _memory("edit\nabc1\nnew text", owner="user1")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# delete action
+# ---------------------------------------------------------------------------
+
+class TestManageMemoryDelete:
+    @pytest.mark.asyncio
+    async def test_delete_missing_id_returns_error(self) -> None:
+        result = await _memory("delete")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_id_returns_error(self, mock_memory_manager) -> None:
+        mock_memory_manager.load_all.return_value = [
+            {"id": "other_id", "text": "Some text", "owner": "user1"}
+        ]
+        result = await _memory("delete\nunknown_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, mock_memory_manager) -> None:
+        mock_memory_manager.load_all.return_value = [
+            {"id": "abc12345", "text": "To delete", "owner": "user1"}
+        ]
+        result = await _memory("delete\nabc1")
+        assert result.get("action") == "delete"
+        mock_memory_manager.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_respects_owner(self, mock_memory_manager) -> None:
+        """Cannot delete another user's memory."""
+        mock_memory_manager.load_all.return_value = [
+            {"id": "abc12345", "text": "Secret", "owner": "other_user"}
+        ]
+        result = await _memory("delete\nabc1", owner="user1")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# search action
+# ---------------------------------------------------------------------------
+
+class TestManageMemorySearch:
+    @pytest.mark.asyncio
+    async def test_search_missing_query_returns_error(self) -> None:
+        result = await _memory("search")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, mock_memory_manager) -> None:
+        mock_memory_manager.load.return_value = []
+        mock_memory_manager.get_relevant_memories = MagicMock(return_value=[])
+
+        result = await _memory("search\nsome query")
+        assert "results" in result
+        assert "No memories" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_search_uses_vector_search_when_available(self, mock_memory_manager) -> None:
+        memories = [{"id": "abc12345", "category": "fact", "text": "Python is great"}]
+        mock_memory_manager.load.return_value = memories
+        mock_memory_manager.get_relevant_memories = MagicMock(return_value=memories)
+
+        result = await _memory("search\nPython")
+        assert "results" in result
+        assert "Python is great" in result["results"]
+        mock_memory_manager.get_relevant_memories.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_falls_back_to_text_search(self, mock_memory_manager) -> None:
+        """When get_relevant_memories is absent, fall back to text search."""
+        memories = [{"id": "abc12345", "category": "fact", "text": "Python is great"}]
+        mock_memory_manager.load.return_value = memories
+        del mock_memory_manager.get_relevant_memories  # Remove the method
+
+        result = await _memory("search\nPython")
+        assert "results" in result
+        assert "Python is great" in result["results"]
+
+
+# ---------------------------------------------------------------------------
+# Unknown action
+# ---------------------------------------------------------------------------
+
+class TestManageMemoryUnknownAction:
+    @pytest.mark.asyncio
+    async def test_unknown_action_returns_error(self) -> None:
+        result = await _memory("unknown_action_xyz")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_error_mentions_valid_actions(self) -> None:
+        result = await _memory("bad_action")
+        assert "error" in result
+        error_msg = result["error"]
+        assert any(a in error_msg for a in ("list", "add", "edit", "delete", "search"))

--- a/tests/test_ai_interaction_manage_memory.py
+++ b/tests/test_ai_interaction_manage_memory.py
@@ -28,7 +28,7 @@ def mock_memory_manager(monkeypatch):
 
 async def _memory(content: str, owner: str = "user1") -> Dict:
     from src.ai_interaction import do_manage_memory
-    return await do_manage_memory(content, owner=owner)
+    return do_manage_memory(content, owner=owner)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ai_interaction_manage_rag.py
+++ b/tests/test_ai_interaction_manage_rag.py
@@ -21,7 +21,7 @@ def mock_managers(monkeypatch):
 
 async def _rag(content: str) -> Dict:
     from src.ai_interaction import do_manage_rag
-    return await do_manage_rag(content)
+    return do_manage_rag(content)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ai_interaction_manage_rag.py
+++ b/tests/test_ai_interaction_manage_rag.py
@@ -1,0 +1,164 @@
+"""
+Tests for do_manage_rag() and its action handlers.
+
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typing import Dict
+
+
+@pytest.fixture(autouse=True)
+def mock_managers(monkeypatch):
+    rag = MagicMock()
+    docs = MagicMock()
+    docs.index = []
+    monkeypatch.setattr("src.ai_interaction._rag_manager", rag)
+    monkeypatch.setattr("src.ai_interaction._personal_docs_manager", docs)
+    return rag, docs
+
+
+async def _rag(content: str) -> Dict:
+    from src.ai_interaction import do_manage_rag
+    return await do_manage_rag(content)
+
+
+# ---------------------------------------------------------------------------
+# list action
+# ---------------------------------------------------------------------------
+
+class TestManageRagList:
+
+    @pytest.mark.asyncio
+    async def test_list_no_docs_manager_returns_message(self, monkeypatch) -> None:
+        monkeypatch.setattr("src.ai_interaction._personal_docs_manager", None)
+        result = await _rag("list")
+        assert "results" in result
+        assert "not available" in result["results"].lower()
+
+    @pytest.mark.asyncio
+    async def test_list_empty_returns_message(self, mock_managers) -> None:
+        _, docs = mock_managers
+        docs.index = []
+        docs.get_indexed_directories = MagicMock(return_value=[])
+        result = await _rag("list")
+        assert "results" in result
+        assert "No files" in result["results"] or "No" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_list_shows_directories(self, mock_managers) -> None:
+        _, docs = mock_managers
+        docs.index = []
+        docs.get_indexed_directories = MagicMock(return_value=["/home/user/docs"])
+        result = await _rag("list")
+        assert "/home/user/docs" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_list_shows_files(self, mock_managers) -> None:
+        _, docs = mock_managers
+        docs.index = [{"name": "report.pdf"}, {"name": "notes.txt"}]
+        docs.get_indexed_directories = MagicMock(return_value=[])
+        result = await _rag("list")
+        assert "report.pdf" in result["results"]
+        assert "notes.txt" in result["results"]
+
+    @pytest.mark.asyncio
+    async def test_list_truncates_long_file_list(self, mock_managers) -> None:
+        _, docs = mock_managers
+        docs.index = [{"name": f"file_{i}.txt"} for i in range(60)]
+        docs.get_indexed_directories = MagicMock(return_value=[])
+        result = await _rag("list")
+        assert "more" in result["results"]
+
+
+# ---------------------------------------------------------------------------
+# add_directory action
+# ---------------------------------------------------------------------------
+
+class TestManageRagAddDirectory:
+
+    @pytest.mark.asyncio
+    async def test_missing_path_returns_error(self) -> None:
+        result = await _rag("add_directory")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_directory_returns_error(self) -> None:
+        with patch("os.path.isdir", return_value=False):
+            result = await _rag("add_directory\n/nonexistent/path")
+        assert "error" in result
+        assert "not found" in result["error"].lower() or "directory" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_rag_manager_returns_error(self, mock_managers, monkeypatch) -> None:
+        monkeypatch.setattr("src.ai_interaction._rag_manager", None)
+        with patch("os.path.isdir", return_value=True):
+            result = await _rag("add_directory\n/some/path")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_add_directory_success(self, mock_managers) -> None:
+        rag, _ = mock_managers
+        rag.index_personal_documents.return_value = {"indexed": 5}
+        with patch("os.path.isdir", return_value=True), \
+             patch("os.path.expanduser", return_value="/some/path"):
+            result = await _rag("add_directory\n/some/path")
+        assert result.get("action") == "add_directory"
+        assert "5" in result.get("results", "")
+
+
+# ---------------------------------------------------------------------------
+# remove_directory action
+# ---------------------------------------------------------------------------
+
+class TestManageRagRemoveDirectory:
+
+    @pytest.mark.asyncio
+    async def test_missing_path_returns_error(self) -> None:
+        result = await _rag("remove_directory")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_no_docs_manager_returns_error(self, mock_managers, monkeypatch) -> None:
+        monkeypatch.setattr("src.ai_interaction._personal_docs_manager", None)
+        result = await _rag("remove_directory\n/some/path")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_remove_directory_success(self, mock_managers) -> None:
+        rag, docs = mock_managers
+        docs.remove_directory = MagicMock()
+        result = await _rag("remove_directory\n/some/path")
+        assert result.get("action") == "remove_directory"
+        docs.remove_directory.assert_called_once_with("/some/path")
+
+    @pytest.mark.asyncio
+    async def test_remove_directory_triggers_index_rebuild(self, mock_managers) -> None:
+        rag, docs = mock_managers
+        docs.remove_directory = MagicMock()
+        await _rag("remove_directory\n/some/path")
+        rag.rebuild_index.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Unknown action
+# ---------------------------------------------------------------------------
+
+class TestManageRagUnknownAction:
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_returns_error(self) -> None:
+        result = await _rag("bad_action")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_error_mentions_valid_actions(self) -> None:
+        result = await _rag("bad_action")
+        assert "list" in result["error"]
+        assert "add_directory" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_content_returns_error(self) -> None:
+        result = await _rag("")
+        assert "error" in result

--- a/tests/test_ai_interaction_manage_session.py
+++ b/tests/test_ai_interaction_manage_session.py
@@ -315,3 +315,74 @@ class TestManageSessionUnknownAction:
         assert "error" in result
         error_msg = result["error"]
         assert any(action in error_msg for action in ("rename", "archive", "delete", "list"))
+
+
+# ---------------------------------------------------------------------------
+# Input parsing helpers (extracted from _parse_manage_session_input)
+# ---------------------------------------------------------------------------
+
+class TestParseSessionJson:
+    """Tests for _parse_session_json()."""
+
+    def test_basic_json(self) -> None:
+        from src.ai_interaction import _parse_session_json
+        result = _parse_session_json('{"action": "rename", "session_id": "abc", "value": "New"}')
+        assert result == ("rename", "abc", "New", "")
+
+    def test_session_alias_keys(self) -> None:
+        from src.ai_interaction import _parse_session_json
+        # 'session' and 'id' are accepted aliases for session_id
+        assert _parse_session_json('{"action": "delete", "session": "s1"}')[1] == "s1"
+        assert _parse_session_json('{"action": "delete", "id": "s2"}')[1] == "s2"
+
+    def test_value_alias_keys(self) -> None:
+        from src.ai_interaction import _parse_session_json
+        # name/new_name/title/keep_count are accepted aliases for value
+        assert _parse_session_json('{"action": "rename", "session_id": "s", "name": "N"}')[2] == "N"
+        assert _parse_session_json('{"action": "rename", "session_id": "s", "title": "T"}')[2] == "T"
+        assert _parse_session_json('{"action": "truncate", "session_id": "s", "keep_count": "5"}')[2] == "5"
+
+    def test_filter_key(self) -> None:
+        from src.ai_interaction import _parse_session_json
+        assert _parse_session_json('{"action": "list", "filter": "python"}')[3] == "python"
+
+    def test_invalid_json_returns_none(self) -> None:
+        from src.ai_interaction import _parse_session_json
+        assert _parse_session_json("{not valid json") is None
+
+    def test_non_dict_json_returns_none(self) -> None:
+        from src.ai_interaction import _parse_session_json
+        assert _parse_session_json("[1, 2, 3]") is None
+
+
+class TestParseSessionLines:
+    """Tests for _parse_session_lines()."""
+
+    def test_three_lines(self) -> None:
+        from src.ai_interaction import _parse_session_lines
+        action, sid, value, _ = _parse_session_lines("rename\nabc\nNew Name")
+        assert action == "rename"
+        assert sid == "abc"
+        assert value == "New Name"
+
+    def test_action_only(self) -> None:
+        from src.ai_interaction import _parse_session_lines
+        action, sid, value, _ = _parse_session_lines("list")
+        assert action == "list"
+        assert sid == ""
+        assert value is None
+
+    def test_empty_returns_blank_action(self) -> None:
+        from src.ai_interaction import _parse_session_lines
+        action, sid, value, lf = _parse_session_lines("")
+        assert action == ""
+
+    def test_list_filter_joins_remaining_lines(self) -> None:
+        from src.ai_interaction import _parse_session_lines
+        _, _, _, list_filter = _parse_session_lines("list\npython\nprojects")
+        assert "python" in list_filter
+
+    def test_action_lowercased(self) -> None:
+        from src.ai_interaction import _parse_session_lines
+        action, _, _, _ = _parse_session_lines("RENAME\nabc\nNew")
+        assert action == "rename"

--- a/tests/test_ai_interaction_manage_session.py
+++ b/tests/test_ai_interaction_manage_session.py
@@ -59,7 +59,7 @@ def mock_session_manager(monkeypatch):
 
 async def _manage(content: str, session_id: str = "sess1", owner: str = "user1") -> Dict:
     from src.ai_interaction import do_manage_session
-    return await do_manage_session(content, session_id=session_id, owner=owner)
+    return do_manage_session(content, session_id=session_id, owner=owner)
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +86,8 @@ class TestManageSessionList:
     @pytest.mark.asyncio
     async def test_list_action_dispatches_to_list_sessions(self) -> None:
         """manage_session with 'list' should delegate to list_sessions logic."""
-        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as mock_list:
+        # do_list_sessions is now sync, so patch with a plain MagicMock.
+        with patch("src.ai_interaction.do_list_sessions", new_callable=MagicMock) as mock_list:
             mock_list.return_value = {"results": "listed"}
             result = await _manage("list")
         mock_list.assert_called_once()

--- a/tests/test_ai_interaction_manage_session.py
+++ b/tests/test_ai_interaction_manage_session.py
@@ -1,0 +1,317 @@
+"""
+Tests for do_manage_session() and its refactored sub-handlers.
+
+Covers: list, rename, archive, unarchive, delete, important, unimportant,
+truncate, fork, switch/open/select/view actions.
+
+Uses mocks for session_manager and get_db_session to stay unit-level.
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch, AsyncMock
+from typing import Dict, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SENTINEL = object()  # Distinguish "not passed" from None
+
+
+def _make_db_mock(first_result=_SENTINEL) -> Tuple:
+    """Return a (ctx, mock_db, mock_db_sess) tuple.
+
+    mock_db.query(X).filter(...).first() always returns first_result.
+    Pass first_result=None to simulate "not found".
+    Omit first_result to get a fresh MagicMock.
+    """
+    mock_db_sess = MagicMock() if first_result is _SENTINEL else first_result
+    mock_db = MagicMock()
+    # Support both single-filter and double-filter query chains
+    filter_mock = MagicMock()
+    filter_mock.filter.return_value = filter_mock
+    filter_mock.first.return_value = mock_db_sess
+    mock_db.query.return_value.filter.return_value = filter_mock
+
+    @contextmanager
+    def _ctx():
+        yield mock_db
+
+    return _ctx, mock_db, mock_db_sess
+
+
+def _null_db_mock() -> Tuple:
+    """Return a DB mock where .first() returns None (session not found)."""
+    return _make_db_mock(first_result=None)
+
+
+@pytest.fixture(autouse=True)
+def mock_session_manager(monkeypatch):
+    """Inject a mock session manager into ai_interaction module."""
+    mgr = MagicMock()
+    mgr.get_sessions_for_user.return_value = {}
+    monkeypatch.setattr("src.ai_interaction._session_manager", mgr)
+    return mgr
+
+
+async def _manage(content: str, session_id: str = "sess1", owner: str = "user1") -> Dict:
+    from src.ai_interaction import do_manage_session
+    return await do_manage_session(content, session_id=session_id, owner=owner)
+
+
+# ---------------------------------------------------------------------------
+# Missing / unavailable manager
+# ---------------------------------------------------------------------------
+
+class TestManageSessionNoManager:
+    """Tests when session manager is not available."""
+
+    @pytest.mark.asyncio
+    async def test_no_manager_returns_error(self, monkeypatch) -> None:
+        monkeypatch.setattr("src.ai_interaction._session_manager", None)
+        result = await _manage("list")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# list action
+# ---------------------------------------------------------------------------
+
+class TestManageSessionList:
+    """Tests for the list action."""
+
+    @pytest.mark.asyncio
+    async def test_list_action_dispatches_to_list_sessions(self) -> None:
+        """manage_session with 'list' should delegate to list_sessions logic."""
+        with patch("src.ai_interaction.do_list_sessions", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = {"results": "listed"}
+            result = await _manage("list")
+        mock_list.assert_called_once()
+        assert result == {"results": "listed"}
+
+
+# ---------------------------------------------------------------------------
+# switch / open / select / view actions
+# ---------------------------------------------------------------------------
+
+class TestManageSessionSwitch:
+    """Tests for the switch/open/select/view actions."""
+
+    @pytest.mark.asyncio
+    async def test_switch_missing_session_id_returns_error(self) -> None:
+        result = await _manage("switch")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_switch_unknown_session_returns_error(self) -> None:
+        with patch("src.ai_interaction._session_action_view") as mock_view:
+            mock_view.return_value = {"error": "not found"}
+            result = await _manage("switch\nunknown_session_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_open_alias_works(self) -> None:
+        """'open' should route the same as 'switch'."""
+        with patch("src.ai_interaction._session_action_view") as mock_view:
+            mock_view.return_value = {"error": "not found"}
+            result = await _manage("open\nunknown_id")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# rename action
+# ---------------------------------------------------------------------------
+
+class TestManageSessionRename:
+    """Tests for the rename action."""
+
+    @pytest.mark.asyncio
+    async def test_rename_missing_session_id_returns_error(self) -> None:
+        result = await _manage("rename")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_rename_missing_new_name_returns_error(self) -> None:
+        ctx, mock_db, mock_db_sess = _make_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("rename\nsome_session_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_rename_unknown_session_returns_error(self) -> None:
+        ctx, mock_db, _ = _null_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("rename\nunknown_session\nnew name")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_rename_success(self, mock_session_manager) -> None:
+        mock_sess = MagicMock()
+        mock_sess.name = "old name"
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("rename\nsome_id\nnew name")
+
+        assert result.get("action") == "rename"
+        assert "new name" in result.get("results", "")
+        assert mock_sess.name == "new name"
+
+
+# ---------------------------------------------------------------------------
+# archive / unarchive actions
+# ---------------------------------------------------------------------------
+
+class TestManageSessionArchive:
+    """Tests for archive and unarchive actions."""
+
+    @pytest.mark.asyncio
+    async def test_archive_unknown_session_returns_error(self) -> None:
+        ctx, _, _ = _null_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("archive\nunknown_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_archive_success(self) -> None:
+        mock_sess = MagicMock()
+        mock_sess.name = "My Chat"
+        mock_sess.archived = False
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("archive\nsome_id")
+
+        assert result.get("action") == "archive"
+        assert mock_sess.archived is True
+
+    @pytest.mark.asyncio
+    async def test_unarchive_success(self) -> None:
+        mock_sess = MagicMock()
+        mock_sess.name = "My Chat"
+        mock_sess.archived = True
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("unarchive\nsome_id")
+
+        assert result.get("action") == "unarchive"
+        assert mock_sess.archived is False
+
+
+# ---------------------------------------------------------------------------
+# delete action
+# ---------------------------------------------------------------------------
+
+class TestManageSessionDelete:
+    """Tests for the delete action."""
+
+    @pytest.mark.asyncio
+    async def test_delete_current_session_returns_error(self) -> None:
+        """Deleting the active session should be refused."""
+        mock_sess = MagicMock()
+        mock_sess.is_important = False
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("delete\nsess1", session_id="sess1")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_session_returns_error(self) -> None:
+        ctx, _, _ = _null_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("delete\nunknown_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_starred_session_returns_error(self) -> None:
+        mock_sess = MagicMock()
+        mock_sess.is_important = True
+        mock_sess.name = "Important Chat"
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("delete\nother_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, mock_session_manager) -> None:
+        mock_sess = MagicMock()
+        mock_sess.is_important = False
+        mock_sess.name = "Old Chat"
+        mock_session_manager.delete_session.return_value = True
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("delete\nother_id")
+
+        assert result.get("action") == "delete"
+
+
+# ---------------------------------------------------------------------------
+# truncate action
+# ---------------------------------------------------------------------------
+
+class TestManageSessionTruncate:
+    """Tests for the truncate action."""
+
+    @pytest.mark.asyncio
+    async def test_truncate_unknown_session_returns_error(self) -> None:
+        ctx, _, _ = _null_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("truncate\nunknown_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_truncate_uses_default_keep_count(self, mock_session_manager) -> None:
+        from src.ai_interaction import SESSION_TRUNCATE_DEFAULT_KEEP
+        mock_sess = MagicMock()
+        mock_session_manager.truncate_messages.return_value = True
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("truncate\nsome_id")
+
+        mock_session_manager.truncate_messages.assert_called_once_with(
+            "some_id", SESSION_TRUNCATE_DEFAULT_KEEP
+        )
+        assert result.get("action") == "truncate"
+
+    @pytest.mark.asyncio
+    async def test_truncate_with_custom_keep_count(self, mock_session_manager) -> None:
+        mock_sess = MagicMock()
+        mock_session_manager.truncate_messages.return_value = True
+        ctx, _, _ = _make_db_mock(first_result=mock_sess)
+
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("truncate\nsome_id\n25")
+
+        mock_session_manager.truncate_messages.assert_called_once_with("some_id", 25)
+
+
+# ---------------------------------------------------------------------------
+# Unknown action
+# ---------------------------------------------------------------------------
+
+class TestManageSessionUnknownAction:
+    """Tests for unknown action handling."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_returns_error(self) -> None:
+        ctx, _, _ = _make_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("totally_unknown_action_xyz\nsome_id")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_error_mentions_valid_actions(self) -> None:
+        ctx, _, _ = _make_db_mock()
+        with patch("src.ai_interaction.get_db_session", ctx):
+            result = await _manage("not_an_action\nsome_id")
+        assert "error" in result
+        error_msg = result["error"]
+        assert any(action in error_msg for action in ("rename", "archive", "delete", "list"))

--- a/tests/test_ai_interaction_pipeline.py
+++ b/tests/test_ai_interaction_pipeline.py
@@ -1,0 +1,220 @@
+"""
+Tests for do_pipeline() and do_second_opinion() and their sub-functions.
+
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict
+
+
+async def _pipeline(content: str) -> Dict:
+    from src.ai_interaction import do_pipeline
+    return await do_pipeline(content)
+
+
+async def _second_opinion(content: str, session_id: str = "s1") -> Dict:
+    from src.ai_interaction import do_second_opinion
+    return await do_second_opinion(content, session_id=session_id)
+
+
+# ---------------------------------------------------------------------------
+# do_pipeline — input parsing
+# ---------------------------------------------------------------------------
+
+class TestPipelineInputParsing:
+
+    def test_parse_steps_from_json(self) -> None:
+        from src.ai_interaction import _pipeline_parse_steps
+        steps, err = _pipeline_parse_steps('{"steps": [{"model": "a", "instruction": "do x"}]}')
+        assert err is None
+        assert len(steps) == 1
+        assert steps[0]["model"] == "a"
+
+    def test_parse_steps_from_json_list(self) -> None:
+        from src.ai_interaction import _pipeline_parse_steps
+        steps, err = _pipeline_parse_steps('[{"model": "a", "instruction": "do x"}]')
+        assert err is None
+        assert len(steps) == 1
+
+    def test_parse_steps_from_pipe_format(self) -> None:
+        from src.ai_interaction import _pipeline_parse_steps
+        steps, err = _pipeline_parse_steps("model_a | Draft essay\nmodel_b | Review it")
+        assert err is None
+        assert len(steps) == 2
+        assert steps[0]["model"] == "model_a"
+        assert steps[1]["instruction"] == "Review it"
+
+    def test_parse_empty_content_returns_error(self) -> None:
+        from src.ai_interaction import _pipeline_parse_steps
+        steps, err = _pipeline_parse_steps("")
+        assert err is not None
+        assert "error" in err
+
+    def test_parse_line_without_pipe_returns_error(self) -> None:
+        from src.ai_interaction import _pipeline_parse_steps
+        steps, err = _pipeline_parse_steps("model_a do x without pipe")
+        assert err is not None
+        assert "error" in err
+
+
+# ---------------------------------------------------------------------------
+# do_pipeline — validation
+# ---------------------------------------------------------------------------
+
+class TestPipelineValidation:
+
+    @pytest.mark.asyncio
+    async def test_empty_pipeline_returns_error(self) -> None:
+        result = await _pipeline("")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_too_many_steps_returns_error(self) -> None:
+        from src.ai_interaction import MAX_PIPELINE_STEPS
+        lines = "\n".join(f"model | step {i}" for i in range(MAX_PIPELINE_STEPS + 1))
+        result = await _pipeline(lines)
+        assert "error" in result
+        assert str(MAX_PIPELINE_STEPS) in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_step_missing_model_returns_error(self) -> None:
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model", {})):
+            result = await _pipeline('{"steps": [{"instruction": "do x"}]}')
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_step_missing_instruction_returns_error(self) -> None:
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model", {})):
+            result = await _pipeline('{"steps": [{"model": "gpt-4"}]}')
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_returns_error(self) -> None:
+        with patch("src.ai_interaction._resolve_model", side_effect=ValueError("not found")):
+            result = await _pipeline("nonexistent_model | do something")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# do_pipeline — successful execution
+# ---------------------------------------------------------------------------
+
+class TestPipelineExecution:
+
+    @pytest.mark.asyncio
+    async def test_single_step_pipeline(self) -> None:
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model-a", {})), \
+             patch("src.ai_interaction.llm_call_async", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "Step 1 output"
+            result = await _pipeline("model-a | Draft an essay about the ocean")
+        assert "results" in result
+        assert "final_output" in result
+        assert result["final_output"] == "Step 1 output"
+        assert len(result["steps"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_step_pipeline_chains_output(self) -> None:
+        outputs = ["Draft output", "Reviewed output"]
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model", {})), \
+             patch("src.ai_interaction.llm_call_async", new_callable=AsyncMock) as mock_llm:
+            mock_llm.side_effect = outputs
+            result = await _pipeline("model-a | Draft\nmodel-b | Review")
+        assert result["final_output"] == "Reviewed output"
+        assert len(result["steps"]) == 2
+        # Second call should receive first output
+        second_call_args = mock_llm.call_args_list[1]
+        messages = second_call_args[0][2]
+        user_msg = next(m for m in messages if m["role"] == "user")
+        assert "Draft output" in user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_pipeline_result_contains_step_info(self) -> None:
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model-a", {})), \
+             patch("src.ai_interaction.llm_call_async", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "output"
+            result = await _pipeline("model-a | Do task")
+        step = result["steps"][0]
+        assert step["step"] == 1
+        assert step["model"] == "model-a"
+        assert "instruction" in step
+        assert "output" in step
+
+    @pytest.mark.asyncio
+    async def test_pipeline_step_output_is_truncated(self) -> None:
+        from src.ai_interaction import RESPONSE_TRUNCATE_PIPELINE
+        long_output = "x" * (RESPONSE_TRUNCATE_PIPELINE + 100)
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model", {})), \
+             patch("src.ai_interaction.llm_call_async", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = long_output
+            result = await _pipeline("model | do task")
+        step_output = result["steps"][0]["output"]
+        assert len(step_output) <= RESPONSE_TRUNCATE_PIPELINE + 30
+
+
+# ---------------------------------------------------------------------------
+# do_second_opinion — input validation
+# ---------------------------------------------------------------------------
+
+class TestSecondOpinionInput:
+
+    @pytest.mark.asyncio
+    async def test_missing_model_returns_error(self) -> None:
+        result = await _second_opinion("")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_no_session_context_returns_error(self) -> None:
+        """Without session manager, there is no context to review."""
+        with patch("src.ai_interaction._resolve_model", return_value=("url", "model", {})), \
+             patch("src.ai_interaction._session_manager", None):
+            result = await _second_opinion("model-name", session_id=None)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_model_not_found_returns_error(self) -> None:
+        with patch("src.ai_interaction._resolve_model", side_effect=ValueError("not found")):
+            result = await _second_opinion("nonexistent_model_xyz")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# do_second_opinion — context extraction helper
+# ---------------------------------------------------------------------------
+
+class TestSecondOpinionContextExtraction:
+
+    def test_extract_context_from_messages(self) -> None:
+        from src.ai_interaction import _second_opinion_build_context
+        messages = [
+            {"role": "user", "content": "How do I use Python?"},
+            {"role": "assistant", "content": "You can install it with pip."},
+        ]
+        context = _second_opinion_build_context(messages)
+        assert "[USER]" in context
+        assert "[ASSISTANT]" in context
+        assert "How do I use Python?" in context
+
+    def test_extract_context_limits_message_count(self) -> None:
+        from src.ai_interaction import _second_opinion_build_context, SESSION_CONTEXT_WINDOW
+        messages = [{"role": "user", "content": f"msg {i}"} for i in range(SESSION_CONTEXT_WINDOW + 10)]
+        context = _second_opinion_build_context(messages)
+        # Only last SESSION_CONTEXT_WINDOW messages should appear
+        assert "msg 0" not in context
+        assert f"msg {SESSION_CONTEXT_WINDOW + 9}" in context
+
+    def test_extract_context_handles_multipart_content(self) -> None:
+        from src.ai_interaction import _second_opinion_build_context
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Part 1"}, {"type": "text", "text": "Part 2"}]},
+        ]
+        context = _second_opinion_build_context(messages)
+        assert "Part 1" in context
+        assert "Part 2" in context
+
+    def test_extract_context_truncates_long_messages(self) -> None:
+        from src.ai_interaction import _second_opinion_build_context, CONTEXT_MESSAGE_TEXT_LIMIT
+        messages = [{"role": "user", "content": "x" * (CONTEXT_MESSAGE_TEXT_LIMIT + 100)}]
+        context = _second_opinion_build_context(messages)
+        assert len(context) < CONTEXT_MESSAGE_TEXT_LIMIT + 200

--- a/tests/test_ai_interaction_ui_control.py
+++ b/tests/test_ai_interaction_ui_control.py
@@ -20,7 +20,7 @@ from typing import Dict
 async def _ui(content: str, session_id: str = None) -> Dict:
     """Shortcut to call do_ui_control."""
     from src.ai_interaction import do_ui_control
-    return await do_ui_control(content, session_id=session_id)
+    return do_ui_control(content, session_id=session_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ai_interaction_ui_control.py
+++ b/tests/test_ai_interaction_ui_control.py
@@ -1,0 +1,303 @@
+"""
+Tests for do_ui_control() and its extracted sub-handlers.
+
+Covers every action branch: toggle, set_mode, switch_model, set_theme,
+create_theme, highlight, clear_highlight, open_panel, open_email_reply,
+get_toggles.
+
+Follows pytest and Python standards (PEP 8, PEP 484).
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from typing import Dict
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _ui(content: str, session_id: str = None) -> Dict:
+    """Shortcut to call do_ui_control."""
+    from src.ai_interaction import do_ui_control
+    return await do_ui_control(content, session_id=session_id)
+
+
+# ---------------------------------------------------------------------------
+# Toggle action
+# ---------------------------------------------------------------------------
+
+class TestUiControlToggle:
+    """Tests for the toggle action."""
+
+    @pytest.mark.asyncio
+    async def test_toggle_on(self) -> None:
+        result = await _ui("toggle bash on")
+        assert result["ui_event"] == "toggle"
+        assert result["toggle_name"] == "bash"
+        assert result["state"] is True
+
+    @pytest.mark.asyncio
+    async def test_toggle_off(self) -> None:
+        result = await _ui("toggle bash off")
+        assert result["ui_event"] == "toggle"
+        assert result["toggle_name"] == "bash"
+        assert result["state"] is False
+
+    @pytest.mark.asyncio
+    async def test_toggle_alias_shell_to_bash(self) -> None:
+        result = await _ui("toggle shell on")
+        assert result["toggle_name"] == "bash", "Alias 'shell' should map to 'bash'"
+
+    @pytest.mark.asyncio
+    async def test_toggle_alias_search_to_web(self) -> None:
+        result = await _ui("toggle search on")
+        assert result["toggle_name"] == "web"
+
+    @pytest.mark.asyncio
+    async def test_toggle_state_true_variants(self) -> None:
+        for val in ("on", "true", "1", "yes", "enable", "enabled"):
+            result = await _ui(f"toggle web {val}")
+            assert result["state"] is True, f"State should be True for '{val}'"
+
+    @pytest.mark.asyncio
+    async def test_toggle_state_false_variants(self) -> None:
+        for val in ("off", "false", "0", "no"):
+            result = await _ui(f"toggle web {val}")
+            assert result["state"] is False, f"State should be False for '{val}'"
+
+    @pytest.mark.asyncio
+    async def test_toggle_missing_args_returns_error(self) -> None:
+        result = await _ui("toggle")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_toggle_unknown_name_returns_error(self) -> None:
+        result = await _ui("toggle nonexistent_toggle_xyz on")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_toggle_result_has_results_key(self) -> None:
+        result = await _ui("toggle web on")
+        assert "results" in result
+
+
+# ---------------------------------------------------------------------------
+# set_mode action
+# ---------------------------------------------------------------------------
+
+class TestUiControlSetMode:
+    """Tests for the set_mode action."""
+
+    @pytest.mark.asyncio
+    async def test_set_mode_agent(self) -> None:
+        result = await _ui("set_mode agent")
+        assert result["ui_event"] == "set_mode"
+        assert result["mode"] == "agent"
+
+    @pytest.mark.asyncio
+    async def test_set_mode_chat(self) -> None:
+        result = await _ui("set_mode chat")
+        assert result["ui_event"] == "set_mode"
+        assert result["mode"] == "chat"
+
+    @pytest.mark.asyncio
+    async def test_set_mode_invalid_returns_error(self) -> None:
+        result = await _ui("set_mode invalid_mode")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_set_mode_missing_arg_returns_error(self) -> None:
+        result = await _ui("set_mode")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_set_mode_result_has_results_key(self) -> None:
+        result = await _ui("set_mode chat")
+        assert "results" in result
+
+
+# ---------------------------------------------------------------------------
+# set_theme action
+# ---------------------------------------------------------------------------
+
+class TestUiControlSetTheme:
+    """Tests for the set_theme action."""
+
+    @pytest.mark.asyncio
+    async def test_set_theme_valid_dark(self) -> None:
+        result = await _ui("set_theme dark")
+        assert result["ui_event"] == "set_theme"
+        assert result["theme_name"] == "dark"
+
+    @pytest.mark.asyncio
+    async def test_set_theme_valid_light(self) -> None:
+        result = await _ui("set_theme light")
+        assert result["ui_event"] == "set_theme"
+        assert result["theme_name"] == "light"
+
+    @pytest.mark.asyncio
+    async def test_set_theme_unknown_returns_error(self) -> None:
+        result = await _ui("set_theme totally_unknown_theme_xyz")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_set_theme_result_has_results_key(self) -> None:
+        result = await _ui("set_theme dark")
+        assert "results" in result
+
+
+# ---------------------------------------------------------------------------
+# open_panel action
+# ---------------------------------------------------------------------------
+
+class TestUiControlOpenPanel:
+    """Tests for the open_panel action."""
+
+    @pytest.mark.asyncio
+    async def test_open_panel_documents(self) -> None:
+        result = await _ui("open_panel documents")
+        assert result["ui_event"] == "open_panel"
+        assert result["panel"] == "documents"
+
+    @pytest.mark.asyncio
+    async def test_open_panel_alias_doc(self) -> None:
+        result = await _ui("open_panel doc")
+        assert result["panel"] == "documents", "'doc' alias should resolve to 'documents'"
+
+    @pytest.mark.asyncio
+    async def test_open_panel_alias_mail(self) -> None:
+        result = await _ui("open_panel mail")
+        assert result["panel"] == "email", "'mail' alias should resolve to 'email'"
+
+    @pytest.mark.asyncio
+    async def test_open_panel_alias_chats(self) -> None:
+        result = await _ui("open_panel chats")
+        assert result["panel"] == "sessions"
+
+    @pytest.mark.asyncio
+    async def test_open_panel_alias_brain(self) -> None:
+        result = await _ui("open_panel brain")
+        assert result["panel"] == "memories"
+
+    @pytest.mark.asyncio
+    async def test_open_panel_unknown_returns_error(self) -> None:
+        result = await _ui("open_panel totally_unknown_panel_xyz")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_open_panel_result_has_results_key(self) -> None:
+        result = await _ui("open_panel documents")
+        assert "results" in result
+
+
+# ---------------------------------------------------------------------------
+# open_email_reply action
+# ---------------------------------------------------------------------------
+
+class TestUiControlOpenEmailReply:
+    """Tests for the open_email_reply action."""
+
+    @pytest.mark.asyncio
+    async def test_open_email_reply_basic(self) -> None:
+        result = await _ui("open_email_reply 12345")
+        assert result["ui_event"] == "open_email_reply"
+        assert result["uid"] == "12345"
+
+    @pytest.mark.asyncio
+    async def test_open_email_reply_defaults(self) -> None:
+        result = await _ui("open_email_reply 12345")
+        assert result["folder"] == "INBOX"
+        assert result["mode"] == "reply"
+
+    @pytest.mark.asyncio
+    async def test_open_email_reply_with_folder(self) -> None:
+        result = await _ui("open_email_reply 12345 Sent")
+        assert result["folder"] == "Sent"
+
+    @pytest.mark.asyncio
+    async def test_open_email_reply_with_mode(self) -> None:
+        result = await _ui("open_email_reply 12345 INBOX reply-all")
+        assert result["mode"] == "reply-all"
+
+    @pytest.mark.asyncio
+    async def test_open_email_reply_invalid_mode_defaults_to_reply(self) -> None:
+        result = await _ui("open_email_reply 12345 INBOX invalid_mode")
+        assert result["mode"] == "reply"
+
+    @pytest.mark.asyncio
+    async def test_open_email_reply_missing_uid_returns_error(self) -> None:
+        result = await _ui("open_email_reply")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# highlight / clear_highlight actions
+# ---------------------------------------------------------------------------
+
+class TestUiControlHighlight:
+    """Tests for highlight and clear_highlight actions."""
+
+    @pytest.mark.asyncio
+    async def test_highlight_with_selector(self) -> None:
+        result = await _ui("highlight #my-button Click me")
+        assert result["ui_event"] == "highlight"
+        assert result["selector"] == "#my-button"
+
+    @pytest.mark.asyncio
+    async def test_highlight_missing_selector_returns_error(self) -> None:
+        result = await _ui("highlight")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_clear_highlight(self) -> None:
+        result = await _ui("clear_highlight")
+        assert result["ui_event"] == "clear_highlight"
+
+    @pytest.mark.asyncio
+    async def test_clear_highlight_has_results_key(self) -> None:
+        result = await _ui("clear_highlight")
+        assert "results" in result
+
+
+# ---------------------------------------------------------------------------
+# get_toggles action
+# ---------------------------------------------------------------------------
+
+class TestUiControlGetToggles:
+    """Tests for the get_toggles action."""
+
+    @pytest.mark.asyncio
+    async def test_get_toggles_returns_results(self) -> None:
+        result = await _ui("get_toggles")
+        assert "results" in result
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_toggles_mentions_available_toggles(self) -> None:
+        result = await _ui("get_toggles")
+        # Should mention the available toggles
+        assert "bash" in result["results"] or "web" in result["results"]
+
+
+# ---------------------------------------------------------------------------
+# Empty / unknown input
+# ---------------------------------------------------------------------------
+
+class TestUiControlEdgeCases:
+    """Tests for edge cases in do_ui_control."""
+
+    @pytest.mark.asyncio
+    async def test_empty_content_returns_error(self) -> None:
+        result = await _ui("")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_returns_error(self) -> None:
+        result = await _ui("totally_unknown_action_xyz")
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_error_response_has_no_ui_event(self) -> None:
+        result = await _ui("toggle nonexistent_toggle on")
+        assert "ui_event" not in result

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -45,6 +45,20 @@ def test_validate_gpus_accepts_indexes_only():
         _validate_gpus("0; rm -rf /")
 
 
+# TODO(cross-platform): the two tests below FAIL on Windows (pre-existing,
+# unrelated to the ai_interaction refactor). Root cause: _local_tooling_path_export
+# in routes/cookbook_helpers.py builds the bash PATH line with os.path.abspath/
+# dirname, which are OS-dependent. On Windows a POSIX input like
+# "/opt/venv/bin/python" becomes "C:\opt\venv\bin" (drive letter + backslashes),
+# so the produced line is  export PATH="C:\\opt\\venv\\bin:$PATH"  instead of the
+# expected  export PATH="/opt/venv/bin:$PATH".  These exports are bash-only
+# ("Local runs only", consumed by tmux/login shells on Linux/macOS), so the path
+# math should be POSIX regardless of host OS.
+# Fix: in _local_tooling_path_export use posixpath instead of os.path, e.g.
+#   bin_dir = posixpath.dirname(executable)  # keep forward slashes, no drive letter
+# (and drop abspath, which only injects a Windows drive). Then these tests pass on
+# every OS. Alternatively, gate the tests with
+# @pytest.mark.skipif(os.name == "nt", reason="bash PATH export is POSIX-only").
 def test_local_tooling_path_export_prepends_interpreter_bin():
     """The cookbook runners must see the venv's bin (where `hf`/`python` live)
     so tmux shells can find them without an activated venv."""


### PR DESCRIPTION
## Summary

Maintainability refactor of `src/ai_interaction.py` (the AI-to-AI tool dispatcher: `chat_with_model`, `create_session`, `manage_session`, `manage_memory`, `pipeline`, `ui_control`, `generate_image`, …).

The module had grown to ~1,800 lines of long, hard-to-test functions with scattered magic numbers and duplicated logic. This PR restructures it into small, single-responsibility functions **with no change to observable behavior**, adds a full unit-test suite where there was none, and clears the SonarLint findings on the file.

All work was done **test-first (TDD)** and is **behavior-preserving** — verified by unit tests, an end-to-end smoke test, and line-by-line review.

> Rebased onto latest `main` (`5c390d6`); the only conflict (`tests/test_review_regressions.py`) was resolved by taking your fix from #301 and dropping a now-obsolete TODO I'd added there. PR is `MERGEABLE` / `CLEAN`. `src/ai_interaction.py` was untouched by upstream, so the core work had no conflicts.

## What changed

- **Constants & helpers extracted** — 40+ magic numbers (timeouts, truncation limits, display caps) and all reused strings/system-prompts pulled into named constants; shared helpers for truncation, content parsing, model resolution, UI alias resolution, and a `get_db_session()` context manager replacing raw `SessionLocal()` try/finally blocks.
- **Long functions decomposed** — `do_ui_control` (290 → ~30 lines + focused handlers), `do_manage_session`, `do_manage_memory`, `do_generate_image` (205 → ~60), `do_pipeline`, `do_second_opinion`, `do_list_sessions`, `do_list_models`, and `dispatch_ai_tool` (if/elif chain → data-driven registry). Average function length is now ~24 lines.
- **Two real bugs fixed along the way**:
  - `do_ui_control("")` raised `IndexError` on empty input → now returns a clean error.
  - `second_opinion` was unreachable through `dispatch_ai_tool` (missing registry entry) → now routed.
- **SonarLint cleanup (24 findings → 0 on this file)**: removed dead imports left by the extraction, de-duplicated string literals (S1192), `== True` → `.is_(True)` (S6779), reduced cognitive complexity below threshold (S3776), nested ternary extracted (S3358), sync `httpx.get` in an async fn → `httpx.AsyncClient` (S7499), and removed pointless `async`/unused `session_id` params (S7503/S1172) by making the dispatcher await-agnostic.
- **Type hints** added across the module; consistency nits fixed (e.g. `UUID_SHORT_ID_LENGTH`, precise `Tuple[str, str]` returns).

## Checks run

Per CONTRIBUTING, here's exactly what was and wasn't run (re-run after the rebase onto latest `main`):

- ✅ `python -m pytest tests/test_ai_interaction_*.py` → **264 passed** (the new suite for this file)
- ✅ `python -m py_compile app.py routes/*.py src/*.py` → **OK** (everything compiles)
- ✅ `python scripts/smoke_ai_interaction.py` → **20/20 passed** — end-to-end integration smoke test driving the **real** `dispatch_ai_tool` → real handlers → real `SessionManager`/`MemoryManager` + a throwaway SQLite DB (only the LLM/endpoint I/O is mocked). Covers real DB round-trips (create → rename → delete), memory add/list/search, alias resolution, and both sync and async dispatch paths.
- ⚠️ `python -m pytest` (full suite) → **603 passed, 4 pre-existing failures unrelated to this change** (see below).
- ❌ **Not run: Docker / full app boot** (`docker compose up`) — no configured LLM endpoint or live stack available in my dev environment, so I validated the dispatcher via the smoke test above instead.
- ℹ️ **Developed on Windows**, which the project notes isn't actively tested. The unit + smoke tests pass here; a maintainer run on Linux/Docker would be a good final confirmation.

## Compatibility

No public-API changes. `dispatch_ai_tool`, `stream_ai_tool`, the manager setters, and `do_generate_image` keep their signatures. No callers exist outside the module (verified across `routes/`, `src/`, `app.py`, `mcp_servers/`). `pyflakes` is clean and the module imports without error.

## Scope note (re: CONTRIBUTING "keep PRs small")

I'm aware this is larger than the project's preferred small, single-purpose PR, and that I didn't open an issue first — apologies for that. It's intentionally scoped to **one file** (`src/ai_interaction.py`) plus its new tests, and is **behavior-preserving** apart from the two clearly-called-out bug fixes. The commit history is split into reviewable, themed steps (constants/helpers → per-function decomposition → SonarLint cleanup → tests → smoke test), so it can be reviewed commit-by-commit.

If you'd prefer, I'm happy to **split this into a stack of smaller PRs** (e.g. constants/helpers, then decomposition, then the SonarLint pass, with the two bug fixes broken out on their own) — just say the word and I'll resubmit.

## Notes on the pre-existing test failures

The 4 remaining full-suite failures are **pre-existing and unrelated** to this change — none touch any file in this PR (all confirmed reproducible on a clean `main` worktree):

- `tests/test_cookbook_helpers.py` (2) — Windows-only: `_local_tooling_path_export` uses `os.path`, so a POSIX input becomes `C:\...` with backslashes, breaking the bash-PATH assertion. Documented inline with a `TODO(cross-platform)` explaining the root cause and the one-line fix (use `posixpath`).
- `tests/test_reply_recipients_js.py` (2) — added upstream in recent `main`; fail on a clean `main` checkout as well, independent of this branch.

(The two `test_review_regressions.py` failures I previously noted are now fixed by your #301 on `main`, so they're gone — and I dropped the obsolete TODO during the rebase.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
