### PR TITLE
fix: deep research discards valid sources mentioning cookies/copyright

### DIFF
--- a/src/research_utils.py
+++ b/src/research_utils.py
@@ -39,9 +39,7 @@ LOW_QUALITY_MARKERS = [
     "unable to extract",
     "completely unrelated",
     "boilerplate",
-    "cookie",
     "footer text",
-    "copyright",
 ]
 
 

--- a/src/research_utils.py
+++ b/src/research_utils.py
@@ -40,6 +40,15 @@ LOW_QUALITY_MARKERS = [
     "completely unrelated",
     "boilerplate",
     "footer text",
+    # Phrases (not bare "cookie"/"copyright") so we still catch boilerplate
+    # like consent banners and footers without discarding legitimate findings
+    # that merely discuss cookies or copyright as their subject.
+    "cookie consent",
+    "cookie banner",
+    "cookie notice",
+    "copyright notice",
+    "copyright footer",
+    "all rights reserved",
 ]
 
 

--- a/tests/test_research_utils.py
+++ b/tests/test_research_utils.py
@@ -79,3 +79,19 @@ class TestIsLowQuality:
 
     def test_copyright_marker(self):
         assert is_low_quality("Just a copyright notice at the bottom.") is True
+
+    # Regression: bare "cookie"/"copyright" used to be substring markers, so
+    # legitimate findings that merely discuss them as their subject were
+    # discarded. They must now be kept.
+    def test_keeps_finding_about_copyright_law(self):
+        assert is_low_quality("This article explains the new EU copyright directive reforms.") is False
+
+    def test_keeps_finding_about_cookies(self):
+        assert is_low_quality("A technical guide to how tracking cookies and session cookies work.") is False
+
+    def test_keeps_recipe_mentioning_cookies(self):
+        assert is_low_quality("Recipe: the best chocolate chip cookies you will ever bake.") is False
+
+    # Boilerplate is still caught via phrases.
+    def test_cookie_consent_banner_still_filtered(self):
+        assert is_low_quality("The page is just a cookie consent banner.") is True


### PR DESCRIPTION
## Summary

The deep-research quality filter (`is_low_quality`) drops any finding whose summary contains the bare substrings `cookie` or `copyright`. Those are matched anywhere in the text, so legitimate sources get silently discarded — e.g. an article on the EU copyright directive, a guide to how tracking cookies work, or any page whose summary happens to say "copyright". `is_low_quality` gates real research findings in `research_handler.py` and `deep_research.py`, so this quietly removes good sources from results.

The markers were meant to catch boilerplate (consent banners, footers). This keeps that intent but matches phrases (`cookie consent`, `cookie banner`, `copyright notice`, `copyright footer`, `all rights reserved`) instead of the bare words, so genuine boilerplate is still filtered while findings that merely discuss cookies/copyright as their subject are kept.

## Changes
- `src/research_utils.py`: replace bare `cookie`/`copyright` markers with specific boilerplate phrases.
- `tests/test_research_utils.py`: regression tests — legit copyright/cookie/recipe findings kept; consent-banner/footer boilerplate still filtered.