### PR TITLE
fix: clear session headers on endpoint deletion to fix #444

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1382,6 +1382,7 @@ def setup_model_routes(model_discovery):
             if _session_uses_endpoint_url(row.endpoint_url or "", base_url):
                 row.endpoint_url = ""
                 row.model = ""
+                row.headers = {}
                 row.updated_at = datetime.utcnow()
                 cleared += 1
         return cleared


### PR DESCRIPTION
### description
resolves #444 (deepseek api key not updating — old key persists after delete and re-add).

when an endpoint is deleted in settings, the `_clear_sessions_for_endpoint` routine iterates over all database sessions using that endpoint and unlinks them by clearing `endpoint_url` and `model`. however, it neglected to clear the `headers` column. because the api key is stored within `headers` (e.g. `{"Authorization": "Bearer ****"}`), the stale key remained permanently lodged in the database row.

if the server restarted or the session was reloaded from sqlite, the chat session would inherit the stale api key. then, even if the user re-added the endpoint (or fell back to the new default), the old `headers` from the db took precedence, causing authentication failures.

this pr adds the missing `row.headers = {}` to the database cleanup routine, perfectly aligning it with the ram cleanup routine (`_clear_loaded_sessions_for_endpoint`) which already did this correctly.

### tests performed
- verified python syntax with `python -m py_compile routes/model_routes.py`
- confirmed database migration/schema compatibility (json/dict column handles `{}`)
