### PR TITLE
Add Z.AI Coding Plan endpoint + GLM vision model support

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -89,9 +89,12 @@ _PROVIDER_CURATED = {
         "claude-sonnet-4-5", "claude-haiku-3-5",
     ],
     "zai": [
-        "glm-5", "glm-4.7", "glm-4.7-flash",
+        "glm-5", "glm-5.1", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash",
         "glm-4.6", "glm-4.6v",
         "glm-4.5", "glm-4.5v", "glm-4.5-air", "glm-4.5-flash",
+    ],
+    "zai-coding": [
+        "glm-5.1", "glm-5v-turbo", "glm-5-turbo", "glm-4.7", "glm-4.5-air",
     ],
     "deepseek": [
         "deepseek-chat", "deepseek-reasoner",
@@ -151,9 +154,14 @@ _HOST_TO_CURATED = (
 def _match_provider_curated(base_url: str, provider: str) -> str:
     """Return the curated-list key for a given endpoint.
 
-    Matches the base URL's hostname against known providers; falls back to
-    the raw provider string from _detect_provider().
+    Checks path-based overrides first (for hosts serving multiple plans),
+    then matches the base URL's hostname against known providers, and
+    finally falls back to the raw provider string from _detect_provider().
     """
+    # Path-based overrides for hosts that serve multiple curated lists.
+    parsed = urlparse(base_url)
+    if _host_match(base_url, "z.ai") and "/api/coding" in (parsed.path or ""):
+        return "zai-coding"
     for domain, key in _HOST_TO_CURATED:
         if _host_match(base_url, domain):
             return key
@@ -352,6 +360,13 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
         if not models:
             models = [m.get("name") or m.get("model") for m in (data.get("models") or []) if m.get("name") or m.get("model")]
         if models:
+            # Z.AI coding plan omits some working models from /models;
+            # append curated-only entries for that endpoint only.
+            if _host_match(base, "z.ai") and "/api/coding" in (urlparse(base).path or ""):
+                _ck = _match_provider_curated(base, None)
+                for _e in _PROVIDER_CURATED.get(_ck, []):
+                    if _e not in set(models) and not any(m.startswith(_e) for m in models):
+                        models.append(_e)
             return models
     except httpx.HTTPStatusError as e:
         if api_key:

--- a/src/chat_helpers.py
+++ b/src/chat_helpers.py
@@ -34,6 +34,8 @@ _VISION_MODEL_KEYWORDS = (
     # open / local
     "vision", "llava", "bakllava", "moondream", "pixtral", "minicpm",
     "internvl", "cogvlm", "qwen-vl", "qwen2-vl", "qwen3-vl", "qwen3vl",
+    # zhipu / glm (glm-4.5v, glm-4.6v, glm-5v-turbo, etc.)
+    "glm-4.5v", "glm-4.6v", "glm-5v",
 )
 # Catches the "*-VL-*" / "*VL*" family not covered by a literal keyword above
 # (e.g. Qwen2.5-VL and various tags): a standalone "vl" token, plus "vlm".

--- a/static/index.html
+++ b/static/index.html
@@ -2071,6 +2071,7 @@
                   <option value="https://generativelanguage.googleapis.com/v1beta/openai" data-logo="gemini">Google Gemini</option>
                   <option value="https://api.x.ai/v1" data-logo="grok">xAI Grok</option>
                   <option value="https://api.z.ai/api/paas/v4" data-logo="zhipu">Z.AI (Zhipu)</option>
+                  <option value="https://api.z.ai/api/coding/paas/v4" data-logo="zhipu">Z.AI Coding Plan</option>
                 </select>
                 <div class="admin-model-form-row">
                   <input id="adm-epApiKey" type="password" placeholder="API key">


### PR DESCRIPTION
### What
Adds the Z.AI Coding Plan as a first-class provider option and fixes image
uploads for GLM vision models.

### Why
- Z.AI offers a separate coding plan endpoint (`api.z.ai/api/coding/paas/v4`)
  with models like `glm-5.1` and `glm-5-turbo` that aren't available on the
  standard endpoint. Users had no way to add it from the admin UI.
- `glm-5v-turbo` (and other GLM vision models) couldn't process images because
  `is_vision_model()` didn't recognize them — images were silently stripped,
  causing degraded responses.

### Changes
- **`routes/model_routes.py`** (+12/-1)
  - Add `zai-coding` curated model list
  - Add `z.ai/api/coding` → `zai-coding` URL mapping (more specific than
    generic substring)
  - Add `glm-5.1` and `glm-5v-turbo` to existing `zai` curated list
  - Append curated-only models to probe results (z.ai omits `glm-5v-turbo`
    from its `/models` response even though the model works)

- **`src/chat_helpers.py`** (+2)
  - Add `glm-4.5v`, `glm-4.6v`, `glm-5v` to `_VISION_MODEL_KEYWORDS`

- **`static/index.html`** (+1)
  - Add "Z.AI Coding Plan" to the provider dropdown

### Testing
- Docker rebuild clean, no startup errors
- Verified curated merge appends missing models on probe
- Vision gate now passes image content through to GLM vision models