### PR TITLE
fix: add _setup_lock to prevent race condition in first-run setup

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -60,6 +60,9 @@ class AuthManager:
         # Guards mutations of self._sessions and the on-disk sessions.json.
         # Validate/create/revoke run concurrently from the FastAPI threadpool.
         self._sessions_lock = threading.RLock()
+        # Guards the first-run setup check-and-write so concurrent requests
+        # cannot both observe is_configured==False and both create admin accounts.
+        self._setup_lock = threading.Lock()
         self._load()
         self._load_sessions()
         self._migrate_single_user()
@@ -157,9 +160,10 @@ class AuthManager:
 
     def setup(self, username: str, password: str) -> bool:
         """First-run admin setup. Only works if no users exist."""
-        if self.is_configured:
-            return False
-        return self.create_user(username, password, is_admin=True)
+        with self._setup_lock:
+            if self.is_configured:
+                return False
+            return self.create_user(username, password, is_admin=True)
 
     def create_user(self, username: str, password: str, is_admin: bool = False) -> bool:
         """Create a new user account."""


### PR DESCRIPTION
## What
The `setup()` method in `core/auth.py` has no locking around the 
check-then-create sequence. Two concurrent requests can both observe 
`is_configured == False`, both pass the guard, and both call 
`create_user(..., is_admin=True)` — potentially creating a hidden 
second admin account or silently overwriting the legitimate one.

## Fix
Added `_setup_lock = threading.Lock()` in `__init__`, immediately 
after the existing `_sessions_lock` (which already uses this pattern 
correctly). Wrapped the full check-and-write in `setup()` as a single 
atomic unit.

## Risk level
Low for typical localhost deployments. Higher for any network-accessible 
instance where an attacker can race the setup endpoint before the first 
admin account exists.

## Testing
Normal first-run setup flow completes successfully with the patch applied.
Verified fix by code inspection — lock acquired before check, no path 
escapes the lock scope before write completes.

## Checks run
- `python -m py_compile core/auth.py` — passes clean
- Normal first-run setup flow tested manually on Windows native install
- Fix verified by Claude Code static analysis: lock acquired before 
  check, no path escapes lock scope before write completes
- Note: running on Windows native (not Docker), per CONTRIBUTING.md 
  caveat that Windows is not actively tested