### PR TITLE
Add multiple CalDAV account support

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -1522,6 +1522,7 @@ def init_db():
     _migrate_add_calendar_metadata()
     _migrate_add_calendar_is_utc()
     _migrate_add_caldav_account_id()
+    _migrate_clear_legacy_caldav_data()
     _migrate_encrypt_email_passwords()
     _migrate_encrypt_signatures()
     _migrate_encrypt_endpoint_keys()
@@ -1657,6 +1658,37 @@ def _migrate_add_caldav_account_id():
         conn.close()
     except Exception as e:
         logging.getLogger(__name__).warning(f"caldav account_id migration failed: {e}")
+
+
+def _migrate_clear_legacy_caldav_data():
+    """One-time wipe of CalDAV rows that used the old URL-only calendar ID.
+    Guards on NULL account_id so it only runs once; CalDAV data re-syncs
+    automatically on next calendar open."""
+    import sqlite3
+    db_path = DATABASE_URL.replace("sqlite:///", "").replace("sqlite://", "")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT COUNT(*) FROM calendars WHERE source='caldav' AND account_id IS NULL"
+        ).fetchone()
+        if row and row[0] > 0:
+            conn.execute(
+                "DELETE FROM calendar_events WHERE calendar_id IN "
+                "(SELECT id FROM calendars WHERE source='caldav' AND account_id IS NULL)"
+            )
+            conn.execute(
+                "DELETE FROM calendars WHERE source='caldav' AND account_id IS NULL"
+            )
+            conn.commit()
+            logging.getLogger(__name__).info(
+                "Migrated: cleared %d legacy caldav calendar(s) for re-sync with "
+                "account-scoped IDs", row[0]
+            )
+        conn.close()
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"caldav legacy data clear failed: {e}")
 
 
 def _migrate_add_calendar_metadata():

--- a/core/database.py
+++ b/core/database.py
@@ -1365,11 +1365,12 @@ class CalendarCal(TimestampMixin, Base):
     """A calendar (e.g. 'Personal', 'TimeTree')."""
     __tablename__ = "calendars"
 
-    id    = Column(String, primary_key=True, index=True)
-    owner = Column(String, nullable=True, index=True)
-    name  = Column(String, nullable=False)
-    color = Column(String, default="#5b8abf")
-    source = Column(String, default="local")  # "local" or "timetree"
+    id         = Column(String, primary_key=True, index=True)
+    owner      = Column(String, nullable=True, index=True)
+    name       = Column(String, nullable=False)
+    color      = Column(String, default="#5b8abf")
+    source     = Column(String, default="local")  # "local" or "timetree"
+    account_id = Column(String, nullable=True, index=True)
 
     events = relationship("CalendarEvent", back_populates="calendar", cascade="all, delete-orphan")
 
@@ -1520,6 +1521,7 @@ def init_db():
     _migrate_seed_email_account()
     _migrate_add_calendar_metadata()
     _migrate_add_calendar_is_utc()
+    _migrate_add_caldav_account_id()
     _migrate_encrypt_email_passwords()
     _migrate_encrypt_signatures()
     _migrate_encrypt_endpoint_keys()
@@ -1634,6 +1636,27 @@ def _migrate_add_calendar_is_utc():
         conn.close()
     except Exception as e:
         logging.getLogger(__name__).warning(f"is_utc migration failed: {e}")
