### PR TITLE
Refactor open registration state switching

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -339,7 +339,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         Toggle open registration on/off. Admin only.
 
         DEPRECATED: This endpoint uses toggle semantics which can lead to unsafe state changes.
-        Use PUT /open-registration instead.
+        Use PUT /open-signup instead.
 
         This endpoint is kept for backward compatibility and may be removed in future versions.
         """
@@ -349,9 +349,9 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         auth_manager.signup_enabled = not auth_manager.signup_enabled
         return {"ok": True, "signup_enabled": auth_manager.signup_enabled}
 
-    @router.put("/open-registration")
+    @router.put("/open-signup")
     async def set_signup_enabled(body: SetOpenRegistrationRequest, request: Request):
-        """Set open registration enabled state. Admin only."""
+        """Set open signup enabled state. Admin only."""
         user = _get_current_user(request)
         if not user or not auth_manager.is_admin(user):
             raise HTTPException(403, "Admin only")

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -67,6 +67,8 @@ class DeleteUserRequest(BaseModel):
 class RenameUserRequest(BaseModel):
     username: str
 
+class SetOpenRegistrationRequest(BaseModel):
+    enabled: bool
 
 SESSION_COOKIE = "odysseus_session"
 
@@ -331,14 +333,30 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
             raise HTTPException(400, "Cannot rename user")
         return {"ok": True, "username": new_username, "renamed_self": old_username == user}
 
-    @router.post("/signup-toggle")
+    @router.post("/signup-toggle", deprecated=True)
     async def toggle_signup(request: Request):
-        """Toggle open registration on/off. Admin only."""
+        """
+        Toggle open registration on/off. Admin only.
+
+        DEPRECATED: This endpoint uses toggle semantics which can lead to unsafe state changes.
+        Use PUT /open-registration instead.
+
+        This endpoint is kept for backward compatibility and may be removed in future versions.
+        """
         user = _get_current_user(request)
         if not user or not auth_manager.is_admin(user):
             raise HTTPException(403, "Admin only")
         auth_manager.signup_enabled = not auth_manager.signup_enabled
         return {"ok": True, "signup_enabled": auth_manager.signup_enabled}
+
+    @router.put("/open-registration")
+    async def set_signup_enabled(body: SetOpenRegistrationRequest, request: Request):
+        """Set open registration enabled state. Admin only."""
+        user = _get_current_user(request)
+        if not user or not auth_manager.is_admin(user):
+            raise HTTPException(403, "Admin only")
+        auth_manager.signup_enabled = body.enabled
+        return {"ok": True,"signup_enabled": auth_manager.signup_enabled}
 
     @router.delete("/users")
     async def admin_delete_user(body: DeleteUserRequest, request: Request):


### PR DESCRIPTION
This PR improves the registration control API by introducing an explicit endpoint and deprecating the existing toggle implementation.

Changes:
- Added PUT /open-signup to explicitly control registration state
- Deprecated POST /signup-toggle due to unsafe toggle semantics

The previous toggle-based endpoint is not idempotent, which makes it unsafe. An explicit state-based API is more predictable and aligns better with REST.

POST /signup-toggle is kept for legacy usage and marked as deprecated