### PR TITLE
fix: macOS quick-start to install and run from the repo venv

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -22,6 +22,7 @@ PROBE_HOST="$HOST"
 if [ "$PROBE_HOST" = "0.0.0.0" ] || [ "$PROBE_HOST" = "::" ]; then
   PROBE_HOST="127.0.0.1"
 fi
+VENV_DIR="$REPO_DIR/venv"
 
 # Friendly message on any failure — re-running is safe (every step is idempotent).
 trap 'echo; echo "✗ Setup failed above. It is safe to re-run ./start-macos.sh."; exit 1' ERR
@@ -113,20 +114,21 @@ fi
 # 3. Python environment + dependencies (kept inside the repo, in venv/).
 #    Named `venv` to match the manual steps and build-macos-app.sh, so the
 #    clickable .app reuses this same environment.
-if [ ! -d venv ]; then
+if [ ! -x "$VENV_DIR/bin/python" ]; then
   echo "▶ Creating Python environment…"
-  "$PY" -m venv venv
+  "$PY" -m venv "$VENV_DIR"
 fi
+VENV_PY="$VENV_DIR/bin/python"
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$PY" -m pip install --quiet --upgrade pip
+"$VENV_PY" -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
-"$PY" -m pip install -r requirements.txt
+"$VENV_PY" -m pip install -r requirements.txt
 
 # 4. First-run setup: creates data dirs and prints an initial admin password
 #    the first time (idempotent — does nothing if already set up). Suppress its
 #    manual run hint — we launch the server ourselves just below.
 echo "▶ Preparing Odysseus…"
-ODYSSEUS_SKIP_RUN_HINT=1 ./venv/bin/python setup.py
+ODYSSEUS_SKIP_RUN_HINT=1 "$VENV_PY" setup.py
 
 # 5. Launch. Bind to loopback by default; opt into LAN/Tailscale with
 #    ODYSSEUS_HOST=0.0.0.0.
@@ -179,4 +181,4 @@ if [ -n "$TAILSCALE_URL" ]; then
 fi
 echo "  (this takes a few seconds; press Ctrl+C here to stop)"
 echo
-"$PY" -m uvicorn app:app --host "$HOST" --port "$PORT"
+"$VENV_PY" -m uvicorn app:app --host "$HOST" --port "$PORT"

--- a/tests/test_launcher_scripts.py
+++ b/tests/test_launcher_scripts.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_start_macos_uses_repo_venv_for_install_and_runtime():
+    script = Path("start-macos.sh").read_text(encoding="utf-8")
+
+    assert 'VENV_PY="$VENV_DIR/bin/python"' in script
+    assert '"$VENV_PY" -m pip install --quiet --upgrade pip' in script
+    assert '"$VENV_PY" -m pip install -r requirements.txt' in script
+    assert 'ODYSSEUS_SKIP_RUN_HINT=1 "$VENV_PY" setup.py' in script
+    assert '"$VENV_PY" -m uvicorn app:app --host 127.0.0.1 --port "$PORT"' in script
+
+    assert '"$PY" -m pip install --quiet --upgrade pip' not in script
+    assert '"$PY" -m pip install -r requirements.txt' not in script
+    assert '"$PY" -m uvicorn app:app --host 127.0.0.1 --port "$PORT"' not in script

--- a/tests/test_launcher_scripts.py
+++ b/tests/test_launcher_scripts.py
@@ -4,12 +4,22 @@ from pathlib import Path
 def test_start_macos_uses_repo_venv_for_install_and_runtime():
     script = Path("start-macos.sh").read_text(encoding="utf-8")
 
+    assert script.startswith("#!/bin/bash\n")
+    assert 'HOST="${ODYSSEUS_HOST:-127.0.0.1}"' in script
+    assert 'PROBE_HOST="$HOST"' in script
+    assert 'if (exec 3<>"/dev/tcp/$PROBE_HOST/$PORT") 2>/dev/null; then' in script
+    assert 'brew_ensure() {' in script
+    assert 'brew_ensure tmux tmux' in script
+    assert 'brew_ensure llama-server llama.cpp' in script
+
+    assert 'if [ ! -x "$VENV_DIR/bin/python" ]; then' in script
     assert 'VENV_PY="$VENV_DIR/bin/python"' in script
     assert '"$VENV_PY" -m pip install --quiet --upgrade pip' in script
     assert '"$VENV_PY" -m pip install -r requirements.txt' in script
     assert 'ODYSSEUS_SKIP_RUN_HINT=1 "$VENV_PY" setup.py' in script
-    assert '"$VENV_PY" -m uvicorn app:app --host 127.0.0.1 --port "$PORT"' in script
+    assert 'TAILSCALE_URL=""' in script
+    assert '"$VENV_PY" -m uvicorn app:app --host "$HOST" --port "$PORT"' in script
 
     assert '"$PY" -m pip install --quiet --upgrade pip' not in script
     assert '"$PY" -m pip install -r requirements.txt' not in script
-    assert '"$PY" -m uvicorn app:app --host 127.0.0.1 --port "$PORT"' not in script
+    assert '"$PY" -m uvicorn app:app --host "$HOST" --port "$PORT"' not in script


### PR DESCRIPTION
start-macos.sh created venv/ but then still used the Homebrew/PATH interpreter for pip install and python -m uvicorn.

  On Homebrew Python 3.12+, that can fail during setup with PEP 668 (externally-managed-environment) because pip is being run against the Homebrew-managed interpreter instead of the newly created virtual
  environment. If setup is forced past that point, launch can still fail with No module named uvicorn because runtime is also using the wrong interpreter.

  This change keeps PY only as the bootstrap interpreter used to create the venv, then switches all repo-local package installs and runtime execution to venv/bin/python.

  Why this is safe:

  - It matches the documented manual setup flow, which installs into and runs from venv.
  - It matches the existing Windows launcher and CLI wrappers, which already prefer the project venv.
  - It matches the macOS app bundle, which already expects venv/bin/uvicorn.
  - It preserves the current Apple Silicon bootstrap logic: the venv is still created from the selected arm64 Homebrew Python.

  Testing:

  - bash -n start-macos.sh
  - venv/bin/python -m pytest tests/test_launcher_scripts.py
