### PR TITLE
docs: clarify Browser MCP setup guidance

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1127,7 +1127,7 @@ const MCP_PRESETS = [
   { name: "Brave Search",    command: "npx", args: ["-y", "@modelcontextprotocol/server-brave-search"], env: { BRAVE_API_KEY: "" },
     help: "1. Go to brave.com/search/api\n2. Sign up for a free plan (2000 queries/month)\n3. Copy your API key" },
   { name: "Browser (Playwright)", command: "npx", args: ["-y", "@playwright/mcp@latest", "--headless"],  env: {},
-    help: "Browser automation via Playwright. The AI can navigate pages, click, fill forms, and read content.\nRuns headless by default. Remove --headless from Args to see the browser window.\nFirst run installs Chromium automatically." },
+    help: "Browser automation via Playwright. The AI can navigate pages, click, fill forms, and read content.\nRuns headless by default. Remove --headless from Args to see the browser window.\nBefore adding this server on a fresh install, cache the package once with:\n\nnpx -y @playwright/mcp@latest --version\n\nThis installs @playwright/mcp and Playwright. Restart Odysseus after the install so the built-in Browser MCP can register cleanly." },
   { name: "Filesystem",      command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "/home"], env: {},
     help: "Edit the Args field to change which directory the server has access to." },
   { name: "Memory",          command: "npx", args: ["-y", "@modelcontextprotocol/server-memory"],        env: {} },


### PR DESCRIPTION
## Summary

Clarifies the Browser (Playwright) MCP preset guidance in the admin UI.

The README notes that `@playwright/mcp` should be cached once before the Browser MCP server is available on fresh installs. The admin UI previously said only that Chromium installs automatically, which could make first-run MCP setup failures harder to understand.

This updates the Browser MCP preset help text to include the recommended cache command:

`npx -y @playwright/mcp@latest --version`

and reminds users to restart Odysseus afterward.

## Testing

Not run; text-only UI help copy change.