### PR TITLE
Cookbook: make the GPU process popup actually visible

### DIFF
--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -949,9 +949,24 @@ function _rerenderCachedModels() {
           document.body.appendChild(popup);
           panel._gpuProbe.popup = popup;
 
+          // Position below the button using viewport coords (popup is
+          // position:fixed). Measure the popup AFTER it's in the DOM so
+          // we get the real rendered size, then clamp both axes so the
+          // popup stays fully visible — GPU buttons near the right edge
+          // of the modal previously anchored the popup mostly off-screen.
           const r = anchorBtn.getBoundingClientRect();
-          popup.style.left = `${Math.max(8, r.left)}px`;
-          popup.style.top  = `${r.bottom + 4 + window.scrollY}px`;
+          const vw = window.innerWidth  || document.documentElement.clientWidth;
+          const vh = window.innerHeight || document.documentElement.clientHeight;
+          const pw = popup.offsetWidth  || 320;
+          const ph = popup.offsetHeight || 200;
+          let left = r.left;
+          let top  = r.bottom + 4;
+          // Push left so the popup doesn't overflow the right edge.
+          if (left + pw > vw - 8) left = Math.max(8, vw - pw - 8);
+          // If there isn't room below, render above the button instead.
+          if (top + ph > vh - 8) top = Math.max(8, r.top - ph - 4);
+          popup.style.left = `${left}px`;
+          popup.style.top  = `${top}px`;
 
           popup.querySelector('.cookbook-gpu-popup-close')?.addEventListener('click', _closeProbePopup);
           popup.querySelectorAll('.cookbook-gpu-kill').forEach(btn => {

--- a/static/style.css
+++ b/static/style.css
@@ -17773,8 +17773,12 @@ body.gallery-selecting .gallery-dl-btn,
 .cookbook-gpu-clear:disabled { opacity: 0.4; cursor: wait; }
 /* GPU probe popup — per-GPU process list with kill buttons */
 .cookbook-gpu-popup {
-  position: absolute;
-  z-index: 240;
+  /* Fixed positioning (relative to viewport) so we never get pulled into
+     a scrolling/transform stacking context from an ancestor. Z-index has
+     to clear the cookbook modal (260) and the rest of the high-z UI
+     layers (themed-confirm and various overlays sit around 9000-10000). */
+  position: fixed;
+  z-index: 10010;
   min-width: 280px;
   max-width: 420px;
   background: var(--panel, #1a1a1a);


### PR DESCRIPTION
## Bug

Double-clicking (or right-clicking) a GPU button in the Cookbook Serve panel opens a popup listing the processes currently using VRAM on that GPU, with kill buttons. Two bugs combined to hide it:

1. **z-index 240 vs the cookbook modal at z-index 260** — the popup rendered behind the modal that spawned it.
2. **Horizontal position was just `button.left`** with no clamp against the viewport. GPU buttons sit near the right edge of the modal, so the popup got anchored at a left coordinate that pushed most of its body past the viewport's right edge.

The combined effect: only a thin sliver of the popup header poked out next to the modal — you could see "free ·" and an × close button but the actual process list was invisible.

### Before

<img width="927" height="517" alt="shotty_20260602_011815" src="https://github.com/user-attachments/assets/593fc0ca-0048-4b8c-bf72-7fbb26849a50" />


### After


<img width="871" height="518" alt="shotty_20260602_012412" src="https://github.com/user-attachments/assets/6dbaa7b9-dd06-4816-959b-ae9cd9cbae90" />


## Fix

- Switch the popup to `position: fixed` so it escapes any scrolling / transform stacking context on an ancestor.
- Bump `z-index` to `10010` so it clears the cookbook modal (260) and the higher overlay layers (themed-confirm and friends sit around 9000–10000).
- Measure the popup's rendered size after appending it, then clamp `left` and `top` against the viewport — including flipping above the button if there isn't room below.

The popup now anchors directly under the button (or above it when below would overflow), and is always fully visible regardless of which GPU button it was anchored to or how narrow the viewport is.

## Files

- `static/style.css` — `.cookbook-gpu-popup` switched to `position: fixed` + `z-index: 10010`
- `static/js/cookbookServe.js` — viewport-clamped positioning in `_openProbePopup`
