### PR TITLE
fix: normalize username keys to lowercase on auth config load

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -73,6 +73,15 @@ class AuthManager:
             if os.path.exists(self.auth_path):
                 with open(self.auth_path, "r", encoding="utf-8") as f:
                     self._config = json.load(f)
+                # Normalize all stored usernames to lowercase so they match
+                # the .strip().lower() applied at login/verify time. Fixes
+                # "Invalid credentials" when auth.json was written with
+                # mixed-case keys (e.g. via manual edit or a future migration).
+                if "users" in self._config:
+                    self._config["users"] = {
+                        k.strip().lower(): v
+                        for k, v in self._config["users"].items()
+                    }
                 logger.info("Auth config loaded")
             else:
                 self._config = {}


### PR DESCRIPTION
Fixes #423

## Root cause

`verify_password()` and `create_session()` both call `.strip().lower()` on the incoming username before lookup, but `_load()` stores keys verbatim from `auth.json`. Any mixed-case key (manual edit, future migration, or the legacy single-user migration block) never matches — permanent *"Invalid credentials"* with no indication why.

## Fix

Normalize all username keys to lowercase at load time in `_load()`, so the in-memory dict always matches what the login path expects. One dict comprehension, no behavior change for correctly-lowercase keys.

## Testing

- `auth.json` with `"Admin"` key → login as `admin` now works
- `auth.json` with `"Yatsu"` key → login as `yatsu` now works
- existing lowercase keys → unaffected