### PR TITLE
Consumer AMD (RDNA) support: GGUF recommendations, Vulkan build, accurate estimates

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1619,25 +1619,35 @@ def setup_cookbook_routes() -> APIRouter:
         except Exception as e:
             return {"models": [], "error": str(e)}
 
-        # Estimate VRAM from the model id. Looks for patterns like "7B", "70B", "1.5B" etc.
-        # Returns approx VRAM in GB at fp16 (params*2). Caller adjusts for quant.
-        def _est_vram_fp16(repo_id: str) -> float | None:
+        # Extract parameter count (billions) from the model id: "7B", "70B", "1.5B".
+        def _params_b(repo_id: str) -> float | None:
             m = re.search(r'[-_/](\d+(?:\.\d+)?)\s*[Bb](?![a-zA-Z])', repo_id)
-            if not m:
-                return None
-            params_b = float(m.group(1))
-            return params_b * 2.0  # fp16 baseline
+            return float(m.group(1)) if m else None
 
-        # Detect quantization from repo_id / tags. Returns a multiplier on fp16 size.
-        def _quant_factor(repo_id: str, tags: list) -> float:
+        # Bytes-per-param at the quant we'd ACTUALLY run. The old code assumed
+        # fp16 (2 B/param) for any repo without an explicit quant marker, so a
+        # 30B model looked like 60 GB and got filtered out of a 16 GB card's list
+        # — leaving only tiny 1-3B models. In reality you'd run a big model
+        # quantized (Q4 ≈ 0.55 B/param incl. overhead), so estimate that way:
+        # if the repo names a quant use it, otherwise assume Q4 (the common case).
+        def _bytes_per_param(repo_id: str, tags: list) -> float:
             text = (repo_id + " " + " ".join(tags or [])).lower()
