### PR TITLE
Fix local OpenAI-compatible model setup

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -27,7 +27,14 @@ from .exceptions import (
     WebSearchError,
 )
 from .models import Session, ChatMessage
-from .session_manager import SessionManager
+
+
+def __getattr__(name):
+    if name == "SessionManager":
+        from .session_manager import SessionManager
+
+        return SessionManager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     # LLM

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -50,6 +50,8 @@ class EmbeddingClient:
         # of stalling startup ~30s per probe. Read stays generous for a real
         # endpoint (embedding a short string returns in well under a second).
         self._client = httpx.Client(timeout=httpx.Timeout(connect=3.0, read=10.0, write=5.0, pool=3.0))
+        self._batch_size = max(1, int(os.getenv("EMBEDDING_BATCH_SIZE", "8")))
+        self._max_chars = max(200, int(os.getenv("EMBEDDING_MAX_CHARS", "900")))
 
     def get_sentence_embedding_dimension(self) -> int:
         """Probe the endpoint for embedding dimension if not yet known."""
@@ -68,22 +70,10 @@ class EmbeddingClient:
         if not texts:
             return np.array([], dtype="float32")
 
-        # Batch in chunks of 64 to avoid oversized requests
         all_vecs = []
-        for i in range(0, len(texts), 64):
-            batch = texts[i : i + 64]
-            resp = self._client.post(
-                self.url,
-                json={"input": batch, "model": self.model},
-            )
-            resp.raise_for_status()
-            data = resp.json()
-
-            # OpenAI format: {"data": [{"embedding": [...], "index": 0}, ...]}
-            embeddings = data.get("data", [])
-            embeddings.sort(key=lambda e: e.get("index", 0))
-            for emb in embeddings:
-                all_vecs.append(emb["embedding"])
+        for i in range(0, len(texts), self._batch_size):
+            batch = texts[i : i + self._batch_size]
+            all_vecs.extend(self._embed_batch(batch))
 
         vecs = np.array(all_vecs, dtype="float32")
 
@@ -96,6 +86,41 @@ class EmbeddingClient:
             self._dim = vecs.shape[1]
 
         return vecs
