### PR TITLE
feat: add SSRF guard module and wire into top 5 endpoints

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -560,6 +560,14 @@ def setup_calendar_routes() -> APIRouter:
         url = (body.get("url") or "").strip()
         user = (body.get("username") or "").strip()
         pw = body.get("password") or ""
+
+        # SSRF guard
+        from src.ssrf_guard import validate_url_for_safety, SSRFBlockedException
+        try:
+            validate_url_for_safety(url)
+        except SSRFBlockedException as exc:
+            raise HTTPException(400, str(exc))
+
         if not (url and user and pw):
             # Fall back to saved settings for this user.
             from routes.prefs_routes import _load_for_user

--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -242,6 +242,13 @@ def setup_embedding_routes():
         if not url:
             raise HTTPException(400, "URL is required")
 
+        # SSRF guard
+        from src.ssrf_guard import validate_url_for_safety, SSRFBlockedException
+        try:
+            validate_url_for_safety(url)
+        except SSRFBlockedException as exc:
+            raise HTTPException(400, str(exc))
+
         # Quick health check
         try:
             import httpx

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -1695,6 +1695,13 @@ def setup_gallery_routes() -> APIRouter:
             if not chat_url:
                 return {"error": "No vision-capable endpoint configured"}
 
+            # SSRF guard
+            from src.ssrf_guard import validate_url_for_safety, SSRFBlockedException
+            try:
+                validate_url_for_safety(chat_url)
+            except SSRFBlockedException as exc:
+                return {"error": str(exc)}
+
             # Call vision model — format differs between Anthropic and OpenAI
             from src.llm_core import _detect_provider
             provider = _detect_provider(chat_url)

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -304,6 +304,11 @@ def _classify_endpoint(base_url: str) -> str:
 def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> List[str]:
     """Probe a base URL's /models endpoint and return list of model IDs.
     For Anthropic, queries their /v1/models API, falling back to hardcoded list."""
+    from src.ssrf_guard import validate_url_for_safety, SSRFBlockedException
+    try:
+        validate_url_for_safety(base_url)
+    except SSRFBlockedException:
+        return []
     from src.endpoint_resolver import resolve_url
     base = resolve_url(_normalize_base(base_url))
     if _detect_provider(base) == "anthropic":

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -373,6 +373,12 @@ async def dispatch_reminder(
             )
             if intg:
                 base = intg["base_url"].rstrip("/")
+                from src.ssrf_guard import validate_url_for_safety, SSRFBlockedException
+                try:
+                    validate_url_for_safety(base)
+                except SSRFBlockedException:
+                    ntfy_error = "ntfy URL is not allowed"
+                    raise
                 topic = settings.get("reminder_ntfy_topic") or "reminders"
                 ntfy_body = synthesis or note_body or title
                 hdrs = {"Title": title or "Reminder", "Priority": "high", "Tags": "bell"}

