### PR TITLE
Add OpenAI-Codex via OAuth (sub) provider + Codex Responses transport

### DIFF
--- a/app.py
+++ b/app.py
@@ -588,6 +588,10 @@ app.include_router(setup_embedding_routes())
 from routes.model_routes import setup_model_routes
 app.include_router(setup_model_routes(model_discovery))
 
+# OpenAI-Codex (ChatGPT-subscription) OAuth — owner-scoped connect/status/disconnect
+from routes.codex_oauth_routes import setup_codex_oauth_routes
+app.include_router(setup_codex_oauth_routes())
+
 # TTS
 from routes.tts_routes import setup_tts_routes
 app.include_router(setup_tts_routes(tts_service))

--- a/core/database.py
+++ b/core/database.py
@@ -367,6 +367,76 @@ class ModelEndpoint(TimestampMixin, Base):
     # the endpoint to that user (admins always see everything).
     owner = Column(String, nullable=True, index=True)
 
+
+class EndpointOAuthToken(TimestampMixin, Base):
+    """OAuth credentials for a ChatGPT-subscription (codex) model endpoint.
+
+    One row per OAuth `ModelEndpoint` (1:1 via the unique `endpoint_id`). The
+    access + refresh tokens are Fernet-encrypted at rest (EncryptedText) — they
+    are bearer credentials to the user's ChatGPT subscription and must never sit
+    plaintext in the DB file, nor be logged. `account_id` (the JWT
+    `chatgpt_account_id` claim) is an identifier, not a secret, but is likewise
+    never logged. Refresh is single-flighted in `auth.resolve` keyed on
+    `endpoint_id`; `expires_at` drives refresh-on-expiry (120s skew).
+    """
+    __tablename__ = "endpoint_oauth_tokens"
+
+    id = Column(String, primary_key=True, index=True)
+    # 1:1 with the owning endpoint. CASCADE: deleting the endpoint drops its tokens.
+    endpoint_id = Column(String, ForeignKey("model_endpoints.id", ondelete="CASCADE"),
+                         nullable=False, unique=True, index=True)
+    # Owner-scoped: OAuth endpoints belong to the connecting user (NULL only for a
+    # deliberately-shared admin endpoint, which is not the default).
+    owner = Column(String, nullable=True, index=True)
+    provider_id = Column(String, nullable=False, default="openai-codex")
+    access_token = Column(EncryptedText, nullable=True)    # Bearer, encrypted at rest
+    refresh_token = Column(EncryptedText, nullable=True)   # rotated on refresh, encrypted at rest
+    account_id = Column(String, nullable=True)             # chatgpt_account_id (never logged)
+    expires_at = Column(DateTime, nullable=True)           # access-token expiry (UTC)
+    last_refresh_at = Column(DateTime, nullable=True)
+    # active | needs_relogin | quota | error  — surfaced to status endpoints (no token values)
+    status = Column(String, nullable=False, default="active")
+    last_error_redacted = Column(Text, nullable=True)      # redacted; never contains token material
+
+    # Many-to-one so the unit of work flushes the endpoint INSERT before the
+    # token's — SQLite enforces the FK at insert time (PRAGMA foreign_keys=ON).
+    endpoint = relationship("ModelEndpoint", foreign_keys=[endpoint_id])
+
+
+class CodexLoginAttempt(TimestampMixin, Base):
+    """In-flight device-code login attempt for a codex OAuth endpoint.
+
+    Created (PENDING) when a user starts `connect`; a background task polls
+    auth.openai.com until authorized/expired. `device_auth_id` (the device_code
+    poll secret) is Fernet-encrypted; `user_code` / `verification_uri` are
+    user-facing display values (not secret). The PKCE verifier is never stored —
+    the device-auth service returns it in the poll response and it is forwarded
+    to the token exchange in the same iteration. Status endpoints expose state
+    only — never the encrypted field.
+    """
+    __tablename__ = "codex_login_attempts"
+
+    id = Column(String, primary_key=True, index=True)
+    owner = Column(String, nullable=True, index=True)
+    # The PENDING endpoint this attempt will activate once authorized. SET NULL
+    # (not CASCADE): an attempt is a log row, so cleaning up a failed pending
+    # endpoint must not erase the attempt's terminal status before the UI reads it.
+    endpoint_id = Column(String, ForeignKey("model_endpoints.id", ondelete="SET NULL"),
+                         nullable=True, index=True)
+    device_auth_id = Column(EncryptedText, nullable=True)  # device_code poll secret, encrypted
+    user_code = Column(String, nullable=True)              # user-facing display code
+    verification_uri = Column(String, nullable=True)       # user-facing verification URL
+    # pending | authorized | expired | error | cancelled
+    status = Column(String, nullable=False, default="pending")
+    expires_at = Column(DateTime, nullable=True)
+    interval = Column(Integer, nullable=False, default=5)  # poll interval (seconds)
+    last_error_redacted = Column(Text, nullable=True)
+
+    # Many-to-one so the unit of work flushes the endpoint INSERT before the
+    # attempt's (connect creates both in one commit) under enforced FKs.
+    endpoint = relationship("ModelEndpoint", foreign_keys=[endpoint_id])
+
+
 class McpServer(TimestampMixin, Base):
     """Admin-configured MCP (Model Context Protocol) tool servers."""
     __tablename__ = "mcp_servers"

--- a/core/database.py
+++ b/core/database.py
@@ -92,6 +92,12 @@ class Session(TimestampMixin, Base):
     # Session metadata
     name = Column(String, nullable=False)
     endpoint_url = Column(String, nullable=False)
+    # Identity of the ModelEndpoint this session is bound to. Carried so OAuth
+    # (codex) endpoints can resolve + refresh their token per request — static
+    # API-key endpoints bake the key into `headers`, but an OAuth endpoint has no
+    # static key, so without the id its identity is lost. NULL = legacy row /
+    # endpoint not recorded (resolution falls back to URL+owner lookup).
+    endpoint_id = Column(String, nullable=True)
     model = Column(String, nullable=False)
     owner = Column(String, nullable=True, index=True)  # username; null = legacy/shared
     
@@ -975,6 +981,29 @@ def _migrate_add_folder_column():
     except Exception as e:
         logging.getLogger(__name__).warning(f"Migration check for folder failed: {e}")
 
+def _migrate_add_endpoint_id_column():
+    """Add endpoint_id column to sessions table if it doesn't exist.
+
+    Carries the bound endpoint's identity so OAuth (codex) sessions can resolve +
+    refresh their token per request. Existing rows get NULL (resolution falls back
+    to URL+owner lookup), so the migration is behavior-preserving for them.
+    """
+    import sqlite3
+    db_path = DATABASE_URL.replace("sqlite:///", "")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute("PRAGMA table_info(sessions)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if "endpoint_id" not in columns:
+            conn.execute("ALTER TABLE sessions ADD COLUMN endpoint_id TEXT")
+            conn.commit()
+            logging.getLogger(__name__).info("Migrated: added 'endpoint_id' column to sessions")
+        conn.close()
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"Migration check for endpoint_id failed: {e}")
+
 def _migrate_add_token_columns():
     """Add cumulative token tracking columns to sessions table."""
     import sqlite3
@@ -1578,6 +1607,7 @@ def init_db():
     _migrate_add_document_archived_column()
     _migrate_add_last_message_at_column()
     _migrate_add_folder_column()
+    _migrate_add_endpoint_id_column()
     _migrate_add_token_columns()
     _migrate_add_mode_column()
     _migrate_add_multiuser_owner_columns()

--- a/core/models.py
+++ b/core/models.py
@@ -50,6 +50,7 @@ class Session:
     rag: bool = False
     archived: bool = False
     headers: Optional[Dict[str, str]] = None
+    endpoint_id: Optional[str] = None
     history: List[ChatMessage] = None
     owner: Optional[str] = None
     is_important: bool = False

--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -117,6 +117,7 @@ class SessionManager:
             history=[],
             owner=getattr(db_session, "owner", None),
             is_important=getattr(db_session, "is_important", False) or False,
+            endpoint_id=getattr(db_session, "endpoint_id", None),
         )
         session.message_count = getattr(db_session, "message_count", 0) or 0
         return session
@@ -175,6 +176,7 @@ class SessionManager:
             history=history,
             owner=getattr(db_session, 'owner', None),
             is_important=getattr(db_session, 'is_important', False) or False,
+            endpoint_id=getattr(db_session, 'endpoint_id', None),
         )
 
         session.message_count = getattr(db_session, 'message_count', len(history))
@@ -385,6 +387,7 @@ class SessionManager:
                     headers = {}
             session.name = db_session.name
             session.endpoint_url = db_session.endpoint_url or ""
+            session.endpoint_id = getattr(db_session, "endpoint_id", None)
             session.model = db_session.model or ""
             session.headers = headers or {}
             session.rag = db_session.rag
@@ -447,7 +450,8 @@ class SessionManager:
         endpoint_url: str,
         model: str,
         rag: bool = False,
-        owner: str = None
+        owner: str = None,
+        endpoint_id: str = None
     ) -> Session:
         """Create a new session and save to database."""
         db = SessionLocal()
@@ -456,6 +460,7 @@ class SessionManager:
                 id=session_id,
                 name=name,
                 endpoint_url=endpoint_url,
+                endpoint_id=endpoint_id,
                 model=model,
                 rag=rag,
                 headers={},
@@ -470,6 +475,7 @@ class SessionManager:
                 id=session_id,
                 name=name,
                 endpoint_url=endpoint_url,
+                endpoint_id=endpoint_id,
                 model=model,
                 rag=rag,
                 headers={},

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -18,7 +18,7 @@ from src.agent_loop import stream_agent_loop
 from src import agent_runs
 from src.model_context import estimate_tokens
 from src.chat_helpers import coerce_message_and_session
-from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url
+from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url, resolve_session_ref
 from src.prompt_security import untrusted_context_message
 from core.exceptions import SessionNotFoundError
 from src.auth_helpers import get_current_user
@@ -320,6 +320,7 @@ def setup_chat_routes(
             temperature=ctx.preset.temperature,
             max_tokens=ctx.preset.max_tokens,
             prompt_type=preset_id,
+            ref=resolve_session_ref(sess),
         )
         _clean_reply, _clean_md = clean_thinking_for_save(reply, {"model": sess.model})
         sess.add_message(ChatMessage("assistant", _clean_reply, metadata=_clean_md))
@@ -833,7 +834,7 @@ def setup_chat_routes(
                 _answered_by = None  # set if the selected model failed and a fallback answered
                 # ── Chat mode: call stream_llm directly, NO tools, NO document access ──
                 try:
-                    _chat_candidates = [(sess.endpoint_url, sess.model, sess.headers)] + _fallback_candidates
+                    _chat_candidates = [(sess.endpoint_url, sess.model, sess.headers, resolve_session_ref(sess))] + _fallback_candidates
                     async for chunk in stream_llm_with_fallback(
                         _chat_candidates,
                         messages,
@@ -963,6 +964,7 @@ def setup_chat_routes(
                         disabled_tools=disabled_tools if disabled_tools else None,
                         owner=_user,
                         fallbacks=_fallback_candidates,
+                        ref=resolve_session_ref(sess),
                     ):
                         if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
                             try:
@@ -1228,6 +1230,7 @@ def setup_chat_routes(
                     # on "Rewriting...". Same fix as the chat max_tokens cap.
                     max_tokens=0,
                     tools=None,
+                    ref=resolve_session_ref(sess),
                 ):
                     if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
                         try:

--- a/routes/codex_oauth_routes.py
+++ b/routes/codex_oauth_routes.py
@@ -164,7 +164,7 @@ async def _run_login_poll(attempt_id: str) -> None:
         return
     deadline = data.expires_at or (_utcnow_naive() + timedelta(seconds=cx.DEFAULT_DEVICE_CODE_TTL_SECONDS))
 
-    async with httpx.AsyncClient(timeout=cx._HTTP_TIMEOUT) as client:
+    async with cx._new_async_client() as client:
         while _utcnow_naive() < deadline:
             if _attempt_status(attempt_id) != "pending":
                 return  # cancelled or already resolved

--- a/routes/codex_oauth_routes.py
+++ b/routes/codex_oauth_routes.py
@@ -1,0 +1,353 @@
+"""Routes for connecting a ChatGPT-subscription (codex) endpoint via OAuth.
+
+Owner-scoped, self-service: any authenticated user connects *their own* ChatGPT
+subscription (no admin required). The device-code flow runs server-side because
+Odysseus is a remote host — a `localhost` callback can't land in the user's
+browser (see `src/providers/auth/codex_oauth.py`).
+
+Responses expose connection STATE only — never `access_token`, `refresh_token`,
+`device_auth_id`, `account_id`, or full callback URLs. The user-facing
+`user_code` + `verification_uri` are the only login values returned (by design).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+
+from core.database import CodexLoginAttempt, EndpointOAuthToken, ModelEndpoint, SessionLocal
+from src.auth_helpers import require_user
+from src.providers.auth import codex_oauth as cx
+from src.providers.auth.oauth_store import persist_tokens
+# Curated model list (the codex backend has no chat-compatible /models probe);
+# owned by the provider spec, applied to the endpoint on connect.
+from src.providers.spec import CODEX_MODELS
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_ID = "openai-codex"
+DEFAULT_ENDPOINT_NAME = "ChatGPT (Codex)"
+
+# Keep strong refs to in-flight poll tasks so they aren't GC'd mid-flight.
+_BG_TASKS: set[asyncio.Task] = set()
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _owner(request: Request) -> Optional[str]:
+    """Current user as the owner value (None in single-user/first-run mode)."""
+    return require_user(request) or None
+
+
+# ---------------------------------------------------------------------------
+# DB helpers (sync, short-lived sessions)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _AttemptFields:
+    attempt_id: str
+    endpoint_id: Optional[str]
+    owner: Optional[str]
+    device_auth_id: str
+    user_code: str
+    interval: int
+    expires_at: Optional[datetime]
+
+
+def _load_attempt_fields(attempt_id: str) -> Optional[_AttemptFields]:
+    db = SessionLocal()
+    try:
+        row = db.get(CodexLoginAttempt, attempt_id)
+        if row is None:
+            return None
+        return _AttemptFields(
+            attempt_id=row.id, endpoint_id=row.endpoint_id, owner=row.owner,
+            device_auth_id=row.device_auth_id or "", user_code=row.user_code or "",
+            interval=row.interval or cx.DEFAULT_POLL_INTERVAL_SECONDS,
+            expires_at=row.expires_at,
+        )
+    finally:
+        db.close()
+
+
+def _attempt_status(attempt_id: str) -> Optional[str]:
+    db = SessionLocal()
+    try:
+        row = db.get(CodexLoginAttempt, attempt_id)
+        return row.status if row else None
+    finally:
+        db.close()
+
+
+def _mark_attempt(attempt_id: str, status: str, err: Optional[cx.CodexAuthError] = None) -> None:
+    db = SessionLocal()
+    try:
+        row = db.get(CodexLoginAttempt, attempt_id)
+        if row is None:
+            return
+        row.status = status
+        if err is not None:
+            row.last_error_redacted = str(err)[:500]  # redacted by construction
+        db.commit()
+    finally:
+        db.close()
+
+
+def _purge_endpoint_rows(db, endpoint_id: str) -> None:
+    """Delete an endpoint's token row and detach its attempt log rows explicitly.
+    The schema's ON DELETE CASCADE / SET NULL also fire now that the engine
+    enables SQLite FK enforcement, but the explicit purge keeps deletion behavior
+    independent of connection-level PRAGMA state. Caller commits."""
+    db.query(EndpointOAuthToken).filter(
+        EndpointOAuthToken.endpoint_id == endpoint_id
+    ).delete(synchronize_session=False)
+    db.query(CodexLoginAttempt).filter(
+        CodexLoginAttempt.endpoint_id == endpoint_id
+    ).update({"endpoint_id": None}, synchronize_session=False)
+
+
+def _delete_pending_endpoint(endpoint_id: Optional[str]) -> None:
+    """Drop a still-disabled endpoint (and its token row) after a failed or
+    cancelled login. Enabled endpoints are left alone."""
+    if not endpoint_id:
+        return
+    db = SessionLocal()
+    try:
+        ep = db.get(ModelEndpoint, endpoint_id)
+        if ep is not None and not ep.is_enabled:
+            _purge_endpoint_rows(db, endpoint_id)
+            db.delete(ep)
+            db.commit()
+    finally:
+        db.close()
+
+
+def _enable_endpoint(endpoint_id: str) -> None:
+    db = SessionLocal()
+    try:
+        ep = db.get(ModelEndpoint, endpoint_id)
+        if ep is None:
+            return
+        ep.is_enabled = True
+        ep.cached_models = json.dumps(CODEX_MODELS)
+        ep.model_type = "llm"
+        db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Background device-code poll loop
+# ---------------------------------------------------------------------------
+
+def _spawn(coro) -> None:
+    task = asyncio.create_task(coro)
+    _BG_TASKS.add(task)
+    task.add_done_callback(_BG_TASKS.discard)
+
+
+async def _run_login_poll(attempt_id: str) -> None:
+    """Poll the deviceauth token endpoint until the user signs in, expiry, or
+    cancellation. On success: exchange + persist + enable. Owns its own DB
+    sessions and HTTP client (the request that started it is long gone)."""
+    data = _load_attempt_fields(attempt_id)
+    if data is None or not data.device_auth_id:
+        return
+    deadline = data.expires_at or (_utcnow_naive() + timedelta(seconds=cx.DEFAULT_DEVICE_CODE_TTL_SECONDS))
+
+    async with httpx.AsyncClient(timeout=cx._HTTP_TIMEOUT) as client:
+        while _utcnow_naive() < deadline:
+            if _attempt_status(attempt_id) != "pending":
+                return  # cancelled or already resolved
+            try:
+                result = await cx.poll_device_token(data.device_auth_id, data.user_code, client=client)
+            except cx.CodexAuthError as err:
+                logger.warning("codex login poll failed (attempt=%s, code=%s)", attempt_id, err.code)
+                _mark_attempt(attempt_id, "error", err)
+                _delete_pending_endpoint(data.endpoint_id)
+                return
+            if result is not None:
+                await _finalize_login(data, result, client)
+                return
+            await asyncio.sleep(data.interval)
+
+    _mark_attempt(attempt_id, "expired")
+    _delete_pending_endpoint(data.endpoint_id)
+
+
+async def _finalize_login(data: _AttemptFields, result: cx.DeviceAuthResult,
+                          client: httpx.AsyncClient) -> None:
+    try:
+        token_set = await cx.exchange_device_code(
+            result.authorization_code, result.code_verifier, client=client)
+    except cx.CodexAuthError as err:
+        logger.warning("codex token exchange failed (attempt=%s, code=%s)", data.attempt_id, err.code)
+        _mark_attempt(data.attempt_id, "error", err)
+        _delete_pending_endpoint(data.endpoint_id)
+        return
+    if data.endpoint_id:
+        persist_tokens(data.endpoint_id, token_set, owner=data.owner,
+                       provider_id=PROVIDER_ID, create_if_missing=True)
+        _enable_endpoint(data.endpoint_id)
+    _mark_attempt(data.attempt_id, "authorized")
+    logger.info("codex login authorized (attempt=%s)", data.attempt_id)
+
+
+# ---------------------------------------------------------------------------
+# Public serializers (state only)
+# ---------------------------------------------------------------------------
+
+def _attempt_public(row: CodexLoginAttempt, *, expire_if_stale: bool = False) -> dict:
+    status = row.status
+    if status == "pending" and row.expires_at is not None and _utcnow_naive() >= row.expires_at:
+        status = "expired"
+        if expire_if_stale:
+            _mark_attempt(row.id, "expired")
+            _delete_pending_endpoint(row.endpoint_id)
+    return {
+        "attempt_id": row.id,
+        "status": status,
+        "endpoint_id": row.endpoint_id,
+        "user_code": row.user_code,
+        "verification_uri": row.verification_uri,
+        "expires_at": row.expires_at.isoformat() + "Z" if row.expires_at else None,
+    }
+
+
+def _require_owned(row, owner: Optional[str]):
+    # 404 (not 403) so we don't leak existence of another user's row.
+    if row is None or row.owner != owner:
+        raise HTTPException(404, "Not found")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+def setup_codex_oauth_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/providers/openai-codex")
+
+    @router.post("/connect")
+    async def connect(request: Request, name: str = DEFAULT_ENDPOINT_NAME):
+        """Start a device-code login. Creates a disabled pending endpoint + an
+        attempt row, kicks off background polling, and returns the user-facing
+        code + verification URL (never tokens)."""
+        owner = _owner(request)
+        try:
+            start = await cx.request_device_code()
+        except cx.CodexAuthError as err:
+            logger.warning("codex device-code request failed (code=%s)", err.code)
+            raise HTTPException(502, "Could not start ChatGPT login. Try again shortly.")
+
+        endpoint_id = str(uuid.uuid4())[:8]
+        attempt_id = uuid.uuid4().hex
+        db = SessionLocal()
+        try:
+            db.add(ModelEndpoint(
+                id=endpoint_id, name=name.strip() or DEFAULT_ENDPOINT_NAME,
+                base_url=cx.BASE_URL, api_key=None, is_enabled=False,
+                model_type="llm", owner=owner,
+            ))
+            db.add(CodexLoginAttempt(
+                id=attempt_id, owner=owner, endpoint_id=endpoint_id,
+                device_auth_id=start.device_auth_id, user_code=start.user_code,
+                verification_uri=start.verification_uri, status="pending",
+                expires_at=start.expires_at, interval=start.interval,
+            ))
+            db.commit()
+        finally:
+            db.close()
+
+        _spawn(_run_login_poll(attempt_id))
+        return {
+            "attempt_id": attempt_id,
+            "endpoint_id": endpoint_id,
+            "user_code": start.user_code,
+            "verification_uri": start.verification_uri,
+            "interval": start.interval,
+            "expires_at": start.expires_at.isoformat() + "Z" if start.expires_at else None,
+        }
+
+    @router.get("/connect/{attempt_id}")
+    def attempt_status(attempt_id: str, request: Request):
+        """Poll a login attempt's status (UI calls this on a timer)."""
+        owner = _owner(request)
+        db = SessionLocal()
+        try:
+            row = _require_owned(db.get(CodexLoginAttempt, attempt_id), owner)
+            return _attempt_public(row, expire_if_stale=True)
+        finally:
+            db.close()
+
+    @router.post("/connect/{attempt_id}/cancel")
+    def cancel(attempt_id: str, request: Request):
+        owner = _owner(request)
+        db = SessionLocal()
+        try:
+            row = _require_owned(db.get(CodexLoginAttempt, attempt_id), owner)
+            endpoint_id = row.endpoint_id
+            if row.status == "pending":
+                row.status = "cancelled"
+                db.commit()
+        finally:
+            db.close()
+        _delete_pending_endpoint(endpoint_id)
+        return {"status": "cancelled"}
+
+    @router.get("/status")
+    def status(request: Request):
+        """Owner-scoped connection summary: connected endpoints + pending logins.
+        State only — no token values, no account id."""
+        owner = _owner(request)
+        db = SessionLocal()
+        try:
+            tokens = db.query(EndpointOAuthToken).filter(
+                EndpointOAuthToken.owner == owner,
+                EndpointOAuthToken.provider_id == PROVIDER_ID,
+            ).all()
+            connected = []
+            for t in tokens:
+                ep = db.get(ModelEndpoint, t.endpoint_id)
+                connected.append({
+                    "endpoint_id": t.endpoint_id,
+                    "name": ep.name if ep else None,
+                    "enabled": bool(ep.is_enabled) if ep else False,
+                    "status": t.status,
+                    "expires_at": t.expires_at.isoformat() + "Z" if t.expires_at else None,
+                    "last_error": t.last_error_redacted,
+                })
+            pending_rows = db.query(CodexLoginAttempt).filter(
+                CodexLoginAttempt.owner == owner,
+                CodexLoginAttempt.status == "pending",
+            ).all()
+            pending = [_attempt_public(r, expire_if_stale=True) for r in pending_rows]
+            pending = [p for p in pending if p["status"] == "pending"]
+            return {"connected": connected, "pending": pending}
+        finally:
+            db.close()
+
+    @router.post("/disconnect/{endpoint_id}")
+    def disconnect(endpoint_id: str, request: Request):
+        """Remove a connected codex endpoint and its tokens (owner-scoped)."""
+        owner = _owner(request)
+        db = SessionLocal()
+        try:
+            ep = _require_owned(db.get(ModelEndpoint, endpoint_id), owner)
+            _purge_endpoint_rows(db, endpoint_id)
+            db.delete(ep)
+            db.commit()
+        finally:
+            db.close()
+        return {"ok": True}
+
+    return router

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1038,6 +1038,10 @@ def setup_model_routes(model_discovery):
             chat_url = build_chat_url(base)
             kind = _effective_endpoint_kind(ep, base)
             category = _classify_endpoint(base, kind)
+            # Flag OAuth/subscription endpoints (e.g. ChatGPT-sub via codex) so the
+            # UI can distinguish them from metered API-key endpoints.
+            from src.providers import registry
+            is_subscription = registry.is_codex_url(base)
 
             if model_ids:
                 curated_key = _match_provider_curated(base, None)
@@ -1055,6 +1059,7 @@ def setup_model_routes(model_discovery):
                     "category": category,
                     "endpoint_kind": kind,
                     "model_type": ep_model_type,
+                    "is_subscription": is_subscription,
                 })
             else:
                 # Endpoint unreachable but still show it greyed out
