### PR TITLE
Honor disabled TTS and STT service toggles

### DIFF
--- a/services/stt/stt_service.py
+++ b/services/stt/stt_service.py
@@ -40,6 +40,8 @@ class STTService:
     @property
     def available(self) -> bool:
         settings = self._load_settings()
+        if settings.get("stt_enabled") is False:
+            return False
         provider = settings["stt_provider"]
         if provider == "disabled":
             return False
@@ -140,6 +142,8 @@ class STTService:
 
     def transcribe(self, audio_bytes: bytes) -> Optional[str]:
         settings = self._load_settings()
+        if settings.get("stt_enabled") is False:
+            return None
         provider = settings["stt_provider"]
         model = settings["stt_model"]
         language = settings.get("stt_language", "")

--- a/services/tts/tts_service.py
+++ b/services/tts/tts_service.py
@@ -34,6 +34,7 @@ class TTSService:
         from src.settings import load_settings
         saved = load_settings()
         return {
+            "tts_enabled": saved.get("tts_enabled", True),
             "tts_provider": saved.get("tts_provider", "disabled"),
             "tts_model": saved.get("tts_model", "tts-1"),
             "tts_voice": saved.get("tts_voice", "alloy"),
@@ -43,6 +44,8 @@ class TTSService:
     @property
     def available(self) -> bool:
         settings = self._load_settings()
+        if settings.get("tts_enabled") is False:
+            return False
         provider = settings["tts_provider"]
         if provider == "disabled":
             return False
@@ -128,6 +131,8 @@ class TTSService:
 
     def synthesize(self, text: str, use_cache: bool = True) -> Optional[bytes]:
         settings = self._load_settings()
+        if settings.get("tts_enabled") is False:
+            return None
         provider = settings["tts_provider"]
         model = settings["tts_model"]
         voice = settings["tts_voice"]

--- a/tests/test_speech_service_toggles.py
+++ b/tests/test_speech_service_toggles.py
@@ -1,0 +1,57 @@
+from services.stt.stt_service import STTService
+from services.tts.tts_service import TTSService
+
+
+def test_tts_disabled_toggle_blocks_synthesis(monkeypatch, tmp_path):
+    service = TTSService(cache_dir=str(tmp_path))
+    calls = {"endpoint": 0, "kokoro": 0}
+
+    monkeypatch.setattr(service, "_load_settings", lambda: {
+        "tts_enabled": False,
+        "tts_provider": "endpoint:voice-endpoint",
+        "tts_model": "tts-1",
+        "tts_voice": "alloy",
+        "tts_speed": "1",
+    })
+
+    def fake_endpoint(*args, **kwargs):
+        calls["endpoint"] += 1
+        return b"audio"
+
+    def fake_kokoro():
+        calls["kokoro"] += 1
+        return None
+
+    monkeypatch.setattr(service, "_synthesize_api", fake_endpoint)
+    monkeypatch.setattr(service, "_get_kokoro", fake_kokoro)
+
+    assert service.available is False
+    assert service.synthesize("hello") is None
+    assert calls == {"endpoint": 0, "kokoro": 0}
+
+
+def test_stt_disabled_toggle_blocks_transcription(monkeypatch):
+    service = STTService()
+    calls = {"endpoint": 0, "whisper": 0}
+
+    monkeypatch.setattr(service, "_load_settings", lambda: {
+        "stt_enabled": False,
+        "stt_provider": "endpoint:transcribe-endpoint",
+        "stt_model": "whisper-1",
+        "stt_language": "",
+    })
+
+    def fake_endpoint(*args, **kwargs):
+        calls["endpoint"] += 1
+        return "transcript"
+
+    def fake_whisper():
+        calls["whisper"] += 1
+        return None
+
+    monkeypatch.setattr(service, "_transcribe_api", fake_endpoint)
+    monkeypatch.setattr(service, "_get_whisper", fake_whisper)
+
+    assert service.available is False
+    assert service.transcribe(b"audio") is None
+    assert calls == {"endpoint": 0, "whisper": 0}


### PR DESCRIPTION
## Summary

Backend-enforce the existing speech feature toggles.

- `tts_enabled=false` now makes `TTSService.available` false and prevents `synthesize()` from reaching local/API providers.
- `stt_enabled=false` now makes `STTService.available` false and prevents `transcribe()` from reaching local/API providers.
- Adds regression tests that prove disabled speech services do not call endpoint or local provider paths.

## Why

The frontend already hides/blocks speech controls when these settings are disabled, and STT stats already reports the effective provider as disabled. But the service methods themselves still trusted only the provider field. That meant a direct `/api/tts/synthesize` or `/api/stt/transcribe` request could still use a configured local/API provider after the feature toggle was switched off.

This keeps the existing provider configuration intact while making the enabled/disabled toggle authoritative at the backend boundary.

## Tests

- `venv/bin/python -m py_compile services/tts/tts_service.py services/stt/stt_service.py tests/test_speech_service_toggles.py`
- `git diff --check`
- `venv/bin/python -m pytest tests/test_speech_service_toggles.py -q`
- `venv/bin/python -m pytest tests/test_speech_service_toggles.py tests/test_settings_scrub.py -q`