### PR TITLE
Add Codex OAuth provider with Agent mode tool support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,13 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Do not commit a real password.
 # ODYSSEUS_ADMIN_PASSWORD=change_me_before_first_boot
 
+# Codex / ChatGPT device-code auth.
+# Requires the official Codex CLI (`npm install -g @openai/codex` or equivalent).
+# Odysseus delegates token storage to Codex and never stores ~/.codex/auth.json.
+# CODEX_BIN=codex
+# CODEX_HOME=~/.codex
+# ODYSSEUS_CODEX_AUTH_ENABLED=true
+
 # CORS allowed origins (default: localhost-only; restrict to your public origin in production)
 # ALLOWED_ORIGINS=http://localhost:7000,http://localhost:8000
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,13 @@ dev-docs/
 # Windows-port working docs (local only, not for public repo)
 docs/windows-port/
 
+# Local Codex CLI installs and credential homes
+codex-bin/
+codex-home/
+.codex/
+**/.codex/
+**/codex-home/
+
 # Local config
 compound.config.json
 *.error.log

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Key settings:
 | `LLM_HOST` | `localhost` | Your LLM server (e.g. `llm-host.local:8000`) |
 | `LLM_HOSTS` | -- | Comma-separated list for model discovery |
 | `OPENAI_API_KEY` | -- | Optional OpenAI key. Prefer adding providers in the app unless pre-seeding. |
+| `CODEX_BIN` | `codex` | Optional path/name for the official Codex CLI used by Settings -> Integrations -> Codex / ChatGPT sign-in. |
+| `CODEX_HOME` | Codex default | Optional Codex credential/config home. If unset, the Codex CLI uses its own default, normally `~/.codex`. |
+| `ODYSSEUS_CODEX_AUTH_ENABLED` | `true` | Enables the admin-gated Codex / ChatGPT device-code auth UI. Set to `false` to hide/disable the flow. |
 | `SEARXNG_INSTANCE` | `http://localhost:8080` | SearXNG URL. Docker overrides this to `http://searxng:8080`. |
 | `SEARXNG_SECRET` | generated on first Docker boot | Optional SearXNG cookie/CSRF secret. Leave blank unless you need to pin it. |
 | `AUTH_ENABLED` | `true` | Enable/disable login |
@@ -247,6 +250,25 @@ npx -y @playwright/mcp@latest --version
 ```
 
 That installs `@playwright/mcp` plus Playwright (~300MB total). Restart Odysseus and the server will register at startup.
+
+### Codex / ChatGPT Sign-In
+Admins can link the Odysseus host to Codex from **Settings -> Integrations -> Codex / ChatGPT**. Odysseus starts the official Codex CLI device-code flow, equivalent to:
+
+```bash
+codex login --device-auth
+```
+
+The UI shows the verification URL and one-time device code, polls the CLI process for completion, and then uses `codex login status` / `codex logout` for status checks and unlinking. Install the Codex CLI first (`npm install -g @openai/codex`, or the current official install method), and set `CODEX_BIN` only if `codex` is not on the service user's `PATH`.
+
+Security notes:
+
+- Odysseus does not read, copy, or store Codex access or refresh tokens. Credential storage stays with Codex, normally under `~/.codex`.
+- Treat `~/.codex/auth.json`, any custom `CODEX_HOME`, and Codex login logs as secrets. Do not commit or upload them.
+- The Codex sign-in routes are admin-gated because logout/unlink affects the Codex identity available to the Odysseus host.
+- If you run Odysseus in Docker, mount a persistent, private Codex home and set strict host permissions, or sign-in state will be lost when the container is recreated.
+- Device-code auth can be disabled by a ChatGPT workspace admin. In that case the UI reports the Codex CLI failure and you must use a supported Codex login method outside Odysseus.
+
+MCP is not used for this authentication path. Odysseus MCP settings manage tool servers and are admin-only command execution plumbing; Codex account login belongs with provider/integration setup and should remain isolated from MCP server registration.
 
 ## Architecture
 ```

--- a/app.py
+++ b/app.py
@@ -619,6 +619,9 @@ app.include_router(setup_font_routes())
 from routes.codex_auth_routes import setup_codex_auth_routes
 app.include_router(setup_codex_auth_routes())
 
+from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+app.include_router(setup_codex_model_provider_routes())
+
 
 # MCP (Model Context Protocol)
 from src.mcp_manager import McpManager

