### PR TITLE
Importing files bug

### DIFF
--- a/static/js/documentLibrary.js
+++ b/static/js/documentLibrary.js
@@ -3101,7 +3101,7 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
       importFileBtn.addEventListener('click', () => fileInput.click());
       fileInput.addEventListener('change', async () => {
         if (fileInput.files.length === 0) return;
-        const files = fileInput.files;
+        const files = Array.from(fileInput.files);
         fileInput.value = '';
         // Swap the import icon for a whirlpool while files upload.
         const _orig = importFileBtn.innerHTML;

--- a/static/style.css
+++ b/static/style.css
@@ -32793,6 +32793,7 @@ button.cal-event-more:hover { opacity:1 !important; }
 .cal-form-bespoke input[type="time"]::-webkit-calendar-picker-indicator,
 .cal-form-bespoke input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   background-color: var(--accent, var(--red));
+  background-image: none;
   cursor: pointer;
   width: 14px; height: 14px;
 }


### PR DESCRIPTION
### Problem
I found a bug that wouldn't let me upload files in the library window during the documents tab, when a user selected a file, the code grabbed a reference to fileInput.files and immediately cleared the input value (fileInput.value = '') to allow for re-uploading the same file later. However, because fileInput.files is a live FileList tied directly to the DOM element, clearing the input inherently emptied our saved variable as well, resulting in lost file data.

### Note 
this error might be browser specific as it worked fine on Zen/Firefox but failed on Edge and chrome

### Fix 
use Array.From which copies the value into files instead of using refrence