### PR TITLE
Exempt task webhook trigger from auth middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,17 +151,25 @@ if AUTH_ENABLED:
         "/api/version",
         "/login",
     }
-    AUTH_EXEMPT_PREFIXES = [
-        "/static",
-        "/api/tasks/",
-    ]
+    AUTH_EXEMPT_PREFIXES = ["/static"]
+
+    def _is_public_task_webhook_path(path: str) -> bool:
+        parts = path.strip("/").split("/")
+        return (
+            len(parts) == 5
+            and parts[0] == "api"
+            and parts[1] == "tasks"
+            and bool(parts[2])
+            and parts[3] == "webhook"
+            and bool(parts[4])
+        )
 
     def _is_auth_exempt(path: str) -> bool:
-        if path in AUTH_EXEMPT_EXACT:
-            return True
-        if path.endswith("/webhook-regenerate"):
-            return False
-        return any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES) and "/webhook/" in path
+        return (
+            path in AUTH_EXEMPT_EXACT
+            or any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES)
+            or _is_public_task_webhook_path(path)
+        )
 
     # In-memory token cache: prefix → list[(token_id, token_hash, owner, scopes)]. The DB
     # query was running on every API-bearer request and scanning bcrypt

--- a/app.py
+++ b/app.py
@@ -151,10 +151,17 @@ if AUTH_ENABLED:
         "/api/version",
         "/login",
     }
-    AUTH_EXEMPT_PREFIXES = ["/static"]
+    AUTH_EXEMPT_PREFIXES = [
+        "/static",
+        "/api/tasks/",
+    ]
 
     def _is_auth_exempt(path: str) -> bool:
-        return path in AUTH_EXEMPT_EXACT or any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES)
+        if path in AUTH_EXEMPT_EXACT:
+            return True
+        if path.endswith("/webhook-regenerate"):
+            return False
+        return any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES) and "/webhook/" in path
 
     # In-memory token cache: prefix → list[(token_id, token_hash, owner, scopes)]. The DB
     # query was running on every API-bearer request and scanning bcrypt

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -265,6 +265,8 @@ def test_task_payload_exposes_crew_member_id_for_ui_category():
 
 
 def test_task_webhook_route_is_auth_exempt_but_regenerate_is_not():
+    from routes import task_routes
+
     app_path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         "app.py",
@@ -293,8 +295,28 @@ def test_task_webhook_route_is_auth_exempt_but_regenerate_is_not():
     ns = {}
     exec(compile(ast.Module(body=extracted, type_ignores=[]), app_path, "exec"), ns)
     is_auth_exempt = ns["_is_auth_exempt"]
+    assert ns["AUTH_EXEMPT_PREFIXES"] == ["/static"]
 
-    assert is_auth_exempt("/static/app.js") is True
-    assert is_auth_exempt("/api/tasks/task-123/webhook/token-456") is True
-    assert is_auth_exempt("/api/tasks/task-123/webhook-regenerate") is False
-    assert is_auth_exempt("/api/tasks/task-123/webhook") is False
+    task_routes_src = open(task_routes.__file__, encoding="utf-8").read()
+    assert 'APIRouter(prefix="/api/tasks"' in task_routes_src
+    assert '@router.post("/{task_id}/webhook/{token}")' in task_routes_src
+    assert '@router.post("/{task_id}/webhook-regenerate")' in task_routes_src
+
+    public_cases = [
+        "/static/app.js",
+        "/api/tasks/task-123/webhook/token-456",
+    ]
+    protected_cases = [
+        "/api/tasks/task-123/webhook-regenerate",
+        "/api/tasks/{task_id}/webhook-regenerate",
+        "/api/tasks/task-123/webhook",
+        "/api/tasks/task-123/webhook/",
+        "/api/tasks/task-123/webhook/token-456/extra",
+        "/api/tasks//webhook/token-456",
+        "/api/tasks/task-123/webhooks/token-456",
+    ]
+
+    for path in public_cases:
+        assert is_auth_exempt(path) is True, path
+    for path in protected_cases:
+        assert is_auth_exempt(path) is False, path

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -261,3 +261,9 @@ def test_task_payload_exposes_crew_member_id_for_ui_category():
 
     src = open(task_routes.__file__, encoding="utf-8").read()
     assert '"crew_member_id"' in src
+
+
+def test_task_webhook_route_is_auth_exempt_but_regenerate_is_not():
+    src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "app.py"), encoding="utf-8").read()
+    assert 'if path.endswith("/webhook-regenerate"):' in src
+    assert 'return any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES) and "/webhook/" in path' in src

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -9,11 +9,12 @@ don't regress. Specifically:
   anonymous/no-owner callers.
 """
 
+import asyncio
+import ast
 import os
+import pytest
 import sys
 import types
-import asyncio
-import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -264,6 +265,36 @@ def test_task_payload_exposes_crew_member_id_for_ui_category():
 
 
 def test_task_webhook_route_is_auth_exempt_but_regenerate_is_not():
-    src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "app.py"), encoding="utf-8").read()
-    assert 'if path.endswith("/webhook-regenerate"):' in src
-    assert 'return any(path.startswith(p) for p in AUTH_EXEMPT_PREFIXES) and "/webhook/" in path' in src
+    app_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "app.py",
+    )
+    module = ast.parse(open(app_path, encoding="utf-8").read(), filename=app_path)
+    auth_block = next(
+        node for node in module.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "AUTH_ENABLED"
+    )
+    wanted = {"AUTH_EXEMPT_EXACT", "AUTH_EXEMPT_PREFIXES"}
+    extracted = []
+    for node in auth_block.body:
+        if isinstance(node, ast.Assign):
+            targets = {
+                target.id for target in node.targets if isinstance(target, ast.Name)
+            }
+            if wanted & targets:
+                extracted.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in {
+            "_is_public_task_webhook_path",
+            "_is_auth_exempt",
+        }:
+            extracted.append(node)
+    ns = {}
+    exec(compile(ast.Module(body=extracted, type_ignores=[]), app_path, "exec"), ns)
+    is_auth_exempt = ns["_is_auth_exempt"]
+
+    assert is_auth_exempt("/static/app.js") is True
+    assert is_auth_exempt("/api/tasks/task-123/webhook/token-456") is True
+    assert is_auth_exempt("/api/tasks/task-123/webhook-regenerate") is False
+    assert is_auth_exempt("/api/tasks/task-123/webhook") is False


### PR DESCRIPTION
## Summary

Fixes the task webhook trigger route so `/api/tasks/{task_id}/webhook/{token}` works without a logged-in session, as intended by the route contract.

Closes #621.

## What Changed

- narrowed auth exemption logic in `app.py` so tokenized task webhook trigger URLs bypass auth
- kept `/webhook-regenerate` protected
- added a regression test in `tests/test_auth_regressions.py`

## Testing

Ran:

- `python -m pytest tests/test_auth_regressions.py -k webhook_route_is_auth_exempt_but_regenerate_is_not`
- `python -m py_compile app.py tests/test_auth_regressions.py`