### PR TITLE
fix: background tasks ignoring session model

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -149,6 +149,9 @@ async def auto_name_session(session_manager, sess):
         t_url, t_model, t_headers = resolve_task_endpoint(
             sess.endpoint_url, sess.model, sess.headers,
         )
+        if not t_model:
+            logger.debug("[auto-name] No model provided, skipping")
+            return
 
         # max_tokens big enough that reasoning models (Minimax M2,
         # DeepSeek R1, QwQ, etc.) have headroom for <think>…</think>

--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -235,6 +235,10 @@ async def extract_and_store(
     Designed to run as a background task (asyncio.create_task).
     Errors are logged, never raised.
     """
+    if not endpoint_url or not model:
+        logger.debug("[memory-extract] No model or URL provided, skipping")
+        return
+
     try:
         from src.llm_core import llm_call_async
 
@@ -245,11 +249,30 @@ async def extract_and_store(
         if len(recent) < 2:
             return  # Need at least a user message and assistant response
 
-        fallback_facts = _fallback_memory_candidates(recent)
+        # Strip media (images/audio) from messages — background memory extraction
+        # only needs the text. The VL-generated descriptions are already in the
+        # text content of the messages. This avoids sending image tokens to
+        # non-vision models and prevents accidental "vision grounding" triggers.
+        stripped_recent = []
+        for msg in recent:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                # Filter out multimodal blocks that aren't text
+                text_only = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+                if not text_only and content:
+                    continue
+                content = text_only
+            stripped_recent.append({"role": role, "content": content})
+
+        if not stripped_recent:
+            return
+
+        fallback_facts = _fallback_memory_candidates(stripped_recent)
 
         extraction_messages = [
             {"role": "system", "content": EXTRACT_SYSTEM_PROMPT},
-        ] + recent
+        ] + stripped_recent
 
         facts = []
         try:

--- a/services/memory/skill_extractor.py
+++ b/services/memory/skill_extractor.py
@@ -59,6 +59,10 @@ async def maybe_extract_skill(
     owner: Optional[str] = None,
 ):
     """Extract a skill if the agent run was complex enough."""
+    if not model:
+        logger.debug("[skill-extract] No model provided, skipping")
+        return None
+
     # Quiet by default; flip to DEBUG when chasing extractor issues.
     logger.debug(
         "[skill-extract] start: rounds=%d tools=%d model=%s owner=%s",
@@ -78,9 +82,23 @@ async def maybe_extract_skill(
             logger.debug("[skill-extract] no recent messages, skipping")
             return None
 
+        # Strip media (images/audio) from messages
+        stripped_recent = []
+        for msg in recent:
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                text_only = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+                if not text_only and content:
+                    continue
+                content = text_only
+            stripped_recent.append({"role": msg.get("role"), "content": content})
+
+        if not stripped_recent:
+            return None
+
         # Build conversation summary for extraction
         conv_lines = []
-        for msg in recent:
+        for msg in stripped_recent:
             role = msg.get("role", "?")
             content = msg.get("content", "")
             if isinstance(content, list):

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -199,9 +199,14 @@ def resolve_endpoint(
     ep_id = (get_user_setting(f"{setting_prefix}_endpoint_id", owner or "", settings.get(f"{setting_prefix}_endpoint_id", "")) or "").strip()
     model = (get_user_setting(f"{setting_prefix}_model", owner or "", settings.get(f"{setting_prefix}_model", "")) or "").strip()
 
-    # Unset Utility means "same as Default Chat Model". This keeps background
-    # features usable out of the box and lets users override Utility only when
-    # they explicitly want a separate cheaper/faster model.
+    # If the specific endpoint is not configured, but the caller provided a 
+    # valid fallback (e.g. the active session model), use that immediately.
+    # This prevents background tasks from jumping to the global default_model
+    # when the user is mid-conversation with a different model.
+    if not ep_id and fallback_url and fallback_model:
+        return fallback_url, fallback_model, fallback_headers
+
+    # Unset Utility means "same as Default Chat Model".
     if setting_prefix == "utility" and not ep_id:
         ep_id = (get_user_setting("default_endpoint_id", owner or "", settings.get("default_endpoint_id", "")) or "").strip()
         model = (get_user_setting("default_model", owner or "", settings.get("default_model", "")) or "").strip()


### PR DESCRIPTION
This PR resolves a bug where background tasks (Memory Extraction,
  Auto-naming, and Skill Extraction) were incorrectly defaulting to the
  global default_model rather than respecting the user's active session
  model. It also implements media stripping for these tasks to prevent
  accidental activation of vision/multimodal pipelines (e.g., "Qwen-VL
  grounding") during text-only background processing.

  The Bug
   1. Model Snap-back: Even if a user selected a specific model for their
      chat session, the endpoint_resolver would revert background tasks to
      the global "Default Model" configured in Admin Settings. This made it
      impossible to truly "disable" certain models for background work.
   2. Accidental Vision Triggers: Background tasks were sending the full raw
      context to the LLM, including image_url and audio content blocks. For
      multimodal models like the Qwen-VL family, this triggered
      resource-heavy vision grounding tasks in backends like LM Studio, even
      when the task only required text analysis.

  How to Reproduce
   1. Set a global default_model in Odysseus (e.g., qwen3.5-9b).
   2. Open a new chat and switch to a different model (e.g., a Llama-3 local
      endpoint).
   3. Send several messages (or an image) to trigger a background task like
      auto-naming or memory extraction.
   4. Observe: The backend logs (e.g., LM Studio) show a request for the
      qwen3.5-9b model instead of the Llama model, and the request payload
      contains image tokens.

  The Fix
   1. Prioritized Resolution (src/endpoint_resolver.py): Updated
      resolve_endpoint to prioritize the fallback_model passed by the caller
      (the active session model) if no specific task-specific endpoint is
      configured.
   2. Media Stripping (services/memory/memory_extractor.py,
      services/memory/skill_extractor.py): Implemented a filter that removes
      image_url and audio blocks from the message history before sending
      them to background tasks. These tasks now process the text-only
      descriptions of images, saving bandwidth and preventing accidental
      vision pipeline triggers.
   3. Graceful Silence: Added strict checks to auto_name_session,
      extract_and_store, and maybe_extract_skill to ensure they silently
      exit if no valid model or endpoint is resolved, preventing "fallback
      to hardcoded name" errors.

  Files Changed
   - src/endpoint_resolver.py: Updated resolution logic.
   - services/memory/memory_extractor.py: Added media stripping and graceful
     skip.
   - services/memory/skill_extractor.py: Added media stripping and graceful
     skip.
   - routes/chat_helpers.py: Added graceful skip for the auto-naming task.

  ---
  Verified on Windows native installation. No regressions in primary chat
  functionality.
  Used Qwen3.5 and SmolLm3 along with LM Studio for testing after the fix 
  
  
  Below is the image that shows the bug, The models used were Qwen3.5 and SmolLm3
  
<img width="1919" height="914" alt="Screenshot 2026-06-01 181702" src="https://github.com/user-attachments/assets/bbb358fd-340e-43b5-82bb-3496716c138a" />

