### PR TITLE
Fix: Expand ~ in read_file and write_file paths

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -373,7 +373,7 @@ async def _direct_fallback(
             return {"output": output or "(no output)", "exit_code": rc or 0}
 
         if tool == "read_file":
-            path = content.split("\n", 1)[0].strip()
+            path = os.path.expanduser(content.split("\n", 1)[0].strip())
             if not path:
                 return {"error": "read_file: path required", "exit_code": 1}
             try:
@@ -395,7 +395,7 @@ async def _direct_fallback(
 
         if tool == "write_file":
             lines = content.split("\n", 1)
-            path = lines[0].strip()
+            path = os.path.expanduser(lines[0].strip())
             body = lines[1] if len(lines) > 1 else ""
             if not path:
                 return {"error": "write_file: path required", "exit_code": 1}


### PR DESCRIPTION
## Summary
`read_file` and `write_file` passed the raw path straight to `open()`. There is no shell in the tool layer, so a tilde path like `~/notes.txt` was never expanded and failed with "not found". Agents then worked around it by shelling out to bash to reach home-directory files.

Fix: `os.path.expanduser()` the path (handles `~` and `~user`) before opening, in both tools.

## Files
- `src/tool_execution.py` — `read_file` + `write_file` path handling (2 lines).

## Testing
- `python -m py_compile app.py routes/*.py src/*.py` — passes.
- `python -m pytest` — 471 passed. 2 unrelated failures (`test_auth_manager_migrates_legacy_admin_role`, `test_session_delivery_survives_empty_database`) are pre-existing and also fail on clean `main` (auth-migration / scheduler env, not touched by this change).
- Manual: `read_file ~/x.txt` / `write_file ~/x.txt` now resolve to the home directory instead of erroring.