### PR TITLE
fix: source thumbnails dropped for http-only og:image URLs

### DIFF
--- a/src/search/content.py
+++ b/src/search/content.py
@@ -130,9 +130,9 @@ def _extract_og_image(soup: BeautifulSoup) -> str:
     tag = soup.find("meta", attrs={"name": "thumbnail"})
     if tag and tag.get("content", "").strip():
         candidates.append(tag["content"].strip())
-    # Return first absolute https URL
+    # Return first absolute http(s) URL
     for url in candidates:
-        if url.startswith("https://") and not url.endswith((".svg", ".ico")):
+        if url.startswith(("https://", "http://")) and not url.endswith((".svg", ".ico")):
             return url
     return ""
 

--- a/tests/test_og_image_extraction.py
+++ b/tests/test_og_image_extraction.py
@@ -1,0 +1,32 @@
+"""Tests for og:image extraction (src/search/content.py)."""
+import pytest
+
+pytest.importorskip("bs4")
+from bs4 import BeautifulSoup
+
+from src.search.content import _extract_og_image
+
+
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
+
+
+def test_accepts_http_og_image():
+    # Regression: only https URLs were returned, so plain-http og:image
+    # (still common) yielded no thumbnail despite the docstring promising
+    # "http(s)".
+    html = '<meta property="og:image" content="http://example.com/cover.jpg">'
+    assert _extract_og_image(_soup(html)) == "http://example.com/cover.jpg"
+
+
+def test_still_accepts_https_og_image():
+    html = '<meta property="og:image" content="https://example.com/cover.png">'
+    assert _extract_og_image(_soup(html)) == "https://example.com/cover.png"
+
+
+def test_skips_relative_and_svg():
+    html = (
+        '<meta property="og:image" content="/relative/logo.png">'
+        '<meta name="twitter:image" content="https://example.com/icon.svg">'
+    )
+    assert _extract_og_image(_soup(html)) == ""


### PR DESCRIPTION
## Summary

`_extract_og_image` documents that it "returns absolute http(s) URLs", but the code only accepts `https://`. Sites that still serve their `og:image` over plain `http://` therefore yield no thumbnail for the research source card, even though a perfectly good absolute image URL is present.

Fix: accept both `http://` and `https://` (still skipping relative paths, data URIs, and `.svg`/`.ico`), matching the docstring.

## Changes
- `src/search/content.py`: accept `http://` og:image URLs.
- `tests/test_og_image_extraction.py`: http accepted, https still works, relative/svg skipped.