### PR TITLE
Fix document deep links on page load and show load errors

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -110,6 +110,7 @@ import * as Modals from './modalManager.js';
   // Multi-document state
   let activeDocId = null;           // currently visible doc
   let _lastSessionId = '';          // session context for "+" button
+  let _docHashRouteBound = false;
   const docs = new Map();           // docId -> { id, title, language, content, version, sessionId }
 
   const _docOpenKey = (sessionId) => 'odysseus-doc-open-' + sessionId;
@@ -152,6 +153,20 @@ import * as Modals from './modalManager.js';
       addDocToTabs,
       syncDocIndicator: _syncDocIndicator,
     });
+    if (!_docHashRouteBound) {
+      _docHashRouteBound = true;
+      window.addEventListener('hashchange', _maybeOpenDocumentFromHash);
+      _maybeOpenDocumentFromHash();
+    }
+  }
+
+  function _maybeOpenDocumentFromHash() {
+    const hash = window.location.hash || '';
+    const match = hash.match(/^#document-(.+)$/);
+    if (!match) return;
+    const docId = decodeURIComponent(match[1] || '').trim();
+    if (!docId) return;
+    void loadDocument(docId);
   }
 
   /** Update overflow-doc-btn accent indicator, toolbar indicator, and session list icon */
@@ -5818,6 +5833,12 @@ import * as Modals from './modalManager.js';
       switchToDoc(doc.id);
     } catch (e) {
       console.error('Failed to load document:', e);
+      if (uiModule) {
+        const isMissing = e && typeof e.message === 'string' && e.message === 'Not found';
+        uiModule.showError(isMissing
+          ? 'Document not found. Try opening it from the Documents tab.'
+          : 'Failed to load document.');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes document deep links so `#document-*` URLs work on initial page load and browser hash changes, and shows a user-facing error when a document cannot be loaded instead of failing silently.

Fixes #560.

## What Changed

- Added document hash routing in `static/js/document.js` during module init
- Added `hashchange` handling for `#document-*` links
- Added a visible error message when document loading fails
- Kept the change focused to a single UI module for easier review

## Files Changed

- `static/js/document.js`

## Testing

Ran:

- `node --check static/js/document.js`

Also verified the branch diff against `origin/main` is limited to this one file.

## Notes

- This does not broaden scope into document-link generation because the current code already emits UUID-based document links.
- The change is limited to deep-link handling and error feedback in the document panel.
