### PR TITLE
fix: several security vulnerabilities (privilege escalation, SSRF, path traversal)

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -242,6 +242,22 @@ def setup_embedding_routes():
         if not url:
             raise HTTPException(400, "URL is required")
 
+        # SSRF guard: block private/internal ranges
+        from urllib.parse import urlparse
+        import ipaddress
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise HTTPException(400, "Only http/https URLs are allowed")
+        hostname = parsed.hostname or ""
+        try:
+            ip = ipaddress.ip_address(hostname)
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                raise HTTPException(400, "Private/internal addresses are not allowed")
+        except ValueError:
+            blocked_domains = ("metadata.google.internal", "instance-data", "169.254.169.254")
+            if any(d in hostname for d in blocked_domains):
+                raise HTTPException(400, "Metadata service addresses are not allowed")
+
         # Quick health check
         try:
             import httpx

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -3,6 +3,9 @@
 import os
 import hashlib
 import logging
+import re
+import uuid
+from pathlib import Path
 from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -122,7 +125,10 @@ def setup_gallery_routes() -> APIRouter:
             content = await file.read()
             img_dir = Path("data/generated_images")
             img_dir.mkdir(parents=True, exist_ok=True)
-            img_path = img_dir / img.filename
+            safe_fname = re.sub(r'[^\w\-_\.]', '_', Path(img.filename).name)[:128]
+            if not safe_fname:
+                safe_fname = uuid.uuid4().hex[:12]
+            img_path = img_dir / safe_fname
             img_path.write_bytes(content)
 
             # Refresh dimensions in case the editor resized the canvas.

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -559,6 +559,12 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         safe_name = re.sub(r'[^\w\-_]', '_', session.name)
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 
+        def _safe_export_name(name: str) -> str:
+            name = (name or "").replace("\r", "").replace("\n", "")
+            import re as _re
+            name = _re.sub(r'[/\\:\x00]', '_', name)
+            return name[:128]
+
         if fmt == "json":
             import json as _json
             data = {
@@ -567,7 +573,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 "exported": datetime.now().isoformat(),
                 "messages": [{"role": m.role, "content": m.content} for m in session.history],
             }
-            out_name = filename or f"conversation_{safe_name}_{timestamp}.json"
+            out_name = _safe_export_name(filename) or f"conversation_{safe_name}_{timestamp}.json"
             return Response(
                 content=_json.dumps(data, indent=2, ensure_ascii=False),
                 media_type="application/json",
@@ -580,7 +586,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 lines.append(f"[{m.role.upper()}]")
                 lines.append(m.content)
                 lines.append("")
-            out_name = filename or f"conversation_{safe_name}_{timestamp}.txt"
+            out_name = _safe_export_name(filename) or f"conversation_{safe_name}_{timestamp}.txt"
             return Response(
                 content="\n".join(lines),
                 media_type="text/plain",
@@ -605,7 +611,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 content = content.replace("\n", "<br>")
                 html_parts.append(f'<div class="msg {cls}"><div class="role">{m.role}</div>{content}</div>')
             html_parts.append("</body></html>")
-            out_name = filename or f"conversation_{safe_name}_{timestamp}.html"
+            out_name = _safe_export_name(filename) or f"conversation_{safe_name}_{timestamp}.html"
             return Response(
                 content="\n".join(html_parts),
                 media_type="text/html",
@@ -626,7 +632,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             markdown_lines.append("---\n")
         if len(markdown_lines) > 3:
             markdown_lines.pop()
-        out_name = filename or f"conversation_{safe_name}_{timestamp}.md"
+        out_name = _safe_export_name(filename) or f"conversation_{safe_name}_{timestamp}.md"
         return Response(
             content="\n".join(markdown_lines),
             media_type="text/markdown",

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -168,6 +168,7 @@ async def _run_subprocess_streaming(
     )
 
 _ADMIN_TOOLS = {
+    "app_api",
     "manage_endpoints",
     "manage_mcp",
     "manage_webhooks",
@@ -175,6 +176,7 @@ _ADMIN_TOOLS = {
     "manage_settings",
     "download_model",
     "serve_model",
+    "serve_preset",
     "stop_served_model",
     "cancel_download",
 }

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -8,6 +8,7 @@ These handle the actual execution logic for each tool type.
 import json
 import logging
 import os
+import posixpath
 import re
 from typing import Any, Dict, List, Optional
 
@@ -2585,6 +2586,11 @@ _APP_API_BLOCKLIST_PREFIXES = (
     "/api/tokens/",        # api token mgmt
     "/api/admin/",         # admin one-shots (wipe etc.)
     "/api/backup/restore", # destructive restore
+    "/api/shell/",         # shell exec / streaming — RCE vector
+    "/api/cookbook/",      # setup/kill-pid/packages — destructive
+    "/api/settings/",      # system settings
+    "/api/prefs/",         # security preferences
+    "/api/email/accounts", # owner-filtered bypass — use list_email_accounts
 )
 
 # (method, prefix) pairs to refuse specifically. Used for endpoints
@@ -2693,6 +2699,8 @@ async def do_app_api(content: str, owner: Optional[str] = None) -> Dict:
         return {"error": "path is required (e.g. '/api/cookbook/gpus')", "exit_code": 1}
     if not path.startswith("/"):
         path = "/" + path
+    # Normalize path to prevent double-slash and traversal bypasses
+    path = posixpath.normpath(path)
     if any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES):
         return {"error": f"Path blocked for safety: {path}. Auth/user/admin endpoints are off-limits via app_api.", "exit_code": 1}
 


### PR DESCRIPTION
Fixes several security issues found during an audit.

## Changes

### Privilege escalation via app_api (critical)
Added app_api and serve_preset to _ADMIN_TOOLS so they require admin access. Previously any authenticated user could call app_api to hit internal endpoints (including shell exec) and serve_preset to spin up model servers.

### Path normalization bypass on app_api blocklist (critical)
Normalized the request path with posixpath.normpath() before checking against the blocklist. Double-slash and traversal sequences like //api/admin/... bypassed the startswith check.
Expanded _APP_API_BLOCKLIST_PREFIXES to cover /api/shell/, /api/cookbook/, /api/settings/, /api/prefs/, and /api/email/accounts.

### HTTP response splitting on session export (critical)
Sanitized the filename query parameter in export_session - stripped CR/LF, path separators, and null bytes. The raw value was interpolated into Content-Disposition headers on all four export formats, allowing header injection.

### Path traversal on gallery image replace (high)
The replace endpoint used the raw multipart filename to construct the write path. Sanitized to alphanumeric plus dash/underscore/dot with a UUID fallback.

### SSRF via embedding endpoint (high)
The custom embedding endpoint URL was used directly in an httpx POST with no validation. Added scheme and IP checks to block private, loopback, link-local, reserved, and metadata service addresses.
