### PR TITLE
[Docker / ROCm setup] Allow to customize the render GID to match the one on the host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,8 +136,9 @@ SEARXNG_INSTANCE=http://localhost:8080
 # configure --runtime=docker` on the host):
 # COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.yml
 #
-# AMD ROCm (requires ROCm drivers on the host):
+# AMD ROCm (requires ROCm drivers on the host and the GID of the render group):
 # COMPOSE_FILE=docker-compose.yml:docker/gpu.amd.yml
+# RENDER_GID=992
 #
 # These overlays only expose the GPU devices. The slim Odysseus image
 # still needs CUDA/ROCm userspace via Cookbook -> Dependencies (vLLM,

--- a/docker/gpu.amd.yml
+++ b/docker/gpu.amd.yml
@@ -15,4 +15,4 @@ services:
       - /dev/dri
     group_add:
       - video
-      - render
+      - ${RENDER_GID:-render}


### PR DESCRIPTION
# Description
This PR addresses an issue encountered when running the gpu.amd.yml Docker Compose overlay on systems where the render group name is not resolved within the container or has a non-standard GID.

This issue exists as well here #503

# Problem
When attempting to run `docker compose up --build -d`, the startup failed with the following error:
```
Unable to find group render: no matching entries in group file.
```

This happens because the render group is not present inside the container's /etc/group file, or the host's system configuration cannot be natively mapped to the container's environment.

# Solution

- Updated docker/gpu.amd.yml to allow the render group to be specified via an environment variable (RENDER_GID).
- Added a fallback to the literal string render if the variable is not set, maintaining backward compatibility.
- Updated .env.example to include the RENDER_GID configuration, allowing users to easily match the host's render group ID (e.g., 992).

# How to test

- Identify the GID of the render group on your host: `getent group render | cut -d: -f3`
- Update your .env file with the corresponding ID: RENDER_GID=992

Run your compose command as usual: `docker compose up --build -d`