### PR TITLE
fix(start-macos.sh): Resolve PEP 668 externally-managed-environment error

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -118,9 +118,9 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$PY" -m pip install --quiet --upgrade pip
+./venv/bin/python -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
-"$PY" -m pip install -r requirements.txt
+./venv/bin/python -m pip install -r requirements.txt
 
 # 4. First-run setup: creates data dirs and prints an initial admin password
 #    the first time (idempotent — does nothing if already set up). Suppress its
@@ -179,4 +179,4 @@ if [ -n "$TAILSCALE_URL" ]; then
 fi
 echo "  (this takes a few seconds; press Ctrl+C here to stop)"
 echo
-"$PY" -m uvicorn app:app --host "$HOST" --port "$PORT"
+./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"


### PR DESCRIPTION
## Overview
Fixes `./start-macos.sh` failing on macOS with Homebrew Python 3.13+ due to PEP 668 restrictions on system-managed interpreters.

## Problem
When running `./start-macos.sh` on macOS with Homebrew's Python 3.13+, the script fails during pip operations with: 
error: ```externally-managed-environment × This environment is externally managed```

This occurs because Homebrew marks its Python as an externally-managed environment (PEP 668), preventing direct pip usage to protect system integrity.

## Root Cause
The script used the Homebrew Python (`$PY`) for all operations, including pip installs and server startup. Homebrew Python blocks pip usage to prevent breaking system packages.

## Solution
After creating the virtual environment, use `./venv/bin/python` for all pip and uvicorn operations instead of the Homebrew Python. Virtual environments are not externally-managed, so pip operates normally.

## Changes
- **Line 93**: Changed `"$PY" -m pip install --quiet --upgrade pip` → `./venv/bin/python -m pip install --quiet --upgrade pip`
- **Line 95**: Changed `"$PY" -m pip install -r requirements.txt` → `./venv/bin/python -m pip install -r requirements.txt`
- **Line 139**: Changed `"$PY" -m uvicorn` → `./venv/bin/python -m uvicorn`

## Impact
- ✅ Fixes startup on macOS with Homebrew Python 3.11+
- ✅ No breaking changes; maintains compatibility with other Python installations
- ✅ Minimal change (3 lines)
- ✅ Idempotent; safe to re-run

## Testing
- ✅ Tested on macOS with Homebrew Python 3.13.5
- ✅ `./start-macos.sh` successfully completes setup
- ✅ All Python packages install without errors
- ✅ Server starts and opens browser as expected

## References
- [PEP 668](https://peps.python.org/pep-0668/) – Externally managed Python environments
- Follows [CONTRIBUTING.md](CONTRIBUTING.md) – focused fix, single concern

## Checklist
- [x] Follows CONTRIBUTING.md guidelines
- [x] Single focused fix (no formatting/refactoring)
- [x] Changes are self-explanatory and minimal
- [x] Tested and verified working
- [x] No new dependencies introduced