### PR TITLE
fix: don't bill self-hosted models reached by a container/service hostname

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -661,6 +661,12 @@ export function isLocalEndpoint(url) {
   if (!host) return true;
   if (host === 'localhost' || host === '0.0.0.0' || host === 'host.docker.internal' || host.endsWith('.local')) return true;
   if (typeof window !== 'undefined' && window.location && host === window.location.hostname) return true;
+  // A single-label hostname (no dot) is an internal/Docker service name
+  // (e.g. "nim-nano", "llamaswap", "nemotron-super-49b") or a LAN shortname —
+  // never a public API, which always needs an FQDN. Treat as local → free.
+  // (Without this, container-name endpoints get billed at cloud rates because
+  // the pricing table matches on a name substring, e.g. "nemotron".)
+  if (!host.includes('.')) return true;
   if (/^127\./.test(host)) return true;
   if (/^10\./.test(host)) return true;
   if (/^192\.168\./.test(host)) return true;

--- a/tests/test_local_endpoint_js.py
+++ b/tests/test_local_endpoint_js.py
@@ -1,0 +1,63 @@
+"""Pin the billing/display classifier `isLocalEndpoint` in chatRenderer.js.
+
+Self-hosted endpoints reached by a bare Docker/Compose service name (e.g.
+`http://llamaswap:8000`) must classify as LOCAL so they aren't priced at cloud
+rates against the substring-matched MODEL_PRICING table. Cloud FQDNs must stay
+billable.
+
+Driven through `node --input-type=module` against the real function (extracted
+from source — chatRenderer.js can't be imported standalone since it pulls in
+browser-only modules), same spirit as test_reply_recipients_js.py. Skips when
+`node` is not installed rather than failing.
+"""
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_SRC = _REPO / "static" / "js" / "chatRenderer.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _is_local(url: str) -> bool:
+    src = _SRC.read_text(encoding="utf-8")
+    m = re.search(r"export function isLocalEndpoint\(.*?\n\}", src, re.DOTALL)
+    assert m, "isLocalEndpoint not found in chatRenderer.js"
+    fn = m.group(0).replace("export function", "function", 1)
+    js = fn + f"\nconsole.log(JSON.stringify(isLocalEndpoint({json.dumps(url)})));"
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+@pytest.mark.parametrize("url", [
+    "http://llamaswap:8000",            # bare Docker/Compose service name
+    "http://nim-nano:8000/v1",
+    "http://localhost:7000",
+    "http://127.0.0.1:11434",
+    "http://192.168.50.244",            # private ranges
+    "http://10.0.0.5:8080",
+    "http://172.16.0.9",
+    "http://server.local",              # mDNS / .local
+])
+def test_self_hosted_endpoints_classify_local(url):
+    assert _is_local(url) is True, f"{url} should be treated as local (free)"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+@pytest.mark.parametrize("url", [
+    "https://api.openai.com/v1",
+    "https://openrouter.ai/api/v1",
+    "https://api.anthropic.com",
+    "https://generativelanguage.googleapis.com",
+])
+def test_cloud_endpoints_classify_billable(url):
+    assert _is_local(url) is False, f"{url} should NOT be treated as local"


### PR DESCRIPTION

<img width="949" height="515" alt="after" src="https://github.com/user-attachments/assets/ab993bc2-51b3-44cc-831a-b37ffe3e4015" />
<img width="934" height="507" alt="before" src="https://github.com/user-attachments/assets/af748722-588e-44af-a24b-12fa59ddf221" />
## What

`isLocalEndpoint()` (`static/js/chatRenderer.js`) decides whether a model is local — and therefore free. It recognizes IPs, `localhost`, and `.local`, but **not a bare single-label hostname** like a Docker/Compose service name (`nim-nano`, `llamaswap`, …). Because `getModelCost()` matches the pricing table on a name **substring**, a self-hosted model whose id contains e.g. `nemotron` or `llama` then gets billed at cloud rates — the cost badge and Message Stats show a phantom non-zero cost.

## Fix

Treat any hostname with no dot as local. A public API always needs an FQDN, so a single-label host can only be internal:

```js
if (!host.includes('.')) return true;
```

IPs (which contain dots) still fall through to the existing private-range checks, and real cloud FQDNs are unaffected.

## Files

- `static/js/chatRenderer.js` — one guard in `isLocalEndpoint()` (+6 lines).

## Testing

- **Syntax:** validated as an ES module (`node --check` on a `.mjs` copy — the file is browser ESM, so the literal `node --check *.js` misreads the `import` as CommonJS).
- **Manual:** served a local model via a Compose service name (`http://nim-nano:8000`) whose id contains `nemotron`.

**Before** — local model billed at cloud rates:

<!-- ⬇⬇ drag-drop your "before" screenshot on the line below ⬇⬇ -->


**After** — correctly free ($0):

<!-- ⬇⬇ drag-drop your "after" screenshot on the line below ⬇⬇ -->


## Related

Complements #518 (cloud spend billing) — it reads the same cost path, so without this guard self-hosted models would also inflate its new spend graphs/budgets.