### PR TITLE
Fix: Correct token cache invalidation logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,11 +145,9 @@ if AUTH_ENABLED:
     # in app.state, called by routes/api_token_routes.
     _token_cache: dict = {}
     _token_cache_lock = _asyncio.Lock()
-    _token_cache_dirty = True
 
     def _token_cache_invalidate():
-        nonlocal_dict = app.state.__dict__
-        nonlocal_dict["_token_cache_dirty"] = True
+        app.state._token_cache_dirty = True
     app.state.invalidate_token_cache = _token_cache_invalidate
     app.state._token_cache = _token_cache
     app.state._token_cache_dirty = True


### PR DESCRIPTION
Fixed a bug where `_token_cache_invalidate` was incorrectly attempting to update `app.state.__dict__` directly. In Starlette/FastAPI, `app.state` attributes should be set directly to ensure they land in the internal `_state` storage. This fix ensures the token cache dirty flag is correctly propagated to the middleware, preventing unnecessary database hits and bcrypt checks on every request.