### PR TITLE
ci: publish prebuilt Docker images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ build/
 /data/
 /logs/
 .git/
+.github/
 .claude/
 .playwright-mcp/
 .pytest_cache/

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Change this if another local service already uses 7000 (macOS AirPlay often does).
 # APP_PORT=7000
 
+# Prebuilt Docker image tag used by docker-compose.prebuilt.yml.
+# Use latest, main, sha-<short>, or a release tag like v1.2.3.
+# ODYSSEUS_IMAGE_TAG=latest
+
 # Development-only auth bypass for loopback requests.
 # Keep false for Docker, LAN, reverse proxy, and any shared deployment.
 # LOCALHOST_BYPASS=false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,14 +3,10 @@ name: Docker image
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "Dockerfile"
-      - "requirements*.txt"
-      - ".dockerignore"
-      - "docker/**"
-      - "docker-compose*.yml"
-      - "config/searxng/**"
-      - ".github/workflows/docker-publish.yml"
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "dev-docs/**"
   push:
     branches: [main]
     tags: ["v*"]
@@ -47,6 +43,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.0.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -61,9 +60,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false
-          load: true
           tags: odysseus:ci
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
@@ -75,13 +73,17 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
-      attestations: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Validate Compose files
+        run: |
+          cp .env.example .env
+          docker compose config --quiet
+          docker compose -f docker-compose.prebuilt.yml config --quiet
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.0.0
@@ -101,9 +103,11 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
+            type=raw,value=main,enable={{is_default_branch}}
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,130 @@
+name: Docker image
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "requirements*.txt"
+      - ".dockerignore"
+      - "docker/**"
+      - "docker-compose*.yml"
+      - "config/searxng/**"
+      - ".github/workflows/docker-publish.yml"
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "dev-docs/**"
+  workflow_dispatch:
+  schedule:
+    # Rebuild weekly so the moving tags pick up python:3.12-slim security updates.
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build image
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Validate Compose files
+        run: |
+          cp .env.example .env
+          docker compose config --quiet
+          docker compose -f docker-compose.prebuilt.yml config --quiet
+
+      - name: Build image without pushing
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: odysseus:ci
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+  publish:
+    name: Publish image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name != 'schedule' }}
+
+      - name: Build and publish image
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          sbom: true
+          provenance: true
+
+      - name: Print image digest
+        run: |
+          echo "Published ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Use the prebuilt image for the quickest startup:
 ```bash
 git clone https://github.com/pewdiepie-archdaemon/odysseus.git
 cd odysseus
-cp .env.example .env       # optional, but recommended for explicit defaults
+cp .env.example .env       # required; edit for deployment-level overrides
 docker compose -f docker-compose.prebuilt.yml up -d
 ```
 
 The prebuilt image is published to `ghcr.io/pewdiepie-archdaemon/odysseus`
 for `linux/amd64` and `linux/arm64`. It defaults to `:latest`; set
-`ODYSSEUS_IMAGE_TAG=v1.2.3` in `.env` to pin a release tag, or use a `sha-*`
-tag for an immutable build. Update with:
+`ODYSSEUS_IMAGE_TAG=v1.2.3` in `.env` to pin a release tag, use a `sha-*`
+tag for a commit-specific build, or pin by digest for immutability. Update with:
 
 ```bash
 docker compose -f docker-compose.prebuilt.yml pull

--- a/README.md
+++ b/README.md
@@ -55,12 +55,33 @@ Contributing? See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and
 pull request guidelines.
 
 ### Docker (recommended)
+
+Use the prebuilt image for the quickest startup:
+
 ```bash
 git clone https://github.com/pewdiepie-archdaemon/odysseus.git
 cd odysseus
 cp .env.example .env       # optional, but recommended for explicit defaults
