### PR TITLE
Fix Cookbook dep installs when Odysseus runs from a venv

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -808,6 +808,15 @@ def setup_cookbook_routes() -> APIRouter:
                 r"[A-Za-z0-9][A-Za-z0-9._\-\[\]<>=!,~]{0,200}", req.repo_id
             ):
                 raise HTTPException(400, "Invalid pip package name")
+            # The runner script prepends the Odysseus venv's bin to PATH so
+            # `python3 -m pip` is always available. But pip inside a venv
+            # rejects `--user` ("Can not perform a '--user' install"). Strip
+            # both flags so the install goes directly into the venv instead
+            # of ~/.local. The serve runners already prepend venv/bin to PATH,
+            # so tools like `vllm`/`llama-server` are found there at serve time.
+            # Only applies to local runs (remote hosts manage their own pip).
+            if not req.remote_host and sys.base_prefix != sys.prefix:
+                req.cmd = re.sub(r'\s+--(?:user|break-system-packages)\b', '', req.cmd)
         else:
             _validate_serve_model_id(req.repo_id)
         TMUX_LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -894,6 +903,10 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines.append(f"export HF_TOKEN='{_bash_squote(req.hf_token)}'")
             if req.gpus:
                 runner_lines.append(f"export CUDA_VISIBLE_DEVICES='{req.gpus}'")
+            # Redirect pip/Python temp files to ~/.cache to avoid exhausting a
+            # small tmpfs at /tmp when installing large packages (torch wheels, etc.).
+            if is_pip_install and not remote:
+                runner_lines.append('export TMPDIR="${TMPDIR:-$HOME/.cache/pip-tmp}"; mkdir -p "$TMPDIR"')
             if req.env_prefix:
                 runner_lines.append(_safe_env_prefix(req.env_prefix))
             else:


### PR DESCRIPTION
## Summary

- **Bug:** Clicking Install in Cookbook → Dependencies failed silently on systems where the system Python has no `pip` module (Arch Linux, CachyOS, newer Debian).
- **Root cause:** The runner script prepends the Odysseus venv's `bin/` to `PATH` so `python3 -m pip` resolves to the venv's pip — but the frontend sends `--user --break-system-packages`, which pip inside a virtualenv always rejects (`Can not perform a '--user' install. User site-packages are not visible in this virtualenv.`).
- **Second fix:** Large dep installs (vllm pulls multi-GB torch wheels) can exhaust a small tmpfs at `/tmp`. Runner now redirects `TMPDIR` to `~/.cache/pip-tmp` for local pip installs.

## Changes

`routes/cookbook_routes.py` only — two additions, no deletions:

1. After pip package name validation: strip `--user` and `--break-system-packages` from the command when `sys.base_prefix != sys.prefix` (i.e., Odysseus is running from a venv) and the install is local. Remote installs are untouched.
2. For local pip install runner scripts: export `TMPDIR=${TMPDIR:-$HOME/.cache/pip-tmp}` before running pip so wheel extraction lands on persistent disk.

Packages now install into the Odysseus venv rather than `~/.local`. Serve runners already prepend `venv/bin` to `PATH`, so `vllm serve`, `llama-server`, etc. resolve correctly.

## Test plan

- [ ] Confirmed failure on `main`: `bash -c 'export PATH="<project>/venv/bin:$PATH"; hash -r; python3 -m pip install --user --break-system-packages vllm'` → `ERROR: Can not perform a '--user' install`
- [ ] With fix applied, same invocation without `--user` succeeds against the venv pip
- [ ] Regex tested against all frontend command variants: standard, `-U` upgrade, reversed flag order, extras (`sglang[all]`), version specifiers
- [ ] PATH bootstrap verified correct (colon-separated) for bash, zsh, fish, sh
- [ ] `TMPDIR` line valid in bash and sh
- [ ] `py_compile routes/cookbook_routes.py` passes
- [ ] 66/67 tests pass — 1 pre-existing ordering failure in `test_calendar_owner_scope` unrelated to this change (fails on `main` as well)
- [ ] Manually triggered Install for a small package via Cookbook UI — installed successfully into venv