+
+
+def _migrate_add_caldav_account_id():
+    """Add account_id to the calendars table for multi-account CalDAV tracking."""
+    import sqlite3
+    db_path = DATABASE_URL.replace("sqlite:///", "").replace("sqlite://", "")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(calendars)").fetchall()]
+        if cols and "account_id" not in cols:
+            conn.execute("ALTER TABLE calendars ADD COLUMN account_id VARCHAR")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS ix_calendars_account_id ON calendars(account_id)"
+            )
+            conn.commit()
+            logging.getLogger(__name__).info("Migrated: added 'account_id' column to calendars")
+        conn.close()
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"caldav account_id migration failed: {e}")
 
 
 def _migrate_add_calendar_metadata():

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -498,61 +498,155 @@ def _expand_rrule(
 
 # ── Routes ──
 
+async def _propfind_test(url: str, user: str, pw: str) -> dict:
+    """PROPFIND handshake against a CalDAV URL. Shared by /test and /accounts/{id}/test."""
+    import httpx
+    propfind_body = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<d:propfind xmlns:d="DAV:"><d:prop><d:resourcetype/>'
+        '</d:prop></d:propfind>'
+    )
+    try:
+        async with httpx.AsyncClient(timeout=8.0, follow_redirects=True) as cx:
+            r = await cx.request(
+                "PROPFIND", url,
+                auth=(user, pw),
+                headers={"Depth": "0", "Content-Type": "application/xml"},
+                content=propfind_body,
+            )
+        if r.status_code in (200, 207):
+            return {"ok": True}
+        if r.status_code == 401:
+            return {"ok": False, "error": "Auth failed — check username/password"}
+        if r.status_code == 403:
+            return {"ok": False, "error": "Forbidden — user can't access that URL"}
+        if r.status_code == 404:
+            return {"ok": False, "error": "Not found — check the URL path"}
+        return {"ok": False, "error": f"HTTP {r.status_code}"}
+    except httpx.ConnectError as e:
+        return {"ok": False, "error": f"Connection refused: {e}"[:200]}
+    except httpx.TimeoutException:
+        return {"ok": False, "error": "Connection timed out"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)[:200]}
+
+
 def setup_calendar_routes() -> APIRouter:
     router = APIRouter(prefix="/api/calendar", tags=["calendar"])
 
-    # CalDAV connect form (Integrations → Calendar). Storage is local
-    # SQLite; sync (src/caldav_sync.py) pulls remote events into it on
-    # calendar open and periodically via the scheduler.
-    @router.get("/config")
-    async def get_config(request: Request):
-        owner = _require_user(request)
-        from routes.prefs_routes import _load_for_user
-        cfg = (_load_for_user(owner) or {}).get("caldav", {}) or {}
-        # Surface url+username but never hand the password back to the
-        # client — saved-state UI shouldn't leak the credential.
-        return {
-            "url": cfg.get("url", "") or "",
-            "username": cfg.get("username", "") or "",
-            "password": "",
-            "has_password": bool(cfg.get("password")),
-            "local": not bool(cfg.get("url")),
-        }
+    # ── CalDAV multi-account endpoints ──────────────────────────────────
 
-    @router.post("/config")
-    async def save_config(request: Request):
+    @router.get("/accounts")
+    async def list_accounts(request: Request):
         owner = _require_user(request)
-        from routes.prefs_routes import _load_for_user, _save_for_user
+        from routes.prefs_routes import _load_caldav_accounts
+        accounts = _load_caldav_accounts(owner)
+        safe = [
+            {
+                "id": a.get("id"),
+                "name": a.get("name", ""),
+                "url": a.get("url", ""),
+                "username": a.get("username", ""),
+                "has_password": bool(a.get("password")),
+            }
+            for a in accounts
+        ]
+        return {"accounts": safe}
+
+    @router.post("/accounts")
+    async def create_account(request: Request):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_caldav_accounts, _save_caldav_accounts
         try:
             body = await request.json()
         except Exception:
             body = {}
-        prefs = _load_for_user(owner) or {}
-        cfg = dict(prefs.get("caldav") or {})
-        # Empty url => clear the whole entry (treat as "remove integration").
-        if not (body.get("url") or "").strip():
-            prefs.pop("caldav", None)
-            _save_for_user(owner, prefs)
-            return {"ok": True, "cleared": True}
-        cfg["url"] = body.get("url", "").strip()
-        cfg["username"] = (body.get("username") or "").strip()
-        # Preserve the stored password when the client sends an empty
-        # one (edit form re-submitted without re-typing the password).
+        url = (body.get("url") or "").strip()
+        username = (body.get("username") or "").strip()
+        password = body.get("password") or ""
+        name = (body.get("name") or "").strip() or "CalDAV"
+        if not (url and username and password):
+            raise HTTPException(status_code=400, detail="url, username, and password are required")
+        account_id = str(uuid.uuid4())
+        accounts = _load_caldav_accounts(owner)
+        accounts.append({"id": account_id, "name": name, "url": url,
+                         "username": username, "password": password})
+        _save_caldav_accounts(owner, accounts)
+        return {"ok": True, "id": account_id}
+
+    @router.put("/accounts/{account_id}")
+    async def update_account(request: Request, account_id: str):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_caldav_accounts, _save_caldav_accounts
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        accounts = _load_caldav_accounts(owner)
+        acc = next((a for a in accounts if a.get("id") == account_id), None)
+        if not acc:
+            raise HTTPException(status_code=404, detail="Account not found")
+        if body.get("name") is not None:
+            acc["name"] = body["name"]
+        if body.get("url"):
+            acc["url"] = body["url"].strip()
+        if body.get("username") is not None:
+            acc["username"] = body["username"].strip()
         if body.get("password"):
