### PR TITLE
Security: Harden owner_filter against anonymous bypass

### DIFF
--- a/src/auth_helpers.py
+++ b/src/auth_helpers.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 from fastapi import Request, HTTPException
+from sqlalchemy import false as _false
 
 
 def get_current_user(request: Request) -> Optional[str]:
@@ -60,8 +61,12 @@ def require_privilege(request: Request, key: str) -> str:
 
 def owner_filter(query, model_cls, user: str, *, include_shared: bool = True):
     """Filter `query` so only rows owned by `user` (and optionally null-owner
-    'shared' rows) come through. No-op when `user` is empty (single-user
-    mode). Returns the modified query."""
+    'shared' rows) come through. Returns an empty filter (false) for None
+    users to prevent anonymous data leaks in multi-tenant mode. No-op (returns
+    the query as-is) when `user` is empty string (single-user/bypass mode).
+    """
+    if user is None:
+        return query.filter(_false())
     if not user:
         return query
     if include_shared:


### PR DESCRIPTION
Refined the `owner_filter` helper to explicitly handle anonymous users (`user=None`). Previously, if the user was missing, it would return an unfiltered query, potentially leaking data in multi-tenant deployments. The filter now correctly returns a contradictory clause (`filter(False)`) when no user is provided, while still supporting single-user mode (empty string).