### PR TITLE
fix(llm): normalize conversation shape before sending to providers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       # static/ over it so CSS/JS edits show up on a browser reload without a
       # rebuild. The served files are then always the working-tree copy.
       - ./static:/app/static
+      # Likewise mount the Python source so backend edits take effect on a
+      # container restart instead of an image rebuild.
+      - ./src:/app/src
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # land under /app/.local for the odysseus user. Persist them so a
       # container recreate does not silently remove installed serve engines.
       - ./data/local:/app/.local
+      # Frontend assets are baked into the image at build time. Mount the host
+      # static/ over it so CSS/JS edits show up on a browser reload without a
+      # rebuild. The served files are then always the working-tree copy.
+      - ./static:/app/static
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -385,6 +385,47 @@ def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
             cleaned.append(item)
     return cleaned
 
+
+def _normalize_conversation(messages: List[Dict]) -> List[Dict]:
+    """Coerce a message list into the user-first, alternating shape that strict
+    chat templates (e.g. Qwen's jinja, which raises "No user query found in
+    messages") require — without changing meaning.
+
+    The chat UI seeds a greeting as an ``assistant`` message and, when a turn
+    fails, can leave two ``user`` turns back-to-back. Both produce a sequence
+    these templates reject. This:
+      - keeps a single leading ``system`` message untouched,
+      - drops any assistant/tool turns that precede the first ``user`` turn,
+      - merges consecutive same-role text turns into one (joined by a blank
+        line), leaving tool-call/non-string turns alone.
+    """
+    if not messages:
+        return messages
+    out: List[Dict] = []
+    body = messages
+    if body[0].get("role") == "system":
+        out.append(body[0])
+        body = body[1:]
+    # Drop leading non-user turns (the seeded assistant greeting, stray tools).
+    start = 0
+    while start < len(body) and body[start].get("role") != "user":
+        start += 1
+    for msg in body[start:]:
+        prev = out[-1] if out else None
+        mergeable = (
+            prev is not None
+            and prev.get("role") == msg.get("role")
+            and isinstance(prev.get("content"), str)
+            and isinstance(msg.get("content"), str)
+            and "tool_calls" not in prev and "tool_calls" not in msg
+            and "tool_call_id" not in prev and "tool_call_id" not in msg
+        )
+        if mergeable:
+            out[-1] = {**prev, "content": f"{prev['content']}\n\n{msg['content']}".strip()}
+        else:
+            out.append(msg)
+    return out
+
 def _normalize_anthropic_url(url: str) -> str:
     """Ensure Anthropic URL points to /v1/messages."""
     url = url.rstrip("/")
@@ -464,6 +505,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         messages_copy = [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
     else:
         messages_copy = non_sys
+    messages_copy = _normalize_conversation(messages_copy)
 
     provider = _detect_provider(url)
     cache_key = _get_cache_key(url, model, messages_copy, temperature, max_tokens)
@@ -572,6 +614,7 @@ async def llm_call_async(
         messages_copy = [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
     else:
         messages_copy = non_sys
+    messages_copy = _normalize_conversation(messages_copy)
 
     cache_key = _get_cache_key(url, model, messages_copy, temperature, max_tokens)
     cached_response = _get_cached_response(cache_key)
@@ -668,6 +711,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         messages_copy = [{"role": "system", "content": "\n\n".join(sys_parts)}] + non_sys
     else:
         messages_copy = non_sys
+    messages_copy = _normalize_conversation(messages_copy)
 
     if provider == "anthropic":
         target_url = _normalize_anthropic_url(url)

--- a/static/style.css
+++ b/static/style.css
@@ -1690,6 +1690,10 @@ body.bg-pattern-sparkles {
       overflow: hidden;
       text-overflow: clip;
       white-space: nowrap;
+      /* .list-item sets line-height:1, which clips the tops of Fira Code's
+         tall ascenders under overflow:hidden. Give the label its own roomier
+         line box so glyph tops aren't sliced. */
+      line-height: 1.4;
     }
     input, textarea, button, select {
       background:var(--bg);


### PR DESCRIPTION
## Problem

Local models served via LM Studio (and any backend using a strict chat template, e.g. Qwen's jinja) **error before generating a single token**:

```
Error rendering prompt with jinja template: "No user query found in messages."
```

The request still appears to "work" from the UI's perspective — it just spins on a perpetual loading state, because the upstream error isn't surfaced.

### Root cause

The chat UI seeds its greeting (`"Odysseus is yours to explore, enjoy the voyage!"`) as an **assistant** message, and a previously-failed turn can leave **two consecutive user** messages. So the payload sent upstream looks like:

```
system → assistant → user → user
```

That's a leading assistant turn before any user turn, plus back-to-back same-role turns — a sequence strict templates reject.

## Fix

Add `_normalize_conversation()` and apply it in all three outbound paths (`llm_call`, `llm_call_async`, `stream_llm`) right after the existing system-message consolidation:

- keep a single leading `system` message,
- drop assistant/tool turns that precede the first `user` turn,
- merge consecutive same-role **text** turns (tool-call / non-string turns are left untouched).

Result: providers receive a clean `system → user → assistant → …` sequence.

## Testing

Unit-tested against the exact failing payload plus regression cases:
- leading assistant greeting dropped; two user turns merged into one
- tool-call flow (`user → assistant[tool_calls] → tool → assistant`) unchanged
- normal alternation unchanged; empty / no-user inputs handled

Verified live: same conversation that errored now streams a normal reply from LM Studio (Qwen3 27B), with no jinja error in the server log.

## Also

Adds `./src:/app/src` to `docker-compose.yml` so backend edits take effect on a container restart instead of a full image rebuild (mirrors the existing pattern; pairs with the `static/` mount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)