### PR TITLE
fix: restore scrolling in brain memory review list

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -10503,6 +10503,11 @@ textarea.memory-add-input {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
 }
 
 .memory-suggestions.hidden {


### PR DESCRIPTION
## Summary
- restore scrolling in the Brain memory review/suggestions panel
- constrain the suggestions container so long review lists scroll inside the modal
- keep the fix localized to CSS with no JS changes

## Root cause
`.memory-suggestions` did not have its own bounded flex sizing or vertical overflow, so long imported/suggested memory review lists expanded beyond the modal body and were clipped by the parent panel.

## Testing
- Reproduced locally with a long injected memory review list in the browser
- Verified `.memory-suggestions` reports `overflow-y: auto` and becomes scrollable when content exceeds available height
- Ran `python -m py_compile app.py routes/*.py src/*.py`

## Changed files
- `static/style.css`

Closes #455
