### PR TITLE
Recognize Gemma as a tool-capable model family

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1358,7 +1358,7 @@ async def stream_agent_loop(
     except Exception as _e:
         logger.debug(f"endpoint supports_tools lookup failed: {_e}")
     _model_supports_tools = any(kw in _model_lc for kw in (
-        "deepseek", "gpt-4", "gpt-5", "gpt-o", "claude", "gemini",
+        "deepseek", "gpt-4", "gpt-5", "gpt-o", "claude", "gemini", "gemma",
         "qwen3", "qwen2.5", "mixtral", "mistral", "llama-3.1", "llama-3.2",
         "llama-3.3", "llama-4",
         # Local-served models that follow OpenAI-style function calling


### PR DESCRIPTION
**What:** Gemma models support OpenAI-style function calling, but `gemma` was missing from the `_model_supports_tools` capability heuristic in `src/agent_loop.py`.

**The bug:** In `stream_agent_loop()`, when an endpoint isn't on the `_API_HOSTS` allowlist and the per-endpoint `supports_tools` flag is unset, tool-capability is decided from a model-name keyword list (deepseek/qwen/llama/mistral/claude/gemini… but not `gemma`). So a Gemma-backed agent on a self-hosted OpenAI-compatible endpoint never receives native tool schemas (`tools_sent=0`, `_is_api_model=False`) and falls back to the prompt-text tool-call convention. Gemma doesn't follow that convention — it emits its own tool-call format, which leaks into the chat as raw text and never executes. Net effect: web search and all agent tools silently no-op for Gemma users.

**The fix:** Add `"gemma"` to the keyword list, alongside the other tool-capable families. One line. (Kept as the bare family name to match the existing `claude`/`gemini`/`mistral` entries and to stay valid for future Gemma releases.)

**Files changed:** `src/agent_loop.py` (one line in `_model_supports_tools`).

**Testing:**
- `python -m py_compile src/agent_loop.py` — OK
- `python -m pytest tests/test_agent_loop.py` — 37 passed
- Manual: on a self-hosted OpenAI-compatible Gemma endpoint, agent tool calls leaked as raw text and never ran before this change; after, native tool schemas are sent (`_is_api_model=True`) and `web_search` executes end-to-end.
