### PR TITLE
fix: reply-all Cc's the user's own other addresses (multi-account)

### DIFF
--- a/static/js/emailInbox.js
+++ b/static/js/emailInbox.js
@@ -721,10 +721,12 @@ async function _openEmail(em, itemEl, preloadedData = null, mode = 'reply') {
     em.is_read = true;
     if (itemEl) itemEl.classList.remove('email-unread');
 
-    // Get my own address to exclude from Reply All. window._myEmailAddress
-    // is populated from the configured account on init; the empty fallback
-    // simply means "no exclusion" — better than baking in a real address.
-    const myAddress = (window._myEmailAddress || '').toLowerCase();
+    // Addresses to exclude from Reply All. Prefer the full set of configured
+    // accounts (so a multi-account user's other mailboxes are excluded too),
+    // falling back to the single active address. Empty ⇒ no exclusion.
+    const myAddresses = (Array.isArray(window._myEmailAddresses) && window._myEmailAddresses.length)
+      ? window._myEmailAddresses
+      : (window._myEmailAddress ? [window._myEmailAddress] : []);
 
     let toAddress = data.from_address;
     let ccAddresses = '';
@@ -732,7 +734,7 @@ async function _openEmail(em, itemEl, preloadedData = null, mode = 'reply') {
 
     if (mode === 'reply-all') {
       // Build reply-all: TO = original sender, CC = everyone else (To + Cc minus me)
-      ccAddresses = buildReplyAllCc(data, myAddress);
+      ccAddresses = buildReplyAllCc(data, myAddresses);
     } else if (mode === 'forward') {
       toAddress = '';
       subjectPrefix = 'Fwd: ';

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -514,6 +514,15 @@ function _publishActiveAccount() {
       || accts.find(a => a && a.is_default)
       || accts[0];
     window._myEmailAddress = (active && (active.from_address || active.imap_user)) || '';
+    // Also publish every configured address so reply-all can exclude all of
+    // the user's own mailboxes, not just the active one (multi-account users
+    // were getting their other addresses added to Cc).
+    const all = [];
+    for (const a of accts) {
+      if (a && a.from_address) all.push(a.from_address);
+      if (a && a.imap_user) all.push(a.imap_user);
+    }
+    window._myEmailAddresses = all;
   } catch (_) {}
 }
 

--- a/static/js/emailLibrary/replyRecipients.js
+++ b/static/js/emailLibrary/replyRecipients.js
@@ -12,14 +12,16 @@ export function extractEmail(addr) {
 // Reply-all CC = everyone on the original To + Cc, minus ourselves, with the
 // original "Name <email>" form preserved.
 //
-// `myAddress` empty/unknown ⇒ no exclusion. Comparing by exact extracted email
-// (not a substring `includes`) is what fixes issue #360: an empty self address
-// made `"...".includes("")` true for every recipient, so reply-all dropped the
-// entire Cc list and kept only the original sender.
-export function buildReplyAllCc(data, myAddress) {
-  const me = (myAddress || '').toLowerCase();
+// `mine` is a single address or a list of the user's own addresses (a
+// multi-account user has more than one). Empty/unknown ⇒ no exclusion.
+// Comparing by exact extracted email (not a substring `includes`) is what
+// fixes issue #360: an empty self address made `"...".includes("")` true for
+// every recipient, so reply-all dropped the entire Cc list.
+export function buildReplyAllCc(data, mine) {
+  const list = Array.isArray(mine) ? mine : [mine];
+  const me = new Set(list.map((a) => (a || '').toLowerCase()).filter(Boolean));
   const split = (s) => (s || '').split(',').map((x) => x.trim()).filter(Boolean);
   return [...split(data && data.to), ...split(data && data.cc)]
-    .filter((addr) => !me || extractEmail(addr) !== me)
+    .filter((addr) => !me.has(extractEmail(addr)))
     .join(', ');
 }

--- a/tests/test_reply_recipients_js.py
+++ b/tests/test_reply_recipients_js.py
@@ -51,3 +51,16 @@ def test_reply_all_excludes_only_self_exactly():
     cc = json.loads(_run(js))
     # Our own address is dropped; a substring-similar address is kept.
     assert cc == "Alice <alice@x.com>, bob@x.com"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_reply_all_excludes_all_of_my_addresses():
+    # Multi-account user: every one of their own addresses must be excluded,
+    # not just the active one.
+    data = {"to": "Alice <alice@x.com>, me@work.com", "cc": "me@personal.com, bob@x.com"}
+    js = f"""
+    import {{ buildReplyAllCc }} from '{_HELPER.as_posix()}';
+    console.log(JSON.stringify(buildReplyAllCc({json.dumps(data)}, ["me@work.com", "me@personal.com"])));
+    """
+    cc = json.loads(_run(js))
+    assert cc == "Alice <alice@x.com>, bob@x.com"


### PR DESCRIPTION
## Summary

Reply All excludes the user's own address from the recipient list, but only the **active** account's address (`window._myEmailAddress`). A user with more than one configured account therefore gets their *other* mailboxes added to Cc when they reply-all — replying to themselves.

This publishes the full set of configured addresses (`window._myEmailAddresses`) and teaches `buildReplyAllCc` to exclude all of them. The helper still accepts a single address (back-compat) and an empty value still means "no exclusion" (the #360 fallback).

## Changes
- `static/js/emailLibrary.js`: publish every account's `from_address` / `imap_user` as `window._myEmailAddresses`.
- `static/js/emailLibrary/replyRecipients.js`: `buildReplyAllCc` accepts a single address or a list and excludes all.
- `static/js/emailInbox.js`: pass the full address set into reply-all.
- `tests/test_reply_recipients_js.py`: multi-account exclusion test.