### PR TITLE
Restrict provider discovery to admins

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -865,8 +865,9 @@ def setup_model_routes(model_discovery):
     _PROVIDERS_CACHE_TTL = 30  # seconds
 
     @router.get("/providers")
-    def providers(refresh: bool = False):
+    def providers(request: Request, refresh: bool = False):
         """Get all available providers (cached for 30s)."""
+        require_admin(request)
         now = _time.time()
         if not refresh and _providers_cache["data"] is not None and (now - _providers_cache["time"]) < _PROVIDERS_CACHE_TTL:
             return _providers_cache["data"]

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -97,6 +97,42 @@ def _install_core_auth_stub(monkeypatch):
     return auth_mod
 
 
+def test_providers_requires_admin_before_discovery_and_cache(monkeypatch):
+    _install_model_route_import_stubs(monkeypatch)
+    import routes.model_routes as model_routes
+
+    class _Discovery:
+        def __init__(self):
+            self.calls = 0
+
+        def get_providers(self):
+            self.calls += 1
+            return {"providers": [{"host": "internal.example"}]}
+
+    discovery = _Discovery()
+    router = model_routes.setup_model_routes(discovery)
+    endpoint = next(
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "path", "") == "/api/providers"
+    )
+    request = SimpleNamespace()
+
+    assert endpoint(request, refresh=True) == {"providers": [{"host": "internal.example"}]}
+    assert discovery.calls == 1
+
+    def deny_admin(_request):
+        raise PermissionError("admin required")
+
+    monkeypatch.setattr(model_routes, "require_admin", deny_admin)
+
+    with pytest.raises(PermissionError):
+        endpoint(request, refresh=True)
+    with pytest.raises(PermissionError):
+        endpoint(request, refresh=False)
+    assert discovery.calls == 1
+
+
 def test_default_chat_does_not_auto_pick_shared_endpoint_for_fresh_user(monkeypatch):
     _install_model_route_import_stubs(monkeypatch)
     import routes.model_routes as model_routes


### PR DESCRIPTION
## Summary

Restricts `GET /api/providers` to admin users.

## Changes

- Require admin access before returning provider discovery data.
- Ensure non-admin callers cannot trigger provider discovery.
- Ensure non-admin callers cannot receive cached provider discovery data.
- Preserve `/api/models` for normal user model-list behavior.
- Preserve existing admin-only `/api/discover` behavior.

## Motivation

Provider discovery can include internal/local model host information and may trigger local provider discovery. This keeps active discovery and provider host visibility aligned with the existing admin-only discovery routes.

## Validation

- `python3 -m py_compile routes/model_routes.py tests/test_review_regressions.py`
- `python3 -m pytest tests/test_review_regressions.py -k providers_requires_admin_before_discovery_and_cache`
- `git diff --check`

## Notes

Focused route-level hardening only. No frontend, Docker, deployment docs, or unrelated model route changes.