### PR TITLE
Fix stuck Cookbook dependency installs

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -33,6 +33,7 @@ _TOKEN_RE = re.compile(r"^[A-Za-z0-9._~+/=-]+$")
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 _SSH_PORT_RE = re.compile(r"^\d{1,5}$")
 _GPU_LIST_RE = re.compile(r"^\d+(?:,\d+)*$")
+_PROCESS_EXIT_RE = re.compile(r"===\s*Process exited with code\s+(\d+)\s*===", re.IGNORECASE)
 # A download target directory. Absolute or ~-relative path; safe path glyphs
 # only (no quotes, shell metacharacters, or spaces) since it lands in a shell
 # command. A leading ~ is expanded to $HOME at command-build time.
@@ -325,6 +326,35 @@ def _append_serve_exit_code_lines(runner_lines: list[str], *, keep_shell_open: b
         runner_lines.append('echo ""; echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="; exec "${SHELL:-/bin/bash}"')
     else:
         runner_lines.append('echo ""; echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="')
+
+
+def _classify_cookbook_task_status(task_type: str, full_snapshot: str, is_alive: bool) -> str:
+    """Classify a Cookbook background task from its captured terminal output."""
+    text = full_snapshot or ""
+    lower = text.lower()
+    exit_match = _PROCESS_EXIT_RE.search(text)
+    if exit_match:
+        exit_code = int(exit_match.group(1))
+        if task_type == "serve":
+            # Serve tasks should keep running; any exit means the launch failed
+            # or the server died, even if the wrapped command returned 0.
+            return "error"
+        return "completed" if exit_code == 0 else "error"
+
+    has_error = "error" in lower or "failed" in lower or "traceback" in lower
+    if "unrecognized arguments" in lower:
+        return "error"
+    if has_error and "application startup complete" not in lower:
+        return "error"
+    if task_type == "download" and ("100%" in text or "DOWNLOAD_OK" in text):
+        # Only download tasks treat these as completion markers. Serve tasks
+        # can log progress bars during inference and should keep running.
+        return "completed"
+    if "application startup complete" in lower:
+        return "ready"
+    if not is_alive:
+        return "stopped"
+    return "running"
 
 
 class ModelDownloadRequest(BaseModel):

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -37,7 +37,7 @@ from routes.cookbook_helpers import (
     _validate_local_dir, _validate_ssh_port, _validate_gpus, _shell_path,
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
     _safe_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
-    _append_serve_exit_code_lines, _cached_model_scan_script,
+    _append_serve_exit_code_lines, _classify_cookbook_task_status, _cached_model_scan_script,
     ModelDownloadRequest, ServeRequest,
 )
 
@@ -1863,28 +1863,7 @@ def setup_cookbook_routes() -> APIRouter:
             # when the PID is gone instead of blindly reporting "stopped".
             status = "unknown"
             if is_alive or (local_win_task and full_snapshot):
-                lower = full_snapshot.lower()
-                has_exit = "=== process exited with code" in lower
-                has_error = "error" in lower or "failed" in lower or "traceback" in lower
-                if has_exit and task_type == "serve":
-                    # Serve tasks that exit are always errors — they should run indefinitely
-                    status = "error"
-                elif has_exit and "unrecognized arguments" in lower:
-                    status = "error"
-                elif has_error and not ("application startup complete" in lower):
-                    status = "error"
-                elif task_type == "download" and ("100%" in full_snapshot or "DOWNLOAD_OK" in full_snapshot):
-                    # Only download tasks treat 100% as "completed".
-                    # Serve tasks log 100%|██████| during inference progress
-                    # (diffusion sampling, etc.) — that's "running", not done.
-                    status = "completed"
-                elif "application startup complete" in lower:
-                    status = "ready"
-                elif not is_alive:
-                    # local-Windows: process gone, log has no success/ready marker.
-                    status = "stopped"
-                else:
-                    status = "running"
+                status = _classify_cookbook_task_status(task_type, full_snapshot, is_alive)
             else:
                 # Session is dead — check if it completed or crashed
                 status = "stopped"

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -127,6 +127,27 @@ def _docker_row_status(*, on_remote, in_container, installed, default_hint):
     return DockerRowStatus(applicable=True, install_hint=default_hint)
 
 
+def _ensure_user_site_on_path() -> None:
+    """Make freshly-created pip --user installs visible to dependency probes."""
+    try:
+        import importlib
+        import site
+        import sys
+
+        paths = site.getusersitepackages()
+        if isinstance(paths, str):
+            paths = [paths]
+        added = False
+        for path in paths or []:
+            if path and os.path.isdir(path) and path not in sys.path:
+                sys.path.append(path)
+                added = True
+        if added:
+            importlib.invalidate_caches()
+    except Exception:
+        pass
+
+
 def _package_installed_from_probe(name: str, probe: dict) -> bool:
     """Return whether an optional dependency is usable by Cookbook.
 
@@ -792,6 +813,7 @@ def setup_shell_routes() -> APIRouter:
         _require_admin(request)
         _reject_cross_site(request)
         import importlib, importlib.metadata as importlib_metadata, shlex, json as _json
+        _ensure_user_site_on_path()
         if ssh_port and str(ssh_port).strip() not in ("", "22"):
             _port = str(ssh_port).strip()
             if not _SSH_PORT_RE.match(_port) or not (1 <= int(_port) <= 65535):

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -641,7 +641,7 @@ async function _fetchDependencies() {
         }
         // _dep flags this as a pip dependency/driver install (not a servable
         // model) so the running-task card doesn't offer a "Serve →" button.
-        const payload = { repo_id: pipName, _cmd: cmd, remote_host: _envState.remoteHost || '', _dep: true };
+        const payload = { repo_id: pipName, _cmd: cmd, remote_host: _envState.remoteHost || '', _dep: true, env_path: _envState.envPath || '' };
         _addTask(data.session_id, 'pip ' + pkgName, 'download', payload);
         if (statusEl) { statusEl.textContent = upgrade ? 'Updating...' : 'Installing...'; statusEl.disabled = true; }
         uiModule.showToast(`${upgrade ? 'Updating' : 'Installing'} ${pkgName} on ${targetHost}...`);

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -382,6 +382,32 @@ function _refreshDepsAfterInstall(task) {
   } catch {}
 }
 
+function _applyBackendTaskStatus(t) {
+  if (!t || !t.session_id || (t.status !== 'completed' && t.status !== 'error')) return false;
+  const localTask = _loadTasks().find(lt => lt.sessionId === t.session_id);
+  if (!localTask) return false;
+  if (t.status === 'completed' && localTask.status === 'done') return false;
+  if (t.status === 'error' && localTask.status === 'error') return false;
+
+  const updates = {};
+  if (t.output_tail) updates.output = t.output_tail;
+  if (t.status === 'completed') {
+    updates.status = 'done';
+    updates.progress = '';
+  } else {
+    updates.status = 'error';
+  }
+  _updateTask(t.session_id, updates);
+  if (t.status === 'completed') _refreshDepsAfterInstall(localTask);
+  return true;
+}
+
+function _runningTabLabel(tasks) {
+  const count = tasks.filter(t => t.status === 'running' || t.status === 'queued' || t.status === 'ready' || t.status === 'error' || t.status === 'crashed').length;
+  const errCount = tasks.filter(t => t.status === 'error' || t.status === 'crashed').length;
+  return count ? `Running <span class="cookbook-tab-count">${count}</span>${errCount ? '<span class="cookbook-tab-error-dot"></span>' : ''}` : 'Running';
+}
+
 export function _removeTask(sessionId) {
   _tombstoneTask(sessionId);  // so sync/poll can't resurrect it
   const tasks = _loadTasks().filter(t => t.sessionId !== sessionId);
@@ -1158,8 +1184,7 @@ export function _renderRunningTab() {
     runTab = document.createElement('button');
     runTab.className = 'cookbook-tab';
     runTab.dataset.backend = 'Running';
-    const _errCount = tasks.filter(t => t.status === 'error' || t.status === 'crashed').length;
-    runTab.innerHTML = `Running <span class="cookbook-tab-count">${tasks.length}</span>${_errCount ? `<span class="cookbook-tab-error-dot"></span>` : ''}`;
+    runTab.innerHTML = _runningTabLabel(tasks);
     tabBar.insertBefore(runTab, tabBar.firstChild);
     runTab.addEventListener('click', () => {
       tabBar.querySelectorAll('.cookbook-tab').forEach(t => t.classList.remove('active'));
@@ -1169,8 +1194,7 @@ export function _renderRunningTab() {
       });
     });
   } else if (runTab) {
-    const _errCount2 = tasks.filter(t => t.status === 'error' || t.status === 'crashed').length;
-    runTab.innerHTML = tasks.length ? `Running <span class="cookbook-tab-count">${tasks.length}</span>${_errCount2 ? '<span class="cookbook-tab-error-dot"></span>' : ''}` : 'Running';
+    runTab.innerHTML = tasks.length ? _runningTabLabel(tasks) : 'Running';
     if (!hasContent) {
       if (runTab.classList.contains('active')) {
         const wfTab = tabBar.querySelector('.cookbook-tab[data-backend="Search"]');
@@ -2547,6 +2571,11 @@ async function _pollBackgroundStatus() {
     if (!res.ok) return;
     const data = await res.json();
     const tasks = data.tasks || [];
+    let reconciled = false;
+    for (const t of tasks) {
+      if (_applyBackendTaskStatus(t)) reconciled = true;
+    }
+    if (reconciled) _renderRunningTab();
 
     const statusEl = document.getElementById('cookbook-bg-status');
     const activeTasks = tasks.filter(t => t.status === 'running' || t.status === 'ready');

--- a/tests/test_cookbook_dependency_completion_js.py
+++ b/tests/test_cookbook_dependency_completion_js.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_background_status_poll_persists_completed_dependency_tasks():
+    source = (ROOT / "static/js/cookbookRunning.js").read_text(encoding="utf-8")
+
+    assert "function _applyBackendTaskStatus(t)" in source
+    assert "t.status !== 'completed' && t.status !== 'error'" in source
+    assert "updates.status = 'done';" in source
+    assert "_updateTask(t.session_id, updates);" in source
+    assert "_refreshDepsAfterInstall(localTask);" in source
+    assert "for (const t of tasks)" in source
+
+
+def test_running_tab_count_ignores_completed_tasks():
+    source = (ROOT / "static/js/cookbookRunning.js").read_text(encoding="utf-8")
+
+    assert "function _runningTabLabel(tasks)" in source
+    assert "t.status === 'running'" in source
+    assert "t.status === 'queued'" in source
+    assert "t.status === 'ready'" in source
+    assert "t.status === 'error'" in source
+    assert "t.status === 'crashed'" in source
+    assert "${tasks.length}" not in source
+
+
+def test_dependency_install_task_remembers_env_path_for_refresh():
+    source = (ROOT / "static/js/cookbook.js").read_text(encoding="utf-8")
+
+    assert "env_path: _envState.envPath || ''" in source

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -9,6 +9,7 @@ from routes.cookbook_helpers import (
     _cached_model_scan_script,
     _append_serve_exit_code_lines,
     _append_serve_preflight_exit_lines,
+    _classify_cookbook_task_status,
     _local_tooling_path_export,
     _safe_env_prefix,
     _validate_gpus,
@@ -112,6 +113,26 @@ def test_serve_runner_preserves_command_exit_code():
     assert "ODYSSEUS_CMD_EXIT=$?" in script
     assert 'echo "=== Process exited with code $ODYSSEUS_CMD_EXIT ==="' in script
     assert 'echo "=== Process exited with code $? ==="' not in script
+
+
+def test_download_task_exit_zero_is_completed():
+    snapshot = "Successfully installed playwright\n\n=== Process exited with code 0 ==="
+    assert _classify_cookbook_task_status("download", snapshot, True) == "completed"
+
+
+def test_download_task_exit_nonzero_is_error():
+    snapshot = "Could not install package\n\n=== Process exited with code 1 ==="
+    assert _classify_cookbook_task_status("download", snapshot, True) == "error"
+
+
+def test_serve_task_exit_zero_is_error():
+    snapshot = "Application stopped\n\n=== Process exited with code 0 ==="
+    assert _classify_cookbook_task_status("serve", snapshot, True) == "error"
+
+
+def test_exit_zero_beats_successful_pip_error_wording():
+    snapshot = "Successfully installed package-with-error-in-name\n\n=== Process exited with code 0 ==="
+    assert _classify_cookbook_task_status("download", snapshot, True) == "completed"
 
 
 def test_cached_model_scan_reports_plain_dir_gguf(tmp_path):

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -13,6 +13,7 @@ from routes.shell_routes import (
     _find_line_break,
     _running_in_container,
     _docker_row_status,
+    _ensure_user_site_on_path,
     _package_installed_from_probe,
     _package_status_note,
     _reject_cross_site,
@@ -193,6 +194,18 @@ class TestDockerRowStatus:
 
 class TestPackageProbeStatus:
     """Dependency rows should reflect serve readiness, not import coincidences."""
+
+    def test_created_user_site_is_added_to_sys_path(self, monkeypatch, tmp_path):
+        import site
+
+        user_site = tmp_path / "site-packages"
+        user_site.mkdir()
+        monkeypatch.setattr(site, "getusersitepackages", lambda: str(user_site))
+        monkeypatch.setattr(sys, "path", [p for p in sys.path if p != str(user_site)])
+
+        _ensure_user_site_on_path()
+
+        assert str(user_site) in sys.path
 
     def test_vllm_namespace_without_cli_is_not_installed(self):
         probe = {


### PR DESCRIPTION
Fixes #572.

I saw the note in the issue that there was already a small PR ready. I had already traced this locally, so opening this in case it is useful or saves a round trip.

The stuck state was coming from two places. Dependency installs run through the generic Cookbook runner, so a successful pip install ends with `=== Process exited with code 0 ===` instead of the model download markers the status API was looking for. The background poller also read completed/error statuses from the backend without writing them back to the persisted task list.

This makes successful dependency/download runner exits count as complete, syncs backend completed/error states back into the Cookbook task store, refreshes Dependencies after install, and makes local package probes see newly-created `pip --user` site dirs without restarting the app.

Checked:
- `python -m py_compile routes/cookbook_helpers.py routes/cookbook_routes.py routes/shell_routes.py tests/test_cookbook_helpers.py tests/test_shell_routes.py tests/test_cookbook_dependency_completion_js.py`
- `python -m pytest -q tests/test_cookbook_helpers.py tests/test_shell_routes.py tests/test_cookbook_dependency_completion_js.py`
- `node --check static/js/cookbookRunning.js`
- `node --check static/js/cookbook.js`
- `git diff --check`
