### PR TITLE
chore: use explicit utf-8 for shell job files

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -469,7 +469,8 @@ async def _generate_tmux(cmd: str, request: Request):
         f"EC=${{PIPESTATUS[0]}}\n"
         f"echo ':::EXIT_CODE:::'$EC >> '{log_path}'\n"
         f"rm -f '{script_path}'\n"
-        f"exit $EC\n"
+        f"exit $EC\n",
+        encoding="utf-8",
     )
     script_path.chmod(0o755)
     logger.info("tmux wrapper script created: session=%s path=%s", session_id, script_path)
@@ -504,7 +505,7 @@ async def _generate_tmux(cmd: str, request: Request):
         # Read new lines from log
         try:
             if log_path.exists():
-                lines = log_path.read_text(errors="replace").splitlines()
+                lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
                 new_lines = lines[lines_sent:]
                 for line in new_lines:
                     if line.startswith(":::EXIT_CODE:::"):
@@ -532,7 +533,7 @@ async def _generate_tmux(cmd: str, request: Request):
             # Session ended — do one final read
             await asyncio.sleep(0.5)
             if log_path.exists():
-                lines = log_path.read_text(errors="replace").splitlines()
+                lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
                 for line in lines[lines_sent:]:
                     if line.startswith(":::EXIT_CODE:::"):
                         try:

--- a/src/bg_jobs.py
+++ b/src/bg_jobs.py
@@ -195,7 +195,7 @@ def refresh() -> Dict[str, Dict[str, Any]]:
         exit_path = Path(rec.get("exit_path", ""))
         if exit_path.exists():
             try:
-                code = int(exit_path.read_text().strip() or "1")
+                code = int(exit_path.read_text(encoding="utf-8", errors="replace").strip() or "1")
             except Exception:
                 code = 1
             rec["exit_code"] = code


### PR DESCRIPTION
## Summary
- use explicit UTF-8 when writing the tmux wrapper script
- use explicit UTF-8 with replacement decoding when reading shell job log/exit files
- align shell/background job file handling with the surrounding explicit-encoding style

## Before / after
Before, a few shell/background job text reads and writes used the host platform default encoding. That can vary across environments and is especially visible on Windows.

After, generated wrapper scripts and job status/log reads use explicit UTF-8. Log/exit-code reads keep `errors="replace"` so command output with unexpected bytes still streams instead of failing decoding.

## Verification
- `python -m py_compile src\bg_jobs.py routes\shell_routes.py`
- PowerShell-expanded equivalent of the documented compile check: `python -m py_compile app.py routes/*.py src/*.py`