### PR TITLE
Cookbook: fix "--user" pip install failing inside a venv (#702)

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1016,7 +1016,22 @@ def setup_cookbook_routes() -> APIRouter:
                 runner_lines,
                 keep_shell_open=not local_windows,
             )
-            runner_lines.append(req.cmd)
+            # Issue #702: `python -m pip install --user` aborts inside a venv/
+            # conda env ("User site-packages are not visible in this virtualenv").
+            # The client can't reliably know the runtime env, so it emits the
+            # placeholder __ODYSSEUS_PIPFLAGS__ and we resolve it HERE, in the
+            # shell where the env is actually visible: add `--user
+            # --break-system-packages` only when NOT in a venv/conda (for
+            # PEP-668-locked system pythons); otherwise add nothing.
+            _exec_cmd = req.cmd
+            if "__ODYSSEUS_PIPFLAGS__" in _exec_cmd:
+                runner_lines.append(
+                    'if [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ] || '
+                    'python3 -c "import sys; sys.exit(0 if sys.prefix!=getattr(sys,\\"base_prefix\\",sys.prefix) else 1)" 2>/dev/null; then '
+                    '_ODY_PIPFLAGS=""; else _ODY_PIPFLAGS="--user --break-system-packages"; fi'
+                )
+                _exec_cmd = _exec_cmd.replace("__ODYSSEUS_PIPFLAGS__", "$_ODY_PIPFLAGS")
+            runner_lines.append(_exec_cmd)
             if local_windows:
                 # Detached background process — no interactive shell to keep open.
                 # Print the exit marker the status poller looks for, then stop.

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -595,12 +595,21 @@ async function _fetchDependencies() {
       const targetHost = isLocalOnly ? 'this server' : (_envState.remoteHost || 'local');
       // Always go through `python -m pip` so the leading token is `python`
       // — matches the /api/model/serve allow-list (bare `pip` is blocked).
-      // Inside a venv/conda env, `--user` is invalid (pip refuses), so we
-      // only add `--user --break-system-packages` when there's no env —
-      // for PEP-668-locked system pythons (Arch, newer Debian).
-      const _inEnv = _envState.env === 'venv' || _envState.env === 'conda';
-      const _pipFlags = (!_isWindows() && !_inEnv) ? ' --user --break-system-packages' : '';
+      //
+      // `--user` is INVALID inside a venv/conda env (pip aborts with "Can not
+      // perform a '--user' install. User site-packages are not visible in this
+      // virtualenv" — see issue #702). We previously decided this from the
+      // UI-declared env (_envState.env), but that's a guess: a user who runs
+      // Odysseus from a venv without setting the venv field in the UI got
+      // `--user` added and the install hard-failed. Decide at RUNTIME instead,
+      // in the shell where the env is actually visible. The placeholder
+      // __ODYSSEUS_PIPFLAGS__ is replaced server-side with a one-liner that
+      // resolves to `--user --break-system-packages` ONLY when not in a venv/
+      // conda env (for PEP-668-locked system pythons: Arch, newer Debian).
       const _py = _isWindows() ? 'python' : 'python3';
+      // Windows pip has no PEP-668 lock and no meaningful --user story here;
+      // keep it flag-free. POSIX uses the runtime-resolved flag placeholder.
+      const _pipFlags = _isWindows() ? '' : ' __ODYSSEUS_PIPFLAGS__';
       const cmd = `${_py} -m pip install${upgrade ? ' -U' : ''}${_pipFlags} "${pipName}"`;
       let envPrefix = '';
       if (_isWindows()) {


### PR DESCRIPTION
## What

Fixes #702 — installing a Cookbook dependency from inside a venv aborts with:

```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

## Why

The install command is built client-side and bakes in `--user --break-system-packages` whenever the UI-declared environment (`_envState.env`) isn't `venv`/`conda`. That's only a guess: a user who runs Odysseus from a venv **without** setting the venv field in the UI gets `--user` added, and pip refuses `--user` inside a virtualenv. (Reported on CachyOS; reproduces on any venv where the UI env field is unset.)

## Fix

Decide the flag at **runtime, in the shell where the environment is actually visible**, instead of from a UI guess:

- The client emits a `__ODYSSEUS_PIPFLAGS__` placeholder instead of hardcoding `--user`.
- The serve runner resolves it: `--user --break-system-packages` **only** when not in a venv/conda (checked via `$VIRTUAL_ENV` / `$CONDA_PREFIX` / `sys.prefix != base_prefix`), otherwise empty.

So a PEP-668-locked system python still gets the flags (Arch, newer Debian), and a venv/conda env never does — regardless of what the UI was told. The placeholder is plain `[A-Z_]` so it passes serve-command validation; substitution happens post-validation.

## Files changed

- `static/js/cookbook.js` — emit the placeholder instead of baking in `--user`.
- `routes/cookbook_routes.py` — resolve the placeholder in the runner via a runtime venv check.

(2 files, +30/-6.)

## Testing

- `python -m py_compile routes/cookbook_routes.py` → pass
- `node --check static/js/cookbook.js` → pass
- Verified the runtime guard resolves correctly in all three cases:
  - system python (no venv) → `--user --break-system-packages`
  - `$VIRTUAL_ENV` set → empty (no `--user`)
  - `$CONDA_PREFIX` set → empty

_Implemented with Claude (Anthropic) as a coding assistant; commit carries a `Co-Authored-By` trailer._

Fixes #702
