### PR TITLE
Enable NVIDIA GPU support for the Odysseus container in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 services:
   odysseus:
     build: .
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     ports:
       - "${APP_PORT:-7000}:7000"
     volumes:


### PR DESCRIPTION
### What does this PR do?
This PR updates the `docker-compose.yml` file to include explicit GPU passthrough instructions for the `odysseus` service.

### Why is this needed?
By default, Docker containers cannot see or utilize the host machine's GPU. For users running Odysseus with local LLMs or GPU-accelerated workloads, this causes the container to fall back to CPU-only execution, resulting in severe performance degradation.

This change utilizes the modern Docker Compose specification to request access to the host's NVIDIA GPUs. 

### How was it implemented?
I added the `deploy` block under the `odysseus` service with the following configuration:
- `driver: nvidia`
- `count: all`
- `capabilities: [gpu]`

This ensures that whether a user is on Linux with the NVIDIA Container Toolkit, or on Windows using Docker Desktop with WSL2, the container will properly detect and utilize available NVIDIA hardware.
