### PR TITLE
fix(llm): handle Ollama delta.reasoning field for thinking models

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1003,8 +1003,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                     delta = j["choices"][0].get("delta", {})
                                     if isinstance(delta, dict):
                                         # Text content
-                                        # Reasoning tokens (VLLM --reasoning-parser, e.g. Qwen3/DeepSeek-R1)
-                                        reasoning = delta.get("reasoning_content", "")
+                                        # Reasoning tokens: vLLM uses "reasoning_content", Ollama uses "reasoning"
+                                        reasoning = delta.get("reasoning_content", "") or delta.get("reasoning", "")
                                         if reasoning:
                                             yield f'data: {json.dumps({"delta": reasoning, "thinking": True})}\n\n'
                                         content = delta.get("content", "")


### PR DESCRIPTION
## Bug

Ollama's `/v1/chat/completions` endpoint sends thinking tokens in `delta.reasoning`, but the stream parser in `src/llm_core.py` only checked for `delta.reasoning_content` (vLLM's field name).

For Ollama thinking models (Qwen3, DeepSeek-R1), this meant every streamed chunk had empty `content` and non-empty `reasoning` (ignored) — so the chat UI received no content tokens and showed an infinite spinner or 502 timeout.

The thinking pipeline itself (frontend collapsible UI, `_thinking_model` flag, `<think>` tag handling) was already correct — only the field name lookup was missing.

## Fix

`src/llm_core.py` line 1007 — fall back to `delta.reasoning` if `delta.reasoning_content` is absent:

Before: `reasoning = delta.get("reasoning_content", "")`
After:  `reasoning = delta.get("reasoning_content", "") or delta.get("reasoning", "")`

## Files changed

- `src/llm_core.py` — 1 line changed

## Testing

- `python -m py_compile src/llm_core.py` — ok
- `python -m pytest tests/test_llm_core_ollama.py -v` — 2/2 passed
- Manual: Qwen3 1.7B and DeepSeek-R1 1.5B via Ollama (localhost:11434/v1) — thinking block now renders in the chat UI; responses come through correctly

Fixes #315
