### PR TITLE
Authentik handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,19 @@ SEARXNG_INSTANCE=http://localhost:8080
 # by a trusted reverse proxy or private access gateway.
 # SECURE_COOKIES=true
 
+# Optional Authentik SSO / OIDC provider.
+# AUTHENTIK_ENABLE=false
+# AUTHENTIK_AUTO_CREATE_USERS=true
+# AUTHENTIK_ID=your_authentik_client_id
+# AUTHENTIK_SECRET=your_authentik_client_secret
+# AUTHENTIK_ISSUER=https://auth.example.com/application/o/odysseus/
+# AUTHENTIK_REDIRECT_URI=https://app.example.com/api/auth/oidc/callback
+# AUTHENTIK_SCOPE=openid email profile
+# AUTHENTIK_REQUIRE_EMAIL_VERIFIED=true
+
+# Optional local registration default.
+# AUTH_SIGNUP_ENABLE=false
+
 # Optional: pre-seed the first admin password during setup.
 # Do not commit a real password.
 # ODYSSEUS_ADMIN_PASSWORD=change_me_before_first_boot

--- a/README.md
+++ b/README.md
@@ -390,6 +390,15 @@ Key settings:
 | `AUTH_ENABLED` | `true` | Enable/disable login |
 | `LOCALHOST_BYPASS` | `false` | Development-only auth bypass for loopback requests. Keep false for shared/network deployments. |
 | `SECURE_COOKIES` | `false` | Set true when serving Odysseus through HTTPS at a trusted proxy or private access gateway. |
+| `AUTHENTIK_ENABLE` | `false` | Enable the optional Authentik login provider. Admins can still override this in Settings. |
+| `AUTHENTIK_AUTO_CREATE_USERS` | `true` | Auto-create a local user on first Authentik login. Admins can still override this in Settings. |
+| `AUTHENTIK_ID` | -- | Authentik OIDC client ID. |
+| `AUTHENTIK_SECRET` | -- | Authentik OIDC client secret. |
+| `AUTHENTIK_ISSUER` | -- | Authentik issuer URL used for OIDC discovery. |
+| `AUTHENTIK_REDIRECT_URI` | -- | Optional explicit callback URL to register in Authentik. |
+| `AUTHENTIK_SCOPE` | `openid email profile` | OIDC scopes requested from Authentik. |
+| `AUTHENTIK_REQUIRE_EMAIL_VERIFIED` | `true` | Require the email claim to be verified before creating or logging in a user. |
+| `AUTH_SIGNUP_ENABLE` | `false` | Default local registration state when no saved auth config exists.
 | `DATABASE_URL` | `sqlite:///./data/app.db` | Database connection string |
 | `CHROMADB_HOST` | `localhost` | ChromaDB host for vector memory. Docker overrides this to `chromadb`. |
 | `CHROMADB_PORT` | `8100` | ChromaDB port for manual host runs. Docker overrides this to `8000`. |
@@ -398,6 +407,8 @@ Key settings:
 ### Built-in MCP servers (optional setup)
 
 Odysseus auto-registers a few built-in MCP servers at startup. The npx-based ones (currently the browser server, `@playwright/mcp`) only start when their npm package is already in the local npx cache. If a package isn't cached, that server is skipped with a startup log message explaining what to do, so a fresh install does not block on a multi-minute npm download or hang if Playwright system deps are missing.
+
+If you enable Authentik, the login page shows a dedicated SSO button and the first successful login auto-creates a local account by default. Both behaviors can be overridden from the admin Users settings.
 
 To enable the browser MCP (page navigation, screenshots, vision), run once:
 

--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ import logging
 import secrets
 from datetime import datetime
 from typing import Dict
+from urllib.parse import quote
 
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, HTTPException
@@ -163,6 +164,8 @@ if AUTH_ENABLED:
         "/api/auth/setup",
         "/api/auth/signup",
         "/api/auth/login",
+        "/api/auth/oidc/login",
+        "/api/auth/oidc/callback",
         "/api/auth/logout",
         "/api/auth/status",
         "/api/auth/features",
@@ -350,7 +353,7 @@ if AUTH_ENABLED:
             if not auth_manager.validate_token(token):
                 if path.startswith("/api/"):
                     return JSONResponse(status_code=401, content={"error": "Not authenticated"})
-                return RedirectResponse(url="/login", status_code=302)
+                return RedirectResponse(url=f"/login?next={quote(path, safe='')}", status_code=302)
 
             # Attach current username to request state for downstream routes
             request.state.current_user = auth_manager.get_username_for_token(token)

