### PR TITLE
fix: validate hour/minute in /remind and /event time parsing

### DIFF
--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -1464,7 +1464,7 @@ function _parseTimeSpec(input) {
     const mer = (m[4] || '').toLowerCase();
     if (mer === 'pm' && hh < 12) hh += 12;
     if (mer === 'am' && hh === 12) hh = 0;
-    if (hh > 23) return null;
+    if (hh > 23 || mm > 59) return null;
     d.setHours(hh, mm, 0, 0);
     return { date: d, rest: m[5].trim() };
   }
@@ -1478,9 +1478,9 @@ function _parseTimeSpec(input) {
     const mer = (m[3] || '').toLowerCase();
     if (mer === 'pm' && hh < 12) hh += 12;
     if (mer === 'am' && hh === 12) hh = 0;
-    // Require an hour <= 23 and either a minute field or am/pm to avoid
-    // eating plain numbers like "3 apples".
-    if (hh > 23) return null;
+    // Require a valid hour/minute and either a minute field or am/pm to
+    // avoid eating plain numbers like "3 apples".
+    if (hh > 23 || mm > 59) return null;
     if (m[2] == null && !mer) return null;
     d.setHours(hh, mm, 0, 0);
     if (d.getTime() <= now.getTime()) d.setDate(d.getDate() + 1);

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -1464,6 +1464,7 @@ function _parseTimeSpec(input) {
     const mer = (m[4] || '').toLowerCase();
     if (mer === 'pm' && hh < 12) hh += 12;
     if (mer === 'am' && hh === 12) hh = 0;
+    if (hh > 23) return null;
     d.setHours(hh, mm, 0, 0);
     return { date: d, rest: m[5].trim() };
   }


### PR DESCRIPTION
## Summary

`_parseTimeSpec` (used by `/remind` and `/event`) accepts out-of-range times and silently rolls them over via `Date` overflow, scheduling the reminder at an unexpected moment:

- `today 30:00 ...` → `setHours(30, …)` rolls to 06:00 the next day.
- `today 9:99 ...` / `9:99 ...` → `setHours(9, 99)` becomes 10:39.

The bare-time branch already rejected `hour > 23` but not minutes; the `today/tomorrow` branch validated neither. This adds `hour <= 23` and `minute <= 59` checks to both branches so an invalid time fails to parse (falling through) instead of producing a silently-wrong reminder.

## Changes
- `static/js/slashCommands.js`: reject `hour > 23` / `minute > 59` in both time-parsing branches.