### PR TITLE
Chat: show true generation t/s (llama.cpp timings) + Always-Show-Speed / Wide-Chat toggles

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -718,6 +718,15 @@ def setup_chat_routes(
                                         pct = min(round((last_metrics["input_tokens"] / ctx.context_length) * 100, 1), 100.0)
                                         last_metrics["context_percent"] = pct
                                         last_metrics["context_length"] = ctx.context_length
+                                    # The frontend reads `tokens_per_second`; the raw usage event
+                                    # carries the backend's true gen speed as `gen_tps` (llama.cpp
+                                    # timings). Map it through so this direct-chat path shows real
+                                    # t/s instead of "n/a" → falling back to a bare token count.
+                                    if last_metrics.get("gen_tps") and not last_metrics.get("tokens_per_second"):
+                                        last_metrics["tokens_per_second"] = last_metrics["gen_tps"]
+                                        last_metrics["tps_source"] = "backend"
+                                    # Wall-clock response time for the stats popup ("Time").
+                                    last_metrics.setdefault("response_time", round(time.time() - _chat_start, 2))
                                     yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
                             except json.JSONDecodeError:
                                 yield chunk

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1101,6 +1101,8 @@ def _compute_final_metrics(
     model: str = "",
     last_round_input_tokens: int = 0,
     prep_timings: Optional[Dict[str, float]] = None,
+    backend_gen_tps: float = 0,
+    backend_prefill_tps: float = 0,
 ) -> dict:
     """Compute token counts, TPS, and build the final metrics dict."""
     if has_real_usage:
@@ -1113,7 +1115,15 @@ def _compute_final_metrics(
                 input_content += msg["content"] + "\n"
         input_tokens = len(input_content) // 4
         output_tokens = len(full_response) // 4
-    tps = output_tokens / total_duration if total_duration > 0 else 0
+    # Prefer the backend's true generation speed (llama.cpp
+    # timings.predicted_per_second) — pure decode, no prefill/tool/network time.
+    # Fall back to tokens/wall-clock only when the backend didn't report it
+    # (e.g. cloud APIs without timings); that figure reads low because
+    # total_duration includes prefill + agent overhead.
+    if backend_gen_tps and backend_gen_tps > 0:
+        tps = backend_gen_tps
+    else:
+        tps = output_tokens / total_duration if total_duration > 0 else 0
     # Use last round's input tokens for context % (peak usage) when available
     ctx_tokens = last_round_input_tokens if last_round_input_tokens > 0 else input_tokens
     ctx_pct = min(round((ctx_tokens / context_length) * 100, 1), 100.0) if context_length else 0
@@ -1124,12 +1134,17 @@ def _compute_final_metrics(
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "tokens_per_second": round(tps, 2),
+        # True decode speed when the backend reported it; "computed" = the
+        # tokens/wall-clock fallback (reads low — includes prefill/overhead).
+        "tps_source": "backend" if (backend_gen_tps and backend_gen_tps > 0) else "computed",
         "total_tokens": input_tokens + output_tokens,
         "context_length": context_length,
         "context_percent": ctx_pct,
         "usage_source": "real" if has_real_usage else "estimated",
         "model": model,
     }
+    if backend_prefill_tps and backend_prefill_tps > 0:
+        metrics["prefill_tps"] = round(backend_prefill_tps, 2)
     if prep_timings:
         prep_total = round(sum(prep_timings.values()), 3)
         metrics["agent_prep_time"] = prep_total
@@ -1431,6 +1446,8 @@ async def stream_agent_loop(
     real_output_tokens = 0
     last_round_input_tokens = 0  # Last round's input tokens (for context % peak)
     has_real_usage = False
+    backend_gen_tps = 0      # backend-reported true gen speed (llama.cpp timings)
+    backend_prefill_tps = 0  # backend-reported prefill speed
     total_tool_calls = 0  # for budget enforcement
 
     # Loop-breaker state. Small models (e.g. deepseek-v4-flash) can get
@@ -1580,6 +1597,14 @@ async def stream_agent_loop(
                         real_output_tokens += u.get("output_tokens", 0)
                         last_round_input_tokens = round_input
                         has_real_usage = True
+                        # Backend-reported TRUE generation speed (llama.cpp
+                        # timings.predicted_per_second) — pure decode, excludes
+                        # prefill/network. Preferred over tokens/wall-clock, which
+                        # reads low. Keep the last round's value (the gen phase).
+                        if u.get("gen_tps"):
+                            backend_gen_tps = u["gen_tps"]
+                        if u.get("prefill_tps"):
+                            backend_prefill_tps = u["prefill_tps"]
                     elif "delta" in data:
                         if not first_token_received:
                             time_to_first_token = time.time() - total_start
@@ -2088,6 +2113,8 @@ async def stream_agent_loop(
         has_real_usage, tool_events, round_texts, model=model,
         last_round_input_tokens=last_round_input_tokens,
         prep_timings=prep_timings,
+        backend_gen_tps=backend_gen_tps,
+        backend_prefill_tps=backend_prefill_tps,
     )
     yield f"data: {json.dumps({'type': 'metrics', 'data': metrics})}\n\n"
 

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -998,7 +998,19 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                 _delta0 = _choices[0].get("delta") if _choices else None
                                 if "usage" in j and _delta0 in (None, {}, {"content": None}):
                                     u = j["usage"]
-                                    yield f'data: {json.dumps({"type": "usage", "data": {"input_tokens": u.get("prompt_tokens", 0), "output_tokens": u.get("completion_tokens", 0)}})}\n\n'
+                                    _usage_data = {"input_tokens": u.get("prompt_tokens", 0), "output_tokens": u.get("completion_tokens", 0)}
+                                    # llama.cpp puts a `timings` block alongside `usage` with the
+                                    # TRUE generation speed (predicted_per_second) — pure decode,
+                                    # excluding prefill/network. Pass it through so the UI shows the
+                                    # real gen t/s instead of recomputing tokens/wall-clock (which
+                                    # includes prefill and reads ~20-40% low). Prefill speed too.
+                                    _tm = j.get("timings")
+                                    if isinstance(_tm, dict):
+                                        if _tm.get("predicted_per_second"):
+                                            _usage_data["gen_tps"] = round(_tm["predicted_per_second"], 2)
+                                        if _tm.get("prompt_per_second"):
+                                            _usage_data["prefill_tps"] = round(_tm["prompt_per_second"], 2)
+                                    yield f'data: {json.dumps({"type": "usage", "data": _usage_data})}\n\n'
                                 elif "choices" in j:
                                     delta = j["choices"][0].get("delta") or {}
                                     if isinstance(delta, dict):

--- a/static/app.js
+++ b/static/app.js
@@ -2368,7 +2368,7 @@ function initializeEventListeners() {
   };
 
   // Keys hidden by default on first run (no localStorage yet)
-  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn']);
+  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat']);
 
   // Keys that need admin to toggle off (reserved for future use)
   const UI_VIS_ADMIN_ONLY = new Set([]);
@@ -2403,6 +2403,12 @@ function initializeEventListeners() {
     applyTextEmojis(state['text-emojis'] !== false);
     // Hide thinking sections toggle (show-thinking: checked=show, unchecked=hide)
     document.body.classList.toggle('hide-thinking', state['show-thinking'] === false);
+    // Always-prominent tokens/sec: makes the per-message t/s metric bright and
+    // a touch larger instead of the dim muted footer text that's easy to miss.
+    document.body.classList.toggle('tps-prominent', state['prominent-tps'] === true);
+    // Wide chat: let the message column use the full window width (like
+    // ChatGPT/Claude's wide mode) instead of the default reading-width cap.
+    document.body.classList.toggle('chat-wide', state['wide-chat'] === true);
   }
 
   // Rearrange toggles in session/model sort dropdowns

--- a/static/index.html
+++ b/static/index.html
@@ -1757,6 +1757,16 @@
                 <input type="checkbox" checked data-ui-key="show-thinking"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
+                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
+                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
+                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/><path d="M4 4l16 16"/></svg></span>
                 <span class="vis-label">Sensitive Blur <span class="vis-hint">Blur emails, tokens, and secrets in AI output</span></span>
                 <input type="checkbox" data-privacy-key="sensitive-blur"><span class="vis-switch"></span>

--- a/static/style.css
+++ b/static/style.css
@@ -1742,6 +1742,20 @@ body.bg-pattern-sparkles {
       padding-left: max(0px, calc((100% - var(--chat-max)) / 2));
       padding-right: max(12px, calc((100% - var(--chat-max)) / 2 + 12px));
     }
+    /* Wide-chat toggle (Appearance → "Wide chat"): widen the reading column to
+       near-full-window, like ChatGPT/Claude wide mode. Just lifts the --chat-max
+       cap the existing centering math already keys off — no layout rewrite. */
+    body.chat-wide .chat-history { --chat-max: 1400px; }
+    /* Prominent t/s toggle (Appearance → "Always show tokens/sec"): the per-
+       message metric is normally dim muted footer text that's easy to miss.
+       Make it bright, slightly larger, and full-opacity so the speed is always
+       legible at a glance. */
+    body.tps-prominent .msg-footer .response-metrics {
+      color: var(--fg);
+      font-weight: 600;
+      font-size: 0.82rem;
+      opacity: 1;
+    }
     /* Welcome screen — centered in available space above input bar */
     #welcome-screen {
       position:absolute;


### PR DESCRIPTION
## What

Two small chat-quality improvements.

1. **Show the backend's true generation speed.**
   The per-message tokens/sec was computed as `output_tokens / total_duration`, where `total_duration` is wall-clock — including prefill, tool calls, and network — so it read low and could show "Speed: n/a / 27 tok" when usage arrived without a separate event. llama.cpp already reports the real decode speed in its stream (`timings.predicted_per_second`); we now read and display that (with a `tokens ÷ wall-clock` fallback for backends that don't report timings). Fixed on both the agent path and the direct-chat path. Also surfaces `prefill_tps`.

2. **Two opt-in appearance toggles** (off by default), via the existing `data-ui-key` system:
   - **Always Show Speed** — make the per-message t/s bright/legible instead of dim muted footer text that's easy to miss.
   - **Wide Chat** — let the message column use the full window width (lifts the existing `--chat-max` variable; no layout rewrite), like ChatGPT/Claude wide mode.

## Files

`src/llm_core.py`, `src/agent_loop.py`, `routes/chat_routes.py`, `static/app.js`, `static/index.html`, `static/style.css`.

## Testing

- `python -m py_compile src/llm_core.py src/agent_loop.py routes/chat_routes.py` → pass
- `node --check static/app.js` → pass
- Verified live against a local llama.cpp: the displayed t/s now matches the model's real decode speed (~79 t/s on a test) and is stable regardless of prompt length; both toggles default off and apply via body classes.

_Implemented with Claude (Anthropic) as a coding assistant; commits carry a `Co-Authored-By` trailer._