--- a/core/auth.py
+++ b/core/auth.py
@@ -59,6 +59,13 @@ TOKEN_TTL = 60 * 60 * 24 * 7  # 7 days
 RESERVED_USERNAMES = frozenset({"internal-tool", "api", "demo", "system"})
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() == "true"
+
+
 def _hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
@@ -174,7 +181,9 @@ class AuthManager:
 
     @property
     def signup_enabled(self) -> bool:
-        return self._config.get("signup_enabled", False)
+        if "signup_enabled" in self._config:
+            return bool(self._config.get("signup_enabled"))
+        return _env_bool("AUTH_SIGNUP_ENABLE", False)
 
     @signup_enabled.setter
     def signup_enabled(self, value: bool):
@@ -197,7 +206,7 @@ class AuthManager:
                 return False
             return self.create_user(username, password, is_admin=True)
 
-    def create_user(self, username: str, password: str, is_admin: bool = False) -> bool:
+    def create_user(self, username: str, password: Optional[str], is_admin: bool = False, passwordless: bool = False) -> bool:
         """Create a new user account."""
         username = username.strip().lower()
         if not username:
@@ -210,11 +219,16 @@ class AuthManager:
                 return False
             if "users" not in self._config:
                 self._config["users"] = {}
+            if passwordless or password is None:
+                password_hash = None
+            else:
+                password_hash = _hash_password(password)
             self._config["users"][username] = {
-                "password_hash": _hash_password(password),
+                "password_hash": password_hash,
                 "created": time.time(),
                 "is_admin": is_admin,
                 "privileges": dict(ADMIN_PRIVILEGES if is_admin else DEFAULT_PRIVILEGES),
+                "passwordless": bool(passwordless or password is None),
             }
             self._save()
         logger.info(f"Created user '{username}' (admin={is_admin})")
@@ -340,10 +354,14 @@ class AuthManager:
         username = username.strip().lower()
         if username not in self.users:
             return False
-        if not _verify_password(current_password, self.users[username]["password_hash"]):
-            return False
+        current_hash = self.users[username].get("password_hash")
+        passwordless = bool(self.users[username].get("passwordless"))
+        if not (passwordless and not (current_password or "").strip()):
+            if not current_hash or not _verify_password(current_password, current_hash):
+                return False
         with self._config_lock:
             self._config["users"][username]["password_hash"] = _hash_password(new_password)
+            self._config["users"][username]["passwordless"] = False
             self._save()
         return True
 
@@ -440,7 +458,24 @@ class AuthManager:
         username = username.strip().lower()
         if username not in self.users:
             return False
-        return _verify_password(password, self.users[username]["password_hash"])
+        hashed = self.users[username].get("password_hash")
+        if not hashed:
+            return False
+        return _verify_password(password, hashed)
+
+    def create_session_for_user(self, username: str) -> Optional[str]:
+        """Create a session token for an already-authenticated user."""
+        username = username.strip().lower()
+        if username not in self.users:
+            return None
+        token = secrets.token_hex(32)
+        with self._sessions_lock:
+            self._sessions[token] = {
+                "username": username,
+                "expiry": time.time() + TOKEN_TTL,
+            }
+        self._save_sessions()
+        return token
 
     def create_session(self, username: str, password: str) -> Optional[str]:
         """Verify credentials and return a session token, or None."""
@@ -538,4 +573,5 @@ class AuthManager:
         }
         if authenticated:
             result["privileges"] = self.get_privileges(username)
+            result["passwordless"] = bool(self.users.get(username, {}).get("passwordless"))
         return result

--- a/core/oidc.py
+++ b/core/oidc.py
@@ -167,7 +167,8 @@ async def validate_id_token(id_token: str, nonce: str) -> Dict[str, Any]:
     key_set = JsonWebKey.import_key_set(jwks_resp.json())
     claims = jwt.decode(id_token, key_set)
     claims.validate()
-    if claims.get("iss") != AUTHENTIK_ISSUER:
+    token_iss = claims.get("iss", "").rstrip("/")
+    if token_iss != AUTHENTIK_ISSUER:
         raise ValueError("Invalid token issuer")
     aud = claims.get("aud")
     if isinstance(aud, list):

