### PR TITLE
fix(ui): unify topmost modal stacking and escape handling

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -3188,6 +3188,12 @@ function openCalendar() {
   Modals.register('calendar-modal', {
     railBtnId: 'rail-calendar',
     sidebarBtnId: 'tool-calendar-btn',
+    escapeFn: () => {
+      const settings = document.getElementById('cal-settings-panel');
+      if (settings) { settings.remove(); return true; }
+      if (document.querySelector('.cal-form')) { _render(); return true; }
+      return false;
+    },
     closeFn: () => _doCloseCalendar(),
     restoreFn: () => {},
   });
@@ -3196,21 +3202,14 @@ function openCalendar() {
   _view = 'month';
   _scrollToTodayOnOpen = true;  // first render lands on today's row
   _escHandler = (e) => {
-    if (e.key === 'Escape') {
-      // Layer Esc: close the topmost calendar surface first, only fall through
-      // to closing the whole calendar when nothing else is on top.
-      const settings = document.getElementById('cal-settings-panel');
-      if (settings) { settings.remove(); return; }
-      if (document.querySelector('.cal-form')) { _render(); return; }
-      closeCalendar();
-    }
-    else if (e.key === 'ArrowLeft') document.getElementById('cal-prev')?.click();
+    if (!Modals.isTopmostModal('calendar-modal')) return;
+    if (e.key === 'ArrowLeft') document.getElementById('cal-prev')?.click();
     else if (e.key === 'ArrowRight') document.getElementById('cal-next')?.click();
     else if (e.key === 't' || e.key === 'T') document.getElementById('cal-today')?.click();
     // Cmd/Ctrl+Z is handled by the module-level `_calUndoBound` listener,
     // which consumes the shared `_calUndoStack`. Don't duplicate here.
   };
-  document.addEventListener('keydown', _escHandler);
+  document.addEventListener('keydown', _escHandler, true);
   const body = document.getElementById('cal-body');
   if (body) {
     body.innerHTML = '<div class="cal-loading"></div>';
@@ -3259,7 +3258,7 @@ function _doCloseCalendar() {
     _modal.style.display = 'none';
     _modal.classList.add('hidden');
   }
-  if (_escHandler) { document.removeEventListener('keydown', _escHandler); _escHandler = null; }
+  if (_escHandler) { document.removeEventListener('keydown', _escHandler, true); _escHandler = null; }
   // Drop any pending undo — closures captured event uids/state that may
   // no longer be valid by the time the user reopens. A reopened calendar
   // starts with a clean slate.

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -651,6 +651,16 @@ export function openEmailLibrary(opts = {}) {
     Modals.register('email-lib-modal', {
       label: 'Email',
       icon: 'M2 4h20v16H2zM22 7l-9.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7',
+      escapeFn: () => {
+        if (state._selectMode) {
+          state._selectMode = false;
+          state._selectedUids.clear();
+          _updateBulkBar();
+          _renderGrid();
+          return true;
+        }
+        return false;
+      },
       closeFn: () => {
         const m = document.getElementById('email-lib-modal');
         if (m) m.classList.add('hidden');
@@ -1022,20 +1032,7 @@ export function openEmailLibrary(opts = {}) {
   state._libEscHandler = (e) => {
     const modal = document.getElementById('email-lib-modal');
     if (!modal || modal.classList.contains('hidden')) return;
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      e.stopPropagation();
-      e.stopImmediatePropagation?.();
-      if (state._selectMode) {
-        state._selectMode = false;
-        state._selectedUids.clear();
-        _updateBulkBar();
-        _renderGrid();
-        return;
-      }
-      closeEmailLibrary();
-      return;
-    }
+    if (!Modals.isTopmostModal(modal)) return;
     // Don't hijack arrows / delete while the user is typing somewhere.
     const t = e.target;
     if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -2001,6 +2001,22 @@ export function openGallery() {
   Modals.register('gallery-modal', {
     railBtnId: 'rail-gallery',
     sidebarBtnId: 'tool-gallery-btn',
+    escapeFn: () => {
+      const editorContainer = document.getElementById('gallery-editor-container');
+      const editorVisible = !!(
+        editorContainer &&
+        getComputedStyle(editorContainer).display !== 'none' &&
+        editorContainer.querySelector('.gallery-editor')
+      );
+      if (editorVisible || isEditorOpen()) return true;
+      const detail = document.getElementById('gallery-detail');
+      if (detail && detail.style.display !== 'none') {
+        const back = document.getElementById('gallery-detail-back');
+        if (back) back.click(); else detail.style.display = 'none';
+        return true;
+      }
+      return false;
+    },
     closeFn: () => _doCloseGallery(),
     restoreFn: () => {},
   });
@@ -2686,38 +2702,7 @@ export function openGallery() {
   });
 
   _escHandler = (e) => {
-    if (e.key === 'Escape') {
-      // While the image editor is visible, Escape is reserved for the
-      // editor (cancel transform/lasso/crop, dismiss size prompt, etc.).
-      // Don't close the gallery — users would lose their in-progress edit.
-      // We check the editor container's visibility AND the isEditorOpen()
-      // flag so a crop popup, transform handles, etc. all keep Esc.
-      const editorContainer = document.getElementById('gallery-editor-container');
-      const editorVisible = !!(
-        editorContainer &&
-        getComputedStyle(editorContainer).display !== 'none' &&
-        editorContainer.querySelector('.gallery-editor')
-      );
-      if (editorVisible || isEditorOpen()) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        return;
-      }
-      const detail = document.getElementById('gallery-detail');
-      if (detail && detail.style.display !== 'none') {
-        // Click Back so Esc and the visible button always do the same thing —
-        // future tweaks to Back's teardown automatically apply to Esc too.
-        // stopImmediatePropagation blocks app.js's generic dynamic-modal Esc
-        // handler that would otherwise close the whole gallery underneath us.
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        const back = document.getElementById('gallery-detail-back');
-        if (back) back.click(); else detail.style.display = 'none';
-      } else {
-        closeGallery();
-      }
-      return;
-    }
+    if (!Modals.isTopmostModal('gallery-modal')) return;
     // Arrow-key navigation inside detail view (ignore when typing in inputs)
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
     const detail = document.getElementById('gallery-detail');
@@ -2730,9 +2715,7 @@ export function openGallery() {
       btn.click();
     }
   };
-  // Capture phase + stopImmediatePropagation (see _escHandler) so app.js's
-  // generic dynamic-modal Esc dismiss doesn't close the whole gallery before
-  // we get a chance to close just the photo detail.
+  // Keep gallery keyboard navigation scoped to the topmost gallery window.
   document.addEventListener('keydown', _escHandler, true);
 
   const btn = document.getElementById('tool-gallery-btn');

--- a/static/js/modalManager.js
+++ b/static/js/modalManager.js
@@ -14,6 +14,7 @@
  *   // After building the modal element and adding it to the body:
  *   Modals.register('gallery-modal', {
  *     railBtnId: 'tool-gallery-btn',
+ *     escapeFn: () => { ...close an inner panel and return true, or return false... },
  *     restoreFn: () => { ...whatever the tool needs to do when un-hiding... },
  *     closeFn:   () => { ...full teardown — remove modal element etc... },
  *   });
@@ -28,7 +29,7 @@
 import { previewZoneAt, clearPreview, snapModalToZone } from './tileManager.js';
 import { suspendDock, resumeDock, clearRightDock, applyEdgeDock } from './modalSnap.js';
 
-const _state = new Map(); // id -> { restoreFn, closeFn, railBtnId, isMinimized, restoreMinHeight }
+const _state = new Map(); // id -> { restoreFn, closeFn, escapeFn, railBtnId, isMinimized, restoreMinHeight }
 
 const _rememberedDockKey = (id) => `odysseus-modal-remembered-dock-${id}`;
 function _rememberDock(id, side) {
@@ -63,6 +64,57 @@ function _applyRememberedDock(id) {
 let _modalTopZ = 300;
 function _bringToFront(modal) {
   if (modal) modal.style.setProperty('z-index', String(++_modalTopZ), 'important');
+}
+
+function _isVisibleModal(modal) {
+  return !!(modal
+    && modal.classList?.contains('modal')
+    && !modal.classList.contains('hidden')
+    && getComputedStyle(modal).display !== 'none');
+}
+
+function _resolveModal(modalOrId) {
+  if (!modalOrId) return null;
+  if (typeof modalOrId === 'string') return document.getElementById(modalOrId);
+  return modalOrId.nodeType === 1 ? modalOrId : null;
+}
+
+export function getTopmostModal() {
+  const modals = [...document.querySelectorAll('.modal')].filter(_isVisibleModal);
+  if (!modals.length) return null;
+  return modals.reduce((top, modal) =>
+    (parseInt(getComputedStyle(modal).zIndex, 10) || 0) >= (parseInt(getComputedStyle(top).zIndex, 10) || 0)
+      ? modal : top
+  );
+}
+
+export function isTopmostModal(modalOrId) {
+  const modal = _resolveModal(modalOrId);
+  if (!_isVisibleModal(modal)) return false;
+  return getTopmostModal() === modal;
+}
+
+export function dispatchEscape(modalOrId, event) {
+  const modal = _resolveModal(modalOrId);
+  const id = modal?.id;
+  const escapeFn = id ? _state.get(id)?.escapeFn : null;
+  if (typeof escapeFn !== 'function') return false;
+  try {
+    return escapeFn(event, modal) !== false;
+  } catch (err) {
+    console.error('modal escapeFn failed:', err);
+    return false;
+  }
+}
+
+if (!window._odyModalFrontFocus) {
+  window._odyModalFrontFocus = true;
+  const _promoteEventModal = (e) => {
+    const modal = e.target?.closest?.('.modal');
+    if (_isVisibleModal(modal)) _bringToFront(modal);
+  };
+  document.addEventListener('pointerdown', _promoteEventModal, true);
+  document.addEventListener('focusin', _promoteEventModal, true);
 }
 
 function _emitModalOpened(id, modal) {
@@ -1119,7 +1171,7 @@ function _wireChipDrag(chip, dock) {
 // `unregister` — built-in labels stay for the lifetime of the page.
 const _customLabelIds = new Set();
 
-export function register(id, { restoreFn, closeFn, railBtnId, sidebarBtnId, label, icon } = {}) {
+export function register(id, { restoreFn, closeFn, escapeFn, railBtnId, sidebarBtnId, label, icon } = {}) {
   // railBtnId can be a single id or an array; we accept both rail and sidebar separately too.
   const btnIds = [];
   if (railBtnId) btnIds.push(...(Array.isArray(railBtnId) ? railBtnId : [railBtnId]));
@@ -1127,6 +1179,7 @@ export function register(id, { restoreFn, closeFn, railBtnId, sidebarBtnId, labe
   _state.set(id, {
     restoreFn: restoreFn || (() => {}),
     closeFn:   closeFn   || (() => {}),
+    escapeFn:  escapeFn  || null,
     btnIds,
     isMinimized: false,
     restoreMinHeight: '',

--- a/static/js/research/panel.js
+++ b/static/js/research/panel.js
@@ -5,6 +5,7 @@ import * as jobs from './jobs.js';
 import themeModule from '../theme.js';
 import createResearchSynapse from '../researchSynapse.js';
 import spinnerModule from '../spinner.js';
+import * as Modals from '../modalManager.js';
 import { sortModelIds } from '../modelSort.js';
 
 // jobId -> { synapse, status } — survives across _renderJobs() rebuilds so
@@ -35,7 +36,6 @@ function _toggleSynapseMinimized() {
 }
 
 let _open = false;
-let _onDocKeydown = null;
 let _apiBase = '';
 let _endpoints = [];
 let _expandedJobId = null;
@@ -253,20 +253,16 @@ export function openPanel(focusJobId) {
 
   overlay.appendChild(pane);
   document.body.appendChild(overlay);
+  Modals.register('research-overlay', {
+    railBtnId: 'rail-research',
+    sidebarBtnId: 'tool-research-btn',
+    closeFn: () => closePanel(),
+    restoreFn: () => {},
+  });
 
   overlay.addEventListener('click', (e) => {
     if (e.target === overlay) closePanel();
   });
-
-  // Document-level ESC handler — overlay-only listener never fired because
-  // overlay isn't focused. Tracked in module scope so closePanel can detach.
-  _onDocKeydown = (e) => {
-    if (e.key === 'Escape' && _open) {
-      e.preventDefault();
-      closePanel();
-    }
-  };
-  document.addEventListener('keydown', _onDocKeydown);
 
   // Make the pane draggable by its header — same pattern as Library/Calendar.
   const paneHeader = pane.querySelector('.research-pane-header');
@@ -309,10 +305,7 @@ export function closePanel() {
   if (!_open) return;
   _open = false;
 
-  if (_onDocKeydown) {
-    document.removeEventListener('keydown', _onDocKeydown);
-    _onDocKeydown = null;
-  }
+  Modals.unregister('research-overlay');
 
   document.body.classList.remove('research-panel-view');
   const btn = document.getElementById('tool-research-btn');

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3,6 +3,7 @@
 
 import uiModule from './ui.js';
 import searchModule from './search.js';
+import * as Modals from './modalManager.js';
 import { makeWindowDraggable } from './windowDrag.js';
 import { clearDockSide } from './modalSnap.js';
 import { sortModelIds } from './modelSort.js';
@@ -82,23 +83,6 @@ function initClose() {
   modalEl.addEventListener('mousedown', e => {
     if (uiModule.isTouchInsideModal()) return;
     if (e.target === modalEl) close();
-  });
-  document.addEventListener('keydown', e => {
-    if (e.key !== 'Escape' || !modalEl || modalEl.classList.contains('hidden')) return;
-    // If an integration edit/add form is open inside the modal, close
-    // just that — don't dismiss the whole settings modal. (Pressing
-    // ESC mid-edit and losing the modal was a fast-typing footgun.)
-    const innerForm = modalEl.querySelector('#unified-intg-form, #set-email-accounts-form');
-    if (innerForm && innerForm.style.display !== 'none' && innerForm.children.length > 0) {
-      e.preventDefault();
-      e.stopPropagation();
-      innerForm.style.display = 'none';
-      innerForm.innerHTML = '';
-      return;
-    }
-    e.preventDefault();
-    e.stopPropagation();
-    close();
   });
 }
 
@@ -2092,6 +2076,23 @@ function initAccount() {
 
 function initAll() {
   modalEl = el('settings-modal');
+  if (modalEl && !Modals.isRegistered('settings-modal')) {
+    Modals.register('settings-modal', {
+      railBtnId: 'rail-settings',
+      sidebarBtnId: 'user-bar-settings',
+      escapeFn: (_e, modal) => {
+        const innerForm = modal?.querySelector('#unified-intg-form, #set-email-accounts-form');
+        if (innerForm && innerForm.style.display !== 'none' && innerForm.children.length > 0) {
+          innerForm.style.display = 'none';
+          innerForm.innerHTML = '';
+          return true;
+        }
+        return false;
+      },
+      closeFn: () => close(),
+      restoreFn: () => {},
+    });
+  }
   initTabs();
   initDrag();
   initClose();

--- a/static/js/tasks.js
+++ b/static/js/tasks.js
@@ -5,6 +5,7 @@
 import uiModule from './ui.js';
 import markdownModule from './markdown.js';
 import * as spinnerModule from './spinner.js';
+import * as Modals from './modalManager.js';
 import { makeWindowDraggable } from './windowDrag.js';
 import { sortModelIds } from './modelSort.js';
 
@@ -13,7 +14,6 @@ let _open = false;
 let _tasksCascadeNext = false;   // play the domino-in entrance on the next render
 let _tasks = [];
 let _tasksFetched = false;   // first-fetch sentinel — `false` → show loading row instead of "No tasks yet"
-let _escHandler = null;
 let _viewingRuns = null; // task id when viewing run history
 let _clockInterval = null;
 
@@ -2400,6 +2400,27 @@ export function openTasks(focusId) {
     </div>
   `;
   document.body.appendChild(modal);
+  Modals.register('tasks-modal', {
+    railBtnId: 'rail-tasks',
+    sidebarBtnId: 'tool-tasks-btn',
+    escapeFn: () => {
+      if (_viewingRuns) {
+        _viewingRuns = null;
+        _renderMainView();
+        return true;
+      }
+      const _modal = document.getElementById('tasks-modal');
+      const _addActive = _modal?.querySelector('.tasks-tab.active[data-tab="new"]');
+      const _formMounted = _modal?.querySelector('#task-form-name');
+      if (_addActive && _formMounted) {
+        _showPresetPicker();
+        return true;
+      }
+      return false;
+    },
+    closeFn: () => closeTasks(),
+    restoreFn: () => {},
+  });
 
   // Tab routing
   modal.querySelectorAll('.tasks-tab').forEach(btn => {
@@ -2436,28 +2457,6 @@ export function openTasks(focusId) {
     if (uiModule.isTouchInsideModal()) return;
     if (e.target === modal) closeTasks();
   });
-
-  _escHandler = (e) => {
-    if (e.key === 'Escape') {
-      if (_viewingRuns) {
-        _viewingRuns = null;
-        _renderMainView();
-        return;
-      }
-      // If we're on the "Add" tab inside the new-task form (preset already
-      // picked), step back to the preset picker instead of closing the modal.
-      // Detect by: Add tab active + the form's name input is mounted.
-      const _modal = document.getElementById('tasks-modal');
-      const _addActive = _modal?.querySelector('.tasks-tab.active[data-tab="new"]');
-      const _formMounted = _modal?.querySelector('#task-form-name');
-      if (_addActive && _formMounted) {
-        _showPresetPicker();
-        return;
-      }
-      closeTasks();
-    }
-  };
-  document.addEventListener('keydown', _escHandler);
 
   // Paint the scaffolding immediately so the modal-enter animation reveals a
   // populated shell (header/search/sort/empty list with a spinner row) instead
@@ -2510,10 +2509,7 @@ export function closeTasks() {
       modal.remove();
     }
   }
-  if (_escHandler) {
-    document.removeEventListener('keydown', _escHandler);
-    _escHandler = null;
-  }
+  Modals.unregister('tasks-modal');
   if (_clockInterval) {
     clearInterval(_clockInterval);
     _clockInterval = null;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1072,8 +1072,8 @@ if ('ontouchstart' in window || window.innerWidth <= 768) {
 
 // ── Global Escape arbiter: close exactly one thing per press ──
 // Priority: expanded library card → open chat thinking block → topmost modal.
-// Runs capture-phase + stopImmediatePropagation so per-modal ESC listeners
-// never also fire (which would otherwise close several modals at once).
+// Runs capture-phase + stopImmediatePropagation, then gives the topmost modal
+// one chance to consume ESC via ModalManager before falling back to close.
 if (!window._odyEscExpandGuard) {
   window._odyEscExpandGuard = true;
 
@@ -1103,15 +1103,6 @@ if (!window._odyEscExpandGuard) {
   }).observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class', 'style'] });
   document.querySelectorAll('.modal').forEach(_promote);
 
-  const pickTopModal = () => {
-    const modals = [...document.querySelectorAll('.modal')].filter(_isVisible);
-    if (!modals.length) return null;
-    return modals.reduce((top, m) =>
-      (parseInt(getComputedStyle(m).zIndex, 10) || 0) >= (parseInt(getComputedStyle(top).zIndex, 10) || 0)
-        ? m : top
-    );
-  };
-
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape' || e.defaultPrevented) return;
     const t = e.target;
@@ -1140,36 +1131,12 @@ if (!window._odyEscExpandGuard) {
       }
       return;
     }
-    const galleryEditor = document.getElementById('gallery-editor-container');
-    const galleryModal = galleryEditor?.closest('.modal');
-    const galleryEditing = !!(
-      galleryEditor &&
-      galleryModal &&
-      !galleryModal.classList.contains('hidden') &&
-      getComputedStyle(galleryEditor).display !== 'none' &&
-      galleryEditor.querySelector('.gallery-editor')
-    );
-    if (galleryEditing) {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      return;
-    }
-    const settingsModal = document.getElementById('settings-modal');
-    if (settingsModal && _isVisible(settingsModal)) {
-      const innerForm = settingsModal.querySelector('#unified-intg-form, #set-email-accounts-form');
-      if (innerForm && innerForm.style.display !== 'none' && innerForm.children.length > 0) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        innerForm.style.display = 'none';
-        innerForm.innerHTML = '';
-        return;
-      }
-    }
-    const topModal = pickTopModal();
+    const topModal = Modals.getTopmostModal();
     if (!topModal) return;
-    const closeBtn = topModal.querySelector('.close-btn, .modal-close-btn, [data-action="close"]');
     e.stopImmediatePropagation();
     e.preventDefault();
+    if (Modals.dispatchEscape(topModal, e)) return;
+    const closeBtn = topModal.querySelector('.close-btn, .modal-close-btn, [data-action="close"]');
     if (closeBtn) { try { closeBtn.click(); } catch {} }
     else { try { topModal.classList.add('hidden'); } catch {} }
   }, true);


### PR DESCRIPTION
 ## Summary

  This PR fixes one user-facing UI bug theme: inconsistent modal stacking and
  Escape-key behavior across major app windows.

  Before this change, modal behavior could diverge depending on which window was
  opened first, which one had the higher static z-index, and whether a feature
  used its own document-level Escape handler or the global one. In practice, that
  could lead to cases where:

  - the most recently interacted-with modal did not come to the front
  - pressing `Escape` closed the wrong modal
  - pressing `Escape` bypassed modal-specific inner UI and closed the whole window
  - different windows handled the same interaction differently

  ## What Changed

  This change unifies modal stacking and Escape handling around a single shared
  flow:

  - Added shared topmost-modal helpers in `static/js/modalManager.js`
  - Promoted visible modals to the front on pointer/focus interaction
  - Routed global `Escape` handling through the topmost modal first
  - Added per-modal `escapeFn` hooks so a modal can consume `Escape` for its
    own inner layer before the generic close fallback runs
  - Registered previously inconsistent windows with the shared modal manager

  ## Areas Changed

  - `static/js/modalManager.js`
  - `static/js/ui.js`
  - `static/js/settings.js`
  - `static/js/calendar.js`
  - `static/js/emailLibrary.js`
  - `static/js/gallery.js`
  - `static/js/tasks.js`
  - `static/js/research/panel.js`

  ## Behavior Fixed

  Examples of the corrected behavior:

  - Clicking or focusing a modal now brings it to the front consistently
  - `Escape` now targets the single topmost modal instead of competing handlers
  - Settings can close its inner integration form before closing the modal
  - Calendar can dismiss its topmost internal surface before closing the window
  - Gallery can keep editor/detail-specific Escape behavior without closing the
    whole gallery underneath
  - Tasks can step back from nested task views before closing the modal
  - Email Library can exit select mode before closing the modal

  ## Manual Test Steps

  1. Open two or more major windows, for example Settings and Calendar.
  2. Click the background window, then verify it comes to the front.
  3. Press `Escape` and verify only the topmost modal responds.
  4. Repeat with:
     - Settings while an inner integration form is open
     - Calendar while an internal settings/form surface is open
     - Gallery while detail view or editor UI is active
     - Tasks while viewing runs or the new-task form flow
     - Email Library while select mode is active
     - Research after opening it on top of another modal

  ## Checks Run

  Ran:

  git diff --check

  Result:

  - no diff/whitespace errors

  ## Notes

  This PR is intentionally limited to one bug-fix theme: modal stacking and
  Escape consistency. It does not attempt to refactor unrelated window drag,
  dock, layout, or styling behavior.