@@ -1071,6 +1076,7 @@ def setup_model_routes(model_discovery):
                     "category": category,
                     "endpoint_kind": kind,
                     "model_type": ep_model_type,
+                    "is_subscription": is_subscription,
                     "offline": True,
                 })
 

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -344,6 +344,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             model=model_to_use,
             rag=str(rag).lower() == "true" if rag else False,
             owner=user,
+            endpoint_id=(endpoint_id.strip() or None) if endpoint_id else None,
         )
         # Set auth headers for custom API-key endpoints
         resolved_key = request_api_key
@@ -400,6 +401,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db.close()
         # Switch model/endpoint mid-session
         if model is not None and endpoint_url is not None:
+            endpoint_id = (endpoint_id.strip() or None) if endpoint_id else None
             user = get_current_user(request)
             _reject_raw_endpoint_url_for_non_admin(request, user, endpoint_id, endpoint_url)
             endpoint_api_key = ""
@@ -426,6 +428,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                     _db.close()
             session.model = model
             session.endpoint_url = endpoint_url
+            session.endpoint_id = endpoint_id
             # Update auth headers from the endpoint's stored API key
             if endpoint_api_key:
                 from src.endpoint_resolver import build_headers
@@ -440,6 +443,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                     db_session.model = model
                     db_session.endpoint_url = endpoint_url
                     db_session.headers = session.headers or {}
+                    db_session.endpoint_id = endpoint_id
                     db_session.updated_at = datetime.utcnow()
                     db.commit()
             finally:

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1267,7 +1267,7 @@ def _build_actions_snapshot(tool_events: list, limit: int = 8000) -> str:
 
 async def _run_verifier_subagent(
     instruction: str, actions_snapshot: str,
-    *, endpoint_url: str, model: str, headers: dict,
+    *, endpoint_url: str, model: str, headers: dict, ref=None,
 ) -> list:
     """Fresh-context completion verifier. A second model instance with NO
     shared history reads the user's request + a record of what the agent did
@@ -1300,6 +1300,7 @@ async def _run_verifier_subagent(
             url=endpoint_url, model=model,
             messages=[{"role": "user", "content": prompt}],
             headers=headers, temperature=0.0, max_tokens=600, timeout=60,
+            ref=ref,
         )
     except Exception as e:
         logger.warning(f"[agent] verifier subagent failed: {e}")
@@ -1356,6 +1357,7 @@ async def stream_agent_loop(
     owner: Optional[str] = None,
     relevant_tools: Optional[Set[str]] = None,
     fallbacks: Optional[List[tuple]] = None,
+    ref=None,  # EndpointRef identity for the PRIMARY target (OAuth/codex); fallbacks stay static
     _is_teacher_run: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Streaming agent loop generator.
@@ -1665,7 +1667,7 @@ async def stream_agent_loop(
         # Primary target + any configured fallback models. stream_llm_with_fallback
         # only switches on a pre-content failure, so streamed output is never
         # duplicated; the dead-host cooldown keeps repeat primary attempts cheap.
-        _candidates = [(endpoint_url, model, headers)] + list(fallbacks or [])
+        _candidates = [(endpoint_url, model, headers, ref)] + list(fallbacks or [])
         # stream_llm enforces a per-read INACTIVITY timeout (httpx read=timeout),
         # which kills a wedged/silent endpoint. This wall-clock deadline is the
         # complementary cap for the rare stream that trickles bytes forever and
@@ -1853,6 +1855,7 @@ async def stream_agent_loop(
                     _raw = await llm_call_async(
                         url=endpoint_url, model=model, messages=_synth_messages,
                         headers=headers, temperature=0.3, max_tokens=max_tokens, timeout=60,
+                        ref=ref,
                     )
                     _synth = _THINK_RE.sub("", strip_tool_blocks(_raw or "")).strip()
                 except Exception as _e:
@@ -1925,7 +1928,7 @@ async def stream_agent_loop(
                 _vfail = await _run_verifier_subagent(
                     _verifier_instruction,
                     _build_actions_snapshot(tool_events),
-                    endpoint_url=endpoint_url, model=model, headers=headers,
+                    endpoint_url=endpoint_url, model=model, headers=headers, ref=ref,
                 )
                 if _vfail:
                     _verifier_rounds += 1

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -336,6 +336,104 @@ def resolve_endpoint_by_id(
         db.close()
 
 
+def _lookup_owned_endpoint(ep_id: Optional[str], owner: Optional[str]):
+    """Fetch an enabled ModelEndpoint by id, scoped to `owner` when one is set."""
+    if not ep_id:
+        return None
+    db = SessionLocal()
+    try:
+        q = db.query(ModelEndpoint).filter(
+            ModelEndpoint.id == ep_id,
+            ModelEndpoint.is_enabled == True,
+        )
+        if owner:
+            from src.auth_helpers import owner_filter
+            return owner_filter(q, ModelEndpoint, owner).first()
+        return q.first()
+    except Exception as e:
+        logger.debug(f"resolve_session_ref: endpoint lookup failed: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def _match_single_oauth_endpoint(url: str, owner: Optional[str]):
+    """Backfill: the single enabled OAuth endpoint whose base URL matches `url`.
+
+    Returns the endpoint only when EXACTLY ONE owner-scoped candidate matches —
+    never guesses between several (a wrong identity would mis-auth).
+    """
+    from src.providers import registry
+    base = normalize_base(url)
+    if not base:
+        return None
+    db = SessionLocal()
+    try:
+        q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            from src.auth_helpers import owner_filter
+            q = owner_filter(q, ModelEndpoint, owner)
+        matches = [
+            ep for ep in q.all()
+            if normalize_base(ep.base_url) == base
+            and registry.detect_spec(ep.base_url).auth_type == "oauth"
+        ]
+        return matches[0] if len(matches) == 1 else None
+    except Exception as e:
+        logger.debug(f"resolve_session_ref: oauth backfill match failed: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def resolve_session_ref(session):
+    """Build an identity-bearing EndpointRef for a chat session's PRIMARY endpoint.
+
+    OAuth providers (e.g. openai-codex / ChatGPT-subscription) resolve and refresh
+    their credential per call from endpoint IDENTITY — a frozen header can't refresh.
+    This returns an EndpointRef carrying a validated ``endpoint_id`` (exists, enabled,
+    owned by the session owner) so the codex path in ``llm_core`` can resolve OAuth.
+
+    Returns ``None`` for everything the legacy ``(url, model, headers)`` path already
+    serves byte-identically — every api_key endpoint. Callers then use
+    ``EndpointRef.from_legacy`` / the existing dispatch unchanged. Only OAuth
+    endpoints need a ref, so only they get one.
+    """
+    try:
+        from src.providers import registry
+        from src.providers.endpoint_ref import EndpointRef
+    except Exception:
+        return None
+
+    url = getattr(session, "endpoint_url", None) or ""
+    spec = registry.detect_spec(url)
+    if spec.auth_type != "oauth":
+        return None  # static / api_key — legacy path is byte-identical
+
+    owner = getattr(session, "owner", None)
+    ep_id = (getattr(session, "endpoint_id", None) or "").strip() or None
+
+    # Path A — durable identity: trust the stored id only after validation.
+    ep = _lookup_owned_endpoint(ep_id, owner)
+    # Path B — backfill for sessions created before endpoint_id was persisted.
+    if ep is None:
+        ep = _match_single_oauth_endpoint(url, owner)
+    if ep is None:
+        # No safe identity → return None. The codex path builds from_legacy and the
+        # auth guard raises a clear (surfaced) error rather than silently mis-authing.
+        return None
+
+    return EndpointRef(
+        url=normalize_base(ep.base_url) or url,
+        model=getattr(session, "model", None),
+        headers=getattr(session, "headers", None),
+        endpoint_id=ep.id,
+        owner=owner,
+        provider_id=spec.id,
+        auth_type="oauth",
+    )
+
+
 def resolve_chat_fallback_candidates(owner: Optional[str] = None) -> list:
     """Build the configured default-chat fallback chain as a list of
     (chat_url, model, headers) tuples, skipping any that can't resolve.
@@ -365,6 +463,7 @@ def resolve_vision_fallback_candidates(owner: Optional[str] = None) -> list:
 
 
 def _resolve_fallback_candidates(setting_key: str, owner: Optional[str] = None) -> list:
+    from src.providers import registry
     out = []
     try:
         from src.settings import get_user_setting, load_settings
@@ -376,6 +475,13 @@ def _resolve_fallback_candidates(setting_key: str, owner: Optional[str] = None) 
         if not isinstance(entry, dict):
             continue
         resolved = resolve_endpoint_by_id(entry.get("endpoint_id", ""), entry.get("model", ""), owner=owner)
-        if resolved:
-            out.append(resolved)
+        if not resolved:
+            continue
+        # OAuth providers (e.g. codex / ChatGPT-subscription) cannot serve as
+        # fallback targets: a fallback candidate carries no endpoint identity, so
+        # its per-call OAuth token can't be resolved/refreshed. Keep fallbacks
+        # static-only (mirrors the primary-only ref threading in chat/agent paths).
+        if registry.detect_spec(resolved[0]).auth_type == "oauth":
+            continue
+        out.append(resolved)
     return out

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1696,16 +1696,22 @@ def _summarize_stream_error(err_chunk: Optional[str]) -> str:
 async def stream_llm_with_fallback(candidates, messages, **kwargs):
     """Wrap stream_llm with an ordered fallback chain.
 
-    `candidates` is a list of (url, model, headers). Each is tried in order,
-    but only retried on a *pre-content* failure — i.e. an ``event: error``
-    that arrives before any assistant text / tool-call data has been yielded.
-    Once a candidate has emitted real output we never switch (that would
-    duplicate streamed tokens); a later error from that candidate passes
-    through unchanged. The dead-host cooldown in stream_llm makes repeat
-    attempts at an offline primary effectively instant.
+    Each candidate is ``(url, model, headers)`` or ``(url, model, headers, ref)``.
+    A 4th element carries an ``EndpointRef`` identity (needed for OAuth/codex);
+    3-tuples resolve as static creds. Only the primary candidate should carry a
+    ref — fallback candidates stay static-only (a ref is not threaded through them
+    by design, so codex never appears as a fallback target).
+
+    Each is tried in order, but only retried on a *pre-content* failure — i.e. an
+    ``event: error`` that arrives before any assistant text / tool-call data has
+    been yielded. Once a candidate has emitted real output we never switch (that
+    would duplicate streamed tokens); a later error from that candidate passes
+    through unchanged. The dead-host cooldown in stream_llm makes repeat attempts
+    at an offline primary effectively instant.
 
     Yields the same SSE chunk protocol as stream_llm.
     """
+    kwargs.pop("ref", None)  # refs travel per-candidate (the 4-tuple), never globally
     cands = _dedupe_candidates(candidates)
     if not cands:
         yield f'event: error\ndata: {json.dumps({"error": "No model endpoint configured", "status": 503})}\n\n'
@@ -1713,11 +1719,14 @@ async def stream_llm_with_fallback(candidates, messages, **kwargs):
 
     primary_model = cands[0][1]
     last_error = None
-    for i, (url, model, headers) in enumerate(cands):
+    for i, cand in enumerate(cands):
+        url, model = cand[0], cand[1]
+        headers = cand[2] if len(cand) > 2 else None
+        ref = cand[3] if len(cand) > 3 else None
         is_last = (i == len(cands) - 1)
         emitted = False
         retried = False
-        async for chunk in stream_llm(url, model, messages, headers=headers, **kwargs):
+        async for chunk in stream_llm(url, model, messages, headers=headers, ref=ref, **kwargs):
             if chunk.startswith("event: error"):
                 if not emitted and not is_last:
                     # Pre-content failure with fallbacks left — swallow and

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -11,6 +11,13 @@ from typing import Optional, Dict, List
 from src.model_context import get_context_length, DEFAULT_CONTEXT
 from urllib.parse import urlparse
 
+# Provider seam — codex (ChatGPT-subscription / OAuth) endpoints route through a
+# pure transport + a per-request credential resolver. Other providers stay on the
+# legacy dispatch in this module; the seam is one-directional (providers never
+# import llm_core), so there is no cycle.
+from src.providers import registry, auth
+from src.providers.endpoint_ref import EndpointRef
+
 logger = logging.getLogger(__name__)
 
 class LLMConfig:
@@ -862,6 +869,15 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
              max_tokens: int = LLMConfig.DEFAULT_MAX_TOKENS, headers: Optional[Dict] = None, 
              timeout: int = LLMConfig.DEFAULT_TIMEOUT, prompt_type: Optional[str] = None) -> str:
     """Synchronous LLM call with optional prompt type enhancement."""
+    # Codex (ChatGPT-subscription / OAuth) endpoints are async-only: credential
+    # resolution refreshes tokens, which the sync path cannot do. Fail loudly
+    # rather than POSTing an unauthenticated chat/completions payload upstream.
+    if registry.is_codex_url(url):
+        raise HTTPException(
+            501,
+            "ChatGPT-subscription (codex) endpoints require async credential "
+            "resolution and are not supported on the sync llm_call path",
+        )
     h = _provider_headers(_detect_provider(url))
     # Tolerate headers that arrive as a JSON string (some sessions stored them
     # double-encoded) — otherwise h.update() throws "dictionary update sequence
@@ -1005,6 +1021,138 @@ async def llm_call_async_with_fallback(candidates, messages, **kwargs) -> str:
     raise last_err if last_err else HTTPException(503, "All fallback candidates failed")
 
 
