### PR TITLE
Test: Resolve test pollution and improve stability

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,19 @@ def _has_module(mod_name: str) -> bool:
 
 # Stub optional dependencies only when they are not installed. Do not replace
 # real FastAPI/Starlette/Pydantic modules: route tests import their subpackages.
+if "core.database" not in sys.modules:
+    try:
+        import core.database
+    except Exception:
+        # If the real module can't be imported (e.g. missing deps in a minimal
+        # test env), install a stub so later top-level stubs don't pollute
+        # the global namespace with a raw MagicMock.
+        _db_mod = types.ModuleType("core.database")
+        _db_mod.SessionLocal = MagicMock()
+        _db_mod.ModelEndpoint = MagicMock()
+        _db_mod.Session = MagicMock()
+        sys.modules["core.database"] = _db_mod
+
 for mod_name in [
     "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.types", "sqlalchemy.ext", "sqlalchemy.ext.declarative",
     "sqlalchemy.ext.hybrid", "sqlalchemy.sql", "sqlalchemy.sql.expression",

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -66,22 +66,6 @@ def _ensure_stub(name: str, **attrs):
         setattr(parent, child_name, mod)
     return mod
 
-_ensure_stub("core.database",
-    SessionLocal=MagicMock(), ScheduledTask=MagicMock(), TaskRun=MagicMock(),
-    ModelEndpoint=MagicMock(), Session=MagicMock(), ChatMessage=MagicMock(),
-    CalendarCal=MagicMock(), CalendarEvent=MagicMock(),
-    Document=MagicMock(), DocumentVersion=MagicMock(),
-    GalleryImage=MagicMock(), GalleryAlbum=MagicMock(), Note=MagicMock(),
-    McpServer=MagicMock(),
-)
-_ensure_stub("core.auth", AuthManager=MagicMock())
-_ensure_stub("src.endpoint_resolver",
-    resolve_endpoint=MagicMock(return_value=("", "", {})),
-    normalize_base=MagicMock(),
-    build_chat_url=MagicMock(),
-    build_headers=MagicMock(),
-)
-
 from fastapi import HTTPException
 
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -13,17 +13,6 @@ if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__"
     sys.modules.pop("src.endpoint_resolver", None)
     sys.modules.pop("routes.model_routes", None)
 
-if "core.database" not in sys.modules:
-    _core_db = types.ModuleType("core.database")
-    for _name in [
-        "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
-        "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
-        "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun",
-        "McpServer",
-    ]:
-        setattr(_core_db, _name, MagicMock())
-    sys.modules["core.database"] = _core_db
-
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 from routes.model_routes import (

--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -18,37 +18,6 @@ import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-# `tests/conftest.py` stubs the heavy optional deps. We additionally
-# stub `core.database` here because the real module instantiates
-# SQLAlchemy declarative classes at import-time — which blows up under
-# the conftest's `sqlalchemy.*` MagicMock stubs ("metaclass conflict").
-# Stub also a handful of route modules each of these targeted modules
-# happens to drag in at import-time.
-for _stub in [
-    "core.database",
-    "core.auth",
-    "src.endpoint_resolver",
-]:
-    if _stub not in sys.modules:
-        m = types.ModuleType(_stub)
-        # Provide the names the importers will look up.
-        if _stub == "core.database":
-            m.SessionLocal = MagicMock()
-            m.CalendarCal = MagicMock()
-            m.CalendarEvent = MagicMock()
-            m.Document = MagicMock()
-            m.DocumentVersion = MagicMock()
-            m.Session = MagicMock()
-            m.GalleryImage = MagicMock()
-            m.GalleryAlbum = MagicMock()
-            m.Note = MagicMock()
-            m.ScheduledTask = MagicMock()
-            m.TaskRun = MagicMock()
-            m.ModelEndpoint = MagicMock()
-        elif _stub == "core.auth":
-            m.AuthManager = MagicMock()
-        sys.modules[_stub] = m
-
 from fastapi import HTTPException
 
 

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -68,6 +68,7 @@ def _install_model_route_import_stubs(monkeypatch):
     db_mod = types.ModuleType("core.database")
     db_mod.SessionLocal = lambda: _FakeDb([])
     db_mod.ModelEndpoint = _FakeModelEndpoint
+    db_mod.Session = MagicMock()
     middleware_mod = types.ModuleType("core.middleware")
     middleware_mod.require_admin = lambda request: None
     multipart_mod = types.ModuleType("python_multipart")


### PR DESCRIPTION
Improved test suite stability by resolving cross-test pollution in `sys.modules`.
- Refactored `conftest.py` to ensure `core.database` is loaded before any top-level mocking occurs.
- Removed global `sys.modules` stubbing from individual test files to prevent side effects on subsequent tests.
- Fixed a broken stub in `test_review_regressions.py` that was causing `ImportError` due to the missing `Session` model.
These changes ensure that the test suite can be run reliably in parallel or in any order.