### PR TITLE
Fix externally-managed-environment error

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+  #!/bin/bash
 # Odysseus — one-command quick start for macOS (Apple Silicon).
 #
 #   ./start-macos.sh
@@ -89,6 +89,7 @@ if [ ! -d venv ]; then
   echo "▶ Creating Python environment…"
   "$PY" -m venv venv
 fi
+PY="./venv/bin/python"
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
 "$PY" -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).


### PR DESCRIPTION
Without changing the PY flag to the virtual environment we get a externally-managed-environment error, hence we tell the script explicitly to use the previously created venv to install the requirements.