### PR TITLE
fix: topic analysis false-matches keywords as substrings (e.g. 'ai' in 'email')

### DIFF
--- a/src/topic_analyzer.py
+++ b/src/topic_analyzer.py
@@ -53,7 +53,7 @@ def analyze_topics(session_manager, owner: str = None) -> Dict[str, Any]:
                         topic_counts[topic] += 1
                         sentences = re.split(r'[.!?]', str(content_raw))
                         for sentence in sentences:
-                            if kw in sentence.lower():
+                            if re.search(rf"\b{re.escape(kw)}\b", sentence.lower()):
                                 topic_matches[topic].append({
                                     "session_id": session_id,
                                     "session_name": session_name,

--- a/src/topic_analyzer.py
+++ b/src/topic_analyzer.py
@@ -49,7 +49,7 @@ def analyze_topics(session_manager, owner: str = None) -> Dict[str, Any]:
 
             for topic, keywords in TOPIC_KEYWORDS.items():
                 for kw in keywords:
-                    if kw in content:
+                    if re.search(rf"\b{re.escape(kw)}\b", content):
                         topic_counts[topic] += 1
                         sentences = re.split(r'[.!?]', str(content_raw))
                         for sentence in sentences:

--- a/tests/test_topic_analyzer.py
+++ b/tests/test_topic_analyzer.py
@@ -1,0 +1,30 @@
+"""Tests for topic keyword matching (src/topic_analyzer.py)."""
+from types import SimpleNamespace
+
+from src.topic_analyzer import analyze_topics
+
+
+def _sm(*messages):
+    history = [{"role": "user", "content": c} for c in messages]
+    return SimpleNamespace(sessions={"s1": {"owner": None, "name": "S", "history": history}})
+
+
+def _freq(result):
+    return {t["topic"]: t["frequency"] for t in result["topics"]}
+
+
+def test_substring_does_not_false_match_technology():
+    # Regression: "ai" matched inside "email"/"again"/"rain"/"wait", flagging
+    # Technology for messages with no technical content at all.
+    result = analyze_topics(_sm("Can you send me an email again about the rain? I will wait."))
+    assert "Technology" not in _freq(result)
+
+
+def test_real_keywords_still_match():
+    result = analyze_topics(_sm("I wrote some Python code to test the algorithm."))
+    assert _freq(result).get("Technology", 0) >= 1
+
+
+def test_multiword_keyword_matches():
+    result = analyze_topics(_sm("Can you explain how to set this up?"))
+    assert "Learning" in _freq(result)


### PR DESCRIPTION
## Summary

`analyze_topics` matches topic keywords with a plain substring test (`kw in content`), so short keywords match inside unrelated words. The worst offender is `"ai"` (Technology), which matches **email, again, rain, wait, explain, detail, maintain, said** — so a message like "send me an email again about the rain" gets flagged as *Technology*. Others: `"art"` in start/part/smart, `"code"` in decode, `"work"` in network/framework.

The result is wildly inflated topic counts (Technology especially) and irrelevant example snippets in `/api/conversations/topics`.

Fix: match on word boundaries (`\bkeyword\b`) instead of substrings, in both the frequency count and the example-snippet extraction. Multi-word keywords ("how to", "machine learning") still match.

## Changes
- `src/topic_analyzer.py`: word-boundary keyword matching for counts and example snippets.
- `tests/test_topic_analyzer.py`: no false-positive on "email/rain/wait"; real keywords and multi-word keywords still match.