--- a/core/oidc.py
+++ b/core/oidc.py
@@ -1,0 +1,188 @@
+"""Minimal OpenID Connect helpers for optional Authentik login."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+import httpx
+from authlib.jose import JsonWebKey, jwt
+
+log = logging.getLogger(__name__)
+
+AUTHENTIK_ISSUER = os.getenv("AUTHENTIK_ISSUER", "").strip().rstrip("/")
+AUTHENTIK_CLIENT_ID = os.getenv("AUTHENTIK_ID", "").strip()
+AUTHENTIK_CLIENT_SECRET = os.getenv("AUTHENTIK_SECRET", "").strip()
+AUTHENTIK_SCOPE = os.getenv("AUTHENTIK_SCOPE", "openid email profile").strip() or "openid email profile"
+AUTHENTIK_REQUIRE_EMAIL_VERIFIED = os.getenv("AUTHENTIK_REQUIRE_EMAIL_VERIFIED", "true").lower() != "false"
+AUTHENTIK_REDIRECT_URI = os.getenv("AUTHENTIK_REDIRECT_URI", "").strip()
+
+
+def authentik_env_configured() -> bool:
+    return bool(AUTHENTIK_ISSUER and AUTHENTIK_CLIENT_ID and AUTHENTIK_CLIENT_SECRET)
+
+
+def get_authentik_config(settings: Optional[dict] = None) -> Dict[str, Any]:
+    cfg = settings or {}
+    enabled_default = os.getenv("AUTHENTIK_ENABLE", "false").lower() == "true"
+    auto_create_default = os.getenv("AUTHENTIK_AUTO_CREATE_USERS", "true").lower() != "false"
+    return {
+        "enabled": bool(cfg.get("authentik_enabled", enabled_default)),
+        "auto_create_users": bool(cfg.get("authentik_auto_create_users", auto_create_default)),
+        "configured": authentik_env_configured(),
+        "issuer": AUTHENTIK_ISSUER,
+        "client_id": AUTHENTIK_CLIENT_ID,
+        "scope": AUTHENTIK_SCOPE,
+    }
+
+
+def sanitize_username(value: str) -> str:
+    clean = re.sub(r"[^a-z0-9._-]+", "-", (value or "").strip().lower())
+    clean = re.sub(r"[-_.]{2,}", "-", clean).strip("-._")
+    return clean or f"authentik-{secrets.token_hex(4)}"
+
+
+def derive_username(claims: Dict[str, Any]) -> str:
+    preferred = (claims.get("preferred_username") or "").strip()
+    email = (claims.get("email") or "").strip()
+    sub = (claims.get("sub") or "").strip()
+    if preferred:
+        return sanitize_username(preferred)
+    if email:
+        return sanitize_username(email.split("@", 1)[0])
+    if sub:
+        return sanitize_username(f"authentik-{sub[:12]}")
+    return sanitize_username("")
+
+
+def get_login_redirect_path(request) -> str:
+    path = (request.query_params.get("next") or "/").strip()
+    if not path.startswith("/") or path.startswith("//"):
+        return "/"
+    return path
+
+
+def build_redirect_uri(request) -> str:
+    if AUTHENTIK_REDIRECT_URI:
+        return AUTHENTIK_REDIRECT_URI
+    try:
+        return str(request.url_for("authentik_callback"))
+    except Exception:
+        return f"{str(request.base_url).rstrip('/')}/api/auth/oidc/callback"
+
+
+@lru_cache(maxsize=1)
+def _issuer_metadata_cache_key() -> str:
+    return AUTHENTIK_ISSUER
+
+
+async def discover_provider() -> Dict[str, Any]:
+    if not AUTHENTIK_ISSUER:
+        raise RuntimeError("AUTHENTIK_ISSUER is not configured")
+    url = f"{AUTHENTIK_ISSUER}/.well-known/openid-configuration"
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+
+def _state_payload(state: str, nonce: str, next_path: str) -> str:
+    raw = json.dumps({"state": state, "nonce": nonce, "next": next_path}, separators=(",", ":"))
+    return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def decode_state_payload(payload: str) -> Dict[str, str]:
+    padded = payload + "=" * (-len(payload) % 4)
+    raw = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+    data = json.loads(raw)
+    return {
+        "state": str(data.get("state") or ""),
+        "nonce": str(data.get("nonce") or ""),
+        "next": str(data.get("next") or "/"),
+    }
+
+
+def create_state_payload(next_path: str) -> Dict[str, str]:
+    state = secrets.token_urlsafe(32)
+    nonce = secrets.token_urlsafe(32)
+    return {
+        "state": state,
+        "nonce": nonce,
+        "payload": _state_payload(state, nonce, next_path),
+    }
+
+
+async def build_authorization_url(request, next_path: str) -> Dict[str, Any]:
+    discovery = await discover_provider()
+    state_data = create_state_payload(next_path)
+    params = {
+        "response_type": "code",
+        "client_id": AUTHENTIK_CLIENT_ID,
+        "redirect_uri": build_redirect_uri(request),
+        "scope": AUTHENTIK_SCOPE,
+        "state": state_data["state"],
+        "nonce": state_data["nonce"],
+    }
+    auth_url = httpx.URL(discovery["authorization_endpoint"]).copy_merge_params(params)
+    return {"authorization_url": str(auth_url), **state_data}
+
+
+async def exchange_code(code: str, request) -> Dict[str, Any]:
+    discovery = await discover_provider()
+    redirect_uri = build_redirect_uri(request)
+    payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": AUTHENTIK_CLIENT_ID,
+        "client_secret": AUTHENTIK_CLIENT_SECRET,
+    }
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+        resp = await client.post(discovery["token_endpoint"], data=payload, headers={"Accept": "application/json"})
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def fetch_userinfo(access_token: str) -> Dict[str, Any]:
+    discovery = await discover_provider()
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        resp = await client.get(discovery["userinfo_endpoint"], headers={"Authorization": f"Bearer {access_token}"})
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def validate_id_token(id_token: str, nonce: str) -> Dict[str, Any]:
+    discovery = await discover_provider()
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        jwks_resp = await client.get(discovery["jwks_uri"])
+        jwks_resp.raise_for_status()
+    key_set = JsonWebKey.import_key_set(jwks_resp.json())
+    claims = jwt.decode(id_token, key_set)
+    claims.validate()
+    if claims.get("iss") != AUTHENTIK_ISSUER:
+        raise ValueError("Invalid token issuer")
+    aud = claims.get("aud")
+    if isinstance(aud, list):
+        ok_aud = AUTHENTIK_CLIENT_ID in aud
+    else:
+        ok_aud = aud == AUTHENTIK_CLIENT_ID
+    if not ok_aud:
+        raise ValueError("Invalid token audience")
+    if claims.get("nonce") != nonce:
+        raise ValueError("Invalid token nonce")
+    return dict(claims)
+
+
+def merge_claims(token_claims: Dict[str, Any], userinfo: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    merged = dict(token_claims)
+    if userinfo:
+        merged.update({k: v for k, v in userinfo.items() if v not in (None, "")})
+    return merged

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn
 python-multipart
 python-dotenv
 httpx
+authlib
 pydantic>=2.0
 pydantic-settings>=2.0
 SQLAlchemy

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,6 +1,7 @@
 """Authentication routes — login, logout, signup, status, user management."""
 
 from fastapi import APIRouter, Request, Response, HTTPException
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from typing import Optional
 import asyncio
@@ -8,6 +9,20 @@ import logging
 import os
 
 from core.auth import AuthManager
+from core.oidc import (
+    AUTHENTIK_REQUIRE_EMAIL_VERIFIED,
+    AUTHENTIK_REDIRECT_URI,
+    build_authorization_url,
+    decode_state_payload,
+    derive_username,
+    exchange_code,
+    fetch_userinfo,
+    get_authentik_config,
+    get_login_redirect_path,
+    merge_claims,
+    sanitize_username,
+    validate_id_token,
+)
 from src.rate_limiter import RateLimiter
 from src.settings_scrub import scrub_settings
 from src.settings import (
@@ -71,6 +86,8 @@ class SetOpenRegistrationRequest(BaseModel):
     enabled: bool
 
 SESSION_COOKIE = "odysseus_session"
+OIDC_STATE_COOKIE = "odysseus_oidc_state"
+OIDC_NEXT_COOKIE = "odysseus_oidc_next"
 
 
 def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
@@ -148,6 +165,88 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         response.set_cookie(**cookie_kwargs)
         return {"ok": True, "username": username}
 
+    @router.get("/oidc/login", name="authentik_login")
+    async def authentik_login(request: Request):
+        config = get_authentik_config(_load_settings())
+        if not config["enabled"]:
+            return RedirectResponse(url="/login?oidc_error=authentik_disabled", status_code=302)
+        if not config["configured"]:
+            return RedirectResponse(url="/login?oidc_error=authentik_not_configured", status_code=302)
+        try:
+            auth_data = await build_authorization_url(request, get_login_redirect_path(request))
+        except Exception as exc:
+            logger.warning("Authentik login start failed: %s", exc)
+            return RedirectResponse(url="/login?oidc_error=authentik_login_unavailable", status_code=302)
+        response = RedirectResponse(url=auth_data["authorization_url"], status_code=302)
+        cookie_kwargs = dict(httponly=True, samesite="lax", secure=os.getenv("SECURE_COOKIES", "false").lower() == "true", path="/")
+        response.set_cookie(OIDC_STATE_COOKIE, auth_data["payload"], max_age=600, **cookie_kwargs)
+        response.set_cookie(OIDC_NEXT_COOKIE, get_login_redirect_path(request), max_age=600, **cookie_kwargs)
+        return response
+
+    @router.get("/oidc/callback", name="authentik_callback")
+    async def authentik_callback(request: Request, response: Response):
+        config = get_authentik_config(_load_settings())
+        if not config["enabled"] or not config["configured"]:
+            return RedirectResponse(url="/login?oidc_error=authentik_not_available", status_code=302)
+        if request.query_params.get("error"):
+            err = request.query_params.get("error_description") or request.query_params.get("error") or "authentik_login_failed"
+            return RedirectResponse(url=f"/login?oidc_error={err}", status_code=302)
+        state_cookie = request.cookies.get(OIDC_STATE_COOKIE) or ""
+        next_cookie = request.cookies.get(OIDC_NEXT_COOKIE) or "/"
+        code = request.query_params.get("code") or ""
+        state = request.query_params.get("state") or ""
+        if not code or not state or not state_cookie:
+            return RedirectResponse(url="/login?oidc_error=authentik_missing_state", status_code=302)
+        try:
+            parsed = decode_state_payload(state_cookie)
+        except Exception:
+            return RedirectResponse(url="/login?oidc_error=authentik_bad_state", status_code=302)
+        if parsed.get("state") != state:
+            return RedirectResponse(url="/login?oidc_error=authentik_state_mismatch", status_code=302)
+        if not next_cookie.startswith("/") or next_cookie.startswith("//"):
+            next_cookie = "/"
+        try:
+            token_data = await exchange_code(code, request)
+            id_token = token_data.get("id_token")
+            access_token = token_data.get("access_token")
+            if not id_token:
+                raise ValueError("missing id_token")
+            claims = await validate_id_token(id_token, parsed.get("nonce") or "")
+            if access_token:
+                try:
+                    userinfo = await fetch_userinfo(access_token)
+                    claims = merge_claims(claims, userinfo)
+                except Exception:
+                    pass
+            if AUTHENTIK_REQUIRE_EMAIL_VERIFIED and claims.get("email") and not claims.get("email_verified", False):
+                return RedirectResponse(url="/login?oidc_error=email_not_verified", status_code=302)
+            username = sanitize_username(derive_username(claims))
+            if username not in auth_manager.users:
+                if not config["auto_create_users"]:
+                    return RedirectResponse(url="/login?oidc_error=auto_create_disabled", status_code=302)
+                ok = await asyncio.to_thread(auth_manager.create_user, username, None, False, True)
+                if not ok:
+                    return RedirectResponse(url="/login?oidc_error=user_creation_failed", status_code=302)
+            token = await asyncio.to_thread(auth_manager.create_session_for_user, username)
+            if not token:
+                return RedirectResponse(url="/login?oidc_error=session_failed", status_code=302)
+            cookie_kwargs = dict(
+                key=SESSION_COOKIE,
+                value=token,
+                httponly=True,
+                samesite="lax",
+                secure=os.getenv("SECURE_COOKIES", "false").lower() == "true",
+                path="/",
+            )
+            response = RedirectResponse(url=next_cookie, status_code=302)
+            response.set_cookie(**cookie_kwargs)
+            response.delete_cookie(OIDC_STATE_COOKIE, path="/")
+            response.delete_cookie(OIDC_NEXT_COOKIE, path="/")
+            return response
+        except Exception as exc:
+            logger.warning("Authentik callback failed: %s", exc)
+            return RedirectResponse(url="/login?oidc_error=authentik_login_failed", status_code=302)
+
     @router.post("/logout")
     async def logout(request: Request, response: Response):
         token = request.cookies.get(SESSION_COOKIE)
@@ -161,6 +260,13 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         token = request.cookies.get(SESSION_COOKIE)
         result = auth_manager.status(token)
         result["signup_enabled"] = auth_manager.signup_enabled
+        result.update({
+            "authentik_enabled": get_authentik_config(_load_settings())["enabled"],
+            "authentik_configured": get_authentik_config(_load_settings())["configured"],
+            "authentik_auto_create_users": get_authentik_config(_load_settings())["auto_create_users"],
+            "authentik_login_available": get_authentik_config(_load_settings())["enabled"] and get_authentik_config(_load_settings())["configured"],
+            "authentik_redirect_uri": AUTHENTIK_REDIRECT_URI or "(derived from request host)",
+        })
         # Include the caller's effective privileges so the frontend can
         # hide / dim UI controls the user isn't allowed to use. Admins get
         # ADMIN_PRIVILEGES (everything on), regular users get their stored

--- a/src/settings.py
+++ b/src/settings.py
@@ -6,6 +6,7 @@ All modules should import from here instead of accessing files directly.
 """
 
 import json