-            if "fp4" in text or "nf4" in text or "int4" in text or "4bit" in text or "q4" in text or "awq" in text or "gptq" in text:
-                return 0.25
-            if "int8" in text or "8bit" in text or "q8" in text or "fp8" in text:
-                return 0.5
-            if "bf16" in text or "fp16" in text:
-                return 1.0
-            return 1.0  # default fp16
+            if any(t in text for t in ("q2", "iq2", "2bit")):
+                return 0.34
+            if any(t in text for t in ("q3", "iq3", "3bit")):
+                return 0.46
+            if any(t in text for t in ("fp4", "nf4", "int4", "4bit", "q4", "iq4", "awq", "gptq")):
+                return 0.55
+            if any(t in text for t in ("q5", "5bit")):
+                return 0.68
+            if any(t in text for t in ("q6", "6bit")):
+                return 0.82
+            if any(t in text for t in ("int8", "8bit", "q8", "fp8")):
+                return 1.06
+            if any(t in text for t in ("bf16", "fp16", "f16")):
+                return 2.0
+            # No quant marker → a GGUF/llama.cpp user would run it at ~Q4.
+            return 0.55
 
         # Exclude adapters, LoRAs, datasets, GGUF-only repos, and other non-runnable artifacts
         EXCLUDE_TAG_SUBSTRINGS = (
@@ -1680,18 +1690,27 @@ def setup_cookbook_routes() -> APIRouter:
             if _is_excluded(repo_id, tags):
                 continue
 
-            est_fp16 = _est_vram_fp16(repo_id)
-            quant_mult = _quant_factor(repo_id, tags)
-            est_vram = (est_fp16 * quant_mult) if est_fp16 else None
+            params_b = _params_b(repo_id)
+            # Skip if no size info — without a size we can't tell a real
+            # full-weight model from a tiny adapter, so we'd rather drop it.
+            if params_b is None:
+                continue
+            bpp = _bytes_per_param(repo_id, tags)
+            est_vram = params_b * bpp
             # Add 30% headroom for KV cache, activations, etc.
-            needed_vram = (est_vram * 1.3) if est_vram else None
+            needed_vram = est_vram * 1.3
 
-            if vram_gb > 0 and needed_vram is not None and needed_vram > vram_gb:
-                continue
-            # Skip if no size info — without a size we can't tell if it's a real
-            # full-weight model or a tiny adapter, so we'd rather drop it
-            if est_vram is None:
-                continue
+            if vram_gb > 0:
+                if needed_vram > vram_gb:
+                    continue  # doesn't fit
+                # Lower bound: don't recommend models that barely use the card —
+                # a 1-3B model on 16 GB is a poor use of the hardware when much
+                # larger (smarter) models also fit. Require the model to use at
+                # least ~35% of available VRAM (skip the tiny-model clutter).
+                # Always keep a couple of small ones isn't needed; the Scan list
+                # below already covers the full range.
+                if needed_vram < vram_gb * 0.35:
+                    continue
 
             out.append({
                 "repo_id": repo_id,
@@ -1700,13 +1719,18 @@ def setup_cookbook_routes() -> APIRouter:
                 "createdAt": entry.get("createdAt", ""),
                 "tags": tags[:5],  # trim
                 "pipeline_tag": pipeline_tag,
-                "est_vram_gb": round(est_vram, 1) if est_vram else None,
-                "needed_vram_gb": round(needed_vram, 1) if needed_vram else None,
+                "params_b": params_b,
+                "est_vram_gb": round(est_vram, 1),
+                "needed_vram_gb": round(needed_vram, 1),
             })
-            if len(out) >= limit:
-                break
 
-        return {"models": out}
+        # Order so the best use of the hardware surfaces first: biggest model
+        # that still fits (more params ≈ smarter), trending score as tiebreak
+        # (the pool already arrived in trending order, so a stable sort by
+        # -params keeps trending order within a size). Then cap to `limit`.
+        if vram_gb > 0:
+            out.sort(key=lambda m: m.get("params_b") or 0, reverse=True)
+        return {"models": out[:limit]}
 
     @router.get("/api/cookbook/tasks/status")
     async def cookbook_tasks_status(request: Request):

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -952,16 +952,35 @@ def setup_cookbook_routes() -> APIRouter:
                 # failed CUDA attempt) doesn't cause the next configure to reuse
                 # stale settings and silently produce a CPU-only binary.
                 runner_lines.append('    cd ~/llama.cpp && rm -rf build')
+                # GPU backend auto-detection, in preference order:
+                #   NVIDIA  -> CUDA (nvcc)
+                #   AMD     -> Vulkan if the Vulkan SDK is present (best on consumer
+                #              RDNA — what works without a full ROCm toolchain), else
+                #              ROCm/HIP (hipcc) for datacenter/Instinct setups.
+                #   none    -> CPU (with a clear message)
+                # Vulkan is the pragmatic AMD path: it needs only the Vulkan headers +
+                # a driver (mesa/RADV), runs on virtually any GPU, and avoids the heavy
+                # ROCm install — matching how most AMD llama.cpp users actually serve.
+                runner_lines.append('    _have_vulkan() { command -v glslc &>/dev/null || pkg-config --exists vulkan 2>/dev/null || [ -e /usr/include/vulkan/vulkan.h ]; }')
                 runner_lines.append('    if command -v nvcc &>/dev/null; then')
                 runner_lines.append('      echo "[odysseus] CUDA nvcc found — building llama-server with CUDA (GPU) support..."')
                 runner_lines.append('      cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON \\')
                 runner_lines.append('        && cmake --build build -j"$NPROC" --target llama-server \\')
                 runner_lines.append('        && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
+                runner_lines.append('    elif _have_vulkan; then')
+                runner_lines.append('      echo "[odysseus] Vulkan SDK found — building llama-server with Vulkan (GPU) support (works on AMD/Intel/NVIDIA)..."')
+                runner_lines.append('      cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=ON \\')
+                runner_lines.append('        && cmake --build build -j"$NPROC" --target llama-server \\')
+                runner_lines.append('        && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
+                runner_lines.append('    elif command -v hipcc &>/dev/null || [ -d /opt/rocm ]; then')
+                runner_lines.append('      echo "[odysseus] ROCm/HIP found — building llama-server with ROCm (GPU) support..."')
+                runner_lines.append('      cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_HIP=ON \\')
+                runner_lines.append('        && cmake --build build -j"$NPROC" --target llama-server \\')
+                runner_lines.append('        && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')
                 runner_lines.append('    else')
-                runner_lines.append('      echo "[odysseus] WARNING: nvcc not found — building llama-server for CPU only."')
-                runner_lines.append('      echo "[odysseus]   GPU inference will not be available for this llama.cpp build."')
-                runner_lines.append('      echo "[odysseus]   To get a GPU build, first install vLLM via Cookbook -> Dependencies"')
-                runner_lines.append('      echo "[odysseus]   (its CUDA wheels include nvcc), then re-launch this serve task."')
+                runner_lines.append('      echo "[odysseus] WARNING: no GPU toolchain found (no nvcc / Vulkan SDK / ROCm) — building llama-server for CPU only."')
+                runner_lines.append('      echo "[odysseus]   For a GPU build on AMD: install the Vulkan SDK (e.g. vulkan-headers + glslang, or your distro\\047s vulkan-devel) and re-launch."')
+                runner_lines.append('      echo "[odysseus]   On NVIDIA: install CUDA (nvcc), or install vLLM via Cookbook -> Dependencies (its CUDA wheels include nvcc), then re-launch."')
                 runner_lines.append('      cmake -B build -DCMAKE_BUILD_TYPE=Release \\')
                 runner_lines.append('        && cmake --build build -j"$NPROC" --target llama-server \\')
                 runner_lines.append('        && ln -sf ~/llama.cpp/build/bin/llama-server ~/bin/llama-server')

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -239,6 +239,21 @@ def _quant_bits(q):
     return 0
 
 
+def _is_vision(model) -> bool:
+    """True if the model accepts image input (multimodal / vision). Detected from
+    the catalog's pipeline_tag ('image-text-to-text'), a 'vision' capability, or
+    a vision-y name (-VL, Omni, vision). Used for the Vision badge + sort."""
+    if model.get("is_multimodal") or model.get("vision") or model.get("mmproj"):
+        return True
+    if (model.get("pipeline_tag") or "").lower() in ("image-text-to-text", "image-to-text", "visual-question-answering"):
+        return True
+    caps = model.get("capabilities") or []
+    if any("vision" in str(c).lower() or "image" in str(c).lower() for c in caps):
+        return True
+    name = (model.get("name") or "").lower()
+    return any(tok in name for tok in ("-vl", "vl-", "omni", "vision", "-vision"))
+
+
 def analyze_model(model, system, target_quant=None):
     pb = params_b(model)
     if pb <= 0:
@@ -389,6 +404,7 @@ def analyze_model(model, system, target_quant=None):
         "gguf_sources": model.get("gguf_sources", []),
         "context_length": model.get("context_length", 4096),
         "release_date": model.get("release_date", ""),
+        "is_vision": _is_vision(model),
     }
 
 
@@ -402,6 +418,9 @@ SORT_KEYS = {
     # string sort is chronological. Missing dates sort last (empty < any date,
     # and we sort reverse=True for newest, so "" lands at the bottom).
     "newest": lambda r: r.get("release_date") or "",
+    # Vision-capable first (then by score within each group — see secondary sort
+    # in rank_models). Boolean True sorts above False under reverse=True.
+    "vision": lambda r: (1 if r.get("is_vision") else 0, r.get("score") or 0),
 }
 
 

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -18,7 +18,7 @@ GPU_BANDWIDTH = {
     "7900 xtx": 960, "7900 xt": 800, "7900 gre": 576, "7800 xt": 624, "7700 xt": 432, "7600": 288,
     "6950 xt": 576, "6900 xt": 512, "6800 xt": 512, "6800": 512, "6700 xt": 384, "6600 xt": 256, "6600": 224,
     "mi300x": 5300, "mi300": 5300, "mi250x": 3277, "mi250": 3277, "mi210": 1638, "mi100": 1229,
-    "9070 xt": 624, "9070": 488,
+    "9070 xt": 624, "9070": 488, "9060 xt": 322, "9060": 322,
     # Apple Silicon unified-memory bandwidth (GB/s). Keyed off the chip name
     # reported by sysctl machdep.cpu.brand_string (e.g. "Apple M4 Max"). Listed
     # before the bare "m_" keys matters less than length-sorting (done below),
@@ -69,8 +69,18 @@ def _lookup_bandwidth(gpu_name):
     return None
 
 
-def _estimate_speed(model, quant, run_mode, system):
-    """Estimate tok/s. Uses active params for MoE (only active experts run per token)."""
+def _estimate_speed(model, quant, run_mode, system, offload_frac=0.0):
+    """Estimate tok/s. Uses active params for MoE (only active experts run per token).
+
+    offload_frac (0..1): fraction of the model's weights that spill to system RAM
+    (CPU) because they don't fit VRAM. Generation reads every active weight per
+    token, so when part lives in CPU RAM the per-token time is dominated by the
+    slow path. We model effective bandwidth as a blend of GPU VRAM bandwidth and
+    system-RAM bandwidth weighted by what's where — far more accurate than a flat
+    "halve it" for partial offload, which under/over-shoots depending on amount.
+    Calibrated against a measured RX 9060 XT: DeepSeek-Coder-V2-Lite Q4_K_M with
+    light offload → ~59 t/s est vs 59.8 measured.
+    """
     pb = _active_params_b(model)
     is_moe = model.get("is_moe", False)
     bw = _lookup_bandwidth(system.get("gpu_name"))
@@ -82,14 +92,24 @@ def _estimate_speed(model, quant, run_mode, system):
         if model_gb <= 0:
             return 0.0
         efficiency = 0.55
-        raw_tps = (bw / model_gb) * efficiency
         if run_mode == "cpu_offload":
-            mode_factor = 0.5
-        elif is_moe:
-            mode_factor = 0.8
-        else:
-            mode_factor = 1.0
-        return raw_tps * mode_factor
+            # Dual-channel DDR4-3200 ≈ 50 GB/s; DDR5 systems higher, but be
+            # conservative since offloaded MoE is also compute-bound on CPU.
+            cpu_bw = 55.0
+            frac = min(max(offload_frac, 0.0), 1.0)
+            # If we don't know the fraction (legacy callers pass 0 with
+            # cpu_offload), assume a meaningful spill so we don't overestimate.
+            if frac <= 0.0:
+                frac = 0.5
+            # Harmonic-style blend: time = frac/cpu_bw + (1-frac)/gpu_bw, so the
+            # slow CPU portion dominates as it grows (matches the steep real-world
+            # drop-off when more experts offload).
+            eff_bw = 1.0 / (frac / cpu_bw + (1.0 - frac) / bw)
+            raw_tps = (eff_bw / model_gb) * efficiency
+            return raw_tps * (0.8 if is_moe else 1.0)
+        # Fully on GPU.
+        raw_tps = (bw / model_gb) * efficiency
+        return raw_tps * (0.8 if is_moe else 1.0)
 
     k = FALLBACK_K.get(backend, 70)
     if pb <= 0:
@@ -331,7 +351,12 @@ def analyze_model(model, system, target_quant=None):
     else:
         fit_level = "marginal"
 
-    tps = _estimate_speed(model, quant, run_mode, system)
+    # Fraction of the model that spills to CPU RAM (drives the offload speed
+    # model). When offloading, anything beyond the GPU's VRAM lives in system RAM.
+    offload_frac = 0.0
+    if run_mode == "cpu_offload" and required_gb > 0 and effective_vram > 0:
+        offload_frac = max(0.0, (required_gb - effective_vram) / required_gb)
+    tps = _estimate_speed(model, quant, run_mode, system, offload_frac=offload_frac)
 
     q_score = _quality_score(model, quant, use_case)
     s_score = _speed_score(tps, use_case)
@@ -363,6 +388,7 @@ def analyze_model(model, system, target_quant=None):
         },
         "gguf_sources": model.get("gguf_sources", []),
         "context_length": model.get("context_length", 4096),
+        "release_date": model.get("release_date", ""),
     }
 
 
@@ -372,6 +398,10 @@ SORT_KEYS = {
     "vram": lambda r: r["required_gb"],
     "params": lambda r: r["params_b"],
     "context": lambda r: r["context"],
+    # Newest first. release_date is an ISO-ish string ("2026-05-30"); plain
+    # string sort is chronological. Missing dates sort last (empty < any date,
+    # and we sort reverse=True for newest, so "" lands at the bottom).
+    "newest": lambda r: r.get("release_date") or "",
 }
 
 

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -424,6 +424,16 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
     system_backend = (system.get("backend") or "").lower()
     apple_silicon = system_backend in ("mps", "metal", "apple")
 
+    # Consumer AMD Radeon (RDNA, gfx10/11/12): the practical local serving path
+    # is GGUF via llama.cpp. vLLM/SGLang on ROCm are validated for datacenter
+    # Instinct (CDNA, gfx9xx) but are unreliable on consumer RDNA — AWQ kernels
+    # are largely unsupported there and FP8 needs out-of-tree patches. So treat
+    # consumer RDNA like Apple Silicon (GGUF-only) and leave CDNA untouched.
+    # Unknown family (no rocminfo) is left untouched to avoid hiding models from
+    # a possibly-capable Instinct box on a misdetect.
+    gpu_family = (system.get("gpu_family") or "").lower()
+    consumer_amd = system_backend == "rocm" and gpu_family == "rdna"
+
     for m in models:
         native_q = m.get("quantization", "")
 
@@ -442,7 +452,12 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
         # default GGUF quant) and vLLM-only AWQ/GPTQ/FP8 builds alike. Without
         # this the Cookbook recommends models the Mac can't run; on CUDA these
         # stay visible because vLLM serves safetensors directly.
-        if apple_silicon and not (m.get("is_gguf") or m.get("gguf_sources")):
+        #
+        # Consumer AMD (RDNA) is the same story: GGUF via llama.cpp is the
+        # servable path, so a model needs a real GGUF to be recommended.
+        # Otherwise the Cookbook rates vLLM-only AWQ/GPTQ builds "GOOD" on a
+        # Radeon that can't actually serve them.
+        if (apple_silicon or consumer_amd) and not (m.get("is_gguf") or m.get("gguf_sources")):
             continue
 
         # Format filter: AWQ tab → only AWQ models, FP8 tab → only FP8 models

--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 import shutil
 import subprocess
 import time
@@ -130,6 +131,33 @@ def _detect_nvidia():
     }
 
 
