### PR TITLE
fix: normalize JS static MIME types on Windows

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,22 @@
 # app.py — slim orchestrator
+import mimetypes
 import os
+
+
+def register_static_mime_types() -> None:
+    """Force stable JS module MIME types across platforms.
+
+    Some native Windows setups inherit stale/incorrect registry mappings for
+    ``.js``/``.mjs``, which can make Starlette serve ES modules with a non-JS
+    ``Content-Type`` and cause the UI to load but fail on click. Re-register the
+    standard MIME types at startup so static assets are served consistently.
+    """
+
+    mimetypes.add_type("text/javascript", ".js")
+    mimetypes.add_type("application/javascript", ".mjs")
+
+
+register_static_mime_types()
 
 # Windows: force HuggingFace/fastembed to COPY model files instead of symlinking.
 # On a network-share/UNC data dir Windows can't follow HF's symlinks ([WinError

--- a/tests/test_app_static_mime.py
+++ b/tests/test_app_static_mime.py
@@ -1,0 +1,37 @@
+import ast
+import mimetypes
+from pathlib import Path
+
+
+def _load_register_static_mime_types():
+    app_path = Path(__file__).resolve().parents[1] / "app.py"
+    tree = ast.parse(app_path.read_text(encoding="utf-8"), filename=str(app_path))
+    fn = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "register_static_mime_types")
+    module = ast.Module(body=[fn], type_ignores=[])
+    ns = {"mimetypes": mimetypes}
+    exec(compile(module, str(app_path), "exec"), ns)
+    return ns["register_static_mime_types"]
+
+
+def test_register_static_mime_types_restores_js_module_types():
+    register_static_mime_types = _load_register_static_mime_types()
+    original_js = mimetypes.types_map.get(".js")
+    original_mjs = mimetypes.types_map.get(".mjs")
+    try:
+        mimetypes.types_map[".js"] = "text/plain"
+        mimetypes.types_map.pop(".mjs", None)
+
+        register_static_mime_types()
+
+        assert mimetypes.types_map[".js"] == "text/javascript"
+        assert mimetypes.types_map[".mjs"] == "application/javascript"
+    finally:
+        if original_js is None:
+            mimetypes.types_map.pop(".js", None)
+        else:
+            mimetypes.types_map[".js"] = original_js
+
+        if original_mjs is None:
+            mimetypes.types_map.pop(".mjs", None)
+        else:
+            mimetypes.types_map[".mjs"] = original_mjs


### PR DESCRIPTION
## Issue
Refs #802 — https://github.com/pewdiepie-archdaemon/odysseus/issues/802

## Summary
- register stable JavaScript MIME types at app startup (`.js` → `text/javascript`, `.mjs` → `application/javascript`)
- keep the change local to `app.py`, where static assets are mounted
- add a regression test that extracts and executes the startup helper from `app.py`

## Intentionally not changed
- does **not** touch HuggingFace cache healing, embedding startup, or other Windows compatibility work
- does **not** change Starlette static serving behavior beyond the MIME registration
- does **not** attempt a broader Python 3.14 compatibility sweep

## Duplicate preflight
Checked open PRs before coding and again immediately before opening with these queries:
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open #802`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open 802`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open "Odysseus not working on Windows 11"`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open "clicking any button"`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open "text/javascript"`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open "application/javascript"`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open "tests/test_app_static_mime.py"`
- `repo:pewdiepie-archdaemon/odysseus is:pr is:open "app.py" windows mime`

No open PR matched this narrow MIME-registration scope.

Nearby but distinct work:
- #328 (`Heal cross-OS HuggingFace embedding cache on native Windows`) touches other Windows startup problems, but this PR deliberately stays out of HF cache / embedding logic and only fixes JS module MIME registration for static assets.

## Test Plan
- `python3 -m py_compile /tmp/odysseus-pr-802/app.py /tmp/odysseus-pr-802/tests/test_app_static_mime.py`
- `pytest -q /tmp/odysseus-pr-802/tests/test_app_static_mime.py /tmp/odysseus-pr-802/tests/test_app.py`