+docker compose -f docker-compose.prebuilt.yml up -d
+```
+
+The prebuilt image is published to `ghcr.io/pewdiepie-archdaemon/odysseus`
+for `linux/amd64` and `linux/arm64`. It defaults to `:latest`; set
+`ODYSSEUS_IMAGE_TAG=v1.2.3` in `.env` to pin a release tag, or use a `sha-*`
+tag for an immutable build. Update with:
+
+```bash
+docker compose -f docker-compose.prebuilt.yml pull
+docker compose -f docker-compose.prebuilt.yml up -d
+```
+
+If you are contributing or want to build locally instead, use the source build
+compose file:
+
+```bash
 docker compose up -d --build
 ```
+
 Open `http://localhost:7000` when the containers are healthy. Docker Compose
 binds the web UI to `127.0.0.1` by default. If the port is taken, set
 `APP_PORT=7001` in `.env` and recreate the container. Set `APP_BIND=0.0.0.0`

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,0 +1,104 @@
+# End-user compose that runs Odysseus from the prebuilt GHCR image instead of
+# building it locally. Keep this file in sync with docker-compose.yml; only the
+# odysseus image source intentionally differs.
+services:
+  odysseus:
+    image: ghcr.io/pewdiepie-archdaemon/odysseus:${ODYSSEUS_IMAGE_TAG:-latest}
+    ports:
+      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+      # Cookbook remote-server SSH identity. Odysseus can generate a key here;
+      # add the shown public key to each remote server's authorized_keys.
+      - ./data/ssh:/app/.ssh
+      # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
+      # container, so persist its HuggingFace cache under ./data/huggingface.
+      - ./data/huggingface:/app/.cache/huggingface
+      # Cookbook-installed Python CLIs/packages (vLLM, llama-cpp-python, etc.)
+      # land under /app/.local for the odysseus user. Persist them so a
+      # container recreate does not silently remove installed serve engines.
+      - ./data/local:/app/.local
+    extra_hosts:
+      # Lets the container reach local services on the Docker host, including
+      # Ollama at http://host.docker.internal:11434.
+      - "host.docker.internal:host-gateway"
+    env_file:
+      - .env
+    environment:
+      - SEARXNG_INSTANCE=http://searxng:8080
+      - CHROMADB_HOST=chromadb
+      - CHROMADB_PORT=8000
+      # PUID / PGID — the user/group the container drops to before
+      # running uvicorn (entrypoint also chowns /app/data + /app/logs
+      # to match, so bind-mounted files stay editable from the host).
+      # 1000 is the default first user on most Linux installs. If your
+      # host user has a different id, override here or via .env, e.g.:
+      #   PUID=1001
+      #   PGID=1001
+      # Find yours with:  id -u  /  id -g
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+    depends_on:
+      searxng:
+        condition: service_healthy
+      chromadb:
+        condition: service_started
+    restart: unless-stopped
+
+  chromadb:
+    image: docker.io/chromadb/chroma:latest
+    ports:
+      - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
+    volumes:
+      - chromadb-data:/chroma/chroma
+    environment:
+      - ANONYMIZED_TELEMETRY=FALSE
+    restart: unless-stopped
+
+  searxng:
+    image: docker.io/searxng/searxng:latest
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        if [ ! -s /etc/searxng/settings.yml ] || grep -q 'odysseus-local-searxng-json-2026-05-30\|__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
+          secret="$${SEARXNG_SECRET:-}"
+          if [ -z "$$secret" ]; then
+            secret="$$(python -c 'import secrets; print(secrets.token_urlsafe(48))')"
+          fi
+          sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
+        fi
+        exec /usr/local/searxng/entrypoint.sh
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - searxng-data:/etc/searxng
+      - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro
+    environment:
+      - SEARXNG_BASE_URL=http://localhost:8080/
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-}
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
+      interval: 5s
+      timeout: 6s
+      retries: 20
+      start_period: 10s
+    restart: unless-stopped
+
+  ntfy:
+    image: docker.io/binwiederhier/ntfy
+    command: serve
+    ports:
+      - "${NTFY_BIND:-127.0.0.1}:8091:80"
+    volumes:
+      - ntfy-cache:/var/cache/ntfy
+    environment:
+      - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+    restart: unless-stopped
+
+volumes:
+  searxng-data:
+  chromadb-data:
+  ntfy-cache:


### PR DESCRIPTION
## Why

Give users a no-build Docker path so Odysseus can be deployed from a published image instead of rebuilding locally every install/update. Hosted images also make it possible for home server platforms such as Umbrel to distribute Odysseus through app stores like the [Umbrel App Store](https://github.com/getumbrel/umbrel-apps), where users expect install/update flows to pull published images.

This is a separate PR from #165 because it takes a more conservative path based on the review feedback there: the existing source-build `docker-compose.yml` stays unchanged, the prebuilt path is opt-in, Actions permissions are least-privilege, actions are pinned to SHAs, CI validates both Compose files, and the image publishes for both `linux/amd64` and `linux/arm64`.

## How

- Adds a GitHub Actions workflow that validates PR builds and publishes multi-arch `linux/amd64` + `linux/arm64` images to GHCR from `main`, tags, manual runs, and weekly rebuilds.
- Adds `docker-compose.prebuilt.yml` for the prebuilt image path while leaving the existing source-build `docker-compose.yml` unchanged.
- Documents the prebuilt quickstart, image tags, and update flow.

## Tested

- Fork PR merged and publish workflow completed successfully: https://github.com/aidencole98/odysseus/actions/runs/26774157036
- Verified GHCR package, tags, digest, and `linux/amd64` + `linux/arm64` manifest.
- Verified Compose config for both source-build and prebuilt compose files.

Resolves #136

