### PR TITLE
Expose CC and BCC on send_email

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -285,9 +285,9 @@ Notes, checklists, AND user reminders. Use this for "create/add/write a note", t
     "list_email_accounts": "- ```list_email_accounts``` — List configured email accounts. Use this before reading/sending when the user says Gmail, work mail, custom domain mail, or any non-default mailbox; pass the returned account name/email/id as `account` to email tools.",
     "send_email": """\
 ```send_email
-{"to": "recipient@example.com", "subject": "Re: Your question", "body": "Hi, ...", "account": "gmail"}
+{"to": "recipient@example.com", "cc": "manager@example.com", "bcc": "archive@example.com", "subject": "Re: Your question", "body": "Hi, ...", "account": "gmail"}
 ```
-Send a new email via SMTP. Use `resolve_contact` first if you only have a name. If multiple email accounts exist, call `list_email_accounts` first and pass the chosen `account`.""",
+Send a new email via SMTP. If the user asks to CC or BCC someone, pass the exact `cc` or `bcc` recipient(s). Use `resolve_contact` first if you only have a name. If multiple email accounts exist, call `list_email_accounts` first and pass the chosen `account`.""",
     "list_emails": """\
 ```list_emails
 {"folder": "INBOX", "max_results": 20, "unread_only": false, "account": "gmail"}

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -892,6 +892,8 @@ FUNCTION_TOOL_SCHEMAS = [
                 "type": "object",
                 "properties": {
                     "to": {"type": "string", "description": "Recipient email address"},
+                    "cc": {"type": "string", "description": "Optional CC recipient address(es), comma-separated"},
+                    "bcc": {"type": "string", "description": "Optional BCC recipient address(es), comma-separated"},
                     "subject": {"type": "string", "description": "Email subject line"},
                     "body": {"type": "string", "description": "Email body text"},
                     "account": {"type": "string", "description": "Optional account name/email/id from list_email_accounts, e.g. Gmail or user@example.com"},

--- a/tests/test_email_cc_bcc_tools.py
+++ b/tests/test_email_cc_bcc_tools.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from src import agent_tools
+
+
+def _schema_for(name):
+    return next(
+        schema["function"]
+        for schema in agent_tools.FUNCTION_TOOL_SCHEMAS
+        if schema["function"]["name"] == name
+    )
+
+
+def test_send_email_native_schema_exposes_cc_and_bcc():
+    props = _schema_for("send_email")["parameters"]["properties"]
+
+    assert "cc" in props
+    assert "bcc" in props
+    assert props["cc"]["type"] == "string"
+    assert props["bcc"]["type"] == "string"
+
+
+def test_send_email_native_call_preserves_cc_and_bcc_for_mcp():
+    block = agent_tools.function_call_to_tool_block(
+        "send_email",
+        json.dumps(
+            {
+                "to": "recipient@example.com",
+                "cc": "manager@example.com",
+                "bcc": "archive@example.com",
+                "subject": "Status",
+                "body": "Sending the update.",
+            }
+        ),
+    )
+
+    assert block.tool_type == "mcp__email__send_email"
+    assert json.loads(block.content)["cc"] == "manager@example.com"
+    assert json.loads(block.content)["bcc"] == "archive@example.com"
+
+
+def test_send_email_agent_prompt_mentions_cc_and_bcc():
+    prompt_source = Path("src/agent_loop.py").read_text(encoding="utf-8")
+
+    assert '"cc": "manager@example.com"' in prompt_source
+    assert '"bcc": "archive@example.com"' in prompt_source
+    assert "If the user asks to CC or BCC someone" in prompt_source


### PR DESCRIPTION
I tracked this down to the tool shape the model sees, not the SMTP sender itself. The email server already accepts `cc` and `bcc`, but the native `send_email` schema and the short agent hint only exposed `to`, `subject`, `body`, and `account`, so a model had no clean way to include CC/BCC when it decided to call the tool.

Changed:
- added optional `cc` and `bcc` fields to the native `send_email` schema
- updated the agent's `send_email` example so CC/BCC requests are passed through instead of being implied in prose
- added a small regression test that checks the schema and the MCP handoff keep both fields intact

Fixes #471

Checked with:
- `venv/bin/python -m py_compile src/tool_schemas.py src/agent_loop.py tests/test_email_cc_bcc_tools.py`
- `venv/bin/python -m pytest -q tests/test_email_cc_bcc_tools.py`
- `git diff origin/main...HEAD --check`