+def classify_amd_gfx(gfx):
+    """Map an AMD ISA target (e.g. "gfx1200") to (gfx, family).
+
+    family is one of:
+      "rdna"    — consumer Radeon RX (gfx10xx RDNA1/2, gfx11xx RDNA3, gfx12xx RDNA4)
+      "cdna"    — datacenter Instinct (gfx908 MI100, gfx90a MI200, gfx94x/95x MI300+)
+      "gcn"     — older GCN/Vega (gfx900/906)
+      "unknown" — empty/unrecognized; callers must treat conservatively
+
+    This drives the serving decision: vLLM/SGLang on ROCm are validated on CDNA
+    but fragile on consumer RDNA (AWQ kernels largely unsupported, FP8 needs
+    out-of-tree patches), so RDNA is steered to GGUF/llama.cpp.
+    """
+    gfx = (gfx or "").lower().strip()
+    m = re.fullmatch(r"gfx(\d+[a-f]?)", gfx)
+    if not m:
+        return "", "unknown"
+    digits = m.group(1)
+    if digits[:2] in ("10", "11", "12"):
+        return gfx, "rdna"
+    if digits in ("908", "90a") or digits[:2] in ("94", "95"):
+        return gfx, "cdna"
+    if digits[:1] == "9":
+        return gfx, "gcn"
+    return gfx, "unknown"
+
+
 def _detect_amd():
     """Detect AMD GPUs. Handles both discrete cards (with mem_info_vram_total)
     and APUs / unified-memory SoCs like Strix Halo (which expose
@@ -154,6 +182,17 @@ def _detect_amd():
             return [e for e in os.listdir("/sys/class/drm") if e.startswith("card") and "-" not in e]
         except Exception:
             return []
+
+    def _amd_arch():
+        """Best-effort AMD GPU ISA + family from rocminfo.
+
+        rocminfo is the source of truth; its GPU agents report a `Name: gfxNNNN`
+        line (CPU agents report a brand string, not a gfx target), so the first
+        gfx match is the GPU ISA. Returns (gfx, family) — see classify_amd_gfx.
+        """
+        info = _run(["rocminfo"]) or _run(["/opt/rocm/bin/rocminfo"]) or ""
+        m = re.search(r"gfx\d+[a-f]?", info)
+        return classify_amd_gfx(m.group(0) if m else "")
 
     try:
         cards = []
@@ -187,6 +226,7 @@ def _detect_amd():
             return None
         total_vram = sum(c["vram_gb"] for c in cards)
         groups = _group_gpus(cards)
+        gfx, family = _amd_arch()
         # NOTE: for APUs with BIOS UMA carveout (e.g. Strix Halo), vis_vram_total
         # is the real usable GPU memory — it's physically backed but reserved
         # by BIOS so it doesn't appear in /proc/meminfo. Don't cap it at system
@@ -200,6 +240,13 @@ def _detect_amd():
             "homogeneous": len(groups) <= 1,
             "backend": "rocm",
             "unified_memory": is_apu,
+            # AMD ISA/family so downstream can tell datacenter Instinct (CDNA,
+            # where vLLM/SGLang run AWQ/GPTQ reliably) from consumer Radeon
+            # (RDNA, where the practical path is GGUF via llama.cpp). Empty/
+            # "unknown" when rocminfo isn't available — callers must treat
+            # unknown conservatively, not assume vLLM works.
+            "gpu_arch": gfx,
+            "gpu_family": family,
         }
     except Exception:
         return None

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -517,11 +517,23 @@ export async function _hwfitFetch(fresh = false) {
       const sortSel = document.getElementById('hwfit-sort');
       const sortKey = sortSel?.value || 'score';
       const asc = sortSel?.dataset.reverse === '1';   // reversed → ascending (lowest first)
-      const field = { score: 'score', vram: 'required_gb', speed: 'speed_tps', params: 'params_b', context: 'context' }[sortKey] || 'score';
-      data.models.sort((a, b) => {
-        const av = Number(a[field]) || 0, bv = Number(b[field]) || 0;
-        return asc ? av - bv : bv - av;
-      });
+      if (sortKey === 'newest') {
+        // release_date is an ISO-ish string ("2026-05-30"); compare as strings
+        // (chronological). Newest first by default; missing dates sort last.
+        data.models.sort((a, b) => {
+          const ad = a.release_date || '', bd = b.release_date || '';
+          if (ad === bd) return 0;
+          if (!ad) return 1;        // a undated → after b
+          if (!bd) return -1;       // b undated → after a
+          return asc ? (ad < bd ? -1 : 1) : (ad < bd ? 1 : -1);
+        });
+      } else {
+        const field = { score: 'score', vram: 'required_gb', speed: 'speed_tps', params: 'params_b', context: 'context' }[sortKey] || 'score';
+        data.models.sort((a, b) => {
+          const av = Number(a[field]) || 0, bv = Number(b[field]) || 0;
+          return asc ? av - bv : bv - av;
+        });
+      }
     }
     _hwfitRenderList(list, data.models);
     // Persist this result so the next page load can paint it instantly.
@@ -718,7 +730,9 @@ export const _fitColors = { perfect: 'var(--green, #50fa7b)', good: 'var(--yello
 
 export const _hwfitColumns = [
   { key: 'score', label: 'Fit',    cls: 'hwfit-fit' },
-  { key: null,    label: 'Model',  cls: 'hwfit-name' },
+  // Model header sorts by release date (newest first) — the catalog carries
+  // release_date for ~97% of models, so "sort by new" needs no new data.
+  { key: 'newest', label: 'Model',  cls: 'hwfit-name' },
   { key: 'params',label: 'Param', cls: 'hwfit-c-params' },
   { key: null,    label: 'Quant',  cls: 'hwfit-c-quant' },
   { key: 'vram',  label: 'VRAM',   cls: 'hwfit-c-vram' },
@@ -779,7 +793,8 @@ export function _hwfitRenderList(el, models) {
     const dlDot = (_cachedModelIds && (_cachedModelIds.has(m.name) || [..._cachedModelIds].some(id => id === m.name?.split('/').pop()))) ? '<span class="hwfit-dl-dot" title="Downloaded">\u25CF</span>' : '';
     html += `<div class="hwfit-row" data-model="${esc(m.name)}">`;
     html += `<span class="hwfit-col hwfit-fit" style="color:${fitColor}">${esc(fitLabel)}</span>`;
-    html += `<span class="hwfit-col hwfit-name">${modelLogo(m.name)}${esc(m.name?.split('/').pop() || m.name)}${moeBadge}${imgBadge}${dlDot}</span>`;
+    const _relTitle = m.release_date ? ` title="Released ${esc(m.release_date)}"` : '';
+    html += `<span class="hwfit-col hwfit-name"${_relTitle}>${modelLogo(m.name)}${esc(m.name?.split('/').pop() || m.name)}${moeBadge}${imgBadge}${dlDot}</span>`;
     html += `<span class="hwfit-col hwfit-c-params">${esc(pcount)}</span>`;
     html += `<span class="hwfit-col hwfit-c-quant">${esc(m.quant || '?')}</span>`;
     html += `<span class="hwfit-col hwfit-c-vram">${vramLabel}</span>`;

--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -527,6 +527,13 @@ export async function _hwfitFetch(fresh = false) {
           if (!bd) return -1;       // b undated → after a
           return asc ? (ad < bd ? -1 : 1) : (ad < bd ? 1 : -1);
         });
+      } else if (sortKey === 'vision') {
+        // Vision-capable first, then by score within each group.
+        data.models.sort((a, b) => {
+          const av = (a.is_vision ? 1 : 0), bv = (b.is_vision ? 1 : 0);
+          if (av !== bv) return asc ? av - bv : bv - av;
+          return (Number(b.score) || 0) - (Number(a.score) || 0);
+        });
       } else {
         const field = { score: 'score', vram: 'required_gb', speed: 'speed_tps', params: 'params_b', context: 'context' }[sortKey] || 'score';
         data.models.sort((a, b) => {
@@ -790,11 +797,13 @@ export function _hwfitRenderList(el, models) {
     const vramLabel = m.required_gb ? m.required_gb.toFixed(1) + 'G' : '?';
     const moeBadge = m.is_moe ? '<span class="hwfit-badge hwfit-moe">MoE</span>' : '';
     const imgBadge = m.is_image_gen ? '<span class="hwfit-badge" style="background:color-mix(in srgb, var(--red) 20%, transparent);color:var(--red);font-size:8px;padding:1px 4px;border-radius:3px;margin-left:4px;">IMG</span>' : '';
+    // Vision (image-input) capable \u2014 accepts images, distinct from image *gen*.
+    const visBadge = m.is_vision ? '<span class="hwfit-badge" title="Accepts image input (vision)" style="background:color-mix(in srgb, var(--green, #50fa7b) 22%, transparent);color:var(--green, #50fa7b);font-size:8px;padding:1px 4px;border-radius:3px;margin-left:4px;">VISION</span>' : '';
     const dlDot = (_cachedModelIds && (_cachedModelIds.has(m.name) || [..._cachedModelIds].some(id => id === m.name?.split('/').pop()))) ? '<span class="hwfit-dl-dot" title="Downloaded">\u25CF</span>' : '';
     html += `<div class="hwfit-row" data-model="${esc(m.name)}">`;
     html += `<span class="hwfit-col hwfit-fit" style="color:${fitColor}">${esc(fitLabel)}</span>`;
     const _relTitle = m.release_date ? ` title="Released ${esc(m.release_date)}"` : '';
-    html += `<span class="hwfit-col hwfit-name"${_relTitle}>${modelLogo(m.name)}${esc(m.name?.split('/').pop() || m.name)}${moeBadge}${imgBadge}${dlDot}</span>`;
+    html += `<span class="hwfit-col hwfit-name"${_relTitle}>${modelLogo(m.name)}${esc(m.name?.split('/').pop() || m.name)}${moeBadge}${visBadge}${imgBadge}${dlDot}</span>`;
     html += `<span class="hwfit-col hwfit-c-params">${esc(pcount)}</span>`;
     html += `<span class="hwfit-col hwfit-c-quant">${esc(m.quant || '?')}</span>`;
     html += `<span class="hwfit-col hwfit-c-vram">${vramLabel}</span>`;

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -1449,7 +1449,7 @@ function _renderRecipes() {
   html += '<select class="cookbook-field-input hwfit-sort" id="hwfit-sort" style="display:none">';
   html += '<option value="score">Score</option><option value="vram">VRAM</option>';
   html += '<option value="speed">Speed</option><option value="params">Params</option>';
-  html += '<option value="context">Context</option></select>';
+  html += '<option value="context">Context</option><option value="newest">Newest</option></select>';
   html += '</div>';
   html += '<div class="hwfit-manual-panel hidden" id="hwfit-manual-panel">';
   html += '<span class="hwfit-manual-note" style="font-size:10px;opacity:0.6;width:100%;margin-bottom:2px;">Simulator — these values REPLACE detected hardware.</span>';

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -248,6 +248,12 @@ export function _detectBackend(model) {
   const q = (model.quant || '').toUpperCase();
   const sysBackend = String(_hwfitCache?.system?.backend || '').toLowerCase();
   const isRocm = sysBackend === 'rocm';
+  // Consumer AMD Radeon (RDNA, gfx10/11/12): vLLM/SGLang on ROCm are validated
+  // for datacenter Instinct (CDNA), not consumer cards — AWQ kernels are largely
+  // unsupported and FP8 needs out-of-tree patches. The working local path is
+  // GGUF via llama.cpp. So on consumer RDNA, never auto-route to CUDA-style vLLM.
+  const gpuFamily = String(_hwfitCache?.system?.gpu_family || '').toLowerCase();
+  const consumerAmd = isRocm && gpuFamily === 'rdna';
 
   // Image gen models → diffusers
   if (model.is_image_gen || model.is_diffusion || model._tag === 'image') {
@@ -263,6 +269,14 @@ export function _detectBackend(model) {
   // don't run on macOS; AWQ/GPTQ/FP8 (vLLM-only) models are already filtered out
   // of metal Cookbook results, so llama.cpp is always the right engine here.
   if (['metal', 'mps', 'apple'].includes(sysBackend)) {
+    return { backend: 'llamacpp', label: 'llama.cpp' };
+  }
+
+  // Consumer AMD Radeon → llama.cpp (GGUF), same as Apple Silicon. AWQ/GPTQ/FP8
+  // are filtered out of consumer-RDNA Cookbook results (see fit.py), so a real
+  // GGUF is the only servable artifact here. This must come before the AWQ→vLLM
+  // rule below, otherwise a stray AWQ model would route to a vLLM that can't run.
+  if (consumerAmd) {
     return { backend: 'llamacpp', label: 'llama.cpp' };
   }
 

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -1449,7 +1449,7 @@ function _renderRecipes() {
   html += '<select class="cookbook-field-input hwfit-sort" id="hwfit-sort" style="display:none">';
   html += '<option value="score">Score</option><option value="vram">VRAM</option>';
   html += '<option value="speed">Speed</option><option value="params">Params</option>';
-  html += '<option value="context">Context</option><option value="newest">Newest</option></select>';
+  html += '<option value="context">Context</option><option value="newest">Newest</option><option value="vision">Vision</option></select>';
   html += '</div>';
   html += '<div class="hwfit-manual-panel hidden" id="hwfit-manual-panel">';
   html += '<span class="hwfit-manual-note" style="font-size:10px;opacity:0.6;width:100%;margin-bottom:2px;">Simulator — these values REPLACE detected hardware.</span>';

--- a/tests/test_hwfit_amd.py
+++ b/tests/test_hwfit_amd.py
@@ -122,3 +122,60 @@ def test_detect_amd_reports_family(monkeypatch):
     assert info["backend"] == "rocm"
     assert info["gpu_family"] == "rdna"
     assert info["gpu_arch"] == "gfx1200"
+
+
+def test_consumer_amd_cards_have_real_bandwidth():
+    """Consumer AMD cards must be in the bandwidth table so speed estimates use
+    real VRAM bandwidth, not the crude rocm FALLBACK_K constant. The RX 9060 XT
+    was missing entirely, so its estimates fell back to the constant and were off."""
+    from services.hwfit.fit import _lookup_bandwidth
+    for name, expected_min in [
+        ("AMD Radeon RX 9060 XT", 300),
+        ("AMD Radeon RX 9070 XT", 600),
+        ("AMD Radeon RX 7900 XTX", 900),
+    ]:
+        bw = _lookup_bandwidth(name)
+        assert bw and bw >= expected_min, f"{name}: {bw} GB/s (expected >= {expected_min})"
+
+
+def test_9060xt_speed_estimate_is_realistic():
+    """Calibration guard: a small MoE fully on a 9060 XT at Q4 should estimate in
+    a believable range, not the absurd numbers the missing-bandwidth fallback gave.
+    Measured reference: DeepSeek-Coder-V2-Lite Q4 ~60-86 t/s on this card."""
+    from services.hwfit.fit import _estimate_speed
+    model = {"name": "DeepSeek-Coder-V2-Lite-Instruct", "parameter_count": "16B",
+             "is_moe": True, "active_parameters": 2_400_000_000}
+    sys = {"backend": "rocm", "gpu_name": "AMD Radeon RX 9060 XT", "gpu_vram_gb": 15.9}
+    tps = _estimate_speed(model, "Q4_K_M", "gpu", sys)
+    assert 40 <= tps <= 130, f"unrealistic estimate: {tps} t/s"
+
+
+def test_offload_is_slower_than_full_gpu():
+    """Partial CPU offload must estimate slower than the same model fully on GPU,
+    and heavier offload slower than lighter — the blend model, not a flat halving."""
+    from services.hwfit.fit import _estimate_speed
+    model = {"name": "X", "parameter_count": "35B", "is_moe": True,
+             "active_parameters": 3_000_000_000}
+    sys = {"backend": "rocm", "gpu_name": "AMD Radeon RX 9060 XT", "gpu_vram_gb": 15.9}
+    full = _estimate_speed(model, "Q4_K_M", "gpu", sys)
+    light = _estimate_speed(model, "Q4_K_M", "cpu_offload", sys, offload_frac=0.2)
+    heavy = _estimate_speed(model, "Q4_K_M", "cpu_offload", sys, offload_frac=0.6)
+    assert full > light > heavy, (full, light, heavy)
+
+
+def test_sort_by_newest_orders_by_release_date():
+    """sort='newest' orders results by release_date descending (newest first),
+    with undated models sorted last."""
+    sys = {"backend": "rocm", "gpu_name": "AMD Radeon RX 9060 XT", "gpu_vram_gb": 15.9,
+           "gpu_family": "rdna", "gpu_count": 1, "available_ram_gb": 22.0, "total_ram_gb": 31.0}
+    res = rank_models(sys, sort="newest", limit=50)
+    dated = [r.get("release_date") for r in res if r.get("release_date")]
+    # dates present must be in descending order
+    assert dated == sorted(dated, reverse=True), "release dates not descending"
+    # any undated entries must come after all dated ones
+    seen_blank = False
+    for r in res:
+        if not r.get("release_date"):
+            seen_blank = True
+        elif seen_blank:
+            assert False, "a dated model appeared after an undated one"

--- a/tests/test_hwfit_amd.py
+++ b/tests/test_hwfit_amd.py
@@ -1,0 +1,124 @@
+"""AMD ROCm support for Cookbook hardware-fit.
+
+Consumer AMD Radeon (RDNA: gfx10/11/12) can realistically only serve GGUF via
+llama.cpp — vLLM/SGLang on ROCm are validated for datacenter Instinct (CDNA,
+gfx9xx), not consumer cards, where AWQ kernels are largely unsupported and FP8
+needs out-of-tree patches. These tests lock in that consumer RDNA is treated
+like Apple Silicon (GGUF-only recommendations) while datacenter CDNA and
+unknown-family AMD are left untouched, and that CUDA is unchanged.
+"""
+
+from services.hwfit import hardware
+from services.hwfit.fit import rank_models
+from services.hwfit.models import get_models
+
+
+def _rocm_system(family="rdna", ram_gb=32.0, vram_gb=16.0):
+    return {
+        "has_gpu": True,
+        "backend": "rocm",
+        "gpu_name": "AMD Radeon RX 9060 XT" if family == "rdna" else "AMD Instinct MI300X",
+        "gpu_vram_gb": vram_gb,
+        "gpu_count": 1,
+        "available_ram_gb": ram_gb * 0.7,
+        "total_ram_gb": ram_gb,
+        "gpu_arch": "gfx1200" if family == "rdna" else "gfx942",
+        "gpu_family": family,
+    }
+
+
+def _cuda_system():
+    return {
+        "has_gpu": True, "backend": "cuda", "gpu_name": "NVIDIA RTX 4090",
+        "gpu_vram_gb": 24.0, "gpu_count": 1, "available_ram_gb": 32.0, "total_ram_gb": 64.0,
+    }
+
+
+def test_only_gguf_models_recommended_on_consumer_rdna():
+    """llama.cpp (GGUF) is the servable path on consumer Radeon, so every model
+    recommended on RDNA must ship a real GGUF — no vLLM-only AWQ/GPTQ/FP8."""
+    catalog = {m["name"]: m for m in get_models()}
+    unservable = [
+        r["name"] for r in rank_models(_rocm_system(family="rdna"), limit=900)
+        if not (catalog.get(r["name"], {}).get("is_gguf")
+                or catalog.get(r["name"], {}).get("gguf_sources"))
+    ]
+    assert unservable == [], f"{len(unservable)} non-GGUF models on RDNA, e.g. {unservable[:3]}"
+
+
+def test_safetensors_models_still_recommended_on_cdna():
+    """Datacenter Instinct (CDNA) runs vLLM/SGLang on ROCm fine, so non-GGUF
+    repos must NOT be filtered there — the GGUF-only rule is consumer-RDNA only."""
+    names = {r["name"] for r in rank_models(_rocm_system(family="cdna"), limit=900)}
+    assert "microsoft/Phi-mini-MoE-instruct" in names
+
+
+def test_unknown_amd_family_not_filtered():
+    """When rocminfo is unavailable (family 'unknown'), don't hide non-GGUF
+    models — a possibly-capable Instinct box shouldn't lose models on misdetect."""
+    names = {r["name"] for r in rank_models(_rocm_system(family="unknown"), limit=900)}
+    assert "microsoft/Phi-mini-MoE-instruct" in names
+
+
+def test_safetensors_models_still_recommended_on_cuda():
+    """Regression guard: the GGUF-only rule must not leak onto CUDA."""
+    names = {r["name"] for r in rank_models(_cuda_system(), limit=900)}
+    assert "microsoft/Phi-mini-MoE-instruct" in names
+
+
+def test_classify_amd_gfx_rdna_vs_cdna():
+    """classify_amd_gfx maps gfx targets to the right family: consumer RDNA
+    (gfx10/11/12) vs datacenter CDNA (gfx9xx Instinct) vs older GCN."""
+    cases = {
+        "gfx1200": "rdna",   # RX 9060 XT (RDNA4)
+        "gfx1201": "rdna",   # RX 9070 (RDNA4)
+        "gfx1100": "rdna",   # RX 7900 (RDNA3)
+        "gfx1030": "rdna",   # RX 6800 (RDNA2)
+        "gfx942": "cdna",    # MI300 (CDNA3)
+        "gfx950": "cdna",    # MI350 (CDNA4)
+        "gfx90a": "cdna",    # MI200 (CDNA2)
+        "gfx908": "cdna",    # MI100 (CDNA1)
+        "gfx906": "gcn",     # Radeon VII / MI50 (GCN5/Vega)
+        "": "unknown",
+        "gfx": "unknown",
+    }
+    for gfx, expected_family in cases.items():
+        out_gfx, family = hardware.classify_amd_gfx(gfx)
+        assert family == expected_family, f"{gfx} -> {family}, expected {expected_family}"
+        if expected_family != "unknown":
+            assert out_gfx == gfx
+
+
+def test_detect_amd_reports_family(monkeypatch):
+    """_detect_amd surfaces gpu_family from rocminfo so fit/serve can branch on
+    consumer-RDNA vs datacenter-CDNA. rocminfo lists the CPU agent first, then
+    the GPU's gfx target. Drive it through the remote-read path (no real sysfs)."""
+    rocminfo_out = "  Name:  AMD Ryzen 7 3700X\n  Name:  gfx1200\n  Marketing Name: AMD Radeon RX 9060 XT\n"
+
+    def fake_run(cmd):
+        if not cmd:
+            return None
+        if "rocminfo" in cmd[0]:
+            return rocminfo_out
+        if cmd[0] == "ls":
+            return "card1\ncard1-DP-1\nrenderD128"
+        if cmd[0] == "cat":
+            path = cmd[1]
+            if path.endswith("/vendor"):
+                return "0x1002"
+            if path.endswith("/mem_info_vram_total"):
+                return str(16 * 1024**3)
+            if path.endswith("/product_name"):
+                return "AMD Radeon RX 9060 XT"
+            return None
+        return None
+
+    # _remote_host truthy routes _read/_list_drm_cards through _run (no real sysfs).
+    monkeypatch.setattr(hardware, "_remote_host", "fake-host")
+    monkeypatch.setattr(hardware, "_run", fake_run)
+
+    info = hardware._detect_amd()
+    assert info is not None
+    assert info["backend"] == "rocm"
+    assert info["gpu_family"] == "rdna"
+    assert info["gpu_arch"] == "gfx1200"

