### PR TITLE
Fix: default model ignores hidden_models — returns hidden model on new chat

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -96,6 +96,58 @@ def _clear_orphaned_session_endpoint(sess) -> bool:
         db.close()
 
 
+def _resolve_empty_session_model(sess, session_id: str) -> bool:
+    """If the session has no model, resolve from the matching ModelEndpoint
+    row using cached_models (filtered by hidden_models) so the user's model
+    visibility settings are respected. Returns True if a model was resolved."""
+    if sess.model or not sess.endpoint_url:
+        return False
+    domain = sess.endpoint_url.split("//")[1].split("/")[0] if "//" in sess.endpoint_url else ""
+    if not domain:
+        return False
+    db = SessionLocal()
+    try:
+        ep = db.query(ModelEndpoint).filter(
+            ModelEndpoint.base_url.contains(domain),
+            ModelEndpoint.is_enabled == True
+        ).first()
+        if not ep:
+            return False
+        model_ids = []
+        if ep.cached_models:
+            try:
+                model_ids = json.loads(ep.cached_models) if isinstance(ep.cached_models, str) else ep.cached_models
+            except Exception:
+                pass
+        if not model_ids:
+            return False
+        hidden = set()
+        if ep.hidden_models:
+            try:
+                hidden = set(json.loads(ep.hidden_models)) if isinstance(ep.hidden_models, str) else set(ep.hidden_models)
+            except Exception:
+                pass
+        visible = [m for m in model_ids if m not in hidden]
+        if not visible:
+            return False
+        _NON_CHAT = ("text-embedding", "embedding", "tts-", "whisper",
+                     "text-moderation", "moderation-", "dall-e", "rerank")
+        chat_ids = [m for m in visible if not any(p in m.lower() for p in _NON_CHAT)]
+        model_to_use = (chat_ids or visible)[0]
+        sess.model = model_to_use
+        db.query(DBSession).filter(DBSession.id == session_id).update(
+            {"model": model_to_use}
+        )
+        db.commit()
+        logger.info(f"Resolved empty session model to {model_to_use} for session {session_id}")
+        return True
+    except Exception:
+        db.rollback()
+        return False
+    finally:
+        db.close()
+
+
 def setup_chat_routes(
     session_manager,
     chat_handler,
@@ -289,6 +341,11 @@ def setup_chat_routes(
 
         # Ensure session has auth headers
         resolve_session_auth(sess, session)
+
+        # Fallback: if session model was cleared (e.g. endpoint deleted and
+        # recreated), probe the endpoint and pick the first chat model.
+        if not sess.model:
+            _resolve_empty_session_model(sess, session)
 
         # Check for research_pending BEFORE mode persist overwrites it
         do_research = str(use_research).lower() == "true"

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1275,9 +1275,13 @@ def setup_model_routes(model_discovery):
             chat_url = build_chat_url(base)
             if not model and getattr(ep, "cached_models", None):
                 try:
-                    models = _json.loads(ep.cached_models) if isinstance(ep.cached_models, str) else ep.cached_models
-                    if models:
-                        model = models[0]
+                    all_models = _json.loads(ep.cached_models) if isinstance(ep.cached_models, str) else ep.cached_models
+                    hidden = set()
+                    if getattr(ep, "hidden_models", None):
+                        hidden = set(_json.loads(ep.hidden_models) if isinstance(ep.hidden_models, str) else ep.hidden_models)
+                    visible_models = [m for m in all_models if m not in hidden]
+                    if visible_models:
+                        model = visible_models[0]
                 except Exception:
                     pass
             return {"endpoint_id": ep.id, "endpoint_url": chat_url, "model": model}
@@ -1311,6 +1315,13 @@ def setup_model_routes(model_discovery):
                     ep.name = body["name"].strip() or ep.name
                 if "model_type" in body and isinstance(body["model_type"], str):
                     ep.model_type = body["model_type"].strip() or ep.model_type
+                if "api_key" in body:
+                    v = body["api_key"]
+                    ep.api_key = v.strip() if isinstance(v, str) and v.strip() else None
+                    _invalidate_models_cache()
+                if "base_url" in body and isinstance(body["base_url"], str):
+                    ep.base_url = body["base_url"].strip()
+                    _invalidate_models_cache()
             else:
                 ep.is_enabled = not ep.is_enabled
             db.commit()
@@ -1321,6 +1332,8 @@ def setup_model_routes(model_discovery):
                 "supports_tools": ep.supports_tools,
                 "name": ep.name,
                 "model_type": ep.model_type,
+                "base_url": ep.base_url,
+                "has_key": bool(ep.api_key),
             }
         finally:
             db.close()
@@ -1380,8 +1393,6 @@ def setup_model_routes(model_discovery):
         rows = db.query(DbSession).filter(DbSession.endpoint_url.isnot(None)).all()
         for row in rows:
             if _session_uses_endpoint_url(row.endpoint_url or "", base_url):
-                row.endpoint_url = ""
-                row.model = ""
                 row.headers = {}
                 row.updated_at = datetime.utcnow()
                 cleared += 1
@@ -1399,8 +1410,6 @@ def setup_model_routes(model_discovery):
         try:
             for sess in list(getattr(manager, "sessions", {}).values()):
                 if _session_uses_endpoint_url(getattr(sess, "endpoint_url", "") or "", base_url):
-                    sess.endpoint_url = ""
-                    sess.model = ""
                     sess.headers = {}
                     cleared += 1
         except Exception:

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -12,6 +12,9 @@ let modalEl = null;
 // the endpoints list can flash a glow on that row. Cleared once the
 // animation fires.
 let _recentlyAddedEpId = null;
+// When editing an endpoint, store its id so the Add/Save button knows
+// to PATCH instead of POST. Cleared after save or cancel.
+let _editingEpId = null;
 
 function el(id) { return document.getElementById(id); }
 function esc(s) { return uiModule.esc(s); }
@@ -423,6 +426,7 @@ async function loadEndpoints() {
             </div>
             <div style="display:flex;gap:4px;align-items:center;">
               <button class="admin-btn-sm" data-adm-toggle-ep="${ep.id}">${ep.is_enabled ? 'Disable' : 'Enable'}</button>
+              <button class="admin-btn-sm" data-adm-edit-ep="${ep.id}" data-adm-ep-name="${esc(ep.name)}" data-adm-ep-base-url="${esc(ep.base_url)}" data-adm-ep-type="${esc(ep.model_type || 'llm')}" data-adm-ep-has-key="${ep.has_key ? '1' : '0'}">Edit</button>
               <button class="admin-btn-delete" data-adm-del-ep="${ep.id}" data-adm-ep-online="${ep.online ? '1' : '0'}">Delete</button>
               ${hasModels ? '<svg class="admin-user-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;transition:transform 0.2s,opacity 0.2s;"><polyline points="6 9 12 15 18 9"/></svg>' : ''}
             </div>
@@ -509,6 +513,55 @@ async function loadEndpoints() {
           .then(() => _refreshAfterEndpointChange(epId))
           .then(() => loadEndpoints())
           .catch(() => loadEndpoints());
+      });
+    });
+    queryAll('[data-adm-edit-ep]').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const epId = btn.dataset.admEditEp;
+        const epName = btn.dataset.admEpName || '';
+        const epBaseUrl = btn.dataset.admEpBaseUrl || '';
+        const epType = btn.dataset.admEpType || 'llm';
+        const hasKey = btn.dataset.admEpHasKey === '1';
+
+        // Expand the API add section and scroll to it
+        const section = document.getElementById('adm-add-api');
+        if (section) {
+          section.classList.remove('collapsed');
+          const toggle = section.querySelector('.adm-section-toggle');
+          if (toggle) toggle.setAttribute('aria-expanded', 'true');
+        }
+        const formEl = document.getElementById('adm-add-api');
+        if (formEl) formEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+        // Fill the form with endpoint details
+        const urlInput = el('adm-epUrl');
+        const apiKeyInput = el('adm-epApiKey');
+        const epTypeSelect = el('adm-epType');
+
+        if (urlInput) urlInput.value = epBaseUrl;
+        if (epTypeSelect) epTypeSelect.value = epType;
+
+        // Show key-hint in the password field
+        if (apiKeyInput) {
+          apiKeyInput.value = '';
+          apiKeyInput.placeholder = hasKey ? 'Key is set — enter new to replace' : 'API key';
+        }
+
+        // Store the editing ID and switch button to Save mode
+        _editingEpId = epId;
+        const addBtn = el('adm-epAddBtn');
+        if (addBtn) addBtn.textContent = 'Save';
+
+        // Show a cancel button
+        const msg = _endpointMsg('api');
+        if (msg) {
+          msg.innerHTML = `<span style="opacity:0.6">Editing ${esc(epName)}</span> <button class="admin-btn-sm" id="adm-epCancelEditBtn" style="margin-left:6px;font-size:10px;">Cancel</button>`;
+          const cancelBtn = msg.querySelector('#adm-epCancelEditBtn');
+          if (cancelBtn) {
+            cancelBtn.addEventListener('click', () => _cancelEndpointEdit(), { once: true });
+          }
+        }
       });
     });
     // Clear the just-added marker now that the row has been rendered
