### PR TITLE
Add UI scale control for large/ultrawide displays

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -84,6 +84,14 @@
       if (t && t.density && t.density !== 'comfortable') {
         document.documentElement.classList.add('density-' + t.density);
       }
+      // Apply saved UI scale (whole-interface zoom) before first paint so the
+      // chrome doesn't flash at 100% then jump. Stored on its own key, so it's
+      // read independently of the theme object above.
+      var uiScale = parseFloat(localStorage.getItem('odysseus-ui-scale'));
+      if (isFinite(uiScale)) {
+        uiScale = Math.min(2, Math.max(0.8, uiScale));
+        if (Math.abs(uiScale - 1) > 0.001) document.documentElement.style.zoom = String(uiScale);
+      }
       // Apply background pattern on body once available
       if (t && t.bgPattern && t.bgPattern !== 'none') {
         document.addEventListener('DOMContentLoaded', function() {
@@ -579,6 +587,23 @@
               <input type="checkbox" id="theme-frosted-toggle">
               <span class="admin-slider"></span>
             </label>
+          </div>
+        </div>
+        <div class="theme-fd-row">
+          <div class="theme-fd-group" style="flex:1 1 0;">
+            <label class="theme-fd-label">
+              UI Scale
+              <span id="theme-scale-value" class="theme-scale-value">100%</span>
+            </label>
+            <div class="theme-scale-row">
+              <button type="button" id="theme-scale-dec" class="theme-scale-btn" aria-label="Decrease UI scale" title="Smaller">&minus;</button>
+              <input type="range" id="theme-scale-range" class="theme-scale-range"
+                     min="80" max="200" step="5" value="100"
+                     aria-label="Interface scale" title="Interface scale">
+              <button type="button" id="theme-scale-inc" class="theme-scale-btn" aria-label="Increase UI scale" title="Larger">+</button>
+              <button type="button" id="theme-scale-reset" class="theme-scale-reset" title="Reset to 100%">Reset</button>
+            </div>
+            <div class="theme-scale-hint">Scales the whole interface — handy on large or high-resolution displays.</div>
           </div>
         </div>
         <div class="theme-fd-row">

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -23,7 +23,11 @@ export const KEYS = {
   MCP_ACTIVE: 'odysseus-mcp-active',
   SECTION_ORDER: 'sidebar-section-order',
   ADMIN_LAST_TAB: 'admin-last-tab',
-  DENSITY: 'odysseus-density'
+  DENSITY: 'odysseus-density',
+  // Whole-interface zoom factor (e.g. "1.25"). Stored separately from the
+  // theme object so the chosen scale survives theme switches — it's a display
+  // preference, not a per-theme attribute. Applied as CSS `zoom` on <html>.
+  UI_SCALE: 'odysseus-ui-scale'
 };
 
 /**

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -44,6 +44,17 @@ const DEFAULT_FONT = 'mono';
 const DEFAULT_DENSITY = 'comfortable';
 const MAX_CUSTOM_THEMES = 8;
 
+// ── UI scale (whole-interface zoom) ──
+// The stylesheet is overwhelmingly px-based, so a root font-size tweak (what
+// `density` does) barely moves most of the chrome. To genuinely scale the
+// interface up on high-resolution / ultrawide monitors we apply CSS `zoom`
+// to <html>, which Chromium (Edge) and Firefox 126+ both honour and which
+// scales every px, rem and em uniformly — exactly like native browser zoom.
+const DEFAULT_UI_SCALE = 1;
+const MIN_UI_SCALE = 0.8;   //  80%
+const MAX_UI_SCALE = 2.0;   // 200%
+const UI_SCALE_STEP = 0.05; //   5% increments
+
 // Default background patterns for built-in themes
 const THEME_DEFAULT_PATTERN = {
   dark:       'none',
@@ -383,6 +394,42 @@ export function applyFontDensity(font, density) {
   document.documentElement.style.setProperty('--font-family', family);
   document.documentElement.classList.remove('density-compact', 'density-spacious');
   if (d !== 'comfortable') document.documentElement.classList.add('density-' + d);
+}
+
+// Clamp an arbitrary value to the supported scale range, falling back to the
+// default when it isn't a finite number.
+function _clampScale(v) {
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  if (!isFinite(n)) return DEFAULT_UI_SCALE;
+  return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, n));
+}
+
+// Read the persisted UI scale (defaults to 1 / 100%).
+export function getUiScale() {
+  return _clampScale(Storage.get(Storage.KEYS.UI_SCALE, ''));
+}
+
+// Apply a scale to the live document without persisting it. Pass nothing to
+// re-apply the stored value. Returns the clamped scale actually applied.
+export function applyUiScale(scale) {
+  const s = _clampScale(scale === undefined ? getUiScale() : scale);
+  // Leave the property untouched at 100% so we don't establish a zoom
+  // containing block (and its fixed-position quirks) for the default case.
+  if (Math.abs(s - 1) < 0.001) document.documentElement.style.zoom = '';
+  else document.documentElement.style.zoom = String(s);
+  return s;
+}
+
+// Apply *and* persist a scale. Returns the clamped scale stored.
+export function setUiScale(scale) {
+  const s = applyUiScale(scale);
+  Storage.set(Storage.KEYS.UI_SCALE, String(s));
+  return s;
+}
+
+// Expose the bounds so UI code (sliders, buttons) stays in sync with the model.
+export function getUiScaleBounds() {
+  return { min: MIN_UI_SCALE, max: MAX_UI_SCALE, step: UI_SCALE_STEP, default: DEFAULT_UI_SCALE };
 }
 
 const _BG_CLASSES = ['bg-pattern-dots',
@@ -1138,6 +1185,42 @@ export function initThemeUI() {
       applyBgPattern(np.value);
       const s = getSaved(); if (s) _saveFull(s.name, s.colors);
     });
+  }
+
+  // ── UI scale slider (independent of the saved theme) ──
+  // The early head-script already applied the stored scale on first paint;
+  // here we just sync the controls to it and wire user interaction. Scale is
+  // persisted on its own key, so we never funnel it through _saveFull().
+  const scaleRange = document.getElementById('theme-scale-range');
+  if (scaleRange && !scaleRange.dataset.wired) {
+    const bounds = getUiScaleBounds();
+    const valueLabel = document.getElementById('theme-scale-value');
+    const decBtn = document.getElementById('theme-scale-dec');
+    const incBtn = document.getElementById('theme-scale-inc');
+    const resetBtn = document.getElementById('theme-scale-reset');
+    // Slider works in whole-percent units (80–200) for clean stepping.
+    scaleRange.min = String(Math.round(bounds.min * 100));
+    scaleRange.max = String(Math.round(bounds.max * 100));
+    scaleRange.step = String(Math.round(bounds.step * 100));
+    const render = (scale) => {
+      const pct = Math.round(scale * 100);
+      scaleRange.value = String(pct);
+      if (valueLabel) valueLabel.textContent = pct + '%';
+      if (decBtn) decBtn.disabled = scale <= bounds.min + 1e-6;
+      if (incBtn) incBtn.disabled = scale >= bounds.max - 1e-6;
+      if (resetBtn) resetBtn.disabled = Math.abs(scale - bounds.default) < 1e-6;
+    };
+    render(getUiScale());
+    // Live-apply while dragging; persistence on every input is cheap and keeps
+    // a refresh mid-drag consistent.
+    scaleRange.addEventListener('input', () => {
+      render(setUiScale(parseFloat(scaleRange.value) / 100));
+    });
+    const nudge = (dir) => render(setUiScale(getUiScale() + dir * bounds.step));
+    if (decBtn) decBtn.addEventListener('click', () => nudge(-1));
+    if (incBtn) incBtn.addEventListener('click', () => nudge(+1));
+    if (resetBtn) resetBtn.addEventListener('click', () => render(setUiScale(bounds.default)));
+    scaleRange.dataset.wired = '1';
   }
 
   const effectColorPicker = document.getElementById('theme-bg-effect-color');
@@ -2046,6 +2129,7 @@ const themeModule = { initThemeUI, togglePopup, closePopup, makeDraggable,
                        THEMES, applyColors, applyFontDensity, applyBgPattern,
                        applyBgEffectColor, applyBgEffectIntensity, applyBgEffectSize,
                        applyFrostedGlass,
+                       applyUiScale, setUiScale, getUiScale, getUiScaleBounds,
                        save, getSaved, saveCustomTheme, deleteCustomTheme,
                        getCustomThemes };
 

--- a/static/style.css
+++ b/static/style.css
@@ -6251,6 +6251,59 @@ pre { background: var(--code-bg, var(--hl-bg, #282c34)) !important; }
       background: var(--red); border: none; cursor: pointer;
     }
     .theme-fd-range:focus { outline: none; }
+    /* UI Scale control (whole-interface zoom) */
+    .theme-scale-value {
+      font-weight: 600; opacity: 1; margin-left: 6px;
+      color: var(--red); font-variant-numeric: tabular-nums;
+    }
+    .theme-scale-row { display: flex; align-items: center; gap: 8px; }
+    .theme-scale-range {
+      flex: 1 1 auto; min-width: 0;
+      box-sizing: border-box; margin: 0; padding: 0; height: 24px;
+      background: transparent; cursor: pointer;
+      -webkit-appearance: none; appearance: none; accent-color: var(--red);
+    }
+    .theme-scale-range::-webkit-slider-runnable-track {
+      height: 4px; background: var(--border); border-radius: 2px;
+    }
+    .theme-scale-range::-moz-range-track {
+      height: 4px; background: var(--border); border-radius: 2px;
+    }
+    .theme-scale-range::-webkit-slider-thumb {
+      -webkit-appearance: none; appearance: none;
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--red); border: none; margin-top: -5px; cursor: pointer;
+    }
+    .theme-scale-range::-moz-range-thumb {
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--red); border: none; cursor: pointer;
+    }
+    .theme-scale-range:focus { outline: none; }
+    .theme-scale-btn {
+      flex: 0 0 auto;
+      width: 26px; height: 26px; line-height: 1;
+      display: inline-flex; align-items: center; justify-content: center;
+      border: 1px solid var(--border); border-radius: 6px;
+      background: var(--bg); color: var(--fg);
+      font-size: 16px; font-family: inherit; cursor: pointer;
+      transition: border-color 0.12s, background 0.12s, opacity 0.12s;
+    }
+    .theme-scale-btn:hover:not(:disabled) { border-color: var(--red); }
+    .theme-scale-reset {
+      flex: 0 0 auto;
+      padding: 0 10px; height: 26px; line-height: 1;
+      border: 1px solid var(--border); border-radius: 6px;
+      background: transparent; color: var(--fg); opacity: 0.85;
+      font-size: 11px; font-family: inherit; cursor: pointer;
+      transition: border-color 0.12s, opacity 0.12s;
+    }
+    .theme-scale-reset:hover:not(:disabled) { border-color: var(--red); opacity: 1; }
+    .theme-scale-btn:disabled, .theme-scale-reset:disabled {
+      opacity: 0.35; cursor: default;
+    }
+    .theme-scale-hint {
+      font-size: 10.5px; opacity: 0.5; margin-top: 4px; line-height: 1.35;
+    }
     /* Color Harmony Generator */
     .theme-harmony-row { display: flex; gap: 8px; align-items: flex-end; }
     .harmony-generate-btn {


### PR DESCRIPTION
## Summary

On 3440×1440 (and other high-resolution / ultrawide) displays the interface rendered far too small, with no visible way to scale it. This adds a discoverable **UI Scale** control. Fixes #209.

> The Edge sidebar text-clipping fix originally bundled here has been split out into its own PR (#1420), per review.

## Changes

**New "UI Scale" control — Theme → Customize → Font & Layout**
- A slider, − / + steppers and a **Reset** button spanning **80%–200%**, with a live `%` readout and helper text.
- Applies CSS `zoom` to `<html>` so every `px` / `rem` / `em` scales uniformly. The existing **Density** option only nudges the root `font-size`, which barely moves the overwhelmingly px-based chrome; `zoom` behaves like native browser zoom and is honoured by Edge (Chromium) and Firefox 126+.
- Persisted on its own `localStorage` key (`odysseus-ui-scale`), **independent of the theme**, so the chosen scale survives theme switches.
- Re-applied in the early `<head>` script so there is **no flash of unscaled UI** on load.

## Screenshots

Tested across normal desktop, ultrawide, and mobile.

**The control — desktop (Theme → Customize → Font & Layout):**

![UI Scale control on desktop](https://raw.githubusercontent.com/Zeus-Deus/odysseus/pr-assets-209/screenshots/issue-209-desktop-scale-control.png)

**Ultrawide 3440×1440 — before (100%):** tiny UI, lost in the canvas.

![Ultrawide before, 100%](https://raw.githubusercontent.com/Zeus-Deus/odysseus/pr-assets-209/screenshots/issue-209-ultrawide-before-3440.png)

**Ultrawide 3440×1440 — after (UI Scale 150%):** same canvas, interface legible.

![Ultrawide after, 150%](https://raw.githubusercontent.com/Zeus-Deus/odysseus/pr-assets-209/screenshots/issue-209-ultrawide-after-3440.png)

**Mobile 390×844 — 100%:** responsive layout unaffected (sidebar collapses to the hamburger).

![Mobile at 100%](https://raw.githubusercontent.com/Zeus-Deus/odysseus/pr-assets-209/screenshots/issue-209-mobile-100.png)

**Mobile 390×844 — scaled to 130%:** the global scale cooperates with the responsive layout — no horizontal overflow, breakpoints still fire.

![Mobile scaled to 130%](https://raw.githubusercontent.com/Zeus-Deus/odysseus/pr-assets-209/screenshots/issue-209-mobile-scaled-130.png)

## Testing

- Slider, − / +, Reset and the 80% / 200% boundary clamping all work; the readout, `zoom` and `localStorage` stay in sync.
- Scale persists across a full reload via the flash-free early-apply path.
- Measured horizontal overflow at 0.8×, 1.3× and 2.0× on a 390px mobile viewport — **none** at any scale, and the mobile breakpoint keeps firing. The global scale does not fight the hand-tuned responsive CSS.
- No console errors.

## Notes
- Frontend-only change across four files: `static/index.html`, `static/js/theme.js`, `static/js/storage.js`, `static/style.css`.
