### PR TITLE
Anchor Settings window to top to stop layout shift between tabs

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -20110,6 +20110,22 @@ body.gallery-selecting .gallery-dl-btn,
   container-name: settings-modal;
 }
 
+/* Issue #208 — anchor the Settings window to the TOP of the chat area instead
+   of vertically centering it. The base .modal uses `align-items:center`, so a
+   centered window grows and shrinks around its own midpoint when you switch
+   between tabs whose content differs in height (Add Models vs. Shortcuts,
+   etc.). That makes the in-modal nav rail — and the whole window — appear to
+   jump up and down between pages. Pinning the top edge keeps the nav rail and
+   surrounding layout visually stable; the panel only ever grows downward.
+   Desktop only: on mobile the panel is a full-height bottom sheet that is
+   already top-stable, and a margin there would push it past the viewport. The
+   drag/dock code clears this margin (sets inline margin:0) the moment a window
+   is dragged, so moving the window still works exactly as before. */
+@media (min-width: 769px) {
+  #settings-modal { align-items: flex-start; }
+  #settings-modal .settings-modal-content { margin-top: 7vh; }
+}
+
 .settings-modal-content .modal-header {
   padding: 16px 20px;
   border-bottom: 1px solid var(--border);


### PR DESCRIPTION
Fixes #208.

## Problem
The Settings window inherits the base `.modal` vertical centering (`align-items:center`). Its height is content-driven, so every tab is a different height — and a vertically centered window grows and shrinks around its own midpoint. The result is that the in-modal nav rail (and the whole window) appears to jump up and down when switching between tabs of differing content height (e.g. Add Models vs. Account).

## Fix
Top-anchor the Settings window on desktop so the top edge stays put and the panel only ever grows downward:

```css
@media (min-width: 769px) {
  #settings-modal { align-items: flex-start; }
  #settings-modal .settings-modal-content { margin-top: 7vh; }
}
```

- **Desktop-only** — on mobile the panel is already a full-height bottom sheet (and a top margin there would push it past the viewport).
- `settings.js`'s `resetWindowPlacement()` clears inline `margin`/`top`/`position` on every open, and the drag/dock code sets them while dragging — so opening and moving the window are otherwise unchanged.

## Verification
Measured the top of the window and the nav rail (`getBoundingClientRect().top`) across six tabs, with the rule off vs. on:

| | Nav-rail top across tabs |
|---|---|
| **Before** (centered) | ranges over **216px** — AI Defaults `171`, Add Models/Search/Shortcuts/Account `393` |
| **After** (top-anchored) | **0px range** — every tab `171`; content still grows downward |

### Before — centered: window + nav rail jump between tabs
![before](https://raw.githubusercontent.com/Zeus-Deus/odysseus/issue-208-screenshots/before.png)

### After — top-anchored: window + nav rail stay put
![after](https://raw.githubusercontent.com/Zeus-Deus/odysseus/issue-208-screenshots/after.png)
