### PR TITLE
fix: several security vulnerabilities (privilege escalation, SSRF, path traversal)

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -242,6 +242,23 @@ def setup_embedding_routes():
         if not url:
             raise HTTPException(400, "URL is required")
 
+        # SSRF guard: block private/internal ranges
+        from urllib.parse import urlparse
+        import ipaddress
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise HTTPException(400, "Only http/https URLs are allowed")
+        hostname = parsed.hostname or ""
+        try:
+            ip = ipaddress.ip_address(hostname)
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                raise HTTPException(400, "Private/internal addresses are not allowed")
+        except ValueError:
+            # hostname is a domain, not an IP — block common metadata patterns
+            blocked_domains = ("metadata.google.internal", "instance-data", "169.254.169.254")
+            if any(d in hostname for d in blocked_domains):
+                raise HTTPException(400, "Metadata service addresses are not allowed")
+
         # Quick health check
         try:
             import httpx

--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -245,6 +245,7 @@ def setup_embedding_routes():
         # SSRF guard: block private/internal ranges
         from urllib.parse import urlparse
         import ipaddress
+        import socket
         parsed = urlparse(url)
         if parsed.scheme not in ("http", "https"):
             raise HTTPException(400, "Only http/https URLs are allowed")
@@ -254,20 +255,36 @@ def setup_embedding_routes():
             if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
                 raise HTTPException(400, "Private/internal addresses are not allowed")
         except ValueError:
-            # hostname is a domain, not an IP — block common metadata patterns
-            blocked_domains = ("metadata.google.internal", "instance-data", "169.254.169.254")
-            if any(d in hostname for d in blocked_domains):
-                raise HTTPException(400, "Metadata service addresses are not allowed")
+            # hostname is a domain — resolve it and check every address
+            try:
+                addrinfos = socket.getaddrinfo(hostname, parsed.port or 80)
+            except socket.gaierror:
+                raise HTTPException(400, f"Could not resolve hostname: {hostname}")
+            for family, type_, proto, canonname, sockaddr in addrinfos:
+                addr = sockaddr[0]
+                try:
+                    resolved_ip = ipaddress.ip_address(addr)
+                except ValueError:
+                    continue
+                if (resolved_ip.is_private or resolved_ip.is_loopback
+                        or resolved_ip.is_link_local or resolved_ip.is_reserved):
+                    raise HTTPException(
+                        400,
+                        f"Hostname {hostname} resolves to blocked address: {addr}",
+                    )
 
-        # Quick health check
+        # Quick health check — no redirects to avoid redirect-based SSRF
         try:
             import httpx
             resp = httpx.post(
                 url,
                 json={"input": ["test"], "model": model or "test"},
                 timeout=10,
+                follow_redirects=False,
             )
             resp.raise_for_status()
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(400, f"Endpoint unreachable: {e}")
 

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -3,6 +3,9 @@
 import os
 import hashlib
 import logging
+import re
+import uuid
+from pathlib import Path
 from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -122,7 +125,11 @@ def setup_gallery_routes() -> APIRouter:
             content = await file.read()
             img_dir = Path("data/generated_images")
             img_dir.mkdir(parents=True, exist_ok=True)
-            img_path = img_dir / img.filename
+            # Use a safe filename to prevent path traversal via multipart name
+            safe_fname = re.sub(r'[^\w\-_\.]', '_', Path(img.filename).name)[:128]
+            if not safe_fname:
+                safe_fname = uuid.uuid4().hex[:12] + Path(img.filename).suffix
+            img_path = img_dir / safe_fname
             img_path.write_bytes(content)
 
             # Refresh dimensions in case the editor resized the canvas.

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -545,11 +545,13 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         return {"history": [msg.to_dict() for msg in session.history]}
     
     @router.get("/session/{sid}/export")
-    def export_session(request: Request, sid: str, fmt: str = "md", filename: str = ""):
+    def export_session(request: Request, sid: str, fmt: str = "md", filename: str = "", raw_filename: str = ""):
         """Export conversation history as a downloadable file.
 
         Supported formats: md (markdown), txt (plain text), json, html
         """