-            cfg["password"] = body["password"]
-        prefs["caldav"] = cfg
-        _save_for_user(owner, prefs)
+            acc["password"] = body["password"]
+        _save_caldav_accounts(owner, accounts)
         return {"ok": True}
+
+    @router.delete("/accounts/{account_id}")
+    async def delete_account(request: Request, account_id: str):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_caldav_accounts, _save_caldav_accounts
+        accounts = _load_caldav_accounts(owner)
+        if not any(a.get("id") == account_id for a in accounts):
+            raise HTTPException(status_code=404, detail="Account not found")
+        _save_caldav_accounts(owner, [a for a in accounts if a.get("id") != account_id])
+        db = SessionLocal()
+        try:
+            cal_ids = [
+                c.id for c in db.query(CalendarCal).filter(
+                    CalendarCal.owner == owner,
+                    CalendarCal.account_id == account_id,
+                ).all()
+            ]
+            for cid in cal_ids:
+                db.query(CalendarEvent).filter(CalendarEvent.calendar_id == cid).delete()
+            if cal_ids:
+                db.query(CalendarCal).filter(CalendarCal.id.in_(cal_ids)).delete()
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            logger.error("Failed to clean up CalDAV account calendars: %s", e)
+        finally:
+            db.close()
+        return {"ok": True}
+
+    @router.post("/accounts/{account_id}/test")
+    async def test_account(request: Request, account_id: str):
+        owner = _require_user(request)
+        from routes.prefs_routes import _load_caldav_accounts
+        accounts = _load_caldav_accounts(owner)
+        acc = next((a for a in accounts if a.get("id") == account_id), None)
+        if not acc:
+            raise HTTPException(status_code=404, detail="Account not found")
+        return await _propfind_test(acc.get("url", ""), acc.get("username", ""), acc.get("password", ""))
+
+    @router.post("/accounts/{account_id}/sync")
+    async def sync_account_endpoint(request: Request, account_id: str):
+        owner = _require_user(request)
+        from src.caldav_sync import sync_caldav_account
+        return await sync_caldav_account(owner, account_id)
 
     @router.post("/test")
     async def test_connection(request: Request):
-        """Actually probe the configured CalDAV server with a PROPFIND
-        request (the same handshake every CalDAV client uses). Accepts
-        an optional {url, username, password} body so the user can test
-        a configuration BEFORE saving it; falls back to the stored
-        creds otherwise. Returns {ok, error?} with a useful message on
-        failure (status code, auth issue, network error)."""
-        owner = _require_user(request)
+        """Probe a CalDAV server with a PROPFIND before saving credentials.
+        Accepts {url, username, password} in the body (inline creds).
+        Returns {ok, error?}."""
+        _require_user(request)
         try:
             body = await request.json()
         except Exception:
@@ -561,45 +655,8 @@ def setup_calendar_routes() -> APIRouter:
         user = (body.get("username") or "").strip()
         pw = body.get("password") or ""
         if not (url and user and pw):
-            # Fall back to saved settings for this user.
-            from routes.prefs_routes import _load_for_user
-            cfg = (_load_for_user(owner) or {}).get("caldav", {}) or {}
-            url = url or (cfg.get("url") or "")
-            user = user or (cfg.get("username") or "")
-            pw = pw or (cfg.get("password") or "")
-        if not (url and user and pw):
             return {"ok": False, "error": "Missing URL, username, or password"}
