### PR TITLE
Allow toggling favorite models from the chat model picker

### DIFF
--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -7,6 +7,26 @@ import settingsModule from './settings.js';
 import { sortModelObjects } from './modelSort.js';
 
 const API_BASE = window.location.origin;
+const FAVORITES_KEY = 'odysseus-model-favorites';
+
+function _loadFavorites() {
+  try { return JSON.parse(localStorage.getItem(FAVORITES_KEY) || '[]'); }
+  catch { return []; }
+}
+function _saveFavorites(list) {
+  try { localStorage.setItem(FAVORITES_KEY, JSON.stringify(list)); } catch {}
+}
+function _isFavorite(mid) {
+  return _loadFavorites().includes(mid);
+}
+function _toggleFavorite(mid) {
+  const favs = _loadFavorites();
+  const idx = favs.indexOf(mid);
+  if (idx >= 0) favs.splice(idx, 1);
+  else favs.push(mid);
+  _saveFavorites(favs);
+  return idx < 0; // returns true if now favorited
+}
 
 // ── Shared keyboard nav for model pickers ──
 function _handlePickerKeydown(e, listEl, itemSelector, closeFn) {
@@ -174,8 +194,8 @@ function _initModelPickerDropdown() {
       searchRow.classList.toggle('searching', !!filter);
     }
 
-    // Load favorites
-    const favs = (function() { try { return JSON.parse(localStorage.getItem('odysseus-model-favorites') || '[]'); } catch { return []; } })();
+    // Load favorites (shared with models.js — same localStorage key)
+    const favs = _loadFavorites();
 
     // Partition: favorites first, then rest
     const favModels = [];
@@ -202,6 +222,24 @@ function _initModelPickerDropdown() {
         row.style.opacity = '0.45';
         row.title = `Local server appears offline: ${m.staleReason}. Click to try anyway, or relaunch in Cookbook.`;
       }
+      // Favorite star — click toggles persistence, doesn't pick the model
+      const favBtn = document.createElement('span');
+      const _favActive = _isFavorite(m.mid);
+      favBtn.className = 'model-switch-fav' + (_favActive ? ' active' : '');
+      favBtn.title = _favActive ? 'Remove from favorites' : 'Add to favorites';
+      favBtn.setAttribute('role', 'button');
+      favBtn.setAttribute('aria-label', favBtn.title);
+      favBtn.setAttribute('aria-pressed', _favActive ? 'true' : 'false');
+      favBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const nowFav = _toggleFavorite(m.mid);
+        uiModule.showToast(nowFav ? `Pinned ${m.display} to top` : `Unpinned ${m.display}`);
+        // Re-render immediately so the row moves between the Favorites and
+        // All-models sections without the user having to reopen the picker.
+        // Preserve whatever is currently typed in the search box.
+        _populate(search ? search.value : '');
+      });
+      row.appendChild(favBtn);
       const _mlogo = providerLogo(m.mid);
       if (_mlogo) {
         const logoSpan = document.createElement('span');
@@ -226,7 +264,10 @@ function _initModelPickerDropdown() {
       const _epDisplay = m.epName && !m.display.toLowerCase().includes(m.epName.toLowerCase().split('/').pop()) ? m.epName : '';
       epSpan.textContent = _epDisplay;
       row.appendChild(epSpan);
-      row.addEventListener('click', () => _pick(m));
+      row.addEventListener('click', (e) => {
+        if (e.target.closest('.model-switch-fav')) return;
+        _pick(m);
+      });
       listEl.appendChild(row);
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -2711,6 +2711,53 @@ body.bg-pattern-sparkles {
       opacity: 0.4;
       padding: 6px 8px 2px;
     }
+    /* Keep the endpoint label flush-right and the model name flexible so the
+       fav star + logo + name + endpoint stay aligned whether or not a row has
+       a provider logo. The name span is the flex-growing element. */
+    .model-picker-list .model-switch-item > span:not(.provider-logo):not(.model-switch-fav):not(.model-switch-ep):not(.model-switch-stale-badge) {
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .model-picker-list .model-switch-ep {
+      margin-left: auto;
+      flex-shrink: 0;
+      padding-left: 8px;
+      opacity: 0.5;
+    }
+    /* Favorite star inside the chat model picker.
+       Mirrors the .model-fav-btn style used in the side panel so the
+       affordance is consistent: hollow ring by default, filled on active. */
+    .model-picker-list .model-switch-fav {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 1.5px solid color-mix(in srgb, var(--fg) 35%, transparent);
+      flex-shrink: 0;
+      cursor: pointer;
+      transition: all 0.15s;
+      position: relative;
+      box-sizing: border-box;
+    }
+    .model-picker-list .model-switch-fav::before {
+      content: '';
+      position: absolute;
+      top: -8px; left: -8px; right: -8px; bottom: -8px;
+    }
+    .model-picker-list .model-switch-fav:hover {
+      border-color: var(--fg);
+      background: color-mix(in srgb, var(--fg) 25%, transparent);
+      transform: scale(1.3);
+    }
+    .model-picker-list .model-switch-fav.active {
+      background: var(--fg);
+      border-color: var(--fg);
+    }
+    .model-picker-list .model-switch-fav.active:hover {
+      opacity: 0.7;
+    }
     /* Overflow "+" menu */
     .overflow-wrapper {
       position: relative;


### PR DESCRIPTION
Chat picker already displayed favorites and shared the `odysseus-model-favorites` key, but favorites could only be toggled from the side panel. This adds the toggle to the chat picker too.

New:
- Clickable toggle per row to pin/unpin a model.
- Re-renders on toggle (keeps search text) so rows move between Favorites/All-models without reopening.
- Star clicks isolated from row clicks (toggling never picks the model).
- Inline favorites loader refactored into shared helpers.

Files: `static/js/modelPicker.js`, `static/style.css` (`.model-switch-fav`).

## Testing
- `node --check static/js/modelPicker.js` — passes.
- Manual: open chat model picker, click the star on a row → model pins to Favorites and toast shows; click again → unpins. Search text preserved across toggle. Clicking the row body (not the star) still selects the model.

<img width="381" height="382" alt="Screenshot 2026-06-01 at 17 33 00" src="https://github.com/user-attachments/assets/7fe15ebd-648d-42ae-b906-2b8c74eb3574" />