### PR TITLE
Removed masking in time input

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -32793,6 +32793,7 @@ button.cal-event-more:hover { opacity:1 !important; }
 .cal-form-bespoke input[type="time"]::-webkit-calendar-picker-indicator,
 .cal-form-bespoke input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   background-color: var(--accent, var(--red));
+  background-image: none;
   cursor: pointer;
   width: 14px; height: 14px;
 }


### PR DESCRIPTION
Small edit to the time pickers in the calendar  modal/window when editing a day. 

The browser was rendering its native clock glyph as a background-image on ::-webkit-calendar-picker-indicator, which was stacking on top of the custom SVG mask and causing the black line overlap. Just needed to add a prop in the css to get rid of it

Before:
<img width="1329" height="332" alt="Time_Picker_Error" src="https://github.com/user-attachments/assets/93396f8c-fa7b-49d3-b4ae-f1aaef9f4e6b" />


After ' background-image: none; '
<img width="887" height="263" alt="image" src="https://github.com/user-attachments/assets/7d3b10e7-62cc-40a2-9334-9667c53bbb92" />

I have a feeling this issue is prevalent elsewhere, I'll check later
