### PR TITLE
fix: require auth on document, calendar, editor draft, model, and auth routes

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -380,7 +380,9 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         for keybinds + TTS prefs, so it stays callable without admin."""
         user = _get_current_user(request)
         settings = _load_settings()
-        if user and auth_manager.is_admin(user):
+        if not user:
+            raise HTTPException(403, "Authentication required")
+        if auth_manager.is_admin(user):
             return settings
         return scrub_settings(settings)
 

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -49,7 +49,9 @@ def _get_or_404_calendar(db, cal_id: str, owner: str) -> CalendarCal:
     # belongs to a different user, treat it as not-found. The previous
     # rule (`if cal.owner and cal.owner != owner`) silently allowed any
     # authenticated user to read/edit any calendar with owner=None.
-    if owner and (cal.owner is None or cal.owner != owner):
+    if not owner:
+        raise HTTPException(403, "Authentication required")
+    if cal.owner is None or cal.owner != owner:
         raise HTTPException(404, "Calendar not found")
     return cal
 
@@ -59,7 +61,9 @@ def _get_or_404_event(db, uid: str, owner: str) -> CalendarEvent:
     if not ev:
         raise HTTPException(404, "Event not found")
     cal = ev.calendar
-    if owner and cal and (cal.owner is None or cal.owner != owner):
+    if not owner:
+        raise HTTPException(403, "Authentication required")
+    if cal and (cal.owner is None or cal.owner != owner):
         raise HTTPException(404, "Event not found")
     return ev
 

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -63,7 +63,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                 # unconfigured / localhost-bypass mode the middleware leaves
                 # current_user unset (None), and those sessions are already
                 # served freely everywhere else.
-                if user and session.owner and session.owner != user:
+                if user is None:
+                    raise HTTPException(403, "Authentication required")
+                if session.owner != user:
                     raise HTTPException(403, "Cannot create document in another user's session")
 
             doc_id = str(uuid.uuid4())
@@ -160,7 +162,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                 sess = db.query(DbSession).filter(DbSession.id == session_id).first()
                 if not sess:
                     raise HTTPException(404, "Session not found")
-                if user and sess.owner and sess.owner != user:
+                if user is None:
+                    raise HTTPException(403, "Authentication required")
+                if sess.owner != user:
                     raise HTTPException(403, "Cannot import into another user's session")
             finally:
                 db.close()
@@ -352,7 +356,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             # auth failures.
             if not session:
                 raise HTTPException(404, "Session not found")
-            if user and session.owner and session.owner != user:
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            if session.owner != user:
                 raise HTTPException(403, "Access denied")
             docs = db.query(Document).filter(
                 Document.session_id == session_id
@@ -1298,8 +1304,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                     # someone else's signature ID from doc markdown and have
                     # it stamped/exported.
                     _sig_q = db.query(Signature).filter(Signature.id.in_(ann_sig_ids))
-                    if user:
-                        _sig_q = _sig_q.filter(Signature.owner == user)
+                    if user is None:
+                        raise HTTPException(403, "Authentication required")
+                    _sig_q = _sig_q.filter(Signature.owner == user)
                     sig_rows = _sig_q.all()
                     for s in sig_rows:
                         try:
@@ -1384,9 +1391,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             stamps: dict = {}
             if sig_ids:
                 # SECURITY: filter by owner — same reason as render_pdf.
+                if user is None:
+                    raise HTTPException(403, "Authentication required")
                 _sig_q2 = db.query(Signature).filter(Signature.id.in_(list(sig_ids.values())))
-                if user:
-                    _sig_q2 = _sig_q2.filter(Signature.owner == user)
+                _sig_q2 = _sig_q2.filter(Signature.owner == user)
                 rows = _sig_q2.all()
                 by_id = {s.id: s for s in rows}
                 for field_name, sid in sig_ids.items():
@@ -1433,9 +1441,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                     # SECURITY: filter by owner so a caller can't reference
                     # someone else's signature ID from doc markdown and have
                     # it stamped/exported.
+                    if user is None:
+                        raise HTTPException(403, "Authentication required")
                     _sig_q = db.query(Signature).filter(Signature.id.in_(ann_sig_ids))
-                    if user:
-                        _sig_q = _sig_q.filter(Signature.owner == user)
+                    _sig_q = _sig_q.filter(Signature.owner == user)
                     sig_rows = _sig_q.all()
                     for s in sig_rows:
                         try:
@@ -1526,9 +1535,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             stamps: dict = {}
             if sig_ids:
                 # SECURITY: filter by owner — same reason as render_pdf.
+                if user is None:
+                    raise HTTPException(403, "Authentication required")
                 _sig_q2 = db.query(Signature).filter(Signature.id.in_(list(sig_ids.values())))
-                if user:
-                    _sig_q2 = _sig_q2.filter(Signature.owner == user)
+                _sig_q2 = _sig_q2.filter(Signature.owner == user)
                 rows = _sig_q2.all()
                 by_id = {s.id: s for s in rows}
                 for fname, sid in sig_ids.items():
@@ -1569,9 +1579,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                     # SECURITY: filter by owner so a caller can't reference
                     # someone else's signature ID from doc markdown and have
                     # it stamped/exported.
+                    if user is None:
+                        raise HTTPException(403, "Authentication required")
                     _sig_q = db.query(Signature).filter(Signature.id.in_(ann_sig_ids))
-                    if user:
-                        _sig_q = _sig_q.filter(Signature.owner == user)
+                    _sig_q = _sig_q.filter(Signature.owner == user)
                     sig_rows = _sig_q.all()
                     for s in sig_rows:
                         try:

--- a/routes/editor_draft_routes.py
+++ b/routes/editor_draft_routes.py
@@ -49,7 +49,7 @@ class DraftUpdate(BaseModel):
 
 def _owns(d: EditorDraft, user: Optional[str]) -> bool:
     if user is None:
-        return True
+        return False
     return (d.owner or None) == user
 
 
@@ -76,8 +76,9 @@ def setup_editor_draft_routes() -> APIRouter:
         db = SessionLocal()
         try:
             q = db.query(EditorDraft).filter(EditorDraft.is_active == True)
-            if user is not None:
-                q = q.filter(EditorDraft.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            q = q.filter(EditorDraft.owner == user)
             rows = q.order_by(EditorDraft.updated_at.desc()).limit(200).all()
             return {"drafts": [_summary(d) for d in rows]}
         finally:

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -519,7 +519,9 @@ def setup_model_routes(model_discovery):
         db = SessionLocal()
         try:
             q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
-            if owner and not is_admin:
+            if not owner:
+                raise HTTPException(403, "Authentication required")
+            if not is_admin:
                 # Regular users see: their own endpoints + null-owner
                 # (legacy / shared). Admins see everything.
                 q = owner_filter(q, ModelEndpoint, owner)
@@ -611,7 +613,9 @@ def setup_model_routes(model_discovery):
         _is_admin = False
         try:
             auth_mgr = getattr(request.app.state, "auth_manager", None)
-            if owner and auth_mgr is not None and getattr(auth_mgr, "is_admin", None):
+            if not owner:
+                raise HTTPException(403, "Authentication required")
+            if auth_mgr is not None and getattr(auth_mgr, "is_admin", None):
                 _is_admin = bool(auth_mgr.is_admin(owner))
         except Exception:
             _is_admin = False


### PR DESCRIPTION
Fixes null-owner authorization bypass in document, calendar, editor draft, model, and auth routes.

## Problem

Throughout the codebase, ownership checks used patterns like `if user and X.owner != user` or `if owner and (cal.owner is None or cal.owner != owner)`. When the user/owner is `None`, the entire check is skipped — allowing unauthenticated callers to access or modify any record.

## Fix

Replaced every instance with an early fail-closed guard:
```python
if user is None:
    raise HTTPException(403, "Authentication required")
if X.owner != user:
    raise HTTPException(404, "Not found")
```

## Files changed

- routes/document_routes.py — 6 checks (create, import, list session docs, 4 signature query filters)
- routes/calendar_routes.py — 2 checks (get calendar, get event)
- routes/editor_draft_routes.py — 2 checks (_owns helper, list drafts)
- routes/model_routes.py — 2 checks (list endpoints, list models cached)
- routes/auth_routes.py — 1 check (get settings admin bypass)
