### PR TITLE
fix: require auth on gallery, email, upload, and AI interaction paths

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -504,7 +504,7 @@ def _get_email_config(account_id: str | None = None, owner: str = "") -> dict:
 
     def _owner_or_matching_legacy_account(query):
         if not owner:
-            return query
+            raise HTTPException(403, "Authentication required")
         from sqlalchemy import and_, or_
         unowned = or_(_EA.owner == None, _EA.owner == "")  # noqa: E711
         same_mailbox = or_(_EA.imap_user == owner, _EA.from_address == owner)

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -259,10 +259,11 @@ def _resolve_send_config(account_id: str | None = None, owner: str = "") -> dict
         db = _SL()
         try:
             q = db.query(_EA).filter(_EA.enabled == True)  # noqa: E712
-            if owner:
-                unowned = or_(_EA.owner == None, _EA.owner == "")  # noqa: E711
-                same_mailbox = or_(_EA.imap_user == owner, _EA.from_address == owner)
-                q = q.filter(or_(_EA.owner == owner, and_(unowned, same_mailbox)))
+            if not owner:
+                raise HTTPException(403, "Authentication required")
+            unowned = or_(_EA.owner == None, _EA.owner == "")  # noqa: E711
+            same_mailbox = or_(_EA.imap_user == owner, _EA.from_address == owner)
+            q = q.filter(or_(_EA.owner == owner, and_(unowned, same_mailbox)))
             for row in q.order_by(_EA.is_default.desc(), _EA.created_at.asc()).all():
                 trial = _get_email_config(account_id=row.id, owner=owner)
                 if _smtp_ready(trial):
@@ -2884,10 +2885,11 @@ def setup_email_routes():
             # the logged-in mailbox; _get_email_config already accepts those,
             # so Settings should not hide the active account.
             q = db.query(EmailAccount)
-            if owner:
-                unowned = or_(EmailAccount.owner == None, EmailAccount.owner == "")  # noqa: E711
-                same_mailbox = or_(EmailAccount.imap_user == owner, EmailAccount.from_address == owner)
-                q = q.filter(or_(EmailAccount.owner == owner, and_(unowned, same_mailbox)))
+            if not owner:
+                raise HTTPException(403, "Authentication required")
+            unowned = or_(EmailAccount.owner == None, EmailAccount.owner == "")  # noqa: E711
+            same_mailbox = or_(EmailAccount.imap_user == owner, EmailAccount.from_address == owner)
+            q = q.filter(or_(EmailAccount.owner == owner, and_(unowned, same_mailbox)))
             for r in q.order_by(
                 EmailAccount.is_default.desc(), EmailAccount.created_at.asc()
             ).all():
@@ -2947,8 +2949,9 @@ def setup_email_routes():
             # otherwise creating a default would clear every other user's
             # default flag too.
             scope_q = db.query(EmailAccount)
-            if owner:
-                scope_q = scope_q.filter(EmailAccount.owner == owner)
+            if not owner:
+                raise HTTPException(403, "Authentication required")
+            scope_q = scope_q.filter(EmailAccount.owner == owner)
             existing_count = scope_q.count()
             if row.is_default or existing_count == 0:
                 scope_q.update({EmailAccount.is_default: False})
@@ -3010,8 +3013,9 @@ def setup_email_routes():
             # it as their default.
             if was_default:
                 promote_q = db.query(EmailAccount).filter(EmailAccount.enabled == True)  # noqa: E712
-                if owner:
-                    promote_q = promote_q.filter(EmailAccount.owner == owner)
+                if not owner:
+                    raise HTTPException(403, "Authentication required")
+                promote_q = promote_q.filter(EmailAccount.owner == owner)
                 promote = promote_q.order_by(EmailAccount.created_at.asc()).first()
                 if promote:
                     promote.is_default = True
@@ -3147,8 +3151,9 @@ def setup_email_routes():
             # SECURITY: scope the "clear other defaults" sweep to this user's
             # accounts so we don't unset another user's default flag.
             clear_q = db.query(EmailAccount)
-            if owner:
-                clear_q = clear_q.filter(EmailAccount.owner == owner)
+            if not owner:
+                raise HTTPException(403, "Authentication required")
+            clear_q = clear_q.filter(EmailAccount.owner == owner)
             clear_q.update({EmailAccount.is_default: False})
             row.is_default = True
             db.commit()

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -47,8 +47,9 @@ def setup_gallery_routes() -> APIRouter:
                 GalleryImage.file_hash == file_hash,
                 GalleryImage.is_active == True,
             )
