### PR TITLE
macOS: Replace PY with venv py after venv is created and present in start-macos

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -90,6 +90,7 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
+PY="$(pwd)/venv/bin/python"
 "$PY" -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
 "$PY" -m pip install -r requirements.txt


### PR DESCRIPTION
Resolves: https://github.com/pewdiepie-archdaemon/odysseus/issues/578

**Files changed**: `./start-macos.sh` script

Before this echo $PY resolves to `/opt/homebrew/bin/python3.13` and after the fix it resolves to: `$ABSOLUTE/odysseus/venv/bin/pytho` where $ABSOLUTE is the absolute parent path of odysseus. This was necessary because it wouldn't use the venv's python to install dependencies and it would result in the error below: 

```
▶ Odysseus quick start for macOS
▶ Installing dependencies (Homebrew)…
  (using Python 3.13.13 at /opt/homebrew/bin/python3.13)
Warning: tmux 3.6b is already installed and up-to-date.
To reinstall 3.6b, run:
  brew reinstall tmux
Warning: llama.cpp 9430 is already installed and up-to-date.
To reinstall 9430, run:
  brew reinstall llama.cpp
▶ Creating Python environment…
▶ Installing Python packages (first run downloads a few — can take a few minutes)…
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a Python library that isn't in Homebrew,
    use a virtual environment:

    python3 -m venv path/to/venv
    source path/to/venv/bin/activate
    python3 -m pip install xyz

    If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. You can install pipx with

    brew install pipx

    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip, or by adding
    'break-system-packages = true' to your pip.conf file. The latter
    will permanently disable this error.

    If you disable this error, we STRONGLY recommend that you additionally
    pass the '--user' flag to pip, or set 'user = true' in your pip.conf
    file. Failure to do this can result in a broken Homebrew installation.

    Read more about this behavior here: <https://peps.python.org/pep-0668/>

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.

✗ Setup failed above. It is safe to re-run ./start-macos.sh.
```

After Odysseus boots and I am able to use it. 