--- a/app.py
+++ b/app.py
@@ -616,6 +616,9 @@ app.include_router(setup_backup_routes(memory_manager, preset_manager, skills_ma
 from routes.font_routes import setup_font_routes
 app.include_router(setup_font_routes())
 
+from routes.codex_auth_routes import setup_codex_auth_routes
+app.include_router(setup_codex_auth_routes())
+
 
 # MCP (Model Context Protocol)
 from src.mcp_manager import McpManager

--- a/docs/codex_model_provider_design.md
+++ b/docs/codex_model_provider_design.md
@@ -1,0 +1,179 @@
+# Codex Model Provider Draft
+
+Status: research/prototype only. Not ready for PR.
+
+This branch intentionally keeps Codex model/provider work separate from the
+Codex / ChatGPT device-code authentication branch. The auth branch should stay
+focused on sign-in and sign-out. Model picker, chat, and agent integration need
+their own design because a naive `codex exec --json` provider would not match
+Odysseus' streaming, session, or tool-round contracts.
+
+## Current Model Architecture
+
+Odysseus model selection is built around admin-configured `ModelEndpoint` rows.
+The table shape in `core/database.py` is:
+
+- `id`: endpoint identifier used by settings, sessions, and picker payloads.
+- `name`: display label.
+- `base_url`: provider base URL such as `http://localhost:8002/v1` or
+  `https://openrouter.ai/api/v1`.
+- `api_key`: encrypted optional provider API key.
+- `is_enabled`: endpoint visibility switch.
+- `hidden_models`: JSON list of model ids hidden after probe failures.
+- `cached_models`: JSON list of last discovered model ids.
+- `model_type`: `llm` or `image`.
+- `supports_tools`: nullable function-calling capability override.
+- `owner`: optional user scoping; admins see all endpoints.
+
+`routes/model_routes.py` owns the API surface:
+
+- `/api/model-endpoints`: admin CRUD over `ModelEndpoint` rows.
+- `/api/model-endpoints/test`: one-off model-list/ping validation.
+- `/api/model-endpoints/{id}/probe`: SSE probe over chat-capable models.
+- `/api/model-endpoints/{id}/models`: model visibility management.
+- `/api/models`: user-scoped model picker payload. It emits endpoint-shaped
+  items with `url`, `models`, `models_extra`, `endpoint_id`, `endpoint_name`,
+  `category`, `model_type`, and `offline`.
+- `/api/default-chat`: resolves the default chat endpoint/model with per-user
+  scoping and fallback settings.
+
+Provider detection is URL based. `src/llm_core.py` and
+`src/endpoint_resolver.py` infer OpenAI-compatible, Anthropic, OpenRouter,
+Groq, and Ollama behavior from the endpoint URL. HTTP calls are then built as:
+
+- OpenAI-compatible: `{base}/chat/completions`, SSE deltas from
+  `choices[0].delta.content`, accumulated `tool_calls`, optional usage chunks.
+- Anthropic: native `/v1/messages`, translated message/tool schema, native
+  SSE event parsing.
+- Ollama: native `/api/chat`, newline JSON streaming, native tool call
+  accumulation.
+
+The selected model path is:
+
+1. Settings/admin UI creates or updates a `ModelEndpoint`.
+2. `/api/models` returns visible endpoint items.
+3. `static/js/models.js` and `static/js/modelPicker.js` render rows and store
+   `endpoint_url`, `model`, and `endpoint_id` on a session.
+4. `routes/chat_routes.py` receives `/api/chat` or `/api/chat_stream`.
+5. `routes/chat_helpers.py` prepares context, validates privileges, and
+   normalizes model ids.
+6. Plain chat calls `stream_llm_with_fallback`.
+7. Agent mode calls `stream_agent_loop`, which wraps `stream_llm_with_fallback`
+   across multiple tool rounds.
+
+Fallbacks are configured as endpoint/model pairs in settings. The resolver
+turns them into `(chat_url, model, headers)` tuples. Streaming fallback only
+switches before any real content is emitted, so duplicate partial answers are
+avoided.
+
+## Codex CLI Findings
+
+The requested help probes were attempted:
+
+- `codex --help`
+- `codex login status`
+- `codex exec --help`
+
+On this Windows host, `codex.exe` resolves to:
+
+`C:\Program Files\WindowsApps\OpenAI.Codex_26.527.3686.0_x64__2p2nqsd0c76g0\app\resources\codex.exe`
+
+All three commands failed before producing help text with PowerShell reporting
+`Access is denied`. That means this runtime cannot validate `codex exec`
+capabilities directly. The branch must not depend on undocumented behavior from
+this CLI install.
+
+Reliable enough today:
+
+- Existing `src/codex_auth.py` can report CLI presence, executable status, and
+  `codex login status` output when the binary is executable.
+- Auth status does not read, parse, store, log, or expose raw Codex tokens.
+- The integration can safely build capability/status reporting around the auth
+  service.
+
+Not reliable enough today:
+
+- JSON event shape from `codex exec`.
+- Whether true token deltas exist.
+- Session/resume identity and lifecycle.
+- Tool execution controls suitable for a chat-provider mode.
+- Docker runtime behavior, because the current host binary is inaccessible and
+  the project should not bundle the CLI in this branch.
+
+## Proposed Integration
+
+Do not add Codex as a normal `ModelEndpoint` yet. The current endpoint schema is
+URL/API-key oriented and does not have a clean auth mode field such as
+`auth_type = api_key | codex_cli`. Overloading `base_url` with a fake URL would
+make picker selection look like a normal provider while chat routing still has
+different semantics.
+
+Instead, stage the work:
+
+1. Keep Codex sign-in in Settings -> Integrations.
+2. Add a feature-flagged internal Codex model-provider capability probe:
+   `ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=false` by default.
+3. Report a synthetic model only when the feature flag is enabled, the CLI is
+   available, and Codex auth status is authenticated.
+4. Mark chat support, token streaming, session resume, and tool execution as
+   unsupported until each has a concrete implementation and tests.
+5. Only later add schema support for a provider auth type or a first-class
+   non-HTTP provider registry.
+6. Only after that expose Add Models / model picker UI, with clear experimental
+   copy and sign-in-required state.
+
+The Add Models UI should link to the existing Integrations Codex form instead
+of duplicating auth implementation. The sign-in state is host-wide and
+admin-gated, so a second auth card in Add Models would increase security and UX
+surface area without adding capability.
+
+## Hook Points
+
+Minimum clean hook points:
+
+- `src/codex_auth.py`: source of truth for CLI availability and auth state.
+- A new internal provider module for feature flag, capability shape, and
+  eventual adapter boundary.
+- A new admin-gated status route, separate from `/api/models`, until chat
+  behavior is ready.
+
+Future hook points after adapter design:
+
+- Provider registry used by `/api/models`, returning endpoint-shaped entries
+  with explicit metadata such as `experimental`, `requires_sign_in`, and
+  `streaming_supported`.
+- `src/llm_core.py` or a sibling dispatch layer that routes non-HTTP providers
+  without pretending they are OpenAI-compatible URLs.
+- `routes/chat_routes.py` plain-chat branch only after session/resume and
+  streaming semantics are explicit.
+- Agent mode only after tool execution is intentionally disabled or mapped to
+  Odysseus agent rounds.
+
+## Test Plan
+
+Current stage:
+
+- Feature flag disabled returns no synthetic models.
+- Feature flag enabled but unauthenticated returns sign-in-required.
+- Feature flag enabled and authenticated returns a clearly experimental model.
+- Capability responses expose no token fields.
+- CLI unavailable state is reported clearly.
+- Existing Codex auth tests continue passing.
+- Existing model route tests continue passing.
+
+Deferred before PR:
+
+- Mocked Codex CLI adapter success/failure/timeout behavior.
+- No fake token streaming.
+- Session/resume behavior.
+- Explicit tool execution isolation.
+- UI gated behind feature flag.
+- Docker validation with sign-in, model selection, chat call, logout, and
+  failure states.
+
+## Readiness
+
+Not ready for PR. This branch can document the architecture and carry a small
+internal capability probe. It should not claim full Codex-backed chat/provider
+support until streaming, session/resume, tool isolation, and Docker behavior are
+implemented and validated end to end.

--- a/docs/codex_model_provider_docker_validation.md
+++ b/docs/codex_model_provider_docker_validation.md
@@ -30,7 +30,9 @@ The script validates:
 - feature flag enabled plus logged-out Codex returns `status=sign_in_required`
 - feature flag enabled plus logged-in Codex returns `status=available`
 - the synthetic model id is `codex-cli/chatgpt-experimental`
-- chat, streaming, session resume, and tool execution support remain false
+- `POST /api/codex-model-provider/test-chat` returns a completed assistant message
+- status reports chat support only when the adapter passes safety preflight
+- streaming, session resume, and tool execution support remain false
 - response bodies do not include token-like fields such as access or refresh tokens
 - logout returns the provider status to `sign_in_required`
 

--- a/docs/codex_model_provider_docker_validation.md
+++ b/docs/codex_model_provider_docker_validation.md
@@ -1,0 +1,43 @@
+# Codex Model Provider Docker Validation
+
+This validates the experimental status probe in the real Docker deployment
+without exposing Codex in the model picker and without adding a `codex exec`
+chat adapter.
+
+Run on the Proxmox/Docker host:
+
+```bash
+cd /opt/odysseus
+git fetch fork codex-model-provider-draft
+git switch codex-model-provider-draft
+git pull --ff-only fork codex-model-provider-draft
+
+ODYSSEUS_ADMIN_USER=admin \
+ODYSSEUS_ADMIN_PASSWORD='your-admin-password' \
+scripts/validate_codex_model_provider_docker.sh
+```
+
+If the admin account uses TOTP, add:
+
+```bash
+ODYSSEUS_ADMIN_TOTP=123456
+```
+
+The script validates:
+
+- unauthenticated access to `/api/codex-model-provider/status` is rejected
+- feature flag disabled returns `status=disabled`
+- feature flag enabled plus logged-out Codex returns `status=sign_in_required`
+- feature flag enabled plus logged-in Codex returns `status=available`
+- the synthetic model id is `codex-cli/chatgpt-experimental`
+- chat, streaming, session resume, and tool execution support remain false
+- response bodies do not include token-like fields such as access or refresh tokens
+- logout returns the provider status to `sign_in_required`
+
+The script temporarily edits the deployment `.env` file to toggle
+`ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED`, recreates only the `odysseus` service,
+restores `.env` before exit, and removes its temporary `.env` backup. It does
+not modify Dockerfile or Compose files.
+
+It intentionally logs Codex out during validation. That is part of the requested
+state coverage and cannot be undone without signing in again.

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -434,10 +434,17 @@ async def build_chat_context(
     for transcript in preprocessed.youtube_transcripts:
         preface.append(untrusted_context_message("youtube transcript", transcript))
 
-    # Normalize model ID
-    norm = normalize_model_id(sess.endpoint_url, sess.model)
-    if norm:
-        sess.model = norm
+    # Normalize model ID. Virtual providers such as Codex CLI are not
+    # OpenAI-compatible HTTP endpoints, so never probe /models for them.
+    try:
+        from src.codex_model_provider import is_codex_provider_selection
+        _virtual_provider = is_codex_provider_selection(sess.endpoint_url, sess.model)
+    except Exception:
+        _virtual_provider = False
+    if not _virtual_provider:
+        norm = normalize_model_id(sess.endpoint_url, sess.model)
+        if norm:
+            sess.model = norm
 
     # Build messages
     messages = preface + sess.get_context_messages()

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -36,6 +36,11 @@ from routes.chat_helpers import (
     _enforce_chat_privileges,
 )
 from src.action_intents import message_needs_tools as _message_needs_tools
+from src.codex_model_provider import (
+    codex_complete_chat,
+    is_codex_provider_selection,
+    stream_codex_chat,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +77,8 @@ def _session_url_matches_endpoint(session_url: str, endpoint_base: str) -> bool:
 def _clear_orphaned_session_endpoint(sess) -> bool:
     """Clear a session model if its endpoint was deleted from ModelEndpoint."""
     if not getattr(sess, "endpoint_url", ""):
+        return False
+    if is_codex_provider_selection(sess.endpoint_url, getattr(sess, "model", "")):
         return False
     db = SessionLocal()
     try:
@@ -133,6 +140,8 @@ def setup_chat_routes(
         if _clear_orphaned_session_endpoint(sess):
             raise HTTPException(400, "Selected model endpoint was removed. Pick another model in Settings.")
 
+        is_codex_session = is_codex_provider_selection(sess.endpoint_url, sess.model)
+
         # Same allowed_models + daily-cap gate as chat_stream (mirror so the
         # non-streaming path can't be used to bypass).
         _enforce_chat_privileges(request, sess)
@@ -168,15 +177,21 @@ def setup_chat_routes(
             except Exception as e:
                 logger.error(f"Research failed: {e}")
 
-        reply = await llm_call_async(
-            sess.endpoint_url,
-            sess.model,
-            ctx.messages,
-            headers=sess.headers,
-            temperature=ctx.preset.temperature,
-            max_tokens=ctx.preset.max_tokens,
-            prompt_type=preset_id,
-        )
+        if is_codex_session:
+            result = await codex_complete_chat(ctx.messages, model=sess.model)
+            if not result.get("ok"):
+                raise HTTPException(502, result.get("error") or result.get("status") or "Codex provider failed")
+            reply = result.get("message") or ""
+        else:
+            reply = await llm_call_async(
+                sess.endpoint_url,
+                sess.model,
+                ctx.messages,
+                headers=sess.headers,
+                temperature=ctx.preset.temperature,
+                max_tokens=ctx.preset.max_tokens,
+                prompt_type=preset_id,
+            )
         _clean_reply, _clean_md = clean_thinking_for_save(reply, {"model": sess.model})
         sess.add_message(ChatMessage("assistant", _clean_reply, metadata=_clean_md))
 
@@ -289,6 +304,7 @@ def setup_chat_routes(
 
         # Ensure session has auth headers
         resolve_session_auth(sess, session)
+        is_codex_session = is_codex_provider_selection(sess.endpoint_url, sess.model)
 
         # Check for research_pending BEFORE mode persist overwrites it
         do_research = str(use_research).lower() == "true"
@@ -630,6 +646,45 @@ def setup_chat_routes(
             if ctx.preset.character_name:
                 _model_info["character_name"] = ctx.preset.character_name
             yield f'data: {json.dumps(_model_info)}\n\n'
+
+            if is_codex_session and _effective_mode == "chat":
+                try:
+                    async for chunk in stream_codex_chat(messages, model=sess.model):
+                        if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
+                            try:
+                                data = json.loads(chunk[6:])
+                                if "delta" in data:
+                                    full_response += data["delta"]
+                                    _stream_set(session, partial=full_response)
+                                elif data.get("type") == "metrics":
+                                    last_metrics = data.get("data", {})
+                            except json.JSONDecodeError:
+                                pass
+                        yield chunk
+                    if full_response:
+                        _saved_id = save_assistant_response(
+                            sess, session_manager, session, full_response, last_metrics,
+                            character_name=ctx.preset.character_name,
+                            web_sources=web_sources,
+                            rag_sources=ctx.rag_sources,
+                            research_sources=research_sources,
+                            used_memories=ctx.used_memories,
+                            do_research=do_research,
+                            incognito=incognito,
+                        )
+                        if _saved_id:
+                            yield f'data: {json.dumps({"type": "message_saved", "id": _saved_id})}\n\n'
+                        run_post_response_tasks(
+                            sess, session_manager, session, message, full_response,
+                            last_metrics, ctx.uprefs, memory_manager, memory_vector, webhook_manager,
+                            incognito=incognito, compare_mode=compare_mode,
+                            character_name=ctx.preset.character_name,
+                            owner=_user,
+                        )
+                    _stream_set(session, status="done")
+                finally:
+                    _active_streams.pop(session, None)
+                return
 
             # Detect image models and route directly to image generation
             _IMAGE_MODEL_PREFIXES = ("gpt-image", "dall-e", "chatgpt-image")

--- a/routes/codex_auth_routes.py
+++ b/routes/codex_auth_routes.py
@@ -1,0 +1,37 @@
+"""Admin-gated Codex / ChatGPT device-code auth routes."""
+
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+from src.codex_auth import get_codex_auth_service
+
+
+def setup_codex_auth_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/codex-auth", tags=["codex-auth"])
+
+    @router.get("/status")
+    async def status(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().status()
+
+    @router.post("/start")
+    async def start(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().start()
+
+    @router.post("/cancel")
+    async def cancel(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().cancel()
+
+    @router.post("/logout")
+    async def logout(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().logout()
+
+    @router.post("/test")
+    async def test(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().test()
+
+    return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,9 +1,18 @@
 """Admin-gated experimental Codex model-provider routes."""
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
+from typing import Any
 
 from core.middleware import require_admin
 from src.codex_model_provider import CodexModelProvider
+
+
+class CodexTestChatRequest(BaseModel):
+    prompt: str | None = None
+    messages: list[dict[str, Any]] | None = None
+    model: str | None = None
+    timeout_seconds: int | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -14,5 +23,23 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
     async def status(request: Request):
         require_admin(request)
         return await provider.status()
+
+    @router.post("/test-chat")
+    async def test_chat(request: Request, body: CodexTestChatRequest):
+        require_admin(request)
+        messages = body.messages or []
+        if not messages and body.prompt:
+            messages = [{"role": "user", "content": body.prompt}]
+        if not messages:
+            return {
+                "ok": False,
+                "status": "invalid_request",
+                "error": "Provide either prompt or messages",
+            }
+        return await provider.test_chat(
+            messages,
+            model=body.model,
+            timeout_seconds=body.timeout_seconds or 120,
+        )
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,17 +1,25 @@
 """Admin-gated experimental Codex model-provider routes."""
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from typing import Any
 
 from core.middleware import require_admin
-from src.codex_model_provider import CodexModelProvider
+from src.auth_helpers import get_current_user
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_MODEL_ID,
+    CODEX_PROVIDER_ENDPOINT_ID,
+    CODEX_PROVIDER_ENDPOINT_NAME,
+    CODEX_PROVIDER_ENDPOINT_URL,
+    CodexModelProvider,
+)
 
 
 class CodexTestChatRequest(BaseModel):
     prompt: str | None = None
     messages: list[dict[str, Any]] | None = None
     model: str | None = None
+    models: list[str] | None = None
     timeout_seconds: int | None = None
 
 
@@ -23,6 +31,90 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
     async def status(request: Request):
         require_admin(request)
         return await provider.status()
+
+
+    @router.post("/add-model")
+    async def add_model(request: Request, body: CodexTestChatRequest | None = None):
+        """Add selected Codex CLI models to the normal Added Models list.
+
+        Codex is backed by a virtual codex-cli:// endpoint, but we still store
+        a ModelEndpoint row so the existing Added Models UI, checkbox manager,
+        and session endpoint-id validation behave like Local/API providers.
+        """
+        require_admin(request)
+        owner = get_current_user(request)
+        status = await provider.status()
+        models = status.get("models") or []
+        model_ids = [m.get("id") if isinstance(m, dict) else str(m) for m in models]
+        model_ids = [m for m in model_ids if m]
+        if status.get("status") != "available" or not status.get("chat_supported") or not model_ids:
+            raise HTTPException(400, status.get("message") or "Codex is not available. Sign in with Codex first.")
+
+        requested = []
+        if body:
+            if body.models:
+                requested.extend(str(m).strip() for m in body.models if str(m).strip())
+            elif body.model:
+                requested.append(body.model.strip())
+        selected = [m for m in requested if m in model_ids]
+        if not selected:
+            selected = [model_ids[0]]
+
+        # Preserve Codex CLI order, not checkbox click/order quirks.
+        selected_set = set(selected)
+        selected = [m for m in model_ids if m in selected_set]
+        hidden = [m for m in model_ids if m not in selected_set]
+        default_model = selected[0]
+
+        import json
+        from core.database import ModelEndpoint, SessionLocal
+        from routes.model_routes import _load_settings, _save_settings
+
+        db = SessionLocal()
+        try:
+            ep = db.query(ModelEndpoint).filter(ModelEndpoint.id == CODEX_PROVIDER_ENDPOINT_ID).first()
+            if not ep:
+                ep = ModelEndpoint(
+                    id=CODEX_PROVIDER_ENDPOINT_ID,
+                    name=CODEX_PROVIDER_ENDPOINT_NAME,
+                    base_url=CODEX_PROVIDER_ENDPOINT_URL,
+                    api_key=None,
+                    is_enabled=True,
+                    model_type="llm",
+                    supports_tools=True,
+                    owner=owner,
+                )
+                db.add(ep)
+            ep.name = CODEX_PROVIDER_ENDPOINT_NAME
+            ep.base_url = CODEX_PROVIDER_ENDPOINT_URL
+            ep.api_key = None
+            ep.is_enabled = True
+            ep.model_type = "llm"
+            ep.supports_tools = True
+            ep.owner = owner
+            ep.cached_models = json.dumps(model_ids)
+            ep.hidden_models = json.dumps(hidden) if hidden else None
+            db.commit()
+        finally:
+            db.close()
+
+        settings = _load_settings()
+        settings["default_endpoint_id"] = CODEX_PROVIDER_ENDPOINT_ID
+        settings["default_model"] = default_model
+        _save_settings(settings)
+
+        endpoint = {
+            "id": CODEX_PROVIDER_ENDPOINT_ID,
+            "name": CODEX_PROVIDER_ENDPOINT_NAME,
+            "base_url": CODEX_PROVIDER_ENDPOINT_URL,
+            "models": selected,
+            "online": True,
+            "status": "online",
+            "is_enabled": True,
+            "model_type": "llm",
+            "virtual": True,
+        }
+        return {"ok": True, "endpoint": endpoint, "model": default_model, "models": selected}
 
     @router.post("/test-chat")
     async def test_chat(request: Request, body: CodexTestChatRequest):

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,0 +1,18 @@
+"""Admin-gated experimental Codex model-provider routes."""
+
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+from src.codex_model_provider import CodexModelProvider
+
+
+def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
+    router = APIRouter(prefix="/api/codex-model-provider", tags=["codex-model-provider"])
+    provider = provider or CodexModelProvider()
+
+    @router.get("/status")
+    async def status(request: Request):
+        require_admin(request)
+        return await provider.status()
+
+    return router

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -6,6 +6,8 @@ import json
 import time as _time
 import logging
 import httpx
+import asyncio
+import copy
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 from urllib.parse import urlparse
@@ -585,6 +587,61 @@ def setup_model_routes(model_discovery):
 
         return {"hosts": [], "items": items}
 
+    def _append_codex_model_item(result: Dict[str, Any], owner: str = "", is_admin: bool = False) -> Dict[str, Any]:
+        """Refresh visible Codex CLI provider data without widening access.
+
+        Codex OAuth is server-local. Only expose it in the normal model picker
+        after an authorized Add Models flow has created a visible ModelEndpoint
+        row for this caller. This preserves /api/models owner filtering and
+        avoids leaking the server's Codex OAuth to unrelated users.
+        """
+        out = copy.deepcopy(result or {"hosts": [], "items": []})
+        items = out.setdefault("items", [])
+        try:
+            from src.codex_model_provider import CODEX_PROVIDER_ENDPOINT_ID, codex_model_picker_item
+        except Exception as exc:
+            logger.debug("Codex model picker imports unavailable: %s", exc)
+            return out
+
+        codex_already_visible = any((i or {}).get("endpoint_id") == CODEX_PROVIDER_ENDPOINT_ID for i in items)
+        if not codex_already_visible:
+            db = SessionLocal()
+            try:
+                q = db.query(ModelEndpoint).filter(
+                    ModelEndpoint.id == CODEX_PROVIDER_ENDPOINT_ID,
+                    ModelEndpoint.is_enabled == True,
+                )
+                if owner and not is_admin:
+                    q = owner_filter(q, ModelEndpoint, owner)
+                codex_already_visible = q.first() is not None
+            except Exception as exc:
+                logger.debug("Codex endpoint visibility check failed: %s", exc)
+                codex_already_visible = False
+            finally:
+                db.close()
+        if not codex_already_visible:
+            return out
+
+        try:
+            item = asyncio.run(codex_model_picker_item())
+        except RuntimeError:
+            # Defensive fallback if this sync route is ever called from a thread
+            # with a running loop; fail closed rather than breaking /api/models.
+            item = None
+        except Exception as exc:
+            logger.debug("Codex model picker item unavailable: %s", exc)
+            item = None
+        if item:
+            for idx, existing in enumerate(items):
+                if (existing or {}).get("endpoint_id") == item["endpoint_id"] or (existing or {}).get("url") == item.get("url"):
+                    merged = dict(existing or {})
+                    merged.update(item)
+                    items[idx] = merged
+                    break
+            else:
+                items.append(item)
+        return out
+
     @router.get("/models")
     def api_models(request: Request, refresh: bool = False):
         """Get available models — per-user (caller sees only their endpoints +
@@ -621,12 +678,12 @@ def setup_model_routes(model_discovery):
         _cache_key = (owner, _is_admin)
         cache_entry = _models_cache.get(_cache_key)
         if not refresh and cache_entry is not None and (now - cache_entry["time"]) < _MODELS_CACHE_TTL:
-            return cache_entry["data"]
+            return _append_codex_model_item(cache_entry["data"], owner=owner, is_admin=_is_admin)
         result = _fetch_models(owner=owner, is_admin=_is_admin)
         _models_cache[_cache_key] = {"data": result, "time": now}
         # Kick off background refresh to update caches from live endpoints
         _refresh_caches_bg()
-        return result
+        return _append_codex_model_item(result, owner=owner, is_admin=_is_admin)
 
     # Brief cache for local-probe results so picker-open doesn't hammer
     # /v1/models every time. 8s TTL — long enough to amortize cost,
@@ -1270,6 +1327,21 @@ def setup_model_routes(model_discovery):
                     _last_q = owner_filter(_last_q, ModelEndpoint, _user, include_shared=False)
                 ep = _last_q.first()
             if not ep:
+                try:
+                    from src.codex_model_provider import (
+                        CODEX_EXPERIMENTAL_MODEL_ID,
+                        CODEX_PROVIDER_ENDPOINT_ID,
+                        CODEX_PROVIDER_ENDPOINT_URL,
+                        codex_model_picker_item,
+                    )
+                    if asyncio.run(codex_model_picker_item()):
+                        return {
+                            "endpoint_id": CODEX_PROVIDER_ENDPOINT_ID,
+                            "endpoint_url": CODEX_PROVIDER_ENDPOINT_URL,
+                            "model": CODEX_EXPERIMENTAL_MODEL_ID,
+                        }
+                except Exception:
+                    pass
                 return {"endpoint_id": "", "endpoint_url": "", "model": ""}
             base = _normalize_base(ep.base_url)
             chat_url = build_chat_url(base)

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -9,8 +9,8 @@ import logging
 from core.session_manager import SessionManager
 from core.models import ChatMessage
 from src.request_models import SessionResponse
-from core.database import Session as DbSession, SessionLocal, Document, GalleryImage
-from src.auth_helpers import get_current_user
+from core.database import Session as DbSession, SessionLocal, Document, GalleryImage, ModelEndpoint
+from src.auth_helpers import get_current_user, owner_filter
 
 
 def _verify_session_owner(request: Request, session_id: str):
@@ -171,6 +171,34 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         endpoint_id: str = Form(""),
     ):
         skip_val = str(skip_validation).lower() == "true"
+        try:
+            from src.codex_model_provider import CODEX_PROVIDER_ENDPOINT_ID, is_codex_provider_selection
+            if is_codex_provider_selection(endpoint_url, model):
+                user = get_current_user(request) or ""
+                is_admin = False
+                try:
+                    auth_mgr = getattr(request.app.state, "auth_manager", None)
+                    if user and auth_mgr is not None and getattr(auth_mgr, "is_admin", None):
+                        is_admin = bool(auth_mgr.is_admin(user))
+                except Exception:
+                    is_admin = False
+                db = SessionLocal()
+                try:
+                    q = db.query(ModelEndpoint).filter(
+                        ModelEndpoint.id == CODEX_PROVIDER_ENDPOINT_ID,
+                        ModelEndpoint.is_enabled == True,
+                    )
+                    if user and not is_admin:
+                        q = owner_filter(q, ModelEndpoint, user)
+                    if q.first() is None:
+                        raise HTTPException(403, "Codex model endpoint is not enabled for this user")
+                finally:
+                    db.close()
+                skip_val = True
+        except HTTPException:
+            raise
+        except Exception:
+            pass
 
         if not endpoint_url and not skip_val:
             raise HTTPException(400, "endpoint_url is required (choose from /api/models)")
@@ -229,7 +257,6 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         resolved_key = api_key.strip() if api_key else ""
         resolved_base = endpoint_url
         if not resolved_key and endpoint_id and endpoint_id.strip():
-            from core.database import ModelEndpoint
             _db = SessionLocal()
             try:
                 ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id.strip()).first()
@@ -285,10 +312,14 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                     result["folder"] = folder if folder else None
             finally:
                 db.close()
-        # Switch model/endpoint mid-session
+        _is_codex_patch = False
+        try:
+            from src.codex_model_provider import CODEX_PROVIDER_ENDPOINT_ID, is_codex_provider_selection
+            _is_codex_patch = endpoint_id == CODEX_PROVIDER_ENDPOINT_ID or is_codex_provider_selection(endpoint_url, model)
+        except Exception:
+            _is_codex_patch = False
         if model is not None and endpoint_url is not None:
-            if endpoint_id:
-                from core.database import ModelEndpoint
+            if endpoint_id and not _is_codex_patch:
                 _db = SessionLocal()
                 try:
                     ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id).first()

--- a/scripts/validate_codex_model_provider_docker.sh
+++ b/scripts/validate_codex_model_provider_docker.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Validate the experimental Codex model-provider status probe in a real Docker
+# deployment. Run this on the deployment host, usually:
+#
+#   cd /opt/odysseus
+#   ODYSSEUS_ADMIN_USER=admin ODYSSEUS_ADMIN_PASSWORD='...' \
+#     scripts/validate_codex_model_provider_docker.sh
+#
+# The script edits only the deployment .env file, backs it up, and restores it
+# before exit. It never reads Codex credential files and redirects CLI logout
+# output so token-like material is not printed.
+
+set -euo pipefail
+
+APP_DIR="${1:-/opt/odysseus}"
+SERVICE="${ODYSSEUS_DOCKER_SERVICE:-odysseus}"
+APP_PORT="${APP_PORT:-7000}"
+BASE_URL="${ODYSSEUS_BASE_URL:-http://127.0.0.1:${APP_PORT}}"
+FLAG_KEY="ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
+MODEL_ID="codex-cli/chatgpt-experimental"
+COOKIE_JAR=""
+ENV_BACKUP=""
+RESTORE_DONE=0
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "${COOKIE_JAR}" ] && [ -f "${COOKIE_JAR}" ]; then
+    rm -f "${COOKIE_JAR}"
+  fi
+  if [ "${RESTORE_DONE}" = "0" ] && [ -n "${ENV_BACKUP}" ] && [ -f "${ENV_BACKUP}" ]; then
+    log "Restoring original .env feature-flag state"
+    cp "${ENV_BACKUP}" "${APP_DIR}/.env"
+    rm -f "${ENV_BACKUP}"
+    (cd "${APP_DIR}" && docker compose up -d --force-recreate "${SERVICE}" >/dev/null)
+    RESTORE_DONE=1
+  fi
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+json_get() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+cur = data
+for part in key.split("."):
+    if isinstance(cur, dict):
+        cur = cur.get(part)
+    else:
+        cur = None
+        break
+print("" if cur is None else cur)
+PY
+}
+
+assert_status_payload() {
+  local file="$1"
+  local expected_status="$2"
+  local expected_feature="$3"
+  python3 - "$file" "$expected_status" "$expected_feature" "$MODEL_ID" <<'PY'
+import json, sys
+path, expected_status, expected_feature, model_id = sys.argv[1:5]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+def fail(msg):
+    raise SystemExit(msg)
+
+if data.get("status") != expected_status:
+    fail(f"expected status={expected_status!r}, got {data.get('status')!r}: {data}")
+if bool(data.get("feature_enabled")) != (expected_feature == "true"):
+    fail(f"feature_enabled mismatch: {data}")
+for key in ("chat_supported", "streaming_supported", "session_resume_supported", "tool_execution_allowed"):
+    if data.get(key) is not False:
+        fail(f"{key} must remain false: {data}")
+dump = json.dumps(data).lower()
+for forbidden in ("access_token", "refresh_token", "id_token", "secret", "bearer "):
+    if forbidden in dump:
+        fail(f"response contains forbidden token-like field/text: {forbidden}")
+models = data.get("models") or []
+if expected_status == "available":
+    ids = [m.get("id") for m in models if isinstance(m, dict)]
+    if model_id not in ids:
+        fail(f"missing experimental model {model_id}: {data}")
+else:
+    if models:
+        fail(f"models should be empty for status {expected_status}: {data}")
+print("ok")
+PY
+}
+
+set_flag() {
+  local value="$1"
+  python3 - "${APP_DIR}/.env" "${FLAG_KEY}" "${value}" <<'PY'
+import os, sys
+path, key, value = sys.argv[1:4]
+lines = []
+if os.path.exists(path):
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+out = []
+seen = False
+for line in lines:
+    if line.startswith(key + "=") or line.startswith("#" + key + "="):
+        out.append(f"{key}={value}")
+        seen = True
+    else:
+        out.append(line)
+if not seen:
+    if out and out[-1].strip():
+        out.append("")
+    out.append(f"{key}={value}")
+with open(path, "w", encoding="utf-8") as f:
+    f.write("\n".join(out) + "\n")
+PY
+}
+
+restart_app() {
+  (cd "${APP_DIR}" && docker compose up -d --build --force-recreate "${SERVICE}" >/dev/null)
+  for _ in $(seq 1 60); do
+    if curl -fsS "${BASE_URL}/api/auth/status" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  die "app did not become reachable at ${BASE_URL}"
+}
+
+login_admin() {
+  local body login_file
+  if [ -n "${COOKIE_JAR}" ] && [ -f "${COOKIE_JAR}" ]; then
+    rm -f "${COOKIE_JAR}"
+  fi
+  COOKIE_JAR="$(mktemp)"
+  login_file="$(mktemp)"
+  body="$(python3 - <<'PY'
+import json, os
+body = {
+    "username": os.environ["ODYSSEUS_ADMIN_USER"],
+    "password": os.environ["ODYSSEUS_ADMIN_PASSWORD"],
+    "remember": False,
+}
+totp = os.environ.get("ODYSSEUS_ADMIN_TOTP")
+if totp:
+    body["totp_code"] = totp
+print(json.dumps(body))
+PY
+)"
+  local code
+  code="$(curl -sS -o "${login_file}" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -c "${COOKIE_JAR}" \
+    -X POST "${BASE_URL}/api/auth/login" \
+    --data "${body}")"
+  if [ "${code}" != "200" ]; then
+    rm -f "${login_file}"
+    die "admin login failed with HTTP ${code}"
+  fi
+  if [ "$(json_get "${login_file}" ok)" != "True" ]; then
+    rm -f "${login_file}"
+    die "admin login did not return ok=true"
+  fi
+  rm -f "${login_file}"
+}
+
+request_status() {
+  local file="$1"
+  curl -fsS -b "${COOKIE_JAR}" "${BASE_URL}/api/codex-model-provider/status" > "${file}"
+}
+
+request_codex_auth() {
+  local method="$1"
+  local path="$2"
+  local file="$3"
+  curl -fsS -b "${COOKIE_JAR}" -X "${method}" "${BASE_URL}/api/codex-auth/${path}" > "${file}"
+}
+
+poll_until_codex_authenticated() {
+  local status_file
+  status_file="$(mktemp)"
+  for _ in $(seq 1 310); do
+    request_codex_auth GET status "${status_file}"
+    if [ "$(json_get "${status_file}" authenticated)" = "True" ] || [ "$(json_get "${status_file}" codex_authenticated)" = "True" ]; then
+      rm -f "${status_file}"
+      return
+    fi
+    sleep 3
+  done
+  rm -f "${status_file}"
+  die "Codex did not become authenticated before timeout"
+}
+
+main() {
+  need docker
+  need curl
+  need python3
+  [ -d "${APP_DIR}" ] || die "deployment path not found: ${APP_DIR}"
+  [ -f "${APP_DIR}/docker-compose.yml" ] || die "docker-compose.yml not found under ${APP_DIR}"
+  [ -n "${ODYSSEUS_ADMIN_USER:-}" ] || die "set ODYSSEUS_ADMIN_USER in the environment"
+  [ -n "${ODYSSEUS_ADMIN_PASSWORD:-}" ] || die "set ODYSSEUS_ADMIN_PASSWORD in the environment"
+
+  local branch
+  branch="$(git -C "${APP_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [ "${SKIP_GIT_BRANCH_CHECK:-0}" != "1" ] && [ "${branch}" != "codex-model-provider-draft" ]; then
+    die "expected ${APP_DIR} to be on codex-model-provider-draft, got ${branch:-unknown}"
+  fi
+  [ -f "${APP_DIR}/src/codex_model_provider.py" ] || die "provider probe source is missing"
+
+  ENV_BACKUP="${APP_DIR}/.env.codex-provider-validation.$(date +%Y%m%d%H%M%S).bak"
+  if [ -f "${APP_DIR}/.env" ]; then
+    cp "${APP_DIR}/.env" "${ENV_BACKUP}"
+  else
+    : > "${ENV_BACKUP}"
+    : > "${APP_DIR}/.env"
+  fi
+
+  log "State 1: feature flag disabled"
+  set_flag false
+  restart_app
+  login_admin
+  local unauth_code disabled_file logged_out_file logged_in_file after_logout_file start_file logout_file
+  disabled_file="$(mktemp)"
+  unauth_code="$(curl -sS -o /dev/null -w "%{http_code}" "${BASE_URL}/api/codex-model-provider/status")"
+  [ "${unauth_code}" = "403" ] || die "admin gate check failed: unauthenticated status returned HTTP ${unauth_code}, expected 403"
+  request_status "${disabled_file}"
+  assert_status_payload "${disabled_file}" disabled false >/dev/null
+  rm -f "${disabled_file}"
+
+  log "State 2: feature flag enabled, Codex logged out"
+  set_flag true
+  restart_app
+  login_admin
+  (cd "${APP_DIR}" && docker compose exec -T "${SERVICE}" codex logout >/dev/null 2>&1 || true)
+  restart_app
+  login_admin
+  logged_out_file="$(mktemp)"
+  request_status "${logged_out_file}"
+  assert_status_payload "${logged_out_file}" sign_in_required true >/dev/null
+  rm -f "${logged_out_file}"
+
+  log "State 3: feature flag enabled, Codex logged in"
+  start_file="$(mktemp)"
+  request_codex_auth POST start "${start_file}"
+  local st
+  st="$(json_get "${start_file}" status)"
+  if [ "${st}" = "pending" ] || [ "${st}" = "starting" ]; then
+    local url code
+    url="$(json_get "${start_file}" verification_url)"
+    code="$(json_get "${start_file}" user_code)"
+    if [ -n "${url}" ] && [ -n "${code}" ]; then
+      printf 'Open this URL and enter the one-time code:\n%s\n%s\n' "${url}" "${code}"
+    else
+      printf 'Codex login started. Complete verification in the browser.\n'
+    fi
+    poll_until_codex_authenticated
+  elif [ "${st}" = "already_authenticated" ] || [ "$(json_get "${start_file}" authenticated)" = "True" ]; then
+    :
+  else
+    rm -f "${start_file}"
+    die "Codex auth start failed with status ${st}"
+  fi
+  rm -f "${start_file}"
+  logged_in_file="$(mktemp)"
+  request_status "${logged_in_file}"
+  assert_status_payload "${logged_in_file}" available true >/dev/null
+  rm -f "${logged_in_file}"
+
+  log "State 4: logout after login"
+  logout_file="$(mktemp)"
+  request_codex_auth POST logout "${logout_file}"
+  rm -f "${logout_file}"
+  after_logout_file="$(mktemp)"
+  request_status "${after_logout_file}"
+  assert_status_payload "${after_logout_file}" sign_in_required true >/dev/null
+  rm -f "${after_logout_file}"
+
+  log "Restoring original .env"
+  cp "${ENV_BACKUP}" "${APP_DIR}/.env"
+  rm -f "${ENV_BACKUP}"
+  restart_app
+  RESTORE_DONE=1
+
+  log "Codex model-provider Docker validation passed"
+}
+
+main "$@"

--- a/scripts/validate_codex_model_provider_docker.sh
+++ b/scripts/validate_codex_model_provider_docker.sh
@@ -85,7 +85,13 @@ if data.get("status") != expected_status:
     fail(f"expected status={expected_status!r}, got {data.get('status')!r}: {data}")
 if bool(data.get("feature_enabled")) != (expected_feature == "true"):
     fail(f"feature_enabled mismatch: {data}")
-for key in ("chat_supported", "streaming_supported", "session_resume_supported", "tool_execution_allowed"):
+if expected_status == "available":
+    if data.get("chat_supported") is not True:
+        fail(f"chat_supported must be true only for safe available provider: {data}")
+else:
+    if data.get("chat_supported") is not False:
+        fail(f"chat_supported must remain false for status {expected_status}: {data}")
+for key in ("streaming_supported", "session_resume_supported", "tool_execution_allowed"):
     if data.get(key) is not False:
         fail(f"{key} must remain false: {data}")
 dump = json.dumps(data).lower()
@@ -100,6 +106,33 @@ if expected_status == "available":
 else:
     if models:
         fail(f"models should be empty for status {expected_status}: {data}")
+print("ok")
+PY
+}
+
+assert_test_chat_payload() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+def fail(msg):
+    raise SystemExit(msg)
+
+if data.get("ok") is not True:
+    fail(f"expected ok=true from test-chat: {data}")
+message = data.get("message")
+if not isinstance(message, str) or not message.strip():
+    fail(f"test-chat response missing assistant message: {data}")
+for key in ("streaming_supported", "session_resume_supported", "tool_execution_allowed"):
+    if data.get(key) is not False:
+        fail(f"{key} must remain false: {data}")
+dump = json.dumps(data).lower()
+for forbidden in ("access_token", "refresh_token", "id_token", "secret", "bearer "):
+    if forbidden in dump:
+        fail(f"response contains forbidden token-like field/text: {forbidden}")
 print("ok")
 PY
 }
@@ -190,6 +223,15 @@ request_codex_auth() {
   curl -fsS -b "${COOKIE_JAR}" -X "${method}" "${BASE_URL}/api/codex-auth/${path}" > "${file}"
 }
 
+request_test_chat() {
+  local file="$1"
+  curl -fsS -b "${COOKIE_JAR}" \
+    -H "Content-Type: application/json" \
+    -X POST "${BASE_URL}/api/codex-model-provider/test-chat" \
+    --data '{"prompt":"Reply with exactly: codex provider test ok","timeout_seconds":180}' \
+    > "${file}"
+}
+
 poll_until_codex_authenticated() {
   local status_file
   status_file="$(mktemp)"
@@ -233,7 +275,7 @@ main() {
   set_flag false
   restart_app
   login_admin
-  local unauth_code disabled_file logged_out_file logged_in_file after_logout_file start_file logout_file
+  local unauth_code disabled_file logged_out_file logged_in_file test_chat_file after_logout_file start_file logout_file
   disabled_file="$(mktemp)"
   unauth_code="$(curl -sS -o /dev/null -w "%{http_code}" "${BASE_URL}/api/codex-model-provider/status")"
   [ "${unauth_code}" = "403" ] || die "admin gate check failed: unauthenticated status returned HTTP ${unauth_code}, expected 403"
@@ -279,6 +321,10 @@ main() {
   request_status "${logged_in_file}"
   assert_status_payload "${logged_in_file}" available true >/dev/null
   rm -f "${logged_in_file}"
+  test_chat_file="$(mktemp)"
+  request_test_chat "${test_chat_file}"
+  assert_test_chat_payload "${test_chat_file}" >/dev/null
+  rm -f "${test_chat_file}"
 
   log "State 4: logout after login"
   logout_file="$(mktemp)"

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -168,7 +168,7 @@ class CodexAuthService:
         if "not logged in" in lower:
             return False, "", "Not logged in"
         if clean:
-            return False, "", clean[:300]
+            return False, "", "Codex login status returned an unrecognized response"
         return False, "", "Unable to determine Codex login status"
 
     async def _run_command(self, args: list[str], timeout: float = 15.0) -> tuple[int, str]:
@@ -320,7 +320,7 @@ class CodexAuthService:
                 if "device code login is not enabled" in line.lower():
                     last_safe_line = "Device-code login is not enabled for this Codex account or server"
                 elif "error" in line.lower():
-                    last_safe_line = line[:300]
+                    last_safe_line = "Codex CLI reported an error during device-code login"
                 found_url = URL_RE.search(line)
                 if found_url and any(host in found_url.group(0).lower() for host in ("openai.com", "chatgpt.com")):
                     url = found_url.group(0)
@@ -409,10 +409,10 @@ class CodexAuthService:
         rc, out = await self._run_command(["logout"], timeout=20)
         clean = ANSI_RE.sub("", out or "").strip()
         if rc == 0:
-            state = CodexAuthState(status="logged_out", message=clean or "Codex credentials removed")
+            state = CodexAuthState(status="logged_out", message="Codex credentials removed")
         else:
             log.warning("Codex logout failed with rc=%s", rc)
-            state = CodexAuthState(status="failed", message=(clean or "Codex logout failed")[:300], error_code="logout_failed")
+            state = CodexAuthState(status="failed", message="Codex logout failed", error_code="logout_failed")
         async with self._lock:
             self._state = state
         return {**self._base_capabilities(), **state.public()}

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -212,7 +212,7 @@ class CodexAuthService:
                 state["process_running"] = True
                 return {**caps, **state}
             if (
-                self._state.status in {"failed", "timeout", "canceled", "logged_out", "succeeded"}
+                self._state.status in {"failed", "timeout", "canceled", "succeeded"}
                 and time.time() - self._state.updated_at < 300
             ):
                 return {**caps, **state}

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -1,0 +1,354 @@
+"""Codex CLI device-code authentication service.
+
+This deliberately delegates credential storage and token refresh to the
+official Codex CLI. Odysseus only tracks the in-flight login state needed by
+the browser UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import shutil
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+URL_RE = re.compile(r"https?://[^\s]+/codex/device\b")
+CODE_RE = re.compile(r"\b[A-Z0-9]{4,}(?:-[A-Z0-9]{3,})+\b")
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class CodexAuthState:
+    status: str = "idle"
+    message: str = ""
+    authenticated: bool = False
+    auth_mode: str = ""
+    verification_url: str = ""
+    user_code: str = ""
+    started_at: float = 0.0
+    updated_at: float = field(default_factory=time.time)
+    error_code: str = ""
+    process_running: bool = False
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "message": self.message,
+            "authenticated": self.authenticated,
+            "auth_mode": self.auth_mode,
+            "verification_url": self.verification_url,
+            "user_code": self.user_code,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "error_code": self.error_code,
+            "process_running": self.process_running,
+        }
+
+
+class CodexAuthService:
+    """Small async wrapper around `codex login --device-auth`."""
+
+    def __init__(
+        self,
+        *,
+        codex_bin: str | None = None,
+        codex_home: str | None = None,
+        enabled: bool | None = None,
+        login_timeout_seconds: int = 15 * 60 + 30,
+        code_timeout_seconds: int = 45,
+    ) -> None:
+        self.codex_bin = codex_bin or os.getenv("CODEX_BIN", "codex")
+        self.codex_home = codex_home if codex_home is not None else os.getenv("CODEX_HOME", "")
+        self.enabled = (
+            enabled
+            if enabled is not None
+            else not _truthy(os.getenv("ODYSSEUS_CODEX_AUTH_DISABLED"))
+            and _truthy(os.getenv("ODYSSEUS_CODEX_AUTH_ENABLED", "true"))
+        )
+        self.login_timeout_seconds = login_timeout_seconds
+        self.code_timeout_seconds = code_timeout_seconds
+        self._lock = asyncio.Lock()
+        self._state = CodexAuthState()
+        self._process: asyncio.subprocess.Process | None = None
+        self._watch_task: asyncio.Task | None = None
+
+    def _bin_path(self) -> Optional[str]:
+        if os.path.sep in self.codex_bin or (os.path.altsep and os.path.altsep in self.codex_bin):
+            return self.codex_bin if os.path.exists(self.codex_bin) else None
+        return shutil.which(self.codex_bin)
+
+    def _env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        if self.codex_home:
+            env["CODEX_HOME"] = os.path.expanduser(self.codex_home)
+        return env
+
+    def _base_capabilities(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "method": "codex_cli",
+            "sdk_available": False,
+            "sdk_status": "not_available",
+            "codex_cli_available": self._bin_path() is not None,
+            "codex_home": "custom" if self.codex_home else "default",
+            "stores_credentials": "codex_cli",
+        }
+
+    @staticmethod
+    def _classify_status_output(output: str, returncode: int) -> tuple[bool, str, str]:
+        clean = ANSI_RE.sub("", output or "").strip()
+        lower = clean.lower()
+        if returncode == 0 and "logged in using chatgpt" in lower:
+            return True, "ChatGPT", "Logged in using ChatGPT"
+        if returncode == 0 and "logged in using an api key" in lower:
+            return True, "API key", "Logged in using an API key"
+        if returncode == 0 and "logged in using access token" in lower:
+            return True, "access token", "Logged in using access token"
+        if "not logged in" in lower:
+            return False, "", "Not logged in"
+        if clean:
+            return False, "", clean[:300]
+        return False, "", "Unable to determine Codex login status"
+
+    async def _run_command(self, args: list[str], timeout: float = 15.0) -> tuple[int, str]:
+        bin_path = self._bin_path()
+        if not bin_path:
+            return 127, "Codex CLI is not installed or CODEX_BIN is invalid"
+        proc = await asyncio.create_subprocess_exec(
+            bin_path,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=self._env(),
+        )
+        try:
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return 124, "Command timed out"
+        return proc.returncode or 0, (out or b"").decode("utf-8", errors="replace")
+
+    async def status(self) -> dict[str, Any]:
+        caps = self._base_capabilities()
+        if not self.enabled:
+            return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
+        if not caps["codex_cli_available"]:
+            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+
+        async with self._lock:
+            state = self._state.public()
+            running = self._process is not None and self._process.returncode is None
+            if running:
+                state["process_running"] = True
+                return {**caps, **state}
+            if (
+                self._state.status in {"failed", "timeout", "canceled", "logged_out", "succeeded"}
+                and time.time() - self._state.updated_at < 300
+            ):
+                return {**caps, **state}
+
+        rc, out = await self._run_command(["login", "status"], timeout=10)
+        authenticated, mode, msg = self._classify_status_output(out, rc)
+        status = "authenticated" if authenticated else "not_authenticated"
+        return {
+            **caps,
+            **CodexAuthState(
+                status=status,
+                message=msg,
+                authenticated=authenticated,
+                auth_mode=mode,
+            ).public(),
+        }
+
+    async def start(self) -> dict[str, Any]:
+        caps = self._base_capabilities()
+        if not self.enabled:
+            return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
+        bin_path = self._bin_path()
+        if not bin_path:
+            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+
+        current = await self.status()
+        if current.get("authenticated"):
+            current["status"] = "already_authenticated"
+            return current
+
+        async with self._lock:
+            if self._process is not None and self._process.returncode is None:
+                return {**caps, **self._state.public()}
+            self._state = CodexAuthState(
+                status="starting",
+                message="Starting Codex device-code login",
+                started_at=time.time(),
+                process_running=True,
+            )
+            self._process = await asyncio.create_subprocess_exec(
+                bin_path,
+                "login",
+                "--device-auth",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env(),
+            )
+            self._watch_task = asyncio.create_task(self._watch_login(self._process))
+            return {**caps, **self._state.public()}
+
+    async def _watch_login(self, proc: asyncio.subprocess.Process) -> None:
+        url = ""
+        code = ""
+        code_seen_deadline = time.time() + self.code_timeout_seconds
+        overall_deadline = time.time() + self.login_timeout_seconds
+        last_safe_line = ""
+
+        async def _set(**kwargs: Any) -> None:
+            async with self._lock:
+                for k, v in kwargs.items():
+                    setattr(self._state, k, v)
+                self._state.updated_at = time.time()
+                self._state.process_running = proc.returncode is None
+
+        try:
+            assert proc.stdout is not None
+            while True:
+                if time.time() > overall_deadline:
+                    await self._terminate_process(proc)
+                    await _set(status="timeout", message="Codex device auth timed out", error_code="timeout", process_running=False)
+                    return
+                try:
+                    raw = await asyncio.wait_for(proc.stdout.readline(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    if not code and time.time() > code_seen_deadline:
+                        await self._terminate_process(proc)
+                        await _set(status="failed", message="Codex CLI did not produce a device code", error_code="device_code_unavailable", process_running=False)
+                        return
+                    if proc.returncode is not None:
+                        break
+                    continue
+                if not raw:
+                    break
+                line = ANSI_RE.sub("", raw.decode("utf-8", errors="replace")).strip()
+                if not line:
+                    continue
+                if "device code login is not enabled" in line.lower():
+                    last_safe_line = "Device-code login is not enabled for this Codex account or server"
+                elif "error" in line.lower():
+                    last_safe_line = line[:300]
+                found_url = URL_RE.search(line)
+                if found_url:
+                    url = found_url.group(0)
+                found_code = CODE_RE.search(line)
+                if found_code:
+                    code = found_code.group(0)
+                if url and code:
+                    await _set(
+                        status="pending",
+                        message="Waiting for browser verification",
+                        verification_url=url,
+                        user_code=code,
+                        error_code="",
+                    )
+            rc = await proc.wait()
+            if rc == 0:
+                await _set(
+                    status="succeeded",
+                    message="Codex login completed",
+                    authenticated=True,
+                    auth_mode="ChatGPT",
+                    user_code="",
+                    verification_url="",
+                    error_code="",
+                    process_running=False,
+                )
+            else:
+                msg = last_safe_line or "Codex device-code login failed"
+                err_code = "device_auth_disabled" if "not enabled" in msg.lower() else "login_failed"
+                await _set(status="failed", message=msg, error_code=err_code, user_code="", verification_url="", process_running=False)
+        except Exception:
+            await _set(status="failed", message="Codex device-code login failed", error_code="login_failed", user_code="", verification_url="", process_running=False)
+        finally:
+            async with self._lock:
+                if self._process is proc:
+                    self._process = None
+                self._state.process_running = False
+
+    async def _terminate_process(self, proc: asyncio.subprocess.Process) -> None:
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=3)
+        except ProcessLookupError:
+            return
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                await proc.wait()
+            except Exception:
+                pass
+
+    async def cancel(self) -> dict[str, Any]:
+        async with self._lock:
+            proc = self._process
+            task = self._watch_task
+        if proc is not None and proc.returncode is None:
+            await self._terminate_process(proc)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        async with self._lock:
+            self._process = None
+            self._watch_task = None
+            self._state = CodexAuthState(status="canceled", message="Codex login canceled")
+            return {**self._base_capabilities(), **self._state.public()}
+
+    async def logout(self) -> dict[str, Any]:
+        await self.cancel()
+        if not self.enabled:
+            return {**self._base_capabilities(), **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
+        if not self._bin_path():
+            return {**self._base_capabilities(), **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+        rc, out = await self._run_command(["logout"], timeout=20)
+        clean = ANSI_RE.sub("", out or "").strip()
+        if rc == 0:
+            state = CodexAuthState(status="logged_out", message=clean or "Codex credentials removed")
+        else:
+            state = CodexAuthState(status="failed", message=(clean or "Codex logout failed")[:300], error_code="logout_failed")
+        async with self._lock:
+            self._state = state
+        return {**self._base_capabilities(), **state.public()}
+
+    async def test(self) -> dict[str, Any]:
+        status = await self.status()
+        if not status.get("authenticated"):
+            return {**status, "ok": False}
+        return {**status, "ok": True}
+
+
+_service: CodexAuthService | None = None
+
+
+def get_codex_auth_service() -> CodexAuthService:
+    global _service
+    if _service is None:
+        _service = CodexAuthService()
+    return _service
+
+
+def set_codex_auth_service(service: CodexAuthService | None) -> None:
+    global _service
+    _service = service

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -8,6 +8,7 @@ the browser UI.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import re
 import shutil
@@ -17,8 +18,9 @@ from typing import Any, Optional
 
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-URL_RE = re.compile(r"https?://[^\s]+/codex/device\b")
+URL_RE = re.compile(r"https?://[^\s<>'\"]+")
 CODE_RE = re.compile(r"\b[A-Z0-9]{4,}(?:-[A-Z0-9]{3,})+\b")
+log = logging.getLogger(__name__)
 
 
 def _truthy(value: str | None) -> bool:
@@ -43,6 +45,7 @@ class CodexAuthState:
             "status": self.status,
             "message": self.message,
             "authenticated": self.authenticated,
+            "codex_authenticated": self.authenticated,
             "auth_mode": self.auth_mode,
             "verification_url": self.verification_url,
             "user_code": self.user_code,
@@ -50,6 +53,7 @@ class CodexAuthState:
             "updated_at": self.updated_at,
             "error_code": self.error_code,
             "process_running": self.process_running,
+            "device_login_active": self.process_running or self.status in {"starting", "pending"},
         }
 
 
@@ -79,11 +83,44 @@ class CodexAuthService:
         self._state = CodexAuthState()
         self._process: asyncio.subprocess.Process | None = None
         self._watch_task: asyncio.Task | None = None
+        log.debug(
+            "Codex auth service configured: enabled=%s codex_bin=%s codex_bin_from_env=%s codex_home_configured=%s",
+            self.enabled,
+            self.codex_bin,
+            "CODEX_BIN" in os.environ,
+            bool(self.codex_home),
+        )
+
+    def _candidate_bin_path(self) -> Optional[str]:
+        codex_bin = os.path.expanduser(self.codex_bin)
+        if os.path.sep in codex_bin or (os.path.altsep and os.path.altsep in codex_bin):
+            return codex_bin
+        return shutil.which(self.codex_bin)
 
     def _bin_path(self) -> Optional[str]:
-        if os.path.sep in self.codex_bin or (os.path.altsep and os.path.altsep in self.codex_bin):
-            return self.codex_bin if os.path.exists(self.codex_bin) else None
-        return shutil.which(self.codex_bin)
+        path = self._candidate_bin_path()
+        if not path:
+            return None
+        return path if os.path.isfile(path) and os.access(path, os.X_OK) else None
+
+    def _bin_diagnostics(self) -> dict[str, Any]:
+        candidate = self._candidate_bin_path()
+        cli_found = bool(candidate and os.path.isfile(candidate))
+        cli_executable = bool(cli_found and os.access(candidate, os.X_OK))
+        codex_home_path = os.path.expanduser(self.codex_home) if self.codex_home else os.path.expanduser("~/.codex")
+        return {
+            "configured_binary": self.codex_bin,
+            "binary_source": "CODEX_BIN" if "CODEX_BIN" in os.environ else "default",
+            "resolved_binary_path": candidate,
+            "binary_exists": bool(candidate and os.path.exists(candidate)),
+            "binary_is_file": cli_found,
+            "binary_executable": cli_executable,
+            "cli_found": cli_found,
+            "cli_executable": cli_executable,
+            "codex_home_source": "CODEX_HOME" if "CODEX_HOME" in os.environ else "default",
+            "codex_home_configured": bool(self.codex_home),
+            "codex_home_path": codex_home_path,
+        }
 
     def _env(self) -> dict[str, str]:
         env = os.environ.copy()
@@ -100,7 +137,23 @@ class CodexAuthService:
             "codex_cli_available": self._bin_path() is not None,
             "codex_home": "custom" if self.codex_home else "default",
             "stores_credentials": "codex_cli",
+            "codex_authenticated": False,
+            "device_login_active": False,
+            **self._bin_diagnostics(),
         }
+
+    def _cli_unavailable_state(self, caps: dict[str, Any]) -> CodexAuthState:
+        if caps.get("cli_found"):
+            return CodexAuthState(
+                status="cli_not_executable",
+                message="Codex CLI found but CODEX_BIN is not executable",
+                error_code="cli_not_executable",
+            )
+        return CodexAuthState(
+            status="cli_missing",
+            message="Codex CLI missing or CODEX_BIN invalid",
+            error_code="cli_missing",
+        )
 
     @staticmethod
     def _classify_status_output(output: str, returncode: int) -> tuple[bool, str, str]:
@@ -121,28 +174,36 @@ class CodexAuthService:
     async def _run_command(self, args: list[str], timeout: float = 15.0) -> tuple[int, str]:
         bin_path = self._bin_path()
         if not bin_path:
+            log.warning("Codex command skipped because CLI is unavailable: %s", self._bin_diagnostics())
             return 127, "Codex CLI is not installed or CODEX_BIN is invalid"
-        proc = await asyncio.create_subprocess_exec(
-            bin_path,
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=self._env(),
-        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                bin_path,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env(),
+            )
+        except Exception as exc:
+            log.exception("Failed to start Codex command %s", args[:1])
+            return 1, f"Failed to start Codex CLI: {exc.__class__.__name__}"
         try:
             out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
+            log.warning("Codex command timed out: %s", args[:1])
             return 124, "Command timed out"
         return proc.returncode or 0, (out or b"").decode("utf-8", errors="replace")
 
     async def status(self) -> dict[str, Any]:
         caps = self._base_capabilities()
         if not self.enabled:
+            log.info("Codex auth status requested while disabled")
             return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
         if not caps["codex_cli_available"]:
-            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+            log.warning("Codex auth status reports missing CLI: %s", self._bin_diagnostics())
+            return {**caps, **self._cli_unavailable_state(caps).public()}
 
         async with self._lock:
             state = self._state.public()
@@ -157,8 +218,12 @@ class CodexAuthService:
                 return {**caps, **state}
 
         rc, out = await self._run_command(["login", "status"], timeout=10)
+        if rc != 0:
+            log.warning("Codex login status command returned rc=%s", rc)
         authenticated, mode, msg = self._classify_status_output(out, rc)
         status = "authenticated" if authenticated else "not_authenticated"
+        if not authenticated:
+            msg = "Codex CLI ready. Not signed in."
         return {
             **caps,
             **CodexAuthState(
@@ -172,10 +237,12 @@ class CodexAuthService:
     async def start(self) -> dict[str, Any]:
         caps = self._base_capabilities()
         if not self.enabled:
+            log.info("Codex auth start requested while disabled")
             return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
         bin_path = self._bin_path()
         if not bin_path:
-            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+            log.warning("Codex auth start reports missing CLI: %s", self._bin_diagnostics())
+            return {**caps, **self._cli_unavailable_state(caps).public()}
 
         current = await self.status()
         if current.get("authenticated"):
@@ -191,14 +258,24 @@ class CodexAuthService:
                 started_at=time.time(),
                 process_running=True,
             )
-            self._process = await asyncio.create_subprocess_exec(
-                bin_path,
-                "login",
-                "--device-auth",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                env=self._env(),
-            )
+            try:
+                self._process = await asyncio.create_subprocess_exec(
+                    bin_path,
+                    "login",
+                    "--device-auth",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    env=self._env(),
+                )
+            except Exception as exc:
+                log.exception("Failed to start Codex device auth")
+                self._state = CodexAuthState(
+                    status="failed",
+                    message=f"Failed to start Codex CLI: {exc.__class__.__name__}",
+                    error_code="start_failed",
+                )
+                self._process = None
+                return {**caps, **self._state.public()}
             self._watch_task = asyncio.create_task(self._watch_login(self._process))
             return {**caps, **self._state.public()}
 
@@ -221,6 +298,7 @@ class CodexAuthService:
             while True:
                 if time.time() > overall_deadline:
                     await self._terminate_process(proc)
+                    log.warning("Codex device auth timed out")
                     await _set(status="timeout", message="Codex device auth timed out", error_code="timeout", process_running=False)
                     return
                 try:
@@ -228,6 +306,7 @@ class CodexAuthService:
                 except asyncio.TimeoutError:
                     if not code and time.time() > code_seen_deadline:
                         await self._terminate_process(proc)
+                        log.warning("Codex device auth did not produce a device code")
                         await _set(status="failed", message="Codex CLI did not produce a device code", error_code="device_code_unavailable", process_running=False)
                         return
                     if proc.returncode is not None:
@@ -243,7 +322,7 @@ class CodexAuthService:
                 elif "error" in line.lower():
                     last_safe_line = line[:300]
                 found_url = URL_RE.search(line)
-                if found_url:
+                if found_url and any(host in found_url.group(0).lower() for host in ("openai.com", "chatgpt.com")):
                     url = found_url.group(0)
                 found_code = CODE_RE.search(line)
                 if found_code:
@@ -271,8 +350,10 @@ class CodexAuthService:
             else:
                 msg = last_safe_line or "Codex device-code login failed"
                 err_code = "device_auth_disabled" if "not enabled" in msg.lower() else "login_failed"
+                log.warning("Codex device auth failed with rc=%s error_code=%s", rc, err_code)
                 await _set(status="failed", message=msg, error_code=err_code, user_code="", verification_url="", process_running=False)
         except Exception:
+            log.exception("Codex device auth watcher failed")
             await _set(status="failed", message="Codex device-code login failed", error_code="login_failed", user_code="", verification_url="", process_running=False)
         finally:
             async with self._lock:
@@ -319,14 +400,18 @@ class CodexAuthService:
     async def logout(self) -> dict[str, Any]:
         await self.cancel()
         if not self.enabled:
+            log.info("Codex logout requested while disabled")
             return {**self._base_capabilities(), **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
-        if not self._bin_path():
-            return {**self._base_capabilities(), **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+        caps = self._base_capabilities()
+        if not caps["codex_cli_available"]:
+            log.warning("Codex logout reports missing CLI: %s", self._bin_diagnostics())
+            return {**caps, **self._cli_unavailable_state(caps).public()}
         rc, out = await self._run_command(["logout"], timeout=20)
         clean = ANSI_RE.sub("", out or "").strip()
         if rc == 0:
             state = CodexAuthState(status="logged_out", message=clean or "Codex credentials removed")
         else:
+            log.warning("Codex logout failed with rc=%s", rc)
             state = CodexAuthState(status="failed", message=(clean or "Codex logout failed")[:300], error_code="logout_failed")
         async with self._lock:
             self._state = state
@@ -335,6 +420,7 @@ class CodexAuthService:
     async def test(self) -> dict[str, Any]:
         status = await self.status()
         if not status.get("authenticated"):
+            log.info("Codex test requested while not authenticated: status=%s error_code=%s", status.get("status"), status.get("error_code"))
             return {**status, "ok": False}
         return {**status, "ok": True}
 

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1,0 +1,113 @@
+"""Experimental Codex CLI model-provider capability boundary.
+
+This module does not implement chat dispatch. It reports whether a future
+Codex-backed provider can be exposed safely, without treating completed CLI
+output as token streaming or reading Codex credential files.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+from src.codex_auth import get_codex_auth_service
+
+
+CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
+CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def codex_model_provider_enabled() -> bool:
+    return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
+
+
+class CodexModelProvider:
+    """Status/capability adapter for a future Codex CLI provider."""
+
+    def __init__(self, auth_service_getter: Callable[[], Any] | None = None) -> None:
+        self._auth_service_getter = auth_service_getter or get_codex_auth_service
+
+    async def status(self) -> dict[str, Any]:
+        enabled = codex_model_provider_enabled()
+        base = {
+            "feature_enabled": enabled,
+            "feature_flag": CODEX_MODEL_PROVIDER_FLAG,
+            "provider": "codex_cli",
+            "experimental": True,
+            "models": [],
+            "chat_supported": False,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "limitations": [
+                "Chat dispatch is not implemented.",
+                "True token streaming has not been validated.",
+                "Session/resume behavior has not been designed.",
+                "Codex tool execution is not enabled for Odysseus chat mode.",
+            ],
+        }
+        if not enabled:
+            return {
+                **base,
+                "status": "disabled",
+                "cli_available": False,
+                "authenticated": False,
+                "requires_sign_in": False,
+            }
+
+        try:
+            auth = await self._auth_service_getter().status()
+        except Exception as exc:
+            return {
+                **base,
+                "status": "auth_status_failed",
+                "cli_available": False,
+                "authenticated": False,
+                "requires_sign_in": False,
+                "error": exc.__class__.__name__,
+            }
+
+        cli_available = bool(
+            auth.get("codex_cli_available")
+            or (auth.get("cli_found") and auth.get("cli_executable"))
+        )
+        authenticated = bool(auth.get("codex_authenticated") or auth.get("authenticated"))
+        auth_status = str(auth.get("status") or "")
+        auth_mode = str(auth.get("auth_mode") or "")
+
+        if not cli_available:
+            status = "cli_unavailable"
+            requires_sign_in = False
+        elif not authenticated:
+            status = "sign_in_required"
+            requires_sign_in = True
+        else:
+            status = "available"
+            requires_sign_in = False
+
+        models = []
+        if status == "available":
+            models.append({
+                "id": CODEX_EXPERIMENTAL_MODEL_ID,
+                "display": "codex-cli/chatgpt (experimental)",
+                "experimental": True,
+            })
+
+        return {
+            **base,
+            "status": status,
+            "cli_available": cli_available,
+            "authenticated": authenticated,
+            "requires_sign_in": requires_sign_in,
+            "sign_in_route": "/api/codex-auth/start",
+            "auth": {
+                "status": auth_status,
+                "auth_mode": auth_mode,
+                "codex_home": auth.get("codex_home", ""),
+            },
+            "models": models,
+        }

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,15 +13,27 @@ import os
 import re
 import tempfile
 import time
+from pathlib import Path
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
 
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
+CODEX_PROVIDER_ENDPOINT_URL = "codex-cli://chat"
+CODEX_PROVIDER_ENDPOINT_ID = "codex-cli"
+CODEX_PROVIDER_ENDPOINT_NAME = "Codex / ChatGPT"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
 CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental, non-streaming)"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
+CODEX_MODELS_CACHE_PATH = Path.home() / ".codex" / "models_cache.json"
+CODEX_FALLBACK_MODELS = [
+    {
+        "id": CODEX_EXPERIMENTAL_MODEL_ID,
+        "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+        "experimental": True,
+    }
+]
 
 _TOKEN_PATTERNS = (
     re.compile(r"(?i)(access_token|refresh_token|id_token)\s*[:=]\s*['\"]?[^'\"\s,}]+"),
@@ -31,7 +43,7 @@ _TOKEN_PATTERNS = (
 _LIMITATIONS = [
     "Non-streaming: returns one completed assistant message.",
     "Stateless: session/resume is not implemented.",
-    "Codex tool execution is not mapped into Odysseus agent rounds.",
+    "In Odysseus agent mode, tools are executed by Odysseus agent rounds, not by Codex CLI itself.",
     "The adapter requires Codex CLI sandbox/approval flags before running.",
 ]
 
@@ -49,6 +61,59 @@ def _sanitize_text(text: str | None, limit: int = 2000) -> str:
     for pattern in _TOKEN_PATTERNS:
         safe = pattern.sub("<redacted-token>", safe)
     return safe.strip()[:limit]
+
+
+def normalize_codex_model_id(model: str | None) -> str:
+    """Return the Codex CLI model slug to pass with --model.
+
+    Older Odysseus builds exposed a synthetic codex-cli/chatgpt-experimental id.
+    Modern Codex CLI stores real selectable slugs in ~/.codex/models_cache.json.
+    """
+    raw = (model or "").strip()
+    if not raw or raw == CODEX_EXPERIMENTAL_MODEL_ID:
+        models = codex_available_models()
+        first = models[0]["id"] if models else ""
+        return "" if first == CODEX_EXPERIMENTAL_MODEL_ID else first
+    if raw.startswith("codex-cli/"):
+        slug = raw.split("/", 1)[1]
+        return "" if slug == "chatgpt-experimental" else slug
+    return raw
+
+
+def codex_available_models(cache_path: Path | None = None) -> list[dict[str, Any]]:
+    """Read the model list that Codex CLI/VS Code cache after ChatGPT OAuth.
+
+    We intentionally only expose list-visible, API-supported entries and never
+    return the bulky instruction payloads from the cache.
+    """
+    path = cache_path or CODEX_MODELS_CACHE_PATH
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return [dict(m) for m in CODEX_FALLBACK_MODELS]
+
+    items: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in payload.get("models") or []:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("visibility") != "list" or entry.get("supported_in_api") is False:
+            continue
+        slug = str(entry.get("slug") or entry.get("id") or "").strip()
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        items.append({
+            "id": slug,
+            "display": str(entry.get("display_name") or slug),
+            "description": str(entry.get("description") or ""),
+            "priority": entry.get("priority") if isinstance(entry.get("priority"), int) else 9999,
+            "experimental": False,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+        })
+    items.sort(key=lambda m: (m.get("priority", 9999), str(m.get("display") or m.get("id"))))
+    return items or [dict(m) for m in CODEX_FALLBACK_MODELS]
 
 
 class CodexCliChatAdapter:
@@ -90,6 +155,7 @@ class CodexCliChatAdapter:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        allow_odysseus_tools: bool = False,
     ) -> dict[str, Any]:
         started = time.time()
         availability = await self.available()
@@ -102,19 +168,26 @@ class CodexCliChatAdapter:
             }
 
         preflight = await self._preflight()
-        prompt = self._build_prompt(messages)
+        prompt = self._build_prompt(messages, allow_odysseus_tools=allow_odysseus_tools)
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
 
         with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
+            model_slug = normalize_codex_model_id(model)
+            sandbox_mode = "workspace-write" if allow_odysseus_tools else "read-only"
             args = [
                 preflight["bin_path"],
                 "exec",
+                "-c",
+                "approval_policy=\"never\"",
                 "--sandbox",
-                "read-only",
-                "--ask-for-approval",
-                "never",
-                prompt,
+                sandbox_mode,
+                "--skip-git-repo-check",
+                "--ignore-rules",
+                "--ephemeral",
             ]
+            if model_slug:
+                args.extend(["--model", model_slug])
+            args.append(prompt)
             rc, out, err = await self._run(
                 args,
                 timeout=timeout,
@@ -142,7 +215,7 @@ class CodexCliChatAdapter:
             "limitations": list(_LIMITATIONS),
             "streaming_supported": False,
             "session_resume_supported": False,
-            "tool_execution_allowed": False,
+            "tool_execution_allowed": bool(allow_odysseus_tools),
         }
 
     async def _preflight(self) -> dict[str, Any]:
@@ -191,7 +264,7 @@ class CodexCliChatAdapter:
                 "detail": _sanitize_text(err or out, limit=500),
             }
         help_text = out or ""
-        missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
+        missing = [flag for flag in ("--sandbox",) if flag not in help_text]
         if missing:
             return {
                 "ok": False,
@@ -199,11 +272,18 @@ class CodexCliChatAdapter:
                 "error": "Codex CLI does not advertise required safety flags",
                 "missing_flags": missing,
             }
+        # Codex CLI 0.135+ no longer exposes the old --ask-for-approval flag.
+        # Approval can still be pinned safely for exec runs through config:
+        #   -c approval_policy="never"
+        # Keep accepting older CLIs that advertise --ask-for-approval too, but
+        # do not block modern CLIs just because that legacy flag disappeared.
         return {
             "ok": True,
             "status": "exec_help_ok",
             "supports_json": "--json" in help_text,
             "supports_model": "--model" in help_text or " -m" in help_text,
+            "supports_approval_config": True,
+            "supports_legacy_ask_for_approval": "--ask-for-approval" in help_text,
         }
 
     async def _run(
@@ -239,15 +319,25 @@ class CodexCliChatAdapter:
             return 1, "", f"Failed to start Codex CLI: {exc.__class__.__name__}"
 
     @staticmethod
-    def _build_prompt(messages: list[dict[str, Any]]) -> str:
-        parts = [
-            "You are replying through Odysseus' experimental Codex CLI provider.",
-            "Return only the final assistant response.",
-            "Do not run tools, shell commands, file edits, or web requests.",
-            "If a request requires tools, say that this experimental provider does not support tools yet.",
-            "",
-            "Conversation:",
-        ]
+    def _build_prompt(messages: list[dict[str, Any]], allow_odysseus_tools: bool = False) -> str:
+        parts = ["You are replying through Odysseus' Codex CLI provider."]
+        if allow_odysseus_tools:
+            parts.extend([
+                "You are inside Odysseus agent mode. Odysseus, not Codex CLI, executes tools between rounds.",
+                "You are NOT a read-only agent: the local Codex CLI wrapper is constrained, but Odysseus agent tools are allowed to modify the workspace when the user asks.",
+                "You may create, edit, overwrite, and delete files by requesting Odysseus tool blocks such as ```write_file, ```bash, or ```python.",
+                "Use Odysseus fenced tool blocks for shell commands, file edits, browsing, and other tool work; Odysseus will execute them between rounds.",
+                "When you need a tool, output the exact fenced tool block requested by the system prompt (for example ```read_file or ```write_file).",
+                "After Odysseus executes that block, you will receive the result in a later round and can continue.",
+                "Return only assistant text plus any required Odysseus fenced tool blocks; do not explain this wrapper.",
+            ])
+        else:
+            parts.extend([
+                "Return only the final assistant response.",
+                "Do not run tools, shell commands, file edits, or web requests.",
+                "If a request requires tools, say that this experimental provider does not support tools yet.",
+            ])
+        parts.extend(["", "Conversation:"])
         for msg in messages or []:
             if not isinstance(msg, dict):
                 continue
@@ -365,13 +455,7 @@ class CodexModelProvider:
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
             else:
                 base["chat_supported"] = True
-                models.append({
-                    "id": CODEX_EXPERIMENTAL_MODEL_ID,
-                    "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
-                    "experimental": True,
-                    "streaming_supported": False,
-                    "session_resume_supported": False,
-                })
+                models.extend(codex_available_models())
 
         return {
             **base,
@@ -393,5 +477,107 @@ class CodexModelProvider:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        allow_odysseus_tools: bool = False,
     ) -> dict[str, Any]:
-        return await self._chat_adapter.complete(messages, model=model, timeout_seconds=timeout_seconds)
+        return await self._chat_adapter.complete(
+            messages,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            allow_odysseus_tools=allow_odysseus_tools,
+        )
+
+
+def is_codex_provider_selection(endpoint_url: str | None, model: str | None = None) -> bool:
+    """Return True when a chat/session selection targets the Codex CLI provider."""
+    endpoint = (endpoint_url or "").strip().rstrip("/")
+    model_id = (model or "").strip()
+    return (
+        endpoint == CODEX_PROVIDER_ENDPOINT_URL
+        or endpoint.startswith(CODEX_PROVIDER_ENDPOINT_URL + "/")
+        or model_id == CODEX_EXPERIMENTAL_MODEL_ID
+    )
+
+
+async def codex_model_picker_item(provider: CodexModelProvider | None = None) -> dict[str, Any] | None:
+    """Build an /api/models item when Codex OAuth is ready.
+
+    The Codex provider is virtual: it is backed by the local Codex CLI/OAuth
+    state, not a ModelEndpoint DB row and not an OpenAI-compatible HTTP URL.
+    """
+    provider = provider or CodexModelProvider()
+    status = await provider.status()
+    models = [m.get("id") for m in (status.get("models") or []) if m.get("id")]
+    if status.get("status") != "available" or not models or not status.get("chat_supported"):
+        return None
+    display_by_id = {m.get("id"): m.get("display") for m in status.get("models") or []}
+    return {
+        "host": "codex",
+        "port": 0,
+        "url": CODEX_PROVIDER_ENDPOINT_URL,
+        "models": models,
+        "models_display": [display_by_id.get(m) or m.split("/")[-1] for m in models],
+        "models_extra": [],
+        "models_extra_display": [],
+        "endpoint_id": CODEX_PROVIDER_ENDPOINT_ID,
+        "endpoint_name": CODEX_PROVIDER_ENDPOINT_NAME,
+        "category": "cloud",
+        "model_type": "llm",
+        "experimental": True,
+        "streaming_supported": False,
+        "session_resume_supported": False,
+        "tool_execution_allowed": False,
+    }
+
+
+async def codex_complete_chat(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    provider: CodexModelProvider | None = None,
+    timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+    allow_odysseus_tools: bool = False,
+) -> dict[str, Any]:
+    provider = provider or CodexModelProvider()
+    return await provider.test_chat(
+        messages,
+        model=model or CODEX_EXPERIMENTAL_MODEL_ID,
+        timeout_seconds=timeout_seconds,
+        allow_odysseus_tools=allow_odysseus_tools,
+    )
+
+
+async def stream_codex_chat(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    provider: CodexModelProvider | None = None,
+    timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+    allow_odysseus_tools: bool = False,
+):
+    """SSE wrapper for the non-streaming Codex CLI adapter."""
+    result = await codex_complete_chat(
+        messages,
+        model=model,
+        provider=provider,
+        timeout_seconds=timeout_seconds,
+        allow_odysseus_tools=allow_odysseus_tools,
+    )
+    if not result.get("ok"):
+        payload = {
+            "type": "error",
+            "error": result.get("error") or result.get("status") or "Codex CLI provider failed",
+            "status": result.get("status"),
+            "model": result.get("model") or model or CODEX_EXPERIMENTAL_MODEL_ID,
+        }
+        yield f"event: error\ndata: {json.dumps(payload)}\n\n"
+        yield "data: [DONE]\n\n"
+        return
+    message = result.get("message") or ""
+    if message:
+        yield f"data: {json.dumps({'delta': message})}\n\n"
+    metrics = {
+        "model": result.get("model") or model or CODEX_EXPERIMENTAL_MODEL_ID,
+        "response_time": round((result.get("duration_ms") or 0) / 1000, 2),
+        "usage_source": "codex-cli",
+        "streaming_supported": False,
+    }
+    yield f"data: {json.dumps({'type': 'metrics', 'data': metrics})}\n\n"
+    yield "data: [DONE]\n\n"

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -7,7 +7,12 @@ output as token streaming or reading Codex credential files.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
+import re
+import tempfile
+import time
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
@@ -15,6 +20,20 @@ from src.codex_auth import get_codex_auth_service
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
+CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental, non-streaming)"
+CODEX_CHAT_TIMEOUT_SECONDS = 120
+
+_TOKEN_PATTERNS = (
+    re.compile(r"(?i)(access_token|refresh_token|id_token)\s*[:=]\s*['\"]?[^'\"\s,}]+"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+"),
+)
+
+_LIMITATIONS = [
+    "Non-streaming: returns one completed assistant message.",
+    "Stateless: session/resume is not implemented.",
+    "Codex tool execution is not mapped into Odysseus agent rounds.",
+    "The adapter requires Codex CLI sandbox/approval flags before running.",
+]
 
 
 def _truthy(value: str | None) -> bool:
@@ -25,11 +44,265 @@ def codex_model_provider_enabled() -> bool:
     return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
 
 
+def _sanitize_text(text: str | None, limit: int = 2000) -> str:
+    safe = text or ""
+    for pattern in _TOKEN_PATTERNS:
+        safe = pattern.sub("<redacted-token>", safe)
+    return safe.strip()[:limit]
+
+
+class CodexCliChatAdapter:
+    """Admin-only, non-streaming adapter boundary for `codex exec`.
+
+    This intentionally does not provide a normal chat-provider hook yet. It
+    refuses to run unless the installed CLI advertises the sandbox and approval
+    flags needed for a constrained one-shot completion probe.
+    """
+
+    def __init__(
+        self,
+        auth_service_getter: Callable[[], Any] | None = None,
+        runner: Callable[..., Any] | None = None,
+    ) -> None:
+        self._auth_service_getter = auth_service_getter or get_codex_auth_service
+        self._runner = runner
+
+    async def available(self) -> dict[str, Any]:
+        preflight = await self._preflight()
+        if not preflight.get("ok"):
+            return preflight
+        help_result = await self._exec_help(preflight["bin_path"], preflight["env"])
+        if not help_result.get("ok"):
+            return help_result
+        return {
+            "ok": True,
+            "status": "available",
+            "chat_supported": True,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "supports_json": help_result.get("supports_json", False),
+            "limitations": list(_LIMITATIONS),
+        }
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        started = time.time()
+        availability = await self.available()
+        if not availability.get("ok"):
+            return {
+                **availability,
+                "ok": False,
+                "duration_ms": round((time.time() - started) * 1000),
+                "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            }
+
+        preflight = await self._preflight()
+        prompt = self._build_prompt(messages)
+        timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
+
+        with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
+            args = [
+                preflight["bin_path"],
+                "exec",
+                "--sandbox",
+                "read-only",
+                "--ask-for-approval",
+                "never",
+                prompt,
+            ]
+            rc, out, err = await self._run(
+                args,
+                timeout=timeout,
+                cwd=workdir,
+                env=preflight["env"],
+            )
+
+        duration_ms = round((time.time() - started) * 1000)
+        if rc == 124:
+            return self._error("timeout", "Codex CLI timed out", duration_ms, model)
+        if rc != 0:
+            detail = _sanitize_text(err or out, limit=500)
+            return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model)
+
+        message = self._extract_message(out)
+        if not message:
+            return self._error("empty_response", "Codex CLI returned no assistant message", duration_ms, model)
+
+        return {
+            "ok": True,
+            "status": "ok",
+            "message": message,
+            "duration_ms": duration_ms,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "limitations": list(_LIMITATIONS),
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+        }
+
+    async def _preflight(self) -> dict[str, Any]:
+        if not codex_model_provider_enabled():
+            return {"ok": False, "status": "disabled", "error": "Codex model provider is disabled"}
+
+        service = self._auth_service_getter()
+        try:
+            auth = await service.status()
+        except Exception as exc:
+            return {"ok": False, "status": "auth_status_failed", "error": exc.__class__.__name__}
+
+        cli_available = bool(
+            auth.get("codex_cli_available")
+            or (auth.get("cli_found") and auth.get("cli_executable"))
+        )
+        if not cli_available:
+            return {"ok": False, "status": "cli_unavailable", "error": "Codex CLI is unavailable"}
+
+        authenticated = bool(auth.get("codex_authenticated") or auth.get("authenticated"))
+        if not authenticated:
+            return {"ok": False, "status": "sign_in_required", "error": "Sign in with Codex / ChatGPT first"}
+
+        bin_path = ""
+        try:
+            bin_path = service._bin_path()  # Existing auth service owns CLI resolution.
+        except Exception:
+            bin_path = auth.get("resolved_binary_path") or ""
+        if not bin_path:
+            bin_path = auth.get("resolved_binary_path") or os.getenv("CODEX_BIN", "codex")
+
+        try:
+            env = service._env()
+        except Exception:
+            env = os.environ.copy()
+
+        return {"ok": True, "status": "preflight_ok", "bin_path": bin_path, "env": env}
+
+    async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
+        rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
+        if rc != 0:
+            return {
+                "ok": False,
+                "status": "unsupported_unsafe_cli_mode",
+                "error": "Unable to inspect codex exec safety flags",
+                "detail": _sanitize_text(err or out, limit=500),
+            }
+        help_text = out or ""
+        missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
+        if missing:
+            return {
+                "ok": False,
+                "status": "unsupported_unsafe_cli_mode",
+                "error": "Codex CLI does not advertise required safety flags",
+                "missing_flags": missing,
+            }
+        return {
+            "ok": True,
+            "status": "exec_help_ok",
+            "supports_json": "--json" in help_text,
+            "supports_model": "--model" in help_text or " -m" in help_text,
+        }
+
+    async def _run(
+        self,
+        args: list[str],
+        *,
+        timeout: int,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if self._runner:
+            return await self._runner(args=args, timeout=timeout, cwd=cwd, env=env)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            try:
+                out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return 124, "", "Command timed out"
+            return (
+                proc.returncode or 0,
+                (out or b"").decode("utf-8", errors="replace"),
+                (err or b"").decode("utf-8", errors="replace"),
+            )
+        except Exception as exc:
+            return 1, "", f"Failed to start Codex CLI: {exc.__class__.__name__}"
+
+    @staticmethod
+    def _build_prompt(messages: list[dict[str, Any]]) -> str:
+        parts = [
+            "You are replying through Odysseus' experimental Codex CLI provider.",
+            "Return only the final assistant response.",
+            "Do not run tools, shell commands, file edits, or web requests.",
+            "If a request requires tools, say that this experimental provider does not support tools yet.",
+            "",
+            "Conversation:",
+        ]
+        for msg in messages or []:
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role") or "user").strip() or "user"
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = " ".join(str(part.get("text", part)) if isinstance(part, dict) else str(part) for part in content)
+            parts.append(f"{role}: {content}")
+        return "\n".join(parts).strip()
+
+    @staticmethod
+    def _extract_message(output: str) -> str:
+        text = _sanitize_text(output)
+        if not text:
+            return ""
+        # If a future CLI emits JSONL, prefer common completed-message fields.
+        for line in text.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            for key in ("message", "content", "text", "output"):
+                value = data.get(key) if isinstance(data, dict) else None
+                if isinstance(value, str) and value.strip():
+                    return _sanitize_text(value)
+        return text
+
+    @staticmethod
+    def _error(status: str, error: str, duration_ms: int, model: str | None) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "status": status,
+            "error": _sanitize_text(error, limit=500),
+            "duration_ms": duration_ms,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "limitations": list(_LIMITATIONS),
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+        }
+
+
 class CodexModelProvider:
     """Status/capability adapter for a future Codex CLI provider."""
 
-    def __init__(self, auth_service_getter: Callable[[], Any] | None = None) -> None:
+    def __init__(
+        self,
+        auth_service_getter: Callable[[], Any] | None = None,
+        chat_adapter: CodexCliChatAdapter | None = None,
+    ) -> None:
         self._auth_service_getter = auth_service_getter or get_codex_auth_service
+        self._chat_adapter = chat_adapter or CodexCliChatAdapter(self._auth_service_getter)
 
     async def status(self) -> dict[str, Any]:
         enabled = codex_model_provider_enabled()
@@ -43,12 +316,7 @@ class CodexModelProvider:
             "streaming_supported": False,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
-            "limitations": [
-                "Chat dispatch is not implemented.",
-                "True token streaming has not been validated.",
-                "Session/resume behavior has not been designed.",
-                "Codex tool execution is not enabled for Odysseus chat mode.",
-            ],
+            "limitations": list(_LIMITATIONS),
         }
         if not enabled:
             return {
@@ -90,12 +358,20 @@ class CodexModelProvider:
             requires_sign_in = False
 
         models = []
+        chat_available = {"ok": False}
         if status == "available":
-            models.append({
-                "id": CODEX_EXPERIMENTAL_MODEL_ID,
-                "display": "codex-cli/chatgpt (experimental)",
-                "experimental": True,
-            })
+            chat_available = await self._chat_adapter.available()
+            if not chat_available.get("ok"):
+                status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
+            else:
+                base["chat_supported"] = True
+                models.append({
+                    "id": CODEX_EXPERIMENTAL_MODEL_ID,
+                    "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+                    "experimental": True,
+                    "streaming_supported": False,
+                    "session_resume_supported": False,
+                })
 
         return {
             **base,
@@ -111,3 +387,11 @@ class CodexModelProvider:
             },
             "models": models,
         }
+
+    async def test_chat(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        return await self._chat_adapter.complete(messages, model=model, timeout_seconds=timeout_seconds)

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -189,7 +189,6 @@ def add_integration(data: Dict[str, Any]) -> Dict[str, Any]:
     integration.setdefault("api_key", "")
     integration.setdefault("name", "")
     integration.setdefault("base_url", "")
-    integration.setdefault("integration_type", "api")
 
     integrations = load_integrations()
     integrations.append(integration)
@@ -259,9 +258,6 @@ async def execute_api_call(
     integration = _find_integration(integration_id)
     if not integration:
         return {"error": f"Integration not found: {integration_id}", "exit_code": 1}
-
-    if integration.get("integration_type") == "codex":
-        return {"error": "Codex / ChatGPT is not an HTTP API integration", "exit_code": 1}
 
     if not integration.get("enabled", True):
         return {"error": f"Integration '{integration.get('name')}' is disabled", "exit_code": 1}
@@ -385,10 +381,7 @@ def get_integrations_prompt() -> str:
     Returns empty string if no integrations are enabled.
     """
     integrations = load_integrations()
-    enabled = [
-        i for i in integrations
-        if i.get("enabled", True) and i.get("integration_type", "api") != "codex"
-    ]
+    enabled = [i for i in integrations if i.get("enabled", True)]
     if not enabled:
         return ""
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -189,6 +189,7 @@ def add_integration(data: Dict[str, Any]) -> Dict[str, Any]:
     integration.setdefault("api_key", "")
     integration.setdefault("name", "")
     integration.setdefault("base_url", "")
+    integration.setdefault("integration_type", "api")
 
     integrations = load_integrations()
     integrations.append(integration)
@@ -258,6 +259,9 @@ async def execute_api_call(
     integration = _find_integration(integration_id)
     if not integration:
         return {"error": f"Integration not found: {integration_id}", "exit_code": 1}
+
+    if integration.get("integration_type") == "codex":
+        return {"error": "Codex / ChatGPT is not an HTTP API integration", "exit_code": 1}
 
     if not integration.get("enabled", True):
         return {"error": f"Integration '{integration.get('name')}' is disabled", "exit_code": 1}
@@ -381,7 +385,10 @@ def get_integrations_prompt() -> str:
     Returns empty string if no integrations are enabled.
     """
     integrations = load_integrations()
-    enabled = [i for i in integrations if i.get("enabled", True)]
+    enabled = [
+        i for i in integrations
+        if i.get("enabled", True) and i.get("integration_type", "api") != "codex"
+    ]
     if not enabled:
         return ""
 

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -649,6 +649,23 @@ async def llm_call_async(
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
 
+    try:
+        from src.codex_model_provider import is_codex_provider_selection, codex_complete_chat
+        if is_codex_provider_selection(url, model):
+            result = await codex_complete_chat(
+                messages_copy,
+                model=model,
+                timeout_seconds=timeout,
+                allow_odysseus_tools=True,
+            )
+            if not result.get("ok"):
+                raise HTTPException(502, result.get("error") or result.get("status") or "Codex CLI provider failed")
+            return result.get("message") or ""
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(502, f"Codex CLI provider failed: {exc}")
+
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
     non_sys = []
@@ -751,6 +768,22 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     """
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
+
+    try:
+        from src.codex_model_provider import is_codex_provider_selection, stream_codex_chat
+        if is_codex_provider_selection(url, model):
+            async for chunk in stream_codex_chat(
+                messages_copy,
+                model=model,
+                timeout_seconds=timeout,
+                allow_odysseus_tools=True,
+            ):
+                yield chunk
+            return
+    except Exception as exc:
+        logger.error(f"Codex CLI stream error: {exc}")
+        yield f'event: error\ndata: {json.dumps({"error": str(exc), "status": 502})}\n\n'
+        return
 
     # Consolidate multiple system messages into one at the start.
     # Some models (e.g. Qwen3.5) reject system messages that aren't first.

--- a/static/index.html
+++ b/static/index.html
@@ -2090,24 +2090,6 @@
         <!-- ═══ TOOLS TAB ═══ -->
         <!-- ═══ INTEGRATIONS TAB ═══ -->
         <div data-settings-panel="integrations" class="hidden">
-          <div class="admin-card" id="codex-auth-card">
-            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M12 2v20"/><path d="M2 12h20"/><path d="m16 6 2 2-2 2"/><path d="m8 18-2-2 2-2"/></svg>Codex / ChatGPT</h2>
-            <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
-            <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
-            <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">
-              <div style="font-size:11px;opacity:0.65;margin-bottom:6px;">Open the verification URL, sign in, then enter this one-time code.</div>
-              <div style="display:grid;grid-template-columns:90px minmax(0,1fr);gap:6px 10px;align-items:center;font-size:12px;">
-                <span style="opacity:0.55;">URL</span><a id="codex-auth-url" href="#" target="_blank" rel="noopener noreferrer" style="color:var(--accent,var(--red));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></a>
-                <span style="opacity:0.55;">Code</span><code id="codex-auth-code" style="font-size:18px;letter-spacing:1px;"></code>
-              </div>
-            </div>
-            <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
-              <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
-              <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
-              <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
-              <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
-            </div>
-          </div>
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>Connections</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">All external service connections in one place.</div>

--- a/static/index.html
+++ b/static/index.html
@@ -2072,12 +2072,32 @@
                         <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
                       </div>
                       <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                        Experimental, non-streaming, stateless provider using Codex CLI auth. Not added to the default model picker yet.
+                        Experimental, non-streaming, stateless provider using Codex CLI auth. Sign in, then add its supported model here.
                       </div>
                     </div>
                     <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
                   </div>
                   <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div class="admin-model-form-row adm-codex-add-row" style="align-items:center;gap:8px;margin-top:6px;">
+                    <button type="button" id="adm-codexModelDropdownBtn" class="adm-provider-picker-btn" style="flex:1;min-width:0;justify-content:space-between;">
+                      <span id="adm-codexModelDropdownLabel" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">select models</span>
+                      <span class="admin-user-chevron" id="adm-codexModelChevron" style="opacity:0.45;transition:transform 0.15s;">⌄</span>
+                    </button>
+                    <button type="button" class="admin-btn-add" id="adm-codexAddModelBtn" style="width:55px;text-align:center;flex:0 0 55px;">Add</button>
+                  </div>
+                  <div id="adm-codexModelPanel" class="mcp-tools-panel adm-codex-model-panel hidden" style="padding-top:6px;margin-top:4px;">
+                    <div class="mcp-tools-header">
+                      <span>Models</span>
+                      <span style="display:flex;gap:8px;align-items:center;">
+                        <span id="adm-codexModelCount" class="mcp-tools-count">0/0 selected</span>
+                        <a href="#" id="adm-codexSelectAll">All</a>
+                        <a href="#" id="adm-codexSelectNone">None</a>
+                      </span>
+                    </div>
+                    <div id="adm-codexProviderModelList" class="mcp-tools-list adm-codex-model-list">
+                      <span style="opacity:0.5;font-size:11px;">Sign in to load Codex models</span>
+                    </div>
+                  </div>
                   <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
                     <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>

--- a/static/index.html
+++ b/static/index.html
@@ -2090,6 +2090,24 @@
         <!-- ═══ TOOLS TAB ═══ -->
         <!-- ═══ INTEGRATIONS TAB ═══ -->
         <div data-settings-panel="integrations" class="hidden">
+          <div class="admin-card" id="codex-auth-card">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M12 2v20"/><path d="M2 12h20"/><path d="m16 6 2 2-2 2"/><path d="m8 18-2-2 2-2"/></svg>Codex / ChatGPT</h2>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
+            <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
+            <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">
+              <div style="font-size:11px;opacity:0.65;margin-bottom:6px;">Open the verification URL, sign in, then enter this one-time code.</div>
+              <div style="display:grid;grid-template-columns:90px minmax(0,1fr);gap:6px 10px;align-items:center;font-size:12px;">
+                <span style="opacity:0.55;">URL</span><a id="codex-auth-url" href="#" target="_blank" rel="noopener noreferrer" style="color:var(--accent,var(--red));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></a>
+                <span style="opacity:0.55;">Code</span><code id="codex-auth-code" style="font-size:18px;letter-spacing:1px;"></code>
+              </div>
+            </div>
+            <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+              <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
+              <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
+              <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
+              <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
+            </div>
+          </div>
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>Connections</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">All external service connections in one place.</div>

--- a/static/index.html
+++ b/static/index.html
@@ -2064,6 +2064,27 @@
                   <button class="admin-btn-add" id="adm-epAddBtn" style="width:55px;text-align:center;">Add</button>
                 </div>
                 <div id="adm-epApiMsg" class="adm-ep-inline-msg"></div>
+                <div id="adm-codexProviderCard" class="admin-user-row" style="display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-top:10px;">
+                  <div style="display:flex;align-items:flex-start;gap:10px;">
+                    <div style="flex:1;min-width:0;">
+                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
+                        <span>Codex / ChatGPT</span>
+                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
+                      </div>
+                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                        Experimental, non-streaming, stateless provider using Codex CLI auth. Not added to the default model picker yet.
+                      </div>
+                    </div>
+                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
+                  </div>
+                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                  </div>
+                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
+                </div>
               </div>
             </div>
           </div>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -769,16 +769,31 @@ function initEndpointForm() {
   const codexStatusEl = el('adm-codexProviderStatus');
   const codexDetailsEl = el('adm-codexProviderDetails');
   const codexModelEl = el('adm-codexProviderModel');
+  const codexModelDropdownBtn = el('adm-codexModelDropdownBtn');
+  const codexModelPanel = el('adm-codexModelPanel');
+  const codexModelChevron = el('adm-codexModelChevron');
+  const codexModelList = el('adm-codexProviderModelList');
+  const codexModelCount = el('adm-codexModelCount');
+  const codexSelectAll = el('adm-codexSelectAll');
+  const codexSelectNone = el('adm-codexSelectNone');
   const codexMsgEl = el('adm-codexProviderMsg');
   const codexSignInBtn = el('adm-codexSignInBtn');
   const codexTestBtn = el('adm-codexTestBtn');
   const codexRefreshBtn = el('adm-codexRefreshBtn');
+  const codexAddModelBtn = el('adm-codexAddModelBtn');
   let codexProviderStatus = null;
 
   function _setCodexMsg(text, cls) {
     if (!codexMsgEl) return;
     codexMsgEl.textContent = text || '';
     codexMsgEl.className = cls || 'adm-ep-inline-msg';
+  }
+
+  function _syncCodexModelCount() {
+    if (!codexModelList || !codexModelCount) return;
+    const boxes = Array.from(codexModelList.querySelectorAll('input[type=checkbox]'));
+    const checked = boxes.filter(cb => cb.checked).length;
+    codexModelCount.textContent = `${checked}/${boxes.length} selected`;
   }
 
   function _codexStatusLabel(status) {
@@ -804,12 +819,43 @@ function initEndpointForm() {
     codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
     codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
 
-    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
+    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Add one of the supported Codex models here to make it selectable like Local/API models.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
-    else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
-    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
-    else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
+    else if (signInRequired) details += ' Sign in with Codex / ChatGPT before adding a model.';
+    else if (status === 'unsupported_unsafe_cli_mode') details += ' Chat is blocked until the Codex CLI safety flags are available.';
+    else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before adding a model.';
     codexDetailsEl.textContent = details;
+
+    const models = Array.isArray(data?.models) ? data.models : [];
+    if (codexModelList) {
+      codexModelList.innerHTML = '';
+      if (available) {
+        models.forEach((m, idx) => {
+          const id = typeof m === 'string' ? m : (m && m.id) || '';
+          const display = (m && (m.display || m.name)) || id.split('/').pop() || id;
+          const label = document.createElement('label');
+          label.title = id;
+          label.className = 'adm-model-row';
+          label.dataset.codexModelRow = 'true';
+          label.innerHTML = `
+            <input type="checkbox" class="adm-cb-hidden" data-codex-model-id="${esc(id)}" data-codex-model-display="${esc(display)}" ${idx === 0 ? 'checked' : ''}>
+            <span class="adm-check-dot" aria-hidden="true"></span>
+            <span>${esc(display)}</span>
+          `;
+          codexModelList.appendChild(label);
+        });
+      } else {
+        const empty = document.createElement('span');
+        empty.style.cssText = 'opacity:0.5;font-size:11px;';
+        empty.textContent = signInRequired ? 'Sign in to load Codex models' : _codexStatusLabel(status);
+        codexModelList.appendChild(empty);
+      }
+      codexModelList.querySelectorAll('input[type=checkbox]').forEach(cb => {
+        cb.disabled = !available;
+        cb.addEventListener('change', _syncCodexModelCount);
+      });
+      _syncCodexModelCount();
+    }
 
     if (codexModelEl) {
       if (model && model.id) {
@@ -821,6 +867,8 @@ function initEndpointForm() {
       }
     }
     if (codexTestBtn) codexTestBtn.disabled = !available;
+    if (codexAddModelBtn) codexAddModelBtn.disabled = !available;
+    if (codexModelDropdownBtn) codexModelDropdownBtn.disabled = !available;
     if (codexSignInBtn) codexSignInBtn.disabled = disabled;
   }
 
@@ -896,6 +944,41 @@ function initEndpointForm() {
     if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
   }
 
+  async function _addCodexModelToPicker() {
+    if (!codexAddModelBtn) return;
+    const selectedModels = codexModelList
+      ? Array.from(codexModelList.querySelectorAll('input[type=checkbox]:checked')).map(cb => cb.dataset.codexModelId).filter(Boolean)
+      : [];
+    if (!selectedModels.length && Array.isArray(codexProviderStatus?.models) && codexProviderStatus.models.length) {
+      const first = codexProviderStatus.models[0];
+      selectedModels.push((typeof first === 'string') ? first : first.id);
+    }
+    if (!selectedModels.length) selectedModels.push('codex-cli/chatgpt-experimental');
+    codexAddModelBtn.disabled = true;
+    codexAddModelBtn.textContent = 'Adding...';
+    _setCodexMsg('Adding Codex model to chat picker...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/add-model', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ models: selectedModels }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok && data.endpoint) {
+        await loadEndpoints();
+        await _selectAddedModelInChat(data.endpoint);
+        _setCodexMsg(`Added ${data.models?.length || data.endpoint.models?.length || 1} Codex model(s) — first selected for chat.`, 'admin-success');
+      } else {
+        _setCodexMsg(data.detail || data.message || 'Failed to add Codex model', 'admin-error');
+      }
+    } catch (e) {
+      _setCodexMsg('Failed to add Codex model: ' + (e && e.message ? e.message : 'request failed'), 'admin-error');
+    }
+    codexAddModelBtn.textContent = 'Add';
+    if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+  }
+
   if (codexSignInBtn) {
     codexSignInBtn.addEventListener('click', () => {
       if (settingsModule && typeof settingsModule.open === 'function') settingsModule.open('integrations');
@@ -906,6 +989,24 @@ function initEndpointForm() {
     });
   }
   if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
+  if (codexAddModelBtn) codexAddModelBtn.addEventListener('click', _addCodexModelToPicker);
+  if (codexModelDropdownBtn && codexModelPanel) codexModelDropdownBtn.addEventListener('click', () => {
+    codexModelPanel.classList.toggle('hidden');
+    const isOpen = !codexModelPanel.classList.contains('hidden');
+    if (codexModelChevron) codexModelChevron.style.transform = isOpen ? 'rotate(180deg)' : '';
+  });
+  if (codexSelectAll) codexSelectAll.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (!codexModelList) return;
+    codexModelList.querySelectorAll('input[type=checkbox]').forEach(cb => { if (!cb.disabled) cb.checked = true; });
+    _syncCodexModelCount();
+  });
+  if (codexSelectNone) codexSelectNone.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (!codexModelList) return;
+    codexModelList.querySelectorAll('input[type=checkbox]').forEach(cb => { if (!cb.disabled) cb.checked = false; });
+    _syncCodexModelCount();
+  });
   if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
   _refreshCodexProviderStatus();
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -765,6 +765,150 @@ function initEndpointForm() {
     return el(kind === 'local' ? 'adm-epLocalMsg' : 'adm-epApiMsg') || el('adm-epMsg');
   }
 
+  const codexCard = el('adm-codexProviderCard');
+  const codexStatusEl = el('adm-codexProviderStatus');
+  const codexDetailsEl = el('adm-codexProviderDetails');
+  const codexModelEl = el('adm-codexProviderModel');
+  const codexMsgEl = el('adm-codexProviderMsg');
+  const codexSignInBtn = el('adm-codexSignInBtn');
+  const codexTestBtn = el('adm-codexTestBtn');
+  const codexRefreshBtn = el('adm-codexRefreshBtn');
+  let codexProviderStatus = null;
+
+  function _setCodexMsg(text, cls) {
+    if (!codexMsgEl) return;
+    codexMsgEl.textContent = text || '';
+    codexMsgEl.className = cls || 'adm-ep-inline-msg';
+  }
+
+  function _codexStatusLabel(status) {
+    if (status === 'disabled') return 'Disabled';
+    if (status === 'sign_in_required') return 'Sign-in required';
+    if (status === 'available') return 'Available';
+    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked';
+    if (status === 'cli_unavailable') return 'CLI unavailable';
+    if (status === 'auth_status_failed') return 'Status unavailable';
+    return 'Unavailable';
+  }
+
+  function _renderCodexProviderStatus(data) {
+    if (!codexCard || !codexStatusEl || !codexDetailsEl) return;
+    const status = data && data.status ? data.status : 'unavailable';
+    const model = Array.isArray(data?.models) && data.models.length ? data.models[0] : null;
+    const available = status === 'available' && data.chat_supported === true && !!model;
+    const signInRequired = status === 'sign_in_required';
+    const disabled = status === 'disabled' || data?.feature_enabled === false;
+    codexProviderStatus = data || null;
+
+    codexStatusEl.textContent = _codexStatusLabel(status);
+    codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
+    codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
+
+    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
+    if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
+    else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
+    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
+    else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
+    codexDetailsEl.textContent = details;
+
+    if (codexModelEl) {
+      if (model && model.id) {
+        codexModelEl.style.display = '';
+        codexModelEl.innerHTML = `Model id: <code>${esc(model.id)}</code>`;
+      } else {
+        codexModelEl.style.display = 'none';
+        codexModelEl.textContent = '';
+      }
+    }
+    if (codexTestBtn) codexTestBtn.disabled = !available;
+    if (codexSignInBtn) codexSignInBtn.disabled = disabled;
+  }
+
+  async function _refreshCodexProviderStatus() {
+    if (!codexCard) return;
+    if (codexStatusEl) {
+      codexStatusEl.textContent = 'Checking';
+      codexStatusEl.className = 'admin-badge admin-badge-off';
+      codexStatusEl.style.color = '';
+    }
+    if (codexTestBtn) codexTestBtn.disabled = true;
+    _setCodexMsg('', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/status', { credentials: 'same-origin' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        _renderCodexProviderStatus({ status: res.status === 403 ? 'admin_required' : 'unavailable' });
+        _setCodexMsg(res.status === 403 ? 'Admin access is required to view Codex provider status.' : 'Could not load Codex provider status.', 'admin-error');
+        return;
+      }
+      _renderCodexProviderStatus(data);
+    } catch (_) {
+      _renderCodexProviderStatus({ status: 'unavailable' });
+      _setCodexMsg('Could not load Codex provider status.', 'admin-error');
+    }
+  }
+
+  function _codexTestFailureMessage(data, httpStatus) {
+    const status = data && data.status ? data.status : '';
+    if (status === 'disabled') return 'Codex provider test is disabled. Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true.';
+    if (status === 'sign_in_required') return 'Sign-in required before Codex provider test chat can run.';
+    if (status === 'cli_unavailable') return 'Codex CLI is unavailable in this runtime.';
+    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked: this Codex CLI does not expose the required sandbox/approval flags for UI test chat.';
+    if (status === 'timeout') return 'Codex CLI test timed out.';
+    if (status === 'empty_response') return 'Codex CLI returned no assistant message.';
+    if (status === 'cli_failed') return 'Codex CLI test failed. No raw CLI output is shown in the UI.';
+    if (status === 'invalid_request') return 'Codex provider test request was invalid.';
+    return `Test failed (${httpStatus})`;
+  }
+
+  async function _testCodexProviderChat() {
+    if (!codexTestBtn) return;
+    const model = Array.isArray(codexProviderStatus?.models) && codexProviderStatus.models.length
+      ? codexProviderStatus.models[0].id
+      : 'codex-cli/chatgpt-experimental';
+    codexTestBtn.disabled = true;
+    codexTestBtn.textContent = 'Testing...';
+    _setCodexMsg('Running non-streaming Codex provider test...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/test-chat', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          prompt: 'Reply with exactly: Codex provider UI test ok',
+          timeout_seconds: 60,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok) {
+        if (codexMsgEl) {
+          codexMsgEl.className = 'admin-success';
+          codexMsgEl.innerHTML = `Response: ${esc(data.message || '')}`;
+        }
+      } else {
+        _setCodexMsg(_codexTestFailureMessage(data, res.status), 'admin-error');
+      }
+    } catch (e) {
+      _setCodexMsg('Test failed: ' + (e && e.message ? e.message : 'request failed'), 'admin-error');
+    }
+    codexTestBtn.textContent = 'Test Chat';
+    if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+  }
+
+  if (codexSignInBtn) {
+    codexSignInBtn.addEventListener('click', () => {
+      if (settingsModule && typeof settingsModule.open === 'function') settingsModule.open('integrations');
+      setTimeout(() => {
+        document.dispatchEvent(new CustomEvent('odysseus:open-codex-auth'));
+      }, 50);
+      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this card after sign-in completes.', '');
+    });
+  }
+  if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
+  if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
+  _refreshCodexProviderStatus();
+
   let apiTestController = null;
   const apiTestBtn = el('adm-epApiTestBtn');
   const apiCancelTestBtn = el('adm-epApiCancelTestBtn');

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3072,13 +3072,6 @@ function initCodexAuth(root) {
     diagEl.classList.remove('hidden');
   }
 
-  function safeCodexLogBody(data) {
-    if (!data || typeof data !== 'object') return data;
-    const copy = { ...data };
-    if (copy.user_code) copy.user_code = '[redacted]';
-    return copy;
-  }
-
   function render(data) {
     const st = data.status || 'unknown';
     const codexAuthed = !!(data.codex_authenticated || data.authenticated);
@@ -3124,7 +3117,6 @@ function initCodexAuth(root) {
     try {
       const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
       const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
-      console.debug(`codex ${path} response`, { status: res.status, body: safeCodexLogBody(data) });
       if (res.status === 401 || res.status === 403) {
         data.status = 'auth_required';
         data.error_code = 'auth_required';
@@ -3137,7 +3129,6 @@ function initCodexAuth(root) {
       render(data);
       return data;
     } catch (e) {
-      console.debug(`codex ${path} request failed`, e);
       const data = { status: 'failed', message: `Request failed: ${e.message || e}` };
       render(data);
       return data;
@@ -3157,8 +3148,6 @@ function initCodexAuth(root) {
   }
 
   startBtn.addEventListener('click', async () => {
-    console.debug('codex sign-in clicked');
-    console.debug('calling /api/codex-auth/start');
     const data = await request('start', 'POST', 'Requesting Codex device code...');
     if (data.status === 'pending' && data.verification_url && data.user_code) {
       setResult('Device code ready. Complete sign-in in the browser.', 'var(--green,#50fa7b)');
@@ -3172,8 +3161,6 @@ function initCodexAuth(root) {
     if (!pollTimer) pollTimer = setInterval(refresh, 2500);
   });
   testBtn?.addEventListener('click', async () => {
-    console.debug('codex test clicked');
-    console.debug('calling /api/codex-auth/test');
     const data = await request('test', 'POST', 'Testing Codex connection...');
     if (data.ok) {
       statusEl.textContent = 'Codex connection is available';
@@ -3216,7 +3203,7 @@ async function initUnifiedIntegrations() {
   }
 
   async function fetchAll() {
-    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
+    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes, codexRes] = await Promise.all([
       fetch('/api/auth/integrations', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { integrations: [] }).catch(() => ({ integrations: [] })),
       fetch('/api/calendar/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
@@ -3224,16 +3211,21 @@ async function initUnifiedIntegrations() {
       fetch('/api/email/accounts', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { accounts: [] }).catch(() => ({ accounts: [] })),
       fetch('/api/mcp/servers', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : []).catch(() => []),
       fetch('/api/vault/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
+      fetch('/api/codex-auth/status', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
     ]);
     const items = [];
     // API integrations
     for (const intg of (apiRes.integrations || [])) {
-      if ((intg.integration_type || 'api') === 'codex') {
-        items.push({ type: 'codex', id: intg.id, name: intg.name || 'Codex / ChatGPT', detail: 'ChatGPT sign-in through the Codex CLI', enabled: intg.enabled !== false, data: intg });
-      } else {
-        items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
-      }
+      items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
     }
+    items.push({
+      type: 'codex',
+      id: '__codex__',
+      name: 'Codex / ChatGPT',
+      detail: codexRes.message || 'ChatGPT sign-in through the Codex CLI',
+      enabled: !!(codexRes.codex_authenticated || codexRes.authenticated),
+      data: codexRes,
+    });
     // CalDAV
     if (calRes.url) {
       items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
@@ -3344,7 +3336,7 @@ async function initUnifiedIntegrations() {
           else if (type === 'email') await fetch(`/api/email/accounts/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'mcp') await fetch(`/api/mcp/servers/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'vault') await fetch('/api/vault/logout', { method: 'POST', credentials: 'same-origin' });
-          else if (type === 'codex') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
+          else if (type === 'codex') await fetch('/api/codex-auth/logout', { method: 'POST', credentials: 'same-origin' });
         } catch (_) {}
         formEl.style.display = 'none';
         await renderList();
@@ -4406,65 +4398,7 @@ async function initUnifiedIntegrations() {
   }
 
   // ── Add button with type picker ──
-  async function findCodexIntegration() {
-    try {
-      const r = await fetch('/api/auth/integrations', { credentials: 'same-origin' });
-      const d = await r.json();
-      return (d.integrations || []).find(i => (i.integration_type || 'api') === 'codex') || null;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  async function showCodexForm(editId) {
-    const isEdit = editId && editId !== 'new';
-    if (!isEdit) {
-      const existing = await findCodexIntegration();
-      if (existing?.id) {
-        await showCodexForm(existing.id);
-        return;
-      }
-      formEl.innerHTML = `
-        <div class="admin-card" style="margin-top:8px">
-          <h2 style="font-size:13px">Add Codex / ChatGPT</h2>
-          <div class="admin-toggle-sub" style="margin-bottom:8px">Adds host-level ChatGPT sign-in through the official Codex CLI device-code flow.</div>
-          <div class="settings-row" style="margin-top:4px;flex-wrap:wrap;gap:6px">
-            <button type="button" class="admin-btn-sm" id="uf-codex-add">Add Codex / ChatGPT</button>
-            <button type="button" class="admin-btn-sm" id="uf-codex-cancel" style="opacity:0.75">Cancel</button>
-            <span id="uf-codex-msg" style="font-size:11px"></span>
-          </div>
-        </div>`;
-      el('uf-codex-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
-      el('uf-codex-add').addEventListener('click', async () => {
-        const msg = el('uf-codex-msg');
-        msg.textContent = 'Adding...';
-        msg.style.color = '';
-        try {
-          const r = await fetch('/api/auth/integrations', {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              integration_type: 'codex',
-              name: 'Codex / ChatGPT',
-              auth_type: 'none',
-              enabled: true,
-              description: 'ChatGPT sign-in through the official Codex CLI device-code flow.',
-            }),
-          });
-          const d = await r.json().catch(() => ({}));
-          if (!r.ok || !d.integration?.id) throw new Error(d.detail || d.error || `HTTP ${r.status}`);
-          await renderList();
-          notifyIntegrationsChanged();
-          await showCodexForm(d.integration.id);
-        } catch (e) {
-          msg.textContent = `Failed: ${e.message || e}`;
-          msg.style.color = 'var(--red)';
-        }
-      });
-      return;
-    }
-
+  async function showCodexForm() {
     formEl.innerHTML = `
       <div class="admin-card" id="codex-auth-card" style="margin-top:8px">
         <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex / ChatGPT</h2>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2115,7 +2115,6 @@ function initAll() {
   initEmailSettings();
   initEmailAccountsSettings();
   initReminderSettings();
-  initCodexAuth();
   initUnifiedIntegrations();
 }
 
@@ -3019,23 +3018,27 @@ const INTG_TYPES = {
   email:   { label: 'Email',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>' },
   mcp:     { label: 'MCP',     icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>' },
   vault:   { label: 'Vault',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>' },
+  codex:   { label: 'Codex',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="M2 12h20"/><path d="m16 6 2 2-2 2"/><path d="m8 18-2-2 2-2"/></svg>' },
 };
 
 let _unifiedInited = false;
-let _codexAuthInited = false;
 
-function initCodexAuth() {
-  if (_codexAuthInited) return;
-  _codexAuthInited = true;
-  const statusEl = el('codex-auth-status');
-  const deviceEl = el('codex-auth-device');
-  const urlEl = el('codex-auth-url');
-  const codeEl = el('codex-auth-code');
-  const startBtn = el('codex-auth-start');
-  const testBtn = el('codex-auth-test');
-  const cancelBtn = el('codex-auth-cancel');
-  const logoutBtn = el('codex-auth-logout');
+function initCodexAuth(root) {
+  const scope = root || document;
+  const q = (id) => scope.querySelector ? scope.querySelector(`#${id}`) : el(id);
+  const statusEl = q('codex-auth-status');
+  const deviceEl = q('codex-auth-device');
+  const urlEl = q('codex-auth-url');
+  const codeEl = q('codex-auth-code');
+  const startBtn = q('codex-auth-start');
+  const testBtn = q('codex-auth-test');
+  const cancelBtn = q('codex-auth-cancel');
+  const logoutBtn = q('codex-auth-logout');
+  const resultEl = q('codex-auth-result');
+  const diagEl = q('codex-auth-diagnostics');
   if (!statusEl || !startBtn) return;
+  if (startBtn.dataset.codexAuthInited === '1') return;
+  startBtn.dataset.codexAuthInited = '1';
 
   let pollTimer = null;
 
@@ -3045,16 +3048,56 @@ function initCodexAuth() {
     btn.style.opacity = busy ? '0.45' : '';
   }
 
+  function setResult(text, color) {
+    if (!resultEl) return;
+    resultEl.textContent = text || '';
+    resultEl.style.color = color || '';
+  }
+
+  function renderDiagnostics(data) {
+    if (!diagEl) return;
+    if (!data) {
+      diagEl.classList.add('hidden');
+      diagEl.textContent = '';
+      return;
+    }
+    const parts = [
+      `CLI installed: ${data.cli_found === false ? 'no' : 'yes'}`,
+      `executable: ${data.cli_executable === false ? 'no' : 'yes'}`,
+      `CODEX_BIN: ${data.configured_binary || 'codex'}`,
+      `resolved: ${data.resolved_binary_path || 'not found'}`,
+    ];
+    if (data.codex_home_path) parts.push(`CODEX_HOME: ${data.codex_home_path}`);
+    diagEl.textContent = parts.join('  ');
+    diagEl.classList.remove('hidden');
+  }
+
+  function safeCodexLogBody(data) {
+    if (!data || typeof data !== 'object') return data;
+    const copy = { ...data };
+    if (copy.user_code) copy.user_code = '[redacted]';
+    return copy;
+  }
+
   function render(data) {
     const st = data.status || 'unknown';
+    const codexAuthed = !!(data.codex_authenticated || data.authenticated);
+    const cliMissing = st === 'missing_cli' || st === 'cli_missing' || st === 'cli_not_executable'
+      || data.error_code === 'missing_cli' || data.error_code === 'cli_missing' || data.error_code === 'cli_not_executable'
+      || data.cli_found === false || data.cli_executable === false;
+    const authRequired = st === 'auth_required' || data.error_code === 'auth_required';
     let text = data.message || st;
-    if (data.authenticated && data.auth_mode) text = `${text} (${data.auth_mode})`;
+    if (authRequired) text = 'Odysseus session expired or admin auth required.';
+    else if (cliMissing) text = 'Codex CLI missing or CODEX_BIN invalid.';
+    else if (st === 'not_authenticated' || st === 'logged_out' || st === 'canceled') text = 'Codex CLI ready. Not signed in.';
+    else if (codexAuthed && data.auth_mode) text = `${text} (${data.auth_mode})`;
     if (st === 'pending') text = 'Waiting for browser verification...';
     if (st === 'starting') text = 'Starting device-code login...';
     statusEl.textContent = text;
-    statusEl.style.color = (st === 'failed' || st === 'timeout' || st === 'missing_cli' || st === 'disabled') ? 'var(--red)' : '';
+    statusEl.style.color = (st === 'failed' || st === 'timeout' || cliMissing || st === 'disabled' || authRequired) ? 'var(--red)' : '';
+    renderDiagnostics(data);
 
-    const hasDevice = !!(data.verification_url && data.user_code && (st === 'pending' || st === 'starting'));
+    const hasDevice = !!(data.verification_url && data.user_code && (st === 'pending' || st === 'starting' || data.device_login_active));
     deviceEl?.classList.toggle('hidden', !hasDevice);
     if (hasDevice) {
       urlEl.textContent = data.verification_url;
@@ -3064,19 +3107,41 @@ function initCodexAuth() {
       codeEl.textContent = '';
     }
 
-    const running = st === 'starting' || st === 'pending' || data.process_running;
+    const running = st === 'starting' || st === 'pending' || data.process_running || data.device_login_active;
     cancelBtn?.classList.toggle('hidden', !running);
-    startBtn.textContent = data.authenticated ? 'Sign in again' : 'Sign in with Codex';
+    startBtn.textContent = codexAuthed ? 'Sign in again' : 'Sign in with Codex';
     setBusy(startBtn, running);
     setBusy(testBtn, running);
     setBusy(logoutBtn, running);
   }
 
-  async function request(path, method) {
-    const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
-    const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
-    render(data);
-    return data;
+  async function request(path, method, busyText) {
+    if (busyText) {
+      statusEl.textContent = busyText;
+      statusEl.style.color = '';
+      setResult('', '');
+    }
+    try {
+      const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
+      const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
+      console.debug(`codex ${path} response`, { status: res.status, body: safeCodexLogBody(data) });
+      if (res.status === 401 || res.status === 403) {
+        data.status = 'auth_required';
+        data.error_code = 'auth_required';
+        data.message = 'Odysseus session expired or admin auth required.';
+      }
+      if (!res.ok) {
+        data.status = data.status || 'failed';
+        data.message = data.message || data.detail || `HTTP ${res.status}`;
+      }
+      render(data);
+      return data;
+    } catch (e) {
+      console.debug(`codex ${path} request failed`, e);
+      const data = { status: 'failed', message: `Request failed: ${e.message || e}` };
+      render(data);
+      return data;
+    }
   }
 
   async function refresh() {
@@ -3092,23 +3157,44 @@ function initCodexAuth() {
   }
 
   startBtn.addEventListener('click', async () => {
-    await request('start', 'POST');
+    console.debug('codex sign-in clicked');
+    console.debug('calling /api/codex-auth/start');
+    const data = await request('start', 'POST', 'Requesting Codex device code...');
+    if (data.status === 'pending' && data.verification_url && data.user_code) {
+      setResult('Device code ready. Complete sign-in in the browser.', 'var(--green,#50fa7b)');
+    } else if (data.status === 'starting' || data.device_login_active) {
+      setResult('Waiting for Codex CLI to provide a device code...', '');
+    } else if (data.status === 'already_authenticated' || data.authenticated) {
+      setResult('Codex is already authenticated.', 'var(--green,#50fa7b)');
+    } else if (data.error_code) {
+      setResult(data.message || 'Codex sign-in could not start', 'var(--red)');
+    }
     if (!pollTimer) pollTimer = setInterval(refresh, 2500);
   });
   testBtn?.addEventListener('click', async () => {
-    const data = await request('test', 'POST');
+    console.debug('codex test clicked');
+    console.debug('calling /api/codex-auth/test');
+    const data = await request('test', 'POST', 'Testing Codex connection...');
     if (data.ok) {
       statusEl.textContent = 'Codex connection is available';
       statusEl.style.color = 'var(--green,#50fa7b)';
+      setResult('Test passed', 'var(--green,#50fa7b)');
+    } else {
+      const cliReady = data.cli_found !== false && data.cli_executable !== false;
+      const message = cliReady && (data.status === 'not_authenticated' || data.status === 'logged_out')
+        ? 'Codex CLI ready. Not signed in.'
+        : (data.message || 'Test failed');
+      setResult(message, 'var(--red)');
     }
   });
   cancelBtn?.addEventListener('click', async () => {
-    await request('cancel', 'POST');
+    await request('cancel', 'POST', 'Canceling Codex sign-in...');
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
   });
   logoutBtn?.addEventListener('click', async () => {
     if (!await window.styledConfirm('Logout from Codex on this Odysseus host?', { confirmText: 'Logout', danger: true })) return;
-    await request('logout', 'POST');
+    const data = await request('logout', 'POST', 'Logging out from Codex...');
+    setResult(data.status === 'logged_out' ? 'Logged out' : (data.message || 'Logout finished'), data.status === 'logged_out' ? 'var(--green,#50fa7b)' : '');
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
   });
 
@@ -3142,7 +3228,11 @@ async function initUnifiedIntegrations() {
     const items = [];
     // API integrations
     for (const intg of (apiRes.integrations || [])) {
-      items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
+      if ((intg.integration_type || 'api') === 'codex') {
+        items.push({ type: 'codex', id: intg.id, name: intg.name || 'Codex / ChatGPT', detail: 'ChatGPT sign-in through the Codex CLI', enabled: intg.enabled !== false, data: intg });
+      } else {
+        items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
+      }
     }
     // CalDAV
     if (calRes.url) {
@@ -3254,6 +3344,7 @@ async function initUnifiedIntegrations() {
           else if (type === 'email') await fetch(`/api/email/accounts/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'mcp') await fetch(`/api/mcp/servers/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'vault') await fetch('/api/vault/logout', { method: 'POST', credentials: 'same-origin' });
+          else if (type === 'codex') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
         } catch (_) {}
         formEl.style.display = 'none';
         await renderList();
@@ -3270,6 +3361,7 @@ async function initUnifiedIntegrations() {
     else if (type === 'email') showEmailForm(editId);
     else if (type === 'mcp') showMcpForm(editId);
     else if (type === 'vault') showVaultForm();
+    else if (type === 'codex') showCodexForm(editId);
   }
 
   // ── API form ──
@@ -4314,6 +4406,91 @@ async function initUnifiedIntegrations() {
   }
 
   // ── Add button with type picker ──
+  async function findCodexIntegration() {
+    try {
+      const r = await fetch('/api/auth/integrations', { credentials: 'same-origin' });
+      const d = await r.json();
+      return (d.integrations || []).find(i => (i.integration_type || 'api') === 'codex') || null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async function showCodexForm(editId) {
+    const isEdit = editId && editId !== 'new';
+    if (!isEdit) {
+      const existing = await findCodexIntegration();
+      if (existing?.id) {
+        await showCodexForm(existing.id);
+        return;
+      }
+      formEl.innerHTML = `
+        <div class="admin-card" style="margin-top:8px">
+          <h2 style="font-size:13px">Add Codex / ChatGPT</h2>
+          <div class="admin-toggle-sub" style="margin-bottom:8px">Adds host-level ChatGPT sign-in through the official Codex CLI device-code flow.</div>
+          <div class="settings-row" style="margin-top:4px;flex-wrap:wrap;gap:6px">
+            <button type="button" class="admin-btn-sm" id="uf-codex-add">Add Codex / ChatGPT</button>
+            <button type="button" class="admin-btn-sm" id="uf-codex-cancel" style="opacity:0.75">Cancel</button>
+            <span id="uf-codex-msg" style="font-size:11px"></span>
+          </div>
+        </div>`;
+      el('uf-codex-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
+      el('uf-codex-add').addEventListener('click', async () => {
+        const msg = el('uf-codex-msg');
+        msg.textContent = 'Adding...';
+        msg.style.color = '';
+        try {
+          const r = await fetch('/api/auth/integrations', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              integration_type: 'codex',
+              name: 'Codex / ChatGPT',
+              auth_type: 'none',
+              enabled: true,
+              description: 'ChatGPT sign-in through the official Codex CLI device-code flow.',
+            }),
+          });
+          const d = await r.json().catch(() => ({}));
+          if (!r.ok || !d.integration?.id) throw new Error(d.detail || d.error || `HTTP ${r.status}`);
+          await renderList();
+          notifyIntegrationsChanged();
+          await showCodexForm(d.integration.id);
+        } catch (e) {
+          msg.textContent = `Failed: ${e.message || e}`;
+          msg.style.color = 'var(--red)';
+        }
+      });
+      return;
+    }
+
+    formEl.innerHTML = `
+      <div class="admin-card" id="codex-auth-card" style="margin-top:8px">
+        <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex / ChatGPT</h2>
+        <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
+        <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
+        <div id="codex-auth-diagnostics" class="hidden" style="font-size:10px;opacity:0.65;margin:-2px 0 8px 0;line-height:1.35;word-break:break-word;"></div>
+        <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">
+          <div style="font-size:11px;opacity:0.65;margin-bottom:6px;">Open the verification URL, sign in, then enter this one-time code.</div>
+          <div style="display:grid;grid-template-columns:90px minmax(0,1fr);gap:6px 10px;align-items:center;font-size:12px;">
+            <span style="opacity:0.55;">URL</span><a id="codex-auth-url" href="#" target="_blank" rel="noopener noreferrer" style="color:var(--accent,var(--red));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></a>
+            <span style="opacity:0.55;">Code</span><code id="codex-auth-code" style="font-size:18px;letter-spacing:1px;"></code>
+          </div>
+        </div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+          <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
+          <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
+          <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
+          <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
+          <button type="button" class="admin-btn-sm" id="uf-codex-close" style="opacity:0.75;">Close</button>
+          <span id="codex-auth-result" style="font-size:11px"></span>
+        </div>
+      </div>`;
+    el('uf-codex-close').addEventListener('click', () => { formEl.style.display = 'none'; });
+    initCodexAuth(formEl);
+  }
+
   if (addBtn) {
     addBtn.addEventListener('click', () => {
       formEl.style.display = '';
@@ -4330,6 +4507,7 @@ async function initUnifiedIntegrations() {
                 <option value="carddav">Contacts (CardDAV)</option>
                 <option value="email">Email (IMAP/SMTP)</option>
                 <option value="mcp">MCP Tool Server</option>
+                <option value="codex">Codex / ChatGPT</option>
               </select>
             </div>
           </div>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -4467,6 +4467,11 @@ async function initUnifiedIntegrations() {
     initCodexAuth(formEl, () => renderList());
   }
 
+  document.addEventListener('odysseus:open-codex-auth', () => {
+    formEl.style.display = '';
+    showCodexForm();
+  });
+
   if (addBtn) {
     addBtn.addEventListener('click', () => {
       formEl.style.display = '';

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3023,7 +3023,7 @@ const INTG_TYPES = {
 
 let _unifiedInited = false;
 
-function initCodexAuth(root) {
+function initCodexAuth(root, onStateChange) {
   const scope = root || document;
   const q = (id) => scope.querySelector ? scope.querySelector(`#${id}`) : el(id);
   const statusEl = q('codex-auth-status');
@@ -3041,6 +3041,30 @@ function initCodexAuth(root) {
   startBtn.dataset.codexAuthInited = '1';
 
   let pollTimer = null;
+  let lastListState = null;
+
+  function codexListState(data) {
+    const authenticated = !!(data?.codex_authenticated || data?.authenticated);
+    const running = !!(
+      data?.device_login_active
+      || data?.process_running
+      || data?.status === 'starting'
+      || data?.status === 'pending'
+    );
+    return `${authenticated ? '1' : '0'}:${running ? '1' : '0'}`;
+  }
+
+  function notifyStateChange(data) {
+    if (typeof onStateChange !== 'function') return;
+    const next = codexListState(data);
+    if (lastListState === null) {
+      lastListState = next;
+      return;
+    }
+    if (next === lastListState) return;
+    lastListState = next;
+    onStateChange(data);
+  }
 
   function setBusy(btn, busy) {
     if (!btn) return;
@@ -3127,10 +3151,12 @@ function initCodexAuth(root) {
         data.message = data.message || data.detail || `HTTP ${res.status}`;
       }
       render(data);
+      notifyStateChange(data);
       return data;
     } catch (e) {
       const data = { status: 'failed', message: `Request failed: ${e.message || e}` };
       render(data);
+      notifyStateChange(data);
       return data;
     }
   }
@@ -3218,14 +3244,30 @@ async function initUnifiedIntegrations() {
     for (const intg of (apiRes.integrations || [])) {
       items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
     }
-    items.push({
-      type: 'codex',
-      id: '__codex__',
-      name: 'Codex / ChatGPT',
-      detail: codexRes.message || 'ChatGPT sign-in through the Codex CLI',
-      enabled: !!(codexRes.codex_authenticated || codexRes.authenticated),
-      data: codexRes,
-    });
+    const codexAuthed = !!(codexRes.codex_authenticated || codexRes.authenticated);
+    const codexRunning = !!(
+      codexRes.device_login_active
+      || codexRes.process_running
+      || codexRes.status === 'starting'
+      || codexRes.status === 'pending'
+    );
+    const codexVisible = codexAuthed || codexRunning;
+    if (codexVisible) {
+      let codexDetail = 'ChatGPT sign-in through the Codex CLI';
+      if (codexAuthed && codexRes.auth_mode) codexDetail = `Signed in with ${codexRes.auth_mode}`;
+      else if (codexRunning) codexDetail = 'Device-code sign-in in progress';
+      else if (['not_authenticated', 'logged_out', 'canceled'].includes(codexRes.status)) codexDetail = 'Not signed in';
+      else if (codexRes.status === 'cli_missing' || codexRes.status === 'cli_not_executable') codexDetail = 'Codex CLI unavailable';
+      else if (codexRes.message && !/credential/i.test(codexRes.message)) codexDetail = codexRes.message;
+      items.push({
+        type: 'codex',
+        id: '__codex__',
+        name: 'Codex / ChatGPT',
+        detail: codexDetail,
+        enabled: codexAuthed,
+        data: codexRes,
+      });
+    }
     // CalDAV
     if (calRes.url) {
       items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
@@ -4422,7 +4464,7 @@ async function initUnifiedIntegrations() {
         </div>
       </div>`;
     el('uf-codex-close').addEventListener('click', () => { formEl.style.display = 'none'; });
-    initCodexAuth(formEl);
+    initCodexAuth(formEl, () => renderList());
   }
 
   if (addBtn) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2115,6 +2115,7 @@ function initAll() {
   initEmailSettings();
   initEmailAccountsSettings();
   initReminderSettings();
+  initCodexAuth();
   initUnifiedIntegrations();
 }
 
@@ -3021,6 +3022,98 @@ const INTG_TYPES = {
 };
 
 let _unifiedInited = false;
+let _codexAuthInited = false;
+
+function initCodexAuth() {
+  if (_codexAuthInited) return;
+  _codexAuthInited = true;
+  const statusEl = el('codex-auth-status');
+  const deviceEl = el('codex-auth-device');
+  const urlEl = el('codex-auth-url');
+  const codeEl = el('codex-auth-code');
+  const startBtn = el('codex-auth-start');
+  const testBtn = el('codex-auth-test');
+  const cancelBtn = el('codex-auth-cancel');
+  const logoutBtn = el('codex-auth-logout');
+  if (!statusEl || !startBtn) return;
+
+  let pollTimer = null;
+
+  function setBusy(btn, busy) {
+    if (!btn) return;
+    btn.disabled = !!busy;
+    btn.style.opacity = busy ? '0.45' : '';
+  }
+
+  function render(data) {
+    const st = data.status || 'unknown';
+    let text = data.message || st;
+    if (data.authenticated && data.auth_mode) text = `${text} (${data.auth_mode})`;
+    if (st === 'pending') text = 'Waiting for browser verification...';
+    if (st === 'starting') text = 'Starting device-code login...';
+    statusEl.textContent = text;
+    statusEl.style.color = (st === 'failed' || st === 'timeout' || st === 'missing_cli' || st === 'disabled') ? 'var(--red)' : '';
+
+    const hasDevice = !!(data.verification_url && data.user_code && (st === 'pending' || st === 'starting'));
+    deviceEl?.classList.toggle('hidden', !hasDevice);
+    if (hasDevice) {
+      urlEl.textContent = data.verification_url;
+      urlEl.href = data.verification_url;
+      codeEl.textContent = data.user_code;
+    } else if (codeEl) {
+      codeEl.textContent = '';
+    }
+
+    const running = st === 'starting' || st === 'pending' || data.process_running;
+    cancelBtn?.classList.toggle('hidden', !running);
+    startBtn.textContent = data.authenticated ? 'Sign in again' : 'Sign in with Codex';
+    setBusy(startBtn, running);
+    setBusy(testBtn, running);
+    setBusy(logoutBtn, running);
+  }
+
+  async function request(path, method) {
+    const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
+    const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
+    render(data);
+    return data;
+  }
+
+  async function refresh() {
+    try {
+      const data = await request('status');
+      const running = data.status === 'starting' || data.status === 'pending' || data.process_running;
+      if (running && !pollTimer) pollTimer = setInterval(refresh, 2500);
+      if (!running && pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    } catch (e) {
+      statusEl.textContent = 'Failed to check Codex status';
+      statusEl.style.color = 'var(--red)';
+    }
+  }
+
+  startBtn.addEventListener('click', async () => {
+    await request('start', 'POST');
+    if (!pollTimer) pollTimer = setInterval(refresh, 2500);
+  });
+  testBtn?.addEventListener('click', async () => {
+    const data = await request('test', 'POST');
+    if (data.ok) {
+      statusEl.textContent = 'Codex connection is available';
+      statusEl.style.color = 'var(--green,#50fa7b)';
+    }
+  });
+  cancelBtn?.addEventListener('click', async () => {
+    await request('cancel', 'POST');
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  });
+  logoutBtn?.addEventListener('click', async () => {
+    if (!await window.styledConfirm('Logout from Codex on this Odysseus host?', { confirmText: 'Logout', danger: true })) return;
+    await request('logout', 'POST');
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  });
+
+  refresh();
+}
 
 async function initUnifiedIntegrations() {
   if (_unifiedInited) return;

--- a/tests/test_codex_add_model_ui.py
+++ b/tests/test_codex_add_model_ui.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_codex_add_models_card_has_add_button():
+    html = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    assert 'id="adm-codexAddModelBtn"' in html
+    assert 'id="adm-codexModelDropdownBtn"' in html
+    assert '>select models</span>' in html
+    assert 'class="admin-model-form-row adm-codex-add-row"' in html
+    assert 'id="adm-codexModelPanel" class="mcp-tools-panel adm-codex-model-panel hidden"' in html
+    assert 'id="adm-codexProviderModelList" class="mcp-tools-list adm-codex-model-list"' in html
+    assert 'id="adm-codexSelectAll"' in html
+    assert 'id="adm-codexSelectNone"' in html
+
+
+def test_codex_add_button_calls_backend_and_selects_model():
+    js = (ROOT / "static" / "js" / "admin.js").read_text(encoding="utf-8")
+    assert "const codexModelDropdownBtn = el('adm-codexModelDropdownBtn')" in js
+    assert "codexModelDropdownLabel.textContent" not in js
+    assert "_syncCodexDropdownLabel" not in js
+    assert "codexModelPanel.classList.toggle('hidden')" in js
+    assert "querySelectorAll('input[type=checkbox]:checked')" in js
+    assert "body: JSON.stringify({ models: selectedModels })" in js
+    assert "'/api/codex-model-provider/add-model'" in js
+    assert "_selectAddedModelInChat(data.endpoint" in js
+
+
+def test_codex_add_model_backend_route_exists():
+    py = (ROOT / "routes" / "codex_model_provider_routes.py").read_text(encoding="utf-8")
+    assert '@router.post("/add-model")' in py
+    assert 'default_endpoint_id' in py
+    assert 'ModelEndpoint' in py
+    assert 'cached_models' in py
+    assert 'hidden_models' in py
+    assert 'CODEX_PROVIDER_ENDPOINT_ID' in py

--- a/tests/test_codex_auth_routes.py
+++ b/tests/test_codex_auth_routes.py
@@ -1,0 +1,79 @@
+import asyncio
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+if "core" not in sys.modules:
+    core_pkg = types.ModuleType("core")
+    core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
+    sys.modules["core"] = core_pkg
+
+from routes.codex_auth_routes import setup_codex_auth_routes
+from src.codex_auth import set_codex_auth_service
+
+
+class _AuthManager:
+    is_configured = True
+
+    def is_admin(self, user):
+        return user == "admin"
+
+
+def _request(user="admin"):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=_AuthManager())),
+    )
+
+
+class _FakeService:
+    async def status(self):
+        return {"status": "not_authenticated"}
+
+    async def start(self):
+        return {"status": "pending", "verification_url": "https://auth.openai.com/codex/device", "user_code": "CODE-12345"}
+
+    async def cancel(self):
+        return {"status": "canceled"}
+
+    async def logout(self):
+        return {"status": "logged_out"}
+
+    async def test(self):
+        return {"ok": False, "status": "not_authenticated"}
+
+
+def _endpoint(router, path, method):
+    for route in router.routes:
+        if getattr(route, "path", "") == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_codex_auth_routes_use_service():
+    set_codex_auth_service(_FakeService())
+    try:
+        router = setup_codex_auth_routes()
+        start = _endpoint(router, "/api/codex-auth/start", "POST")
+        out = asyncio.run(start(_request()))
+        assert out["status"] == "pending"
+        assert out["user_code"] == "CODE-12345"
+    finally:
+        set_codex_auth_service(None)
+
+
+def test_codex_auth_routes_admin_gated():
+    set_codex_auth_service(_FakeService())
+    try:
+        router = setup_codex_auth_routes()
+        status = _endpoint(router, "/api/codex-auth/status", "GET")
+        try:
+            asyncio.run(status(_request(user="bob")))
+        except Exception as exc:
+            assert getattr(exc, "status_code", None) == 403
+        else:
+            raise AssertionError("non-admin request should fail")
+    finally:
+        set_codex_auth_service(None)

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 from src.codex_auth import CodexAuthService
 
@@ -34,6 +35,37 @@ def test_status_parses_chatgpt_login(monkeypatch):
     assert out["authenticated"] is True
     assert out["codex_authenticated"] is True
     assert out["auth_mode"] == "ChatGPT"
+
+
+def test_status_does_not_echo_unrecognized_cli_output(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 0, "access_token=secret refresh_token=secret"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.status())
+    assert out["status"] == "not_authenticated"
+    assert "secret" not in out["message"]
+    assert "token" not in out["message"].lower()
+
+
+def test_codex_home_delegated_without_auth_file_access(monkeypatch, tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"access_token":"secret"}')
+    real_open = open
+
+    def guarded_open(path, *args, **kwargs):
+        if os.fspath(path) == os.fspath(auth_file):
+            raise AssertionError("Odysseus must not read or write Codex auth.json")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", guarded_open)
+    svc = CodexAuthService(codex_bin="definitely-not-codex", codex_home=str(tmp_path), enabled=True)
+    out = run(svc.status())
+    assert out["status"] == "cli_missing"
+    assert out["codex_home_configured"] is True
 
 
 def test_disabled_state():
@@ -170,7 +202,22 @@ def test_logout_runs_codex_logout(monkeypatch):
     monkeypatch.setattr(svc, "_run_command", fake_run)
     out = run(svc.logout())
     assert out["status"] == "logged_out"
+    assert out["message"] == "Codex credentials removed"
     assert ["logout"] in calls
+
+
+def test_logout_failure_does_not_echo_cli_output(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "refresh_token=secret"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.logout())
+    assert out["status"] == "failed"
+    assert out["message"] == "Codex logout failed"
+    assert "secret" not in str(out)
 
 
 def test_test_requires_authenticated_status(monkeypatch):

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -1,0 +1,179 @@
+import asyncio
+
+from src.codex_auth import CodexAuthService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_status_reports_missing_cli():
+    svc = CodexAuthService(codex_bin="definitely-not-codex", enabled=True)
+    out = run(svc.status())
+    assert out["status"] == "missing_cli"
+    assert out["error_code"] == "missing_cli"
+    assert out["codex_cli_available"] is False
+
+
+def test_status_parses_chatgpt_login(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 0, "Logged in using ChatGPT\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.status())
+    assert out["status"] == "authenticated"
+    assert out["authenticated"] is True
+    assert out["auth_mode"] == "ChatGPT"
+
+
+def test_disabled_state():
+    svc = CodexAuthService(enabled=False)
+    out = run(svc.start())
+    assert out["status"] == "disabled"
+    assert out["error_code"] == "disabled"
+
+
+class _FakeStdout:
+    def __init__(self, lines):
+        self._lines = [line.encode() for line in lines]
+
+    async def readline(self):
+        await asyncio.sleep(0)
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+
+class _FakeProcess:
+    def __init__(self, lines, returncode=0):
+        self.stdout = _FakeStdout(lines)
+        self.returncode = None
+        self._final_returncode = returncode
+        self.terminated = False
+
+    async def wait(self):
+        self.returncode = self._final_returncode
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.terminated = True
+        self.returncode = -9
+
+
+class _SlowStdout:
+    async def readline(self):
+        await asyncio.sleep(2)
+        return b""
+
+
+def test_start_device_flow_success(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    fake_proc = _FakeProcess([
+        "Open https://auth.openai.com/codex/device\n",
+        "Enter code CODE-12345\n",
+        "Successfully logged in\n",
+    ])
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    async def scenario():
+        first = await svc.start()
+        assert first["status"] == "starting"
+        await asyncio.sleep(0.05)
+        assert svc._state.status == "succeeded"
+        assert svc._state.authenticated is True
+
+    run(scenario())
+
+
+def test_start_device_flow_times_out_waiting_for_code(monkeypatch):
+    svc = CodexAuthService(enabled=True, code_timeout_seconds=0)
+    fake_proc = _FakeProcess([], returncode=1)
+    fake_proc.stdout = _SlowStdout()
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    async def scenario():
+        await svc.start()
+        await asyncio.sleep(1.1)
+        assert svc._state.status == "failed"
+        assert svc._state.error_code == "device_code_unavailable"
+        assert fake_proc.terminated is True
+
+    run(scenario())
+
+
+def test_start_device_flow_reports_cli_failure(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    fake_proc = _FakeProcess([
+        "Error logging in with device code: device code login is not enabled for this Codex server\n",
+    ], returncode=1)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    async def scenario():
+        await svc.start()
+        await asyncio.sleep(0.05)
+        assert svc._state.status == "failed"
+        assert svc._state.error_code == "device_auth_disabled"
+
+    run(scenario())
+
+
+def test_logout_runs_codex_logout(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    calls = []
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        calls.append(args)
+        return 0, "Successfully logged out\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.logout())
+    assert out["status"] == "logged_out"
+    assert ["logout"] in calls
+
+
+def test_test_requires_authenticated_status(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.test())
+    assert out["ok"] is False
+    assert out["authenticated"] is False

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -10,9 +10,15 @@ def run(coro):
 def test_status_reports_missing_cli():
     svc = CodexAuthService(codex_bin="definitely-not-codex", enabled=True)
     out = run(svc.status())
-    assert out["status"] == "missing_cli"
-    assert out["error_code"] == "missing_cli"
+    assert out["status"] == "cli_missing"
+    assert out["error_code"] == "cli_missing"
     assert out["codex_cli_available"] is False
+    assert out["configured_binary"] == "definitely-not-codex"
+    assert out["resolved_binary_path"] is None
+    assert out["binary_exists"] is False
+    assert out["binary_executable"] is False
+    assert out["cli_found"] is False
+    assert out["cli_executable"] is False
 
 
 def test_status_parses_chatgpt_login(monkeypatch):
@@ -26,6 +32,7 @@ def test_status_parses_chatgpt_login(monkeypatch):
     out = run(svc.status())
     assert out["status"] == "authenticated"
     assert out["authenticated"] is True
+    assert out["codex_authenticated"] is True
     assert out["auth_mode"] == "ChatGPT"
 
 
@@ -177,3 +184,6 @@ def test_test_requires_authenticated_status(monkeypatch):
     out = run(svc.test())
     assert out["ok"] is False
     assert out["authenticated"] is False
+    assert out["codex_authenticated"] is False
+    assert out["status"] == "not_authenticated"
+    assert out["message"] == "Codex CLI ready. Not signed in."

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -206,6 +206,27 @@ def test_logout_runs_codex_logout(monkeypatch):
     assert ["logout"] in calls
 
 
+def test_status_after_logout_rechecks_codex_login_status(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    calls = []
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        calls.append(args)
+        if args == ["logout"]:
+            return 0, "Successfully logged out\n"
+        return 1, "Not logged in\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.logout())
+    assert out["status"] == "logged_out"
+
+    status = run(svc.status())
+    assert status["status"] == "not_authenticated"
+    assert status["message"] == "Codex CLI ready. Not signed in."
+    assert calls == [["logout"], ["login", "status"]]
+
+
 def test_logout_failure_does_not_echo_cli_output(monkeypatch):
     svc = CodexAuthService(enabled=True)
     monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_ID,
     CODEX_MODEL_PROVIDER_FLAG,
+    CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+    CodexCliChatAdapter,
     CodexModelProvider,
 )
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
@@ -31,10 +33,42 @@ class _FakeService:
         self.calls += 1
         return dict(self.payload)
 
+    def _bin_path(self):
+        return "/usr/bin/codex"
+
+    def _env(self):
+        return {"PATH": "/usr/bin"}
+
+
+class _FakeAdapter:
+    async def available(self):
+        return {
+            "ok": True,
+            "status": "available",
+            "chat_supported": True,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "limitations": [],
+        }
+
+    async def complete(self, messages, model=None, timeout_seconds=120):
+        return {
+            "ok": True,
+            "status": "ok",
+            "message": "mock response",
+            "duration_ms": 1,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "limitations": [],
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+        }
+
 
 def _provider(payload):
     svc = _FakeService(payload)
-    return CodexModelProvider(lambda: svc), svc
+    return CodexModelProvider(lambda: svc, chat_adapter=_FakeAdapter()), svc
 
 
 def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
@@ -83,7 +117,12 @@ def test_codex_model_provider_reports_experimental_model_when_authenticated(monk
     assert out["status"] == "available"
     assert out["authenticated"] is True
     assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert out["models"][0]["display"] == CODEX_EXPERIMENTAL_MODEL_DISPLAY
     assert out["models"][0]["experimental"] is True
+    assert out["chat_supported"] is True
+    assert out["streaming_supported"] is False
+    assert out["session_resume_supported"] is False
+    assert out["tool_execution_allowed"] is False
     assert "secret" not in str(out)
     assert "access_token" not in str(out)
     assert "refresh_token" not in str(out)
@@ -142,3 +181,133 @@ def test_codex_model_provider_route_is_admin_gated(monkeypatch):
         assert getattr(exc, "status_code", None) == 403
     else:
         raise AssertionError("non-admin request should fail")
+
+
+def test_codex_model_provider_test_chat_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    test_chat = _endpoint(router, "/api/codex-model-provider/test-chat", "POST")
+
+    body = SimpleNamespace(prompt="hello", messages=None, model=None, timeout_seconds=None)
+    out = run(test_chat(_request(user="admin"), body))
+    assert out["ok"] is True
+    assert out["message"] == "mock response"
+
+    try:
+        run(test_chat(_request(user="bob"), body))
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 403
+    else:
+        raise AssertionError("non-admin request should fail")
+
+
+def test_codex_model_provider_test_chat_requires_body(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    test_chat = _endpoint(router, "/api/codex-model-provider/test-chat", "POST")
+
+    body = SimpleNamespace(prompt="", messages=None, model=None, timeout_seconds=None)
+    out = run(test_chat(_request(user="admin"), body))
+    assert out["ok"] is False
+    assert out["status"] == "invalid_request"
+
+
+def test_adapter_success_from_mocked_subprocess(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append((args, cwd, env))
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox <MODE> --ask-for-approval <POLICY> --json", ""
+        return 0, "codex provider test ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "Say ok"}]))
+
+    assert out["ok"] is True
+    assert out["message"] == "codex provider test ok"
+    assert out["streaming_supported"] is False
+    assert out["session_resume_supported"] is False
+    assert out["tool_execution_allowed"] is False
+    assert calls[1][1]
+    assert "--sandbox" in calls[1][0]
+    assert "read-only" in calls[1][0]
+    assert "--ask-for-approval" in calls[1][0]
+    assert "never" in calls[1][0]
+
+
+def test_adapter_handles_timeout(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        return 124, "", "access_token=secret"
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "hello"}], timeout_seconds=1))
+
+    assert out["ok"] is False
+    assert out["status"] == "timeout"
+    assert "secret" not in str(out)
+
+
+def test_adapter_handles_cli_nonzero_and_redacts(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        return 2, "", "refresh_token=secret failed"
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "hello"}]))
+
+    assert out["ok"] is False
+    assert out["status"] == "cli_failed"
+    assert "secret" not in str(out)
+    assert "refresh_token" not in str(out)
+
+
+def test_adapter_refuses_unsafe_cli_help(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        return 0, "Usage: codex exec --json", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.available())
+
+    assert out["ok"] is False
+    assert out["status"] == "unsupported_unsafe_cli_mode"
+    assert "--sandbox" in out["missing_flags"]
+    assert "--ask-for-approval" in out["missing_flags"]
+
+
+def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+
+    class UnsafeAdapter:
+        async def available(self):
+            return {"ok": False, "status": "unsupported_unsafe_cli_mode"}
+
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    provider = CodexModelProvider(lambda: svc, chat_adapter=UnsafeAdapter())
+
+    out = run(provider.status())
+
+    assert out["status"] == "unsupported_unsafe_cli_mode"
+    assert out["models"] == []
+    assert out["chat_supported"] is False

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -10,7 +10,10 @@ from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_DISPLAY,
     CodexCliChatAdapter,
     CodexModelProvider,
+    codex_available_models,
+    normalize_codex_model_id,
 )
+import src.codex_model_provider as codex_provider_module
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
 
 
@@ -41,6 +44,9 @@ class _FakeService:
 
 
 class _FakeAdapter:
+    def __init__(self):
+        self.calls = []
+
     async def available(self):
         return {
             "ok": True,
@@ -52,7 +58,8 @@ class _FakeAdapter:
             "limitations": [],
         }
 
-    async def complete(self, messages, model=None, timeout_seconds=120):
+    async def complete(self, messages, model=None, timeout_seconds=120, **kwargs):
+        self.calls.append({"messages": messages, "model": model, "timeout_seconds": timeout_seconds, **kwargs})
         return {
             "ok": True,
             "status": "ok",
@@ -68,7 +75,8 @@ class _FakeAdapter:
 
 def _provider(payload):
     svc = _FakeService(payload)
-    return CodexModelProvider(lambda: svc, chat_adapter=_FakeAdapter()), svc
+    adapter = _FakeAdapter()
+    return CodexModelProvider(lambda: svc, chat_adapter=adapter), svc
 
 
 def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
@@ -100,8 +108,9 @@ def test_codex_model_provider_requires_sign_in_when_unauthenticated(monkeypatch)
     assert out["streaming_supported"] is False
 
 
-def test_codex_model_provider_reports_experimental_model_when_authenticated(monkeypatch):
+def test_codex_model_provider_reports_experimental_model_when_authenticated(monkeypatch, tmp_path):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_provider_module, "CODEX_MODELS_CACHE_PATH", tmp_path / "missing-models-cache.json")
     provider, _ = _provider({
         "codex_cli_available": True,
         "authenticated": True,
@@ -214,8 +223,181 @@ def test_codex_model_provider_test_chat_requires_body(monkeypatch):
     assert out["status"] == "invalid_request"
 
 
-def test_adapter_success_from_mocked_subprocess(monkeypatch):
+def test_codex_model_picker_item_when_authenticated(monkeypatch, tmp_path):
+    from src.codex_model_provider import CODEX_PROVIDER_ENDPOINT_URL, codex_model_picker_item
+
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_provider_module, "CODEX_MODELS_CACHE_PATH", tmp_path / "missing-models-cache.json")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    item = run(codex_model_picker_item(provider))
+
+    assert item["url"] == CODEX_PROVIDER_ENDPOINT_URL
+    assert item["endpoint_id"] == "codex-cli"
+    assert item["models"] == [CODEX_EXPERIMENTAL_MODEL_ID]
+    assert item["endpoint_name"] == "Codex / ChatGPT"
+    assert item["experimental"] is True
+    assert item["streaming_supported"] is False
+
+
+def test_codex_selection_detection():
+    from src.codex_model_provider import CODEX_PROVIDER_ENDPOINT_URL, is_codex_provider_selection
+
+    assert is_codex_provider_selection(CODEX_PROVIDER_ENDPOINT_URL, CODEX_EXPERIMENTAL_MODEL_ID)
+    assert is_codex_provider_selection(CODEX_PROVIDER_ENDPOINT_URL + "/chat", "anything")
+    assert is_codex_provider_selection("", CODEX_EXPERIMENTAL_MODEL_ID)
+    assert not is_codex_provider_selection("http://localhost:8000/v1", "llama")
+
+
+def test_stream_codex_chat_emits_sse_delta_and_done(monkeypatch):
+    from src.codex_model_provider import stream_codex_chat
+
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def collect():
+        return [chunk async for chunk in stream_codex_chat([{"role": "user", "content": "hi"}], provider=provider)]
+
+    chunks = run(collect())
+
+    assert any('"delta": "mock response"' in chunk for chunk in chunks)
+    assert any('"type": "metrics"' in chunk for chunk in chunks)
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+def test_stream_codex_chat_can_use_odysseus_agent_prompt(monkeypatch):
+    from src.codex_model_provider import stream_codex_chat
+
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def collect():
+        return [
+            chunk async for chunk in stream_codex_chat(
+                [
+                    {"role": "system", "content": "Use ```read_file blocks for files."},
+                    {"role": "user", "content": "read ./README.md"},
+                ],
+                provider=provider,
+                allow_odysseus_tools=True,
+            )
+        ]
+
+    chunks = run(collect())
+
+    assert any('"delta": "mock response"' in chunk for chunk in chunks)
+    adapter_call = provider._chat_adapter.calls[-1]
+    assert adapter_call["allow_odysseus_tools"] is True
+
+
+def test_codex_agent_prompt_says_writes_are_allowed_through_odysseus_tools():
+    from src.codex_model_provider import CodexCliChatAdapter
+
+    prompt = CodexCliChatAdapter._build_prompt(
+        [{"role": "user", "content": "utwórz plik notes.txt"}],
+        allow_odysseus_tools=True,
+    )
+
+    assert "You are NOT a read-only agent" in prompt
+    assert "You may create, edit, overwrite, and delete files" in prompt
+    assert "write_file" in prompt
+    assert "bash" in prompt
+    assert "Codex CLI sandbox" not in prompt
+    assert "Do NOT run shell commands, edit files" not in prompt
+    assert "direct tools" not in prompt.lower()
+
+
+def test_llm_core_routes_codex_virtual_endpoint_to_codex_stream(monkeypatch):
+    from src.codex_model_provider import CODEX_PROVIDER_ENDPOINT_URL
+    import src.llm_core as llm_core
+
+    calls = []
+
+    async def fake_stream(messages, model=None, timeout_seconds=None, allow_odysseus_tools=False, **kwargs):
+        calls.append({
+            "messages": messages,
+            "model": model,
+            "timeout_seconds": timeout_seconds,
+            "allow_odysseus_tools": allow_odysseus_tools,
+        })
+        yield 'data: {"delta": "codex agent"}\n\n'
+        yield 'data: [DONE]\n\n'
+
+    monkeypatch.setattr("src.codex_model_provider.stream_codex_chat", fake_stream)
+
+    async def collect():
+        return [
+            chunk async for chunk in llm_core.stream_llm(
+                CODEX_PROVIDER_ENDPOINT_URL,
+                "gpt-5.5",
+                [{"role": "user", "content": "hi"}],
+            )
+        ]
+
+    chunks = run(collect())
+
+    assert chunks == ['data: {"delta": "codex agent"}\n\n', 'data: [DONE]\n\n']
+    assert calls[0]["allow_odysseus_tools"] is True
+
+
+def test_chat_route_only_bypasses_codex_for_plain_chat_mode():
+    route_path = os.path.join(os.path.dirname(__file__), "..", "routes", "chat_routes.py")
+    route_text = open(route_path, encoding="utf-8").read()
+
+    assert "if is_codex_session and _effective_mode == \"chat\":" in route_text
+    assert "stream_agent_loop(" in route_text
+
+
+def test_model_routes_only_expose_codex_when_endpoint_is_visible_to_user():
+    route_path = os.path.join(os.path.dirname(__file__), "..", "routes", "model_routes.py")
+    route_text = open(route_path, encoding="utf-8").read()
+
+    assert "def _append_codex_model_item(result: Dict[str, Any], owner: str = \"\", is_admin: bool = False)" in route_text
+    assert "codex_already_visible" in route_text
+    assert "if not codex_already_visible:" in route_text
+    assert "return out" in route_text
+    assert "if ep_id == CODEX_PROVIDER_ENDPOINT_ID and asyncio.run(codex_model_picker_item())" not in route_text
+
+
+def test_session_routes_require_visible_codex_endpoint_before_skip_validation():
+    route_path = os.path.join(os.path.dirname(__file__), "..", "routes", "session_routes.py")
+    route_text = open(route_path, encoding="utf-8").read()
+
+    assert "ModelEndpoint" in route_text
+    assert "CODEX_PROVIDER_ENDPOINT_ID" in route_text
+    assert "Codex model endpoint is not enabled for this user" in route_text
+
+
+def test_codex_add_model_route_scopes_endpoint_to_current_admin_and_supports_tools():
+    route_path = os.path.join(os.path.dirname(__file__), "..", "routes", "codex_model_provider_routes.py")
+    route_text = open(route_path, encoding="utf-8").read()
+
+    assert "owner = get_current_user(request)" in route_text
+    assert "supports_tools=True" in route_text
+    assert "ep.supports_tools = True" in route_text
+    assert "ep.owner = owner" in route_text
+    assert "owner=None" not in route_text
+    assert "supports_tools=False" not in route_text
+
+
+def test_adapter_success_from_mocked_subprocess(monkeypatch, tmp_path):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_provider_module, "CODEX_MODELS_CACHE_PATH", tmp_path / "missing-models-cache.json")
     svc = _FakeService({
         "codex_cli_available": True,
         "authenticated": True,
@@ -241,12 +423,83 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
     assert calls[1][1]
     assert "--sandbox" in calls[1][0]
     assert "read-only" in calls[1][0]
-    assert "--ask-for-approval" in calls[1][0]
-    assert "never" in calls[1][0]
+    assert "-c" in calls[1][0]
+    assert 'approval_policy="never"' in calls[1][0]
+    assert "--ask-for-approval" not in calls[1][0]
+    assert "--model" not in calls[1][0]
 
 
-def test_adapter_handles_timeout(monkeypatch):
+def test_adapter_uses_workspace_write_sandbox_for_odysseus_agent_mode(monkeypatch, tmp_path):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_provider_module, "CODEX_MODELS_CACHE_PATH", tmp_path / "missing-models-cache.json")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append((args, cwd, env))
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox <MODE>", ""
+        return 0, "ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete(
+        [{"role": "user", "content": "create a file"}],
+        allow_odysseus_tools=True,
+    ))
+
+    assert out["ok"] is True
+    assert out["tool_execution_allowed"] is True
+    exec_args = calls[1][0]
+    assert "--sandbox" in exec_args
+    assert exec_args[exec_args.index("--sandbox") + 1] == "workspace-write"
+    assert "read-only" not in exec_args
+
+def test_codex_available_models_reads_codex_cli_cache(tmp_path):
+    cache = tmp_path / "models_cache.json"
+    cache.write_text(
+        '{"models": ['
+        '{"slug":"hidden","display_name":"Hidden","visibility":"hidden","supported_in_api":true,"priority":1},'
+        '{"slug":"gpt-5.4-mini","display_name":"GPT-5.4-Mini","visibility":"list","supported_in_api":true,"priority":20},'
+        '{"slug":"gpt-5.5","display_name":"GPT-5.5","description":"Frontier","visibility":"list","supported_in_api":true,"priority":10}'
+        ']}',
+        encoding="utf-8",
+    )
+
+    models = codex_available_models(cache)
+
+    assert [m["id"] for m in models] == ["gpt-5.5", "gpt-5.4-mini"]
+    assert models[0]["display"] == "GPT-5.5"
+    assert "base_instructions" not in models[0]
+
+
+def test_adapter_passes_selected_codex_model_to_cli(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox --model <MODEL>", ""
+        return 0, "ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "hi"}], model="gpt-5.5"))
+
+    assert out["ok"] is True
+    assert "--model" in calls[1]
+    assert calls[1][calls[1].index("--model") + 1] == "gpt-5.5"
+    assert normalize_codex_model_id("codex-cli/gpt-5.4") == "gpt-5.4"
+
+
+def test_adapter_handles_timeout(monkeypatch, tmp_path):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_provider_module, "CODEX_MODELS_CACHE_PATH", tmp_path / "missing-models-cache.json")
     svc = _FakeService({"codex_cli_available": True, "authenticated": True})
 
     async def runner(args, timeout, cwd=None, env=None):
@@ -262,8 +515,9 @@ def test_adapter_handles_timeout(monkeypatch):
     assert "secret" not in str(out)
 
 
-def test_adapter_handles_cli_nonzero_and_redacts(monkeypatch):
+def test_adapter_handles_cli_nonzero_and_redacts(monkeypatch, tmp_path):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_provider_module, "CODEX_MODELS_CACHE_PATH", tmp_path / "missing-models-cache.json")
     svc = _FakeService({"codex_cli_available": True, "authenticated": True})
 
     async def runner(args, timeout, cwd=None, env=None):
@@ -293,7 +547,7 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
     assert out["ok"] is False
     assert out["status"] == "unsupported_unsafe_cli_mode"
     assert "--sandbox" in out["missing_flags"]
-    assert "--ask-for-approval" in out["missing_flags"]
+    assert "--ask-for-approval" not in out["missing_flags"]
 
 
 def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -1,0 +1,144 @@
+import asyncio
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_MODEL_ID,
+    CODEX_MODEL_PROVIDER_FLAG,
+    CodexModelProvider,
+)
+from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+
+
+if "core" not in sys.modules:
+    core_pkg = types.ModuleType("core")
+    core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
+    sys.modules["core"] = core_pkg
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeService:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = 0
+
+    async def status(self):
+        self.calls += 1
+        return dict(self.payload)
+
+
+def _provider(payload):
+    svc = _FakeService(payload)
+    return CodexModelProvider(lambda: svc), svc
+
+
+def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
+    monkeypatch.delenv(CODEX_MODEL_PROVIDER_FLAG, raising=False)
+    provider, svc = _provider({"codex_cli_available": True, "authenticated": True})
+
+    out = run(provider.status())
+
+    assert out["feature_enabled"] is False
+    assert out["status"] == "disabled"
+    assert out["models"] == []
+    assert svc.calls == 0
+
+
+def test_codex_model_provider_requires_sign_in_when_unauthenticated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": False,
+        "status": "not_authenticated",
+    })
+
+    out = run(provider.status())
+
+    assert out["status"] == "sign_in_required"
+    assert out["requires_sign_in"] is True
+    assert out["models"] == []
+    assert out["chat_supported"] is False
+    assert out["streaming_supported"] is False
+
+
+def test_codex_model_provider_reports_experimental_model_when_authenticated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+        "auth_mode": "ChatGPT",
+        "access_token": "secret",
+        "refresh_token": "secret",
+    })
+
+    out = run(provider.status())
+
+    assert out["status"] == "available"
+    assert out["authenticated"] is True
+    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert out["models"][0]["experimental"] is True
+    assert "secret" not in str(out)
+    assert "access_token" not in str(out)
+    assert "refresh_token" not in str(out)
+
+
+def test_codex_model_provider_reports_cli_unavailable(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": False,
+        "cli_found": False,
+        "cli_executable": False,
+        "status": "cli_missing",
+    })
+
+    out = run(provider.status())
+
+    assert out["status"] == "cli_unavailable"
+    assert out["cli_available"] is False
+    assert out["models"] == []
+
+
+class _AuthManager:
+    is_configured = True
+
+    def is_admin(self, user):
+        return user == "admin"
+
+
+def _request(user="admin"):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=_AuthManager())),
+    )
+
+
+def _endpoint(router, path, method):
+    for route in router.routes:
+        if getattr(route, "path", "") == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_codex_model_provider_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    status = _endpoint(router, "/api/codex-model-provider/status", "GET")
+
+    out = run(status(_request(user="admin")))
+    assert out["status"] == "available"
+
+    try:
+        run(status(_request(user="bob")))
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 403
+    else:
+        raise AssertionError("non-admin request should fail")

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -24,15 +24,6 @@ if "core.database" not in sys.modules:
         setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
 
-# Some route regression tests intentionally stub src.endpoint_resolver before
-# importing their target modules. If this file is collected after them in the
-# same process, make sure model_routes sees the real helper module.
-if "src.endpoint_resolver" in sys.modules and isinstance(
-    getattr(sys.modules["src.endpoint_resolver"], "_anthropic_api_root", None),
-    MagicMock,
-):
-    del sys.modules["src.endpoint_resolver"]
-
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 from routes.model_routes import (

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -24,6 +24,15 @@ if "core.database" not in sys.modules:
         setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
 
+# Some route regression tests intentionally stub src.endpoint_resolver before
+# importing their target modules. If this file is collected after them in the
+# same process, make sure model_routes sees the real helper module.
+if "src.endpoint_resolver" in sys.modules and isinstance(
+    getattr(sys.modules["src.endpoint_resolver"], "_anthropic_api_root", None),
+    MagicMock,
+):
+    del sys.modules["src.endpoint_resolver"]
+
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 from routes.model_routes import (


### PR DESCRIPTION
Summary

    This PR adds an experimental Codex / ChatGPT OAuth-backed model provider flow using the Codex CLI, and integrates it with the existing Odysseus model picker and Agent mode.

    The goal is to allow users who already have Codex / ChatGPT access through OAuth to use Codex inside Odysseus without requiring an OpenAI Platform API key.

    Branch with the changes:
    https://github.com/PAW122/odysseus/tree/codex-agent-tools-pr

    What changed

    Codex OAuth / CLI provider

    - Added an experimental Codex CLI-backed provider.
    - Uses the local Codex CLI authentication flow instead of https://api.openai.com/v1.
    - Adds status and test-chat endpoints for checking whether Codex CLI is available and authenticated.
    - Adds support for the virtual endpoint:

      text
      codex-cli://chat


    - Keeps Codex provider behavior separate from normal OpenAI-compatible HTTP endpoints.

    Add Models UI integration

    - Adds Codex / ChatGPT to the existing Admin → Add Models flow.
    - Allows adding Codex models through the same general model-management pattern as Local/API models.
    - Adds a compact dropdown-based model selector.
    - Keeps the dropdown label static as:

      text
      select models


    - Places the Add button in the same row as the selector.
    - Places secondary actions below:
      - Open Codex sign-in
      - Test Chat
      - Refresh

    Agent mode support

    - Routes codex-cli://chat through llm_core.
    - Allows Codex to participate in the normal Odysseus Agent loop instead of bypassing it.
    - Restricts the previous direct Codex chat bypass to plain chat mode only.
    - In Agent mode, Codex can request Odysseus tool blocks and Odysseus executes them between rounds.
    - This allows Codex to use the same Odysseus tool execution path as other tool-capable LLM providers.

    File/tool access behavior

    - Clarifies the Codex Agent-mode prompt so Codex understands that file edits, shell commands, and Python execution should happen through Odysseus tools.
    - Uses a safer separation:
      - plain Codex chat remains read-only,
      - Codex Agent mode uses a workspace-write Codex CLI sandbox so the model no longer receives a misleading read-only context,
      - actual project file writes still go through Odysseus tool execution.

    Owner scoping / visibility

    - Stores the Codex endpoint with the current admin/user as owner.
    - Marks the Codex endpoint as supporting tools.
    - Preserves existing owner visibility checks for:
      - model listing,
      - default model resolution,
      - session creation,
      - Codex endpoint selection.
    - Avoids exposing the server-side Codex OAuth-backed endpoint globally to every user.

    Tests

    Added and updated regression coverage for:

    - Codex auth service and routes.
    - Codex provider status and test-chat flow.
    - Codex Add Models UI.
    - Codex model discovery.
    - codex-cli://chat routing through llm_core.
    - Agent-mode routing through the normal Odysseus Agent loop.
    - Ensuring Codex plain chat mode can still use the direct bypass.
    - Ensuring Codex Agent mode does not bypass the Agent loop.
    - Codex Agent-mode prompt/tool behavior.
    - Codex CLI sandbox behavior.
    - Owner scoping and visibility behavior.

    Local verification

    Tested locally with:

    bash
    pytest tests/test_codex_auth_service.py \
           tests/test_codex_auth_routes.py \
           tests/test_codex_model_provider.py \
           tests/test_codex_add_model_ui.py \
           tests/test_model_routes.py \
           tests/test_session_mode_helpers.py -q


    Result:

    text
    108 passed


    Additional checks:

    bash
    python -m py_compile \
      src/codex_auth.py \
      src/codex_model_provider.py \
      src/llm_core.py \
      routes/codex_auth_routes.py \
      routes/codex_model_provider_routes.py \
      routes/chat_helpers.py \
      routes/chat_routes.py \
      routes/model_routes.py \
      routes/session_routes.py


    bash
    node --check static/js/admin.js
    node --check static/js/settings.js


    Both syntax checks passed.

    Manual testing

    Tested locally with Odysseus running natively.

    Verified that:

    - the app starts successfully,
    - the Add Models UI loads,
    - Codex / ChatGPT appears as an experimental provider,
    - Codex can be added to the chat model picker,
    - Codex can be selected as a model,
    - Codex Agent mode goes through the Odysseus Agent loop,
    - Codex can use Odysseus tools for file operations in Agent mode,
    - the original origin/main UI was also run locally on a separate port for comparison.

    Notes

    This is still experimental and intentionally keeps Codex as a virtual provider rather than pretending it is a normal OpenAI-compatible HTTP endpoint.

    The implementation is designed so that Codex OAuth / ChatGPT access does not require an OpenAI Platform API key or billing quota.