### PR TITLE
fix: run uvicorn natively on Apple Silicon, skip on Intel

### DIFF
--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -119,7 +119,11 @@ fi
 
 notify "Starting…"
 cd "$INSTALL_DIR" || die_gui "Install folder not found: $INSTALL_DIR"
-"$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$LOG" 2>&1 &
+if [ "$(uname -m)" = "arm64" ]; then
+  arch -arm64 "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$LOG" 2>&1 &
+else
+  "$UVICORN" app:app --host 127.0.0.1 --port "$PORT" >>"$LOG" 2>&1 &
+fi
 SERVER_PID=$!
 
 # Quitting the app stops the server it started.


### PR DESCRIPTION
App bundle launcher ran under Rosetta (x86_64), causing dlopen failure on arm64 venv binaries (pydantic_core). Detect arch at runtime with uname -m and wrap with arch -arm64
only on Apple Silicon. Intel Macs unaffected.


Tested on macOS ARM — app starts successfully.

<img width="494" height="357" alt="image" src="https://github.com/user-attachments/assets/e6346806-19ad-472b-bdb5-75f7416449c7" />

