### PR TITLE
refactor(ui): polish settings UX, add tab blurbs, and rename Appearance to Visibility

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1308,7 +1308,7 @@
         </button>
         <button class="close-btn" aria-label="Close settings">✖</button>
       </div>
-      <div class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;">Toggle on/off visibility of tools and modules across the interface.</div>
+      <div id="settings-tab-blurb" class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;"></div>
       <div class="settings-layout">
         <div class="settings-sidebar">
           <!-- Section 1: AI plumbing (Add Models → AI Defaults → Search) -->
@@ -1341,10 +1341,10 @@
             <span>Reminders</span>
           </button>
           <div class="settings-sidebar-divider"></div>
-          <!-- Section 3: UX (Appearance → Shortcuts) -->
-          <button class="settings-nav-item" data-settings-tab="appearance">
+          <!-- Section 3: UX (Visibility → Shortcuts) -->
+          <button class="settings-nav-item" data-settings-tab="visibility">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8"/></svg>
-            <span>Appearance</span>
+            <span>Visibility</span>
           </button>
           <button class="settings-nav-item" data-settings-tab="shortcuts">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10"/></svg>
@@ -1635,8 +1635,8 @@
           </div>
         </div>
 
-        <!-- ═══ APPEARANCE TAB ═══ -->
-        <div data-settings-panel="appearance" class="settings-appearance-panel hidden">
+        <!-- ═══ VISIBILITY TAB ═══ -->
+        <div data-settings-panel="visibility" class="settings-visibility-panel hidden">
           <div class="admin-card" style="padding-bottom:6px;">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>Sidebar</h2>
             <div class="vis-toggles">
@@ -1896,12 +1896,12 @@
 
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>Writing Style</h2>
-            <div class="admin-toggle-sub" style="margin-bottom:8px">AI-extracted from your sent emails. Used when AI drafts replies.</div>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Learns your tone from recent sent mail (max 15, min 3). Used when AI drafts replies.</div>
             <div class="settings-col">
               <textarea id="set-email-style" rows="4" class="settings-select" style="font-family:inherit;resize:vertical" placeholder="e.g. I write emails in this style. I don't use exclamation marks. I sign emails with: ..."></textarea>
               <div class="settings-row" style="margin-top:4px">
                 <span id="set-email-style-msg" style="font-size:11px;"></span>
-                <button class="admin-btn-add" id="set-email-style-extract" style="margin-left:auto;">Extract from Sent (15 emails)</button>
+                <button class="admin-btn-add" id="set-email-style-extract" style="margin-left:auto;">Extract from Sent</button>
                 <button class="admin-btn-add" id="set-email-style-save">Save</button>
               </div>
             </div>
@@ -1982,7 +1982,7 @@
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>Add User</h2>
             <div class="admin-add-form">
-              <input id="adm-newUsername" type="text" placeholder="Username (email)">
+              <input id="adm-newUsername" type="text" placeholder="Username">
               <input id="adm-newPassword" type="password" placeholder="Password (min 8)">
               <div class="admin-switch-inline" title="Grant full admin access"><label class="admin-switch"><input type="checkbox" id="adm-newIsAdmin"><span class="admin-slider"></span></label> Admin</div>
             </div>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,5 +1,5 @@
 // static/js/settings.js — Settings panel module (ES6)
-// User-facing preferences: AI models, search, appearance
+// User-facing preferences: AI models, search, visibility
 
 import uiModule from './ui.js';
 import searchModule from './search.js';
@@ -16,6 +16,30 @@ function esc(s) { return uiModule.esc(s); }
 
 /* ── Tab switching ── */
 const ADMIN_TABS = new Set(['services', 'integrations', 'tools', 'users', 'system']);