-        import httpx
-        propfind_body = (
-            '<?xml version="1.0" encoding="UTF-8"?>\n'
-            '<d:propfind xmlns:d="DAV:"><d:prop><d:resourcetype/>'
-            '</d:prop></d:propfind>'
-        )
-        try:
-            async with httpx.AsyncClient(timeout=8.0, follow_redirects=True) as cx:
-                r = await cx.request(
-                    "PROPFIND", url,
-                    auth=(user, pw),
-                    headers={"Depth": "0", "Content-Type": "application/xml"},
-                    content=propfind_body,
-                )
-            # 207 = Multi-Status — standard CalDAV success. 200 also
-            # acceptable. Anything else (401/403/404/5xx) means trouble.
-            if r.status_code in (200, 207):
-                return {"ok": True}
-            if r.status_code == 401:
-                return {"ok": False, "error": "Auth failed — check username/password"}
-            if r.status_code == 403:
-                return {"ok": False, "error": "Forbidden — user can't access that URL"}
-            if r.status_code == 404:
-                return {"ok": False, "error": "Not found — check the URL path"}
-            return {"ok": False, "error": f"HTTP {r.status_code}"}
-        except httpx.ConnectError as e:
-            return {"ok": False, "error": f"Connection refused: {e}"[:200]}
-        except httpx.TimeoutException:
-            return {"ok": False, "error": "Connection timed out"}
-        except Exception as e:
-            return {"ok": False, "error": str(e)[:200]}
+        return await _propfind_test(url, user, pw)
 
     @router.post("/sync")
     async def sync_caldav_endpoint(request: Request):

--- a/routes/prefs_routes.py
+++ b/routes/prefs_routes.py
@@ -1,6 +1,7 @@
 """User preferences API — per-user key/value store backed by a JSON file."""
 import json
 import os
+import uuid as _uuid
 from typing import Optional
 from fastapi import APIRouter, Request
 from src.auth_helpers import get_current_user
@@ -47,6 +48,38 @@ def _save_for_user(user: Optional[str], prefs: dict):
         all_prefs = {"_users": {}}
     all_prefs["_users"][user] = prefs
     _save(all_prefs)
+
+
+def _migrate_caldav_prefs(prefs: dict) -> dict:
+    """Convert legacy single caldav key → caldav_accounts list. Pure function."""
+    if "caldav_accounts" in prefs or "caldav" not in prefs:
+        return prefs
+    old = prefs.get("caldav") or {}
+    new_prefs = {**prefs}
+    new_prefs.pop("caldav", None)
+    new_prefs["caldav_accounts"] = (
+        [{"id": str(_uuid.uuid4()), "name": "CalDAV", **old}] if old.get("url") else []
+    )
+    return new_prefs
+
+
+def _load_caldav_accounts(owner: Optional[str] = None) -> list:
+    """Return caldav_accounts list, running lazy migration if needed."""
+    try:
+        prefs = _load_for_user(owner) or {}
+        if "caldav" in prefs and "caldav_accounts" not in prefs:
+            prefs = _migrate_caldav_prefs(prefs)
+            _save_for_user(owner, prefs)
+        return list(prefs.get("caldav_accounts") or [])
+    except Exception:
+        return []
+
+
+def _save_caldav_accounts(owner: Optional[str], accounts: list) -> None:
+    prefs = _load_for_user(owner) or {}
+    prefs.pop("caldav", None)
+    prefs["caldav_accounts"] = accounts
+    _save_for_user(owner, prefs)
 
 
 def setup_prefs_routes():

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -56,7 +56,7 @@ def _to_utc_naive(dt):
     return datetime(dt.year, dt.month, dt.day), True
 
 
-def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
+def _sync_blocking(owner: str, url: str, username: str, password: str, account_id: str = "") -> dict:
     """The actual sync — synchronous, intended to run in a threadpool.
     Returns counts: {calendars, events, deleted, errors}."""
     # Lazy imports so a missing `caldav` dep doesn't break app startup —
@@ -116,14 +116,19 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
                         name=display_name,
                         color="#5b8abf",
                         source="caldav",
+                        account_id=account_id or None,
                     )
                     db.add(local_cal)
                     db.commit()
                 else:
-                    # Refresh the display name if the user renamed it
-                    # remotely; preserve any local color override.
+                    changed = False
                     if local_cal.name != display_name:
                         local_cal.name = display_name
+                        changed = True
+                    if account_id and local_cal.account_id != account_id:
+                        local_cal.account_id = account_id
+                        changed = True
+                    if changed:
                         db.commit()
                 result["calendars"] += 1
 
@@ -241,22 +246,51 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
 
 
 async def sync_caldav(owner: str) -> dict:
-    """Pull CalDAV state into local DB for `owner`. Returns counts +
-    errors. Loads credentials from the user's prefs; no-ops with a
-    clear error if CalDAV isn't configured."""
-    from routes.prefs_routes import _load_for_user
+    """Pull CalDAV state for all configured accounts for `owner`."""
+    from routes.prefs_routes import _load_caldav_accounts
 