+import os
 import time
 import logging
 from typing import Any
@@ -132,6 +133,8 @@ DEFAULT_SETTINGS = {
     "utility_model_fallbacks": [],
     "teacher_model": "",
     "teacher_enabled": False,
+    "authentik_enabled": os.getenv("AUTHENTIK_ENABLE", "false").lower() == "true",
+    "authentik_auto_create_users": os.getenv("AUTHENTIK_AUTO_CREATE_USERS", "true").lower() != "false",
     # Skills: minimum self-reported confidence for an auto-written (LLM-authored)
     # DRAFT skill to be injected into the agent prompt. Published skills always
     # qualify. Keeps low-confidence auto-skills out of context until they're

--- a/static/index.html
+++ b/static/index.html
@@ -1415,6 +1415,25 @@
               </div>
               <div class="settings-row">
                 <label class="settings-label">Model</label>
+          <div class="admin-card">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M14 4a6 6 0 1 0 6 6"/><path d="M10 10a4 4 0 1 1 4 4"/></svg>Authentik SSO</h2>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Enable optional Authentik login using AUTHENTIK_ISSUER, AUTHENTIK_ID, and AUTHENTIK_SECRET. The login button appears only when it is configured and enabled.</div>
+            <div class="admin-toggle-row">
+              <div>
+                <div class="admin-toggle-label">Enable provider</div>
+                <div class="admin-toggle-sub">Show the Authentik login button on the login page</div>
+              </div>
+              <label class="admin-switch"><input type="checkbox" id="adm-authentikEnabledToggle"><span class="admin-slider"></span></label>
+            </div>
+            <div class="admin-toggle-row">
+              <div>
+                <div class="admin-toggle-label">Auto-create users</div>
+                <div class="admin-toggle-sub">Create a local account the first time someone signs in with Authentik</div>
+              </div>
+              <label class="admin-switch"><input type="checkbox" id="adm-authentikAutoCreateToggle"><span class="admin-slider"></span></label>
+            </div>
+            <div id="adm-authentikStatus" class="admin-toggle-sub" style="margin-top:8px;opacity:0.7;"></div>
+          </div>
                 <select id="set-defaultModelSelect" class="settings-select"></select>
               </div>
               <div id="set-defaultFallbacks" class="settings-fallbacks"></div>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -279,6 +279,54 @@ function initSignupToggle() {
   });
 }
 
