### PR TITLE
Diagnose llama.cpp CUDA toolkit build failures

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -645,6 +645,118 @@ def _llama_cpp_rebuild_cmd() -> str:
     )
 
 
+def _diagnose_serve_output(text: str) -> dict | None:
+    """Server-side mirror of the Cookbook UI's common serve diagnoses.
+
+    The browser uses cookbook-diagnosis.js for clickable fixes. This gives
+    the agent/tool path the same structured signal so it can retry with an
+    adjusted command instead of guessing from raw tmux output.
+    """
+    if not text:
+        return None
+    tail = text[-6000:]
+    patterns = [
+        (
+            r"No available memory for the cache blocks|Available KV cache memory:.*-",
+            "No GPU memory left for KV cache after loading model.",
+            [
+                {"label": "retry with GPU memory utilization 0.95", "op": "replace", "flag": "--gpu-memory-utilization", "value": "0.95"},
+                {"label": "retry with context 2048", "op": "replace", "flag": "--max-model-len", "value": "2048"},
+            ],
+        ),
+        (
+            r"CUDA out of memory|torch\.cuda\.OutOfMemoryError|CUDA error: out of memory|warming up sampler|max_num_seqs.*gpu_memory_utilization",
+            "GPU ran out of memory during startup or warmup.",
+            [
+                {"label": "retry with context 4096", "op": "replace", "flag": "--max-model-len", "value": "4096"},
+                {"label": "retry with GPU memory utilization 0.80", "op": "replace", "flag": "--gpu-memory-utilization", "value": "0.80"},
+                {"label": "retry with --enforce-eager", "op": "append", "arg": "--enforce-eager"},
+            ],
+        ),
+        (
+            r"not divisib|must be divisible|attention heads.*divisible",
+            "Tensor parallel size is incompatible with the model.",
+            [
+                {"label": "retry with tensor parallel size 1", "op": "replace", "flag": "--tensor-parallel-size", "value": "1"},
+                {"label": "retry with tensor parallel size 2", "op": "replace", "flag": "--tensor-parallel-size", "value": "2"},
+            ],
+        ),
+        (
+            r"KV cache.*too (small|large)|max_model_len.*exceeds|maximum.*context",
+            "Context length is too large for available GPU memory.",
+            [
+                {"label": "retry with context 8192", "op": "replace", "flag": "--max-model-len", "value": "8192"},
+                {"label": "retry with context 4096", "op": "replace", "flag": "--max-model-len", "value": "4096"},
+            ],
+        ),
+        (
+            r"enable-auto-tool-choice requires --tool-call-parser",
+            "Auto tool choice requires an explicit tool call parser.",
+            [{"label": "retry with Hermes tool parser", "op": "append", "arg": "--tool-call-parser hermes"}],
+        ),
+        (
+            r"Please pass.*trust.remote.code=True|contains custom code which must be executed to correctly load|does not recognize this architecture|model type.*but Transformers does not",
+            "Model requires custom code or newer model support.",
+            [{"label": "retry with --trust-remote-code", "op": "append", "arg": "--trust-remote-code"}],
+        ),
+        (
+            r"Either a revision or a version must be specified|transformers\.integrations\.hub_kernels|kernels/layer",
+            "vLLM/Transformers kernel package mismatch.",
+            [{"label": "update vLLM, Transformers, and kernels on this server", "op": "dependency", "package": "vllm transformers kernels"}],
+        ),
+        (
+            r"Could not find nvcc|CUDAToolkit_ROOT|CUDA Toolkit not found|Unable to find cudart library|CUDA_CUDART|ggml-cuda/CMakeLists\.txt|building llama-server for CPU only|GPU inference will not be available",
+            "llama.cpp CUDA toolkit/runtime is missing, so Odysseus is falling back to CPU. Docker GPU visibility only proves passthrough; llama.cpp also needs nvcc and cudart available to CMake. On AMD, this CUDA build path is not usable; use Ollama, a ROCm/Vulkan llama.cpp build, or a registered OpenAI-compatible endpoint.",
+            [{"label": "install a complete CUDA toolkit/runtime for NVIDIA, or use a non-CUDA backend for AMD", "op": "manual"}],
+        ),
+        (
+            r"Address already in use|bind.*address.*in use",
+            "Port is already in use.",
+            [{"label": "retry on port 8001", "op": "replace", "flag": "--port", "value": "8001"}],
+        ),
+        (
+            r"No CUDA GPUs are available|no GPU.*found|CUDA_VISIBLE_DEVICES.*invalid",
+            "No GPUs are visible to the serve process.",
+            [{"label": "clear Cookbook GPU selection or choose available GPUs", "op": "settings", "field": "gpus", "value": ""}],
+        ),
+        (
+            r"vllm.*command not found|No module named vllm|ERROR: vLLM is not installed",
+            "vLLM is not installed or not in PATH on this server.",
+            [{"label": "install vLLM in Cookbook Dependencies", "op": "dependency", "package": "vllm"}],
+        ),
+        (
+            r"sglang.*command not found|No module named sglang|SGLang is not installed",
+            "SGLang is not installed or not in PATH on this server.",
+            [{"label": "install SGLang in Cookbook Dependencies", "op": "dependency", "package": "sglang[all]"}],
+        ),
+        (
+            r"llama-server.*command not found|llama\.cpp.*not found|No module named.*llama_cpp|No module named 'starlette_context'|git: command not found|cmake: command not found",
+            "llama.cpp / llama-cpp-python dependencies are missing.",
+            [{"label": "install llama.cpp dependencies or llama-cpp-python[server]", "op": "dependency", "package": "llama-cpp-python[server]"}],
+        ),
+        (
+            r"No module named 'torch'|No module named torch|No module named 'diffusers'|No module named diffusers",
+            "Diffusion serving requires PyTorch and diffusers.",
+            [{"label": "install diffusers[torch] in Cookbook Dependencies", "op": "dependency", "package": "diffusers[torch]"}],
+        ),
+        (
+            r"403 Forbidden|401 Unauthorized|Access to model.*is restricted|gated repo|not in the authorized list|awaiting a review",
+            "Model access is gated or unauthorized.",
+            [{"label": "set HF token and request model access on HuggingFace", "op": "manual"}],
+        ),
+    ]
+    for pattern, message, suggestions in patterns:
+        if re.search(pattern, tail, re.I):
+            return {"message": message, "suggestions": suggestions}
+    if re.search(r"Traceback \(most recent call last\)", tail, re.I) and not re.search(
+        r"Application startup complete|GET /v1/|Uvicorn running on", tail, re.I
+    ):
+        return {
+            "message": "Python traceback detected during serve startup.",
+            "suggestions": [{"label": "inspect traceback and retry with adjusted backend/settings", "op": "manual"}],
+        }
+    return None
+
 class ModelDownloadRequest(BaseModel):
     repo_id: str
     include: str | None = None  # glob pattern e.g. "*Q4_K_M*"

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -710,6 +710,11 @@ def _diagnose_serve_output(text: str) -> dict | None:
             [{"label": "install a complete CUDA toolkit/runtime for NVIDIA, or use a non-CUDA backend for AMD", "op": "manual"}],
         ),
         (
+            r"unsupported GNU version|gcc versions later than 13 are not supported|exception specification is incompatible.*\bcospi\b|nvcc fatal\s*:\s*Unsupported gpu architecture",
+            "A CUDA toolkit was found, but it does not match this host or GPU, so the llama.cpp CUDA build fails. Two common traps: (1) the host compiler/libc is too new for an older CUDA (CUDA 12.4 and earlier against glibc 2.41+ produces the 'cospi' exception-specification error, and CUDA 12.x rejects gcc newer than 13); (2) the CUDA version is too new for the GPU (CUDA 13 dropped pre-sm_75 support, so it cannot build for Pascal sm_61 cards such as the GTX 10-series). For older NVIDIA GPUs, use CUDA 12.8+ (still supports Pascal and is compatible with glibc 2.41) and build with -DCMAKE_CUDA_ARCHITECTURES set to the card's compute capability. Otherwise skip the source build and place a prebuilt llama-server on PATH.",
+            [{"label": "match the CUDA toolkit to the host and GPU (CUDA 12.8+ for older cards), or use a prebuilt llama-server on PATH", "op": "manual"}],
+        ),
+        (
             r"Address already in use|bind.*address.*in use",
             "Port is already in use.",
             [{"label": "retry on port 8001", "op": "replace", "flag": "--port", "value": "8001"}],

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -40,6 +40,7 @@ from routes.cookbook_helpers import (
     _append_serve_exit_code_lines, _append_llama_cpp_linux_accel_build_lines, _cached_model_scan_script,
     _ollama_bind_from_cmd, _pip_install_fallback_chain, _pip_install_no_cache,
     _user_shell_path_bootstrap, _venv_safe_local_pip_install_cmd,
+    _diagnose_serve_output,
     ModelDownloadRequest, ServeRequest,
 )
 
@@ -80,127 +81,6 @@ def setup_cookbook_routes() -> APIRouter:
                 if isinstance(task, dict) and isinstance(task.get("payload"), dict):
                     task["payload"].pop("hf_token", None)
         return state
-
-    def _diagnose_serve_output(text: str) -> dict | None:
-        """Server-side mirror of the Cookbook UI's common serve diagnoses.
-
-        The browser uses cookbook-diagnosis.js for clickable fixes. This gives
-        the agent/tool path the same structured signal so it can retry with an
-        adjusted command instead of guessing from raw tmux output.
-        """
-        if not text:
-            return None
-        tail = text[-6000:]
-        patterns = [
-            (
-                r"No available memory for the cache blocks|Available KV cache memory:.*-",
-                "No GPU memory left for KV cache after loading model.",
-                [
-                    {"label": "retry with GPU memory utilization 0.95", "op": "replace", "flag": "--gpu-memory-utilization", "value": "0.95"},
-                    {"label": "retry with context 2048", "op": "replace", "flag": "--max-model-len", "value": "2048"},
-                ],
-            ),
-            (
-                r"CUDA out of memory|torch\.cuda\.OutOfMemoryError|CUDA error: out of memory|warming up sampler|max_num_seqs.*gpu_memory_utilization",
-                "GPU ran out of memory during startup or warmup.",
-                [
-                    {"label": "retry with context 4096", "op": "replace", "flag": "--max-model-len", "value": "4096"},
-                    {"label": "retry with GPU memory utilization 0.80", "op": "replace", "flag": "--gpu-memory-utilization", "value": "0.80"},
-                    {"label": "retry with --enforce-eager", "op": "append", "arg": "--enforce-eager"},
-                ],
-            ),
-            (
-                r"not divisib|must be divisible|attention heads.*divisible",
-                "Tensor parallel size is incompatible with the model.",
-                [
-                    {"label": "retry with tensor parallel size 1", "op": "replace", "flag": "--tensor-parallel-size", "value": "1"},
-                    {"label": "retry with tensor parallel size 2", "op": "replace", "flag": "--tensor-parallel-size", "value": "2"},
-                ],
-            ),
-            (
-                r"KV cache.*too (small|large)|max_model_len.*exceeds|maximum.*context",
-                "Context length is too large for available GPU memory.",
-                [
-                    {"label": "retry with context 8192", "op": "replace", "flag": "--max-model-len", "value": "8192"},
-                    {"label": "retry with context 4096", "op": "replace", "flag": "--max-model-len", "value": "4096"},
-                ],
-            ),
-            (
-                r"enable-auto-tool-choice requires --tool-call-parser",
-                "Auto tool choice requires an explicit tool call parser.",
-                [{"label": "retry with Hermes tool parser", "op": "append", "arg": "--tool-call-parser hermes"}],
-            ),
-            (
-                r"Please pass.*trust.remote.code=True|contains custom code which must be executed to correctly load|does not recognize this architecture|model type.*but Transformers does not",
-                "Model requires custom code or newer model support.",
-                [{"label": "retry with --trust-remote-code", "op": "append", "arg": "--trust-remote-code"}],
-            ),
-            (
-                r"Either a revision or a version must be specified|transformers\.integrations\.hub_kernels|kernels/layer",
-                "vLLM/Transformers kernel package mismatch.",
-                [{"label": "update vLLM, Transformers, and kernels on this server", "op": "dependency", "package": "vllm transformers kernels"}],
-            ),
-            (
-                r"Address already in use|bind.*address.*in use",
-                "Port is already in use.",
-                [{"label": "retry on port 8001", "op": "replace", "flag": "--port", "value": "8001"}],
-            ),
-            (
-                r"No CUDA GPUs are available|no GPU.*found|CUDA_VISIBLE_DEVICES.*invalid",
-                "No GPUs are visible to the serve process.",
-                [{"label": "clear Cookbook GPU selection or choose available GPUs", "op": "settings", "field": "gpus", "value": ""}],
-            ),
-            (
-                r"Failed to infer device type|NVML Shared Library Not Found|No module named 'amdsmi'|platform is not available",
-                "vLLM could not find a supported GPU (CUDA or ROCm). "
-                "This machine may have integrated or unsupported graphics only.",
-                [
-                    {"label": "switch to llama.cpp (CPU/Metal, works without a discrete GPU)", "op": "manual"},
-                    {"label": "switch to Ollama (CPU/Metal, works without a discrete GPU)", "op": "manual"},
-                ],
-            ),
-            (
-                r"vllm.*command not found|No module named vllm|ERROR: vLLM is not installed",
-                "vLLM is not installed or not in PATH on this server.",
-                [{"label": "install vLLM in Cookbook Dependencies", "op": "dependency", "package": "vllm"}],
-            ),
-            (
-                r"sglang.*command not found|No module named sglang|SGLang is not installed",
-                "SGLang is not installed or not in PATH on this server.",
-                [{"label": "install SGLang in Cookbook Dependencies", "op": "dependency", "package": "sglang[all]"}],
-            ),
-            (
-                r"llama-server.*command not found|llama\.cpp.*not found|No module named.*llama_cpp|No module named 'starlette_context'|git: command not found|cmake: command not found",
-                "llama.cpp / llama-cpp-python dependencies are missing.",
-                [{"label": "install llama.cpp dependencies or llama-cpp-python[server]", "op": "dependency", "package": "llama-cpp-python[server]"}],
-            ),
-            (
-                r"No GGUF found on this host|no \.gguf file|No GGUF file found",
-                "No GGUF file found for this model on this host. The llama.cpp backend needs a .gguf file.",
-                [{"label": "download a GGUF build of this model (repo name usually ends in -GGUF, file like Q4_K_M.gguf)", "op": "manual"}],
-            ),
-            (
-                r"No module named 'torch'|No module named torch|No module named 'diffusers'|No module named diffusers",
-                "Diffusion serving requires PyTorch and diffusers.",
-                [{"label": "install diffusers[torch] in Cookbook Dependencies", "op": "dependency", "package": "diffusers[torch]"}],
-            ),
-            (
-                r"403 Forbidden|401 Unauthorized|Access to model.*is restricted|gated repo|not in the authorized list|awaiting a review",
-                "Model access is gated or unauthorized.",
-                [{"label": "set HF token and request model access on HuggingFace", "op": "manual"}],
-            ),
-        ]
-        for pattern, message, suggestions in patterns:
-            if re.search(pattern, tail, re.I):
-                return {"message": message, "suggestions": suggestions}
-        if re.search(r"Traceback \(most recent call last\)", tail, re.I) and not re.search(
-            r"Application startup complete|GET /v1/|Uvicorn running on", tail, re.I
-        ):
-            return {
-                "message": "Python traceback detected during serve startup.",
-                "suggestions": [{"label": "inspect traceback and retry with adjusted backend/settings", "op": "manual"}],
-            }
-        return None
 
     def _state_for_client(state):
         """Return cookbook state without raw secrets for browser clients."""

--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -343,6 +343,15 @@ export const ERROR_PATTERNS = [
     ],
   },
   {
+    pattern: /Could not find nvcc|CUDAToolkit_ROOT|CUDA Toolkit not found|Unable to find cudart library|CUDA_CUDART|ggml-cuda\/CMakeLists\.txt|building llama-server for CPU only|GPU inference will not be available/i,
+    message: 'llama.cpp CUDA toolkit/runtime is missing, so Odysseus is falling back to CPU. Docker GPU visibility only proves passthrough; llama.cpp also needs nvcc and cudart available to CMake.',
+    suggestion: 'Suggested action: install a complete CUDA toolkit/runtime on NVIDIA, or use Ollama, a ROCm/Vulkan llama.cpp build, or a registered OpenAI-compatible endpoint on AMD.',
+    fixes: [
+      { label: 'Copy NVIDIA guidance', action: () => _copyText('Install a complete CUDA toolkit/runtime with nvcc and cudart available to CMake. Docker nvidia-smi only confirms GPU passthrough; it does not prove llama.cpp can build with CUDA.') },
+      { label: 'Copy AMD guidance', action: () => _copyText('This llama.cpp build attempted CUDA, which will not work on AMD/Radeon. Use Ollama, a ROCm/Vulkan llama.cpp build, or run a separate OpenAI-compatible endpoint and add it in Settings -> Add Models.') },
+    ],
+  },
+  {
     pattern: /Engine core initialization failed/i,
     message: 'vLLM engine failed to start. Check the error above.',
     fixes: [
@@ -422,15 +431,6 @@ export const ERROR_PATTERNS = [
     fixes: [
       { label: 'Open Dependencies', action: () => _openCookbookDependencies('llama_cpp') },
       { label: 'Copy install command', action: () => _copyText('pip install "llama-cpp-python[server]"') },
-    ],
-  },
-  {
-    pattern: /CUDA Toolkit not found|Unable to find cudart library|missing:\s*CUDA_CUDART/i,
-    message: 'llama.cpp found nvcc, but the CUDA runtime library is missing.',
-    suggestion: 'Suggested action: relaunch with the updated runner so llama.cpp builds CPU-only, or install a complete CUDA toolkit/runtime on this server for GPU llama.cpp.',
-    fixes: [
-      { label: 'Edit serve', action: (panel) => _openServeEditFromDiagnosis(panel) },
-      { label: 'Open Dependencies', action: () => _openCookbookDependencies('llama_cpp') },
     ],
   },
   {

--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -352,6 +352,15 @@ export const ERROR_PATTERNS = [
     ],
   },
   {
+    pattern: /unsupported GNU version|gcc versions later than 13 are not supported|exception specification is incompatible.*\bcospi\b|nvcc fatal\s*:\s*Unsupported gpu architecture/i,
+    message: 'A CUDA toolkit was found, but it does not match this host or GPU, so the llama.cpp CUDA build fails. Two common traps: (1) the host gcc/libc is too new for an older CUDA (CUDA 12.4 and earlier with glibc 2.41+ produces the "cospi" error, and CUDA 12.x rejects gcc newer than 13); (2) the CUDA version is too new for the GPU (CUDA 13 dropped pre-sm_75, so it cannot build for Pascal sm_61 cards like the GTX 10-series).',
+    suggestion: 'Suggested action: for older NVIDIA GPUs use CUDA 12.8+ (still supports Pascal, compatible with glibc 2.41) and build with -DCMAKE_CUDA_ARCHITECTURES set to the card compute capability, or skip the source build and put a prebuilt llama-server on PATH.',
+    fixes: [
+      { label: 'Copy CUDA version guidance', action: () => _copyText('Match the CUDA toolkit to both the host and the GPU. For Pascal sm_61 GPUs (GTX 10-series), CUDA 13 will not build (it dropped pre-sm_75); use CUDA 12.8+ which still supports Pascal and is compatible with glibc 2.41, then build with -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=61. The "cospi" exception-specification error comes from CUDA 12.4 and earlier against glibc 2.41+, and is fixed by CUDA 12.8+.') },
+      { label: 'Copy prebuilt-binary guidance', action: () => _copyText('Skip the source build: place a prebuilt CUDA llama-server on PATH (Cookbook prefers a native llama-server before building from source), expose its CUDA runtime via LD_LIBRARY_PATH, then relaunch and confirm the startup logs show CUDA KV/layer placement instead of dev = CPU.') },
+    ],
+  },
+  {
     pattern: /Engine core initialization failed/i,
     message: 'vLLM engine failed to start. Check the error above.',
     fixes: [

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -589,3 +589,40 @@ def test_serve_diagnosis_explains_llamacpp_cpu_fallback_warning():
 
     assert diag is not None
     assert "falling back to CPU" in diag["message"]
+
+
+def test_serve_diagnosis_explains_cuda_host_glibc_cospi_failure():
+    log = """
+    -- Found CUDAToolkit: /usr/local/cuda-12.4/targets/x86_64-linux/include (found version "12.4.99")
+    -- CUDA Toolkit found
+    error: exception specification is incompatible with that of previous function "cospi"
+    """
+
+    diag = _diagnose_serve_output(log)
+
+    assert diag is not None
+    assert "does not match this host or GPU" in diag["message"]
+    assert "CUDA 12.8+" in diag["message"]
+    assert diag["suggestions"][0]["op"] == "manual"
+
+
+def test_serve_diagnosis_explains_cuda_unsupported_gcc_version():
+    log = """
+    error: #error -- unsupported GNU version! gcc versions later than 13 are not supported!
+    """
+
+    diag = _diagnose_serve_output(log)
+
+    assert diag is not None
+    assert "does not match this host or GPU" in diag["message"]
+
+
+def test_serve_diagnosis_explains_cuda_unsupported_gpu_architecture():
+    log = """
+    nvcc fatal : Unsupported gpu architecture 'compute_61'
+    """
+
+    diag = _diagnose_serve_output(log)
+
+    assert diag is not None
+    assert "Pascal sm_61" in diag["message"]

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -11,6 +11,7 @@ from routes.cookbook_helpers import (
     _append_serve_exit_code_lines,
     _append_serve_preflight_exit_lines,
     _llama_cpp_rebuild_cmd,
+    _diagnose_serve_output,
     _local_tooling_path_export,
     _pip_install_attempt,
     _pip_install_fallback_chain,
@@ -544,3 +545,47 @@ def test_pip_install_no_cache_is_idempotent_and_scoped():
     # not a pip install -> unchanged
     assert _pip_install_no_cache("vllm serve --model x") == "vllm serve --model x"
     assert _pip_install_no_cache("") == ""
+
+
+def test_serve_diagnosis_explains_llamacpp_cuda_toolkit_failure():
+    log = """
+    -- Could not find nvcc, please set CUDAToolkit_ROOT.
+    CMake Error at ggml/src/ggml-cuda/CMakeLists.txt:268 (message):
+      CUDA Toolkit not found
+    """
+
+    diag = _diagnose_serve_output(log)
+
+    assert diag is not None
+    assert "CUDA toolkit/runtime is missing" in diag["message"]
+    assert "falling back to CPU" in diag["message"]
+    assert "Docker GPU visibility only proves passthrough" in diag["message"]
+    assert diag["suggestions"][0]["op"] == "manual"
+
+
+def test_serve_diagnosis_explains_llamacpp_cuda_runtime_failure():
+    log = """
+    [odysseus] CUDA nvcc found — building llama-server with CUDA (GPU) support...
+    -- Unable to find cudart library.
+    -- Could NOT find CUDAToolkit (missing: CUDA_CUDART) (found version "13.3.33")
+    CMake Error at ggml/src/ggml-cuda/CMakeLists.txt:268 (message):
+      CUDA Toolkit not found
+    """
+
+    diag = _diagnose_serve_output(log)
+
+    assert diag is not None
+    assert "cudart available to CMake" in diag["message"]
+    assert "falling back to CPU" in diag["message"]
+
+
+def test_serve_diagnosis_explains_llamacpp_cpu_fallback_warning():
+    log = """
+    [odysseus] WARNING: nvcc found but CUDA runtime library was not found — building llama-server for CPU only.
+    [odysseus]   GPU inference will not be available for this llama.cpp build.
+    """
+
+    diag = _diagnose_serve_output(log)
+
+    assert diag is not None
+    assert "falling back to CPU" in diag["message"]


### PR DESCRIPTION
## Summary

Adds a targeted Cookbook diagnosis for llama.cpp native build failures where CMake tries the CUDA backend but cannot find CUDA toolkit binaries. It does **not** change serving behaviour - it only turns a confusing raw CMake error into actionable guidance.

The new diagnosis catches log lines such as `Could not find nvcc`, `CUDAToolkit_ROOT`, `CUDA Toolkit not found`, `Unable to find cudart library` / `CUDA_CUDART`, and `ggml-cuda/CMakeLists.txt`. When matched, the UI explains that the llama.cpp CUDA build needs the CUDA toolkit / `nvcc`, and that AMD/Radeon users should not follow the CUDA build path at all (they need Ollama, a ROCm/Vulkan llama.cpp build, or an already-running OpenAI-compatible endpoint). It offers copyable NVIDIA and AMD guidance instead of leaving users with raw CMake output. The server-side Cookbook diagnosis mirror returns the same structured signal for agent/tool flows.

To make this testable, the server-side diagnosis helper (previously inline in the route closure) moved into `routes/cookbook_helpers.py`, with `routes/cookbook_routes.py` still importing it - behaviour preserved.

## Linked Issue

Part of #831
Refs #191, #465, #502, #504

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [x] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate. (No open PR adds a CUDA-toolkit build-failure diagnosis to the Cookbook diagnosis path.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I confirmed this is diagnostic messaging only and does not alter serving/build behaviour.

## How to Test

1. Run the focused suite: `venv/bin/python -m pytest -q tests/test_cookbook_helpers.py tests/test_cookbook_package_detection.py` -> 39 passed (covers the new CUDA-toolkit match cases and existing detection).
2. Confirm the frontend module parses: `node --check static/js/cookbook-diagnosis.js`.
3. Manual: feed a Cookbook build log containing `Could not find nvcc, please set CUDAToolkit_ROOT` and confirm the diagnosis surfaces the NVIDIA/AMD guidance instead of raw CMake output.

_Scope note: this surfaces a clearer explanation of the CUDA-toolkit build failure in #831; it is diagnostic guidance, not a functional GPU-enablement fix._
