### PR TITLE
Fix SELinux bind mounts in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,18 @@ services:
     ports:
       - "${APP_BIND:-127.0.0.1}:${APP_PORT:-7000}:7000"
     volumes:
-      - ./data:/app/data
-      - ./logs:/app/logs
+      - ./data:/app/data:z
+      - ./logs:/app/logs:z
       # Cookbook remote-server SSH identity. Odysseus can generate a key here;
       # add the shown public key to each remote server's authorized_keys.
-      - ./data/ssh:/app/.ssh
+      - ./data/ssh:/app/.ssh:z
       # Cookbook local model cache. Inside Docker, "Local" means the Odysseus
       # container, so persist its HuggingFace cache under ./data/huggingface.
-      - ./data/huggingface:/app/.cache/huggingface
+      - ./data/huggingface:/app/.cache/huggingface:z
       # Cookbook-installed Python CLIs/packages (vLLM, llama-cpp-python, etc.)
       # land under /app/.local for the odysseus user. Persist them so a
       # container recreate does not silently remove installed serve engines.
-      - ./data/local:/app/.local
+      - ./data/local:/app/.local:z
     extra_hosts:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.
@@ -72,7 +72,7 @@ services:
       - "127.0.0.1:8080:8080"
     volumes:
       - searxng-data:/etc/searxng
-      - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro
+      - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
     environment:
       - SEARXNG_BASE_URL=http://localhost:8080/
       - SEARXNG_SECRET=${SEARXNG_SECRET:-}


### PR DESCRIPTION
## Summary

Adds shared SELinux relabeling (`:z`) to Docker Compose bind mounts used by Odysseus and
SearXNG.

## Why

On SELinux-enabled hosts, fresh `docker compose up -d --build` can fail even when normal Unix
permissions look correct. The SearXNG container cannot read its mounted settings template, and
the Odysseus app can fail to open its SQLite database under the bind-mounted `data` directory.

Observed failures included:

- `sed: /tmp/searxng-settings.yml.template: Permission denied`
- `sqlite3.OperationalError: unable to open database file`

Using `:z` lets Docker apply a shared SELinux label to the bind-mounted paths so the containers
can access the files consistently across SELinux-enabled distributions.

## Validation

- Ran `docker compose up -d`
- Confirmed `searxng` is healthy
- Confirmed `odysseus` starts and stays running on `127.0.0.1:7000`