+function initAuthentikSettings() {
+  const enabledToggle = el('adm-authentikEnabledToggle');
+  const autoCreateToggle = el('adm-authentikAutoCreateToggle');
+  const statusEl = el('adm-authentikStatus');
+  if (!enabledToggle || !autoCreateToggle || !statusEl) return;
+
+  async function load() {
+    try {
+      const [statusRes, settingsRes] = await Promise.all([
+        fetch('/api/auth/status', { credentials: 'same-origin' }),
+        fetch('/api/auth/settings', { credentials: 'same-origin' }),
+      ]);
+      const status = await statusRes.json();
+      const settings = await settingsRes.json();
+      enabledToggle.checked = !!settings.authentik_enabled;
+      autoCreateToggle.checked = settings.authentik_auto_create_users !== false;
+      const configured = !!status.authentik_configured;
+      const active = !!settings.authentik_enabled;
+      statusEl.textContent = configured
+        ? (active ? 'Configured and enabled' : 'Configured, but disabled')
+        : 'Missing AUTHENTIK_ISSUER / AUTHENTIK_ID / AUTHENTIK_SECRET';
+      statusEl.style.color = configured ? 'color-mix(in srgb, var(--fg) 55%, transparent)' : 'var(--red)';
+    } catch (e) {
+      statusEl.textContent = 'Failed to load Authentik status';
+      statusEl.style.color = 'var(--red)';
+    }
+  }
+
+  async function save(payload) {
+    await fetch('/api/auth/settings', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    await load();
+  }
+
+  enabledToggle.addEventListener('change', async () => {
+    await save({ authentik_enabled: enabledToggle.checked });
+  });
+  autoCreateToggle.addEventListener('change', async () => {
+    await save({ authentik_auto_create_users: autoCreateToggle.checked });
+  });
+
+  load();
+}
+
 function initAddUser() {
   el('adm-addBtn').addEventListener('click', async () => {
     const msg = el('adm-addMsg');
@@ -2178,7 +2226,7 @@ function initDangerZone() {
    ═══════════════════════════════════════════ */
 function initAll() {
   modalEl = el('settings-modal');
-  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
+  const inits = [initSignupToggle, initAuthentikSettings, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
   for (const fn of inits) {
     try { fn(); } catch (e) { console.error('Admin init error in', fn.name || 'anonymous', e); }
   }

--- a/static/login.html
+++ b/static/login.html
@@ -180,6 +180,28 @@
   .toggle { text-align: center; margin-top: calc(1rem + 4px); font-size: 0.85rem; color: color-mix(in srgb, var(--fg) 50%, transparent); }
   .toggle a { color: var(--red); cursor: pointer; text-decoration: none; }
   .toggle a:hover { text-decoration: underline; }
+  .oidc-divider {
+    display: none;
+    align-items: center;
+    gap: 10px;
+    margin: 12px 0 10px;
+    color: color-mix(in srgb, var(--fg) 42%, transparent);
+    font-size: 0.75rem;
+  }
+  .oidc-divider::before, .oidc-divider::after {
+    content: '';
+    height: 1px;
+    flex: 1;
+    background: color-mix(in srgb, var(--border) 82%, transparent);
+  }
+  .oidc-btn {
+    display: none;
+    margin-top: 0;
+    background: color-mix(in srgb, var(--fg) 10%, var(--panel));
+    color: var(--fg);
+    border: 1px solid var(--border);
+  }
+  .oidc-btn:hover { background: color-mix(in srgb, var(--fg) 15%, var(--panel)); }
   .pw-wrapper { position: relative; margin-bottom: 1rem; }
   .pw-wrapper input:not(.remember-check) { padding-right: 2.5rem; margin-bottom: 0; }
   .pw-toggle {
@@ -255,6 +277,7 @@
   <p class="setup-note" id="setupNote" style="display:none"></p>
 
   <div class="error" id="error" role="alert" aria-live="assertive"></div>
+  <div class="oidc-divider" id="oidcDivider">or</div>
 
   <form id="authForm" autocomplete="on">
     <label for="username">Username</label>
@@ -286,6 +309,8 @@
 
     <button type="submit" id="submitBtn">Sign In</button>
   </form>
+
+  <button type="button" id="oidcBtn" class="oidc-btn">Login with Authentik</button>
 
   <div class="toggle" id="toggleArea" style="display:none">
     <span id="toggleText">Don't have an account? </span>
@@ -322,15 +347,24 @@
   const toggleArea = document.getElementById('toggleArea');
   const toggleLink = document.getElementById('toggleLink');
   const toggleText = document.getElementById('toggleText');
+  const oidcBtn = document.getElementById('oidcBtn');
+  const oidcDivider = document.getElementById('oidcDivider');
+  const currentUrl = new URL(window.location.href);
+  const nextPath = (currentUrl.searchParams.get('next') || '/').trim() || '/';
+  const oidcError = currentUrl.searchParams.get('oidc_error') || '';
 
   let mode = 'login'; // 'login' | 'signup' | 'setup'
   let signupAllowed = false;
+  let oidcAvailable = false;
 
   const rememberToggle = document.getElementById('rememberToggle');
 
   function setMode(m) {
     mode = m;
     errEl.style.display = 'none';
+    const showOidc = (m === 'login' || m === 'signup') && oidcAvailable;
+    if (oidcBtn) oidcBtn.style.display = showOidc ? 'block' : 'none';
+    if (oidcDivider) oidcDivider.style.display = showOidc ? 'flex' : 'none';
     if (m === 'setup') {
       setupNote.textContent = 'First-time setup — create your admin account';
       setupNote.style.display = 'block';
@@ -366,6 +400,7 @@
       return;
     }
     signupAllowed = !!data.signup_enabled;
+    oidcAvailable = !!data.authentik_login_available;
     if (!data.configured) {
       setMode('setup');
     } else {
@@ -375,10 +410,33 @@
     setMode('login');
   }
 
+  if (oidcError) {
+    const messages = {
+      authentik_disabled: 'Authentik login is disabled.',
+      authentik_not_configured: 'Authentik is not configured on this server.',
+      authentik_not_available: 'Authentik login is not available.',
+      authentik_login_unavailable: 'Authentik login could not start. Check the issuer URL, client credentials, and TLS trust.',
+      authentik_missing_state: 'Authentik login expired or was interrupted.',
+      authentik_bad_state: 'Authentik login could not be verified.',
+      authentik_state_mismatch: 'Authentik login state did not match.',
+      email_not_verified: 'Your Authentik email address must be verified first.',
+      auto_create_disabled: 'Your account does not exist yet and auto-create is disabled.',
+      authentik_login_failed: 'Authentik login failed. Try again.',
+    };
+    errEl.textContent = messages[oidcError] || 'Authentik login failed.';
+    errEl.style.display = 'block';
+  }
+
   toggleLink.addEventListener('click', (e) => {
     e.preventDefault();
     setMode(mode === 'login' ? 'signup' : 'login');
   });
+
+  if (oidcBtn) {
+    oidcBtn.addEventListener('click', () => {
+      window.location.href = `/api/auth/oidc/login?next=${encodeURIComponent(nextPath)}`;
+    });
+  }
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -468,7 +526,7 @@
         sessionStorage.setItem('ody-prefetch-sessions', JSON.stringify(sess));
         sessionStorage.setItem('ody-prefetch-features', JSON.stringify(feat));
         sessionStorage.setItem('ody-prefetch-settings', JSON.stringify(sett));
-      }).catch(() => {}).finally(() => { window.location.replace('/'); });
+      }).catch(() => {}).finally(() => { window.location.replace(nextPath || '/'); });
     }
     async function doLogin(totpCode) {
       const loginBody = { username, password, remember };
@@ -532,7 +590,7 @@
 })();
 
 // Prevent login button and eye toggles from stealing focus on mobile (keeps keyboard open)
-document.querySelectorAll('#submitBtn, .pw-toggle').forEach(btn => {
+document.querySelectorAll('#submitBtn, .pw-toggle, #oidcBtn').forEach(btn => {
   btn.addEventListener('touchstart', (e) => { e.preventDefault(); }, { passive: false });
   btn.addEventListener('touchend', (e) => {
     e.preventDefault();

--- a/tests/test_authentik_oidc.py
+++ b/tests/test_authentik_oidc.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytest.importorskip("authlib")
+
+from core.auth import AuthManager
+from core.oidc import create_state_payload, decode_state_payload, derive_username, sanitize_username
+
+
+def test_state_payload_roundtrip():
+    payload = create_state_payload("/notes")
+    decoded = decode_state_payload(payload["payload"])
+    assert decoded["state"] == payload["state"]
+    assert decoded["nonce"] == payload["nonce"]
+    assert decoded["next"] == "/notes"
+
+
+def test_username_derivation_prefers_preferred_username_then_email_then_sub():
+    assert sanitize_username(" Jane.Doe+SSO@Example.com ") == "jane.doe-sso-example.com"
+    assert derive_username({"preferred_username": "Jane Doe"}) == "jane-doe"
+    assert derive_username({"email": "jane@example.com"}) == "jane"
+    assert derive_username({"sub": "abc123XYZ"}) == "authentik-abc123xyz"
+
+
+def test_passwordless_authentik_user_can_set_password(tmp_path):
+    auth_path = tmp_path / "auth.json"
+    manager = AuthManager(auth_path=str(auth_path))
+    assert manager.create_user("sso-user", None, is_admin=False, passwordless=True)
+    assert manager.users["sso-user"]["passwordless"] is True
+    assert manager.verify_password("sso-user", "anything") is False
+    assert manager.change_password("sso-user", "", "new-password-123") is True
+    assert manager.users["sso-user"]["passwordless"] is False
+    assert manager.verify_password("sso-user", "new-password-123") is True


### PR DESCRIPTION
## Summary
Adds handling of Authentik authorization. Adds Authentik button on login and register pages. Autocreates user from authentik authorization. New env vars for turning of/on and setting it up. Added a new test "test_authentik_oidc".

## Linked issue
Part of #806 

## Type of Change

- [x] New feature

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (Added note: Is and isn't, depends if the OIDC PR will properly handle Authentik, left to check later)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to test

  1. Setup Authentik provider & app
  2. Set env vars (AUTHENTIK_ENABLE, AUTHENTIK_ID, AUTHENTIK_SECRET, AUTHENTIK_ISSUER, AUTHENTIK_SCOPE and you can try optional others)
  4. Host the app with changes
  5. Go to the app address
  6. Click on Authentik Login button
  7. Login to your Authentik account
  8. You should get redirected to Odysseus with new account there based on the Authentik account.

## Screenshots

<img width="464" height="504" alt="image" src="https://github.com/user-attachments/assets/08d4c82a-3a91-4b34-8444-98e0291b8683" />


## Other notes

Also I am hosting a docker image on: https://hub.docker.com/repository/docker/qbsoon/odysseus-pewds
which works with Truenas Custom Apps (tested on Truenas Community 25.04.2.6).

Offtop, but I am also working on polish translation (am polish native and a part-time translator with years of experience) and want to include it in truenas apps official catalog.