### PR TITLE
fix: three small bugs (PDF marker strip, o1-mini context window, DeepSeek reasoning_content)

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -145,7 +145,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             create_form_markdown_document,
             create_plain_pdf_document,
         )
-        from src.document_processor import _process_pdf
+        from src.document_processor import _process_pdf, strip_pdf_content_marker
         import os
 
         from src.auth_helpers import require_privilege
@@ -184,7 +184,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
 
         title = os.path.splitext(meta.get("original_name") or meta.get("name") or upload_id)[0]
         try:
-            body_text = _process_pdf(pdf_path).lstrip("\n[PDF content]:").strip()
+            body_text = strip_pdf_content_marker(_process_pdf(pdf_path))
         except Exception:
             body_text = None
 
@@ -402,7 +402,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         text extraction was wired, plus for scanned/image-only PDFs where the
         VL model picks up text the basic pypdf path missed."""
         import re
-        from src.document_processor import _process_pdf
+        from src.document_processor import _process_pdf, strip_pdf_content_marker
         from src.pdf_form_doc import find_source_upload_id
 
         user = get_current_user(request)
@@ -423,7 +423,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                 raise HTTPException(404, "Source PDF could not be located")
 
             try:
-                body_text = _process_pdf(pdf_path).lstrip("\n[PDF content]:").strip()
+                body_text = strip_pdf_content_marker(_process_pdf(pdf_path))
             except Exception as e:
                 logger.error(f"extract_pdf_text failed for {pdf_path}: {e}")
                 raise HTTPException(500, f"Extraction failed: {e}")

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -152,6 +152,22 @@ def _process_pdf(path: str) -> str:
         return f"\n\n[PDF processing failed: {str(e)}]"
 
 
+# Marker that _process_pdf prepends to extracted text.
+_PDF_CONTENT_MARKER = "\n\n[PDF content]:"
+
+
+def strip_pdf_content_marker(text: str) -> str:
+    """Remove the leading ``[PDF content]:`` wrapper that ``_process_pdf`` adds.
+
+    Uses ``str.removeprefix`` rather than ``str.lstrip(chars)``: ``lstrip``
+    treats its argument as a *set of characters*, so ``lstrip("\\n[PDF content]:")``
+    keeps chewing into the page text that follows the marker. For example
+    ``"\\n\\n[PDF content]:\\n\\n[Page 1 text]:\\nto the board"`` would lose the
+    leading "to" because 't' and 'o' are in the marker's character set.
+    """
+    return (text or "").removeprefix(_PDF_CONTENT_MARKER).strip()
+
+
 def _load_vl_settings() -> dict:
     """Load admin settings from disk."""
     try:

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -450,7 +450,12 @@ def _parse_anthropic_response(data: dict) -> str:
 
 def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
     """Strip Odysseus-only metadata before sending messages to providers."""
-    allowed = {"role", "content", "name", "tool_call_id", "tool_calls", "function_call"}
+    # reasoning_content is preserved on purpose: _append_tool_results echoes the
+    # prior round's reasoning back on the assistant message because DeepSeek's
+    # API rejects follow-up thinking-mode requests that omit it. Other vendors
+    # ignore the extra field.
+    allowed = {"role", "content", "name", "tool_call_id", "tool_calls",
+               "function_call", "reasoning_content"}
     cleaned = []
     for msg in messages or []:
         if not isinstance(msg, dict):

--- a/src/model_context.py
+++ b/src/model_context.py
@@ -181,14 +181,22 @@ def get_context_length(endpoint_url: str, model: str) -> int:
 
 
 def _lookup_known(model: str) -> Optional[int]:
-    """Check known context windows by substring match."""
+    """Check known context windows by substring match.
+
+    Picks the LONGEST matching key so a short key never shadows a more specific
+    one. Without this, 'o1' (200k) precedes 'o1-mini' (128k) in the table and a
+    first-match return would report o1-mini's window as 200k.
+    """
     name = model.lower()
     basename = name.split("/")[-1] if "/" in name else name
     basename = basename.split(":")[0]  # strip :free, :extended etc.
+    best_key: Optional[str] = None
+    best_ctx: Optional[int] = None
     for key, ctx in KNOWN_CONTEXT_WINDOWS.items():
         if key in basename or key in name:
-            return ctx
-    return None
+            if best_key is None or len(key) > len(best_key):
+                best_key, best_ctx = key, ctx
+    return best_ctx
 
 
 def _query_context_length(endpoint_url: str, model: str) -> int:

--- a/tests/test_document_pdf_marker.py
+++ b/tests/test_document_pdf_marker.py
@@ -1,0 +1,30 @@
+"""Regression test: the '[PDF content]:' wrapper must be removed without eating
+into the page text that follows it.
+
+The old call sites used ``str.lstrip("\\n[PDF content]:")``, which treats the
+argument as a *set of characters* and keeps stripping leading characters that
+happen to be in that set — corrupting the start of the extracted document.
+"""
+from src.document_processor import strip_pdf_content_marker, _PDF_CONTENT_MARKER
+
+
+def test_marker_removed_without_eating_following_text():
+    # Shape that _process_pdf actually returns: marker + "\n\n[Page 1 text]:" + body.
+    raw = "\n\n[PDF content]:\n\n[Page 1 text]:\nto the board, content begins"
+    out = strip_pdf_content_marker(raw)
+    assert out == "[Page 1 text]:\nto the board, content begins"
+    # The old lstrip approach produced "age 1 text]:..." (ate "[P" then "to").
+    assert not out.startswith("age 1 text")
+
+
+def test_marker_constant_matches_processor_output():
+    # If _process_pdf's prefix ever changes, this guards the consumer.
+    assert _PDF_CONTENT_MARKER == "\n\n[PDF content]:"
+
+
+def test_text_without_marker_is_only_stripped():
+    assert strip_pdf_content_marker("  plain text  ") == "plain text"
+
+
+def test_handles_none():
+    assert strip_pdf_content_marker(None) == ""

--- a/tests/test_llm_core_sanitize.py
+++ b/tests/test_llm_core_sanitize.py
@@ -1,0 +1,30 @@
+"""Regression test: reasoning_content must survive message sanitization.
+
+_append_tool_results attaches reasoning_content to the assistant message so
+DeepSeek thinking-mode follow-up requests aren't rejected; the sanitizer used to
+strip it because it wasn't in the allow-list.
+"""
+from src.llm_core import _sanitize_llm_messages
+
+
+def test_reasoning_content_preserved():
+    msgs = [{
+        "role": "assistant",
+        "content": "the answer",
+        "reasoning_content": "step-by-step thinking",
+        "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "x", "arguments": "{}"}}
+        ],
+        "odysseus_internal": "should be dropped",
+    }]
+    out = _sanitize_llm_messages(msgs)
+    assert len(out) == 1
+    assert out[0]["reasoning_content"] == "step-by-step thinking"
+    assert out[0]["tool_calls"][0]["id"] == "c1"
+    assert "odysseus_internal" not in out[0]
+
+
+def test_unknown_keys_still_stripped():
+    out = _sanitize_llm_messages([{"role": "user", "content": "hi", "foo": "bar"}])
+    assert out == [{"role": "user", "content": "hi"}]

--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -107,3 +107,16 @@ class TestLookupKnown:
         """Models with :free or :extended suffixes should still match."""
         result = _lookup_known("deepseek-r1:free")
         assert result == 64000
+
+    def test_o1_mini_not_shadowed_by_o1(self):
+        """'o1' (200k) precedes 'o1-mini' (128k) in the table; longest match wins."""
+        assert _lookup_known("o1-mini") == 128000
+
+    def test_o1_full(self):
+        assert _lookup_known("o1") == 200000
+
+    def test_gpt4o_mini_not_shadowed_by_gpt4(self):
+        assert _lookup_known("gpt-4o-mini") == 128000
+
+    def test_gpt4_base(self):
+        assert _lookup_known("gpt-4") == 8192


### PR DESCRIPTION
Three small, independent bug fixes, each with a regression test. Happy to split into separate PRs if you'd prefer.

---

### 1. PDF import garbles the start of the extracted text

`routes/document_routes.py` (two call sites) dropped the `[PDF content]:` wrapper with:

```python
body_text = _process_pdf(pdf_path).lstrip("\n[PDF content]:").strip()
```

`str.lstrip(chars)` treats its argument as a **set of characters**, not a prefix. `_process_pdf` returns `"\n\n[PDF content]:\n\n[Page 1 text]:\n<body>"`, so the lstrip keeps eating leading characters that happen to be in the set:

```
"\n\n[PDF content]:\n\n[Page 1 text]:\nto the board"
  -> "age 1 text]:\nto the board"   # ate "[P" then "to"
```

**Fix:** added `strip_pdf_content_marker()` in `src/document_processor.py` using `str.removeprefix`, and used it at both call sites. Output is now `"[Page 1 text]:\nto the board"`.

### 2. `o1-mini` reports the wrong context window (200k instead of 128k)

`src/model_context.py::_lookup_known` returned the **first** substring match from `KNOWN_CONTEXT_WINDOWS`. Because `'o1'` (200000) is listed before `'o1-mini'` (128000), a model id of `o1-mini` matched `'o1'` first and got a 200k window — which can let the app pack requests past the model's real limit.

**Fix:** return the **longest** matching key, so a short key can't shadow a more specific one. Order-independent and existing entries are unaffected.

### 3. DeepSeek thinking-mode reasoning is dropped between rounds

`src/agent_loop.py::_append_tool_results` deliberately attaches `reasoning_content` to the assistant message, with a comment noting DeepSeek's API rejects follow-up thinking-mode requests that omit it. But `src/llm_core.py::_sanitize_llm_messages` stripped it, because `reasoning_content` wasn't in the `allowed` set — so the field never reached the provider.

**Fix:** added `reasoning_content` to the allow-list. Other vendors ignore the extra field.

---

### Files changed
- `src/document_processor.py`, `routes/document_routes.py` — PDF marker fix.
- `src/model_context.py` — longest-match context lookup.
- `src/llm_core.py` — keep `reasoning_content` through sanitization.
- `tests/test_document_pdf_marker.py`, `tests/test_llm_core_sanitize.py`, `tests/test_model_context.py` — regression tests.

### Testing
- `python -m pytest tests/test_document_pdf_marker.py tests/test_llm_core_sanitize.py tests/test_model_context.py` — passes.
- Each fix verified as a real regression: the o1-mini and reasoning_content tests fail on the unpatched code; the PDF lstrip vs removeprefix difference is demonstrated above.
- Full suite shows no new failures from these changes (pre-existing failures in a minimal venv are due to optional deps like `bs4` not being installed).
