### PR TITLE
Fix pip --user install failures inside virtual environments

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -49,6 +49,17 @@ _HF_TOKEN_STATUS_SNIPPET = (
     'fi'
 )
 
+
+def _pip_install(pkg: str, upgrade: bool = False) -> str:
+    """pip install that avoids --user inside virtualenvs (PEP 405)."""
+    u = " -U" if upgrade else ""
+    return (
+        f'if [ -n "$VIRTUAL_ENV" ] || python3 -c "import sys;exit(0 if sys.prefix!=sys.base_prefix else 1)" 2>/dev/null; '
+        f'then python3 -m pip install{u} -q {pkg} 2>/dev/null; '
+        f'else python3 -m pip install{u} --user --break-system-packages -q {pkg} 2>/dev/null '
+        f'|| python3 -m pip install{u} -q {pkg} 2>/dev/null; fi'
+    )
+
 def setup_cookbook_routes() -> APIRouter:
     router = APIRouter(tags=["cookbook"])
     _cookbook_state_path = Path(os.environ.get("DATA_DIR", "data")) / "cookbook_state.json"
@@ -431,12 +442,12 @@ def setup_cookbook_routes() -> APIRouter:
         # throughput. Retries set disable_hf_transfer to fall back to the plain,
         # slower-but-reliable downloader (resumes cleanly from the .incomplete files).
         # Use `python3 -m pip` not `pip` — macOS has no bare `pip` command.
-        lines.append("command -v hf >/dev/null 2>&1 || python3 -m pip install --user --break-system-packages -q -U huggingface_hub 2>/dev/null || python3 -m pip install -q -U huggingface_hub 2>/dev/null")
+        lines.append("command -v hf >/dev/null 2>&1 || " + _pip_install("huggingface_hub", upgrade=True))
         if req.disable_hf_transfer:
             lines.append("export HF_HUB_ENABLE_HF_TRANSFER=0")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=4")
         else:
-            lines.append("python3 -c 'import hf_transfer' 2>/dev/null || python3 -m pip install --user --break-system-packages -q hf_transfer 2>/dev/null || python3 -m pip install -q hf_transfer 2>/dev/null")
+            lines.append("python3 -c 'import hf_transfer' 2>/dev/null || " + _pip_install("hf_transfer"))
             lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
             lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")
 
@@ -532,8 +543,8 @@ def setup_cookbook_routes() -> APIRouter:
             runner_lines.append('export PATH="$HOME/.local/bin:$PATH"')
             # Install hf CLI + hf_transfer best-effort so future runs get the fast path.
             # Use --break-system-packages on PEP-668 systems (Arch, newer Debian) so it doesn't bail.
-            runner_lines.append("command -v hf >/dev/null 2>&1 || pip install --user --break-system-packages -q -U huggingface_hub 2>/dev/null || pip install -q -U huggingface_hub 2>/dev/null")
-            runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null || pip install --user --break-system-packages -q hf_transfer 2>/dev/null || pip install -q hf_transfer 2>/dev/null")
+            runner_lines.append("command -v hf >/dev/null 2>&1 || " + _pip_install("huggingface_hub", upgrade=True))
+            runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null || " + _pip_install("hf_transfer"))
             runner_lines.append("python3 -c 'import hf_transfer' 2>/dev/null && export HF_HUB_ENABLE_HF_TRANSFER=1")
             runner_lines.append("export HF_HUB_DOWNLOAD_MAX_WORKERS=8")
             # Surface whether the HF token actually reached THIS server, so a gated
@@ -1011,7 +1022,7 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append('  # If the native build failed, fall back to the Python bindings.')
                 runner_lines.append('  if ! command -v llama-server &>/dev/null && ! python3 -c "import llama_cpp" 2>/dev/null; then')
                 runner_lines.append('    echo "llama-server build failed — installing Python bindings as fallback..."')
-                runner_lines.append('    pip install --user --break-system-packages -q llama-cpp-python 2>/dev/null || pip install -q llama-cpp-python 2>/dev/null || true')
+                runner_lines.append('    ' + _pip_install("llama-cpp-python") + ' || true')
                 runner_lines.append('  fi')
                 runner_lines.append('fi')
             elif "ollama" in req.cmd:
@@ -1214,10 +1225,7 @@ def setup_cookbook_routes() -> APIRouter:
                 "  fi; "
                 "fi; "
                 "command -v tmux >/dev/null 2>&1 || echo 'WARNING: tmux missing and auto-install failed (need passwordless sudo). Install manually.'; "
-                # Install Python bits. Try system install first; fall back to --user --break-system-packages on PEP 668 systems.
-                "pip install -q huggingface_hub hf_transfer 2>/dev/null || "
-                "pip install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null || "
-                "pip3 install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null; "
+                + _pip_install("huggingface_hub hf_transfer") + "; "
                 "python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")'"
             )
             cmd = f"ssh {pf}{host} '{setup_script}'"


### PR DESCRIPTION
## Summary

Cookbook-generated shell scripts unconditionally use `pip install --user --break-system-packages`, which fails inside virtual environments with:

```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

This affects local downloads, remote downloads, and serve fallback installs.

## Changes

- Add a `_pip_install()` helper that detects active virtualenvs (`$VIRTUAL_ENV` or `sys.prefix != sys.base_prefix`) before choosing the install strategy.
- Inside a venv: plain `pip install` (no `--user`).
- Outside a venv: try `--user --break-system-packages` first (for PEP 668 systems), fall back to plain install.
- Replace all 6 occurrences of hardcoded `--user` pip commands in `cookbook_routes.py`.

## Fixes

Fixes #354, #388

## Testing

- `python3 -m py_compile routes/cookbook_routes.py`
- `pytest -q tests/` — 352 passed, no regressions introduced
- Verified generated shell snippets correctly skip `--user` when `$VIRTUAL_ENV` is set