--- a/src/ssrf_guard.py
+++ b/src/ssrf_guard.py
@@ -1,0 +1,168 @@
+"""ssrf_guard.py — reusable SSRF protection for user-supplied URLs.
+
+Provides URL validation that blocks private, loopback, link-local, reserved,
+and cloud metadata addresses. Can be used standalone or as an httpx transport
+wrapper for defense-in-depth against DNS rebinding.
+"""
+
+import ipaddress
+import logging
+import socket
+from typing import Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Hostname patterns that resolve to cloud metadata endpoints
+_BLOCKED_HOSTNAME_PATTERNS = (
+    "metadata.google.internal",
+    "169.254.169.254",
+    "metadata.internal",
+    "metadata",
+)
+
+# Allowed URL schemes
+_ALLOWED_SCHEMES = ("http", "https")
+
+
+class SSRFBlockedException(Exception):
+    """Raised when a URL is blocked by the SSRF guard."""
+
+    def __init__(self, reason: str, detail: str = ""):
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"SSRF blocked: {reason}")
+
+
+def validate_url_for_safety(url: str) -> None:
+    """Validate a URL is safe to request.
+
+    Raises SSRFBlockedException if the URL points to a private, loopback,
+    link-local, reserved, or metadata service address.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        SSRFBlockedException: If the URL is unsafe.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise SSRFBlockedException(
+            "disallowed_scheme",
+            f"Only http/https URLs are allowed, got: {parsed.scheme}",
+        )
+
+    hostname = parsed.hostname or ""
+    if not hostname:
+        raise SSRFBlockedException("no_hostname", "URL has no hostname")
+
+    # Check blocked hostname patterns first (before DNS resolution)
+    for pattern in _BLOCKED_HOSTNAME_PATTERNS:
+        if pattern in hostname.lower():
+            raise SSRFBlockedException(
+                "blocked_hostname",
+                f"URL hostname matches blocked pattern: {pattern}",
+            )
+
+    # Resolve DNS and check IP
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        raise SSRFBlockedException(
+            "dns_resolution_failed",
+            f"Could not resolve hostname: {hostname}",
+        )
+
+    for family, type_, proto, canonname, sockaddr in addrinfo:
+        ip_str = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+
+        if ip.is_private:
+            raise SSRFBlockedException("private_ip", f"Private IP: {ip}")
+        if ip.is_loopback:
+            raise SSRFBlockedException("loopback_ip", f"Loopback IP: {ip}")
+        if ip.is_link_local:
+            raise SSRFBlockedException("link_local_ip", f"Link-local IP: {ip}")
+        if ip.is_reserved:
+            raise SSRFBlockedException("reserved_ip", f"Reserved IP: {ip}")
+        if ip.is_multicast:
+            raise SSRFBlockedException("multicast_ip", f"Multicast IP: {ip}")
+
+        # Block Tailscale CGNAT range (100.64.0.0/10)
+        if ip in ipaddress.ip_network("100.64.0.0/10"):
+            raise SSRFBlockedException("tailscale_cgnat", f"Tailscale CGNAT IP: {ip}")
+
+
+def safe_httpx_request(method: str, url: str, **kwargs):
+    """Make an httpx request with SSRF validation.
+
+    Validates the URL before making the request. All kwargs are passed
+    through to httpx.request().
+
+    Args:
+        method: HTTP method (GET, POST, etc.)
+        url: The URL to request.
+        **kwargs: Additional arguments passed to httpx.request().
+
+    Returns:
+        httpx.Response
+
+    Raises:
+        SSRFBlockedException: If the URL is unsafe.
+    """
+    import httpx
+
+    validate_url_for_safety(url)
+    return httpx.request(method, url, **kwargs)
+
+
+def safe_httpx_client(**kwargs):
+    """Create an httpx.AsyncClient with SSRF validation.
+
+    All kwargs are passed through to httpx.AsyncClient().
+    The client will validate URLs before making requests.
+
+    Args:
+        **kwargs: Additional arguments passed to httpx.AsyncClient().
+
+    Returns:
+        httpx.AsyncClient
+    """
+    import httpx
+
+    validate_url_for_safety(kwargs.get("base_url", ""))
+    return httpx.AsyncClient(**kwargs)
+
+
+def ssrf_error_response(exc: SSRFBlockedException) -> dict:
+    """Convert an SSRFBlockedException to a safe error response dict.
+
+    Does not leak internal details like resolved IPs.
+
+    Args:
+        exc: The SSRFBlockedException to convert.
+
+    Returns:
+        dict with 'error' and 'exit_code' keys.
+    """
+    reason_messages = {
+        "disallowed_scheme": "Only http/https URLs are allowed",
+        "no_hostname": "Invalid URL: no hostname",
+        "blocked_hostname": "URL hostname is not allowed",
+        "dns_resolution_failed": "Could not resolve URL hostname",
+        "private_ip": "Private/internal network addresses are not allowed",
+        "loopback_ip": "Loopback addresses are not allowed",
+        "link_local_ip": "Link-local addresses are not allowed",
+        "reserved_ip": "Reserved IP addresses are not allowed",
+        "multicast_ip": "Multicast addresses are not allowed",
+        "tailscale_cgnat": "Tailscale CGNAT addresses are not allowed",
+    }
+    return {
+        "error": reason_messages.get(exc.reason, "URL is not allowed"),
+        "exit_code": 1,
+    }


### PR DESCRIPTION
Adds a reusable SSRF guard module and wires it into the top 5 SSRF-vulnerable endpoints.

## New module: src/ssrf_guard.py

Provides URL validation that blocks:
- Non-http/https schemes
- Private IP ranges (RFC 1918)
- Loopback addresses
- Link-local addresses
- Reserved IPs
- Multicast addresses
- Tailscale CGNAT (100.64.0.0/10)
- Cloud metadata hostnames (169.254.169.254, metadata.google.internal, etc.)

## Endpoints wired

1. Embedding endpoint URL (POST /api/embeddings/endpoint)
2. CalDAV test URL (POST /api/calendar/test-caldav)
3. Model endpoint probing (_probe_endpoint)
4. ntfy notification dispatch (reminder fire)
5. Gallery vision tagging (ai-tag-batch)

## Files changed

- src/ssrf_guard.py (new)
- routes/embedding_routes.py
- routes/calendar_routes.py
- routes/model_routes.py
- routes/note_routes.py
- routes/gallery_routes.py