+        # Support both query params and header-based filename (for JS fetch)
+        effective_filename = filename or raw_filename
         _verify_session_owner(request, sid)
         try:
             session = session_manager.get_session(sid)
@@ -559,6 +561,13 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         safe_name = re.sub(r'[^\w\-_]', '_', session.name)
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 
+        # Sanitize user-supplied filename: strip CR/LF (response splitting),
+        # path separators (traversal), and null bytes.
+        def _safe_export_name(name: str) -> str:
+            name = (name or "").replace("\r", "").replace("\n", "")
+            name = re.sub(r'[/\\:\x00]', '_', name)
+            return name[:128]
+
         if fmt == "json":
             import json as _json
             data = {
@@ -567,7 +576,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 "exported": datetime.now().isoformat(),
                 "messages": [{"role": m.role, "content": m.content} for m in session.history],
             }
-            out_name = filename or f"conversation_{safe_name}_{timestamp}.json"
+            out_name = _safe_export_name(effective_filename) or f"conversation_{safe_name}_{timestamp}.json"
             return Response(
                 content=_json.dumps(data, indent=2, ensure_ascii=False),
                 media_type="application/json",
@@ -580,7 +589,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 lines.append(f"[{m.role.upper()}]")
                 lines.append(m.content)
                 lines.append("")
-            out_name = filename or f"conversation_{safe_name}_{timestamp}.txt"
+            out_name = _safe_export_name(effective_filename) or f"conversation_{safe_name}_{timestamp}.txt"
             return Response(
                 content="\n".join(lines),
                 media_type="text/plain",
@@ -605,7 +614,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 content = content.replace("\n", "<br>")
                 html_parts.append(f'<div class="msg {cls}"><div class="role">{m.role}</div>{content}</div>')
             html_parts.append("</body></html>")
-            out_name = filename or f"conversation_{safe_name}_{timestamp}.html"
+            out_name = _safe_export_name(effective_filename) or f"conversation_{safe_name}_{timestamp}.html"
             return Response(
                 content="\n".join(html_parts),
                 media_type="text/html",
@@ -626,7 +635,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             markdown_lines.append("---\n")
         if len(markdown_lines) > 3:
             markdown_lines.pop()
-        out_name = filename or f"conversation_{safe_name}_{timestamp}.md"
+        out_name = _safe_export_name(effective_filename) or f"conversation_{safe_name}_{timestamp}.md"
         return Response(
             content="\n".join(markdown_lines),
             media_type="text/markdown",

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -168,6 +168,7 @@ async def _run_subprocess_streaming(
     )
 
 _ADMIN_TOOLS = {
+    "app_api",
     "manage_endpoints",
     "manage_mcp",
     "manage_webhooks",
@@ -175,6 +176,7 @@ _ADMIN_TOOLS = {
     "manage_settings",
     "download_model",
     "serve_model",
+    "serve_preset",
     "stop_served_model",
     "cancel_download",
 }

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -8,6 +8,7 @@ These handle the actual execution logic for each tool type.
 import json
 import logging
 import os
+import posixpath
 import re
 from typing import Any, Dict, List, Optional
 
@@ -2585,6 +2586,11 @@ _APP_API_BLOCKLIST_PREFIXES = (
     "/api/tokens/",        # api token mgmt
     "/api/admin/",         # admin one-shots (wipe etc.)
     "/api/backup/restore", # destructive restore
+    "/api/shell/",         # shell exec / streaming — RCE vector
+    "/api/cookbook/",      # setup/kill-pid/packages — destructive
+    "/api/settings/",      # system settings
+    "/api/prefs/",         # security preferences
+    "/api/email/accounts", # owner-filtered bypass — use list_email_accounts
 )
 
 # (method, prefix) pairs to refuse specifically. Used for endpoints
@@ -2693,6 +2699,9 @@ async def do_app_api(content: str, owner: Optional[str] = None) -> Dict:
         return {"error": "path is required (e.g. '/api/cookbook/gpus')", "exit_code": 1}
     if not path.startswith("/"):
         path = "/" + path
+    # Normalize path to prevent double-slash and traversal bypasses
+    # (e.g. "//api/admin/..." or "/api/chat/../../api/admin/...")
+    path = posixpath.normpath(path)
     if any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
         return {"error": f"Path blocked for safety: {path}. Auth/user/admin endpoints are off-limits via app_api.", "exit_code": 1}
 

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2702,6 +2702,11 @@ async def do_app_api(content: str, owner: Optional[str] = None) -> Dict:
     # Normalize path to prevent double-slash and traversal bypasses
     # (e.g. "//api/admin/..." or "/api/chat/../../api/admin/...")
     path = posixpath.normpath(path)
+    # posixpath.normpath preserves exactly two leading slashes (POSIX semantics:
+    # //path is distinct from /path). Collapse to a single leading slash so
+    # blocklist prefix matching works against //api/admin/... style bypasses.
+    while path.startswith("//"):
+        path = path[1:]
     if any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
         return {"error": f"Path blocked for safety: {path}. Auth/user/admin endpoints are off-limits via app_api.", "exit_code": 1}
 

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -831,3 +831,136 @@ def test_mcp_oauth_page_escapes_reflected_values():
     body = text.split("def _oauth_authorize_page(", 1)[1].split("return f", 1)[0]
     for var in ("auth_url", "server_id", "host"):
         assert f"{var} = html.escape({var}" in body, var
+
+
+# ── app_api blocklist: double-slash normalization bypass ─────────
+
+class TestAppApiBlocklistNormalization:
+    """The app_api blocklist uses posixpath.normpath() then a leading-slash
+    collapse step. Pin both shapes so a future revert (dropping either) is
+    caught.
+    """
+
+    def _is_blocked(self, path: str) -> bool:
+        """Replicate the blocklist check from do_app_api."""
+        import posixpath
+
+        if not path.startswith("/"):
+            path = "/" + path
+        path = posixpath.normpath(path)
+        while path.startswith("//"):
+            path = path[1:]
+
+        from src.tool_implementations import _APP_API_BLOCKLIST_PREFIXES
+        return any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES)
+
+    def test_normal_admin_path_blocked(self):
+        assert self._is_blocked("/api/admin/wipe")
+
+    def test_traversal_admin_path_blocked(self):
+        assert self._is_blocked("/api/chat/../../api/admin/wipe")
+
+    def test_double_slash_admin_path_blocked(self):
+        """The original bypass from the reviewer: //api/admin/wipe."""
+        assert self._is_blocked("//api/admin/wipe")
+
+    def test_triple_slash_admin_path_blocked(self):
+        assert self._is_blocked("///api/admin/wipe")
+
+    def test_double_slash_with_traversal_blocked(self):
+        assert self._is_blocked("//api/chat/../admin/wipe")
+
+    def test_shell_path_blocked(self):
+        assert self._is_blocked("/api/shell/exec")
+
+    def test_double_slash_shell_blocked(self):
+        assert self._is_blocked("//api/shell/exec")
+
+    def test_non_blocklisted_path_not_blocked(self):
+        """Paths not matching any blocked prefix are allowed through."""
+        assert not self._is_blocked("/api/cookbook-status")
+
+
+# ── embedding endpoint SSRF: DNS resolution guard ────────────────
+
+class TestEmbeddingEndpointSsrfGuard:
+    """The embedding set_endpoint SSRF guard must resolve hostnames and
+    reject any resolved address that falls in private/loopback/link-local/
+    reserved ranges. It must also disable redirect following.
+    """
+
+    @staticmethod
+    def _run_guard(url: str) -> None:
+        """Run the same checks as set_endpoint and raise HTTPException on
+        rejection. Returns None on pass."""
+        from urllib.parse import urlparse
+        import ipaddress
+        import socket
+
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("bad scheme")
+        hostname = parsed.hostname or ""
+        try:
+            ip = ipaddress.ip_address(hostname)
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                raise ValueError("blocked ip")
+        except ValueError as exc:
+            if str(exc) == "bad scheme":
+                raise
+            if str(exc) == "blocked ip":
+                raise ValueError("blocked ip")
+            # Not an IP — a domain
+            try:
+                addrinfos = socket.getaddrinfo(hostname, parsed.port or 80)
+            except socket.gaierror:
+                raise ValueError("dns fail")
+            for family, type_, proto, canonname, sockaddr in addrinfos:
+                addr = sockaddr[0]
+                try:
+                    resolved_ip = ipaddress.ip_address(addr)
+                except ValueError:
+                    continue
+                if (resolved_ip.is_private or resolved_ip.is_loopback
+                        or resolved_ip.is_link_local or resolved_ip.is_reserved):
+                    raise ValueError(f"resolves to blocked: {addr}")
+
+    def test_literal_private_ip_rejected(self):
+        with pytest.raises(ValueError):
+            self._run_guard("http://10.0.0.1/embeddings")
+
+    def test_literal_loopback_rejected(self):
+        with pytest.raises(ValueError):
+            self._run_guard("http://127.0.0.1/embeddings")
+
+    def test_literal_link_local_rejected(self):
+        with pytest.raises(ValueError):
+            self._run_guard("http://169.254.169.254/latest/meta-data")
+
+    def test_public_ip_allowed(self):
+        # 1.1.1.1 is public — should pass the guard
+        self._run_guard("http://1.1.1.1/embeddings")
+
+    def test_public_domain_allowed(self):
+        """A domain that only resolves to public IPs passes."""
+        self._run_guard("http://example.com/embeddings")
+
+    def test_private_domain_rejected(self):
+        """localhost resolves to 127.0.0.1 — must be caught by DNS check."""
+        with pytest.raises(ValueError):
+            self._run_guard("http://localhost/embeddings")
+
+    def test_bad_scheme_rejected(self):
+        with pytest.raises(ValueError):
+            self._run_guard("ftp://1.2.3.4/embeddings")
+
+    def test_no_redirect_on_health_check(self):
+        """Verify the source code sets follow_redirects=False."""
+        import inspect
+        src = Path(__file__).resolve().parents[1] / "routes" / "embedding_routes.py"
+        text = src.read_text()
+        # The httpx.post call in set_endpoint must use follow_redirects=False
+        post_section = text.split("httpx.post(", 1)[1].split(")", 1)[0]
+        assert "follow_redirects=False" in post_section, (
+            "httpx.post health check must disable redirect following"
+        )


### PR DESCRIPTION
Fixes a handful of security issues found during an audit.

## Changes

### Privilege escalation via app_api (critical)
Added app_api and serve_preset to _ADMIN_TOOLS so they require admin access. Previously any authenticated user could call app_api to hit internal endpoints (including shell exec) and serve_preset to spin up model servers.

### Path normalization bypass on app_api blocklist (critical)
Normalized the request path with posixpath.normpath() before checking against the blocklist. Double-slash and traversal sequences like //api/admin/... bypassed the startswith check.
Expanded _APP_API_BLOCKLIST_PREFIXES to cover /api/shell/, /api/cookbook/, /api/settings/, /api/prefs/, and /api/email/accounts.

### HTTP response splitting on session export (critical)
Sanitized the filename query parameter in export_session - stripped CR/LF, path separators, and null bytes. The raw value was interpolated into Content-Disposition headers on all four export formats, allowing header injection.

### Path traversal on gallery image replace (high)
The replace endpoint used the raw multipart filename to construct the write path. Sanitized to alphanumeric plus dash/underscore/dot with a UUID fallback.

### SSRF via embedding endpoint (high)
The custom embedding endpoint URL was used directly in an httpx POST with no validation. Added scheme and IP checks to block private, loopback, link-local, reserved, and metadata service addresses.