-    cfg = (_load_for_user(owner) or {}).get("caldav", {}) or {}
-    url = (cfg.get("url") or "").strip()
-    user = (cfg.get("username") or "").strip()
-    pw = cfg.get("password") or ""
+    accounts = _load_caldav_accounts(owner)
+    if not accounts:
+        return {"calendars": 0, "events": 0, "deleted": 0,
+                "errors": ["No CalDAV accounts configured"]}
+    totals: dict = {"calendars": 0, "events": 0, "deleted": 0, "errors": []}
+    for acc in accounts:
+        url = (acc.get("url") or "").strip()
+        user = (acc.get("username") or "").strip()
+        pw = acc.get("password") or ""
+        account_id = acc.get("id") or ""
+        if not (url and user and pw):
+            totals["errors"].append(
+                f"Account '{acc.get('name', account_id)}': missing credentials"
+            )
+            continue
+        try:
+            r = await asyncio.to_thread(_sync_blocking, owner, url, user, pw, account_id)
+            for k in ("calendars", "events", "deleted"):
+                totals[k] += r.get(k, 0)
+            totals["errors"].extend(r.get("errors", []))
+        except Exception as e:
+            logger.exception("CalDAV sync raised for account %s", account_id)
+            totals["errors"].append(str(e)[:200])
+    return totals
+
+
+async def sync_caldav_account(owner: str, account_id: str) -> dict:
+    """Sync a single CalDAV account by id."""
+    from routes.prefs_routes import _load_caldav_accounts
+
+    accounts = _load_caldav_accounts(owner)
+    acc = next((a for a in accounts if a.get("id") == account_id), None)
+    if not acc:
+        return {"calendars": 0, "events": 0, "deleted": 0,
+                "errors": [f"Account {account_id!r} not found"]}
+    url = (acc.get("url") or "").strip()
+    user = (acc.get("username") or "").strip()
+    pw = acc.get("password") or ""
     if not (url and user and pw):
-        return {
-            "calendars": 0, "events": 0, "deleted": 0,
-            "errors": ["CalDAV is not configured"],
-        }
+        return {"calendars": 0, "events": 0, "deleted": 0, "errors": ["Missing credentials"]}
     try:
-        return await asyncio.to_thread(_sync_blocking, owner, url, user, pw)
+        return await asyncio.to_thread(_sync_blocking, owner, url, user, pw, account_id)
     except Exception as e:
-        logger.exception("CalDAV sync raised")
+        logger.exception("CalDAV sync raised for account %s", account_id)
         return {"calendars": 0, "events": 0, "deleted": 0, "errors": [str(e)[:200]]}

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -37,10 +37,12 @@ _LOOKBACK_DAYS = 90
 _LOOKAHEAD_DAYS = 365
 
 
-def _stable_cal_id(remote_url: str) -> str:
-    """Deterministic local id for a remote CalDAV calendar — same URL
-    always maps to the same local row across restarts and re-syncs."""
-    h = hashlib.sha256(remote_url.encode("utf-8")).hexdigest()[:24]
+def _stable_cal_id(remote_url: str, account_id: str = "") -> str:
+    """Deterministic local id for a remote CalDAV calendar.
+    Includes account_id so two accounts pointing at the same server
+    get distinct local rows and never overwrite each other."""
+    key = f"{account_id}::{remote_url}"
+    h = hashlib.sha256(key.encode("utf-8")).hexdigest()[:24]
     return f"caldav-{h}"
 
 
@@ -102,7 +104,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
         for remote_cal in calendars:
             try:
                 remote_url = str(remote_cal.url)