+# ── OpenAI-Codex (ChatGPT-subscription) provider seam ──────────────────────
+# Codex endpoints authenticate via an OAuth session, not a static key, so their
+# credentials must be resolved — and refreshed — per request from endpoint
+# identity. These two helpers are the codex execution path: `llm_core` still owns
+# the wire (httpx pool, dead-host cooldown, error mapping) while the pure
+# `codex_responses` transport shapes the request and normalizes the stream. The
+# response cache is bypassed (a per-user OAuth response must not be shared). All
+# other providers stay on the legacy dispatch — this is a sidecar, not a rewrite.
+
+def _codex_consolidate(messages: List[Dict]) -> List[Dict]:
+    """Sanitize + consolidate system messages, mirroring the legacy entry fns."""
+    msgs = _sanitize_llm_messages(messages)
+    sys_parts = [m["content"] for m in msgs if m.get("role") == "system"]
+    non_sys = [m for m in msgs if m.get("role") != "system"]
+    if sys_parts:
+        return [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
+    return non_sys
+
+
+async def _stream_codex(url, model, messages, temperature, max_tokens, headers, timeout, tools, ref):
+    """Codex streaming path — yields the same SSE chunk protocol as stream_llm."""
+    try:
+        if ref is None:
+            ref = EndpointRef.from_legacy(url, model, headers)
+        messages_copy = _codex_consolidate(messages)
+        spec = registry.detect_spec(ref.url)
+        transport = registry.get_transport(spec)
+        target_url = transport.target_url(ref.url)
+        creds = await auth.resolve(ref, spec)
+        h = transport.build_headers(creds.headers)
+        payload = transport.build_payload(ref.model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
+    except HTTPException as e:
+        # Surface as a stream error rather than raising — a raise here propagates
+        # as a 500 the SPA can't render, which reads as a hang.
+        yield f'event: error\ndata: {json.dumps({"error": e.detail, "status": e.status_code})}\n\n'
+        return
+    except Exception as e:
+        logger.error(f"codex stream setup error: {e}")
+        yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
+        return
+
+    stream_timeout = httpx.Timeout(connect=3.0, read=float(timeout), write=30.0, pool=5.0)
+    if _is_host_dead(target_url):
+        yield f'event: error\ndata: {json.dumps({"error": f"Upstream {_host_key(target_url)} unreachable (cooldown active)", "status": 503})}\n\n'
+        return
+    note_model_activity(target_url, ref.model)
+
+    decoder = transport.stream_decoder(ref.model)
+    try:
+        client = _get_http_client()
+        async with client.stream('POST', target_url, json=payload, headers=h, timeout=stream_timeout) as r:
+            _clear_host_dead(target_url)
+            if r.status_code != 200:
+                raw = (await r.aread()).decode(errors="replace")
+                friendly = _format_upstream_error(r.status_code, raw, target_url)
+                yield f'event: error\ndata: {json.dumps({"status": r.status_code, "text": friendly, "raw": raw[:500]})}\n\n'
+                return
+            async for line in r.aiter_lines():
+                chunks, stop = decoder.decode_line(line)
+                for chunk in chunks:
+                    yield chunk
+                if stop:
+                    return
+            for chunk in decoder.finalize():
+                yield chunk
+    except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+        _cooled = _mark_host_dead(target_url)
+        _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
+        logger.warning(f"codex stream connect to {target_url} failed: {e}{_tail}")
+        yield f'event: error\ndata: {json.dumps({"error": f"Cannot reach {_host_key(target_url)}", "status": 503})}\n\n'
+    except httpx.ReadTimeout:
+        yield f'event: error\ndata: {json.dumps({"error": "Read timeout", "status": 504})}\n\n'
+    except httpx.NetworkError:
+        yield f'event: error\ndata: {json.dumps({"error": "Network error", "status": 502})}\n\n'
+    except Exception as e:
+        logger.error(f"codex stream error: {e}")
+        yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
+
+
+async def _call_codex_async(url, model, messages, temperature, max_tokens, headers, timeout, max_retries, ref):
+    """Codex non-streaming path — returns assistant text (mirrors llm_call_async).
+
+    No response caching: OAuth-backed responses are per-user and must not be
+    shared via the module cache.
+    """
+    if ref is None:
+        ref = EndpointRef.from_legacy(url, model, headers)
+    messages_copy = _codex_consolidate(messages)
+    spec = registry.detect_spec(ref.url)
+    transport = registry.get_transport(spec)
+    target_url = transport.target_url(ref.url)
+    creds = await auth.resolve(ref, spec)
+    h = transport.build_headers(creds.headers)
+    payload = transport.build_payload(ref.model, messages_copy, temperature, max_tokens, stream=False, tools=None)
+
+    if _is_host_dead(target_url):
+        raise HTTPException(503, f"Upstream {_host_key(target_url)} marked unreachable (cooldown active)")
+    call_timeout = httpx.Timeout(connect=3.0, read=float(timeout), write=10.0, pool=5.0)
+    attempt = 0
+    while attempt < max_retries:
+        attempt += 1
+        start = time.time()
+        try:
+            note_model_activity(target_url, ref.model)
+            client = _get_http_client()
+            r = await client.post(target_url, headers=h, json=payload, timeout=call_timeout)
+            duration = time.time() - start
+            if not r.is_success:
+                friendly = _format_upstream_error(r.status_code, r.text, target_url)
+                logger.warning(f"codex async call to {target_url} failed in {duration:.2f}s (attempt {attempt}): HTTP {r.status_code} {friendly}")
+                raise HTTPException(r.status_code, friendly)
+            logger.info(f"codex async call to {target_url} succeeded in {duration:.2f}s (attempt {attempt})")
+            _clear_host_dead(target_url)
+            data = r.json()
+            try:
+                return transport.parse_response(data)
+            except Exception:
+                raise HTTPException(502, f"Unexpected schema from {target_url}: {str(data)[:400]}")
+        except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+            _cooled = _mark_host_dead(target_url)
+            duration = time.time() - start
+            _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
+            logger.warning(f"codex async connect to {target_url} failed after {duration:.2f}s: {e}{_tail}")
+            raise HTTPException(503, f"Cannot reach {_host_key(target_url)}: {e}")
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
+            duration = time.time() - start
+            logger.warning(f"codex async call attempt {attempt} failed after {duration:.2f}s: {e}")
+            if attempt >= max_retries:
+                raise HTTPException(502, f"POST {target_url} failed after {max_retries} attempts: {e}")
+            await asyncio.sleep(LLMConfig.RETRY_DELAY)
+
+
 async def llm_call_async(
     url: str,
     model: str,
@@ -1014,9 +1162,15 @@ async def llm_call_async(
     headers: Optional[Dict] = None,
     timeout: int = LLMConfig.STREAM_TIMEOUT,
     max_retries: int = LLMConfig.MAX_RETRIES,
-    prompt_type: Optional[str] = None
+    prompt_type: Optional[str] = None,
+    ref: Optional[EndpointRef] = None,
 ) -> str:
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
+    # Codex (ChatGPT-subscription / OAuth) endpoints take a self-contained path —
+    # credentials resolve per request from endpoint identity, cache bypassed. All
+    # other providers fall through to the legacy dispatch below, byte-identical.
+    if registry.is_codex_url(url):
+        return await _call_codex_async(url, model, messages, temperature, max_tokens, headers, timeout, max_retries, ref)
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
 
@@ -1117,7 +1271,7 @@ async def llm_call_async(
 async def stream_llm(url: str, model: str, messages: List[Dict], temperature: float = LLMConfig.DEFAULT_TEMPERATURE,
                      max_tokens: int = LLMConfig.DEFAULT_MAX_TOKENS, headers: Optional[Dict] = None,
                      timeout: int = LLMConfig.STREAM_TIMEOUT, prompt_type: Optional[str] = None,
-                     tools: Optional[List[Dict]] = None):
+                     tools: Optional[List[Dict]] = None, ref: Optional[EndpointRef] = None):
     """Stream LLM responses with improved error handling.
 
     Yields SSE chunks:
@@ -1126,6 +1280,12 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
       - event: error                       — errors
       - data: [DONE]                       — end of stream
     """
+    # Codex (ChatGPT-subscription / OAuth) endpoints take a self-contained path;
+    # all other providers fall through to the legacy dispatch below.
+    if registry.is_codex_url(url):
+        async for chunk in _stream_codex(url, model, messages, temperature, max_tokens, headers, timeout, tools, ref):
+            yield chunk
+        return
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
 

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,0 +1,18 @@
+"""Provider seam for the OpenAI-Codex (ChatGPT-subscription) provider.
+
+A small registry of `ProviderSpec`s + a pure `Transport` for the codex Responses
+backend, plus an `EndpointRef`-based credential seam (`providers.auth`) that
+resolves OAuth tokens per request — so a subscription token can refresh without
+re-freezing headers at session-create time.
+
+Transports are PURE — no I/O, no global state: they shape requests
+(`target_url` / `build_payload` / `build_headers`), parse responses
+(`parse_response`), and normalize streaming (`stream_decoder`). `llm_core` stays
+the execution engine (httpx pool, cache, dead-host cooldown, retry, fallback) and
+calls into the transport for codex endpoints; the transport never calls back into
+`llm_core` (no import cycle).
+
+This seam is intentionally codex-only: OpenAI-compatible and Anthropic endpoints
+continue to be served by `llm_core`'s existing provider dispatch. Folding those
+into the registry too is a separate refactor.
+"""

--- a/src/providers/auth/__init__.py
+++ b/src/providers/auth/__init__.py
@@ -1,0 +1,12 @@
+"""Credential resolution seam.
+
+`llm_core` resolves a `Credential` from an `EndpointRef` right before each call.
+Static-key endpoints are the identity case (the headers frozen on the ref ARE
+the credential); OAuth endpoints resolve through the token store, which loads
+and refreshes tokens keyed on `EndpointRef.endpoint_id`. The seam is async
+(`resolve`) with a sync sibling (`resolve_sync`) for the 3 sync `llm_call`
+callers.
+"""
+from src.providers.auth.credentials import Credential, resolve, resolve_sync
+
+__all__ = ["Credential", "resolve", "resolve_sync"]

--- a/src/providers/auth/codex_oauth.py
+++ b/src/providers/auth/codex_oauth.py
@@ -1,0 +1,394 @@
+"""OpenAI Codex (ChatGPT-subscription) OAuth protocol — device-code login + refresh.
+
+Pure protocol helpers against `auth.openai.com`. This module does network I/O
+(its job is credential acquisition) but **no DB and no logging of secrets** —
+persistence is the caller's (the connect route + `credentials.resolve`).
+
+Why device-code (not loopback-PKCE like the codex CLI / pi / opencode): Odysseus
+runs on a remote host reached from a browser elsewhere, so a `localhost:1455`
+callback can never land, and codex's public client whitelists loopback-only
+redirects. Device-code needs no redirect — OpenAI's deviceauth service even
+generates the PKCE pair server-side and hands back BOTH the `authorization_code`
+and the matching `code_verifier` in the poll response; we just forward them to
+`/oauth/token`. (Wire format validated against open-source codex clients running
+this exact pattern on remote deployments.)
+
+NEVER log `access_token` / `refresh_token` / `code_verifier` / `device_auth_id`
+/ `account_id`. Errors carry only status codes and OAuth error *codes*.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Codex CLI's public client id — reused by every Codex OAuth client (pi,
+# opencode, codex itself). No codex CLI binary is required.
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+ISSUER = "https://auth.openai.com"
+TOKEN_URL = f"{ISSUER}/oauth/token"
+DEVICE_USERCODE_URL = f"{ISSUER}/api/accounts/deviceauth/usercode"
+DEVICE_TOKEN_URL = f"{ISSUER}/api/accounts/deviceauth/token"
+DEVICE_VERIFICATION_URI = f"{ISSUER}/codex/device"
+DEVICE_REDIRECT_URI = f"{ISSUER}/deviceauth/callback"
+
+# Inference base URL for codex-backed ChatGPT-subscription endpoints.
+BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+# JWT claim namespace that carries `chatgpt_account_id`.
+JWT_AUTH_CLAIM = "https://api.openai.com/auth"
+
+# Refresh the access token this many seconds before its JWT `exp`.
+REFRESH_SKEW_SECONDS = 120
+
+# Login default poll cadence / TTL when the server omits them.
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+MIN_POLL_INTERVAL_SECONDS = 3
+DEFAULT_DEVICE_CODE_TTL_SECONDS = 15 * 60
+
+_HTTP_TIMEOUT = httpx.Timeout(20.0)
+
+# OAuth error codes that mean the refresh token is dead → user must reconnect.
+_RELOGIN_ERROR_CODES = frozenset(
+    {"invalid_grant", "invalid_token", "invalid_request", "refresh_token_reused"}
+)
+
+
+class CodexAuthError(Exception):
+    """A Codex OAuth failure with a redacted message and routing hints.
+
+    `relogin_required` distinguishes a dead refresh token (reconnect needed)
+    from a transient/quota condition (`code == "quota"`, credentials still
+    valid). The message never contains token material.
+    """
+
+    def __init__(self, message: str, *, code: str, relogin_required: bool = False):
+        super().__init__(message)
+        self.code = code
+        self.relogin_required = relogin_required
+
+
+@dataclass(frozen=True)
+class DeviceCodeStart:
+    """The user-facing half of a started device-code login (no secrets)."""
+    user_code: str
+    device_auth_id: str          # poll secret — encrypt at rest, never log/expose
+    verification_uri: str
+    interval: int
+    expires_at: Optional[datetime]   # naive UTC
+
+
+@dataclass(frozen=True)
+class DeviceAuthResult:
+    """A successful poll: the codes to redeem at the token endpoint."""
+    authorization_code: str
+    code_verifier: str           # server-generated PKCE verifier
+
+
+@dataclass(frozen=True)
+class TokenSet:
+    """A resolved credential pair plus derived identity/expiry (no logging)."""
+    access_token: str
+    refresh_token: str
+    account_id: Optional[str]
+    expires_at: Optional[datetime]   # naive UTC, from the access-token JWT `exp`
+
+
+# ---------------------------------------------------------------------------
+# JWT helpers (no verification — we only read public claims for routing)
+# ---------------------------------------------------------------------------
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _utc_naive_from_epoch(seconds: float) -> datetime:
+    return datetime.fromtimestamp(seconds, tz=timezone.utc).replace(tzinfo=None)
+
+
+def decode_jwt_claims(token: Any) -> Dict[str, Any]:
+    """Decode a JWT payload segment to its claims dict (no signature check)."""
+    if not isinstance(token, str) or token.count(".") != 2:
+        return {}
+    payload = token.split(".")[1]
+    payload += "=" * ((4 - len(payload) % 4) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(payload.encode("utf-8"))
+        claims = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
+def extract_account_id(access_token: Any) -> Optional[str]:
+    """Pull `chatgpt_account_id` from the access-token JWT, tolerating absence."""
+    claims = decode_jwt_claims(access_token)
+    auth = claims.get(JWT_AUTH_CLAIM)
+    if isinstance(auth, dict):
+        acct = auth.get("chatgpt_account_id")
+        if isinstance(acct, str) and acct.strip():
+            return acct.strip()
+    return None
+
+
+def access_token_expiry(access_token: Any) -> Optional[datetime]:
+    """Naive-UTC expiry from the JWT `exp` claim, or None if unreadable."""
+    exp = decode_jwt_claims(access_token).get("exp")
+    if isinstance(exp, (int, float)):
+        return _utc_naive_from_epoch(float(exp))
+    return None
+
+
+def access_token_is_expiring(access_token: Any, skew_seconds: int = REFRESH_SKEW_SECONDS) -> bool:
+    """True when the access token expires within `skew_seconds`. Unknown → False
+    (let a real 401 trigger refresh rather than churning on every call)."""
+    expiry = access_token_expiry(access_token)
+    if expiry is None:
+        return False
+    return expiry <= _utcnow_naive() + _timedelta(skew_seconds)
+
+
+def _timedelta(seconds: int) -> timedelta:
+    return timedelta(seconds=max(0, int(seconds)))
+
+
+# ---------------------------------------------------------------------------
+# Device-code login
+# ---------------------------------------------------------------------------
+
+async def request_device_code(client: Optional[httpx.AsyncClient] = None) -> DeviceCodeStart:
+    """Step 1: ask the deviceauth service for a user_code + device_auth_id."""
+    body = {"client_id": CLIENT_ID}
+    headers = {"Content-Type": "application/json"}
+    data = await _post_json(client, DEVICE_USERCODE_URL, body, headers, what="device code request")
+
+    user_code = str(data.get("user_code") or "")
+    device_auth_id = str(data.get("device_auth_id") or "")
+    if not user_code or not device_auth_id:
+        raise CodexAuthError("Device code response missing required fields.",
+                             code="device_code_incomplete")
+
+    interval = max(MIN_POLL_INTERVAL_SECONDS,
+                   _as_int(data.get("interval"), DEFAULT_POLL_INTERVAL_SECONDS))
+    ttl = _as_int(data.get("expires_in"), DEFAULT_DEVICE_CODE_TTL_SECONDS)
+    expires_at = _utcnow_naive() + _timedelta(ttl)
+
+    logger.info("codex device-code: issued (interval=%ss, ttl=%ss)", interval, ttl)
+    return DeviceCodeStart(
+        user_code=user_code,
+        device_auth_id=device_auth_id,
+        verification_uri=DEVICE_VERIFICATION_URI,
+        interval=interval,
+        expires_at=expires_at,
+    )
+
+
+async def poll_device_token(
+    device_auth_id: str, user_code: str, client: Optional[httpx.AsyncClient] = None
+) -> Optional[DeviceAuthResult]:
+    """Step 3 (one attempt): poll for authorization. Returns None while the user
+    has not finished (403/404); raises CodexAuthError on a hard failure."""
+    body = {"device_auth_id": device_auth_id, "user_code": user_code}
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+    owns = client is None
+    client = client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+    try:
+        resp = await client.post(DEVICE_TOKEN_URL, json=body, headers=headers)
+    except httpx.HTTPError as exc:
+        raise CodexAuthError(f"Device auth poll failed: {type(exc).__name__}",
+                             code="device_code_poll_failed") from exc
+    finally:
+        if owns:
+            await client.aclose()
+
+    if resp.status_code == 200:
+        payload = _json_or_error(resp, "device auth poll")
+        authorization_code = str(payload.get("authorization_code") or "")
+        code_verifier = str(payload.get("code_verifier") or "")
+        if not authorization_code or not code_verifier:
+            raise CodexAuthError(
+                "Device auth response missing authorization_code or code_verifier.",
+                code="device_code_incomplete_exchange",
+            )
+        return DeviceAuthResult(authorization_code=authorization_code, code_verifier=code_verifier)
+
+    if resp.status_code in (403, 404):
+        return None  # user hasn't completed sign-in yet — keep polling
+
+    raise CodexAuthError(f"Device auth polling returned status {resp.status_code}.",
+                         code="device_code_poll_error")
+
+
+async def exchange_device_code(
+    authorization_code: str, code_verifier: str, client: Optional[httpx.AsyncClient] = None
+) -> TokenSet:
+    """Step 4: redeem the authorization code (+ server PKCE verifier) for tokens."""
+    form = {
+        "grant_type": "authorization_code",
+        "code": authorization_code,
+        "redirect_uri": DEVICE_REDIRECT_URI,
+        "client_id": CLIENT_ID,
+        "code_verifier": code_verifier,
+    }
+    payload = await _post_form(client, form, what="token exchange")
+    tokens = _parse_token_payload(payload, prior_refresh=None, require_refresh=True)
+    logger.info("codex device-code: token exchange succeeded")
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+async def refresh_tokens(
+    refresh_token: str, client: Optional[httpx.AsyncClient] = None
+) -> TokenSet:
+    """Refresh the access token. Rotates the refresh token only when the server
+    returns a new one (otherwise the prior one is kept). Classifies 429 (quota,
+    still valid) distinctly from auth failures (relogin required)."""
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        raise CodexAuthError("Missing refresh_token.", code="missing_refresh_token",
+                             relogin_required=True)
+
+    form = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token.strip(),
+        "client_id": CLIENT_ID,
+    }
+    payload = await _post_form(client, form, what="token refresh")
+    tokens = _parse_token_payload(payload, prior_refresh=refresh_token.strip(), require_refresh=False)
+    logger.info("codex: token refresh succeeded")
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Shared HTTP + parsing
+# ---------------------------------------------------------------------------
+
+async def _post_json(
+    client: Optional[httpx.AsyncClient], url: str, body: dict, headers: dict, *, what: str
+) -> dict:
+    owns = client is None
+    client = client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+    try:
+        resp = await client.post(url, json=body, headers=headers)
+    except httpx.HTTPError as exc:
+        raise CodexAuthError(f"{what} failed: {type(exc).__name__}",
+                             code="network_error") from exc
+    finally:
+        if owns:
+            await client.aclose()
+    if resp.status_code != 200:
+        raise _classify_token_error(resp, what)
+    return _json_or_error(resp, what)
+
+
+async def _post_form(
+    client: Optional[httpx.AsyncClient], form: dict, *, what: str
+) -> dict:
+    headers = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
+    owns = client is None
+    client = client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+    try:
+        resp = await client.post(TOKEN_URL, data=form, headers=headers)
+    except httpx.HTTPError as exc:
+        raise CodexAuthError(f"{what} failed: {type(exc).__name__}",
+                             code="network_error") from exc
+    finally:
+        if owns:
+            await client.aclose()
+    if resp.status_code != 200:
+        raise _classify_token_error(resp, what)
+    return _json_or_error(resp, what)
+
+
+def _json_or_error(resp: httpx.Response, what: str) -> dict:
+    try:
+        data = resp.json()
+    except Exception as exc:
+        raise CodexAuthError(f"{what} returned invalid JSON.", code="invalid_json") from exc
+    if not isinstance(data, dict):
+        raise CodexAuthError(f"{what} returned an unexpected payload.", code="invalid_payload")
+    return data
+
+
+def _parse_token_payload(payload: dict, *, prior_refresh: Optional[str], require_refresh: bool) -> TokenSet:
+    access_token = payload.get("access_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        raise CodexAuthError("Token response missing access_token.",
+                             code="missing_access_token", relogin_required=True)
+    access_token = access_token.strip()
+
+    next_refresh = payload.get("refresh_token")
+    if isinstance(next_refresh, str) and next_refresh.strip():
+        refresh_token = next_refresh.strip()
+    elif prior_refresh:
+        refresh_token = prior_refresh
+    elif require_refresh:
+        raise CodexAuthError("Token response missing refresh_token.",
+                             code="missing_refresh_token", relogin_required=True)
+    else:
+        refresh_token = ""
+
+    # Prefer the JWT `exp`; fall back to expires_in if the token is opaque.
+    expires_at = access_token_expiry(access_token)
+    if expires_at is None:
+        ttl = _as_int(payload.get("expires_in"), 0)
+        if ttl > 0:
+            expires_at = _utcnow_naive() + _timedelta(ttl)
+
+    return TokenSet(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=extract_account_id(access_token),
+        expires_at=expires_at,
+    )
+
+
+def _classify_token_error(resp: httpx.Response, what: str) -> CodexAuthError:
+    """Map a non-200 token-endpoint response to a redacted, routable error."""
+    status = resp.status_code
+    if status == 429:
+        return CodexAuthError(
+            "Codex provider quota exhausted (429). Credentials are still valid; "
+            "retry after the usage limit resets.",
+            code="quota", relogin_required=False,
+        )
+
+    code = "codex_token_error"
+    relogin = False
+    try:
+        err = resp.json()
+    except Exception:
+        err = None
+    if isinstance(err, dict):
+        err_obj = err.get("error")
+        if isinstance(err_obj, dict):
+            nested = err_obj.get("code") or err_obj.get("type")
+            if isinstance(nested, str) and nested.strip():
+                code = nested.strip()
+        elif isinstance(err_obj, str) and err_obj.strip():
+            code = err_obj.strip()
+    if code in _RELOGIN_ERROR_CODES:
+        relogin = True
+    if status in (401, 403):
+        relogin = True
+
+    return CodexAuthError(f"{what} failed (status {status}, code {code}).",
+                          code=code, relogin_required=relogin)
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/providers/auth/codex_oauth.py
+++ b/src/providers/auth/codex_oauth.py
@@ -56,6 +56,17 @@ DEFAULT_DEVICE_CODE_TTL_SECONDS = 15 * 60
 
 _HTTP_TIMEOUT = httpx.Timeout(20.0)
 
+
+def _new_async_client():
+    """Single construction point for the device-code/refresh HTTP client.
+
+    Centralized so the call sites share one config and tests can inject an
+    ``httpx.MockTransport`` here — no network-mocking dependency required.
+    Return type is inferred (``httpx.AsyncClient``) to stay parity-clean with
+    the prior inline construction."""
+    return httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+
+
 # OAuth error codes that mean the refresh token is dead → user must reconnect.
 _RELOGIN_ERROR_CODES = frozenset(
     {"invalid_grant", "invalid_token", "invalid_request", "refresh_token_reused"}
@@ -200,7 +211,7 @@ async def poll_device_token(
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
     owns = client is None
-    client = client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+    client = client or _new_async_client()
     try:
         resp = await client.post(DEVICE_TOKEN_URL, json=body, headers=headers)
     except httpx.HTTPError as exc:
@@ -278,7 +289,7 @@ async def _post_json(
     client: Optional[httpx.AsyncClient], url: str, body: dict, headers: dict, *, what: str
 ) -> dict:
     owns = client is None
-    client = client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+    client = client or _new_async_client()
     try:
         resp = await client.post(url, json=body, headers=headers)
     except httpx.HTTPError as exc:
@@ -297,7 +308,7 @@ async def _post_form(
 ) -> dict:
     headers = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
     owns = client is None
-    client = client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+    client = client or _new_async_client()
     try:
         resp = await client.post(TOKEN_URL, data=form, headers=headers)
     except httpx.HTTPError as exc:

--- a/src/providers/auth/credentials.py
+++ b/src/providers/auth/credentials.py
@@ -1,0 +1,69 @@
+"""Credential interface + dispatch + the OAuth guard.
+
+`Credential.headers` are merged into the outgoing request by the transport's
+`build_headers`. For static-key providers the resolved credential is simply the
+headers carried on the `EndpointRef`; OAuth providers resolve through the token
+store (lookup + refresh-on-expiry keyed on `endpoint_id`).
+"""
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from fastapi import HTTPException
+
+from src.providers.endpoint_ref import EndpointRef
+from src.providers.spec import ProviderSpec
+
+
+@dataclass(frozen=True)
+class Credential:
+    headers: Dict[str, str] = field(default_factory=dict)
+
+
+def _effective_auth_type(ref: EndpointRef, spec: Optional[ProviderSpec]) -> str:
+    """The spec is authoritative; the ref's auth_type is a fallback hint."""
+    if spec is not None:
+        return spec.auth_type
+    return ref.auth_type
+
+
+def _guard_oauth(ref: EndpointRef, spec: Optional[ProviderSpec]) -> None:
+    """OAuth providers MUST have endpoint identity (so the token can be looked up
+    and refreshed). A ref built from a legacy tuple has none — fail loudly rather
+    than silently re-freezing a bearer token that can never refresh."""
+    if _effective_auth_type(ref, spec) == "oauth" and not ref.endpoint_id:
+        pid = getattr(spec, "id", None) or ref.provider_id or "?"
+        raise HTTPException(
+            500,
+            f"Provider '{pid}' uses OAuth but this endpoint ref has no identity "
+            f"(it came from a legacy tuple). Resolve it via resolve_endpoint_ref().",
+        )
+
+
+async def resolve(ref: EndpointRef, spec: Optional[ProviderSpec] = None) -> Credential:
+    """Async credential resolution — static-key identity or OAuth lookup/refresh."""
+    _guard_oauth(ref, spec)
+    if _effective_auth_type(ref, spec) == "oauth":
+        # Look up the token by ref.endpoint_id, refresh on expiry (single-flight
+        # per endpoint), and build the bearer + account-id headers.
+        from src.providers.auth import oauth_store  # lazy: avoids import cycle
+        return await oauth_store.resolve_oauth_credential(ref, spec)
+    from src.providers.auth import static  # lazy: avoids auth-package import cycle
+    return static.resolve(ref)
+
+
+def resolve_sync(ref: EndpointRef, spec: Optional[ProviderSpec] = None) -> Credential:
+    """Sync sibling for the 3 sync `llm_call` callers. Static-key only.
+
+    OAuth endpoints are deliberately unreachable from sync paths — refresh is
+    async, and the sync callers (background utility work) never target a
+    user-subscription endpoint. This is a documented boundary, not an oversight.
+    """
+    _guard_oauth(ref, spec)
+    if _effective_auth_type(ref, spec) == "oauth":
+        raise HTTPException(
+            501,
+            "OAuth endpoints require async credential resolution and are "
+            "not reachable from sync llm_call paths",
+        )
+    from src.providers.auth import static  # lazy: avoids auth-package import cycle
+    return static.resolve(ref)

--- a/src/providers/auth/oauth_store.py
+++ b/src/providers/auth/oauth_store.py
@@ -1,0 +1,194 @@
+"""OAuth token store + per-call credential resolution (codex / ChatGPT-sub).
+
+This is the DB-coupled half of the auth seam: `credentials.resolve()` dispatches
+here for `auth_type == "oauth"`. Responsibilities:
+
+  * load the encrypted token row for an endpoint (by `endpoint_id`),
+  * refresh the access token on expiry (single-flight per endpoint, 120s skew),
+  * persist a rotated token pair,
+  * build the credential-derived request headers (`Authorization` +
+    `chatgpt-account-id`).
+
+The provider-constant backend-compat headers (`originator`, `User-Agent`) are
+NOT here — they are not credential-derived, so they belong to the transport's
+`build_headers`, keeping the auth/transport package boundary intact.
+
+Never log token material; `CodexAuthError` messages are already redacted.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+
+from src.providers.auth import codex_oauth as cx
+from src.providers.auth.credentials import Credential
+from src.providers.endpoint_ref import EndpointRef
+from src.providers.spec import ProviderSpec
+
+logger = logging.getLogger(__name__)
+
+# One refresh in flight per endpoint; concurrent resolves for the same endpoint
+# wait, re-read, and reuse the freshly-rotated token instead of each refreshing.
+_refresh_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(endpoint_id: str) -> asyncio.Lock:
+    # setdefault-style; no await between get and set, so this is race-free on
+    # a single event loop.
+    lock = _refresh_locks.get(endpoint_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _refresh_locks[endpoint_id] = lock
+    return lock
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+# ---------------------------------------------------------------------------
+# Sync DB helpers (fast, indexed; each opens its own short-lived session)
+# ---------------------------------------------------------------------------
+
+def _load_row(endpoint_id: str):
+    from core.database import SessionLocal, EndpointOAuthToken
+    db = SessionLocal()
+    try:
+        return db.query(EndpointOAuthToken).filter(
+            EndpointOAuthToken.endpoint_id == endpoint_id
+        ).first()
+    finally:
+        db.close()
+
+
+def persist_tokens(
+    endpoint_id: str,
+    token_set: cx.TokenSet,
+    *,
+    owner: Optional[str] = None,
+    provider_id: str = "openai-codex",
+    create_if_missing: bool = False,
+) -> None:
+    """Write a freshly-acquired/rotated token pair to the endpoint's row.
+
+    Used both by `resolve()` after a refresh and by the connect route after a
+    successful device-code login (`create_if_missing=True`). Marks the row
+    `active` and clears any prior error.
+    """
+    import uuid
+    from core.database import SessionLocal, EndpointOAuthToken
+    db = SessionLocal()
+    try:
+        row = db.query(EndpointOAuthToken).filter(
+            EndpointOAuthToken.endpoint_id == endpoint_id
+        ).first()
+        if row is None:
+            if not create_if_missing:
+                raise HTTPException(404, "No OAuth token row for this endpoint.")
+            row = EndpointOAuthToken(id=uuid.uuid4().hex, endpoint_id=endpoint_id,
+                                     owner=owner, provider_id=provider_id)
+            db.add(row)
+        row.access_token = token_set.access_token
+        row.refresh_token = token_set.refresh_token
+        if token_set.account_id:
+            row.account_id = token_set.account_id
+        row.expires_at = token_set.expires_at
+        row.last_refresh_at = _utcnow_naive()
+        row.status = "active"
+        row.last_error_redacted = None
+        db.commit()
+    finally:
+        db.close()
+
+
+def _record_error(endpoint_id: str, err: cx.CodexAuthError) -> None:
+    from core.database import SessionLocal, EndpointOAuthToken
+    db = SessionLocal()
+    try:
+        row = db.query(EndpointOAuthToken).filter(
+            EndpointOAuthToken.endpoint_id == endpoint_id
+        ).first()
+        if row is None:
+            return
+        if err.relogin_required:
+            row.status = "needs_relogin"
+        elif err.code == "quota":
+            row.status = "quota"
+        else:
+            row.status = "error"
+        row.last_error_redacted = str(err)[:500]  # redacted by construction
+        db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+def _needs_refresh(row) -> bool:
+    if not row.access_token:
+        return True
+    if row.expires_at is not None:
+        return row.expires_at <= _utcnow_naive() + timedelta(seconds=cx.REFRESH_SKEW_SECONDS)
+    # Opaque/unknown expiry — fall back to decoding the JWT directly.
+    return cx.access_token_is_expiring(row.access_token)
+
+
+def _build_credential(access_token: str, account_id: Optional[str]) -> Credential:
+    headers = {"Authorization": f"Bearer {access_token}"}
+    if account_id:
+        headers["chatgpt-account-id"] = account_id
+    return Credential(headers=headers)
+
+
+def _http_from(err: cx.CodexAuthError) -> HTTPException:
+    if err.relogin_required:
+        return HTTPException(401, "Codex authentication expired — reconnect this endpoint.")
+    if err.code == "quota":
+        return HTTPException(429, "Codex usage quota reached — retry after the limit resets.")
+    return HTTPException(502, "Codex token refresh failed.")
+
+
+async def resolve_oauth_credential(ref: EndpointRef, spec: Optional[ProviderSpec]) -> Credential:
+    """Return a live bearer credential for an OAuth endpoint, refreshing on
+    expiry. `credentials._guard_oauth` has already ensured `ref.endpoint_id`."""
+    endpoint_id = ref.endpoint_id
+    assert endpoint_id  # guaranteed by the guard upstream
+
+    row = _load_row(endpoint_id)
+    if row is None:
+        raise HTTPException(401, "Codex endpoint is not connected — connect it first.")
+    if row.status == "needs_relogin":
+        raise HTTPException(401, "Codex authentication expired — reconnect this endpoint.")
+
+    if not _needs_refresh(row):
+        return _build_credential(row.access_token, row.account_id)
+
+    # Refresh path — single-flight per endpoint.
+    async with _lock_for(endpoint_id):
+        row = _load_row(endpoint_id)            # re-read: another coroutine may have rotated
+        if row is None:
+            raise HTTPException(401, "Codex endpoint is not connected — connect it first.")
+        if row.status == "needs_relogin":
+            raise HTTPException(401, "Codex authentication expired — reconnect this endpoint.")
+        if not _needs_refresh(row):
+            return _build_credential(row.access_token, row.account_id)
+        if not row.refresh_token:
+            raise HTTPException(401, "Codex endpoint has no refresh token — reconnect it.")
+
+        try:
+            token_set = await cx.refresh_tokens(row.refresh_token)
+        except cx.CodexAuthError as err:
+            logger.warning("codex refresh failed for endpoint (code=%s, relogin=%s)",
+                           err.code, err.relogin_required)
+            _record_error(endpoint_id, err)
+            raise _http_from(err)
+
+        persist_tokens(endpoint_id, token_set)
+        account_id = token_set.account_id or row.account_id
+        return _build_credential(token_set.access_token, account_id)

--- a/src/providers/auth/static.py
+++ b/src/providers/auth/static.py
@@ -1,0 +1,13 @@
+"""Static-key credential resolution.
+
+The headers frozen on the EndpointRef ARE the credential — this is the identity
+function that makes wrapping today's tuple callers in an `EndpointRef` a no-op.
+The value of routing through here is that the OAuth impl plugs in at the same
+seam without touching the call path.
+"""
+from src.providers.auth.credentials import Credential
+from src.providers.endpoint_ref import EndpointRef
+
+
+def resolve(ref: EndpointRef) -> Credential:
+    return Credential(headers=dict(ref.headers) if ref.headers else {})

--- a/src/providers/codex_responses.py
+++ b/src/providers/codex_responses.py
@@ -1,0 +1,345 @@
+"""ChatGPT-subscription (codex) transport — the OpenAI **Responses** wire format.
+
+Pure request/response shaping + a stateful streaming decoder, mirroring the
+openai_chat / anthropic_messages transports. Speaks the codex Responses API behind
+a ChatGPT Plus/Pro OAuth session (`POST {base}/responses`, `store:false`, low-level
+streamed events) rather than the metered chat/completions API. Wire format
+validated against open-source codex clients (pi, opencode) running this exact
+pattern on remote deployments.
+
+Boundaries (kept deliberately):
+  - Credentials (Authorization + chatgpt-account-id) come from `auth.resolve`; this
+    transport only adds the wire-format headers (originator / User-Agent / Beta).
+  - `store:false` + `include:[reasoning.encrypted_content]` are sent, but the
+    encrypted reasoning is NOT persisted/echoed across turns (Odysseus stores
+    plain chat history). That costs cross-turn reasoning-cache affinity, not
+    correctness. Reasoning round-trip + WebSocket transport are possible follow-ups.
+  - `max_tokens` and `temperature` are intentionally OMITTED — the codex Responses
+    backend rejects both ("Unsupported parameter"). Reasoning models are governed by
+    reasoning effort, not temperature. Mirrors pi / opencode.
+"""
+import json
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from src.providers.common import DOC_TOOLS
+
+logger = logging.getLogger(__name__)
+
+# Backend-compatibility headers — mimic the codex CLI (whose public client_id we
+# reuse). Maintained by hand against the codex CLI's current values.
+ORIGINATOR = "codex_cli_rs"
+USER_AGENT = "codex_cli_rs/0.0.0 (Odysseus)"
+OPENAI_BETA = "responses=experimental"
+
+# Terminal Responses events — any of these ends the stream.
+_TERMINAL_EVENTS = ("response.completed", "response.done", "response.incomplete")
+
+
+def _text_from_blocks(blocks: List[Dict]) -> str:
+    """Join the text of OpenAI-chat multimodal content blocks."""
+    return "".join(b.get("text", "") for b in blocks
+                   if isinstance(b, dict) and b.get("type") == "text")
+
+
+def _to_input_content(content) -> List[Dict]:
+    """OpenAI-chat user content -> Responses `input_text`/`input_image` parts."""
+    if isinstance(content, str):
+        return [{"type": "input_text", "text": content}]
+    parts: List[Dict] = []
+    for b in content or []:
+        if not isinstance(b, dict):
+            continue
+        if b.get("type") == "text":
+            parts.append({"type": "input_text", "text": b.get("text", "")})
+        elif b.get("type") == "image_url":
+            url = (b.get("image_url") or {}).get("url", "")
+            if url:
+                parts.append({"type": "input_image", "detail": "auto", "image_url": url})
+    return parts
+
+
+def _stringify(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return _text_from_blocks(content)
+    return "" if content is None else str(content)
+
+
+def _convert_messages(messages: List[Dict]) -> Tuple[Optional[str], List[Dict]]:
+    """OpenAI-chat transcript -> (instructions, Responses `input` items).
+
+    System messages become `instructions` (codex carries the system prompt out of
+    band). assistant `tool_calls` -> `function_call`; `role:"tool"` results ->
+    `function_call_output`, paired by `call_id`.
+    """
+    instructions_parts: List[str] = []
+    input_items: List[Dict] = []
+    for m in messages:
+        role = m.get("role")
+        content = m.get("content")
+        if role == "system":
+            txt = content if isinstance(content, str) else _text_from_blocks(content or [])
+            if txt:
+                instructions_parts.append(txt)
+        elif role == "user":
+            parts = _to_input_content(content)
+            if parts:
+                input_items.append({"role": "user", "content": parts})
+        elif role == "assistant":
+            text = content if isinstance(content, str) else _text_from_blocks(content or [])
+            if text and text.strip():
+                input_items.append({
+                    "type": "message", "role": "assistant", "status": "completed",
+                    "content": [{"type": "output_text", "text": text, "annotations": []}],
+                })
+            for tc in m.get("tool_calls") or []:
+                fn = tc.get("function") or {}
+                args = fn.get("arguments")
+                if not isinstance(args, str):
+                    args = json.dumps(args or {})
+                # `id` (item id) is intentionally omitted: it only matters for the
+                # reasoning-item pairing OpenAI runs on stored sessions, which this
+                # transport does not use (store:false, no reasoning echo). call_id
+                # pairs the result below.
+                input_items.append({
+                    "type": "function_call", "call_id": tc.get("id", ""),
+                    "name": fn.get("name", ""), "arguments": args,
+                })
+        elif role == "tool":
+            input_items.append({
+                "type": "function_call_output",
+                "call_id": m.get("tool_call_id", ""),
+                "output": _stringify(content),
+            })
+    instructions = "\n\n".join(p for p in instructions_parts if p) or None
+    return instructions, input_items
+
+
+def _convert_tools(tools: Optional[List[Dict]]) -> List[Dict]:
+    """OpenAI-chat tools -> Responses function tools (flat, not nested under `function`)."""
+    out: List[Dict] = []
+    for t in tools or []:
+        fn = t.get("function") or {}
+        out.append({
+            "type": "function",
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "parameters": fn.get("parameters") or {},
+            "strict": None,
+        })
+    return out
+
+
+class CodexStreamDecoder:
+    """Reconstruct Odysseus SSE chunks from low-level codex Responses events.
+
+    Emits the SAME normalized chunk shapes as `OpenAIStreamDecoder` (text `delta`,
+    `thinking` delta, `tool_calls`, `tool_call_delta`, `usage`, `[DONE]`) so the
+    client and `agent_loop` are provider-agnostic.
+    """
+
+    def __init__(self, model: str):
+        self._model = model
+        self._cur_type: Optional[str] = None      # message | reasoning | function_call
+        self._cur_tool: Optional[Dict] = None      # {id, name, arguments}
+        self._tool_calls: List[Dict] = []
+        self._tool_index = 0
+        self._saw_text_delta = False
+
+    # -- chunk emitters (byte-compatible with openai_chat) -------------------
+    @staticmethod
+    def _text_chunk(text: str) -> str:
+        return f'data: {json.dumps({"delta": text})}\n\n'
+
+    @staticmethod
+    def _thinking_chunk(text: str) -> str:
+        return f'data: {json.dumps({"delta": text, "thinking": True})}\n\n'
+
+    @staticmethod
+    def _usage_chunk(usage: Dict) -> str:
+        data = {
+            "input_tokens": usage.get("input_tokens", 0) or 0,
+            "output_tokens": usage.get("output_tokens", 0) or 0,
+        }
+        return f'data: {json.dumps({"type": "usage", "data": data})}\n\n'
+
+    def _emit_tool_calls(self) -> Optional[str]:
+        if not self._tool_calls:
+            return None
+        return f'data: {json.dumps({"type": "tool_calls", "calls": self._tool_calls})}\n\n'
+
+    @staticmethod
+    def _error_chunk(message: str, status: int = 502) -> str:
+        return f'event: error\ndata: {json.dumps({"error": str(message), "status": status})}\n\n'
+
+    def finalize(self) -> List[str]:
+        out: List[str] = []
+        tc = self._emit_tool_calls()
+        if tc:
+            out.append(tc)
+        out.append("data: [DONE]\n\n")
+        return out
+
+    def decode_line(self, line: str) -> Tuple[List[str], bool]:
+        if not line or not line.startswith("data:"):
+            return [], False
+        data = line[5:].strip()
+        if not data:
+            return [], False
+        if data == "[DONE]":
+            return self.finalize(), True
+        try:
+            ev = json.loads(data)
+        except Exception:
+            return [], False
+
+        t = ev.get("type")
+        out: List[str] = []
+        try:
+            if t == "response.output_item.added":
+                item = ev.get("item") or {}
+                self._cur_type = item.get("type")
+                if self._cur_type == "function_call":
+                    self._cur_tool = {
+                        "id": item.get("call_id") or item.get("id") or "",
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments") or "",
+                    }
+                elif self._cur_type == "message":
+                    self._saw_text_delta = False
+
+            elif t in ("response.output_text.delta", "response.refusal.delta"):
+                d = ev.get("delta", "")
+                if d:
+                    self._saw_text_delta = True
+                    out.append(self._text_chunk(d))
+
+            elif t == "response.reasoning_summary_text.delta":
+                d = ev.get("delta", "")
+                if d:
+                    out.append(self._thinking_chunk(d))
+
+            elif t == "response.reasoning_summary_part.done":
+                out.append(self._thinking_chunk("\n\n"))
+
+            elif t == "response.function_call_arguments.delta":
+                if self._cur_tool is not None:
+                    d = ev.get("delta", "")
+                    self._cur_tool["arguments"] += d
+                    if d and self._cur_tool.get("name") in DOC_TOOLS:
+                        out.append(f'data: {json.dumps({"type": "tool_call_delta", "index": self._tool_index, "name": self._cur_tool["name"], "arg_delta": d})}\n\n')
+
+            elif t == "response.function_call_arguments.done":
+                if self._cur_tool is not None:
+                    args = ev.get("arguments")
+                    if args is not None:
+                        self._cur_tool["arguments"] = args
+
+            elif t == "response.output_item.done":
+                item = ev.get("item") or {}
+                it = item.get("type")
+                if it == "function_call" and self._cur_tool is not None:
+                    if not self._cur_tool["arguments"]:
+                        self._cur_tool["arguments"] = item.get("arguments") or ""
+                    self._cur_tool["id"] = self._cur_tool["id"] or item.get("call_id") or item.get("id") or ""
+                    self._cur_tool["name"] = self._cur_tool["name"] or item.get("name", "")
+                    self._tool_calls.append(self._cur_tool)
+                    self._cur_tool = None
+                    self._tool_index += 1
+                elif it == "message" and not self._saw_text_delta:
+                    # Backend streamed no deltas — emit the finished text once so we
+                    # never drop content (the streaming contract normally sends deltas).
+                    text = "".join(
+                        p.get("text", "") for p in (item.get("content") or [])
+                        if isinstance(p, dict) and p.get("type") == "output_text"
+                    )
+                    if text:
+                        out.append(self._text_chunk(text))
+                self._cur_type = None
+
+            elif t in _TERMINAL_EVENTS:
+                resp = ev.get("response") or {}
+                usage = resp.get("usage")
+                if usage:
+                    out.append(self._usage_chunk(usage))
+                out.extend(self.finalize())
+                return out, True
+
+            elif t == "error":
+                msg = ev.get("message") or ev.get("code") or "codex stream error"
+                return [self._error_chunk(msg)], True
+
+            elif t == "response.failed":
+                err = (ev.get("response") or {}).get("error") or {}
+                return [self._error_chunk(err.get("message") or "codex response failed")], True
+
+        except Exception as e:
+            logger.error(f"Error decoding codex stream event: {e}")
+            return out, False
+        return out, False
+
+
+class CodexResponsesTransport:
+    id = "codex_responses"
+
+    def target_url(self, url: str) -> str:
+        n = (url or "").rstrip("/")
+        if n.endswith("/codex/responses"):
+            return n
+        if n.endswith("/codex"):
+            return n + "/responses"
+        return n + "/codex/responses"
+
+    def build_payload(self, model, messages, temperature, max_tokens, *, stream=False, tools=None) -> Dict:
+        instructions, input_items = _convert_messages(messages)
+        payload: Dict = {
+            "model": model,
+            "store": False,
+            "stream": bool(stream),
+            "input": input_items,
+            "include": ["reasoning.encrypted_content"],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+            "text": {"verbosity": "low"},
+        }
+        if instructions:
+            payload["instructions"] = instructions
+        if tools:
+            payload["tools"] = _convert_tools(tools)
+        # temperature + max_tokens are intentionally omitted — the codex Responses
+        # backend rejects both ("Unsupported parameter"). Reasoning models use
+        # reasoning effort, not temperature; matches pi / opencode.
+        return payload
+
+    def build_headers(self, headers: Optional[Dict]) -> Dict:
+        h = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "OpenAI-Beta": OPENAI_BETA,
+            "originator": ORIGINATOR,
+            "User-Agent": USER_AGENT,
+        }
+        if headers:
+            h.update(headers)   # Authorization + chatgpt-account-id from auth.resolve
+        return h
+
+    def parse_response(self, data: Dict) -> str:
+        """Extract assistant text from a non-streaming Responses object.
+
+        Streaming is the proven path; non-stream support depends on the backend
+        honoring `stream:false` (verified in manual smoke, not unit-provable here).
+        """
+        if isinstance(data.get("output_text"), str):
+            return data["output_text"]
+        texts: List[str] = []
+        for item in data.get("output") or []:
+            if isinstance(item, dict) and item.get("type") == "message":
+                for part in item.get("content") or []:
+                    if isinstance(part, dict) and part.get("type") == "output_text":
+                        texts.append(part.get("text", ""))
+        return "".join(texts)
+
+    def stream_decoder(self, model: str) -> CodexStreamDecoder:
+        return CodexStreamDecoder(model)

--- a/src/providers/common.py
+++ b/src/providers/common.py
@@ -1,0 +1,6 @@
+"""Pure helpers shared across transports."""
+
+# Document tools whose streaming arguments are surfaced to the frontend as
+# incremental `tool_call_delta` events (so the document UI can render live).
+# Both the OpenAI and Anthropic stream decoders special-case these names.
+DOC_TOOLS = ("create_document", "update_document", "edit_document")

--- a/src/providers/endpoint_ref.py
+++ b/src/providers/endpoint_ref.py
@@ -1,0 +1,35 @@
+"""EndpointRef — endpoint identity + credential source for one dispatch target.
+
+The load-bearing reason this exists: today's call path freezes auth *headers* at
+resolve time. An OAuth provider can't refresh a token from a frozen header — it
+needs endpoint IDENTITY (which DB endpoint / which owner) so it can look up and
+refresh the credential per call. `EndpointRef` carries that identity alongside
+the static headers.
+
+`from_legacy()` wraps the historical `(url, model, headers)` tuple. It has no
+`endpoint_id`, so it is **static-compatible but NOT OAuth-complete** — a
+documented boundary, not a gap. The auth resolver raises if an OAuth provider is
+handed a legacy ref (see providers.auth.credentials).
+"""
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class EndpointRef:
+    url: str
+    model: Optional[str] = None
+    headers: Optional[Dict[str, str]] = None
+    endpoint_id: Optional[str] = None      # DB identity — REQUIRED for OAuth refresh
+    owner: Optional[str] = None
+    provider_id: Optional[str] = None       # ProviderSpec.id, when known
+    auth_type: str = "api_key"              # "api_key" | "oauth"
+
+    @classmethod
+    def from_legacy(cls, url: str, model: Optional[str] = None,
+                    headers: Optional[Dict[str, str]] = None) -> "EndpointRef":
+        """Build a STATIC-creds ref from the legacy (url, model, headers) tuple.
+
+        No endpoint identity → static-compatible, not OAuth-complete.
+        """
+        return cls(url=url, model=model, headers=headers, auth_type="api_key")

--- a/src/providers/registry.py
+++ b/src/providers/registry.py
@@ -1,0 +1,47 @@
+"""Provider registry — URL → ProviderSpec → Transport.
+
+The minimal seam introduced alongside the OpenAI-Codex (ChatGPT-subscription)
+provider. `detect_spec` recognizes every built-in provider so spec metadata
+(id / label / auth_type / model-list mode) is available uniformly, but only the
+**codex** transport is wired here — OpenAI-compatible and Anthropic endpoints
+continue to be served by `llm_core`'s existing detection/dispatch. Folding those
+transports into this registry is left as a follow-up refactor.
+"""
+from src.providers.codex_responses import CodexResponsesTransport
+from src.providers.spec import BUILTIN_SPECS, OPENAI_SPEC, ProviderSpec
+
+# Singleton transports — pure and stateless, safe to share. Only the codex
+# transport lives here for now (see module docstring).
+_TRANSPORTS = {
+    "codex_responses": CodexResponsesTransport(),
+}
+
+
+def detect_spec(url: str) -> ProviderSpec:
+    """Resolve the ProviderSpec for an endpoint URL (OpenAI is the default)."""
+    for spec in BUILTIN_SPECS:
+        if spec.url_matchers and spec.matches(url):
+            return spec
+    return OPENAI_SPEC
+
+
+def get_transport(spec_or_id):
+    """Resolve a Transport from a ProviderSpec or a transport id.
+
+    Only the codex transport is wired in this seam; resolving any other transport
+    raises — non-codex endpoints must route through `llm_core`'s legacy provider
+    dispatch, not this registry.
+    """
+    tid = spec_or_id.transport if isinstance(spec_or_id, ProviderSpec) else spec_or_id
+    try:
+        return _TRANSPORTS[tid]
+    except KeyError:
+        raise KeyError(
+            f"transport '{tid}' is not wired in the codex seam — non-codex "
+            f"endpoints are served by llm_core's legacy provider dispatch"
+        )
+
+
+def is_codex_url(url: str) -> bool:
+    """True for the codex (ChatGPT-subscription) backend — the one OAuth provider."""
+    return detect_spec(url).id == "openai-codex"

--- a/src/providers/spec.py
+++ b/src/providers/spec.py
@@ -1,0 +1,76 @@
+"""Provider specifications — data-only descriptors.
+
+A `ProviderSpec` names a provider, the transport that speaks its wire format, how
+to recognize its endpoints, and how it authenticates. It holds NO behavior beyond
+URL matching; request shaping lives in the transport, credential resolution in
+`providers.auth`.
+
+`auth_type` is `"api_key"` for the Anthropic and OpenAI builtins, and `"oauth"`
+for the ChatGPT-subscription / codex provider.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+# Curated Anthropic model list (no public /models endpoint to probe).
+ANTHROPIC_MODELS = [
+    "claude-opus-4-20250514", "claude-opus-4",
+    "claude-sonnet-4-20250514", "claude-sonnet-4", "claude-sonnet-4-5-20250929", "claude-sonnet-4-5",
+    "claude-haiku-4-20250514", "claude-haiku-4", "claude-haiku-3-5-20241022", "claude-haiku-3-5",
+]
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    id: str
+    label: str
+    transport: str            # transport id, resolved via registry.get_transport
+    auth_type: str            # "api_key" | "oauth"
+    url_matchers: Tuple[str, ...]
+    default_chat_path: str
+    model_list_mode: str      # "static" | "probe"
+
+    def matches(self, url: str) -> bool:
+        u = url or ""
+        return any(m in u for m in self.url_matchers)
+
+
+ANTHROPIC_SPEC = ProviderSpec(
+    id="anthropic",
+    label="Anthropic",
+    transport="anthropic_messages",
+    auth_type="api_key",
+    url_matchers=("anthropic.com",),
+    default_chat_path="/v1/messages",
+    model_list_mode="static",
+)
+
+# Curated codex model list (ChatGPT-subscription; no public /models probe to ask).
+# Maintained by hand against the backend's current lineup.
+CODEX_MODELS = ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"]
+
+# ChatGPT-subscription provider: the codex Responses backend behind an OAuth
+# session. URL-matched on the distinctive backend path; never the default.
+OPENAI_CODEX_SPEC = ProviderSpec(
+    id="openai-codex",
+    label="ChatGPT (Codex)",
+    transport="codex_responses",
+    auth_type="oauth",
+    url_matchers=("chatgpt.com/backend-api/codex",),
+    default_chat_path="/responses",
+    model_list_mode="static",
+)
+
+# The default/fallthrough provider: any OpenAI-compatible host (OpenAI, xAI, Groq,
+# OpenRouter, local Ollama/vLLM, …). Empty matchers → only selected as the default.
+OPENAI_SPEC = ProviderSpec(
+    id="openai",
+    label="OpenAI",
+    transport="openai_chat",
+    auth_type="api_key",
+    url_matchers=(),
+    default_chat_path="/chat/completions",
+    model_list_mode="probe",
+)
+
+# Order matters: specific matchers first, the empty-matcher default last.
+BUILTIN_SPECS = (ANTHROPIC_SPEC, OPENAI_CODEX_SPEC, OPENAI_SPEC)

--- a/src/providers/transport.py
+++ b/src/providers/transport.py
@@ -1,0 +1,54 @@
+"""Transport protocols.
+
+A `Transport` is the PURE request/response shaping for one provider wire format.
+It performs NO I/O and holds NO global state — `llm_core` owns the httpx client,
+cache, cooldown, retry, and fallback, and drives transports.
+
+Streaming is decoded by a per-stream, stateful (but still I/O-free)
+`StreamDecoder`: `llm_core` reads raw SSE lines off the wire and feeds them in
+one at a time; the decoder returns the normalized SSE chunks to forward to the
+client and a `stop` flag when the provider signals end-of-stream.
+"""
+from typing import Dict, List, Optional, Protocol, Tuple, runtime_checkable
+
+
+class StreamDecoder(Protocol):
+    """Stateful, I/O-free decoder for one streaming response."""
+
+    def decode_line(self, line: str) -> Tuple[List[str], bool]:
+        """Consume one raw SSE line. Return (chunks_to_yield, stop)."""
+        ...
+
+    def finalize(self) -> List[str]:
+        """Chunks to emit when the line stream ends without an explicit stop."""
+        ...
+
+
+@runtime_checkable
+class Transport(Protocol):
+    id: str
+
+    def target_url(self, url: str) -> str:
+        """Map the configured endpoint URL to the wire URL for this provider."""
+        ...
+
+    def build_payload(
+        self,
+        model: str,
+        messages: List[Dict],
+        temperature: float,
+        max_tokens: int,
+        *,
+        stream: bool = False,
+        tools: Optional[List[Dict]] = None,
+    ) -> Dict:
+        ...
+
+    def build_headers(self, headers: Optional[Dict]) -> Dict:
+        ...
+
+    def parse_response(self, data: Dict) -> str:
+        ...
+
+    def stream_decoder(self, model: str) -> StreamDecoder:
+        ...

--- a/static/index.html
+++ b/static/index.html
@@ -2094,6 +2094,29 @@
                 <div id="adm-epApiMsg" class="adm-ep-inline-msg"></div>
               </div>
             </div>
+
+            <!-- Subscription subsection (OAuth sign-in; owner-scoped self-connect,
+                 so deliberately NOT .admin-only — every user links their own account).
+                 Mirrors the API subsection: provider picker (own ids, shared
+                 .adm-provider-* classes) + one generic OAuth card rendered by
+                 codexConnect.js from the selected provider's descriptor. -->
+            <div class="adm-add-section collapsible collapsed" id="adm-add-sub" style="margin-top:14px">
+              <div class="adm-ep-section-head adm-section-toggle" role="button" tabindex="0" aria-expanded="false">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:4px;"><path d="M12 2l2.4 6.6L21 11l-6.6 2.4L12 20l-2.4-6.6L3 11l6.6-2.4L12 2z"/></svg>
+                <span>Subscription</span>
+                <svg class="adm-section-caret" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+              </div>
+              <div class="admin-model-form" id="codex-sub-providers">
+                <div class="adm-provider-picker" id="codex-provider-picker">
+                  <button type="button" class="adm-provider-btn" id="codex-provider-btn" title="Pick provider">
+                    <span class="adm-provider-current"><span class="adm-provider-logo"></span><span class="adm-provider-name">Select Provider</span></span>
+                    <svg class="adm-provider-caret" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                  </button>
+                  <div class="adm-provider-menu hidden" id="codex-provider-menu"></div>
+                </div>
+                <div id="codex-oauth-card"></div>
+              </div>
+            </div>
           </div>
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>Added Models <span style="opacity:0.45;font-weight:normal;font-size:0.82em">(Endpoints)</span></h2>
@@ -2111,6 +2134,16 @@
                 <span>API</span>
               </div>
               <div id="adm-epList-api"></div>
+            </div>
+            <!-- Subscription (OAuth) endpoints — rendered by codexConnect.js from the
+                 provider's owner-scoped status endpoint (the generic list above is
+                 admin-only, so it can't serve regular users' own connections). -->
+            <div class="adm-ep-section" style="margin-top:14px">
+              <div class="adm-ep-section-head">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:4px;"><path d="M12 2l2.4 6.6L21 11l-6.6 2.4L12 20l-2.4-6.6L3 11l6.6-2.4L12 2z"/></svg>
+                <span>Subscription</span>
+              </div>
+              <div id="adm-epList-sub"><div class="admin-empty">None</div></div>
             </div>
           </div>
         </div>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -5,6 +5,7 @@ import uiModule from './ui.js';
 import settingsModule from './settings.js';
 import { providerLogo } from './providers.js';
 import { sortModelObjects } from './modelSort.js';
+import { initCodexConnect, refreshCodexStatus, isSubscriptionEndpointUrl } from './codexConnect.js';
 
 let initialized = false;
 let modalEl = null;
@@ -390,6 +391,12 @@ async function loadEndpoints() {
     let data = [];
     if (res.ok) {
       try { data = await res.json(); } catch { data = []; }
+    }
+    if (Array.isArray(data)) {
+      // Subscription (OAuth) endpoints are managed in the Subscription section
+      // (codexConnect.js) — the generic Delete here would bypass the provider's
+      // disconnect/token-purge path, so keep them out of these lists entirely.
+      data = data.filter(ep => !isSubscriptionEndpointUrl(ep.base_url));
     }
     if (!Array.isArray(data) || data.length === 0) {
       const empty = '<div class="admin-empty">None</div>';
@@ -1069,10 +1076,10 @@ function initEndpointForm() {
     });
   }
 
-  // Collapsible Add-Models subsections (API / Local). Both start collapsed
-  // so the card is compact; the last-used state is remembered per section
-  // in localStorage so a frequent API-adder doesn't re-expand every time.
-  document.querySelectorAll('#adm-add-api, #adm-add-local').forEach((sec) => {
+  // Collapsible Add-Models subsections (API / Local / Subscription). All start
+  // collapsed so the card is compact; the last-used state is remembered per
+  // section in localStorage so a frequent API-adder doesn't re-expand every time.
+  document.querySelectorAll('#adm-add-api, #adm-add-local, #adm-add-sub').forEach((sec) => {
     const head = sec.querySelector('.adm-section-toggle');
     if (!head) return;
     const key = 'odysseus.addModels.' + sec.id + '.open';
@@ -2099,7 +2106,7 @@ function initDangerZone() {
    ═══════════════════════════════════════════ */
 function initAll() {
   modalEl = el('settings-modal');
-  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
+  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations(), initCodexConnect];
   for (const fn of inits) {
     try { fn(); } catch (e) { console.error('Admin init error in', fn.name || 'anonymous', e); }
   }
@@ -2112,6 +2119,7 @@ function refreshAll() {
   loadEndpoints();
   loadBuiltinTools();
   loadMcpServers();
+  refreshCodexStatus();
 }
 
 /* ═══════════════════════════════════════════

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -628,6 +628,19 @@ export function applyModelColor(roleEl, modelName) {
       bindMenuDismiss(popup, () => popup.remove());
     });
   }
+  // Subscription "(sub)" marker, right after the model name. Folded in here
+  // because every role render (streaming, agent, group, history) calls
+  // applyModelColor — the one shared chokepoint. Idempotent; sits before any timestamp.
+  if (!roleEl.querySelector('.model-sub-inline')
+      && window.modelsModule && window.modelsModule.isSubscriptionModel
+      && window.modelsModule.isSubscriptionModel(modelName, '')) {
+    const tag = document.createElement('span');
+    tag.className = 'model-sub-inline';
+    tag.textContent = '(sub)';
+    const ts = roleEl.querySelector('.role-timestamp');
+    if (ts) roleEl.insertBefore(tag, ts);
+    else roleEl.appendChild(tag);
+  }
 }
 
 export function getModelCost(modelName, inputTokens, outputTokens) {

--- a/static/js/codexConnect.js
+++ b/static/js/codexConnect.js
@@ -1,0 +1,493 @@
+// static/js/codexConnect.js — subscription (OAuth) provider connect UI
+//
+// Owner-scoped, self-service: any signed-in user links their own provider
+// subscription (e.g. ChatGPT Plus/Pro) via the device-code flow. The OAuth
+// dance runs server-side (Odysseus is a remote host), so this module only ever
+// shows the user-facing `user_code` + `verification_uri` and polls connection
+// STATE — never any token material.
+//
+// Two mounts inside the Services tab, both data-driven from the registry below:
+//   #codex-sub-providers  (Add Models → Subscription)   provider picker + OAuth card
+//   #adm-epList-sub       (Added Models → Subscription)  connected rows + disconnect
+//
+// The Add Models side mirrors the API subsection's shape: a provider dropdown
+// (same .adm-provider-* classes, own ids) selects one provider, and a single
+// generic OAuth card renders beneath it from that provider's descriptor —
+// adding a provider is one registry entry plus its backend routes, no new UI.
+//
+// Connected rows render from each provider's owner-scoped /status endpoint,
+// NOT from GET /api/model-endpoints — that list is admin-only, so regular
+// users would never see their own connection through it.
+//
+// Backend (see routes/codex_oauth_routes.py), per provider under `api`:
+//   POST  /connect                  -> {attempt_id, endpoint_id, user_code, verification_uri, interval, expires_at}
+//   GET   /connect/{attempt_id}     -> {status, user_code, verification_uri, expires_at, ...}
+//   POST  /connect/{attempt_id}/cancel
+//   GET   /status                   -> {connected:[...], pending:[...]}
+//   POST  /disconnect/{endpoint_id}
+
+import uiModule from './ui.js';
+import { providerLogo } from './providers.js';
+
+// Registry of subscription/OAuth providers. The UI is data-driven from this
+// list — a future provider costs one entry here plus its backend routes.
+// Descriptor: {id, label, sub, logoKey, api, urlPrefix} (+ placeholder:true
+// for a not-yet-wired provider: selectable, renders the card, no backend calls).
+const SUBSCRIPTION_PROVIDERS = [
+  {
+    id: 'openai-codex',
+    label: 'ChatGPT',
+    sub: 'Plus / Pro',
+    logoKey: 'openai',
+    api: '/api/providers/openai-codex',
+    // Owns ModelEndpoint rows whose base_url starts with this prefix; such
+    // rows are managed here and filtered out of the generic endpoint list
+    // (its Delete bypasses the provider's disconnect/token-purge path).
+    urlPrefix: 'https://chatgpt.com/backend-api/codex',
+  },
+];
+
+function providerById(id) {
+  return SUBSCRIPTION_PROVIDERS.find(p => p.id === id) || null;
+}
+
+/** True if `url` belongs to a subscription provider's endpoint (used by
+ *  admin.js to keep those rows out of the generic Added Models lists). */
+export function isSubscriptionEndpointUrl(url) {
+  const u = String(url || '').replace(/\/+$/, '');
+  return SUBSCRIPTION_PROVIDERS.some(p => p.urlPrefix && u.startsWith(p.urlPrefix));
+}
+
+function el(id) { return document.getElementById(id); }
+function esc(s) { return uiModule.esc(String(s == null ? '' : s)); }
+
+async function api(provider, path, opts = {}) {
+  const res = await fetch(provider.api + path, { credentials: 'same-origin', ...opts });
+  let body = null;
+  try { body = await res.json(); } catch (_) { /* empty / non-JSON */ }
+  if (!res.ok) {
+    const detail = (body && (body.detail || body.error)) || `HTTP ${res.status}`;
+    throw new Error(detail);
+  }
+  return body || {};
+}
+
+// ─── Module state ───────────────────────────────────────────────────────────
+let tick = null;        // 1s interval handle
+let attempt = null;     // {provider, id, intervalSec, expiresMs, sinceLastPoll}
+let selectedId = null;  // no auto-selection — the user picks, like the API picker
+let initialized = false;
+
+function flowEl(provider) {
+  return document.querySelector(`[data-codex-flow="${provider.id}"]`);
+}
+
+function setMsg(provider, html, kind = '') {
+  const m = document.querySelector(`[data-codex-msg="${provider.id}"]`);
+  if (!m) return;
+  m.className = kind ? `codex-msg codex-msg-${kind}` : 'codex-msg';
+  m.innerHTML = html;
+}
+
+// ─── Provider picker (Add Models → Subscription) ───────────────────────────
+// Same look as the API subsection's picker (.adm-provider-* classes), own ids.
+function renderPickerMenu() {
+  const menu = el('codex-provider-menu');
+  if (!menu) return;
+  menu.innerHTML = SUBSCRIPTION_PROVIDERS.map(p => {
+    const logo = providerLogo(p.logoKey || p.label) || '';
+    const active = p.id === selectedId ? ' active' : '';
+    return `<div class="adm-provider-item${active}" role="option" data-value="${esc(p.id)}">
+      <span class="adm-provider-logo">${logo}</span>
+      <span>${esc(p.label)}</span>
+    </div>`;
+  }).join('');
+}
+
+function syncPickerCurrent() {
+  const current = document.querySelector('#codex-provider-btn .adm-provider-current');
+  if (!current) return;
+  const p = providerById(selectedId);
+  current.querySelector('.adm-provider-logo').innerHTML = p ? (providerLogo(p.logoKey || p.label) || '') : '';
+  current.querySelector('.adm-provider-name').textContent = p ? p.label : 'Select Provider';
+}
+
+// While a device-code login is mid-flight, switching provider would orphan the
+// visible flow — lock the picker until it completes or is cancelled.
+function syncPickerLock() {
+  const btn = el('codex-provider-btn');
+  if (!btn) return;
+  btn.disabled = !!attempt;
+  btn.title = attempt ? 'Finish or cancel the sign-in in progress first' : 'Pick provider';
+}
+
+function selectProvider(id) {
+  const p = providerById(id);
+  if (!p || id === selectedId) return;
+  selectedId = id;
+  renderPickerMenu();
+  syncPickerCurrent();
+  renderOAuthCard();
+}
+
+// ─── Generic OAuth card (one per selected provider, registry-driven) ───────
+function renderOAuthCard() {
+  const mount = el('codex-oauth-card');
+  if (!mount) return;
+  const p = providerById(selectedId);
+  if (!p) { mount.innerHTML = ''; return; }  // nothing picked yet — just the dropdown
+  const logo = providerLogo(p.logoKey || p.label) || '';
+  const signIn = p.placeholder
+    ? '<button class="admin-btn-add" disabled title="Not yet available">Coming soon</button>'
+    : `<button class="admin-btn-add" data-codex-action="connect" data-provider="${esc(p.id)}">Sign in</button>`;
+  mount.innerHTML = `
+    <div class="codex-provider" data-codex-provider="${esc(p.id)}">
+      <div class="codex-provider-head">
+        <span class="codex-provider-logo">${logo}</span>
+        <div class="codex-provider-titles">
+          <span class="codex-provider-name">Connect ${esc(p.label)} <span class="codex-provider-plan">(${esc(p.sub)})</span></span>
+          <span class="codex-provider-desc">Sign in with your ${esc(p.label)} subscription.</span>
+        </div>
+        ${signIn}
+      </div>
+      <div data-codex-flow="${esc(p.id)}"></div>
+      <div data-codex-msg="${esc(p.id)}"></div>
+    </div>`;
+}
+
+function renderIdle(provider) {
+  const flow = flowEl(provider);
+  if (flow) flow.innerHTML = '';
+  const btn = document.querySelector(`[data-codex-action="connect"][data-provider="${provider.id}"]`);
+  if (btn) { btn.disabled = false; btn.textContent = 'Sign in'; }
+}
+
+// ─── Render: pending device-code ───────────────────────────────────────────
+function renderPending(provider, info) {
+  const flow = flowEl(provider);
+  if (!flow) return;
+  const btn = document.querySelector(`[data-codex-action="connect"][data-provider="${provider.id}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = 'Signing in…'; }
+  flow.innerHTML = `
+    <div class="codex-pending">
+      <div class="codex-step">1. Open the ${esc(provider.label)} login page:</div>
+      <a class="admin-btn-add codex-open-btn" href="${esc(info.verification_uri)}" target="_blank" rel="noopener noreferrer" data-codex-action="open">Open login page ↗</a>
+      <div class="codex-step">2. Enter this code when asked:</div>
+      <div class="codex-code-row">
+        <code class="codex-code" id="codex-usercode">${esc(info.user_code || '')}</code>
+        <button class="admin-btn-sm" data-codex-action="copy" title="Copy code">Copy</button>
+      </div>
+      <div class="codex-wait"><span class="admin-spinner"></span><span id="codex-countdown">Waiting for you to authorize…</span></div>
+      <button class="admin-btn-sm" data-codex-action="cancel">Cancel</button>
+    </div>`;
+}
+
+// ─── Render: connected rows (Added Models → Subscription) ──────────────────
+// Takes [{provider, connected:[...]}] across ALL providers and renders once —
+// a per-provider render would erase the previous provider's rows.
+function renderConnected(results) {
+  const list = el('adm-epList-sub');
+  if (!list) return;
+  const rows = results.flatMap(({ provider, connected }) =>
+    (connected || []).map(c => rowHtml(provider, c)));
+  // Mirror loadEndpoints' empty-group rendering: keep the section visible
+  // with a "None" placeholder so the group lineup matches Local and API.
+  list.innerHTML = rows.length ? rows.join('') : '<div class="admin-empty">None</div>';
+}
+
+function rowHtml(provider, c) {
+  const ok = c.enabled && c.status === 'active';
+  const badge = ok
+    ? '<span class="admin-badge">connected</span>'
+    : c.last_error
+      ? `<span class="admin-badge admin-badge-off" title="${esc(c.last_error)}">needs attention</span>`
+      : `<span class="admin-badge admin-badge-off">${esc(c.status || 'inactive')}</span>`;
+  const reconnect = ok ? '' :
+    `<button class="admin-btn-sm" data-codex-action="reconnect" data-provider="${esc(provider.id)}">Sign in again</button>`;
+  return `
+    <div class="admin-user-row">
+      <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 0;">
+        <div class="admin-user-info" style="flex:1;flex-wrap:wrap;gap:0.3rem;">
+          <span class="codex-dot ${ok ? 'codex-dot-on' : ''}"></span>
+          <span class="admin-user-name">${esc(c.name || provider.label)}</span>
+          ${badge}
+        </div>
+        <div style="display:flex;gap:4px;align-items:center;">
+          ${reconnect}
+          <button class="admin-btn-delete" data-codex-action="disconnect" data-provider="${esc(provider.id)}" data-ep="${esc(c.endpoint_id)}">Disconnect</button>
+        </div>
+      </div>
+    </div>`;
+}
+
+function fmtRemaining(ms) {
+  if (ms <= 0) return 'expiring…';
+  const s = Math.round(ms / 1000);
+  const m = Math.floor(s / 60);
+  return `Waiting for you to authorize… (${m}:${String(s % 60).padStart(2, '0')} left)`;
+}
+
+// ─── Poll loop (single 1s ticker drives countdown + interval-paced poll) ────
+function stopFlow() {
+  if (tick) { clearInterval(tick); tick = null; }
+  attempt = null;
+  syncPickerLock();
+}
+
+function beginFlow(provider, info) {
+  stopFlow();
+  const expiresMs = info.expires_at ? Date.parse(info.expires_at) : (Date.now() + 600000);
+  attempt = {
+    provider,
+    id: info.attempt_id,
+    intervalSec: Math.max(2, info.interval || 5),
+    expiresMs,
+    sinceLastPoll: 0,
+  };
+  // The flow renders into the selected provider's card — make sure it's the
+  // one that owns this attempt (matters when resuming after a reload).
+  selectProvider(provider.id);
+  syncPickerLock();
+  renderPending(provider, info);
+  tick = setInterval(onTick, 1000);
+}
+
+async function onTick() {
+  if (!attempt) return;
+  const provider = attempt.provider;
+  const remaining = attempt.expiresMs - Date.now();
+  const cd = el('codex-countdown');
+  if (cd) cd.textContent = fmtRemaining(remaining);
+  if (remaining <= 0) {
+    const id = attempt.id;
+    stopFlow();
+    try { await api(provider, `/connect/${id}/cancel`, { method: 'POST' }); } catch (_) {}
+    renderIdle(provider);
+    setMsg(provider, 'Login code expired. Try signing in again.', 'warn');
+    loadStatus();
+    return;
+  }
+  attempt.sinceLastPoll += 1;
+  if (attempt.sinceLastPoll < attempt.intervalSec) return;
+  attempt.sinceLastPoll = 0;
+
+  let st;
+  try {
+    st = await api(provider, `/connect/${attempt.id}`);
+  } catch (e) {
+    // Transient poll error — keep waiting; surface only if it persists.
+    return;
+  }
+  if (!attempt) return; // cancelled while awaiting
+  switch (st.status) {
+    case 'authorized':
+      stopFlow();
+      renderIdle(provider);
+      setMsg(provider, `${esc(provider.label)} connected. Its models are now available in the model picker.`, 'ok');
+      loadStatus();
+      refreshModelsCache();
+      break;
+    case 'expired':
+      stopFlow();
+      renderIdle(provider);
+      setMsg(provider, 'Login code expired. Try signing in again.', 'warn');
+      loadStatus();
+      break;
+    case 'cancelled':
+      stopFlow();
+      renderIdle(provider);
+      loadStatus();
+      break;
+    case 'error':
+      stopFlow();
+      renderIdle(provider);
+      setMsg(provider, 'Login failed. Please try again.', 'err');
+      loadStatus();
+      break;
+    // 'pending' → keep ticking
+  }
+}
+
+// The picker builds from modelsModule's cache; refresh it after connect /
+// disconnect so the subscription models (dis)appear without a manual reload.
+function refreshModelsCache() {
+  try {
+    if (window.modelsModule && window.modelsModule.refreshModels) {
+      window.modelsModule.refreshModels(true);
+    }
+  } catch (_) { /* picker refreshes on its own cadence as a fallback */ }
+}
+
+// ─── Actions ───────────────────────────────────────────────────────────────
+async function startConnect(provider, btn) {
+  if (attempt || provider.placeholder) return; // one login at a time; no backend yet
+  setMsg(provider, '');
+  if (btn) { btn.disabled = true; btn.textContent = 'Starting…'; }
+  try {
+    const info = await api(provider, '/connect', { method: 'POST' });
+    beginFlow(provider, info);
+  } catch (e) {
+    if (btn) { btn.disabled = false; btn.textContent = 'Sign in'; }
+    setMsg(provider, `Could not start login: ${esc(e.message)}`, 'err');
+  }
+}
+
+// "Sign in again" on a stale connected row: expand the Add Models →
+// Subscription section, select that provider, and start a fresh device-code
+// login there. The old row keeps its Disconnect button — nothing is removed
+// until the user says so.
+function reconnect(provider) {
+  const sec = el('adm-add-sub');
+  if (sec) {
+    sec.classList.remove('collapsed');
+    const head = sec.querySelector('.adm-section-toggle');
+    if (head) head.setAttribute('aria-expanded', 'true');
+    try { localStorage.setItem('odysseus.addModels.adm-add-sub.open', '1'); } catch {}
+    sec.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+  if (attempt) return; // a login is already mid-flight — just reveal it
+  selectProvider(provider.id);
+  const btn = document.querySelector(`[data-codex-action="connect"][data-provider="${provider.id}"]`);
+  startConnect(provider, btn);
+}
+
+async function cancelAttempt() {
+  if (!attempt) return;
+  const { provider, id } = attempt;
+  stopFlow();
+  renderIdle(provider);
+  try { await api(provider, `/connect/${id}/cancel`, { method: 'POST' }); } catch (_) {}
+  loadStatus();
+}
+
+async function disconnect(provider, endpointId, btn) {
+  if (!endpointId) return;
+  if (btn) { btn.disabled = true; btn.textContent = 'Removing…'; }
+  try {
+    await api(provider, `/disconnect/${endpointId}`, { method: 'POST' });
+    setMsg(provider, 'Disconnected.', '');
+    loadStatus();
+    refreshModelsCache();
+  } catch (e) {
+    if (btn) { btn.disabled = false; btn.textContent = 'Disconnect'; }
+    setMsg(provider, `Could not disconnect: ${esc(e.message)}`, 'err');
+  }
+}
+
+function copyCode(btn) {
+  const code = el('codex-usercode');
+  if (!code) return;
+  const text = code.textContent || '';
+  const flash = (label) => { if (btn) { const p = btn.textContent; btn.textContent = label; setTimeout(() => { btn.textContent = p; }, 1200); } };
+  // navigator.clipboard needs a secure context (HTTPS / localhost). Odysseus is
+  // commonly served over plain HTTP on a LAN IP, where it's undefined — fall
+  // back to a hidden-textarea execCommand copy so the button still works.
+  const legacyCopy = () => {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.top = '-1000px';
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Copy failed');
+    } catch (_) { flash('Copy failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(() => flash('Copied')).catch(legacyCopy);
+  } else {
+    legacyCopy();
+  }
+}
+
+// ─── Status load (also resumes an interrupted pending attempt) ─────────────
+async function loadStatus() {
+  const results = [];
+  for (const provider of SUBSCRIPTION_PROVIDERS) {
+    if (provider.placeholder) continue; // no backend to ask yet
+    try {
+      const data = await api(provider, '/status');
+      results.push({ provider, connected: data.connected || [] });
+      // If a device-code login is mid-flight and we aren't already tracking it
+      // (e.g. modal reopened), resume the poll so the user sees it complete.
+      const pend = (data.pending || [])[0];
+      if (pend && pend.status === 'pending' && !attempt) {
+        beginFlow(provider, {
+          attempt_id: pend.attempt_id,
+          user_code: pend.user_code,
+          verification_uri: pend.verification_uri,
+          expires_at: pend.expires_at,
+          interval: 5,
+        });
+      } else if (!attempt || attempt.provider !== provider) {
+        renderIdle(provider);
+      }
+    } catch (e) {
+      // Owner-scoped endpoint; on 401/unknown just show the idle action.
+      results.push({ provider, connected: [] });
+      if (!attempt || attempt.provider !== provider) renderIdle(provider);
+    }
+  }
+  renderConnected(results);
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
+export function initCodexConnect() {
+  if (initialized) return;
+  const pickerMount = el('codex-sub-providers');
+  const listMount = el('adm-epList-sub');
+  if (!pickerMount && !listMount) return;
+  initialized = true;
+  renderPickerMenu();
+  syncPickerCurrent();
+  renderOAuthCard();
+
+  // Picker open/select/close — mirrors the API subsection's picker wiring.
+  const pickerBtn = el('codex-provider-btn');
+  const pickerMenu = el('codex-provider-menu');
+  const picker = el('codex-provider-picker');
+  if (pickerBtn && pickerMenu && picker) {
+    pickerBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      pickerMenu.classList.toggle('hidden');
+    });
+    pickerMenu.addEventListener('click', (e) => {
+      const item = e.target.closest('.adm-provider-item');
+      if (!item) return;
+      selectProvider(item.dataset.value);
+      pickerMenu.classList.add('hidden');
+    });
+    document.addEventListener('click', (e) => {
+      if (!picker.contains(e.target)) pickerMenu.classList.add('hidden');
+    });
+  }
+
+  // One delegated click handler per mount for card/row actions.
+  [pickerMount, listMount].filter(Boolean).forEach(mount =>
+    mount.addEventListener('click', (e) => {
+      const t = e.target.closest('[data-codex-action]');
+      if (!t) return;
+      const action = t.dataset.codexAction;
+      if (action === 'open') return; // real <a>, let it navigate
+      e.preventDefault();
+      const provider = providerById(t.dataset.provider) || (attempt && attempt.provider);
+      switch (action) {
+        case 'connect': if (provider) startConnect(provider, t); break;
+        case 'reconnect': if (provider) reconnect(provider); break;
+        case 'cancel': cancelAttempt(); break;
+        case 'copy': copyCode(t); break;
+        case 'disconnect': if (provider) disconnect(provider, t.dataset.ep, t); break;
+      }
+    }));
+}
+
+export function refreshCodexStatus() {
+  if (!initialized) return;
+  loadStatus();
+}
+
+const codexConnectModule = { initCodexConnect, refreshCodexStatus, isSubscriptionEndpointUrl };
+export default codexConnectModule;

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -201,6 +201,7 @@ function _initModelPickerDropdown() {
             item.host || '',
             item.url || '',
           ].filter(Boolean).join(' '),
+          subscription: !!item.is_subscription,
           stale: isLocalDead,
           staleReason: isLocalDead ? (probeResult.error || 'not responding') : '',
         });
@@ -318,6 +319,13 @@ function _initModelPickerDropdown() {
         badge.textContent = 'offline';
         badge.style.cssText = 'font-size:10px;opacity:0.7;padding:1px 6px;border:1px solid var(--border);border-radius:8px;margin-left:6px;';
         row.appendChild(badge);
+      }
+      if (m.subscription) {
+        const subBadge = document.createElement('span');
+        subBadge.className = 'model-switch-sub-badge';
+        subBadge.textContent = 'sub';
+        subBadge.title = 'Flat-rate subscription access (no per-token API billing)';
+        row.appendChild(subBadge);
       }
       const epSpan = document.createElement('span');
       epSpan.className = 'model-switch-ep';
@@ -687,9 +695,21 @@ export function updateModelPicker() {
 
   const displayName = modelId ? modelId.split('/').pop() : 'Select model';
   const logo = modelId ? providerLogo(modelId) : null;
+  // providerLogo() returns a trusted SVG string; the model name is appended as
+  // a text node so it can never be parsed as markup.
   if (logo) {
-    label.innerHTML = '<span class="model-picker-logo">' + logo + '</span> ' + displayName;
+    label.innerHTML = '<span class="model-picker-logo">' + logo + '</span> ';
+    label.appendChild(document.createTextNode(displayName));
   } else {
     label.textContent = displayName;
+  }
+  const endpointUrl = (s && s.endpoint_url) || (_pendingChat && _pendingChat.url) || '';
+  if (modelId && window.modelsModule && window.modelsModule.isSubscriptionModel
+      && window.modelsModule.isSubscriptionModel(modelId, endpointUrl)) {
+    label.appendChild(document.createTextNode(' '));
+    const subTag = document.createElement('span');
+    subTag.className = 'model-sub-inline';
+    subTag.textContent = '(sub)';
+    label.appendChild(subTag);
   }
 }

--- a/static/js/models.js
+++ b/static/js/models.js
@@ -631,11 +631,30 @@ export async function refreshProviders() {
 
 export function getCachedItems() { return _cachedItems; }
 
+/**
+ * True if `modelId` is served by a flat-rate subscription endpoint (e.g.
+ * ChatGPT-sub via codex), used to surface a "(sub)" marker in the UI. When
+ * `url` is given, the match is narrowed to that endpoint so the same model id
+ * offered by both a subscription and a metered API key isn't mis-tagged.
+ */
+export function isSubscriptionModel(modelId, url) {
+  if (!modelId || !_cachedItems) return false;
+  const targetUrl = (url || '').replace(/\/+$/, '');
+  return _cachedItems.some(item => {
+    if (item.offline || !item.is_subscription) return false;
+    const itemUrl = (item.url || '').replace(/\/+$/, '');
+    if (targetUrl && itemUrl !== targetUrl) return false;
+    const models = (item.models || []).concat(item.models_extra || []);
+    return models.includes(modelId);
+  });
+}
+
 const modelsModule = {
   init,
   refreshModels,
   refreshProviders,
   getCachedItems,
+  isSubscriptionModel,
 };
 
 export default modelsModule;

--- a/static/style.css
+++ b/static/style.css
@@ -563,12 +563,11 @@ body.bg-pattern-sparkles {
     .sidebar-brand-title {
       font-size: 1rem;
       font-weight: 600;
-      line-height: 1.35;
       color: var(--brand-color, var(--red));
       white-space: nowrap;
       user-select: none;
       position: relative;
-      top: 0;
+      top: 1px;
       left: -10px;
     }
     .sidebar-sep {
@@ -14023,7 +14022,8 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
    left-aligned, accent-colored treatment so they read as "this row is your
    placeholder, click Add" rather than a centered "nothing here" grey blob. */
 #adm-epList-local .admin-empty,
-#adm-epList-api .admin-empty {
+#adm-epList-api .admin-empty,
+#adm-epList-sub .admin-empty {
   text-align: left;
   padding: 8px 4px;
   color: var(--accent-primary, var(--accent, var(--red)));
@@ -35730,4 +35730,108 @@ body.theme-frosted .modal {
   /* Email compose rich-body. Medium (15px) zooms, so bump it; large (17px)
      is already ≥16px and never zoomed — leave it so we don't shrink it. */
   .doc-email-richbody.doc-font-m { font-size: 16px !important; }
+}
+
+/* ─── Subscription (Codex / OAuth) connect — Add Models + Added Models ──── */
+.codex-provider {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  padding: 10px 12px;
+}
+.codex-provider-head {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.codex-provider-logo {
+  width: 18px; height: 18px;
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0; color: var(--fg); opacity: 0.85;
+}
+.codex-provider-logo svg { width: 18px; height: 18px; }
+.codex-provider-titles {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.codex-provider-name { font-size: 12px; font-weight: 600; }
+.codex-provider-plan { opacity: 0.45; font-weight: normal; font-size: 0.85em; }
+.codex-provider-desc {
+  font-size: 10.5px;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+}
+.codex-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--fg) 30%, transparent);
+  flex: 0 0 auto;
+}
+.codex-dot-on { background: #2ecc71; box-shadow: 0 0 5px #2ecc71; }
+.codex-pending {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0 2px;
+}
+.codex-step {
+  font-size: 11.5px;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  margin-top: 4px;
+}
+.codex-open-btn { align-self: flex-start; text-decoration: none; }
+.codex-code-row { display: flex; align-items: center; gap: 8px; }
+.codex-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  user-select: all;
+}
+.codex-wait {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  margin-top: 2px;
+}
+.codex-msg {
+  font-size: 11.5px;
+  margin-top: 8px;
+  min-height: 1px;
+}
+.codex-msg-ok { color: #2ecc71; }
+.codex-msg-warn { color: #e0a93b; }
+.codex-msg-err { color: var(--red); }
+
+
+/* Model-picker badge marking a flat-rate subscription (OAuth) endpoint */
+.model-switch-sub-badge {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  color: #2ecc71;
+  border: 1px solid color-mix(in srgb, #2ecc71 45%, transparent);
+  background: color-mix(in srgb, #2ecc71 12%, transparent);
+}
+
+/* Lightweight "(sub)" marker — collapsed model picker label + inline chat role.
+   Same green subscription signal as .model-switch-sub-badge, minus the pill. */
+.model-sub-inline {
+  font-size: 0.82em;
+  font-weight: 500;
+  color: #2ecc71;
+  opacity: 0.9;
 }

--- a/tests/test_codex_oauth.py
+++ b/tests/test_codex_oauth.py
@@ -1,0 +1,400 @@
+"""Tests for the ChatGPT-subscription (codex) OAuth backend.
+
+Covers the device-code protocol service, the `auth.resolve` OAuth branch
+(refresh-on-expiry, single-flight, error->status mapping), and the connect/
+status/cancel/disconnect/import routes. All network I/O is mocked by injecting an
+`httpx.MockTransport` at the `codex_oauth._new_async_client` seam (a built-in httpx
+primitive — no network-mock dependency); the DB is a throwaway sqlite rebind. No
+real tokens, no real OpenAI calls.
+"""
+import asyncio
+import base64
+import json
+import sys
+import time
+
+import httpx
+import pytest
+
+# --- Real-module isolation -------------------------------------------------
+# In the full suite, earlier-collected files (test_agent_loop.py) stub
+# `sqlalchemy` and `core.database` as MagicMock in sys.modules at collection time
+# and never restore them. This file needs the REAL sqlalchemy + DB models. So:
+# snapshot whatever stubs are present, swap in the real modules just long enough
+# to bind our globals (db, routes_mod, create_engine, sessionmaker), then restore
+# the snapshot byte-for-byte — later-collected files still see the stubs they
+# expect (no cascade). Our bound names keep pointing at the real module objects;
+# the oauth_db fixture re-points sys.modules['core.database'] at the real module
+# per-test, for oauth_store's lazy `from core.database import ...`.
+_iso_keys = ["core.database", "routes.codex_oauth_routes"] + [
+    m for m in list(sys.modules) if m == "sqlalchemy" or m.startswith("sqlalchemy.")
+]
+_iso_snapshot = {k: sys.modules.get(k) for k in dict.fromkeys(_iso_keys)}
+for _k in _iso_snapshot:
+    sys.modules.pop(_k, None)
+try:
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    import core.database as db
+    import routes.codex_oauth_routes as routes_mod
+finally:
+    for _k in [m for m in list(sys.modules) if m == "sqlalchemy" or m.startswith("sqlalchemy.")]:
+        sys.modules.pop(_k, None)
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("routes.codex_oauth_routes", None)
+    for _k, _v in _iso_snapshot.items():
+        if _v is not None:
+            sys.modules[_k] = _v
+
+import src.providers.auth.codex_oauth as cx
+import src.providers.auth.oauth_store as store
+from src.providers import auth
+from src.providers.endpoint_ref import EndpointRef
+from src.providers.spec import ProviderSpec
+
+CODEX_SPEC = ProviderSpec(
+    id="openai-codex", label="ChatGPT", transport="codex_responses", auth_type="oauth",
+    url_matchers=(), default_chat_path="/responses", model_list_mode="static",
+)
+
+
+class _MockHTTP:
+    """Routes httpx traffic to queued responses via ``httpx.MockTransport`` — a
+    built-in httpx primitive, so these tests carry no respx/network-mock dep.
+
+    Captures every outgoing request; per-URL queues allow sequencing (mirrors
+    respx's ``side_effect=[...]``). A single queued response repeats (``return_value=``)."""
+
+    def __init__(self):
+        self.calls = []          # list[httpx.Request], in send order
+        self._routes = {}        # str(url) -> list[httpx.Response]
+
+    def route(self, url, *responses):
+        self._routes.setdefault(str(url), []).extend(responses)
+        return self
+
+    def _handle(self, request):
+        self.calls.append(request)
+        queue = self._routes.get(str(request.url))
+        if not queue:
+            return httpx.Response(500, json={"error": f"unrouted {request.url}"})
+        return queue.pop(0) if len(queue) > 1 else queue[0]
+
+    def new_client(self):
+        return httpx.AsyncClient(transport=httpx.MockTransport(self._handle))
+
+    def count(self, url):
+        return sum(1 for r in self.calls if str(r.url) == str(url))
+
+
+@pytest.fixture
+def codex_http(monkeypatch):
+    """Inject a MockTransport client at codex_oauth's single client-construction
+    seam (`_new_async_client`) — every device-code/refresh call funnels through it,
+    whether issued directly, via `auth.resolve`, or through the FastAPI routes."""
+    mock = _MockHTTP()
+    monkeypatch.setattr(cx, "_new_async_client", mock.new_client)
+    return mock
+
+
+def _jwt(exp_offset=3600, account_id="acct-xyz"):
+    """A minimal unsigned JWT carrying `exp` + the chatgpt_account_id claim."""
+    hdr = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = {"exp": int(time.time()) + exp_offset, cx.JWT_AUTH_CLAIM: {"chatgpt_account_id": account_id}}
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{hdr}.{body}.sig"
+
+
+@pytest.fixture
+def oauth_db(tmp_path, monkeypatch):
+    """Throwaway sqlite bound into core.database (+ the route module's imported
+    SessionLocal). monkeypatch restores the originals after each test."""
+    engine = create_engine(f"sqlite:///{tmp_path}/codex.db", connect_args={"check_same_thread": False})
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    # Re-point sys.modules so oauth_store's lazy `from core.database import ...`
+    # resolves to the real module (the module top restored a MagicMock stub there
+    # in the full suite). monkeypatch restores it after each test.
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    monkeypatch.setattr(db, "engine", engine)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
+    monkeypatch.setattr(routes_mod, "SessionLocal", TestSession)
+    store._refresh_locks.clear()
+    yield TestSession
+    engine.dispose()
+
+
+def _seed_token(session_factory, endpoint_id, access, refresh, expires_at, *, status="active", owner="alice"):
+    s = session_factory()
+    try:
+        import uuid
+        if not s.get(db.ModelEndpoint, endpoint_id):
+            s.add(db.ModelEndpoint(id=endpoint_id, name="codex", base_url=cx.BASE_URL,
+                                   owner=owner, is_enabled=True))
+        s.add(db.EndpointOAuthToken(id=uuid.uuid4().hex, endpoint_id=endpoint_id, owner=owner,
+              provider_id="openai-codex", access_token=access, refresh_token=refresh,
+              account_id="acct-xyz", expires_at=expires_at, status=status))
+        s.commit()
+    finally:
+        s.close()
+
+
+def _ref(endpoint_id, owner="alice"):
+    return EndpointRef(url=cx.BASE_URL + "/responses", model="gpt-5.4", endpoint_id=endpoint_id,
+                       owner=owner, provider_id="openai-codex", auth_type="oauth")
+
+
+def _utcnow():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _delta(seconds):
+    from datetime import timedelta
+    return timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# Service: device-code + refresh protocol
+# ---------------------------------------------------------------------------
+
+class TestCodexOAuthService:
+    async def test_device_code_request(self, codex_http):
+        codex_http.route(cx.DEVICE_USERCODE_URL, httpx.Response(200, json={
+            "user_code": "WXYZ-1234", "device_auth_id": "dev-abc", "interval": 7, "expires_in": 600}))
+        start = await cx.request_device_code()
+        assert start.user_code == "WXYZ-1234" and start.device_auth_id == "dev-abc"
+        assert start.interval == 7 and start.verification_uri == cx.DEVICE_VERIFICATION_URI
+        assert start.expires_at is not None
+
+    async def test_device_code_interval_clamped(self, codex_http):
+        codex_http.route(cx.DEVICE_USERCODE_URL, httpx.Response(200, json={
+            "user_code": "U", "device_auth_id": "d", "interval": 1}))
+        start = await cx.request_device_code()
+        assert start.interval == cx.MIN_POLL_INTERVAL_SECONDS  # 1 -> clamped to 3
+
+    async def test_poll_pending_then_success(self, codex_http):
+        codex_http.route(
+            cx.DEVICE_TOKEN_URL,
+            httpx.Response(403, json={}),
+            httpx.Response(200, json={"authorization_code": "ac", "code_verifier": "cv"}),
+        )
+        assert await cx.poll_device_token("d", "U") is None
+        res = await cx.poll_device_token("d", "U")
+        assert res.authorization_code == "ac" and res.code_verifier == "cv"
+
+    async def test_exchange_and_account_id(self, codex_http):
+        access = _jwt()
+        codex_http.route(cx.TOKEN_URL, httpx.Response(200, json={
+            "access_token": access, "refresh_token": "r1"}))
+        ts = await cx.exchange_device_code("ac", "cv")
+        assert ts.access_token == access and ts.refresh_token == "r1"
+        assert ts.account_id == "acct-xyz" and ts.expires_at is not None
+
+    async def test_refresh_rotates_when_new_token_returned(self, codex_http):
+        codex_http.route(cx.TOKEN_URL, httpx.Response(200, json={
+            "access_token": _jwt(), "refresh_token": "r2"}))
+        ts = await cx.refresh_tokens("r1")
+        assert ts.refresh_token == "r2"
+
+    async def test_refresh_keeps_prior_when_no_new_token(self, codex_http):
+        codex_http.route(cx.TOKEN_URL, httpx.Response(200, json={"access_token": _jwt()}))
+        ts = await cx.refresh_tokens("r-keep")
+        assert ts.refresh_token == "r-keep"
+
+    async def test_refresh_429_is_quota_no_relogin(self, codex_http):
+        codex_http.route(cx.TOKEN_URL, httpx.Response(429, json={}))
+        with pytest.raises(cx.CodexAuthError) as ei:
+            await cx.refresh_tokens("r")
+        assert ei.value.code == "quota" and ei.value.relogin_required is False
+
+    async def test_refresh_invalid_grant_requires_relogin(self, codex_http):
+        codex_http.route(cx.TOKEN_URL, httpx.Response(400, json={"error": "invalid_grant"}))
+        with pytest.raises(cx.CodexAuthError) as ei:
+            await cx.refresh_tokens("r")
+        assert ei.value.code == "invalid_grant" and ei.value.relogin_required is True
+
+    def test_expiry_helpers(self):
+        assert cx.access_token_is_expiring(_jwt(exp_offset=60)) is True
+        assert cx.access_token_is_expiring(_jwt(exp_offset=3600)) is False
+        assert cx.extract_account_id(_jwt(account_id="abc")) == "abc"
+        assert cx.extract_account_id("not-a-jwt") is None
+
+
+# ---------------------------------------------------------------------------
+# auth.resolve OAuth branch
+# ---------------------------------------------------------------------------
+
+class TestResolveOAuth:
+    async def test_fresh_token_passthrough(self, oauth_db):
+        access = _jwt(exp_offset=3600)
+        _seed_token(oauth_db, "ep-fresh", access, "r", _utcnow() + _delta(3600))
+        cred = await auth.resolve(_ref("ep-fresh"), CODEX_SPEC)
+        assert cred.headers["Authorization"] == f"Bearer {access}"
+        assert cred.headers["chatgpt-account-id"] == "acct-xyz"
+
+    async def test_refresh_on_expiry_persists_rotation(self, oauth_db, codex_http):
+        new = _jwt(exp_offset=7200)
+        _seed_token(oauth_db, "ep-exp", _jwt(exp_offset=30), "r-old", _utcnow() - _delta(10))
+        codex_http.route(cx.TOKEN_URL, httpx.Response(200, json={
+            "access_token": new, "refresh_token": "r-new"}))
+        cred = await auth.resolve(_ref("ep-exp"), CODEX_SPEC)
+        assert cred.headers["Authorization"] == f"Bearer {new}"
+        s = oauth_db()
+        try:
+            row = s.query(db.EndpointOAuthToken).filter_by(endpoint_id="ep-exp").first()
+            assert row.access_token == new and row.refresh_token == "r-new"
+            assert row.status == "active" and row.last_refresh_at is not None
+        finally:
+            s.close()
+
+    async def test_single_flight_refresh(self, oauth_db, codex_http):
+        _seed_token(oauth_db, "ep-sf", _jwt(exp_offset=10), "r", _utcnow() - _delta(5))
+        codex_http.route(cx.TOKEN_URL, httpx.Response(200, json={
+            "access_token": _jwt(exp_offset=7200), "refresh_token": "r-sf2"}))
+        results = await asyncio.gather(*[auth.resolve(_ref("ep-sf"), CODEX_SPEC) for _ in range(5)])
+        assert codex_http.count(cx.TOKEN_URL) == 1       # 5 concurrent resolves -> 1 refresh
+        assert all(c.headers["Authorization"].startswith("Bearer ") for c in results)
+
+    async def test_needs_relogin_status_short_circuits_401(self, oauth_db):
+        _seed_token(oauth_db, "ep-relog", _jwt(), "r", _utcnow() + _delta(3600), status="needs_relogin")
+        with pytest.raises(Exception) as ei:
+            await auth.resolve(_ref("ep-relog"), CODEX_SPEC)
+        assert getattr(ei.value, "status_code", None) == 401
+
+    async def test_quota_maps_to_429_and_persists_status(self, oauth_db, codex_http):
+        _seed_token(oauth_db, "ep-q", _jwt(exp_offset=10), "r", _utcnow() - _delta(5))
+        codex_http.route(cx.TOKEN_URL, httpx.Response(429, json={}))
+        with pytest.raises(Exception) as ei:
+            await auth.resolve(_ref("ep-q"), CODEX_SPEC)
+        assert getattr(ei.value, "status_code", None) == 429
+        s = oauth_db()
+        try:
+            assert s.query(db.EndpointOAuthToken).filter_by(endpoint_id="ep-q").first().status == "quota"
+        finally:
+            s.close()
+
+    async def test_invalid_grant_maps_to_401_and_needs_relogin(self, oauth_db, codex_http):
+        _seed_token(oauth_db, "ep-bad", _jwt(exp_offset=10), "r", _utcnow() - _delta(5))
+        codex_http.route(cx.TOKEN_URL, httpx.Response(400, json={"error": "invalid_grant"}))
+        with pytest.raises(Exception) as ei:
+            await auth.resolve(_ref("ep-bad"), CODEX_SPEC)
+        assert getattr(ei.value, "status_code", None) == 401
+        s = oauth_db()
+        try:
+            assert s.query(db.EndpointOAuthToken).filter_by(endpoint_id="ep-bad").first().status == "needs_relogin"
+        finally:
+            s.close()
+
+    async def test_not_connected_is_401(self, oauth_db):
+        with pytest.raises(Exception) as ei:
+            await auth.resolve(_ref("ep-missing"), CODEX_SPEC)
+        assert getattr(ei.value, "status_code", None) == 401
+
+    def test_sync_oauth_still_501(self, oauth_db):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as ei:
+            auth.resolve_sync(_ref("ep-any"), CODEX_SPEC)
+        assert ei.value.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# Connect / status / cancel / disconnect / import routes
+# ---------------------------------------------------------------------------
+
+def _client(user="alice"):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _set_user(request, call_next):
+        request.state.current_user = user
+        return await call_next(request)
+
+    app.include_router(routes_mod.setup_codex_oauth_routes())
+    return TestClient(app)
+
+
+class TestConnectRoutes:
+    def test_connect_creates_pending_without_leaking_secrets(self, oauth_db, monkeypatch, codex_http):
+        monkeypatch.setattr(routes_mod, "_spawn", lambda coro: coro.close())
+        codex_http.route(cx.DEVICE_USERCODE_URL, httpx.Response(200, json={
+            "user_code": "WXYZ-1234", "device_auth_id": "dev-secret", "interval": 5, "expires_in": 900}))
+        body = _client().post("/api/providers/openai-codex/connect").json()
+        assert body["user_code"] == "WXYZ-1234" and body["verification_uri"].endswith("/codex/device")
+        blob = json.dumps(body)
+        assert "dev-secret" not in blob and "access_token" not in blob and "refresh_token" not in blob
+        s = oauth_db()
+        try:
+            ep = s.get(db.ModelEndpoint, body["endpoint_id"])
+            at = s.get(db.CodexLoginAttempt, body["attempt_id"])
+            assert ep.is_enabled is False and ep.owner == "alice" and ep.base_url == cx.BASE_URL
+            assert at.status == "pending" and at.device_auth_id == "dev-secret"
+        finally:
+            s.close()
+
+    def test_poll_loop_authorizes_and_enables(self, oauth_db, monkeypatch, codex_http):
+        monkeypatch.setattr(routes_mod, "_spawn", lambda coro: coro.close())
+        access = _jwt()
+        codex_http.route(cx.DEVICE_USERCODE_URL, httpx.Response(200, json={
+            "user_code": "U", "device_auth_id": "d", "interval": 5, "expires_in": 900}))
+        body = _client().post("/api/providers/openai-codex/connect").json()
+        aid, eid = body["attempt_id"], body["endpoint_id"]
+        s = oauth_db(); s.get(db.CodexLoginAttempt, aid).interval = 0; s.commit(); s.close()
+        codex_http.route(
+            cx.DEVICE_TOKEN_URL,
+            httpx.Response(403, json={}),
+            httpx.Response(200, json={"authorization_code": "ac", "code_verifier": "cv"}),
+        )
+        codex_http.route(cx.TOKEN_URL, httpx.Response(200, json={
+            "access_token": access, "refresh_token": "r-1"}))
+        asyncio.run(routes_mod._run_login_poll(aid))
+        s = oauth_db()
+        try:
+            assert s.get(db.CodexLoginAttempt, aid).status == "authorized"
+            assert s.get(db.ModelEndpoint, eid).is_enabled is True
+            tok = s.query(db.EndpointOAuthToken).filter_by(endpoint_id=eid).first()
+            assert tok.access_token == access and tok.refresh_token == "r-1" and tok.status == "active"
+        finally:
+            s.close()
+
+    def test_status_summary_is_state_only(self, oauth_db):
+        _seed_token(oauth_db, "ep-1", _jwt(), "r", _utcnow() + _delta(3600))
+        summ = _client().get("/api/providers/openai-codex/status").json()
+        assert len(summ["connected"]) == 1 and summ["connected"][0]["status"] == "active"
+        blob = json.dumps(summ)
+        assert "acct-xyz" not in blob and "access_token" not in blob
+
+    def test_disconnect_purges_token_and_endpoint(self, oauth_db):
+        _seed_token(oauth_db, "ep-d", _jwt(), "r", _utcnow() + _delta(3600))
+        assert _client().post("/api/providers/openai-codex/disconnect/ep-d").json()["ok"] is True
+        s = oauth_db()
+        try:
+            assert s.get(db.ModelEndpoint, "ep-d") is None
+            assert s.query(db.EndpointOAuthToken).filter_by(endpoint_id="ep-d").first() is None
+        finally:
+            s.close()
+
+    def test_cancel_deletes_endpoint_but_keeps_attempt(self, oauth_db, monkeypatch, codex_http):
+        monkeypatch.setattr(routes_mod, "_spawn", lambda coro: coro.close())
+        codex_http.route(cx.DEVICE_USERCODE_URL, httpx.Response(200, json={
+            "user_code": "U", "device_auth_id": "d", "interval": 5, "expires_in": 900}))
+        body = _client().post("/api/providers/openai-codex/connect").json()
+        aid, eid = body["attempt_id"], body["endpoint_id"]
+        assert _client().post(f"/api/providers/openai-codex/connect/{aid}/cancel").json()["status"] == "cancelled"
+        s = oauth_db()
+        try:
+            assert s.get(db.ModelEndpoint, eid) is None              # pending endpoint purged
+            surv = s.get(db.CodexLoginAttempt, aid)
+            assert surv.status == "cancelled" and surv.endpoint_id is None   # log row kept, detached
+        finally:
+            s.close()
+
+    def test_owner_isolation_404(self, oauth_db, monkeypatch, codex_http):
+        monkeypatch.setattr(routes_mod, "_spawn", lambda coro: coro.close())
+        codex_http.route(cx.DEVICE_USERCODE_URL, httpx.Response(200, json={
+            "user_code": "U", "device_auth_id": "d", "interval": 5, "expires_in": 900}))
+        body = _client("alice").post("/api/providers/openai-codex/connect").json()
+        resp = _client("bob").get(f"/api/providers/openai-codex/connect/{body['attempt_id']}")
+        assert resp.status_code == 404

--- a/tests/test_codex_responses.py
+++ b/tests/test_codex_responses.py
@@ -1,0 +1,504 @@
+"""Tests for the codex_responses transport, stream decoder, registry/spec wiring,
+and the additive engine guards (OAuth response-cache bypass, sync-path refusal).
+
+The transport/decoder are pure (no DB), so these import cleanly. End-to-end tests
+drive the REAL `src.llm_core` (which imports only httpx/fastapi/stdlib + providers,
+so it is immune to the sys.modules stubbing other test files install) by injecting
+an `httpx.MockTransport` at `llm_core._get_http_client` (every async egress funnels
+through it) plus a monkeypatched `auth.resolve` — no DB, no real OpenAI calls, and
+no network-mocking dependency (MockTransport ships with httpx).
+
+Golden stream/request shapes cribbed from pi's `openai-codex-stream.test.ts` +
+`openai-responses-shared.ts`.
+"""
+import json
+
+import httpx
+import pytest
+
+import src.llm_core as llm_core
+from src.providers import auth, registry
+from src.providers.auth.credentials import Credential
+from src.providers.codex_responses import (
+    CodexResponsesTransport,
+    CodexStreamDecoder,
+    ORIGINATOR,
+    USER_AGENT,
+)
+from src.providers.endpoint_ref import EndpointRef
+from src.providers.spec import CODEX_MODELS, OPENAI_CODEX_SPEC
+
+CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
+OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+
+T = CodexResponsesTransport()
+
+
+# ── SSE helpers (mirror tests/test_llm_core.py) ──────────────────────────────
+
+def _sse(*events: dict) -> bytes:
+    return ("".join(f"data: {json.dumps(e)}\n\n" for e in events)).encode()
+
+
+def _data(chunk: str) -> dict:
+    assert chunk.startswith("data: "), chunk
+    return json.loads(chunk[len("data: "):].strip())
+
+
+async def _collect(agen):
+    return [c async for c in agen]
+
+
+def _codex_ref(endpoint_id="ep-1", owner="alice"):
+    return EndpointRef(url=CODEX_URL, model="gpt-5.4", endpoint_id=endpoint_id,
+                       owner=owner, provider_id="openai-codex", auth_type="oauth")
+
+
+def _fake_creds():
+    return Credential(headers={"Authorization": "Bearer tok-xyz", "chatgpt-account-id": "acct-1"})
+
+
+class _MockHTTP:
+    """Routes httpx traffic to queued responses via ``httpx.MockTransport`` — a
+    built-in httpx primitive, so the e2e tests carry no respx/network-mock dep.
+
+    Captures every outgoing request (for header/body assertions); per-URL queues
+    allow sequencing (mirrors respx's ``side_effect=[...]``). A single URL with one
+    queued response repeats it (mirrors ``return_value=``)."""
+
+    def __init__(self):
+        self.calls = []          # list[httpx.Request], in send order
+        self._routes = {}        # str(url) -> list[httpx.Response]
+
+    def route(self, url, *responses):
+        self._routes.setdefault(str(url), []).extend(responses)
+        return self
+
+    def _handle(self, request):
+        self.calls.append(request)
+        queue = self._routes.get(str(request.url))
+        if not queue:
+            return httpx.Response(500, json={"error": f"unrouted {request.url}"})
+        return queue.pop(0) if len(queue) > 1 else queue[0]
+
+    def new_client(self):
+        return httpx.AsyncClient(transport=httpx.MockTransport(self._handle))
+
+    def count(self, url):
+        return sum(1 for r in self.calls if str(r.url) == str(url))
+
+    @property
+    def last(self):
+        return self.calls[-1]
+
+
+# ── Stream event builders (golden shapes) ────────────────────────────────────
+
+def _ev_msg_added(mid="msg_1"):
+    return {"type": "response.output_item.added",
+            "item": {"type": "message", "id": mid, "role": "assistant", "status": "in_progress", "content": []}}
+
+def _ev_part_added():
+    return {"type": "response.content_part.added", "part": {"type": "output_text", "text": ""}}
+
+def _ev_text_delta(text):
+    return {"type": "response.output_text.delta", "delta": text}
+
+def _ev_msg_done(text, mid="msg_1"):
+    return {"type": "response.output_item.done",
+            "item": {"type": "message", "id": mid, "role": "assistant", "status": "completed",
+                     "content": [{"type": "output_text", "text": text}]}}
+
+def _ev_completed(status="completed", inp=5, out=3):
+    return {"type": "response.completed" if status == "completed" else f"response.{status}",
+            "response": {"status": status,
+                         "usage": {"input_tokens": inp, "output_tokens": out, "total_tokens": inp + out,
+                                   "input_tokens_details": {"cached_tokens": 0}}}}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Spec + registry wiring
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestSpecAndRegistry:
+    def test_detect_codex_by_url(self):
+        spec = registry.detect_spec(CODEX_URL)
+        assert spec.id == "openai-codex" and spec.transport == "codex_responses" and spec.auth_type == "oauth"
+
+    def test_codex_base_url_also_detected(self):
+        assert registry.detect_spec("https://chatgpt.com/backend-api/codex").id == "openai-codex"
+
+    def test_openai_still_default(self):
+        assert registry.detect_spec(OPENAI_URL).id == "openai"
+
+    def test_transport_resolves(self):
+        assert isinstance(registry.get_transport(OPENAI_CODEX_SPEC), CodexResponsesTransport)
+
+    def test_codex_models_nonempty(self):
+        assert CODEX_MODELS and all(isinstance(m, str) for m in CODEX_MODELS)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Pure transport shaping
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestTargetUrl:
+    def test_base_appends_responses(self):
+        assert T.target_url("https://chatgpt.com/backend-api/codex") == CODEX_URL
+
+    def test_full_url_unchanged(self):
+        assert T.target_url(CODEX_URL) == CODEX_URL
+
+    def test_trailing_slash_normalized(self):
+        assert T.target_url("https://chatgpt.com/backend-api/codex/") == CODEX_URL
+
+
+class TestBuildPayload:
+    def _msgs(self):
+        return [{"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "hi"}]
+
+    def test_core_shape(self):
+        p = T.build_payload("gpt-5.4", self._msgs(), 0.7, 4096, stream=True)
+        assert p["store"] is False and p["stream"] is True
+        assert p["include"] == ["reasoning.encrypted_content"]
+        assert p["tool_choice"] == "auto" and p["parallel_tool_calls"] is True
+        assert p["text"] == {"verbosity": "low"}
+        assert p["instructions"] == "You are helpful."
+
+    def test_omits_max_tokens(self):
+        p = T.build_payload("gpt-5.4", self._msgs(), 0.7, 4096)
+        assert "max_tokens" not in p and "max_completion_tokens" not in p and "max_output_tokens" not in p
+
+    def test_uses_input_not_messages(self):
+        p = T.build_payload("gpt-5.4", self._msgs(), 0.7, 0)
+        assert "messages" not in p and "input" in p
+        assert p["input"] == [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+
+    def test_stream_defaults_false(self):
+        assert T.build_payload("gpt-5.4", self._msgs(), 0.7, 0)["stream"] is False
+
+    def test_multimodal_user_content(self):
+        msgs = [{"role": "user", "content": [
+            {"type": "text", "text": "what is this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]}]
+        p = T.build_payload("gpt-5.4", msgs, 0.7, 0)
+        assert p["input"][0]["content"] == [
+            {"type": "input_text", "text": "what is this"},
+            {"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,AAAA"},
+        ]
+
+    def test_tool_transcript_conversion(self):
+        msgs = [
+            {"role": "user", "content": "weather?"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "call_1", "type": "function",
+                             "function": {"name": "get_weather", "arguments": '{"city":"NYC"}'}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "72F"},
+        ]
+        p = T.build_payload("gpt-5.4", msgs, 0.7, 0)
+        # function_call carries call_id + args string; result pairs by call_id.
+        fc = [i for i in p["input"] if i.get("type") == "function_call"][0]
+        fco = [i for i in p["input"] if i.get("type") == "function_call_output"][0]
+        assert fc == {"type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": '{"city":"NYC"}'}
+        assert fco == {"type": "function_call_output", "call_id": "call_1", "output": "72F"}
+
+    def test_assistant_text_becomes_output_message(self):
+        msgs = [{"role": "assistant", "content": "prior answer"}]
+        p = T.build_payload("gpt-5.4", msgs, 0.7, 0)
+        assert p["input"][0] == {"type": "message", "role": "assistant", "status": "completed",
+                                 "content": [{"type": "output_text", "text": "prior answer", "annotations": []}]}
+
+    def test_tools_converted_flat(self):
+        tools = [{"type": "function", "function": {"name": "foo", "description": "d", "parameters": {"type": "object"}}}]
+        p = T.build_payload("gpt-5.4", self._msgs(), 0.7, 0, stream=True, tools=tools)
+        assert p["tools"] == [{"type": "function", "name": "foo", "description": "d",
+                               "parameters": {"type": "object"}, "strict": None}]
+
+    def test_omits_temperature(self):
+        # codex Responses rejects temperature (reasoning models) — mirror max_tokens.
+        assert "temperature" not in T.build_payload("gpt-5.4", self._msgs(), 0.55, 0)
+
+    def test_no_system_no_instructions(self):
+        p = T.build_payload("gpt-5.4", [{"role": "user", "content": "hi"}], 0.7, 0)
+        assert "instructions" not in p
+
+
+class TestBuildHeaders:
+    def test_wire_headers_present(self):
+        h = T.build_headers(None)
+        assert h["OpenAI-Beta"] == "responses=experimental"
+        assert h["originator"] == ORIGINATOR == "codex_cli_rs"
+        assert h["User-Agent"] == USER_AGENT
+        assert h["Accept"] == "text/event-stream"
+
+    def test_credentials_merged(self):
+        h = T.build_headers({"Authorization": "Bearer X", "chatgpt-account-id": "acct"})
+        assert h["Authorization"] == "Bearer X" and h["chatgpt-account-id"] == "acct"
+        assert h["originator"] == "codex_cli_rs"  # creds don't clobber wire headers
+
+
+class TestParseResponse:
+    def test_output_message(self):
+        data = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "Hello"}]}]}
+        assert T.parse_response(data) == "Hello"
+
+    def test_output_text_convenience_field(self):
+        assert T.parse_response({"output_text": "Hi"}) == "Hi"
+
+    def test_skips_reasoning_items(self):
+        data = {"output": [{"type": "reasoning", "summary": []},
+                           {"type": "message", "content": [{"type": "output_text", "text": "A"}]}]}
+        assert T.parse_response(data) == "A"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Stream decoder (golden sequences)
+# ══════════════════════════════════════════════════════════════════════════════
+
+def _run_decoder(events, model="gpt-5.4"):
+    d = CodexStreamDecoder(model)
+    out, stopped = [], False
+    for ev in events:
+        chunks, stop = d.decode_line(f"data: {json.dumps(ev)}")
+        out.extend(chunks)
+        if stop:
+            stopped = True
+            break
+    if not stopped:
+        out.extend(d.finalize())
+    return out
+
+
+class TestCodexStreamDecoder:
+    def test_golden_text_stream(self):
+        out = _run_decoder([_ev_msg_added(), _ev_part_added(), _ev_text_delta("Hello"),
+                            _ev_msg_done("Hello"), _ev_completed()])
+        assert _data(out[0]) == {"delta": "Hello"}
+        assert _data(out[1]) == {"type": "usage", "data": {"input_tokens": 5, "output_tokens": 3}}
+        assert out[-1].strip() == "data: [DONE]"
+
+    def test_text_streamed_via_deltas_not_doubled(self):
+        out = _run_decoder([_ev_msg_added(), _ev_part_added(),
+                            _ev_text_delta("Hel"), _ev_text_delta("lo"),
+                            _ev_msg_done("Hello"), _ev_completed()])
+        deltas = [_data(c)["delta"] for c in out if c.startswith("data: {") and "delta" in _data(c)]
+        assert deltas == ["Hel", "lo"]  # message.done did NOT re-emit "Hello"
+
+    def test_message_done_without_deltas_emits_once(self):
+        # Defensive: if a backend skips deltas, the finished text is emitted once.
+        out = _run_decoder([_ev_msg_added(), _ev_msg_done("Solo"), _ev_completed()])
+        deltas = [_data(c)["delta"] for c in out if c.startswith("data: {") and "delta" in _data(c)]
+        assert deltas == ["Solo"]
+
+    def test_tool_call_accumulation(self):
+        events = [
+            {"type": "response.output_item.added",
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "call_abc", "name": "get_weather", "arguments": ""}},
+            {"type": "response.function_call_arguments.delta", "delta": '{"city":'},
+            {"type": "response.function_call_arguments.delta", "delta": '"NYC"}'},
+            {"type": "response.function_call_arguments.done", "arguments": '{"city":"NYC"}'},
+            {"type": "response.output_item.done",
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "call_abc", "name": "get_weather", "arguments": '{"city":"NYC"}'}},
+            _ev_completed(),
+        ]
+        out = _run_decoder(events)
+        tc = [_data(c) for c in out if c.startswith("data: {") and _data(c).get("type") == "tool_calls"][0]
+        assert tc["calls"] == [{"id": "call_abc", "name": "get_weather", "arguments": '{"city":"NYC"}'}]
+        assert out[-1].strip() == "data: [DONE]"
+
+    def test_doc_tool_arg_deltas_streamed(self):
+        events = [
+            {"type": "response.output_item.added",
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "c1", "name": "create_document", "arguments": ""}},
+            {"type": "response.function_call_arguments.delta", "delta": '{"title":"x"}'},
+            {"type": "response.output_item.done",
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "c1", "name": "create_document", "arguments": '{"title":"x"}'}},
+            _ev_completed(),
+        ]
+        out = _run_decoder(events)
+        deltas = [_data(c) for c in out if c.startswith("data: {") and _data(c).get("type") == "tool_call_delta"]
+        assert deltas and deltas[0]["name"] == "create_document" and deltas[0]["arg_delta"] == '{"title":"x"}'
+
+    def test_reasoning_summary_streams_as_thinking(self):
+        events = [
+            {"type": "response.output_item.added", "item": {"type": "reasoning", "id": "rs_1"}},
+            {"type": "response.reasoning_summary_text.delta", "delta": "pondering"},
+            _ev_msg_added("msg_2"), _ev_text_delta("Done"), _ev_completed(),
+        ]
+        out = _run_decoder(events)
+        assert _data(out[0]) == {"delta": "pondering", "thinking": True}
+        assert _data(out[1]) == {"delta": "Done"}
+
+    def test_incomplete_is_terminal_with_usage(self):
+        out = _run_decoder([_ev_msg_added(), _ev_text_delta("Hi"), _ev_completed(status="incomplete", inp=1, out=1)])
+        assert _data(out[0]) == {"delta": "Hi"}
+        assert _data(out[1]) == {"type": "usage", "data": {"input_tokens": 1, "output_tokens": 1}}
+        assert out[-1].strip() == "data: [DONE]"
+
+    def test_explicit_done_marker(self):
+        d = CodexStreamDecoder("gpt-5.4")
+        chunks, stop = d.decode_line("data: [DONE]")
+        assert stop is True and chunks[-1].strip() == "data: [DONE]"
+
+    def test_error_event_emits_error_and_stops(self):
+        d = CodexStreamDecoder("gpt-5.4")
+        chunks, stop = d.decode_line(f'data: {json.dumps({"type": "error", "code": "rate_limit", "message": "too many"})}')
+        assert stop is True
+        assert chunks[0].startswith("event: error")
+        assert "too many" in chunks[0]
+
+    def test_response_failed_emits_error(self):
+        d = CodexStreamDecoder("gpt-5.4")
+        chunks, stop = d.decode_line(f'data: {json.dumps({"type": "response.failed", "response": {"error": {"message": "boom"}}})}')
+        assert stop is True and "boom" in chunks[0]
+
+    def test_non_data_lines_ignored(self):
+        d = CodexStreamDecoder("gpt-5.4")
+        assert d.decode_line("event: foo") == ([], False)
+        assert d.decode_line("") == ([], False)
+        assert d.decode_line("data: not-json") == ([], False)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# End-to-end through llm_core (httpx.MockTransport-injected codex backend)
+# ══════════════════════════════════════════════════════════════════════════════
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    llm_core._response_cache.clear()
+    llm_core._dead_hosts.clear()
+    llm_core._host_fails.clear()
+    llm_core._model_activity.clear()
+    yield
+    llm_core._response_cache.clear()
+
+
+@pytest.fixture
+def codex_http(monkeypatch):
+    """Inject a MockTransport client at llm_core's single async egress seam
+    (``_get_http_client``) — every codex/openai async call funnels through it."""
+    mock = _MockHTTP()
+    client = mock.new_client()
+    monkeypatch.setattr(llm_core, "_get_http_client", lambda: client)
+    return mock
+
+
+def _patch_oauth_resolve(monkeypatch):
+    async def _fake(ref, spec):
+        return _fake_creds()
+    monkeypatch.setattr(auth, "resolve", _fake)
+
+
+class TestEndToEndStream:
+    async def test_stream_text_through_llm_core(self, monkeypatch, codex_http):
+        _patch_oauth_resolve(monkeypatch)
+        sse = _sse(_ev_msg_added(), _ev_part_added(), _ev_text_delta("Hello"),
+                   _ev_msg_done("Hello"), _ev_completed())
+        codex_http.route(CODEX_URL, httpx.Response(200, content=sse))
+        chunks = await _collect(llm_core.stream_llm(CODEX_URL, "gpt-5.4",
+                                                    [{"role": "user", "content": "hi"}], ref=_codex_ref()))
+        # codex wire headers reached the backend
+        sent = codex_http.last
+        assert sent.headers["originator"] == "codex_cli_rs"
+        assert sent.headers["authorization"] == "Bearer tok-xyz"
+        assert json.loads(sent.content)["store"] is False
+        # normalized chunks
+        text = [_data(c)["delta"] for c in chunks if c.startswith("data: {") and "delta" in _data(c)]
+        assert text == ["Hello"]
+        assert chunks[-1].strip() == "data: [DONE]"
+
+    async def test_stream_tool_call_through_llm_core(self, monkeypatch, codex_http):
+        _patch_oauth_resolve(monkeypatch)
+        sse = _sse(
+            {"type": "response.output_item.added",
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "c9", "name": "search", "arguments": ""}},
+            {"type": "response.function_call_arguments.delta", "delta": '{"q":"x"}'},
+            {"type": "response.output_item.done",
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "c9", "name": "search", "arguments": '{"q":"x"}'}},
+            _ev_completed(),
+        )
+        codex_http.route(CODEX_URL, httpx.Response(200, content=sse))
+        chunks = await _collect(llm_core.stream_llm(CODEX_URL, "gpt-5.4",
+                                                    [{"role": "user", "content": "go"}], ref=_codex_ref()))
+        tc = [_data(c) for c in chunks if c.startswith("data: {") and _data(c).get("type") == "tool_calls"][0]
+        assert tc["calls"][0]["name"] == "search" and tc["calls"][0]["id"] == "c9"
+
+
+class TestOAuthCacheBypass:
+    """The one engine guard: OAuth endpoints share url+model across users, so the
+    shared response cache must never cross-serve (BLOCKER fixed additively in 2b)."""
+
+    async def test_oauth_call_bypasses_cache(self, monkeypatch, codex_http):
+        _patch_oauth_resolve(monkeypatch)
+        ref = _codex_ref(endpoint_id="ep-alice", owner="alice")
+        codex_http.route(
+            CODEX_URL,
+            httpx.Response(200, json={"output": [{"type": "message", "content": [{"type": "output_text", "text": "FIRST"}]}]}),
+            httpx.Response(200, json={"output": [{"type": "message", "content": [{"type": "output_text", "text": "SECOND"}]}]}),
+        )
+        r1 = await llm_core.llm_call_async(CODEX_URL, "gpt-5.4", [{"role": "user", "content": "same"}], ref=ref)
+        r2 = await llm_core.llm_call_async(CODEX_URL, "gpt-5.4", [{"role": "user", "content": "same"}], ref=ref)
+        assert r1 == "FIRST" and r2 == "SECOND"   # not cross-served from cache
+        assert codex_http.count(CODEX_URL) == 2
+        assert len(llm_core._response_cache) == 0  # nothing cached for oauth
+
+    async def test_non_oauth_call_still_cached(self, codex_http):
+        # Control: api_key providers keep using the cache (guard is scoped to oauth).
+        codex_http.route(OPENAI_URL, httpx.Response(
+            200, json={"choices": [{"message": {"content": "CACHED"}}]}))
+        r1 = await llm_core.llm_call_async(OPENAI_URL, "gpt-4o", [{"role": "user", "content": "same"}],
+                                           headers={"Authorization": "Bearer k"})
+        r2 = await llm_core.llm_call_async(OPENAI_URL, "gpt-4o", [{"role": "user", "content": "same"}],
+                                           headers={"Authorization": "Bearer k"})
+        assert r1 == r2 == "CACHED"
+        assert codex_http.count(OPENAI_URL) == 1   # second served from cache
+
+
+class TestSyncPathGuard:
+    """Codex endpoints are async-only (credential resolution refreshes tokens) —
+    the sync llm_call must refuse them loudly, before cache or egress, instead of
+    POSTing an unauthenticated chat/completions payload upstream."""
+
+    def test_sync_llm_call_rejects_codex_url(self):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            llm_core.llm_call(CODEX_URL, "gpt-5.4", [{"role": "user", "content": "hi"}])
+        assert exc.value.status_code == 501
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Fallback-candidate exclusion (multi-user safety; codex tuples can't refresh)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestFallbackExclusion:
+    def test_codex_excluded_from_fallback_candidates(self, monkeypatch):
+        import importlib
+        import sys
+        # Other test files stub src.endpoint_resolver as a MagicMock at collection;
+        # re-import the real module for this test, then restore the stub.
+        snapshot = sys.modules.get("src.endpoint_resolver")
+        sys.modules.pop("src.endpoint_resolver", None)
+        try:
+            er = importlib.import_module("src.endpoint_resolver")
+            codex = (CODEX_URL, "gpt-5.4", {})
+            openai = (OPENAI_URL, "gpt-4o", {"Authorization": "Bearer k"})
+
+            monkeypatch.setattr(er, "resolve_endpoint_by_id",
+                                lambda eid, model, owner=None: {"codex": codex, "oai": openai}.get(eid))
+            import src.settings as settings_mod
+            monkeypatch.setattr(settings_mod, "load_settings",
+                                lambda: {"default_model_fallbacks": [{"endpoint_id": "codex", "model": "gpt-5.4"},
+                                                                     {"endpoint_id": "oai", "model": "gpt-4o"}]})
+            monkeypatch.setattr(settings_mod, "get_user_setting",
+                                lambda key, owner, default: default)
+
+            out = er._resolve_fallback_candidates("default_model_fallbacks")
+            assert openai in out          # api_key endpoint kept
+            assert codex not in out       # oauth endpoint excluded
+        finally:
+            if snapshot is not None:
+                sys.modules["src.endpoint_resolver"] = snapshot
+            else:
+                sys.modules.pop("src.endpoint_resolver", None)


### PR DESCRIPTION
## Summary

This PR adds a ChatGPT/Codex subscription provider for Odysseus, treating subscription-backed access as a first-class provider rather than a metered OpenAI API key.

The reusable foundation is separated from the OAuth/UI slice:

- provider seam: `EndpointRef`, provider specs/registry, credential resolution, and transport helpers
- Codex Responses transport: payload building, backend headers, stream decoding, and SSE normalization
- endpoint identity: `sessions.endpoint_id` and chat/agent dispatch plumbing so identity-bound endpoints can resolve credentials per request
- fallback safety: OAuth endpoints are excluded from legacy fallback candidate chains until fallback identity is first-class
- OAuth slice: owner-scoped device-code routes, encrypted token storage, refresh handling, connect/status/cancel/disconnect flow
- UI slice: Subscription provider section in Add Models (device-code connect flow), connected-state management in Added Models, and `(sub)` markers for subscription-backed models
- tests: 63 `httpx.MockTransport` tests covering OAuth flow, credential refresh, transport payloads, stream decoding, registry wiring, response-cache bypass, and the sync-path guard

## Linked Issue

Part of #82.

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [x] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Install the declared Python dependencies and run the focused test suite: `uv pip install -r requirements.txt && uv run pytest tests/test_codex_oauth.py tests/test_codex_responses.py`. Expect 63 tests to pass.
2. Start Odysseus from this branch with `uvicorn app:app` or `docker compose up`, then open Settings -> Add Models and expand the SUBSCRIPTION section.
3. Choose ChatGPT (Codex) from the provider dropdown and start the device-code flow: open the verification URL, enter the code, and complete sign-in.
4. Confirm the connected endpoint appears under Added Models -> Subscription with a Disconnect action, and that subscription-backed models carry `(sub)` markers in the picker/chat labels.
5. Start a chat with a Codex subscription model and send a prompt. Expect a streamed response through the Codex Responses transport.
6. Disconnect the ChatGPT/Codex endpoint from Added Models and confirm the UI returns to the disconnected state without exposing token values.

## Visual / UI changes - REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like - buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM - needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) - do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first - bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Settings -> Add Models (SUBSCRIPTION section) and Added Models.

Connect state:

<img width="663" height="372" alt="settings" src="https://github.com/user-attachments/assets/0340f57d-01b8-4ca5-8963-8d1c862ed3d3" />

Connected state:

<img width="714" alt="settings" src="https://raw.githubusercontent.com/donjor/odysseus/assets/pr-516/settings.png" />

Working chat / subscription marker:

<img width="913" alt="chat" src="https://raw.githubusercontent.com/donjor/odysseus/assets/pr-516/chat-example.png" />

## Commit Split

The rebased branch is five commits:

```text
3fd7f12 Add provider seam and Codex Responses transport
6ec2465 Preserve session endpoint identity and exclude OAuth endpoints from fallback
c807c1c Add encrypted OAuth token store and device-code connect routes
efde099 Wire Connect ChatGPT UI and subscription model markers
c310cf1 Add respx-free codex test suite (63 tests, httpx.MockTransport)
```

The first two commits are the reusable provider/transport/identity foundation.
The next two are the direct OAuth and UI slice.
The final commit adds focused tests without adding `respx` or another network-mocking dependency.

## Provider Direction

This PR takes the direct provider path: Odysseus keeps durable endpoint identity, resolves/refreshes credentials per request, and talks to the Codex Responses backend directly.

That is the better fit for chat and agent use because streaming, refresh behavior, fallback safety, model picker metadata, and endpoint ownership all stay inside one backend contract.

The provider seam is intentionally small in this PR. It separates the parts that otherwise become hardcoded branches in `llm_core`:

- provider identity
- auth strategy
- endpoint ownership
- request/stream transport
- model catalog defaults
- fallback eligibility

This gives Codex a tested provider/chat path now, and gives later provider work a concrete adapter shape to fit instead of growing provider-specific conditionals.

## Security / Review Notes

The provider is wired as a normal provider path (no feature flag); token custody only begins when a user explicitly connects an account. The controls around it:

- OAuth endpoints are owner-scoped; connecting is a per-user, opt-in device-code sign-in.
- Status APIs return state only, not token values.
- Access/refresh tokens and device-code secrets are encrypted at rest.
- OAuth credentials are resolved per request from durable endpoint identity.
- Legacy `(url, model, headers)` tuples are not treated as sufficient OAuth identity.
- OAuth endpoints are not used as fallback candidates in legacy fallback chains.
- OAuth endpoints bypass the response cache, and the sync `llm_call` path refuses them (501) rather than sending an unauthenticated payload upstream.
- Token-like values are never logged or placed in browser localStorage.
- The Codex Responses backend is the same backend the codex CLI uses, not a published API: breakage surfaces as explicit stream errors, not silent failures.

Known limitation: a pending device-code login does not survive a server restart - the attempt expires by its TTL and the user reconnects.

## Checks

Ran on the pushed branch:

```bash
git diff --check upstream/main...HEAD
python3 -m py_compile app.py core/database.py core/models.py core/session_manager.py routes/chat_routes.py routes/codex_oauth_routes.py routes/model_routes.py routes/session_routes.py src/agent_loop.py src/endpoint_resolver.py src/llm_core.py src/providers/*.py src/providers/auth/*.py
node --check static/js/admin.js && node --check static/js/chatRenderer.js && node --check static/js/codexConnect.js && node --check static/js/modelPicker.js && node --check static/js/models.js
uv run pytest tests/test_codex_oauth.py tests/test_codex_responses.py
```

Result:

```text
63 passed
```

The full test suite was also run in the production Docker image against this branch; results match the upstream `main` baseline, with no new failures observed.

Live/manual verification on this exact head (image rebuilt from the pushed commit):

- Connected ChatGPT/Codex through the device-code UI.
- Sent streamed chat using a Codex subscription model.
- Exercised the message rewrite path through the same endpoint identity plumbing.
- Confirmed agent mode works through the same endpoint identity path.
- Confirmed `(sub)` marker appears in the relevant UI surfaces.
- Confirmed status/disconnect flows never expose token values.

## Review Focus

- OAuth token custody and owner-scoping.
- Endpoint identity and fallback safety invariants.
- Codex Responses request/stream normalization.
- Model picker/Add Models integration and `(sub)` subscription marker placement.
- Whether the commit boundaries are the right split if this needs to land in smaller pieces.
