### PR TITLE
Fix duplicate compare modal on repeated clicks

### DIFF
--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -92,7 +92,9 @@ async function toggleMode() {
     deactivate(true);
     return false;
   }
+  if (state._openingSelector) return false;
 
+  state._openingSelector = true;
   try {
     const confirmed = await showModelSelector();
     if (!confirmed) return false;
@@ -104,6 +106,8 @@ async function toggleMode() {
   } catch (err) {
     console.error('Compare toggleMode error:', err);
     return false;
+  } finally {
+    state._openingSelector = false;
   }
 }
 

--- a/static/js/compare/state.js
+++ b/static/js/compare/state.js
@@ -2,6 +2,7 @@
 const state = {
   API_BASE: '',
   isActive: false,
+  _openingSelector: false,        // prevents duplicate compare modals on rapid re-clicks
   _streaming: false,
   _blindMode: true,
   _saveOnClose: false,
@@ -36,6 +37,7 @@ const state = {
 
 /** Reset transient state to defaults — useful for clean restarts. */
 export function reset() {
+  state._openingSelector = false;
   state._streaming = false;
   state._finishOrder = 0;
   state._paneElapsed = [];

--- a/tests/test_compare_js.py
+++ b/tests/test_compare_js.py
@@ -59,6 +59,7 @@ def test_state_reset_preserves_config(node_available):
         state.API_BASE = 'http://x';
         state._blindMode = true;
         state._parallel = false;
+        state._openingSelector = true;
         state._streaming = true;
         state._finishOrder = 7;
         state._paneSessionIds = ['a','b'];
@@ -71,6 +72,7 @@ def test_state_reset_preserves_config(node_available):
           api_base_sticky: state.API_BASE,
           blind_sticky: state._blindMode,
           parallel_sticky: state._parallel,
+          opening_cleared: state._openingSelector,
           streaming_cleared: state._streaming,
           finish_order_cleared: state._finishOrder,
           session_ids_cleared: state._paneSessionIds.length,
@@ -85,6 +87,7 @@ def test_state_reset_preserves_config(node_available):
         "api_base_sticky": "http://x",
         "blind_sticky": True,
         "parallel_sticky": False,
+        "opening_cleared": False,
         "streaming_cleared": False,
         "finish_order_cleared": 0,
         "session_ids_cleared": 0,


### PR DESCRIPTION
**Summary**

Prevent the Compare tool from opening multiple selector windows when the button is clicked repeatedly while the modal is still opening. This adds a small transient guard around compare startup, keeps the fix isolated to the compare flow, and adds coverage for the opening-state reset in the existing compare JS regression test.

**Manual testing**

- Opened the fork locally on 127.0.0.1:7001

- Clicked Compare repeatedly in quick succession

- Verified only one compare selector window opens

**Checks run**

- node --check static/js/compare/index.js

- node --check static/js/compare/state.js

- python -m pytest tests/test_compare_js.py