### PR TITLE
Add helmchart

### DIFF
--- a/charts/odysseus/.helmignore
+++ b/charts/odysseus/.helmignore
@@ -1,0 +1,9 @@
+.git/
+.github/
+.DS_Store
+*.swp
+*.tmp
+*.bak
+node_modules/
+dist/
+build/

--- a/charts/odysseus/Chart.yaml
+++ b/charts/odysseus/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: odysseus
+description: A Helm chart for deploying Odysseus
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/odysseus/templates/NOTES.txt
+++ b/charts/odysseus/templates/NOTES.txt
@@ -1,0 +1,26 @@
+Odysseus has been installed.
+
+The application Service is:
+  {{ include "odysseus.fullname" . }}:{{ .Values.service.port }}
+
+{{- if .Values.ingress.enabled }}
+Ingress hosts:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+To open a local tunnel:
+  kubectl port-forward svc/{{ include "odysseus.fullname" . }} 7000:{{ .Values.service.port }}
+
+Then visit:
+  http://127.0.0.1:7000
+{{- end }}
+
+If this is the first install and setup.enabled=true, the setup init container
+creates the data directories, initializes SQLite, and creates the first admin
+user when auth.json does not already exist.
+
+To provide secrets such as OPENAI_API_KEY or ODYSSEUS_ADMIN_PASSWORD, use either:
+  --set secretEnv.values.OPENAI_API_KEY=...
+
+or set secretEnv.existingSecret to the name of a Secret containing those keys.

