### PR TITLE
Fix mobile safe-area: keep hamburger nav clear of the iOS status bar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3685,7 +3685,7 @@ body.bg-pattern-sparkles {
     }
     @media (max-width:768px){
       .box { max-height:none; }
-      .chat-container { padding:10px; flex:1; margin-top:0; padding-top:42px; min-height:0; }
+      .chat-container { padding:10px; flex:1; margin-top:0; padding-top:calc(42px + env(safe-area-inset-top, 0px)); min-height:0; }
       .scroll-nav-btn { width:44px; height:44px; font-size:14px; margin-bottom:0; }
       .send-btn { width:48px; height:48px !important; border-radius:12px; }
       .send-btn svg { width:22px; height:22px; }
@@ -3883,9 +3883,9 @@ body.bg-pattern-sparkles {
       .hamburger-btn {
         width: 44px;
         height: 44px;
-        top: 6px;
+        top: calc(6px + env(safe-area-inset-top, 0px));
         left: auto !important;
-        right: 4px !important;
+        right: calc(4px + env(safe-area-inset-right, 0px)) !important;
         -webkit-tap-highlight-color: transparent;
       }
       .hamburger-btn:hover,
@@ -3898,8 +3898,8 @@ body.bg-pattern-sparkles {
       .mobile-new-chat-btn {
         display: flex;
         position: fixed;
-        top: 12px;
-        left: 8px;
+        top: calc(12px + env(safe-area-inset-top, 0px));
+        left: calc(8px + env(safe-area-inset-left, 0px));
         z-index: 210;
         width: 32px;
         height: 32px;

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v326';
+const CACHE_NAME = 'odysseus-v328';
 
 // Core shell precached on install so repeat opens are instant without any
 // network wait. Keep this list in sync with the <script type="module"> tags


### PR DESCRIPTION
## What

Under `viewport-fit=cover` the app had no `safe-area-inset` handling, so on iOS the fixed hamburger (sandwich) nav and the chat title rendered *behind* the status bar — the nav sat directly under the battery / charging icon.

This offsets the fixed hamburger + new-chat buttons and the `chat-container` top padding by `env(safe-area-inset-*)`, so the controls drop into the safe area. The background still fills the whole screen; only the controls move down.

Also bumps the service worker cache (`v326` → `v328`) so the change ships to installed PWAs.

## Areas changed

- `static/style.css` — mobile `.hamburger-btn`, `.mobile-new-chat-btn`, and `.chat-container` top offsets
- `static/sw.js` — cache version bump

All CSS changes are scoped to `@media (max-width: 768px)`; desktop layout is unchanged. The `, 0px)` fallback resolves the insets to 0 on non-notched browsers (no visual change off iOS).

## Scope note

Per review feedback, the iOS **input focus-zoom** fix has been dropped from this PR — the `maximum-scale=1.0` viewport change disabled user pinch-zoom (accessibility concern), and that problem is being solved properly in #1323 (minimum-16px input font). This PR is now safe-area-only.

## Testing

- `node --check static/sw.js` — passes.
- Manually verified on an installed iOS PWA: the hamburger nav now sits below the status bar / charging icon.

No Python changed, so the test suite is unaffected.