### PR TITLE
add fixtures in conftest for db testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,37 @@
-"""Shared test configuration — ensure project root is on sys.path and stub heavy deps."""
+"""Shared test configuration — ensure project root is on sys.path."""
 import sys
 import os
-import types
-import importlib.util
-from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-def _has_module(mod_name: str) -> bool:
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from core import database as db
+
+
+@pytest.fixture(scope="session")
+def engine():
+    test_engine = create_engine("sqlite:///:memory:")
+    db.Base.metadata.create_all(bind=test_engine)
+    yield test_engine
+    db.Base.metadata.drop_all(bind=test_engine)
+    test_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _bind_core_db_to_test_engine(engine, monkeypatch):
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    monkeypatch.setattr(db, "engine", engine, raising=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession, raising=False)
+    yield
+
+
+@pytest.fixture
+def db_session(engine):
+    Session = sessionmaker(bind=engine)
+    session = Session()
     try:
-        return importlib.util.find_spec(mod_name) is not None
-    except (ImportError, ValueError):
-        return False
-
-
-# Stub optional dependencies only when they are not installed. Do not replace
-# real FastAPI/Starlette/Pydantic modules: route tests import their subpackages.
-for mod_name in [
-    "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.types", "sqlalchemy.ext", "sqlalchemy.ext.declarative",
-    "sqlalchemy.ext.hybrid", "sqlalchemy.sql", "sqlalchemy.sql.expression",
-    "sqlalchemy.sql.sqltypes", "bcrypt", "pyotp",
-    "httpx", "fastapi", "fastapi.responses", "fastapi.routing",
-    "starlette", "starlette.responses", "starlette.middleware", "starlette.middleware.base",
-    "pydantic",
-]:
-    if mod_name not in sys.modules and not _has_module(mod_name):
-        sys.modules[mod_name] = MagicMock()
-
-if "src.database" not in sys.modules:
-    _db = types.ModuleType("src.database")
-    _db.SessionLocal = MagicMock()
-    _db.ModelEndpoint = MagicMock()
-    sys.modules["src.database"] = _db
+        yield session
+    finally:
+        session.close()

--- a/tests/test_calendar_owner_scope.py
+++ b/tests/test_calendar_owner_scope.py
@@ -12,37 +12,32 @@ get_upcoming_events scopes to the owner; it fails if the owner filter is
 dropped (the original cross-tenant behavior).
 """
 import os
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
 from datetime import datetime, timedelta
+import pytest_check as check
 
 from core import database as db
 
-
-def test_get_upcoming_events_is_owner_scoped():
-    db.Base.metadata.create_all(bind=db.engine)
+def test_get_upcoming_events_is_owner_scoped(db_session):
+    s = db_session
     soon = datetime.utcnow() + timedelta(days=2)
     end = soon + timedelta(hours=1)
 
-    s = db.SessionLocal()
-    try:
-        s.merge(db.CalendarCal(id="cal-alice", owner="alice", name="Alice"))
-        s.merge(db.CalendarCal(id="cal-bob", owner="bob", name="Bob"))
-        s.merge(db.CalendarEvent(uid="ev-alice", calendar_id="cal-alice",
-                                 summary="Alice 1:1", dtstart=soon, dtend=end))
-        s.merge(db.CalendarEvent(uid="ev-bob", calendar_id="cal-bob",
-                                 summary="Bob 1:1", dtstart=soon, dtend=end))
-        s.commit()
-    finally:
-        s.close()
+    s.merge(db.CalendarCal(id="cal-alice", owner="alice", name="Alice"))
+    s.merge(db.CalendarCal(id="cal-bob", owner="bob", name="Bob"))
+    s.merge(db.CalendarEvent(uid="ev-alice", calendar_id="cal-alice",
+                             summary="Alice 1:1", dtstart=soon, dtend=end))
+    s.merge(db.CalendarEvent(uid="ev-bob", calendar_id="cal-bob",
+                             summary="Bob 1:1", dtstart=soon, dtend=end))
+    s.commit()
 
     alice = {e["uid"] for e in db.get_upcoming_events("alice")}
     bob = {e["uid"] for e in db.get_upcoming_events("bob")}
     everyone = {e["uid"] for e in db.get_upcoming_events(None)}
 
     # An owner sees ONLY their own events — never the other tenant's.
-    assert alice == {"ev-alice"}, alice
-    assert bob == {"ev-bob"}, bob
+    assert alice ==  {"ev-alice"}
+    assert bob == {"ev-bob"}
     assert "ev-bob" not in alice and "ev-alice" not in bob
     # owner=None is the explicit single-user / legacy escape hatch (unscoped).
     assert {"ev-alice", "ev-bob"} <= everyone


### PR DESCRIPTION
Fix for test_calendar_owner_scope.py.  The test currently fails due to global mocks which prevent get_upcoming_events() from returning data.

Removed some AI slop:
-Unused global mocks (they were all installed anyway, so _has_module() short circuits and does nothing)

Added some of my own AI slop:
-Fixtures in conftest.py for db access. These automatically provision a db instance, db sessions, and clean up resources when done.
-Updated test_calendar_owner_scope.py to use these fixtures.