--- a/tests/test_hwfit_amd.py
+++ b/tests/test_hwfit_amd.py
@@ -179,3 +179,25 @@ def test_sort_by_newest_orders_by_release_date():
             seen_blank = True
         elif seen_blank:
             assert False, "a dated model appeared after an undated one"
+
+
+def test_vision_detection_and_sort():
+    """Vision-capable models are flagged (is_vision) and the 'vision' sort puts
+    them first. Detection covers pipeline_tag, capabilities, and -VL/Omni names."""
+    from services.hwfit.fit import _is_vision, rank_models
+    assert _is_vision({"name": "Qwen/Qwen2.5-VL-7B", "pipeline_tag": "image-text-to-text"})
+    assert _is_vision({"name": "x", "capabilities": ["vision", "tool_use"]})
+    assert _is_vision({"name": "some-Omni-30B"})
+    assert not _is_vision({"name": "Qwen3-8B", "pipeline_tag": "text-generation", "capabilities": []})
+
+    sys = {"backend": "rocm", "gpu_name": "AMD Radeon RX 9060 XT", "gpu_vram_gb": 15.9,
+           "gpu_family": "rdna", "gpu_count": 1, "available_ram_gb": 22.0, "total_ram_gb": 31.0}
+    res = rank_models(sys, sort="vision", limit=60)
+    flags = [bool(r.get("is_vision")) for r in res]
+    # once we hit a non-vision model, no vision model may appear after it
+    seen_nonvision = False
+    for f in flags:
+        if not f:
+            seen_nonvision = True
+        elif seen_nonvision:
+            assert False, "a vision model appeared after a non-vision one"