+const VISIBILITY_TAB = 'visibility';
+
+const SETTINGS_TAB_BLURBS = {
+  services: 'Connect local and cloud model endpoints for chat and images.',
+  ai: 'Default chat model, utility model, and related AI behavior.',
+  search: 'Search API used for web search and deep research.',
+  integrations: 'All external service connections in one place.',
+  email: 'Email writing style and links to account setup in Integrations.',
+  reminders: 'How fired note reminders are delivered (browser, email, ntfy).',
+  visibility: 'Toggle visibility of tools and modules across the interface.',
+  shortcuts: 'Click a shortcut to rebind; press Escape to cancel.',
+  account: 'Profile, password, and two-factor authentication.',
+  tools: 'Enable or disable tools available to the AI agent.',
+  users: 'User accounts, open signup, and per-user privileges.',
+  system: 'Backup, import, tokens, webhooks, and server maintenance.',
+};
+
+function syncSettingsTabBlurb(tab) {
+  const blurb = el('settings-tab-blurb');
+  if (!blurb) return;
+  const text = SETTINGS_TAB_BLURBS[tab] || '';
+  blurb.textContent = text;
+  blurb.style.display = text ? '' : 'none';
+}
 
 function initTabs() {
   modalEl.querySelectorAll('[data-settings-tab]').forEach(btn => {
@@ -28,11 +52,12 @@ function initTabs() {
       }
       modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
       modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
-      // Mark when the Appearance tab is open so the modal can go
+      syncSettingsTabBlurb(tab);
+      // Mark when the Visibility tab is open so the modal can go
       // semi-transparent — lets the user see the rest of the UI react as
       // they flip toggles instead of having to close + reopen the modal.
-      document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
-      syncAppearanceOpacity(tab === 'appearance');
+      document.body.classList.toggle('settings-visibility-open', tab === VISIBILITY_TAB);
+      syncAppearanceOpacity(tab === VISIBILITY_TAB);
       if (tab === 'ai') refreshAiModelEndpoints();
     });
   });
@@ -103,11 +128,11 @@ function initClose() {
   });
 }
 
-/* ── Appearance-tab opacity slider ──
+/* ── Visibility-tab opacity slider ──
    Mirrors the Theme customizer's slider: fades the settings modal's
    background (and inner cards) via color-mix so the user can watch the
    rest of the UI react to toggles, while keeping text/controls crisp
-   (no element opacity). Only shown/active on the Appearance tab. */
+   (no element opacity). Only shown/active on the Visibility tab. */
 const _SETTINGS_PEEK = 55; // % opacity when the Peek toggle is on
 function _applySettingsOpacity(on) {
   const content = modalEl && modalEl.querySelector('.settings-modal-content, .modal-content');
@@ -136,14 +161,14 @@ function _applySettingsOpacity(on) {
   }
 }
 
-// Show/hide the Peek toggle for the Appearance tab and apply or clear the fade.
+// Show/hide the Peek toggle for the Visibility tab and apply or clear the fade.
 function syncAppearanceOpacity(active) {
   const toggle = el('settings-opacity-wrap');
   if (toggle) toggle.classList.toggle('hidden', !active);
   if (active) {
     _applySettingsOpacity(toggle ? toggle.classList.contains('active') : false);
   } else {
-    _applySettingsOpacity(false); // clear the fade off the Appearance tab
+    _applySettingsOpacity(false); // clear the fade off the Visibility tab
   }
 }
 
