### PR TITLE
fix: intrusive scroll-snap UX on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,9 +25,17 @@
     --radius: 8px;
   }
   * { box-sizing: border-box; }
-  html { scroll-behavior: smooth; scroll-snap-type: y mandatory; scroll-padding-top: 60px; }
-  /* Each section is a full-viewport "page" with its content centered, so only
-     one shows at a time and the snap is obvious. */
+  html { scroll-behavior: smooth; scroll-padding-top: 60px; }
+  /* REMOVED: "scroll-snap-type: y mandatory"
+     The idea was: >>Each section is a full-viewport "page" with its content centered,
+     so only one shows at a time and the snap is obvious.<<
+
+     PROBLEM: sections easily grow taller than 100vh IRL
+     This cause forced jumps mid-read. It's intrusive UX.
+
+     Preserved: CSS snap-points to avoid destroying code meta-data
+     Less intrusive version: "scroll-snap-type: y proximity"
+     For now: fully removed (bad UX)*/
   .hero, section {
     scroll-snap-align: start; min-height: 100vh;
     display: flex; flex-direction: column; justify-content: center;

--- a/static/landing.html
+++ b/static/landing.html
@@ -25,9 +25,17 @@
     --radius: 8px;
   }
   * { box-sizing: border-box; }
-  html { scroll-behavior: smooth; scroll-snap-type: y mandatory; scroll-padding-top: 60px; }
-  /* Each section is a full-viewport "page" with its content centered, so only
-     one shows at a time and the snap is obvious. */
+  html { scroll-behavior: smooth; scroll-padding-top: 60px; }
+  /* REMOVED: "scroll-snap-type: y mandatory"
+     The idea was: >>Each section is a full-viewport "page" with its content centered,
+     so only one shows at a time and the snap is obvious.<<
+
+     PROBLEM: sections easily grow taller than 100vh IRL
+     This cause forced jumps mid-read. It's intrusive UX.
+
+     Preserved: CSS snap-points to avoid destroying code meta-data
+     Less intrusive version: "scroll-snap-type: y proximity"
+     For now: fully removed (bad UX)*/
   .hero, section {
     scroll-snap-align: start; min-height: 100vh;
     display: flex; flex-direction: column; justify-content: center;


### PR DESCRIPTION
## Disables the scroll-snap in the most very minimal way
*Preserves existing code meta-data and comments.*

**Try scrolling the landing page from any standard Macbook screen.**
The scroll-snap forced me out of every section I was trying to read more about (by scrolling)

I found this comment in the code:
> Each section is a full-viewport "page" with its content centered, so only one shows at a time and the snap is obvious.

This likely helped the coding agent style the landing page with centering content (great!) --> but it's actually not correct. This website is **not** a powerpoint presentation (neither should it try to be) and each section easily outgrow 100vh on many real-life screens. Centering content inside each section is a great design decision that should not enforce how users scroll and explore the content.

In fact I'd reckon you'd need a very very very taaaaaall monitor to experience the landing page sections as "full-viewport height pages" - let's just call this comment a LLM hallucination 😆

### "Scroll Jacking" UX discussions:
- [Medium: "How Scrolljacking Breaks UX Fundamentals"](https://medium.com/@WebdesignerDepot/how-scrolljacking-breaks-ux-fundamentals-3534ccbc261e)
- [nngroup: "Scrolljacking 101" (Conclusion: "usually bad")](https://www.nngroup.com/articles/scrolljacking-101/)
- [Reddit: "Scroll snapping on a landing page - worth keeping?" (Comments: "NO!!!")](https://www.reddit.com/r/webdev/comments/1mqvxyl/scroll_snapping_on_a_landing_page_worth_keeping/)