### PR DESCRIPTION
## What

A set of focused fixes so Cookbook works correctly on **consumer AMD GPUs**. Each addresses a place where the hardware/serving logic implicitly assumed NVIDIA/CUDA. Found while running Odysseus daily on an RX 9060 XT (RDNA4).

## Changes

1. **Recommend GGUF/llama.cpp on consumer AMD, not vLLM-only AWQ/GPTQ.**
   Detects RDNA (gfx10/11/12) vs datacenter CDNA (gfx9xx) and only steers *consumer* cards to GGUF — vLLM/SGLang AWQ kernels are unreliable on RDNA, so recommending AWQ models there leads to models that download but won't serve. Datacenter CDNA and CUDA are unchanged. (Mirrors the existing Apple-Silicon GGUF-only handling.)

2. **Build llama.cpp with Vulkan/ROCm on AMD, not CPU-only.**
   The from-source build path only detected CUDA (`nvcc`); on AMD it silently built a CPU-only binary and told the user to install vLLM (useless on AMD). Now auto-detects Vulkan (`GGML_VULKAN`, the practical consumer path) and ROCm/HIP (`GGML_HIP`, datacenter), falling back to CPU with AMD-aware advice.

3. **Accurate speed/fit estimates + sort by newest.**
   Added missing consumer AMD cards to the bandwidth table (they fell back to a crude constant, producing wildly wrong t/s) and model CPU offload as a GPU/RAM bandwidth blend instead of a flat halving. Also adds a `newest` sort using the catalog's existing `release_date`.

