### PR TITLE
fix(stt): make local microphone transcription work without torch

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,6 +4,14 @@
 # Note: chromadb-client + fastembed moved to requirements.txt — RAG, semantic
 # memory, and tool selection are core paths, so they ship by default now.
 
+# Local speech-to-text (microphone -> text) via faster-whisper, for the
+# "local" STT provider. Runs on CPU out of the box (CTranslate2 backend, no
+# torch needed). Install if you want to dictate/transcribe with the mic
+# without sending audio to an external endpoint.
+# Optional extra: install `torch` too if you have a CUDA GPU and want
+# GPU-accelerated transcription — it's auto-detected, CPU is used otherwise.
+faster-whisper
+
 # DuckDuckGo as a search provider option.
 # Install if you want DDG in the search-provider dropdown.
 # Alternatives: SearXNG, Brave, Tavily, Serper, Google PSE.

--- a/services/stt/stt_service.py
+++ b/services/stt/stt_service.py
@@ -57,17 +57,29 @@ class STTService:
         if self._whisper_model is None:
             try:
                 from faster_whisper import WhisperModel
-                settings = self._load_settings()
-                model_size = settings.get("stt_model", "base")
-                # Use CPU by default; will use CUDA if available
-                import torch
-                device = "cuda" if torch.cuda.is_available() else "cpu"
-                compute_type = "float16" if device == "cuda" else "int8"
-                self._whisper_model = WhisperModel(model_size, device=device, compute_type=compute_type)
-                logger.info(f"faster-whisper model '{model_size}' loaded on {device}")
             except ImportError:
                 logger.warning("faster-whisper not installed. Install with: pip install faster-whisper")
                 return None
+            try:
+                settings = self._load_settings()
+                model_size = settings.get("stt_model", "base")
+                # faster-whisper runs on CTranslate2, not torch. torch is only
+                # used (optionally) to detect a CUDA device for acceleration —
+                # if it's missing or unusable we just run on CPU. Keeping this
+                # probe separate (and tolerant of any failure, e.g. a broken
+                # CUDA/torch install that raises OSError on import) means a
+                # torch-less or torch-broken machine still does CPU
+                # transcription instead of failing with a misleading
+                # "faster-whisper not installed" error.
+                try:
+                    import torch
+                    use_cuda = torch.cuda.is_available()
+                except Exception:
+                    use_cuda = False
+                device = "cuda" if use_cuda else "cpu"
+                compute_type = "float16" if device == "cuda" else "int8"
+                self._whisper_model = WhisperModel(model_size, device=device, compute_type=compute_type)
+                logger.info(f"faster-whisper model '{model_size}' loaded on {device}")
             except Exception as e:
                 logger.error(f"Failed to load whisper model: {e}")
                 return None


### PR DESCRIPTION
## What Makes the **local microphone → text** (speech-to-text) feature usable out of the box for self-hosters.
<img width="1760" height="728" alt="1FtH102W9w" src="https://github.com/user-attachments/assets/e4e5db55-3f89-4d3b-864a-d3cd166d834c" />

Two small, related fixes:

## **1. Local STT no longer requires `torch`.**
`STTService._get_whisper()` imported `torch` solely to check `torch.cuda.is_available()` for device selection. But faster-whisper runs on **CTranslate2, not torch** torch is not one of its runtime dependencies. Because that `import torch` shared the same `try` block as the faster-whisper import, a machine *with* faster-whisper installed but *without* torch hit `ImportError` and was told:

```
faster-whisper not installed. Install with: pip install faster-whisper
```

…which is misleading (faster-whisper *was* installed). Now the torch probe is separate and optional: if torch is present it enables CUDA, otherwise transcription runs on CPU. CPU mic transcription works with just `faster-whisper`.

## **2. Declared the dependency.**
Added `faster-whisper` to `requirements-optional.txt` (following the existing "install only if you use the feature" convention), with a note that `torch` is an optional extra for CUDA acceleration. Previously neither package was listed anywhere, so there was no hint about what to `pip install` to enable the mic.

## Why

On a fresh install, picking the **local** STT provider and clicking the mic button failed with the misleading error above and no guidance. This makes the existing microphone feature actually work for CPU-only self-hosters.

## Testing

- Confirmed `faster-whisper`'s runtime deps (CTranslate2, onnxruntime, av, tokenizers, huggingface-hub) do **not** include torch.
- CPU path: with faster-whisper installed and no torch, `_get_whisper()` now selects `device="cpu"` and loads the model instead of returning `None` with a wrong error.
- GPU path unchanged: if torch is present and reports CUDA, `device="cuda"` as before.