--- a/charts/odysseus/templates/_helpers.tpl
+++ b/charts/odysseus/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "odysseus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "odysseus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "odysseus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "odysseus.labels" -}}
+helm.sh/chart: {{ include "odysseus.chart" . }}
+{{ include "odysseus.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "odysseus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "odysseus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "odysseus.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "odysseus.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "odysseus.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{- define "odysseus.secretName" -}}
+{{- if .Values.secretEnv.existingSecret -}}
+{{- .Values.secretEnv.existingSecret -}}
+{{- else -}}
+{{- printf "%s-env" (include "odysseus.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "odysseus.persistenceClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- include "odysseus.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "odysseus.chromadbName" -}}
+{{- printf "%s-chromadb" (include "odysseus.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "odysseus.searxngName" -}}
+{{- printf "%s-searxng" (include "odysseus.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "odysseus.ntfyName" -}}
+{{- printf "%s-ntfy" (include "odysseus.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "odysseus.envVars" -}}
+{{- range $key, $value := .Values.env }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- if .Values.searxng.enabled }}
+- name: SEARXNG_INSTANCE
+  value: "http://{{ include "odysseus.searxngName" . }}:{{ .Values.searxng.service.port }}"
+{{- end }}
+{{- if .Values.chromadb.enabled }}
+- name: CHROMADB_HOST
+  value: {{ include "odysseus.chromadbName" . | quote }}
+- name: CHROMADB_PORT
+  value: {{ .Values.chromadb.service.port | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/odysseus/templates/chromadb.yaml
+++ b/charts/odysseus/templates/chromadb.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.chromadb.enabled -}}
+{{- $name := include "odysseus.chromadbName" . -}}
+{{- if and .Values.chromadb.persistence.enabled (not .Values.chromadb.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+  {{- with .Values.chromadb.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.chromadb.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.chromadb.persistence.size | quote }}
+  {{- if .Values.chromadb.persistence.storageClass }}
+  storageClassName: {{ .Values.chromadb.persistence.storageClass | quote }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: chromadb
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: chromadb
+    spec:
+      containers:
+        - name: chromadb
+          image: "{{ .Values.chromadb.image.repository }}:{{ .Values.chromadb.image.tag }}"
+          imagePullPolicy: {{ .Values.chromadb.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.chromadb.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+          {{- if .Values.chromadb.persistence.enabled }}
+          volumeMounts:
+            - name: chromadb-data
+              mountPath: /chroma/chroma
+          {{- end }}
+          {{- with .Values.chromadb.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.chromadb.persistence.enabled }}
+      volumes:
+        - name: chromadb-data
+          persistentVolumeClaim:
+            claimName: {{ default $name .Values.chromadb.persistence.existingClaim }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+spec:
+  type: {{ .Values.chromadb.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.chromadb.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+{{- end }}

--- a/charts/odysseus/templates/deployment.yaml
+++ b/charts/odysseus/templates/deployment.yaml
@@ -1,0 +1,147 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "odysseus.fullname" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: odysseus
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: odysseus
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "odysseus.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.setup.enabled }}
+      initContainers:
+        - name: setup
+          image: {{ include "odysseus.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.setup.command | nindent 12 }}
+          env:
+            {{- include "odysseus.envVars" . | nindent 12 }}
+            {{- range $key, $value := .Values.setup.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.secretEnv.existingSecret .Values.secretEnv.values .Values.extraEnvFrom }}
+          envFrom:
+            {{- if or .Values.secretEnv.existingSecret .Values.secretEnv.values }}
+            - secretRef:
+                name: {{ include "odysseus.secretName" . }}
+            {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            {{- range $name, $mount := .Values.volumeMounts }}
+            - name: odysseus-data
+              mountPath: {{ $mount.mountPath | quote }}
+              subPath: {{ $mount.subPath | quote }}
+            {{- end }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: odysseus
+          image: {{ include "odysseus.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.odysseus.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.odysseus.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "odysseus.envVars" . | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.secretEnv.existingSecret .Values.secretEnv.values .Values.extraEnvFrom }}
+          envFrom:
+            {{- if or .Values.secretEnv.existingSecret .Values.secretEnv.values }}
+            - secretRef:
+                name: {{ include "odysseus.secretName" . }}
+            {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 7000
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 4
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            {{- range $name, $mount := .Values.volumeMounts }}
+            - name: odysseus-data
+              mountPath: {{ $mount.mountPath | quote }}
+              subPath: {{ $mount.subPath | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: odysseus-data
+          persistentVolumeClaim:
+            claimName: {{ include "odysseus.persistenceClaimName" . }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/odysseus/templates/ingress.yaml
+++ b/charts/odysseus/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "odysseus.fullname" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "odysseus.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/odysseus/templates/ntfy.yaml
+++ b/charts/odysseus/templates/ntfy.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.ntfy.enabled -}}
+{{- $name := include "odysseus.ntfyName" . -}}
+{{- if and .Values.ntfy.persistence.enabled (not .Values.ntfy.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+  {{- with .Values.ntfy.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.ntfy.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.ntfy.persistence.size | quote }}
+  {{- if .Values.ntfy.persistence.storageClass }}
+  storageClassName: {{ .Values.ntfy.persistence.storageClass | quote }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ntfy
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ntfy
+    spec:
+      containers:
+        - name: ntfy
+          image: "{{ .Values.ntfy.image.repository }}:{{ .Values.ntfy.image.tag }}"
+          imagePullPolicy: {{ .Values.ntfy.image.pullPolicy }}
+          args:
+            - serve
+          env:
+            - name: NTFY_BASE_URL
+              value: {{ .Values.ntfy.baseUrl | quote }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+          {{- if .Values.ntfy.persistence.enabled }}
+          volumeMounts:
+            - name: ntfy-cache
+              mountPath: /var/cache/ntfy
+          {{- end }}
+          {{- with .Values.ntfy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.ntfy.persistence.enabled }}
+      volumes:
+        - name: ntfy-cache
+          persistentVolumeClaim:
+            claimName: {{ default $name .Values.ntfy.persistence.existingClaim }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+spec:
+  type: {{ .Values.ntfy.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.ntfy.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+{{- end }}

--- a/charts/odysseus/templates/pvc.yaml
+++ b/charts/odysseus/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "odysseus.persistenceClaimName" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/odysseus/templates/searxng.yaml
+++ b/charts/odysseus/templates/searxng.yaml
@@ -1,0 +1,163 @@
+{{- if .Values.searxng.enabled -}}
+{{- $name := include "odysseus.searxngName" . -}}
+{{- $secretName := default (printf "%s-secret" $name) .Values.searxng.secret.existingSecret -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $secretKey := .Values.searxng.secret.key -}}
+{{- if not $secretKey -}}
+{{- if and $existingSecret (index $existingSecret.data "secret-key") -}}
+{{- $secretKey = index $existingSecret.data "secret-key" | b64dec -}}
+{{- else -}}
+{{- $secretKey = randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+data:
+  settings.yml: |
+    use_default_settings: {{ .Values.searxng.settings.useDefaultSettings }}
+
+    server:
+      secret_key: "__SEARXNG_SECRET__"
+
+    search:
+      formats:
+        {{- range .Values.searxng.settings.formats }}
+        - {{ . }}
+        {{- end }}
+---
+{{- if and .Values.searxng.secret.create (not .Values.searxng.secret.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+type: Opaque
+stringData:
+  secret-key: {{ $secretKey | quote }}
+---
+{{- end }}
+{{- if and .Values.searxng.persistence.enabled (not .Values.searxng.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+  {{- with .Values.searxng.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.searxng.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.searxng.persistence.size | quote }}
+  {{- if .Values.searxng.persistence.storageClass }}
+  storageClassName: {{ .Values.searxng.persistence.storageClass | quote }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: searxng
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: searxng
+    spec:
+      containers:
+        - name: searxng
+          image: "{{ .Values.searxng.image.repository }}:{{ .Values.searxng.image.tag }}"
+          imagePullPolicy: {{ .Values.searxng.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              if [ ! -s /etc/searxng/settings.yml ] || grep -q 'odysseus-local-searxng-json-2026-05-30\|__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
+                sed "s|__SEARXNG_SECRET__|${SEARXNG_SECRET}|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
+              fi
+              exec /usr/local/searxng/entrypoint.sh
+          env:
+            - name: SEARXNG_BASE_URL
+              value: "http://{{ $name }}:{{ .Values.searxng.service.port }}/"
+            - name: SEARXNG_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ default "secret-key" .Values.searxng.secret.existingSecretKey }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 20
+          volumeMounts:
+            - name: searxng-template
+              mountPath: /tmp/searxng-settings.yml.template
+              subPath: settings.yml
+              readOnly: true
+            {{- if .Values.searxng.persistence.enabled }}
+            - name: searxng-data
+              mountPath: /etc/searxng
+            {{- end }}
+          {{- with .Values.searxng.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: searxng-template
+          configMap:
+            name: {{ $name }}
+        {{- if .Values.searxng.persistence.enabled }}
+        - name: searxng-data
+          persistentVolumeClaim:
+            claimName: {{ default $name .Values.searxng.persistence.existingClaim }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+spec:
+  type: {{ .Values.searxng.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.searxng.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+{{- end }}

--- a/charts/odysseus/templates/secret.yaml
+++ b/charts/odysseus/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.secretEnv.create (not .Values.secretEnv.existingSecret) .Values.secretEnv.values -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "odysseus.secretName" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secretEnv.values }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/odysseus/templates/service.yaml
+++ b/charts/odysseus/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "odysseus.fullname" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus

--- a/charts/odysseus/templates/serviceaccount.yaml
+++ b/charts/odysseus/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "odysseus.serviceAccountName" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/odysseus/values.yaml
+++ b/charts/odysseus/values.yaml
@@ -1,0 +1,167 @@
+replicaCount: 1
+
+image:
+  repository: odysseus
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 7000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: odysseus.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+env:
+  AUTH_ENABLED: "true"
+  LOCALHOST_BYPASS: "false"
+  DATABASE_URL: "sqlite:////app/data/app.db"
+  LLM_HOST: "localhost"
+  ODYSSEUS_INPROCESS_POLLERS: "1"
+  ODYSSEUS_INPROCESS_TASKS: "1"
+
+extraEnv: []
+extraEnvFrom: []
+
+secretEnv:
+  create: true
+  values: {}
+  existingSecret: ""
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  annotations: {}
+  existingClaim: ""
+
+volumeMounts:
+  data:
+    mountPath: /app/data
+    subPath: data
+  logs:
+    mountPath: /app/logs
+    subPath: logs
+  ssh:
+    mountPath: /app/.ssh
+    subPath: ssh
+  huggingface:
+    mountPath: /app/.cache/huggingface
+    subPath: huggingface
+  local:
+    mountPath: /app/.local
+    subPath: local
+
+setup:
+  enabled: true
+  command:
+    - python
+    - setup.py
+  env:
+    ODYSSEUS_SKIP_RUN_HINT: "1"
+
+odysseus:
+  command: []
+  args: []
+
+chromadb:
+  enabled: true
+  image:
+    repository: docker.io/chromadb/chroma
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8000
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+    annotations: {}
+    existingClaim: ""
+  resources: {}
+  env:
+    ANONYMIZED_TELEMETRY: "FALSE"
+
+searxng:
+  enabled: true
+  image:
+    repository: docker.io/searxng/searxng
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8080
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    annotations: {}
+    existingClaim: ""
+  resources: {}
+  secret:
+    create: true
+    key: ""
+    existingSecret: ""
+    existingSecretKey: secret-key
+  settings:
+    useDefaultSettings: true
+    formats:
+      - html
+      - json
+
+ntfy:
+  enabled: false
+  image:
+    repository: docker.io/binwiederhier/ntfy
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+  baseUrl: "http://odysseus-ntfy"
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    annotations: {}
+    existingClaim: ""
+  resources: {}


### PR DESCRIPTION
## Summary

This PR adds first-class Kubernetes deployment support for Odysseus and a GitHub Actions workflow for publishing deployable container images.

## Changes

- Add a Helm chart under `charts/odysseus`
- Add Kubernetes manifests for:
  - Odysseus Deployment, Service, Ingress, ServiceAccount, Secret, and PVC
  - Optional bundled ChromaDB
  - Optional bundled SearXNG
  - Optional bundled ntfy
- Run first-time setup with an init container using `uv run setup.py`
- Persist Odysseus runtime data, logs, SSH keys, Hugging Face cache, and local Cookbook installs with PVC subpaths
- Add chart documentation and root README install notes
- Add GitHub Actions workflow to build and push container images to GHCR
- Publish `latest` from `main`
- Publish tagged images whenever a Git tag is pushed

## Justification

Odysseus already has a Docker-first deployment model, but Kubernetes users still need to hand-roll deployments, persistent volumes, service wiring, and first-run setup. This chart gives operators a repeatable deployment path that matches the existing Compose architecture while exposing the important runtime knobs through `values.yaml`.

The setup init container is especially useful because Odysseus needs first-run initialization before the web process starts. Encoding that in the chart avoids manual pod exec steps and makes fresh installs more reliable.

The bundled ChromaDB and SearXNG options make the chart useful out of the box, while still allowing production installs to disable those services and point at external infrastructure. Persistence is enabled by default so app state, uploads, generated data, SSH identity, model cache, and local Cookbook installs survive pod recreation.

The image publishing workflow completes the deployment story: users should not have to clone the repo and build their own image just to install the chart. Publishing `latest` from `main` supports quick self-hosted installs, while tag-based images provide stable references for release-oriented deployments.