4. **Trending list shows models that use the hardware.**
   "Trending models that fit your hardware" assumed fp16, so big *quantised* models looked too large and were filtered out — leaving only tiny 1–3B models. Now estimates at the quant you'd actually run (Q4 when unmarked), adds a lower VRAM floor to drop tiny-model clutter, and surfaces the biggest-fitting first.

## Files

`services/hwfit/hardware.py`, `services/hwfit/fit.py`, `routes/cookbook_routes.py`, `static/js/cookbook.js`, `static/js/cookbook-hwfit.js`, `tests/test_hwfit_amd.py` (6 files, +402/-57).

## Testing

- `python -m pytest tests/test_hwfit_amd.py` → **10 passed** (RDNA/CDNA classification, GGUF-only filtering on consumer AMD, CUDA/CDNA regression guards, bandwidth presence, realistic 9060 XT estimate, offload-slower-than-full-GPU, newest sort).
- `python -m py_compile services/hwfit/fit.py services/hwfit/hardware.py routes/cookbook_routes.py` → pass
- `node --check static/js/cookbook.js` → pass
- Verified live on an RDNA4 box (gfx1200, RX 9060 XT): GPU classified `rdna`, Vulkan build path selected, estimates match measured t/s.

Happy to split this into smaller PRs if you'd prefer one change per PR — kept them together as one "consumer AMD support" theme since they're closely related.

_Implemented with Claude (Anthropic) as a coding assistant; commits carry a `Co-Authored-By` trailer._



---
**Update:** also adds a **Vision** badge + "Vision" sort to the Cookbook list — flags models that accept image input (detected from pipeline_tag / capabilities / -VL·Omni names) and lets you sort vision-capable first. 135/898 catalog models flag as vision. Tests added to `test_hwfit_amd.py` (now 11 passing).
