### PR TITLE
chore: use running event loop in async helpers

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -160,7 +160,7 @@ def setup_embedding_routes():
         _downloading[model_name] = True
         try:
             # Run in thread to not block the event loop
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             cache = _cache_dir()
             await loop.run_in_executor(
                 None,

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -317,7 +317,7 @@ async def _generate_pty(cmd: str, timeout: int, request: Request):
         yield f"data: {json.dumps({'exit_code': -1, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
         return
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     master_fd, slave_fd = pty.openpty()
 
     # Set master to non-blocking
@@ -735,10 +735,11 @@ def setup_shell_routes() -> APIRouter:
                 ]
 
                 finished = 0
-                deadline = (asyncio.get_event_loop().time() + timeout) if timeout else None
+                loop = asyncio.get_running_loop()
+                deadline = (loop.time() + timeout) if timeout else None
                 while finished < 2:
                     if deadline:
-                        remaining = deadline - asyncio.get_event_loop().time()
+                        remaining = deadline - loop.time()
                         if remaining <= 0:
                             raise asyncio.TimeoutError()
                         wait = min(remaining, 2.0)

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -706,7 +706,7 @@ class ResearchHandler:
             try:
                 import asyncio
                 logger.info("Falling back to legacy ResearchOrchestrator...")
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 result = await loop.run_in_executor(
                     None, self._legacy_engine.start_research, query, max_time
                 )

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -38,7 +38,7 @@ async def _cached(key: Tuple, ttl: float, fetch: Callable[[], Awaitable[Any]]) -
             pending = fut
             owner = False
         else:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             fut = loop.create_future()
             _shared_cache_pending[key] = fut
             pending = fut


### PR DESCRIPTION
## Summary
- replace remaining `asyncio.get_event_loop()` calls in async code with `asyncio.get_running_loop()`
- reuse the running loop for shell streaming timeout calculations instead of asking asyncio repeatedly

## Before / after
Before, async handlers/helpers used `get_event_loop()` even though they were already executing inside an event loop. That API can be ambiguous in newer Python versions and may create or return policy-managed loops in non-running contexts.

After, these call sites explicitly use the currently running event loop, which better matches the surrounding async execution model.

## Verification
- `python -m py_compile routes\embedding_routes.py routes\shell_routes.py src\research_handler.py src\task_scheduler.py`
- PowerShell-expanded equivalent of the documented compile check: `python -m py_compile app.py routes/*.py src/*.py`

I also attempted `python -m pytest tests\test_shell_routes.py`, but collection failed in this Windows environment before the tests ran because importing the route initialized SQLite and raised `sqlite3.OperationalError: unable to open database file`.