### PR TITLE
Add Telegram remote control integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -582,6 +582,15 @@ set_task_scheduler(task_scheduler)
 from routes.task_routes import setup_task_routes
 app.include_router(setup_task_routes(task_scheduler))
 
+from src.remote_control import RemoteControlManager
+remote_control_manager = RemoteControlManager(
+    session_manager=session_manager,
+    task_scheduler=task_scheduler,
+    auth_manager=auth_manager,
+    api_key_manager=api_key_manager,
+    app=app,
+)
+
 from routes.assistant_routes import setup_assistant_routes
 app.include_router(setup_assistant_routes(task_scheduler))
 
@@ -642,7 +651,11 @@ app.include_router(setup_webhook_routes(webhook_manager, auth_manager, session_m
 from routes.api_token_routes import setup_api_token_routes
 app.include_router(setup_api_token_routes())
 
-logger.info("Webhook & API token routes initialized")
+# Telegram remote control adapter
+from routes.remote_control_routes import setup_remote_control_routes
+app.include_router(setup_remote_control_routes(remote_control_manager, auth_manager))
+
+logger.info("Webhook, API token, and remote control routes initialized")
 
 # Notes (Google Keep-style notes/todos)
 from routes.note_routes import setup_note_routes
@@ -783,6 +796,7 @@ async def startup_event():
     app.state._startup_tasks = _startup_tasks
     if upload_cleanup_func:
         upload_cleanup_task = asyncio.create_task(upload_cleanup_func())
+    _startup_tasks.append(asyncio.create_task(remote_control_manager.start()))
     # Always-on monitor that auto-continues the agent when a background bash
     # job (#!bg) finishes — re-invokes the turn with the job output.
     try:
@@ -1000,6 +1014,11 @@ async def shutdown_event():
         await webhook_manager.close()
     except Exception as e:
         logger.warning(f"Webhook manager shutdown error: {e}")
+    # Close remote-control adapters
+    try:
+        await remote_control_manager.close()
+    except Exception as e:
+        logger.warning(f"Remote control shutdown error: {e}")
     # Disconnect all MCP servers
     try:
         await mcp_manager.disconnect_all()

--- a/routes/remote_control_routes.py
+++ b/routes/remote_control_routes.py
@@ -1,0 +1,49 @@
+"""Admin API for Telegram remote control."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core.middleware import require_admin
+from src.auth_helpers import get_current_user
+
+
+def setup_remote_control_routes(remote_control_manager, auth_manager=None) -> APIRouter:
+    router = APIRouter(prefix="/api/remote-control", tags=["remote_control"])
+
+    @router.get("")
+    async def get_remote_control(request: Request):
+        require_admin(request)
+        return remote_control_manager.safe_config()
+
+    @router.put("/{provider}")
+    async def update_remote_control(provider: str, request: Request, body: dict):
+        require_admin(request)
+        try:
+            actor = get_current_user(request)
+            return await remote_control_manager.update_provider(provider, body or {}, actor=actor)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    @router.post("/{provider}/test")
+    async def test_remote_control(provider: str, request: Request, body: Optional[dict] = None):
+        require_admin(request)
+        try:
+            result = await remote_control_manager.test_provider(provider, body or {})
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if not result.get("ok"):
+            return result
+        return result
+
+    @router.post("/{provider}/reload")
+    async def reload_remote_control(provider: str, request: Request):
+        require_admin(request)
+        try:
+            return await remote_control_manager.reload(provider)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    return router

--- a/src/action_intents.py
+++ b/src/action_intents.py
@@ -14,8 +14,10 @@ from typing import Iterable, Pattern
 _ACTION_QUESTION = r"\b(?:can|could|would|will)\s+you\s+"
 _PLEASE = r"^\s*(?:please\s+)?"
 
+_CALENDAR_WORD = r"(?:calendar|calander)"
 _CALENDAR_ACTION = r"(?:add|create|schedule|book|put|set\s+up|make)"
-_CALENDAR_THING = r"(?:calendar|calendar\s+(?:entry|item)|event|meeting|appointment|entry|call)"
+_CALENDAR_THING = rf"(?:{_CALENDAR_WORD}|{_CALENDAR_WORD}\s+(?:entry|item)|event|meeting|appointment|entry|call)"
+_CALENDAR_READ_THING = rf"(?:{_CALENDAR_WORD}(?:\s+(?:entries|entry|items?|events?))?|events?|meetings?|appointments?|entries|schedule|agenda)"
 
 _PANEL = (
     r"(?:calendar|notes?|inbox|email|mail|documents?|docs|library|gallery|"
@@ -28,9 +30,17 @@ _TOOL_INTENT_PATTERNS: tuple[Pattern[str], ...] = tuple(
         # Calendar/event creation. Covers "Can you add an entry to my
         # calendar?" and imperatives like "add lunch to my calendar".
         rf"{_ACTION_QUESTION}{_CALENDAR_ACTION}\b.{{0,120}}\b{_CALENDAR_THING}\b",
-        rf"{_PLEASE}{_CALENDAR_ACTION}\b.{{0,120}}\b(?:to|on|in|into|for)\s+(?:my\s+|the\s+|this\s+)?calendar\b",
+        rf"{_PLEASE}{_CALENDAR_ACTION}\b.{{0,120}}\b(?:to|on|in|into|for)\s+(?:my\s+|the\s+|this\s+)?{_CALENDAR_WORD}\b",
         rf"{_PLEASE}{_CALENDAR_ACTION}\s+(?:a\s+|an\s+)?(?:calendar\s+)?(?:event|meeting|appointment|entry|item|call)\b",
         r"\bput\s+.+\bon\s+(?:my\s+)?calendar\b",
+
+        # Calendar read/list requests. Remote-control messages enter through
+        # the same chat front door, so these need the usual tool promotion too.
+        rf"{_PLEASE}(?:what(?:'s|\s+is)?|show|list|check|view|tell\s+me)\b.{{0,120}}\b(?:on|in|for|from)\s+(?:my\s+|the\s+)?{_CALENDAR_READ_THING}\b",
+        rf"{_PLEASE}(?:show|list|check|view|tell\s+me)\b.{{0,80}}\b(?:my\s+|the\s+){_CALENDAR_READ_THING}\b",
+        rf"{_PLEASE}(?:what|which)\b.{{0,80}}\b{_CALENDAR_READ_THING}\b.{{0,80}}\b(?:do\s+i\s+have|have\s+i\s+got|are\s+there)\b",
+        rf"{_PLEASE}(?:do\s+i\s+have|have\s+i\s+got|are\s+there|any)\b.{{0,80}}\b{_CALENDAR_READ_THING}\b",
+        rf"{_PLEASE}what(?:'s|\s+is)?\s+(?:my\s+|the\s+)(?:schedule|agenda)\b",
 
         # Notes, todos, checklists, and reminders.
         r"\bremind\s+me\b",

--- a/src/remote_control.py
+++ b/src/remote_control.py
@@ -1,0 +1,663 @@
+"""Telegram remote-control adapter.
+
+The generic "integrations" store is prompt-visible API plumbing. Bot tokens
+are process control credentials, so they live in their own config file and are
+only exposed through this manager.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+import httpx
+from sqlalchemy import or_
+
+from core.atomic_io import atomic_write_json
+from core.database import ModelEndpoint, ScheduledTask, SessionLocal
+from src.endpoint_resolver import build_chat_url, build_headers, normalize_base, resolve_endpoint
+
+logger = logging.getLogger(__name__)
+
+VALID_PROVIDERS = {"telegram"}
+DEFAULT_DATA_FILE = os.path.join("data", "remote_control.json")
+TELEGRAM_MAX_CHARS = 3900
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _default_provider_config(provider: str) -> Dict[str, Any]:
+    _clean_provider(provider)
+    return {
+        "enabled": False,
+        "token": "",
+        "allow_all": False,
+        "allowed_chat_ids": [],
+        "sessions": {},
+    }
+
+
+def _default_config() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "providers": {
+            "telegram": _default_provider_config("telegram"),
+        },
+    }
+
+
+def _as_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        parts = value.replace("\r", "\n").replace(",", "\n").split("\n")
+        return [p.strip() for p in parts if p.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _clean_provider(provider: str) -> str:
+    provider = (provider or "").strip().lower()
+    if provider not in VALID_PROVIDERS:
+        raise ValueError(f"Unsupported remote-control provider: {provider}")
+    return provider
+
+
+def _mask_token(token: str) -> str:
+    token = token or ""
+    if not token:
+        return ""
+    if len(token) <= 8:
+        return "*" * len(token)
+    return f"{token[:4]}...{token[-4:]}"
+
+
+def _chunk_text(text: str, limit: int) -> List[str]:
+    text = (text or "").strip() or "(no response)"
+    chunks = []
+    while len(text) > limit:
+        cut = text.rfind("\n", 0, limit)
+        if cut < max(200, limit // 3):
+            cut = text.rfind(" ", 0, limit)
+        if cut < max(200, limit // 3):
+            cut = limit
+        chunks.append(text[:cut].rstrip())
+        text = text[cut:].lstrip()
+    if text:
+        chunks.append(text)
+    return chunks or ["(no response)"]
+
+
+class RemoteControlManager:
+    def __init__(
+        self,
+        *,
+        session_manager,
+        task_scheduler,
+        auth_manager=None,
+        api_key_manager=None,
+        app=None,
+        data_file: str = DEFAULT_DATA_FILE,
+    ):
+        self.session_manager = session_manager
+        self.task_scheduler = task_scheduler
+        self.auth_manager = auth_manager
+        self.api_key_manager = api_key_manager
+        self.app = app
+        self.data_file = data_file
+        self._config = self._load_config()
+        self._status: Dict[str, Dict[str, Any]] = {
+            "telegram": self._empty_status(),
+        }
+        self._tasks: Dict[str, asyncio.Task] = {}
+        self._stop = asyncio.Event()
+        self._lock = asyncio.Lock()
+        self._http: Optional[httpx.AsyncClient] = None
+
+    def _empty_status(self) -> Dict[str, Any]:
+        return {
+            "running": False,
+            "last_error": "",
+            "last_message_at": "",
+            "identity": "",
+        }
+
+    def _client(self) -> httpx.AsyncClient:
+        if self._http is None or self._http.is_closed:
+            self._http = httpx.AsyncClient(timeout=httpx.Timeout(connect=8, read=45, write=10, pool=5))
+        return self._http
+
+    def _load_config(self) -> Dict[str, Any]:
+        cfg = _default_config()
+        try:
+            if os.path.exists(self.data_file):
+                with open(self.data_file, "r", encoding="utf-8") as f:
+                    stored = json.load(f)
+                if isinstance(stored, dict):
+                    cfg.update({k: v for k, v in stored.items() if k != "providers"})
+                    providers = stored.get("providers") or {}
+                    for provider in VALID_PROVIDERS:
+                        merged = _default_provider_config(provider)
+                        if isinstance(providers.get(provider), dict):
+                            merged.update(providers[provider])
+                        merged.pop("mode", None)
+                        merged.pop("owner", None)
+                        merged["allow_all"] = bool(merged.get("allow_all"))
+                        if not isinstance(merged.get("sessions"), dict):
+                            merged["sessions"] = {}
+                        cfg["providers"][provider] = merged
+        except Exception as exc:
+            logger.warning("Failed to load remote-control config: %s", exc)
+        return cfg
+
+    def _save_config(self) -> None:
+        atomic_write_json(self.data_file, self._config, indent=2)
+
+    def _encrypt_token(self, token: str) -> str:
+        if not token:
+            return ""
+        if self.api_key_manager:
+            return self.api_key_manager.encrypt_api_key(token)
+        return token
+
+    def _decrypt_token(self, cfg: Dict[str, Any]) -> str:
+        raw = cfg.get("token") or ""
+        if not raw:
+            return ""
+        if not self.api_key_manager:
+            return raw
+        try:
+            return self.api_key_manager.decrypt_api_key(raw)
+        except Exception:
+            return raw
+
+    def _provider_cfg(self, provider: str) -> Dict[str, Any]:
+        provider = _clean_provider(provider)
+        self._config.setdefault("providers", {})
+        if provider not in self._config["providers"]:
+            self._config["providers"][provider] = _default_provider_config(provider)
+        return self._config["providers"][provider]
+
+    def _status_for(self, provider: str) -> Dict[str, Any]:
+        provider = _clean_provider(provider)
+        self._status.setdefault(provider, self._empty_status())
+        return self._status[provider]
+
+    def _set_status(self, provider: str, **values: Any) -> None:
+        status = self._status_for(provider)
+        status.update(values)
+
+    def _safe_provider(self, provider: str) -> Dict[str, Any]:
+        cfg = deepcopy(self._provider_cfg(provider))
+        token = self._decrypt_token(cfg)
+        cfg.pop("token", None)
+        cfg.pop("owner", None)
+        cfg.pop("mode", None)
+        cfg.pop("sessions", None)
+        cfg["configured"] = bool(token)
+        cfg["token_mask"] = _mask_token(token)
+        cfg["status"] = deepcopy(self._status_for(provider))
+        return cfg
+
+    def safe_config(self) -> Dict[str, Any]:
+        return {
+            "version": self._config.get("version", 1),
+            "providers": {
+                provider: self._safe_provider(provider)
+                for provider in sorted(VALID_PROVIDERS)
+            },
+        }
+
+    async def start(self) -> None:
+        self._stop.clear()
+        for provider in sorted(VALID_PROVIDERS):
+            await self.reload(provider)
+
+    async def close(self) -> None:
+        self._stop.set()
+        tasks = list(self._tasks.values())
+        self._tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if self._http and not self._http.is_closed:
+            await self._http.aclose()
+
+    async def reload(self, provider: Optional[str] = None) -> Dict[str, Any]:
+        providers = [_clean_provider(provider)] if provider else sorted(VALID_PROVIDERS)
+        cancelled: List[asyncio.Task] = []
+        async with self._lock:
+            for name in providers:
+                task = self._tasks.pop(name, None)
+                if task:
+                    task.cancel()
+                    cancelled.append(task)
+                cfg = self._provider_cfg(name)
+                token = self._decrypt_token(cfg)
+                if not cfg.get("enabled") or not token:
+                    self._set_status(name, running=False, last_error="")
+                    continue
+                self._tasks[name] = asyncio.create_task(self._telegram_loop(), name="remote-control-telegram")
+        if cancelled:
+            await asyncio.gather(*cancelled, return_exceptions=True)
+        return self.safe_config()
+
+    async def update_provider(self, provider: str, patch: Dict[str, Any], actor: Optional[str] = None) -> Dict[str, Any]:
+        provider = _clean_provider(provider)
+        patch = patch or {}
+        async with self._lock:
+            if patch.get("reset"):
+                self._config["providers"][provider] = _default_provider_config(provider)
+                cfg = self._provider_cfg(provider)
+            else:
+                cfg = self._provider_cfg(provider)
+                if "enabled" in patch:
+                    cfg["enabled"] = bool(patch.get("enabled"))
+                if "allow_all" in patch:
+                    cfg["allow_all"] = bool(patch.get("allow_all"))
+                if patch.get("clear_token"):
+                    cfg["token"] = ""
+                token = str(patch.get("token") or "").strip()
+                if token:
+                    cfg["token"] = self._encrypt_token(token)
+                if "allowed_chat_ids" in patch:
+                    cfg["allowed_chat_ids"] = _as_list(patch.get("allowed_chat_ids"))
+            self._save_config()
+        await self.reload(provider)
+        return self.safe_config()
+
+    async def test_provider(self, provider: str, patch: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        provider = _clean_provider(provider)
+        patch = patch or {}
+        token = str(patch.get("token") or "").strip()
+        if not token:
+            token = self._decrypt_token(self._provider_cfg(provider))
+        if not token:
+            return {"ok": False, "error": "Bot token is required"}
+        return await self._test_telegram(token)
+
+    async def _test_telegram(self, token: str) -> Dict[str, Any]:
+        try:
+            r = await self._client().get(f"https://api.telegram.org/bot{token}/getMe", timeout=15)
+            data = r.json()
+            if not r.is_success or not data.get("ok"):
+                return {"ok": False, "error": data.get("description") or f"HTTP {r.status_code}"}
+            user = data.get("result") or {}
+            name = user.get("username") or user.get("first_name") or str(user.get("id") or "")
+            return {"ok": True, "identity": name}
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    async def _telegram_loop(self) -> None:
+        provider = "telegram"
+        offset = None
+        backoff = 2.0
+        while not self._stop.is_set():
+            cfg = deepcopy(self._provider_cfg(provider))
+            token = self._decrypt_token(cfg)
+            if not cfg.get("enabled") or not token:
+                self._set_status(provider, running=False, last_error="")
+                return
+            try:
+                params: Dict[str, Any] = {"timeout": 30, "allowed_updates": ["message"]}
+                if offset is not None:
+                    params["offset"] = offset
+                r = await self._client().get(
+                    f"https://api.telegram.org/bot{token}/getUpdates",
+                    params=params,
+                    timeout=40,
+                )
+                data = r.json()
+                if not r.is_success or not data.get("ok"):
+                    raise RuntimeError(data.get("description") or f"HTTP {r.status_code}")
+                self._set_status(provider, running=True, last_error="")
+                backoff = 2.0
+                for update in data.get("result") or []:
+                    update_id = update.get("update_id")
+                    if update_id is not None:
+                        offset = max(offset or 0, int(update_id) + 1)
+                    await self._handle_telegram_update(token, update)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._set_status(provider, running=False, last_error=str(exc)[:500])
+                logger.warning("Telegram remote-control loop error: %s", exc)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 1.5, 30.0)
+
+    async def _handle_telegram_update(self, token: str, update: Dict[str, Any]) -> None:
+        msg = update.get("message") or update.get("edited_message") or {}
+        text = (msg.get("text") or msg.get("caption") or "").strip()
+        if not text:
+            return
+        chat = msg.get("chat") or {}
+        from_user = msg.get("from") or {}
+        chat_id = str(chat.get("id") or "")
+        user_id = str(from_user.get("id") or "")
+        if not chat_id:
+            return
+        if not self._telegram_authorized(chat_id):
+            await self._telegram_send(token, chat_id, self._unauthorized_message(chat_id, user_id))
+            return
+        self._set_status("telegram", last_message_at=_utc_now_iso())
+        surface_id = f"telegram:{chat_id}"
+
+        async def reply(body: str) -> None:
+            await self._telegram_send(token, chat_id, body)
+
+        async def typing() -> None:
+            try:
+                await self._client().post(
+                    f"https://api.telegram.org/bot{token}/sendChatAction",
+                    json={"chat_id": chat_id, "action": "typing"},
+                    timeout=10,
+                )
+            except Exception:
+                pass
+
+        await self._handle_message(
+            surface_id=surface_id,
+            actor_id=user_id,
+            text=text,
+            reply=reply,
+            typing=typing,
+            identity_text=f"Telegram chat id: {chat_id}\nTelegram user id: {user_id or 'unknown'}",
+        )
+
+    async def _telegram_send(self, token: str, chat_id: str, text: str) -> None:
+        for chunk in _chunk_text(text, TELEGRAM_MAX_CHARS):
+            await self._client().post(
+                f"https://api.telegram.org/bot{token}/sendMessage",
+                json={"chat_id": chat_id, "text": chunk},
+                timeout=20,
+            )
+
+    def _telegram_authorized(self, chat_id: str) -> bool:
+        cfg = self._provider_cfg("telegram")
+        if cfg.get("allow_all"):
+            return True
+        return str(chat_id) in set(_as_list(cfg.get("allowed_chat_ids")))
+
+    def _unauthorized_message(self, chat_id: str, user_id: str) -> str:
+        return (
+            "Remote control is not allowed from this Telegram chat yet.\n"
+            f"Chat ID: {chat_id}\n"
+            f"User ID: {user_id or 'unknown'}\n"
+            "Add the chat ID in Settings > Integrations > Remote Control."
+        )
+
+    async def _handle_message(
+        self,
+        *,
+        surface_id: str,
+        actor_id: str,
+        text: str,
+        reply: Callable[[str], Awaitable[None]],
+        typing: Callable[[], Awaitable[None]],
+        identity_text: str,
+    ) -> None:
+        try:
+            command, rest = self._parse_command(text)
+            if command in {"start", "help"}:
+                await reply(self._help_text())
+                return
+            if command == "id":
+                await reply(identity_text)
+                return
+            if command == "status":
+                await reply(self._status_text())
+                return
+            if command == "reset":
+                self._forget_session(surface_id)
+                await reply("Remote conversation reset.")
+                return
+            if command == "tasks":
+                await reply(self._list_tasks_text(self._owner_for()))
+                return
+            if command == "run":
+                await reply(await self._run_task_text(rest, self._owner_for()))
+                return
+            if command in {"chat", "agent"}:
+                if not rest:
+                    await reply(f"Usage: /{command} your message")
+                    return
+                mode = command
+                prompt = rest
+            elif command:
+                await reply(f"Unknown command: /{command}\n\n{self._help_text()}")
+                return
+            else:
+                mode = "chat"
+                prompt = text
+
+            await typing()
+            response = await self._dispatch_to_chat_front_door(surface_id, actor_id, prompt, mode)
+            await reply(response)
+        except Exception as exc:
+            logger.exception("Telegram remote-control message failed")
+            await reply(f"Remote control error: {type(exc).__name__}: {exc}")
+
+    def _parse_command(self, text: str) -> Tuple[str, str]:
+        stripped = (text or "").strip()
+        if not stripped.startswith("/"):
+            return "", stripped
+        first, _, rest = stripped.partition(" ")
+        command = first[1:].split("@", 1)[0].strip().lower()
+        return command, rest.strip()
+
+    def _help_text(self) -> str:
+        return (
+            "Odysseus remote control via Telegram\n"
+            "/id - show IDs for allowlisting\n"
+            "/status - show adapter status\n"
+            "/reset - start a fresh remote chat session\n"
+            "/tasks - list active scheduled tasks\n"
+            "/run <task-id> - run a scheduled task now\n"
+            "/chat <message> - send a plain chat turn\n"
+            "/agent <message> - send an agent turn with tools\n"
+            "Otherwise, send a message and Odysseus auto-routes chat vs tool requests."
+        )
+
+    def _status_text(self) -> str:
+        cfg = self._provider_cfg("telegram")
+        status = self._status_for("telegram")
+        lines = [
+            "Telegram remote control",
+            f"Enabled: {'yes' if cfg.get('enabled') else 'no'}",
+            f"Configured: {'yes' if self._decrypt_token(cfg) else 'no'}",
+            f"Running: {'yes' if status.get('running') else 'no'}",
+        ]
+        if status.get("identity"):
+            lines.append(f"Bot: {status['identity']}")
+        if status.get("last_message_at"):
+            lines.append(f"Last message: {status['last_message_at']}")
+        if status.get("last_error"):
+            lines.append(f"Last error: {status['last_error']}")
+        return "\n".join(lines)
+
+    def _owner_for(self) -> str:
+        if self.auth_manager:
+            try:
+                users = self.auth_manager.users or {}
+                for username, data in users.items():
+                    if data.get("is_admin") is True:
+                        return username
+                if users:
+                    return next(iter(users.keys()))
+            except Exception:
+                pass
+        return ""
+
+    def _forget_session(self, surface_id: str) -> None:
+        cfg = self._provider_cfg("telegram")
+        sessions = cfg.setdefault("sessions", {})
+        if surface_id in sessions:
+            sessions.pop(surface_id, None)
+            self._save_config()
+
+    def _list_tasks_text(self, owner: str) -> str:
+        db = SessionLocal()
+        try:
+            q = db.query(ScheduledTask).filter(ScheduledTask.status == "active")
+            if owner:
+                q = q.filter(ScheduledTask.owner == owner)
+            tasks = q.order_by(ScheduledTask.created_at.desc()).limit(10).all()
+            if not tasks:
+                return "No active scheduled tasks found."
+            lines = ["Active scheduled tasks:"]
+            for task in tasks:
+                name = task.name or "Untitled Task"
+                detail = task.schedule or task.trigger_type or "manual"
+                lines.append(f"{task.id} - {name} ({detail})")
+            return "\n".join(lines)
+        finally:
+            db.close()
+
+    async def _run_task_text(self, task_id: str, owner: str) -> str:
+        task_id = (task_id or "").strip()
+        if not task_id:
+            return "Usage: /run <task-id>"
+        db = SessionLocal()
+        try:
+            q = db.query(ScheduledTask).filter(ScheduledTask.id == task_id)
+            if owner:
+                q = q.filter(ScheduledTask.owner == owner)
+            task = q.first()
+            if not task:
+                return f"Task not found: {task_id}"
+            if task.status != "active":
+                return f"Task '{task.name}' is {task.status or 'not active'}."
+        finally:
+            db.close()
+        ok = await self.task_scheduler.run_task_now(task_id)
+        return f"Started task {task_id}." if ok else f"Task {task_id} is already running."
+
+    async def _dispatch_to_chat_front_door(
+        self,
+        surface_id: str,
+        actor_id: str,
+        prompt: str,
+        mode: str,
+    ) -> str:
+        if self.app is None:
+            return "Remote control is not attached to the Odysseus chat runtime."
+        owner = self._owner_for()
+        endpoint_url, model, _headers = self._resolve_chat_endpoint(owner)
+        if not endpoint_url or not model:
+            return "No default chat model is configured. Set one in Settings > AI."
+        session = self._get_or_create_session(surface_id, owner, endpoint_url, model)
+        session.endpoint_url = endpoint_url
+        session.model = model
+        form_data = {
+            "message": prompt,
+            "session": session.id,
+            "mode": mode,
+            "remote_provider": "telegram",
+            "remote_surface_id": surface_id,
+            "remote_actor_id": actor_id,
+        }
+        from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN
+        headers = {
+            INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN,
+            "X-Odysseus-Owner": owner or "",
+        }
+        transport = httpx.ASGITransport(app=self.app, client=("127.0.0.1", 0))
+        parts: List[str] = []
+        last_error = ""
+        timeout = httpx.Timeout(420.0, connect=10.0, write=10.0, pool=10.0)
+        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:7000", timeout=timeout) as client:
+            async with client.stream("POST", "/api/chat_stream", data=form_data, headers=headers) as response:
+                if response.status_code >= 400:
+                    body = await response.aread()
+                    return f"Remote chat request failed ({response.status_code}): {body.decode(errors='replace')[:500]}"
+                async for line in response.aiter_lines():
+                    line = (line or "").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    payload = line[5:].strip()
+                    if payload == "[DONE]":
+                        break
+                    if not payload:
+                        continue
+                    try:
+                        data = json.loads(payload)
+                    except Exception:
+                        continue
+                    if data.get("delta"):
+                        parts.append(str(data.get("delta")))
+                    elif data.get("type") == "research_done":
+                        parts.append("Research finished in Odysseus.")
+                    elif data.get("type") == "error":
+                        last_error = str(data.get("error") or data.get("message") or data)
+        reply = "".join(parts).strip()
+        return reply or last_error or "(no response)"
+
+    def _resolve_chat_endpoint(self, owner: str) -> Tuple[Optional[str], Optional[str], Dict[str, str]]:
+        url, model, headers = resolve_endpoint("default", owner=owner or None)
+        if url and model:
+            return url, model, headers or {}
+
+        db = SessionLocal()
+        try:
+            q = db.query(ModelEndpoint).filter(
+                ModelEndpoint.is_enabled == True,
+                or_(ModelEndpoint.model_type == None, ModelEndpoint.model_type != "image"),
+            )
+            if owner:
+                q = q.filter((ModelEndpoint.owner == owner) | (ModelEndpoint.owner == None))
+            ep = q.order_by(ModelEndpoint.created_at.desc()).first()
+            if not ep:
+                return None, None, {}
+            base = normalize_base(ep.base_url)
+            model_name = ""
+            if ep.cached_models:
+                try:
+                    models = json.loads(ep.cached_models) or []
+                    if models:
+                        model_name = str(models[0])
+                except Exception:
+                    pass
+            if not model_name:
+                model_name = ep.name or ""
+            return build_chat_url(base), model_name, build_headers(ep.api_key, base)
+        finally:
+            db.close()
+
+    def _get_or_create_session(
+        self,
+        surface_id: str,
+        owner: str,
+        endpoint_url: str,
+        model: str,
+    ):
+        cfg = self._provider_cfg("telegram")
+        sessions = cfg.setdefault("sessions", {})
+        session_id = sessions.get(surface_id)
+        if session_id:
+            try:
+                return self.session_manager.get_session(session_id)
+            except Exception:
+                sessions.pop(surface_id, None)
+        session_id = str(uuid.uuid4())
+        name = f"Remote Telegram {surface_id.split(':', 1)[-1]}"
+        session = self.session_manager.create_session(
+            session_id=session_id,
+            name=name,
+            endpoint_url=endpoint_url,
+            model=model,
+            rag=False,
+            owner=owner or None,
+        )
+        sessions[surface_id] = session_id
+        self._save_config()
+        return session

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3031,6 +3031,7 @@ const INTG_TYPES = {
   carddav: { label: 'CardDAV', icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>' },
   email:   { label: 'Email',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>' },
   mcp:     { label: 'MCP',     icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>' },
+  remote:  { label: 'Telegram', icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="20" x="5" y="2" rx="2" ry="2"/><path d="M12 18h.01"/><path d="M8 6h8"/></svg>' },
   vault:   { label: 'Vault',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>' },
 };
 
@@ -3051,13 +3052,14 @@ async function initUnifiedIntegrations() {
   }
 
   async function fetchAll() {
-    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
+    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, remoteRes, vaultRes] = await Promise.all([
       fetch('/api/auth/integrations', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { integrations: [] }).catch(() => ({ integrations: [] })),
       fetch('/api/calendar/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/list', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { contacts: [], count: 0 }).catch(() => ({ contacts: [], count: 0 })),
       fetch('/api/email/accounts', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { accounts: [] }).catch(() => ({ accounts: [] })),
       fetch('/api/mcp/servers', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : []).catch(() => []),
+      fetch('/api/remote-control', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { providers: {} }).catch(() => ({ providers: {} })),
       fetch('/api/vault/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
     ]);
     const items = [];
@@ -3102,6 +3104,22 @@ async function initUnifiedIntegrations() {
     for (const srv of mcpList) {
       const statusText = srv.needs_oauth ? 'needs auth' : srv.status === 'connected' ? `${srv.enabled_tool_count}/${srv.tool_count} tools` : srv.status === 'error' ? 'error' : 'disconnected';
       items.push({ type: 'mcp', id: srv.id || srv.name, name: srv.name || 'MCP Server', detail: statusText, enabled: srv.is_enabled !== false, data: srv });
+    }
+    // Telegram remote control bot
+    const cfg = (remoteRes.providers || {}).telegram;
+    if (cfg && (cfg.configured || cfg.enabled)) {
+      const status = cfg.status || {};
+      const detailBits = [];
+      detailBits.push(status.running ? 'running' : cfg.enabled ? 'not running' : 'disabled');
+      if (status.last_error) detailBits.push('error');
+      items.push({
+        type: 'remote',
+        id: 'telegram',
+        name: 'Telegram Remote Control',
+        detail: detailBits.join(' - '),
+        enabled: cfg.enabled && !!cfg.configured && !status.last_error,
+        data: cfg,
+      });
     }
     // Vaultwarden removed as an integration option.
     return items;
@@ -3174,6 +3192,7 @@ async function initUnifiedIntegrations() {
           }
           else if (type === 'email') await fetch(`/api/email/accounts/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'mcp') await fetch(`/api/mcp/servers/${id}`, { method: 'DELETE', credentials: 'same-origin' });
+          else if (type === 'remote') await fetch(`/api/remote-control/${id}`, { method: 'PUT', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ reset: true }) });
           else if (type === 'vault') await fetch('/api/vault/logout', { method: 'POST', credentials: 'same-origin' });
         } catch (_) {}
         formEl.style.display = 'none';
@@ -3190,6 +3209,7 @@ async function initUnifiedIntegrations() {
     else if (type === 'contacts' || type === 'carddav') showCardDavForm();
     else if (type === 'email') showEmailForm(editId);
     else if (type === 'mcp') showMcpForm(editId);
+    else if (type === 'remote') showRemoteForm();
     else if (type === 'vault') showVaultForm();
   }
 
@@ -3983,6 +4003,134 @@ async function initUnifiedIntegrations() {
     });
   }
 
+  // ── Telegram remote control bot ──
+  async function showRemoteForm() {
+    let remote = { providers: {} };
+    try {
+      const r = await fetch('/api/remote-control', { credentials: 'same-origin' });
+      if (r.ok) remote = await r.json();
+    } catch (_) {}
+    const provider = 'telegram';
+    const cfg = (remote.providers || {}).telegram || {};
+    const status = cfg.status || {};
+    const hasSavedToken = !!cfg.configured || !!cfg.token_mask;
+    const enabledChecked = hasSavedToken ? !!cfg.enabled : true;
+    const tokenPlaceholder = cfg.configured ? `Saved token (${cfg.token_mask || 'configured'})` : 'Paste bot token';
+    const allowHint = 'Send /id to the bot, then add the Telegram chat ID here.';
+    const needsTelegramIds = !(cfg.allowed_chat_ids || []).length;
+    const setupGuide = `
+          <details class="remote-setup-details" ${needsTelegramIds ? 'open' : ''}>
+            <summary>Telegram setup guide</summary>
+            <ol>
+              <li>Create a bot with <code>@BotFather</code>, paste the bot token here, leave Enabled on, then Save.</li>
+              <li>In Telegram, message the bot with <code>/id</code>. If it replies "not allowed yet", that is expected.</li>
+              <li>Copy the <strong>Chat ID</strong> from the bot reply into Chat IDs above, then Save again.</li>
+              <li>After that, messages use the same routing as Odysseus chat: normal questions stay chat, calendar/notes/email actions can use tools. Use <code>/agent your request</code> to force an agent turn.</li>
+            </ol>
+            <div class="remote-setup-example">Example reply: Chat ID: 8666203886</div>
+          </details>`;
+    const statusBits = [];
+    statusBits.push(cfg.configured ? 'token saved' : 'no token');
+    statusBits.push(enabledChecked ? (cfg.enabled ? 'enabled' : 'enabled after save') : 'disabled');
+    statusBits.push(status.running ? 'running' : 'not running');
+    if (status.identity) statusBits.push(`bot ${status.identity}`);
+    if (status.last_error) statusBits.push(`error: ${status.last_error}`);
+    const statusText = statusBits.join(' - ');
+    const telegramRows = `
+          <div class="settings-row" style="align-items:flex-start"><label class="settings-label">Chat IDs</label><textarea id="uf-remote-telegram-chats" class="settings-input" rows="3" placeholder="-1001234567890" style="min-height:58px;resize:vertical">${esc((cfg.allowed_chat_ids || []).join('\n'))}</textarea></div>`;
+
+    formEl.innerHTML = `
+      <div class="admin-card" style="margin-top:8px">
+        <h2 style="font-size:13px">Telegram Remote Control</h2>
+        <div id="uf-remote-status" style="font-size:11px;opacity:0.7;margin-bottom:8px">${esc(statusText)}</div>
+        <div class="settings-col">
+          <div class="settings-row"><label class="settings-label">Enabled</label><label class="admin-switch" style="margin-left:0"><input type="checkbox" id="uf-remote-enabled" ${enabledChecked ? 'checked' : ''}><span class="admin-slider"></span></label></div>
+          <div class="settings-row"><label class="settings-label">Bot token</label><input id="uf-remote-token" class="settings-input" type="password" placeholder="${esc(tokenPlaceholder)}"></div>
+          <div class="settings-row"><label class="settings-label">Allow anyone</label><label class="admin-switch" style="margin-left:0"><input type="checkbox" id="uf-remote-allow-all" ${cfg.allow_all ? 'checked' : ''}><span class="admin-slider"></span></label><span style="font-size:10px;opacity:0.55;margin-left:6px">Off uses the Chat IDs below</span></div>
+          ${telegramRows}
+          <div style="font-size:10px;opacity:0.56;line-height:1.4;margin-left:106px">${esc(allowHint)}</div>
+          ${setupGuide}
+          <div class="settings-row" style="margin-top:4px;flex-wrap:wrap;gap:4px">
+            <button class="admin-btn-sm" id="uf-remote-save">Save</button>
+            <button class="admin-btn-sm" id="uf-remote-test" style="opacity:0.7">Test</button>
+            <button class="admin-btn-sm" id="uf-remote-reload" style="opacity:0.7">Reload</button>
+            <button class="admin-btn-sm" id="uf-remote-cancel" style="opacity:0.7">Cancel</button>
+            <span id="uf-remote-msg" style="font-size:11px;margin-left:4px"></span>
+          </div>
+        </div>
+      </div>`;
+
+    const msg = (text, color) => {
+      const m = el('uf-remote-msg');
+      if (!m) return;
+      m.textContent = text || '';
+      m.style.color = color || '';
+    };
+    const collect = () => {
+      const body = {
+        enabled: !!el('uf-remote-enabled')?.checked,
+        token: (el('uf-remote-token')?.value || '').trim(),
+        allow_all: !!el('uf-remote-allow-all')?.checked,
+        allowed_chat_ids: el('uf-remote-telegram-chats')?.value || '',
+      };
+      return body;
+    };
+
+    el('uf-remote-cancel')?.addEventListener('click', () => { formEl.style.display = 'none'; });
+    el('uf-remote-save')?.addEventListener('click', async () => {
+      msg('Saving...');
+      try {
+        const r = await fetch(`/api/remote-control/${provider}`, {
+          method: 'PUT', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(collect()),
+        });
+        const d = await r.json();
+        if (r.ok && d.providers) {
+          msg('Saved', 'var(--green,#50fa7b)');
+          await renderList();
+          await showRemoteForm();
+          notifyIntegrationsChanged();
+        } else {
+          msg(d.detail || d.error || 'Failed', 'var(--red)');
+        }
+      } catch (e) {
+        msg('Error: ' + e.message, 'var(--red)');
+      }
+    });
+    el('uf-remote-test')?.addEventListener('click', async () => {
+      msg('Testing...');
+      try {
+        const r = await fetch(`/api/remote-control/${provider}/test`, {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: (el('uf-remote-token')?.value || '').trim() }),
+        });
+        const d = await r.json();
+        if (d.ok) msg(`Connected as ${d.identity || 'bot'}`, 'var(--green,#50fa7b)');
+        else msg(d.error || 'Failed', 'var(--red)');
+      } catch (e) {
+        msg('Error: ' + e.message, 'var(--red)');
+      }
+    });
+    el('uf-remote-reload')?.addEventListener('click', async () => {
+      msg('Reloading...');
+      try {
+        const r = await fetch(`/api/remote-control/${provider}/reload`, { method: 'POST', credentials: 'same-origin' });
+        const d = await r.json();
+        if (r.ok && d.providers) {
+          msg('Reloaded', 'var(--green,#50fa7b)');
+          await renderList();
+          await showRemoteForm();
+        } else {
+          msg(d.detail || d.error || 'Failed', 'var(--red)');
+        }
+      } catch (e) {
+        msg('Error: ' + e.message, 'var(--red)');
+      }
+    });
+  }
+
   // ── Vaultwarden form ──
   async function showVaultForm() {
     formEl.innerHTML = `
@@ -4251,6 +4399,7 @@ async function initUnifiedIntegrations() {
                 <option value="carddav">Contacts (CardDAV)</option>
                 <option value="email">Email (IMAP/SMTP)</option>
                 <option value="mcp">MCP Tool Server</option>
+                <option value="remote">Telegram Remote Control</option>
               </select>
             </div>
           </div>

--- a/static/style.css
+++ b/static/style.css
@@ -21248,6 +21248,45 @@ input.settings-select::placeholder { color: color-mix(in srgb, var(--fg) 35%, tr
   outline: none;
   border-color: var(--red);
 }
+.remote-setup-details {
+  margin: 4px 0 2px 106px;
+  border: 1px solid color-mix(in srgb, var(--fg) 10%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+}
+.remote-setup-details[open] {
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+.remote-setup-details > summary {
+  padding: 6px 8px;
+  background: transparent;
+  border-bottom: 0;
+  color: color-mix(in srgb, var(--fg) 72%, transparent);
+  font-size: 11px;
+  font-weight: 500;
+}
+.remote-setup-details[open] > summary {
+  border-bottom: 1px solid color-mix(in srgb, var(--fg) 8%, transparent);
+}
+.remote-setup-details > ol {
+  margin: 0;
+  padding: 8px 10px 8px 26px;
+  font-size: 11px;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--fg) 68%, transparent);
+}
+.remote-setup-details > ol li {
+  margin: 0 0 5px;
+}
+.remote-setup-details code {
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 82%, transparent);
+}
+.remote-setup-example {
+  padding: 0 10px 8px 26px;
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+}
 /* ── Contacts manager (Settings → Integrations → CardDAV) ── */
 .contacts-add-row {
   display: flex;

--- a/tests/test_action_intents.py
+++ b/tests/test_action_intents.py
@@ -11,6 +11,13 @@ def test_calendar_imperative_variants_promote_to_agent():
     assert message_needs_tools("put dentist appointment on my calendar")
 
 
+def test_calendar_read_requests_promote_to_agent():
+    assert message_needs_tools("What calendar entries do I have?")
+    assert message_needs_tools("What calander entries do I have?")
+    assert message_needs_tools("What's on my calendar today?")
+    assert message_needs_tools("show my appointments for tomorrow")
+
+
 def test_note_todo_and_reminder_actions_promote_to_agent():
     assert message_needs_tools("add milk to my todo list")
     assert message_needs_tools("take a note that the server needs checking")

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -1,0 +1,152 @@
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from src.remote_control import RemoteControlManager
+
+
+class FakeAPIKeyManager:
+    def encrypt_api_key(self, value):
+        return f"enc:{value}"
+
+    def decrypt_api_key(self, value):
+        if not value.startswith("enc:"):
+            raise ValueError("not encrypted")
+        return value[4:]
+
+
+class FakeAuthManager:
+    users = {
+        "ken": {"is_admin": True},
+    }
+
+
+class FakeSession:
+    def __init__(self, session_id, endpoint_url="", model=""):
+        self.id = session_id
+        self.endpoint_url = endpoint_url
+        self.model = model
+        self.headers = {}
+
+
+class FakeSessionManager:
+    def __init__(self):
+        self.sessions = {}
+
+    def get_session(self, session_id):
+        return self.sessions[session_id]
+
+    def create_session(self, session_id, name, endpoint_url, model, rag=False, owner=None):
+        session = FakeSession(session_id, endpoint_url, model)
+        session.name = name
+        session.owner = owner
+        self.sessions[session_id] = session
+        return session
+
+
+class FakeTaskScheduler:
+    async def run_task_now(self, task_id):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_provider_update_encrypts_and_masks_token(tmp_path):
+    manager = RemoteControlManager(
+        session_manager=FakeSessionManager(),
+        task_scheduler=FakeTaskScheduler(),
+        auth_manager=FakeAuthManager(),
+        api_key_manager=FakeAPIKeyManager(),
+        data_file=str(tmp_path / "remote_control.json"),
+    )
+
+    data = await manager.update_provider(
+        "telegram",
+        {"token": "12345:secret", "allowed_chat_ids": "-1001\n-1002", "enabled": False},
+        actor="ken",
+    )
+
+    cfg = data["providers"]["telegram"]
+    assert cfg["configured"] is True
+    assert cfg["token_mask"] == "1234...cret"
+    assert cfg["allowed_chat_ids"] == ["-1001", "-1002"]
+    assert "mode" not in cfg
+    assert "owner" not in cfg
+    assert "sessions" not in cfg
+    assert manager._provider_cfg("telegram")["token"] == "enc:12345:secret"
+
+
+def test_allowlists_default_to_denied(tmp_path):
+    manager = RemoteControlManager(
+        session_manager=FakeSessionManager(),
+        task_scheduler=FakeTaskScheduler(),
+        auth_manager=FakeAuthManager(),
+        data_file=str(tmp_path / "remote_control.json"),
+    )
+
+    assert manager._telegram_authorized("-1001") is False
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_provider_config(tmp_path):
+    manager = RemoteControlManager(
+        session_manager=FakeSessionManager(),
+        task_scheduler=FakeTaskScheduler(),
+        auth_manager=FakeAuthManager(),
+        api_key_manager=FakeAPIKeyManager(),
+        data_file=str(tmp_path / "remote_control.json"),
+    )
+    await manager.update_provider("telegram", {
+        "token": "telegram-token",
+        "enabled": False,
+        "allow_all": True,
+        "allowed_chat_ids": "123",
+    })
+
+    data = await manager.update_provider("telegram", {"reset": True})
+
+    cfg = data["providers"]["telegram"]
+    assert cfg["configured"] is False
+    assert cfg["enabled"] is False
+    assert cfg["allow_all"] is False
+    assert cfg["allowed_chat_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_chat_stream_front_door(tmp_path):
+    app = FastAPI()
+    seen = {}
+
+    @app.post("/api/chat_stream")
+    async def chat_stream(request: Request):
+        form = await request.form()
+        seen["form"] = dict(form)
+        seen["owner"] = request.headers.get("X-Odysseus-Owner")
+
+        async def events():
+            yield 'data: {"delta":"Calendar "}\n\n'
+            yield 'data: {"delta":"works"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    manager = RemoteControlManager(
+        session_manager=FakeSessionManager(),
+        task_scheduler=FakeTaskScheduler(),
+        auth_manager=FakeAuthManager(),
+        app=app,
+        data_file=str(tmp_path / "remote_control.json"),
+    )
+    manager._resolve_chat_endpoint = lambda owner: ("http://model/chat/completions", "model", {})
+
+    reply = await manager._dispatch_to_chat_front_door(
+        "telegram:8666203886",
+        "8666203886",
+        "What calander entries do I have?",
+        "chat",
+    )
+
+    assert reply == "Calendar works"
+    assert seen["owner"] == "ken"
+    assert seen["form"]["message"] == "What calander entries do I have?"
+    assert seen["form"]["mode"] == "chat"
+    assert seen["form"]["remote_provider"] == "telegram"


### PR DESCRIPTION
## Summary

Adds a Telegram remote-control integration that lets allowlisted Telegram chats send messages into the normal Odysseus chat front door.

## What changed

- Added a Telegram-only remote-control manager with polling, allowlisted chat IDs, setup commands, task commands, and safe token masking.
- Added admin API routes for viewing, saving, testing, and reloading Telegram remote-control settings.
- Added Settings > Integrations UI for Telegram Remote Control, including a setup guide for finding the chat ID.
- Routes remote messages through `/api/chat_stream` so chat/agent/tool routing behaves like the in-app chat.
- Added calendar read/list intent patterns so remote messages like "What calendar entries do I have?" promote to tool-capable mode.
- Added focused backend and intent tests.

## Validation

- `venv\Scripts\python.exe -m py_compile src\remote_control.py routes\remote_control_routes.py app.py src\action_intents.py`
- `node --check static\js\settings.js`
- `venv\Scripts\python.exe -m pytest tests\test_remote_control.py tests\test_action_intents.py -q`
- Restarted local app on `http://127.0.0.1:7000` and verified Telegram Remote Control appears in Settings > Integrations.
- Manual Telegram test confirmed working.