### PR TITLE
fix(cookbook): allow serving cached local llama.cpp model ids

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 # HuggingFace repo IDs are <org>/<name>, both alphanumerics plus ._-
 # Rejecting anything else up front closes off shell-interpolation vectors.
 _REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+# Cached models scanned from a custom/local model dir are keyed by their leaf
+# folder name (no slash), e.g. `DeepSeek-R1-UD-IQ4_XS`. The serve command uses
+# the real on-disk path separately; this identifier is only for UI/task
+# bookkeeping, so serving should accept the same safe glyph set as repo IDs.
+_LOCAL_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 # Include pattern is a glob: allow typical safe glyphs only.
 _INCLUDE_RE = re.compile(r"^[A-Za-z0-9._\-*?/\[\]]+$")
 # Remote host: user@host (optionally with :port-free hostname parts).
@@ -37,6 +42,14 @@ def _validate_repo_id(v: str | None) -> str:
     if not v or not _REPO_ID_RE.match(v):
         raise HTTPException(400, "Invalid repo_id — must be <org>/<name> using [A-Za-z0-9._-]")
     return v
+
+
+def _validate_serve_model_id(v: str | None) -> str:
+    if not v:
+        raise HTTPException(400, "repo_id is required")
+    if _REPO_ID_RE.match(v) or _LOCAL_MODEL_ID_RE.match(v):
+        return v
+    raise HTTPException(400, "Invalid repo_id — must be <org>/<name> or a cached local model id using [A-Za-z0-9._-]")
 
 
 def _validate_include(v: str | None) -> str | None:

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 from routes.cookbook_helpers import (
     _SSH_PORT_RE, _REMOTE_HOST_RE, _SESSION_ID_RE,
-    _validate_repo_id, _validate_include, _validate_remote_host, _validate_token,
+    _validate_repo_id, _validate_serve_model_id, _validate_include, _validate_remote_host, _validate_token,
     _validate_local_dir, _validate_ssh_port, _validate_gpus, _shell_path,
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
     _safe_env_prefix, _local_tooling_path_export,
@@ -844,9 +844,11 @@ def setup_cookbook_routes() -> APIRouter:
         """Launch a model server in a tmux session (or PowerShell background process on Windows).
 
         `repo_id` is dual-purpose: a HuggingFace repo (`<org>/<name>`) for
-        model-serve commands, OR a bare pip package name when the cmd is a
-        `python -m pip install …`. We only enforce the strict HF format on
-        the model paths.
+        model-serve commands, a cached local-model id (the folder name reported
+        by `/api/model/cached`) for models scanned from a custom model dir, OR a
+        bare pip package name when the cmd is a `python -m pip install …`. We
+        keep strict validation, but serving local cached models must not require
+        a fake org/name wrapper.
         """
         require_admin(request)
         # Defence-in-depth: reject values that could break out of shell contexts.
@@ -875,7 +877,7 @@ def setup_cookbook_routes() -> APIRouter:
             ):
                 raise HTTPException(400, "Invalid pip package name")
         else:
-            _validate_repo_id(req.repo_id)
+            _validate_serve_model_id(req.repo_id)
         TMUX_LOG_DIR.mkdir(parents=True, exist_ok=True)
         session_id = f"serve-{uuid.uuid4().hex[:8]}"
         remote = req.remote_host

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -5,6 +5,8 @@ from routes.cookbook_helpers import (
     _local_tooling_path_export,
     _safe_env_prefix,
     _validate_gpus,
+    _validate_repo_id,
+    _validate_serve_model_id,
     _validate_ssh_port,
 )
 
@@ -43,6 +45,19 @@ def test_validate_gpus_accepts_indexes_only():
     assert _validate_gpus("0,1,2") == "0,1,2"
     with pytest.raises(HTTPException):
         _validate_gpus("0; rm -rf /")
+
+
+def test_validate_repo_id_stays_strict_for_hf_downloads():
+    assert _validate_repo_id("Qwen/Qwen3-8B") == "Qwen/Qwen3-8B"
+    with pytest.raises(HTTPException):
+        _validate_repo_id("DeepSeek-R1-UD-IQ4_XS")
+
+
+def test_validate_serve_model_id_accepts_cached_local_model_names():
+    assert _validate_serve_model_id("Qwen/Qwen3-8B") == "Qwen/Qwen3-8B"
+    assert _validate_serve_model_id("DeepSeek-R1-UD-IQ4_XS") == "DeepSeek-R1-UD-IQ4_XS"
+    with pytest.raises(HTTPException):
+        _validate_serve_model_id("../escape")
 
 
 def test_local_tooling_path_export_prepends_interpreter_bin():


### PR DESCRIPTION
## Summary
- allow Cookbook serve validation to accept cached local model ids like `DeepSeek-R1-UD-IQ4_XS`
- keep download validation strict for real HuggingFace repo ids
- add regression tests covering the split between download and serve validation

## Why this PR
Issue #456 reports that local llama.cpp / GGUF models fail with `Invalid repo_id` during serve. The cached-model UI passes a safe local model identifier (folder name), but `/api/model/serve` currently validates `repo_id` as if it must always be `<org>/<name>`.

This PR is a narrow alternative focused only on that validation mismatch.

## Duplicate / overlap note
There is already an open broader PR: #512. This PR is intentionally offered as a smaller alternate implementation for the `Invalid repo_id` part of #456 only, in case a minimal patch is easier to review or cherry-pick.

## Test Plan
- `python -m pytest tests/test_cookbook_helpers.py`
- `python -m py_compile app.py routes/*.py src/*.py mcp_servers/*.py`

Refs #456
