### PR TITLE
refactor(ui): polish settings UX, add tab hints, and rename Appearance to Visibility

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1067,29 +1067,22 @@ function initializeEventListeners() {
     });
   }
 
-  // Sidebar user bar — settings, admin, profile
+  // Sidebar user bar — Settings (left) opens last non-Account tab; profile (right) → Account
   const userBarSettings = el('user-bar-settings');
   const userBarProfile = el('user-bar-profile');
-  const userBarAdmin = el('user-bar-admin');
 
   if (userBarSettings) {
     userBarSettings.addEventListener('click', () => settingsModule.open());
   }
   if (userBarProfile) {
-    // Clicking the user (avatar + name) jumps straight to the Account tab
-    // instead of landing on whatever was last selected.
     userBarProfile.addEventListener('click', () => settingsModule.open('account'));
   }
-  if (userBarAdmin) {
-    userBarAdmin.addEventListener('click', () => adminModule.open());
-  }
 
-  // Fetch auth status — populate user bar and show admin button if admin
+  // Fetch auth status — populate user bar
   fetch(`${API_BASE}/api/auth/status`, { credentials: 'same-origin' })
     .then(r => r.json())
     .then(d => {
       window._isAdmin = !!d.is_admin;
-      if (d.is_admin && userBarAdmin) userBarAdmin.style.display = '';
       const userBarName = el('user-bar-name');
       const userBarAvatar = el('user-bar-avatar');
       if (userBarName && d.username) {

--- a/static/index.html
+++ b/static/index.html
@@ -1303,7 +1303,7 @@
         </button>
         <button class="close-btn">✖</button>
       </div>
-      <div class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;">Toggle on/off visibility of tools and modules across the interface.</div>
+      <p class="settings-tab-hint hidden" id="settings-tab-hint" aria-live="polite"></p>
       <div class="settings-layout">
         <div class="settings-sidebar">
           <!-- Section 1: AI plumbing (Add Models → AI Defaults → Search) -->
@@ -1336,10 +1336,10 @@
             <span>Reminders</span>
           </button>
           <div class="settings-sidebar-divider"></div>
-          <!-- Section 3: UX (Appearance → Shortcuts) -->
-          <button class="settings-nav-item" data-settings-tab="appearance">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8"/></svg>
-            <span>Appearance</span>
+          <!-- Section 3: UX (Visibility → Shortcuts) -->
+          <button class="settings-nav-item" data-settings-tab="visibility">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            <span>Visibility</span>
           </button>
           <button class="settings-nav-item" data-settings-tab="shortcuts">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10"/></svg>
@@ -1626,104 +1626,104 @@
           </div>
         </div>
 
-        <!-- ═══ APPEARANCE TAB ═══ -->
-        <div data-settings-panel="appearance" class="settings-appearance-panel hidden">
+        <!-- ═══ VISIBILITY TAB ═══ -->
+        <div data-settings-panel="visibility" class="settings-visibility-panel hidden">
           <div class="admin-card" style="padding-bottom:6px;">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>Sidebar</h2>
             <div class="vis-toggles">
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l2.5 2.5L16 9"/></svg></span>
-                <span class="vis-label">Odysseus <span class="vis-hint">Brand name</span></span>
+                <span class="vis-label">Odysseus <span class="vis-hint">header title</span></span>
                 <input type="checkbox" checked data-ui-key="sidebar-brand"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="10" cy="10" r="7"/><path d="M21 21l-4.35-4.35"/></svg></span>
-                <span class="vis-label">Search</span>
+                <span class="vis-label">Search <span class="vis-hint">find old chats</span></span>
                 <input type="checkbox" checked data-ui-key="sidebar-search"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
-                <span class="vis-label">New Chat</span>
+                <span class="vis-label">New Chat <span class="vis-hint">start blank chat</span></span>
                 <input type="checkbox" checked data-ui-key="sidebar-new-chat"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
-                <span class="vis-label">Chats <span class="vis-hint">Chat history list</span></span>
+                <span class="vis-label">Chats <span class="vis-hint">switch sessions</span></span>
                 <input type="checkbox" checked data-ui-key="sessions-section"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg></span>
-                <span class="vis-label">Email</span>
+                <span class="vis-label">Email <span class="vis-hint">read &amp; send mail</span></span>
                 <input type="checkbox" checked data-ui-key="email-section"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></span>
-                <span class="vis-label">Models <span class="vis-hint">Model selector &amp; quick-chat</span></span>
+                <span class="vis-label">Models <span class="vis-hint">pick model fast</span></span>
                 <input type="checkbox" checked data-ui-key="models-section"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></span>
-                <span class="vis-label">Tools <span class="vis-hint">Whole section (header + all tools)</span></span>
+                <span class="vis-label">Tools <span class="vis-hint">all tool shortcuts</span></span>
                 <input type="checkbox" checked data-ui-key="tools-section"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/></svg></span>
-                <span class="vis-label">Brain</span>
+                <span class="vis-label">Brain <span class="vis-hint">manage stored data</span></span>
                 <input type="checkbox" checked data-ui-key="tool-memory"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span>
-                <span class="vis-label">Calendar</span>
+                <span class="vis-label">Calendar <span class="vis-hint">view schedule</span></span>
                 <input type="checkbox" checked data-ui-key="tool-calendar"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M11 18H8a2 2 0 0 1-2-2V9"/></svg></span>
-                <span class="vis-label">Compare</span>
+                <span class="vis-label">Compare <span class="vis-hint">compare model answers</span></span>
                 <input type="checkbox" checked data-ui-key="tool-compare"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/><path d="M9 7h6M9 11h4"/></svg></span>
-                <span class="vis-label">Cookbook</span>
+                <span class="vis-label">Cookbook <span class="vis-hint">saved workflows</span></span>
                 <input type="checkbox" checked data-ui-key="tool-cookbook"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg></span>
-                <span class="vis-label">Deep Research</span>
+                <span class="vis-label">Deep Research <span class="vis-hint">long web research</span></span>
                 <input type="checkbox" checked data-ui-key="tool-research"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg></span>
-                <span class="vis-label">Gallery</span>
+                <span class="vis-label">Gallery <span class="vis-hint">browse images</span></span>
                 <input type="checkbox" checked data-ui-key="tool-gallery"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="13" y2="17"/></svg></span>
-                <span class="vis-label">Library</span>
+                <span class="vis-label">Library <span class="vis-hint">stored documents</span></span>
                 <input type="checkbox" checked data-ui-key="tool-library"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 7h6M9 11h6M9 15h4"/></svg></span>
-                <span class="vis-label">Notes</span>
+                <span class="vis-label">Notes <span class="vis-hint">scratch notes</span></span>
                 <input type="checkbox" checked data-ui-key="tool-notes"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><path d="M9 16l2 2 4-4"/></svg></span>
-                <span class="vis-label">Tasks</span>
+                <span class="vis-label">Tasks <span class="vis-hint">todos &amp; automations</span></span>
                 <input type="checkbox" checked data-ui-key="tool-tasks"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a10 10 0 0 0 0 20 5 5 0 0 0 5-5 3 3 0 0 0-3-3h-2a3 3 0 0 1-3-3 5 5 0 0 1 5-5"/></svg></span>
-                <span class="vis-label">Theme</span>
+                <span class="vis-label">Theme <span class="vis-hint">customize look</span></span>
                 <input type="checkbox" checked data-ui-key="tool-theme"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
-                <span class="vis-label">User <span class="vis-hint">Avatar &amp; name</span></span>
+                <span class="vis-label">User <span class="vis-hint">your account</span></span>
                 <input type="checkbox" checked data-ui-key="user-bar"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
-                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
+                <span class="vis-label">Settings Button <span class="vis-hint">open settings · <code>/settings</code></span></span>
                 <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
               </label>
             </div>
@@ -1733,32 +1733,32 @@
             <div class="vis-toggles">
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16"/><path d="M4 10h8"/></svg></span>
-                <span class="vis-label">Session Header <span class="vis-hint">Model name &amp; export above chat</span></span>
+                <span class="vis-label">Session Header <span class="vis-hint">rename &amp; export chat</span></span>
                 <input type="checkbox" checked data-ui-key="chat-meta"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 3v2m0 14v2m-7-9H3m18 0h-2m-1.5-6.5L16 7m-8-1.5L6.5 7m11 11l-1.5-1.5M8 18l-1.5 1.5"/><circle cx="12" cy="12" r="4"/></svg></span>
-                <span class="vis-label">Welcome Message <span class="vis-hint">Logo &amp; tips on empty chat</span></span>
+                <span class="vis-label">Welcome Message <span class="vis-hint">tips on empty chat</span></span>
                 <input type="checkbox" checked data-ui-key="welcome-text"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></span>
-                <span class="vis-label">Incognito Mode <span class="vis-hint">No memory, no history saved</span></span>
+                <span class="vis-label">Incognito Mode <span class="vis-hint">chat won’t be saved</span></span>
                 <input type="checkbox" checked data-ui-key="incognito-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon" style="font-size:13px;line-height:14px;">Aa</span>
-                <span class="vis-label">Text-only Emojis <span class="vis-hint">Strip emojis from AI replies</span></span>
+                <span class="vis-label">Text-only Emojis <span class="vis-hint">:text: not emoji</span></span>
                 <input type="checkbox" data-ui-key="text-emojis"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2a7 7 0 0 0-7 7c0 3 2 5.5 4.5 7.5.7.6 1.2 1.3 1.5 2h2c.3-.7.8-1.4 1.5-2C17 14.5 19 12 19 9a7 7 0 0 0-7-7z"/><line x1="10" y1="22" x2="14" y2="22"/></svg></span>
-                <span class="vis-label">Thinking Process <span class="vis-hint">Show &lt;think&gt; collapsible bars</span></span>
+                <span class="vis-label">Thinking Process <span class="vis-hint">show reasoning</span></span>
                 <input type="checkbox" checked data-ui-key="show-thinking"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/><path d="M4 4l16 16"/></svg></span>
-                <span class="vis-label">Sensitive Blur <span class="vis-hint">Blur emails, tokens, and secrets in AI output</span></span>
+                <span class="vis-label">Sensitive Blur <span class="vis-hint">mask secrets in text</span></span>
                 <input type="checkbox" data-privacy-key="sensitive-blur"><span class="vis-switch"></span>
               </label>
             </div>
@@ -1768,42 +1768,42 @@
             <div class="vis-toggles">
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
-                <span class="vis-label">Web Search</span>
+                <span class="vis-label">Web Search <span class="vis-hint">search the web</span></span>
                 <input type="checkbox" checked data-ui-key="web-toggle-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg></span>
-                <span class="vis-label">Document Editor</span>
+                <span class="vis-label">Document Editor <span class="vis-hint">write in docs</span></span>
                 <input type="checkbox" checked data-ui-key="doc-toggle-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>
-                <span class="vis-label">Shell</span>
+                <span class="vis-label">Shell <span class="vis-hint">run terminal commands</span></span>
                 <input type="checkbox" checked data-ui-key="bash-toggle-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></span>
-                <span class="vis-label">More Tools <span class="vis-hint">Overflow menu</span></span>
+                <span class="vis-label">More Tools <span class="vis-hint">attach, docs, RAG…</span></span>
                 <input type="checkbox" checked data-ui-key="overflow-plus-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon vis-icon-text">A|C</span>
-                <span class="vis-label">Agent / Chat <span class="vis-hint">Mode switcher</span></span>
+                <span class="vis-label">Agent / Chat <span class="vis-hint">tools on or off</span></span>
                 <input type="checkbox" checked data-ui-key="mode-toggle"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></span>
-                <span class="vis-label">Attach Files</span>
+                <span class="vis-label">Attach Files <span class="vis-hint">upload to chat</span></span>
                 <input type="checkbox" checked data-ui-key="attach-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg></span>
-                <span class="vis-label">Deep Research</span>
+                <span class="vis-label">Deep Research <span class="vis-hint">research mode toggle</span></span>
                 <input type="checkbox" checked data-ui-key="research-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
-                <span class="vis-label">Characters <span class="vis-hint">Persona picker &amp; system prompt</span></span>
+                <span class="vis-label">Characters <span class="vis-hint">pick AI persona</span></span>
                 <input type="checkbox" checked data-ui-key="preset-mini-btn"><span class="vis-switch"></span>
               </label>
             </div>
@@ -1973,7 +1973,7 @@
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>Add User</h2>
             <div class="admin-add-form">
-              <input id="adm-newUsername" type="text" placeholder="Username (email)">
+              <input id="adm-newUsername" type="text" placeholder="Username">
               <input id="adm-newPassword" type="password" placeholder="Password (min 8)">
               <div class="admin-switch-inline" title="Grant full admin access"><label class="admin-switch"><input type="checkbox" id="adm-newIsAdmin"><span class="admin-slider"></span></label> Admin</div>
             </div>

--- a/static/js/document.js
+++ b/static/js/document.js
@@ -8967,7 +8967,7 @@ import * as Modals from './modalManager.js';
 
     if (!isOpen) openPanel();
 
-    // Force doc button visible (overrides appearance settings & toolbar collapse)
+    // Force doc button visible (overrides visibility settings & toolbar collapse)
     const toggleBtn = document.getElementById('overflow-doc-btn');
     if (toggleBtn) {
       toggleBtn.style.display = '';

--- a/static/js/models.js
+++ b/static/js/models.js
@@ -545,7 +545,7 @@ export async function refreshModels(force = false) {
       noModels.className = 'models-empty-state';
       if (window._isAdmin) {
         noModels.innerHTML = '<span class="muted">No models found</span><br>'
-          + '<a href="#" onclick="document.getElementById(\'user-bar-admin\')?.click();return false;" class="accent-link">Open Admin to add endpoints</a>'
+          + '<a href="#" onclick="document.getElementById(\'user-bar-settings\')?.click();return false;" class="accent-link">Open Settings to add endpoints</a>'
           + '<br><span class="muted-sm">Type /setup for Local models or API setup.</span>';
       } else {
         noModels.innerHTML = '<span class="muted">No models available</span><br>'

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,5 +1,5 @@
 // static/js/settings.js — Settings panel module (ES6)
-// User-facing preferences: AI models, search, appearance
+// User-facing preferences: AI models, search, visibility
 
 import uiModule from './ui.js';
 import searchModule from './search.js';
@@ -16,6 +16,38 @@ function esc(s) { return uiModule.esc(s); }
 /* ── Tab switching ── */
 const ADMIN_TABS = new Set(['services', 'integrations', 'tools', 'users', 'system']);
 
+const SETTINGS_TAB_HINTS = {
+  services: 'Add LLM endpoints and discover models available on each host.',
+  ai: 'Default models for new chats, background tasks, vision, research, and images.',
+  search: 'Web search provider, API keys, and fallback order for agent web lookup.',
+  integrations: 'External accounts and APIs — email, calendars, vaults, and custom HTTP.',
+  email: 'Per-account options; add or edit mailboxes under Integrations.',
+  reminders: 'How fired note reminders reach you (browser, email, ntfy, and copy).',
+  visibility: 'Show or hide sidebar items, launchers, and chat controls.',
+  shortcuts: 'Keyboard shortcuts — click a row to rebind; reset restores defaults.',
+  account: 'Display name, password, two-factor authentication, and sign out.',
+  tools: 'Enable or disable individual tools the agent may call (admin).',
+  users: 'Accounts, admin flag, and per-user privileges (admin).',
+  system: 'Export or import your data, or wipe specific categories (admin).',
+};
+
+function syncSettingsTabHint(tab) {
+  const hintEl = el('settings-tab-hint');
+  if (!hintEl) return;
+  const text = SETTINGS_TAB_HINTS[tab] || '';
+  hintEl.textContent = text;
+  hintEl.classList.toggle('hidden', !text);
+}
+
+function applySettingsTab(tab) {
+  modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
+  modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
+  document.body.classList.toggle('settings-visibility-open', tab === 'visibility');
+  syncAppearanceOpacity(tab === 'visibility');
+  syncSettingsTabHint(tab);
+  if (tab === 'ai') refreshAiModelEndpoints();
+}
+
 function initTabs() {
   modalEl.querySelectorAll('[data-settings-tab]').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -25,14 +57,7 @@ function initTabs() {
         window.adminModule.open(tab);
         return;
       }
-      modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
-      modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
-      // Mark when the Appearance tab is open so the modal can go
-      // semi-transparent — lets the user see the rest of the UI react as
-      // they flip toggles instead of having to close + reopen the modal.
-      document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
-      syncAppearanceOpacity(tab === 'appearance');
-      if (tab === 'ai') refreshAiModelEndpoints();
+      applySettingsTab(tab);
     });
   });
 }
@@ -135,14 +160,14 @@ function _applySettingsOpacity(on) {
   }
 }
 
-// Show/hide the Peek toggle for the Appearance tab and apply or clear the fade.
+// Show/hide the Peek toggle for the Visibility tab and apply or clear the fade.
 function syncAppearanceOpacity(active) {
   const toggle = el('settings-opacity-wrap');
   if (toggle) toggle.classList.toggle('hidden', !active);
   if (active) {
     _applySettingsOpacity(toggle ? toggle.classList.contains('active') : false);
   } else {
-    _applySettingsOpacity(false); // clear the fade off the Appearance tab
+    _applySettingsOpacity(false); // clear the fade off the Visibility tab
   }
 }
 
@@ -1528,9 +1553,9 @@ async function initAgentSettings() {
 }
 
 /* ═══════════════════════════════════════════
-   APPEARANCE TAB
+   VISIBILITY TAB
    ═══════════════════════════════════════════ */
-function initAppearance() {
+function initVisibility() {
   syncAppearanceCheckboxes();
   syncPrivacyCheckboxes();
 
@@ -2108,7 +2133,7 @@ function initAll() {
   initResearchSettings();
   initResearchSearchSettings();
   initAgentSettings();
-  initAppearance();
+  initVisibility();
   initShortcuts();
   initAccount();
   initIntegrations();
@@ -4283,16 +4308,15 @@ export function open(tab) {
   resetWindowPlacement();
   modalEl.classList.remove('hidden');
   syncAdminVisibility();
-  const content = modalEl.querySelector('.settings-modal-content');
-  if (tab) {
-    modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
-    modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
-  }
-  // Auto-init admin data if showing an admin tab
   const activeTab = tab || (modalEl.querySelector('[data-settings-tab].active') || {}).dataset?.settingsTab || 'services';
-  document.body.classList.toggle('settings-appearance-open', activeTab === 'appearance');
-  syncAppearanceOpacity(activeTab === 'appearance');
-  if (activeTab === 'ai') refreshAiModelEndpoints();
+  if (tab) applySettingsTab(tab);
+  else syncSettingsTabHint(activeTab);
+  // Auto-init admin data if showing an admin tab
+  if (!tab) {
+    document.body.classList.toggle('settings-visibility-open', activeTab === 'visibility');
+    syncAppearanceOpacity(activeTab === 'visibility');
+    if (activeTab === 'ai') refreshAiModelEndpoints();
+  }
   if (ADMIN_TABS.has(activeTab) && window.adminModule && !window.adminModule._initialized) {
     window.adminModule._initData();
   }
@@ -4300,9 +4324,9 @@ export function open(tab) {
 
 export function close() {
   if (!modalEl) return;
-  // Always clear the appearance-tab body class so the rest of the app
+  // Always clear the visibility-tab body class so the rest of the app
   // doesn't keep its dimmed state if the modal got closed mid-tab.
-  document.body.classList.remove('settings-appearance-open');
+  document.body.classList.remove('settings-visibility-open');
   syncAppearanceOpacity(false); // clear any opacity-slider fade
   const content = modalEl.querySelector('.modal-content, .settings-modal-content');
   if (content && !content.classList.contains('modal-closing')) {

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -3171,9 +3171,9 @@ async function _cmdTourSettings(args, ctx) {
     { sel: '#settings-modal .settings-nav-item[data-settings-tab="search"]',
       text: '<b>Search</b> — plug in your own search provider, or use the bundled <b>SearXNG</b> out of the box.',
       before: () => _clickNav('search') },
-    { sel: '#settings-modal .settings-nav-item[data-settings-tab="appearance"]',
-      text: '<b>Appearance</b> — too many tools you don\'t need? Adjust them here! Toggle sidebar buttons, tool icons, and section visibility.',
-      before: () => _clickNav('appearance') },
+    { sel: '#settings-modal .settings-nav-item[data-settings-tab="visibility"]',
+      text: '<b>Visibility</b> — too many tools you don\'t need? Adjust them here! Toggle sidebar buttons, tool icons, and section visibility.',
+      before: () => _clickNav('visibility') },
     { sel: '#settings-modal .settings-nav-item[data-settings-tab="email"]',
       text: '<b>Email</b> — sync schedule, drafts, snooze defaults — everything email-flow related.',
       before: () => _clickNav('email') },
@@ -5484,7 +5484,7 @@ const COMMANDS = {
   'tour-settings': {
     alias: ['tour-setting', 'settings-tour'],
     category: 'Tours',
-    help: 'Settings tour: models, integrations, appearance',
+    help: 'Settings tour: models, integrations, visibility',
     handler: _cmdTourSettings,
     usage: '/tour-settings'
   },

--- a/static/style.css
+++ b/static/style.css
@@ -20115,6 +20115,20 @@ body.gallery-selecting .gallery-dl-btn,
   border-bottom: 1px solid var(--border);
 }
 
+.settings-tab-hint {
+  margin: 0;
+  padding: 4px 16px 5px;
+  font-size: 10px;
+  line-height: 1.3;
+  color: var(--fg);
+  opacity: 0.55;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-tab-hint.hidden {
+  display: none;
+}
+
 .settings-layout {
   display: flex;
   min-height: 400px;
@@ -20283,16 +20297,16 @@ body.gallery-selecting .gallery-dl-btn,
   padding: 16px 20px;
   min-width: 0;
 }
-.settings-appearance-panel {
+.settings-visibility-panel {
   flex-direction: column;
 }
-.settings-appearance-panel:not(.hidden) {
+.settings-visibility-panel:not(.hidden) {
   display: flex;
 }
-.settings-appearance-panel > .admin-card:nth-of-type(1) { order: 3; }
-.settings-appearance-panel > .admin-card:nth-of-type(2) { order: 1; }
-.settings-appearance-panel > .admin-card:nth-of-type(3) { order: 2; }
-.settings-appearance-panel > .admin-card:nth-of-type(n+4) { order: 4; }
+.settings-visibility-panel > .admin-card:nth-of-type(1) { order: 3; }
+.settings-visibility-panel > .admin-card:nth-of-type(2) { order: 1; }
+.settings-visibility-panel > .admin-card:nth-of-type(3) { order: 2; }
+.settings-visibility-panel > .admin-card:nth-of-type(n+4) { order: 4; }
 
 /* Mobile: stack tabs on top */
 @media (max-width: 600px) {


### PR DESCRIPTION
### Description
This PR introduces several quality-of-life UI improvements to the Settings and Admin menus to reduce clutter, remove redundancies, and clarify functionality. 

### Key Changes
* **Added Settings Tab Hints:** Introduced dynamic helper text under the settings header (`#settings-tab-hint`) that updates based on the active tab to better explain the purpose of each section.
* **Renamed "Appearance" to "Visibility":** Updated the tab name to "Visibility" across the UI, CSS classes, JS initialization (`initVisibility`), and the `/tour-settings` slash command to more accurately reflect that it toggles UI element visibility.
* **Updated Admin Placeholder:** Changed the "Add User" input placeholder from `Username (email)` to `Username` to prevent user confusion, as email formatting is not strictly enforced.

### Checks Ran
* Manually tested UI changes in the browser (Settings modal tab switching, appearance of hints).
* Syntax checked modified JS files using `node --check static/js/settings.js` and `node --check static/js/slashCommands.js`.

### Screenshots
## Setting tab hints
<img width="1114" height="319" alt="image" src="https://github.com/user-attachments/assets/0ceeb548-a802-411e-95c0-4c8f0a405d01" />

## Renamed appearance to visibility
<img width="332" height="286" alt="image" src="https://github.com/user-attachments/assets/130d4c36-5e97-42fa-b578-4495ab916a23" />

## Removed (email) from username
<img width="373" height="249" alt="image" src="https://github.com/user-attachments/assets/2a36213f-80ac-4d1d-ae2c-60f3d93ca987" />