-            if user:
-                _dup_q = _dup_q.filter(GalleryImage.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            _dup_q = _dup_q.filter(GalleryImage.owner == user)
             existing = _dup_q.first()
             if existing:
                 return {"ok": False, "duplicate": True, "filename": existing.filename,
@@ -382,8 +383,9 @@ def setup_gallery_routes() -> APIRouter:
                 .outerjoin(DbSession, GalleryImage.session_id == DbSession.id)
                 .filter(GalleryImage.is_active == True)
             )
-            if user is not None:
-                q = q.filter(GalleryImage.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            q = q.filter(GalleryImage.owner == user)
 
             # Search filter (prompt + tags + ai_tags)
             if search:
@@ -485,8 +487,9 @@ def setup_gallery_routes() -> APIRouter:
         db = SessionLocal()
         try:
             q = db.query(GalleryAlbum)
-            if user:
-                q = q.filter(GalleryAlbum.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            q = q.filter(GalleryAlbum.owner == user)
             albums = q.order_by(GalleryAlbum.created_at.desc()).all()
             result = []
             for a in albums:
@@ -543,10 +546,11 @@ def setup_gallery_routes() -> APIRouter:
             base = db.query(GalleryImage).filter(GalleryImage.is_active == True)
             size_q = db.query(func.sum(GalleryImage.file_size)).filter(GalleryImage.is_active == True)
             album_q = db.query(GalleryAlbum)
-            if user:
-                base = base.filter(GalleryImage.owner == user)
-                size_q = size_q.filter(GalleryImage.owner == user)
-                album_q = album_q.filter(GalleryAlbum.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            base = base.filter(GalleryImage.owner == user)
+            size_q = size_q.filter(GalleryImage.owner == user)
+            album_q = album_q.filter(GalleryAlbum.owner == user)
             total = base.count()
             total_size = size_q.scalar() or 0
             fav_count = base.filter(GalleryImage.favorite == True).count()
@@ -574,8 +578,9 @@ def setup_gallery_routes() -> APIRouter:
                 GalleryImage.is_active == True,
                 (GalleryImage.ai_tags == None) | (GalleryImage.ai_tags == ""),
             )
-            if user:
-                q = q.filter(GalleryImage.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            q = q.filter(GalleryImage.owner == user)
             if album_id:
                 q = q.filter(GalleryImage.album_id == album_id)
             untagged = q.count()
@@ -1617,8 +1622,9 @@ def setup_gallery_routes() -> APIRouter:
             _get_or_404_album(db, album_id, user)
             # Only move images the caller owns
             q = db.query(GalleryImage).filter(GalleryImage.id.in_(ids))
-            if user:
-                q = q.filter(GalleryImage.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            q = q.filter(GalleryImage.owner == user)
             q.update({"album_id": album_id}, synchronize_session=False)
             db.commit()
             return {"ok": True, "count": len(ids)}
@@ -1636,8 +1642,9 @@ def setup_gallery_routes() -> APIRouter:
             q = db.query(GalleryImage).filter(
                 GalleryImage.id.in_(ids), GalleryImage.album_id == album_id
             )
-            if user:
-                q = q.filter(GalleryImage.owner == user)
+            if user is None:
+                raise HTTPException(403, "Authentication required")
+            q = q.filter(GalleryImage.owner == user)
             q.update({"album_id": None}, synchronize_session=False)
             db.commit()
             return {"ok": True}

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -765,9 +765,9 @@ async def do_manage_session(content: str, session_id: Optional[str] = None, owne
     # result so the user sees a single clickable line.
     def _session_query(db):
         query = db.query(DbSession).filter(DbSession.id == target_sid)
-        if owner is not None:
-            query = query.filter(DbSession.owner == owner)
-        return query
+        if owner is None:
+            return query.filter(DbSession.owner == "__impossible__")
+        return query.filter(DbSession.owner == owner)
 
     if action in ("switch", "open", "select", "view"):
         db = SessionLocal()
@@ -1003,7 +1003,7 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
         for m in memories:
             if m.get("id", "").startswith(memory_id):
                 # Verify ownership
-                if owner and m.get("owner") != owner:
+                if owner is None or m.get("owner") != owner:
                     return {"error": f"Memory '{memory_id}' not found"}
                 m["text"] = new_text
                 m["timestamp"] = int(time.time())
@@ -1036,7 +1036,7 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
         for m in memories:
             if m.get("id", "").startswith(memory_id):
                 # Verify ownership
-                if owner and m.get("owner") != owner:
+                if owner is None or m.get("owner") != owner:
                     return {"error": f"Memory '{memory_id}' not found"}
                 full_id = m["id"]
                 delete_id = m["id"]

--- a/src/settings.py
+++ b/src/settings.py
@@ -9,6 +9,7 @@ import json
 import time
 import logging
 from typing import Any
+from fastapi import HTTPException
 
 from src.constants import SETTINGS_FILE, FEATURES_FILE
 
@@ -186,7 +187,9 @@ def get_user_setting(key: str, owner: str = "", default: Any = None) -> Any:
     Falls back gracefully if the prefs module can't be imported (cycle/early
     boot) — admin-global settings keep working.
     """
-    if owner and key in _PER_USER_KEYS:
+    if owner is None:
+        raise HTTPException(403, "Authentication required")
+    if key in _PER_USER_KEYS:
         try:
             from routes.prefs_routes import _load_for_user
             prefs = _load_for_user(owner) or {}

--- a/src/upload_handler.py
+++ b/src/upload_handler.py
@@ -308,7 +308,9 @@ class UploadHandler:
             except Exception:
                 is_admin = False
 
-        if owner and not is_admin:
+        if not owner:
+            raise HTTPException(403, "Authentication required")
+        if not is_admin:
             if info.get("owner") != owner:
                 logger.warning("Upload %s denied for owner %s", upload_id, owner)
                 return None


### PR DESCRIPTION
Fixes null-owner authorization bypass in gallery, email, upload, and AI interaction paths.

## Problem

When owner/user is `None`, query filters were skipped, returning all rows. Ownership checks on individual records were also bypassed.

## Fix

Added early fail-closed auth guards that return 403 when the caller is unauthenticated.

## Files changed

- routes/gallery_routes.py — 7 checks (upload dup detect, list images, list albums, stats, ai tag batch, add/remove from album)
- routes/email_routes.py — 5 checks (fallback SMTP, list accounts, create, delete, set default)
- routes/email_helpers.py — 1 check (_owner_or_matching_legacy_account returning unfiltered query)
- src/upload_handler.py — 1 check (upload ownership verification)
- src/ai_interaction.py — 3 checks (session query filter, memory edit, memory delete)
- src/settings.py — 1 check (get_user_setting with null owner)
