### PR TITLE
fix: research query entity extraction loses the year (2024 -> 20)

### DIFF
--- a/services/search/query.py
+++ b/services/search/query.py
@@ -29,7 +29,7 @@ def _extract_entities(query: str) -> Dict[str, List[str]]:
         cleaned = re.sub(rf"^{qtype}\b", "", cleaned, flags=re.I).strip()
     for token in re.findall(r"\b[A-Z][a-zA-Z]+\b", cleaned):
         entities["names"].append(token)
-    for year in re.findall(r"\b(19|20)\d{2}\b", cleaned):
+    for year in re.findall(r"\b(?:19|20)\d{2}\b", cleaned):
         entities["dates"].append(year)
     month_day_year = re.findall(
         r"\b(?:Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|Sept|September|Oct|October|Nov|November|Dec|December)\s+\d{1,2},?\s*\d{4}\b",

--- a/src/search/query.py
+++ b/src/search/query.py
@@ -29,7 +29,7 @@ def _extract_entities(query: str) -> Dict[str, List[str]]:
         cleaned = re.sub(rf"^{qtype}\b", "", cleaned, flags=re.I).strip()
     for token in re.findall(r"\b[A-Z][a-zA-Z]+\b", cleaned):
         entities["names"].append(token)
-    for year in re.findall(r"\b(19|20)\d{2}\b", cleaned):
+    for year in re.findall(r"\b(?:19|20)\d{2}\b", cleaned):
         entities["dates"].append(year)
     month_day_year = re.findall(
         r"\b(?:Jan|January|Feb|February|Mar|March|Apr|April|May|Jun|June|Jul|July|Aug|August|Sep|Sept|September|Oct|October|Nov|November|Dec|December)\s+\d{1,2},?\s*\d{4}\b",

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -1,0 +1,21 @@
+"""Tests for research query entity extraction (src/search/query.py)."""
+
+from src.search.query import _extract_entities
+
+
+def test_extracts_full_four_digit_year():
+    # Regression: the year pattern used a capturing group `(19|20)`, so
+    # re.findall returned just the century ("20") instead of the full year.
+    entities = _extract_entities("What happened to OpenAI in 2024")
+    assert "2024" in entities["dates"]
+    assert "20" not in entities["dates"]
+
+
+def test_extracts_multiple_years():
+    entities = _extract_entities("Compare revenue in 1999 and 2008")
+    assert entities["dates"] == ["1999", "2008"]
+
+
+def test_no_false_year_from_other_numbers():
+    entities = _extract_entities("Top 50 albums of all time")
+    assert entities["dates"] == []


### PR DESCRIPTION
## Summary

`_extract_entities` pulls years out of a query to boost search relevance, but the pattern `\b(19|20)\d{2}\b` uses a **capturing group**, so `re.findall` returns only the captured century (`"20"` / `"19"`) instead of the full year. A query like "What happened in 2024" boosts the search with `"20"` rather than `"2024"`, which is useless and can pull in unrelated results.

Fix: make the alternation non-capturing — `\b(?:19|20)\d{2}\b` — so the full four-digit year is extracted. The same bug exists in both the `src/search` (deep research) and `services/search` (search routes) copies, so both are fixed.

## Changes
- `src/search/query.py` and `services/search/query.py`: non-capturing year group.
- `tests/test_search_query.py`: full-year extraction regression test.