### PR TITLE
fix: Cookbook model scan stubbornly opens Microsoft Store Python on Windows

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -672,11 +672,14 @@ def setup_cookbook_routes() -> APIRouter:
                 cwd=str(Path.home()),
             )
         else:
-            # LOCAL scan: run the interpreter directly. `python3` isn't a thing on
-            # Windows (it's `python`/`py`), and shell single-quoting of the path
-            # doesn't survive cmd.exe — so resolve the interpreter and exec it
-            # with the script path as an argv element (no shell quoting needed).
-            local_py = (
+            # LOCAL scan: use sys.executable (the venv Python Odysseus is already
+            # running under) — it's guaranteed real Python on all platforms.
+            # Falling back to which_tool on Windows risks hitting the Microsoft
+            # Store stub alias for "python3"/"python", which prints
+            # "Python was not found; run without arguments to install from the
+            # Microsoft Store" and exits 9009, producing empty stdout and a
+            # JSON parse error. sys.executable bypasses PATH entirely.
+            local_py = sys.executable or (
                 which_tool("python3") or which_tool("python")
                 or which_tool("py") or "python"
             )


### PR DESCRIPTION
## Problem

On Windows, the Cookbook **model cache scan** (the list that shows what models we have downloaded) was broken, showing nothing and logging:

```
WARNING - Failed to parse cached models: Expecting value: line 1 column 1 (char 0)
WARNING - stderr: Python was not found; run without arguments to install from the Microsoft Store,
          or disable this shortcut from Settings > Apps > Advanced app settings > App execution aliases.
```

This happens even when Python **is** properly installed.

### Root Cause

Windows ships `App Execution Aliases` for `python` and `python3` that redirect to the Microsoft Store installer stub. `shutil.which('python3')` resolves to this stub **before** finding the real interpreter.

The local cache scan was doing:

```python
local_py = (
    which_tool("python3") or which_tool("python")
    or which_tool("py") or "python"
)
```

On affected Windows machines, `which_tool('python3')` returns the Store stub path. The stub exits with code 9009 and writes nothing to stdout, so the JSON parse of the scan result fails immediately.

## Fix

Use `sys.executable` as the first choice — Odysseus already runs inside its own venv, so `sys.executable` always points to the real venv Python, bypassing PATH and Store alias resolution entirely:

```python
local_py = sys.executable or (
    which_tool("python3") or which_tool("python")
    or which_tool("py") or "python"
)
```

The `which_tool()` chain is kept as a fallback for any edge case where `sys.executable` is unexpectedly empty.

## Cross-platform safety

`sys.executable` works identically on **Linux** and **macOS** — it returns the real interpreter path regardless of virtualenv or conda. This change has no behavioral impact on non-Windows platforms.
