### PR TITLE
Fix Cookbook Serve tab hiding sub-1GB models

### DIFF
--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -1513,7 +1513,10 @@ export async function _fetchCachedModels() {
     const data = await res.json();
     _dlWp.destroy();
 
-    const ready = data.models.filter(m => m.status === 'ready' && (m.backend === 'ollama' || !m.size.includes('MB')));
+    // CHANGELOG: 'ready' already excludes partial downloads; 
+    // show every complete model regardless of size/backend.
+    const ready = data.models.filter(m => m.status === 'ready');
+
     const downloading = data.models.filter(m => m.status === 'downloading');
     const allModels = [...ready, ...downloading];
     _cachedAllModels = allModels;


### PR DESCRIPTION
## What this fixes

The Cookbook **Serve** tab hides cached models whose size is reported in MB —
i.e. **all sub-1GB models** — for every backend except Ollama. A small
HuggingFace/llama.cpp GGUF (0.5B–3B, embedding models) downloads successfully,
the backend reports it as `ready`, but it never appears in the serve list, so it
can't be selected to serve.

## Background

A recent change (commit `ab0a480`, "Show Ollama models in Cookbook Serve") hit
this same bug — the size filter was hiding small Ollama models — and worked
around it by carving out Ollama:

```js
const ready = data.models.filter(m => m.status === 'ready' && (m.backend === 'ollama' || !m.size.includes('MB')));
```

That fixed small **Ollama** models, but the `!m.size.includes('MB')` clause still
applies to every other backend, so small **HuggingFace/llama.cpp** models remain
hidden. Sizes render as `"379 MB"` or `"4.7 GB"` (see `routes/cookbook_routes.py`,
which formats `<1GB` as MB), so a 4.7 GB model passes but a 379 MB one is dropped.

## Change

Remove the size clause entirely so the filter gates on readiness alone:

```js
const ready = data.models.filter(m => m.status === 'ready');
```

`status === 'ready'` already excludes partial/incomplete downloads (the scan sets
`status: "downloading"` when a `.incomplete` file is present), so the MB check was
never needed to filter incompletes — its only effect was dropping valid small
models. Gating on readiness shows every complete model regardless of size or
backend, and the Ollama carve-out from `ab0a480` becomes unnecessary (Ollama
models are `ready`, so they still show).

**Root cause is purely client-side:** `/api/model/cached` returns small models
with `status: "ready"` in both the broken and fixed cases — only the list filter
changed.

## How I tested

Manual, on macOS (Apple Silicon), app running natively, with four cached models:
two sub-1GB (a 397 MB Ollama model and a 379 MB HuggingFace GGUF,
`unsloth/Qwen2.5-Coder-0.5B-Instruct-GGUF`) and two GB-sized Ollama models.

- **Before** (the `ab0a480` filter): the Serve list shows 4 models. The 397 MB
  Ollama model appears (saved by the Ollama carve-out), but the **379 MB
  HuggingFace GGUF is hidden**.
- **After** (this change): the Serve list shows all 5 models — the HuggingFace
  GGUF now appears and is selectable. The Ollama models are unaffected (still
  shown).
- The GB-sized models showed in both states, isolating the bug to the MB-size
  clause for non-Ollama backends.

Before/after screenshots attached below.

## Screenshots

**Before** — `ab0a480` filter: 4 models, the 379 MB HuggingFace GGUF hidden (only
the Ollama sub-1GB model survives, via the carve-out):

<img width="774" height="550" alt="Screenshot 2026-06-01 at 8 47 23 PM" src="https://github.com/user-attachments/assets/23bddd26-ca01-42a6-a453-eb54fc593298" />


**After** — this fix: 5 models, the 379 MB HuggingFace GGUF now listed and
selectable:

<img width="774" height="550" alt="Screenshot 2026-06-01 at 8 46 18 PM" src="https://github.com/user-attachments/assets/3721f2bd-e522-425d-8244-798c8f06bd3f" />

