### PR TITLE
ci: add GitHub Actions workflow for pytest + node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  test:
+    name: Python tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run tests
+        run: pytest tests/ -q --tb=short


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` — the CI gate described in **Critical-3** of #605.

Every PR and push to `main`/`dev` now runs the full test suite automatically.

## What the workflow does

```yaml
on: [pull_request, push to main/dev]

jobs:
  test (ubuntu-latest):
    - Python 3.11   ← minimum required (str | None syntax needs 3.10+)
    - pip install -r requirements.txt
    - Node 20       ← needed for test_compare_js / test_reply_recipients_js
    - pytest tests/ -q --tb=short
```

**Why Python 3.11?** The codebase uses `X | Y` union type syntax (e.g. `str | None`) which requires Python 3.10+. System Python on many distros is still 3.9 and silently breaks collection with `TypeError: unsupported operand type(s) for |`. 3.11 is what the project venv ships.

**Why Node?** Two test files (`test_compare_js.py`, `test_reply_recipients_js.py`) shell out to `node --input-type=module` to run JS unit tests inline. Without Node installed the tests fail with `node binary not on PATH`.

**Why `requirements.txt` and not `uv`?** `uv` migration is Critical-2 of #605 and hasn't landed yet. This workflow uses what's already there so it works immediately.

## Current expected result on this PR

The suite currently has **1 known failing test** (`test_auth_manager_migrates_legacy_admin_role` in `test_security_regressions.py`) due to a pre-existing stub isolation issue tracked in #844. The remaining 495 tests pass. CI will show the failure until that issue is resolved.

## Relationship to #605

This is **Critical-3** (CI gate). Once this merges, PRs will be blocked from merging with a red build. The natural next steps from #605 are:
1. Critical-2 — `pyproject.toml` + `uv` + `ruff` (can update the workflow to use `uv sync` then)
2. Critical-1 — branch protection rules pointing at this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)