@@ -1563,7 +1588,7 @@ async function initAgentSettings() {
 }
 
 /* ═══════════════════════════════════════════
-   APPEARANCE TAB
+   VISIBILITY TAB
    ═══════════════════════════════════════════ */
 function initAppearance() {
   syncAppearanceCheckboxes();
@@ -4340,8 +4365,9 @@ export function open(tab) {
   }
   // Auto-init admin data if showing an admin tab
   const activeTab = tab || (modalEl.querySelector('[data-settings-tab].active') || {}).dataset?.settingsTab || 'services';
-  document.body.classList.toggle('settings-appearance-open', activeTab === 'appearance');
-  syncAppearanceOpacity(activeTab === 'appearance');
+  syncSettingsTabBlurb(activeTab);
+  document.body.classList.toggle('settings-visibility-open', activeTab === VISIBILITY_TAB);
+  syncAppearanceOpacity(activeTab === VISIBILITY_TAB);
   if (activeTab === 'ai') refreshAiModelEndpoints();
   if (ADMIN_TABS.has(activeTab) && window.adminModule && !window.adminModule._initialized) {
     window.adminModule._initData();
@@ -4350,9 +4376,9 @@ export function open(tab) {
 
 export function close() {
   if (!modalEl) return;
-  // Always clear the appearance-tab body class so the rest of the app
+  // Always clear the visibility-tab body class so the rest of the app
   // doesn't keep its dimmed state if the modal got closed mid-tab.
-  document.body.classList.remove('settings-appearance-open');
+  document.body.classList.remove('settings-visibility-open');
   syncAppearanceOpacity(false); // clear any opacity-slider fade
   const content = modalEl.querySelector('.modal-content, .settings-modal-content');
   if (content && !content.classList.contains('modal-closing')) {

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -3207,9 +3207,9 @@ async function _cmdTourSettings(args, ctx) {
     { sel: '#settings-modal .settings-nav-item[data-settings-tab="search"]',
       text: '<b>Search</b> — plug in your own search provider, or use the bundled <b>SearXNG</b> out of the box.',
       before: () => _clickNav('search') },
-    { sel: '#settings-modal .settings-nav-item[data-settings-tab="appearance"]',
-      text: '<b>Appearance</b> — too many tools you don\'t need? Adjust them here! Toggle sidebar buttons, tool icons, and section visibility.',
-      before: () => _clickNav('appearance') },
+    { sel: '#settings-modal .settings-nav-item[data-settings-tab="visibility"]',
+      text: '<b>Visibility</b> — too many tools you don\'t need? Adjust them here! Toggle sidebar buttons, tool icons, and section visibility.',
+      before: () => _clickNav('visibility') },
     { sel: '#settings-modal .settings-nav-item[data-settings-tab="email"]',
       text: '<b>Email</b> — sync schedule, drafts, snooze defaults — everything email-flow related.',
       before: () => _clickNav('email') },
@@ -5511,7 +5511,7 @@ const COMMANDS = {
   'tour-settings': {
     alias: ['tour-setting', 'settings-tour'],
     category: 'Tours',
-    help: 'Settings tour: models, integrations, appearance',
+    help: 'Settings tour: models, integrations, visibility',
     handler: _cmdTourSettings,
     usage: '/tour-settings'
   },

--- a/static/style.css
+++ b/static/style.css
@@ -20735,16 +20735,16 @@ body.gallery-selecting .gallery-dl-btn,
   padding: 16px 20px;
   min-width: 0;
 }
-.settings-appearance-panel {
+.settings-visibility-panel {
   flex-direction: column;
 }
-.settings-appearance-panel:not(.hidden) {
+.settings-visibility-panel:not(.hidden) {
   display: flex;
 }
-.settings-appearance-panel > .admin-card:nth-of-type(1) { order: 3; }
-.settings-appearance-panel > .admin-card:nth-of-type(2) { order: 1; }
-.settings-appearance-panel > .admin-card:nth-of-type(3) { order: 2; }
-.settings-appearance-panel > .admin-card:nth-of-type(n+4) { order: 4; }
+.settings-visibility-panel > .admin-card:nth-of-type(1) { order: 3; }
+.settings-visibility-panel > .admin-card:nth-of-type(2) { order: 1; }
+.settings-visibility-panel > .admin-card:nth-of-type(3) { order: 2; }
+.settings-visibility-panel > .admin-card:nth-of-type(n+4) { order: 4; }
 
 /* Mobile: stack tabs on top */
 @media (max-width: 600px) {


### PR DESCRIPTION
# Quick message
Sorry for hijacking my PR but please take a look at issue [605](https://github.com/pewdiepie-archdaemon/odysseus/issues/605) as it is quite important. Thank you.

### Description
This PR introduces several quality-of-life UI improvements to the Settings and Admin menus to reduce clutter, clarify functionality, and fix naming inconsistencies. 

### Key Changes
* **Dynamic Settings Tab Blurbs:** Replaced the static subtext under the settings header with dynamic blurbs (`#settings-tab-blurb`) that update based on the active tab to better explain the purpose of each section. 

   This was done because the previous one was static and appeared on all pages.
* **Rename "Appearance" to "Visibility":** Updated the tab name to "Visibility" across the UI, CSS classes, JS initialization, and the `/tour-settings` slash command. This more accurately reflects that the tab toggles UI element visibility rather than visual themes.
* **Copy & Placeholder Tweaks:** 
  * Clarified the "Writing Style" description to specify sample size (max 15, min 3) and purpose.
  * Changed the "Add User" input placeholder from `Username (email)` to `Username` to prevent user confusion, as email formatting is not strictly enforced.

### Screenshots

**Dynamic Tab Blurbs:**
<img width="640" height="333" alt="image" src="https://github.com/user-attachments/assets/cc041012-5a3c-4bb9-80cc-03492c0caf9c" />

**Visibility Tab Rename:**
<img width="448" height="309" alt="image" src="https://github.com/user-attachments/assets/2ba5078c-d5c6-4b92-9e24-fcfc9fe8ed26" />

**Admin & Writing Style Tweaks:**
<img width="374" height="257" alt="image" src="https://github.com/user-attachments/assets/28533f59-62ce-42fd-9ce3-b4bf34871c7a" />

<img width="785" height="365" alt="image" src="https://github.com/user-attachments/assets/3c1e9e6c-1ca2-4289-8640-d78a090588c6" />