+
+    def _embed_batch(self, batch: List[str]) -> List[List[float]]:
+        try:
+            return self._post_embeddings(batch)
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code if e.response is not None else None
+            if status != 400:
+                raise
+            if len(batch) > 1:
+                vecs = []
+                for text in batch:
+                    vecs.extend(self._embed_batch([text]))
+                return vecs
+            text = batch[0]
+            trimmed = text[: self._max_chars]
+            if trimmed != text:
+                logger.warning(
+                    "Embedding input exceeded endpoint context; retrying with %d chars",
+                    len(trimmed),
+                )
+                return self._post_embeddings([trimmed])
+            raise
+
+    def _post_embeddings(self, batch: List[str]) -> List[List[float]]:
+        resp = self._client.post(
+            self.url,
+            json={"input": batch, "model": self.model},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # OpenAI format: {"data": [{"embedding": [...], "index": 0}, ...]}
+        embeddings = data.get("data", [])
+        embeddings.sort(key=lambda e: e.get("index", 0))
+        return [emb["embedding"] for emb in embeddings]
 
 
 class FastEmbedClient:

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -195,6 +195,16 @@ def _normalize_ollama_url(url: str) -> str:
     return base.rstrip("/") + "/chat"
 
 
+def _normalize_openai_chat_url(url: str) -> str:
+    """Ensure an OpenAI-compatible base URL points at /chat/completions."""
+    base = (url or "").strip().rstrip("/")
+    if base.endswith("/chat/completions") or base.endswith("/completions"):
+        return base
+    if base.endswith("/models"):
+        base = base[: -len("/models")].rstrip("/")
+    return base + "/chat/completions"
+
+
 def _build_ollama_payload(
     model: str,
     messages: List[Dict],
@@ -494,7 +504,13 @@ def list_model_ids(base_chat_url: str, timeout: int = LLMConfig.DEFAULT_TIMEOUT,
         if provider == "ollama":
             models_url = _ollama_api_root(base_chat_url) + "/tags"
         else:
-            models_url = base_chat_url.replace("/chat/completions", "/models")
+            base = base_chat_url.rstrip("/")
+            if base.endswith("/chat/completions"):
+                models_url = base[: -len("/chat/completions")] + "/models"
+            elif base.endswith("/models"):
+                models_url = base
+            else:
+                models_url = base + "/models"
         r = httpx.get(models_url, headers=h, timeout=timeout)
         r.raise_for_status()
         data = r.json()
@@ -577,7 +593,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         target_url = _normalize_ollama_url(url)
         payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
     else:
-        target_url = url
+        target_url = _normalize_openai_chat_url(url)
         payload = {
             "model": model,
             "messages": messages_copy,
@@ -692,7 +708,7 @@ async def llm_call_async(
             h.update(headers)
         payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
     else:
-        target_url = url
+        target_url = _normalize_openai_chat_url(url)
         h = _provider_headers(provider, headers)
         payload = {
             "model": model,
@@ -790,7 +806,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             h.update(headers)
         payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
     else:
-        target_url = url
+        target_url = _normalize_openai_chat_url(url)
         payload = {
             "model": model,
             "messages": messages_copy,

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -1710,7 +1710,10 @@ class TaskScheduler:
                 *([DbSession.owner == owner] if owner else []),
             ).order_by(DbSession.created_at.desc()).first()
             if recent:
-                return recent.endpoint_url, recent.model
+                endpoint_url = recent.endpoint_url if isinstance(recent.endpoint_url, str) else None
+                model = recent.model if isinstance(recent.model, str) else None
+                if endpoint_url or model:
+                    return endpoint_url, model
         except Exception:
             pass
         return None, None

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2,7 +2,16 @@
 Uses mock imports to avoid loading the full app stack."""
 
 import sys
+import importlib.util
 from unittest.mock import MagicMock
+
+
+def _has_module(mod_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(mod_name) is not None
+    except (ImportError, ValueError):
+        return False
+
 
 # Mock heavy dependencies before importing
 for mod in [
@@ -12,7 +21,7 @@ for mod in [
     'src.agent_tools',
     'core.models', 'core.database',
 ]:
-    if mod not in sys.modules:
+    if mod not in sys.modules and not _has_module(mod):
         sys.modules[mod] = MagicMock()
 
 from src.agent_loop import _detect_admin_intent, _compute_final_metrics

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -2,7 +2,16 @@
 Uses mock imports to avoid loading the full app stack."""
 
 import sys
+import importlib.util
 from unittest.mock import MagicMock
+
+
+def _has_module(mod_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(mod_name) is not None
+    except (ImportError, ValueError):
+        return False
+
 
 # Mock heavy dependencies before importing
 for mod in [
@@ -11,7 +20,7 @@ for mod in [
     'src.database',
     'core.models', 'core.database',
 ]:
-    if mod not in sys.modules:
+    if mod not in sys.modules and not _has_module(mod):
         sys.modules[mod] = MagicMock()
 
 from src.context_compactor import (

--- a/tests/test_skills_manager_owner_isolation.py
+++ b/tests/test_skills_manager_owner_isolation.py
@@ -25,6 +25,8 @@ import os
 import sys
 import textwrap
 import types
+import json
+import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -33,12 +35,19 @@ import pytest
 
 # ── module-load stubbing (matches other tests in this repo) ──────────
 # Stub heavy deps so importing the skills manager doesn't pull DB / FastAPI.
+def _has_module(mod_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(mod_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
 for _mod in [
     "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext",
     "sqlalchemy.ext.declarative", "src.database",
     "core.atomic_io",  # we'll patch atomic_write_text below
 ]:
-    if _mod not in sys.modules:
+    if _mod not in sys.modules and not _has_module(_mod):
         sys.modules[_mod] = MagicMock()
 
 
@@ -50,7 +59,7 @@ def _fake_atomic_write_text(path, content, **kw):
 _fake_core = types.ModuleType("core.atomic_io")
 _fake_core.atomic_write_text = _fake_atomic_write_text
 _fake_core.atomic_write_json = lambda p, d, **kw: Path(p).write_text(
-    "{}", encoding="utf-8"
+    json.dumps(d, indent=kw.get("indent")), encoding="utf-8"
 )
 sys.modules["core.atomic_io"] = _fake_core
 

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -1,5 +1,6 @@
 """Regression tests for task-result delivery into chat sessions (issue #326)."""
 import asyncio
+import sys
 import types as _types
 
 import pytest
@@ -10,6 +11,13 @@ if not isinstance(sqlalchemy, _types.ModuleType):
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+_core_db = sys.modules.get("core.database")
+if _core_db is not None and not hasattr(_core_db, "Base"):
+    sys.modules.pop("core.database", None)
+    _core_pkg = sys.modules.get("core")
+    if _core_pkg is not None and getattr(_core_pkg, "database", None) is _core_db:
+        delattr(_core_pkg, "database")
 
 from core.database import Base, Session as DbSession
 from src.task_scheduler import TaskScheduler


### PR DESCRIPTION
## Summary

This fixes local OpenAI-compatible model setup issues I hit while configuring Odysseus with Ollama on macOS/Apple Silicon.

The main runtime fixes are:

- Normalize OpenAI-compatible base URLs before chat calls, so endpoints configured as `/v1` correctly call `/v1/chat/completions`.
- Fix model listing for OpenAI-compatible endpoints that are stored as `/v1`.
- Make remote embedding requests safer for local embedding backends by using a smaller configurable batch size and retrying oversized inputs individually/truncated when the endpoint rejects them.
- Avoid eager `SessionManager` import from `core.__init__`, which otherwise pulls in database-backed imports just from importing `core`.

## Why

When setting up Odysseus locally with Ollama, the Ollama OpenAI-compatible endpoint worked for `/v1/models`, but chat calls failed because Odysseus posted directly to the configured `/v1` URL instead of `/v1/chat/completions`.

The embedding warmup also failed with local embedding models when startup indexing sent batches/inputs larger than the endpoint context could accept. The retry path keeps startup indexing moving while preserving normal OpenAI-style response handling.

The test changes reduce order-dependent behavior from module stubs and make the suite pass consistently when real dependencies are installed.

## Changed areas

- `src/llm_core.py`
  - Added OpenAI-compatible chat URL normalization.
  - Fixed model-list URL handling for `/v1` base URLs.

- `src/embeddings.py`
  - Added configurable embedding batch/input limits.
  - Added fallback retry behavior for HTTP 400 embedding failures.

- `core/__init__.py`
  - Lazily resolves `SessionManager` instead of importing the database-backed session manager at package import time.

- Tests
  - Avoid stubbing modules that are actually installed.
  - Preserve real JSON in the skills manager atomic-write stub.
  - Ensure the task scheduler session delivery test loads the real `core.database` module when SQLAlchemy is available.

## Validation

- `venv/bin/python -m pytest`
  - `473 passed, 1 warning`

- `venv/bin/python -m py_compile app.py routes/*.py src/*.py`
  - passed

## Notes

No UI changes; screenshots are not applicable.