### PR TITLE
Fix unauthenticated task webhook triggers

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,7 @@ from core.exceptions import (
 import bcrypt as _bcrypt
 
 from src.app_helpers import abs_join
+from src.auth_helpers import is_public_task_webhook_path
 from starlette.responses import RedirectResponse
 
 # ========= LOGGING =========
@@ -154,7 +155,11 @@ if AUTH_ENABLED:
     AUTH_EXEMPT_PREFIXES = ["/static"]
 
     def _is_auth_exempt(path: str) -> bool:
-        return path in AUTH_EXEMPT_EXACT or any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES)
+        return (
+            path in AUTH_EXEMPT_EXACT
+            or any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES)
+            or is_public_task_webhook_path(path)
+        )
 
     # In-memory token cache: prefix → list[(token_id, token_hash, owner, scopes)]. The DB
     # query was running on every API-bearer request and scanning bcrypt

--- a/src/auth_helpers.py
+++ b/src/auth_helpers.py
@@ -4,6 +4,12 @@ from typing import Optional
 from fastapi import Request, HTTPException
 
 
+def is_public_task_webhook_path(path: str) -> bool:
+    """Return True for task webhook trigger URLs where the path token is auth."""
+    parts = path.strip("/").split("/")
+    return len(parts) == 5 and parts[0] == "api" and parts[1] == "tasks" and parts[3] == "webhook"
+
+
 def get_current_user(request: Request) -> Optional[str]:
     """Get current username from request state (set by auth middleware)."""
     return getattr(request.state, 'current_user', None)

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -243,6 +243,17 @@ def test_task_create_notification_default_allows_action_specific_defaults():
     assert req.notifications_enabled is None
 
 
+def test_task_webhook_trigger_path_is_the_only_public_task_webhook():
+    """Task webhook trigger URLs carry their own secret token in the path.
+    The similarly named regenerate endpoint still needs normal auth."""
+    from src.auth_helpers import is_public_task_webhook_path
+
+    assert is_public_task_webhook_path("/api/tasks/task-1/webhook/secret-token")
+    assert not is_public_task_webhook_path("/api/tasks/task-1/webhook-regenerate")
+    assert not is_public_task_webhook_path("/api/tasks/task-1/webhook")
+    assert not is_public_task_webhook_path("/api/tasks/task-1/runs/webhook/secret-token")
+
+
 def test_ship_paused_housekeeping_stays_paused_by_default():
     """Built-ins marked ship_paused are intentionally opt-in even after
     the user enables the rest of Tasks."""


### PR DESCRIPTION
## Summary
- Exempt only task webhook trigger URLs from the global auth middleware so their path token can act as auth
- Keep similarly named task routes like webhook regeneration behind normal auth
- Add a focused regression test for the path matcher

Fixes #621

## Validation
- python3 -m py_compile app.py src/auth_helpers.py tests/test_auth_regressions.py
- git diff --check
- .venv/bin/python -m pytest tests/test_auth_regressions.py -k task_webhook_trigger_path_is_the_only_public_task_webhook

Note: I installed a minimal local test venv for the targeted regression test. Full project pytest was not run.