-                cal_id = _stable_cal_id(remote_url)
+                cal_id = _stable_cal_id(remote_url, account_id)
                 display_name = (remote_cal.name or "").strip() or "CalDAV"
 
                 local_cal = db.query(CalendarCal).filter(
@@ -158,7 +160,8 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
                     for comp in ical.walk():
                         if comp.name != "VEVENT":
                             continue
-                        uid_val = str(comp.get("uid", "")) or str(uuid.uuid4())
+                        remote_uid = str(comp.get("uid", "")) or str(uuid.uuid4())
+                        uid_val = f"{cal_id}::{remote_uid}"
                         seen_uids.add(uid_val)
 
                         dtstart_p = comp.get("dtstart")
@@ -193,6 +196,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
 
                         existing = pending.get(uid_val) or db.query(CalendarEvent).filter(
                             CalendarEvent.uid == uid_val,
+                            CalendarEvent.calendar_id == local_cal.id,
                         ).first()
                         if existing:
                             existing.calendar_id = local_cal.id

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3037,9 +3037,9 @@ async function initUnifiedIntegrations() {
   }
 
   async function fetchAll() {
-    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
+    const [apiRes, calAccountsRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
       fetch('/api/auth/integrations', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { integrations: [] }).catch(() => ({ integrations: [] })),
-      fetch('/api/calendar/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
+      fetch('/api/calendar/accounts', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { accounts: [] }).catch(() => ({ accounts: [] })),
       fetch('/api/contacts/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/list', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { contacts: [], count: 0 }).catch(() => ({ contacts: [], count: 0 })),
       fetch('/api/email/accounts', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { accounts: [] }).catch(() => ({ accounts: [] })),
@@ -3051,9 +3051,9 @@ async function initUnifiedIntegrations() {
     for (const intg of (apiRes.integrations || [])) {
       items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
     }
-    // CalDAV
-    if (calRes.url) {
-      items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
+    // CalDAV — one card per account
+    for (const acc of (calAccountsRes.accounts || [])) {
+      items.push({ type: 'caldav', id: acc.id, name: acc.name || 'CalDAV', detail: acc.url, enabled: true, data: acc });
     }
     // Contacts import first, then the optional CardDAV sync account.
     const contactCount = Number(contactsRes.count || (contactsRes.contacts || []).length || 0);
@@ -3151,7 +3151,7 @@ async function initUnifiedIntegrations() {
         const id = btn.dataset.intgId;
         try {
           if (type === 'api') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
-          else if (type === 'caldav') await fetch('/api/calendar/config', { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: '', username: '', password: '' }) });
+          else if (type === 'caldav') await fetch(`/api/calendar/accounts/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'contacts') {
             await fetch('/api/contacts/clear', { method: 'DELETE', credentials: 'same-origin' });
           }
@@ -3172,7 +3172,7 @@ async function initUnifiedIntegrations() {
   function showForm(type, editId) {
     formEl.style.display = '';
     if (type === 'api') showApiForm(editId);
-    else if (type === 'caldav') showCalDavForm();
+    else if (type === 'caldav') showCalDavForm(editId);
     else if (type === 'contacts' || type === 'carddav') showCardDavForm();
     else if (type === 'email') showEmailForm(editId);
     else if (type === 'mcp') showMcpForm(editId);
@@ -3290,26 +3290,54 @@ async function initUnifiedIntegrations() {
   }
 
   // ── CalDAV form ──
-  async function showCalDavForm() {
+  const CALDAV_PROVIDERS = {
+    icloud:    { label: 'iCloud',     url: 'https://caldav.icloud.com/' },
+    google:    { label: 'Google',     url: 'https://www.google.com/calendar/dav/' },
+    fastmail:  { label: 'Fastmail',   url: 'https://caldav.fastmail.com/dav/' },
+    radicale:  { label: 'Radicale',   url: 'http://localhost:5232/' },
+    nextcloud: { label: 'Nextcloud',  url: '' },
+    custom:    { label: 'Custom',     url: '' },
+  };
+
+  async function showCalDavForm(editId) {
+    const isEdit = !!(editId && editId !== 'new');
+    let existing = null;
+    if (isEdit) {
+      try {
+        const r = await fetch('/api/calendar/accounts', { credentials: 'same-origin' });
+        const d = await r.json();
+        existing = (d.accounts || []).find(a => a.id === editId) || null;
+      } catch (_) {}
+    }
+    const a = existing || {};
+    const providerOpts = Object.entries(CALDAV_PROVIDERS)
+      .map(([k, p]) => `<option value="${k}">${esc(p.label)}</option>`)
+      .join('');
     formEl.innerHTML = `
       <div class="admin-card" style="margin-top:8px">
-        <h2 style="font-size:13px">Calendar (CalDAV)</h2>
+        <h2 style="font-size:13px">${isEdit ? 'Edit' : 'Add'} Calendar (CalDAV)</h2>
         <div class="settings-col">
-          <div class="settings-row"><label class="settings-label">Server URL</label><input id="uf-caldav-url" class="settings-input" placeholder="http://localhost:5232/user"></div>
+          <div class="settings-row"><label class="settings-label">Name</label><input id="uf-caldav-name" class="settings-input" placeholder="iCloud, Work, etc."></div>
+          <div class="settings-row"><label class="settings-label">Provider</label><select id="uf-caldav-provider" class="settings-select">${providerOpts}</select></div>
+          <div class="settings-row"><label class="settings-label">Server URL</label><input id="uf-caldav-url" class="settings-input" placeholder="https://caldav.icloud.com/"></div>
           <div class="settings-row"><label class="settings-label">Username</label><input id="uf-caldav-user" class="settings-input"></div>
-          <div class="settings-row"><label class="settings-label">Password</label><input id="uf-caldav-pass" class="settings-input" type="password"></div>
+          <div class="settings-row"><label class="settings-label">Password</label><input id="uf-caldav-pass" class="settings-input" type="password" placeholder="${isEdit ? '(unchanged)' : ''}"></div>
           <div class="settings-row" style="margin-top:4px"><button class="admin-btn-sm" id="uf-caldav-save">Save</button><button class="admin-btn-sm" id="uf-caldav-test" style="opacity:0.7">Test</button><button class="admin-btn-sm" id="uf-caldav-cancel" style="opacity:0.7">Cancel</button><span id="uf-caldav-msg" style="font-size:11px"></span></div>
         </div>
       </div>`;
-    try {
-      const r = await fetch('/api/calendar/config', { credentials: 'same-origin' }); const d = await r.json();
-      el('uf-caldav-url').value = d.url || ''; el('uf-caldav-user').value = d.username || '';
-    } catch (_) {}
+    // Pre-populate for edit
+    if (isEdit && existing) {
+      el('uf-caldav-name').value = existing.name || '';
+      el('uf-caldav-url').value = existing.url || '';
+      el('uf-caldav-user').value = existing.username || '';
+    }
+    // Provider preset wires URL on select
+    el('uf-caldav-provider').addEventListener('change', () => {
+      const p = CALDAV_PROVIDERS[el('uf-caldav-provider').value];
+      if (p && p.url) el('uf-caldav-url').value = p.url;
+    });
     el('uf-caldav-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
 
-    // Run a PROPFIND with the form's current url+user+pass. Used by
-    // both the Test button (visible result only) and by Save (refuse
-    // to persist a broken config). Returns the parsed {ok, error?}.
     const _runCalDavTest = async () => {
       const body = {
         url: el('uf-caldav-url').value.trim(),
@@ -3334,27 +3362,27 @@ async function initUnifiedIntegrations() {
     };
 
     el('uf-caldav-save').addEventListener('click', async () => {
-      // Pre-validate by hitting the server with the same PROPFIND the
-      // Test button uses. If the CalDAV server rejects the creds/URL
-      // we won't persist garbage — the user gets the actual error
-      // (HTTP 401, "Not found", "Connection refused", etc.) in red.
-      _setCalDavMsg('Testing…', true);
-      el('uf-caldav-msg').style.color = '';
-      const d = await _runCalDavTest();
-      if (!d.ok) {
-        _setCalDavMsg(d.error || 'Connection failed — not saved', false);
-        return;
+      const pw = el('uf-caldav-pass').value;
+      // For new accounts, a password is required. For edits, it's optional (preserves existing).
+      if (!isEdit && !pw) { _setCalDavMsg('Password is required', false); return; }
+      if (pw) {
+        // Only run the PROPFIND test when a password is provided (new account or re-entering).
+        _setCalDavMsg('Testing…', true);
+        el('uf-caldav-msg').style.color = '';
+        const d = await _runCalDavTest();
+        if (!d.ok) { _setCalDavMsg(d.error || 'Connection failed — not saved', false); return; }
       }
       try {
-        await fetch('/api/calendar/config', {
-          method: 'POST', credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            url: el('uf-caldav-url').value,
-            username: el('uf-caldav-user').value,
-            password: el('uf-caldav-pass').value,
-          }),
-        });
+        const body = {
+          name: el('uf-caldav-name').value.trim() || 'CalDAV',
+          url: el('uf-caldav-url').value.trim(),
+          username: el('uf-caldav-user').value.trim(),
+        };
+        if (pw) body.password = pw;
+        const url = isEdit ? `/api/calendar/accounts/${editId}` : '/api/calendar/accounts';
+        const method = isEdit ? 'PUT' : 'POST';
+        const r = await fetch(url, { method, credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        if (!r.ok) { const e = await r.json().catch(() => ({})); _setCalDavMsg(e.detail || 'Save failed', false); return; }
         _setCalDavMsg('Saved', true);
         formEl.style.display = 'none';
         await renderList();

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3291,12 +3291,11 @@ async function initUnifiedIntegrations() {
 
   // ── CalDAV form ──
   const CALDAV_PROVIDERS = {
-    icloud:    { label: 'iCloud',     url: 'https://caldav.icloud.com/' },
-    google:    { label: 'Google',     url: 'https://www.google.com/calendar/dav/' },
-    fastmail:  { label: 'Fastmail',   url: 'https://caldav.fastmail.com/dav/' },
-    radicale:  { label: 'Radicale',   url: 'http://localhost:5232/' },
-    nextcloud: { label: 'Nextcloud',  url: '' },
-    custom:    { label: 'Custom',     url: '' },
+    icloud:    { label: 'iCloud',    url: 'https://caldav.icloud.com/' },
+    fastmail:  { label: 'Fastmail',  url: 'https://caldav.fastmail.com/dav/' },
+    radicale:  { label: 'Radicale',  url: 'http://localhost:5232/' },
+    nextcloud: { label: 'Nextcloud', url: '' },
+    custom:    { label: 'Custom',    url: '' },
   };
 
   async function showCalDavForm(editId) {
@@ -3339,10 +3338,23 @@ async function initUnifiedIntegrations() {
     el('uf-caldav-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
 
     const _runCalDavTest = async () => {
+      const pw = el('uf-caldav-pass').value;
+      // When editing without re-entering a password, use the stored credentials
+      // via the per-account test endpoint to avoid sending a blank password.
+      if (isEdit && !pw) {
+        try {
+          const r = await fetch(`/api/calendar/accounts/${editId}/test`, {
+            method: 'POST', credentials: 'same-origin',
+          });
+          return await r.json();
+        } catch (e) {
+          return { ok: false, error: 'Network error: ' + e.message };
+        }
+      }
       const body = {
         url: el('uf-caldav-url').value.trim(),
         username: el('uf-caldav-user').value.trim(),
-        password: el('uf-caldav-pass').value,
+        password: pw,
       };
       try {
         const r = await fetch('/api/calendar/test', {


### PR DESCRIPTION
## Summary

Fixes #519

- Users can now connect multiple CalDAV servers simultaneously (iCloud, Google Calendar, Outlook, Nextcloud, etc.) — each appears as a separate card in Settings → Integrations
- Existing single-account users are migrated automatically on first load, no data loss

## Changes

- **`core/database.py`** — `account_id` column on `calendars` table, at-startup migration (no Alembic)
- **`routes/prefs_routes.py`** — `_load_caldav_accounts` / `_save_caldav_accounts` helpers; lazy migration from legacy single `caldav` key → `caldav_accounts` list
- **`src/caldav_sync.py`** — `sync_caldav` iterates all accounts and aggregates results; `_sync_blocking` stamps `account_id` on `CalendarCal` rows; new `sync_caldav_account` for per-account sync
- **`routes/calendar_routes.py`** — old `/config` GET+POST removed; replaced with `GET/POST/PUT/DELETE /api/calendar/accounts` + per-account `/test` and `/sync`; shared `_propfind_test` helper extracted
- **`static/js/settings.js`** — integrations list renders one card per account; add/edit form has Name field + provider preset dropdown (iCloud, Google, Fastmail, Radicale, Nextcloud, Custom)

## Test plan

- [ ] Settings → Integrations → + Add Integration → CalDAV Calendar → add iCloud account → verify card appears
- [ ] Add a second account (Google) → verify two separate cards in the list
- [ ] Open Calendar — events from both accounts appear
- [ ] Edit an account — fields pre-populate, password field shows `(unchanged)`, re-saving without re-entering password preserves it
- [ ] Delete one account — card and its synced events disappear, second account unaffected
- [ ] Restart container — both accounts persist, sync on calendar open
- [ ] Existing user upgrade: add legacy `"caldav": {...}` to `user_prefs.json`, reload — migrates to `caldav_accounts` list with one entry, old key removed
- [ ] `docker compose config` passes, `py_compile` passes on all modified `.py` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)