### PR TITLE
Fix Cookbook diagnosis for vLLM device detection failure

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -149,6 +149,15 @@ def setup_cookbook_routes() -> APIRouter:
                 [{"label": "clear Cookbook GPU selection or choose available GPUs", "op": "settings", "field": "gpus", "value": ""}],
             ),
             (
+                r"Failed to infer device type|NVML Shared Library Not Found|No module named 'amdsmi'|platform is not available",
+                "vLLM could not find a supported GPU (CUDA or ROCm). "
+                "This machine may have integrated or unsupported graphics only.",
+                [
+                    {"label": "switch to llama.cpp (CPU/Metal, works without a discrete GPU)", "op": "manual"},
+                    {"label": "switch to Ollama (CPU/Metal, works without a discrete GPU)", "op": "manual"},
+                ],
+            ),
+            (
                 r"vllm.*command not found|No module named vllm|ERROR: vLLM is not installed",
                 "vLLM is not installed or not in PATH on this server.",
                 [{"label": "install vLLM in Cookbook Dependencies", "op": "dependency", "package": "vllm"}],


### PR DESCRIPTION
## Summary

When vLLM cannot find a supported GPU it exits with `RuntimeError: Failed to infer device type` before serving starts. The existing diagnosis pattern only catches `No CUDA GPUs are available`, which fires later in the startup sequence — so the Cookbook serve card was showing a raw Python traceback instead of an actionable message.

This adds an earlier-stage pattern that catches:
- `Failed to infer device type` (the actual RuntimeError)
- `NVML Shared Library Not Found` (CUDA probe failure logged before the crash)
- `No module named 'amdsmi'` / `platform is not available` (ROCm probe failure)

Surfaces as: *"vLLM could not find a supported GPU (CUDA or ROCm). This machine may have integrated or unsupported graphics only."* with suggestions to switch to llama.cpp or Ollama.

## Changes

`routes/cookbook_routes.py` only — one new entry in `_diagnose_serve_output`, no deletions.

## Test plan

- [x] Regex verified against all four real error variants from an actual crash on a system with Intel Iris Xe (no NVIDIA/AMD GPU)
- [x] `py_compile routes/cookbook_routes.py` passes
- [x] Existing diagnosis patterns unaffected