@@ -632,6 +685,31 @@ async function _saveEpModelState(epId, panel) {
       settingsModule.refreshAiModelEndpoints();
     }
   } catch (e) { /* silent */ }
+}
+
+function _endpointMsg(kind) {
+  return el(kind === 'local' ? 'adm-epLocalMsg' : 'adm-epApiMsg') || el('adm-epMsg');
+}
+
+function _cancelEndpointEdit() {
+  _editingEpId = null;
+  const addBtn = el('adm-epAddBtn');
+  if (addBtn) addBtn.textContent = 'Add';
+  const urlInput = el('adm-epUrl');
+  const apiKeyInput = el('adm-epApiKey');
+  const providerSelect = el('adm-epProvider');
+  const epTypeSelect = el('adm-epType');
+  if (urlInput) { urlInput.value = ''; urlInput.style.display = ''; }
+  if (apiKeyInput) { apiKeyInput.value = ''; apiKeyInput.placeholder = 'API key'; }
+  if (providerSelect) providerSelect.value = '';
+  if (epTypeSelect) epTypeSelect.value = 'llm';
+  const msg = _endpointMsg('api');
+  if (msg) { msg.textContent = ''; msg.className = ''; }
+  const picker = el('adm-provider-picker');
+  if (picker) {
+    const ev = new Event('change', { bubbles: true });
+    providerSelect.dispatchEvent(ev);
+  }
 }
 
 function initEndpointForm() {
@@ -761,10 +839,6 @@ function initEndpointForm() {
     msg.className = 'admin-error';
   }
 
-  function _endpointMsg(kind) {
-    return el(kind === 'local' ? 'adm-epLocalMsg' : 'adm-epApiMsg') || el('adm-epMsg');
-  }
-
   let apiTestController = null;
   const apiTestBtn = el('adm-epApiTestBtn');
   const apiCancelTestBtn = el('adm-epApiCancelTestBtn');
@@ -820,45 +894,74 @@ function initEndpointForm() {
     const rawUrl = (urlInput.value || provider.value).trim();
     const apiKey = el('adm-epApiKey').value.trim();
     if (!rawUrl) { msg.textContent = 'Select a provider or enter a base URL'; msg.className = 'admin-error'; return; }
-    if (provider.value && !apiKey) { msg.textContent = 'API key is required for cloud providers'; msg.className = 'admin-error'; return; }
+    if (!_editingEpId && provider.value && !apiKey) { msg.textContent = 'API key is required for cloud providers'; msg.className = 'admin-error'; return; }
     // Normalize URL (fix typos, add /v1, strip wrong paths)
     const url = provider.value && rawUrl === provider.value ? rawUrl : _normalizeBaseUrl(rawUrl);
     const btn = el('adm-epAddBtn');
-    btn.disabled = true; btn.textContent = 'Adding...';
+    btn.disabled = true;
+    btn.textContent = _editingEpId ? 'Saving...' : 'Adding...';
     try {
-      const fd = new FormData();
-      fd.append('base_url', url);
-      if (apiKey) fd.append('api_key', apiKey);
-      if (provider.value && provider.selectedOptions && provider.selectedOptions[0]) {
-        fd.append('name', provider.selectedOptions[0].textContent.trim());
-      }
-      const epType = el('adm-epType');
-      if (epType) fd.append('model_type', epType.value);
-      if (provider.value && /openrouter\.ai|ollama\.com/i.test(provider.value)) fd.append('require_models', 'true');
-      else fd.append('skip_probe', 'false');
-      const res = await fetch('/api/model-endpoints', { method: 'POST', body: fd, credentials: 'same-origin' });
-      const d = await res.json();
-      if (res.ok) {
-        const count = d.models ? d.models.length : 0;
-        urlInput.value = ''; urlInput.style.display = '';
-        el('adm-epApiKey').value = ''; provider.value = '';
-        if (epType) epType.value = 'llm';
-        if (d.id) _recentlyAddedEpId = String(d.id);
-        await loadEndpoints();
-        await _selectAddedModelInChat(d);
-        if (!d.online) {
-          msg.textContent = 'Added (endpoint offline — will retry on next load)';
-          msg.className = 'admin-error';
-        } else if (d.status === 'empty') {
-          msg.textContent = 'Added — endpoint reachable, no models found';
-          msg.className = 'admin-success';
-        } else {
-          msg.textContent = `Added — found ${count} model${count !== 1 ? 's' : ''}`;
-          msg.className = 'admin-success';
+      if (_editingEpId) {
+        // PATCH (edit) existing endpoint
+        const body = { base_url: url };
+        if (apiKey) body.api_key = apiKey;
+        if (provider.value && provider.selectedOptions && provider.selectedOptions[0]) {
+          body.name = provider.selectedOptions[0].textContent.trim();
         }
-      } else { msg.textContent = d.detail || 'Failed'; msg.className = 'admin-error'; }
+        const epType = el('adm-epType');
+        if (epType) body.model_type = epType.value;
+        const res = await fetch(`/api/model-endpoints/${_editingEpId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          credentials: 'same-origin',
+        });
+        const d = await res.json();
+        if (res.ok) {
+          _cancelEndpointEdit();
+          msg.textContent = 'Saved';
+          msg.className = 'admin-success';
+          await loadEndpoints();
+        } else {
+          msg.textContent = d.detail || 'Failed to save';
+          msg.className = 'admin-error';
+        }
+      } else {
+        // POST (create) new endpoint
+        const fd = new FormData();
+        fd.append('base_url', url);
+        if (apiKey) fd.append('api_key', apiKey);
+        if (provider.value && provider.selectedOptions && provider.selectedOptions[0]) {
+          fd.append('name', provider.selectedOptions[0].textContent.trim());
+        }
+        const epType = el('adm-epType');
+        if (epType) fd.append('model_type', epType.value);
+        if (provider.value && /openrouter\.ai|ollama\.com/i.test(provider.value)) fd.append('require_models', 'true');
+        else fd.append('skip_probe', 'false');
+        const res = await fetch('/api/model-endpoints', { method: 'POST', body: fd, credentials: 'same-origin' });
+        const d = await res.json();
+        if (res.ok) {
+          const count = d.models ? d.models.length : 0;
+          urlInput.value = ''; urlInput.style.display = '';
+          el('adm-epApiKey').value = ''; provider.value = '';
+          if (epType) epType.value = 'llm';
+          if (d.id) _recentlyAddedEpId = String(d.id);
+          await loadEndpoints();
+          await _selectAddedModelInChat(d);
+          if (!d.online) {
+            msg.textContent = 'Added (endpoint offline — will retry on next load)';
+            msg.className = 'admin-error';
+          } else if (d.status === 'empty') {
+            msg.textContent = 'Added — endpoint reachable, no models found';
+            msg.className = 'admin-success';
+          } else {
+            msg.textContent = `Added — found ${count} model${count !== 1 ? 's' : ''}`;
+            msg.className = 'admin-success';
+          }
+        } else { msg.textContent = d.detail || 'Failed'; msg.className = 'admin-error'; }
+      }
     } catch (e) { msg.textContent = 'Request failed'; msg.className = 'admin-error'; }
-    btn.disabled = false; btn.textContent = 'Add';
+    btn.disabled = false; btn.textContent = _editingEpId ? 'Save' : 'Add';
   });
 
   // Local "Add" button — sibling form for self-hosted base URLs.

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -39,12 +39,10 @@ function _modelExists(modelId, url) {
   if (!modelId || !window.modelsModule || !window.modelsModule.getCachedItems) return false;
   const items = window.modelsModule.getCachedItems() || [];
   if (!items.length) return true;
-  const targetUrl = (url || '').replace(/\/+$/, '');
   return items.some(item => {
     if (item.offline) return false;
-    const itemUrl = (item.url || '').replace(/\/+$/, '');
     const models = (item.models || []).concat(item.models_extra || []);
-    return models.includes(modelId) && (!targetUrl || itemUrl === targetUrl);
+    return models.includes(modelId);
   });
 }
 
@@ -457,22 +455,44 @@ export function updateModelPicker() {
   }
   if (!modelId && !_autoSelectingDefault && window.modelsModule && window.modelsModule.getCachedItems) {
     const items = window.modelsModule.getCachedItems();
-    const first = items.find(item => !item.offline && ((item.models || []).length || (item.models_extra || []).length));
-    if (first) {
-      const models = (first.models || []).concat(first.models_extra || []);
-      modelId = models[0];
-      if (!currentSessionId) {
-        _deps.setPendingChat({ url: first.url, modelId, endpointId: first.endpoint_id });
-      } else {
-        if (s) { s.model = modelId; s.endpoint_url = first.url; }
-        _autoSelectingDefault = true;
-        const fd = new FormData();
-        fd.append('model', modelId);
-        fd.append('endpoint_url', first.url || '');
-        if (first.endpoint_id) fd.append('endpoint_id', first.endpoint_id);
-        fetch(`${API_BASE}/api/session/${currentSessionId}`, { method: 'PATCH', body: fd })
-          .catch(() => {})
-          .finally(() => { _autoSelectingDefault = false; });
+    // Prefer user's configured default chat model over first available
+    if (window.__odysseusDefaultChat && window.__odysseusDefaultChat.model && !currentSessionId) {
+      const defaultModel = window.__odysseusDefaultChat.model;
+      const defaultUrl = window.__odysseusDefaultChat.endpoint_url || '';
+      const defaultEpId = window.__odysseusDefaultChat.endpoint_id || '';
+      let matches = items.filter(item => !item.offline && (
+        ((item.models || []).concat(item.models_extra || [])).includes(defaultModel) &&
+        (!defaultUrl || (item.url || '').replace(/\/+$/, '') === defaultUrl.replace(/\/+$/, ''))
+      ));
+      if (!matches.length && defaultModel) {
+        matches = items.filter(item => !item.offline && (
+          ((item.models || []).concat(item.models_extra || [])).includes(defaultModel)
+        ));
+      }
+      if (matches.length) {
+        modelId = defaultModel;
+        const match = matches[0];
+        _deps.setPendingChat({ url: defaultUrl || match.url, modelId, endpointId: defaultEpId || match.endpoint_id });
+      }
+    }
+    if (!modelId) {
+      const first = items.find(item => !item.offline && ((item.models || []).length || (item.models_extra || []).length));
+      if (first) {
+        const models = (first.models || []).concat(first.models_extra || []);
+        modelId = models[0];
+        if (!currentSessionId) {
+          _deps.setPendingChat({ url: first.url, modelId, endpointId: first.endpoint_id });
+        } else {
+          if (s) { s.model = modelId; s.endpoint_url = first.url; }
+          _autoSelectingDefault = true;
+          const fd = new FormData();
+          fd.append('model', modelId);
+          fd.append('endpoint_url', first.url || '');
+          if (first.endpoint_id) fd.append('endpoint_id', first.endpoint_id);
+          fetch(`${API_BASE}/api/session/${currentSessionId}`, { method: 'PATCH', body: fd })
+            .catch(() => {})
+            .finally(() => { _autoSelectingDefault = false; });
+        }
       }
     }
   }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -457,6 +457,9 @@ async function initDefaultChat() {
     var settings = await res.json();
     if (settings.default_endpoint_id) epSel.value = settings.default_endpoint_id;
     refreshModels(settings.default_model || '');
+    if (modelSel.value !== (settings.default_model || '')) {
+      await saveDefault();
+    }
     _fallbacks = Array.isArray(settings.default_model_fallbacks)
       ? settings.default_model_fallbacks.map(function(f) {
           return { endpoint_id: (f && f.endpoint_id) || '', model: (f && f.model) || '' };
@@ -476,6 +479,18 @@ async function initDefaultChat() {
           default_model_fallbacks: clean
         })
       });
+      // Refresh cached default chat so model picker picks up the change immediately
+      try {
+        const dcRes = await fetch('/api/default-chat');
+        const dc = await dcRes.json();
+        window.__odysseusDefaultChat = dc;
+        if (window.modelsModule && window.modelsModule.refreshModels) {
+          await window.modelsModule.refreshModels(true);
+        }
+        if (dc.model && dc.endpoint_url && window.sessionModule) {
+          window.sessionModule.createDirectChat(dc.endpoint_url, dc.model, dc.endpoint_id);
+        }
+      } catch (_) {}
       msg.textContent = 'Saved'; msg.style.color = 'var(--fg)';
       setTimeout(function() { msg.textContent = ''; }, 2000);
     } catch (e) { msg.textContent = 'Failed to save'; msg.style.color = 'var(--red)'; }
@@ -491,8 +506,12 @@ async function initDefaultChat() {
   });
 
   _registerAiEndpointRefresh(function(endpoints) {
+    var prevModel = modelSel.value;
     _endpoints = endpoints;
     refreshEndpointOptions(epSel.value, modelSel.value);
+    if (modelSel.value !== prevModel) {
+      saveDefault();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- `get_default_chat` falls back to `cached_models[0]` unfiltered by
  `hidden_models`, so a hidden model gets returned as the default when
  no explicit `default_model` is saved. Fixed by filtering `cached_models`
  by `hidden_models` before picking the first model.
- Endpoint edit required delete+recreate, which cleared session models.
  Added PATCH support for `api_key`/`base_url` fields and an Edit button in
  the frontend endpoint cards.
- Session model recovery at chat time respects `hidden_models`.
- Frontend persists the default model when an endpoint refresh causes
  the Settings dropdown to change (e.g. when the saved model gets hidden).
  
## Changes

- **`routes/model_routes.py`**: PATCH handler for `api_key`/`base_url`;
  `_clear_sessions_for_endpoint` only clears auth headers;
  `get_default_chat` fallback filters `cached_models` by `hidden_models`
- **`routes/chat_routes.py`**: `_resolve_empty_session_model` filters by
  `hidden_models`
- **`static/js/admin.js`**: Edit button + PATCH flow for endpoint cards
- **`static/js/modelPicker.js`**: Auto-select prefers configured
  `default_model`; fallback model-name matching
- **`static/js/settings.js`**: Persist default model when endpoint refresh
  changes the dropdown value; save for new users
  
Fixes #587