### PR TITLE
Remove unnecessary host port bindings from internal services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,11 @@ services:
 
   chromadb:
     image: docker.io/chromadb/chroma:latest
-    ports:
-      - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
+    # No host port — only Odysseus needs ChromaDB, via Docker-internal
+    # chromadb:8000. If you need to query ChromaDB from the host (e.g.
+    # curl http://localhost:8100/api/v1/heartbeat), uncomment below:
+    # ports:
+    #   - "127.0.0.1:8100:8000"
     volumes:
       - chromadb-data:/chroma/chroma
     environment:
@@ -93,8 +96,11 @@ services:
           sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
         fi
         exec /usr/local/searxng/entrypoint.sh
-    ports:
-      - "127.0.0.1:8080:8080"
+    # No host port — only Odysseus needs SearXNG, via Docker-internal
+    # searxng:8080. If you need the SearXNG UI from the host (e.g.
+    # http://localhost:8080 for testing queries), uncomment below:
+    # ports:
+    #   - "127.0.0.1:8080:8080"
     volumes:
       - searxng-data:/etc/searxng
       - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z


### PR DESCRIPTION
## Summary

ChromaDB and SearXNG are internal services only accessed by the Odysseus container through the Docker network (`chromadb:8000`, `searxng:8080`). Binding their ports to the host occupies ports needlessly and increases the attack surface without any functional benefit.

## Changes

- Remove `ports:` from `chromadb` and `searxng` services (kept as commented-out lines for anyone who needs direct access for debugging).
- Keep ntfy port binding since external devices (phone ntfy app) need direct access to subscribe to push notifications.

## Notes

- Odysseus already references these services by container name (`SEARXNG_INSTANCE=http://searxng:8080`, `CHROMADB_HOST=chromadb`), so removing host ports changes nothing functionally.
- Users who need direct access (e.g. pointing an external tool at ChromaDB) can uncomment the relevant lines.

Closes #460

## Testing

- `docker compose config` validates the updated file
- Verified Odysseus connects to ChromaDB and SearXNG via internal network names (no host port needed)