### PR TITLE
Cookbook: clearer tooltips on saved-config badge and GPU chip

### DIFF
--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -574,8 +574,36 @@ export function _hwfitRenderHw(el, sys) {
   };
   let gpuChip;
   if (sys.gpu_name) {
-    const label = gpuCount > 1 ? `${gpuCount}x ${esc(sys.gpu_name)}` : esc(sys.gpu_name);
-    gpuChip = chip('gpu', label);
+    // Mixed-GPU boxes (#711): `${gpuCount}x ${gpu_name}` uses gpus[0].name for
+    // every card, so a 4090+3060 reads as "2x RTX 4090". Use gpu_groups (the
+    // backend already groups identical cards) to render each pool separately
+    // and put the per-card index+VRAM into the tooltip so it's actually
+    // useful for picking CUDA_VISIBLE_DEVICES.
+    const groups = Array.isArray(sys.gpu_groups) ? sys.gpu_groups : [];
+    // Shorten vendor prefixes so a mixed-GPU label fits in the chip row
+    // without overflowing. Single-GPU label still shows the full name
+    // (that's what users are used to seeing). Tooltip carries the full
+    // unmodified names regardless, so no information is lost.
+    const _shortGpuName = (n) => String(n || '')
+      .replace(/^NVIDIA\s+GeForce\s+/i, '')
+      .replace(/^NVIDIA\s+/i, '')
+      .replace(/^AMD\s+Radeon\s+/i, '')
+      .replace(/^AMD\s+/i, '')
+      .replace(/^Intel\s+/i, '');
+    let label;
+    if (groups.length > 1) {
+      // Heterogeneous: "1× RTX 4090 + 1× RTX 3060"
+      label = groups.map(g => `${g.count}× ${esc(_shortGpuName(g.name))}`).join(' + ');
+    } else if (gpuCount > 1) {
+      label = `${gpuCount}× ${esc(sys.gpu_name)}`;
+    } else {
+      label = esc(sys.gpu_name);
+    }
+    const gpus = Array.isArray(sys.gpus) ? sys.gpus : [];
+    const tip = gpus.length
+      ? gpus.map(g => `GPU ${g.index}: ${g.name} · ${(+g.vram_gb).toFixed(1)} GB`).join('\n')
+      : 'Click to toggle off (X to hide)';
+    gpuChip = chip('gpu', label, tip);
   } else if (sys.gpu_error) {
     gpuChip = _removedHwChips.has('gpu')
       ? ''

--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -372,10 +372,16 @@ function _rerenderCachedModels() {
       // load, × to delete) plus a "Save current config" row — see _showSavedConfigMenu.
       // Split button: "Save" saves the current config directly; the arrow opens
       // the dropdown of saved configs (load / delete). Arrow shows the count.
+      // The arrow button shows just the saved-config count next to a "▾".
+      // Spell out what the number means in the tooltip so users don't have
+      // to click it to find out the badge isn't a notification dot.
       const _arrowLabel = _modelPresets.length > 0 ? `${_modelPresets.length} ▾` : '▾';
+      const _arrowTitle = _modelPresets.length > 0
+        ? `${_modelPresets.length} saved launch config${_modelPresets.length === 1 ? '' : 's'} for ${_repoShort} — click ▾ to load or delete`
+        : `No saved launch configs for ${_repoShort} yet — click Save to add one`;
       let _slotsHtml = `<div class="cookbook-serve-slots cookbook-saved-split">`
         + `<button type="button" class="cookbook-slot-btn cookbook-saved-save" title="Save current config"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>Save</button>`
-        + `<button type="button" class="cookbook-slot-btn cookbook-saved-arrow" title="Saved launch configs">${_arrowLabel}</button>`
+        + `<button type="button" class="cookbook-slot-btn cookbook-saved-arrow" title="${esc(_arrowTitle)}">${_arrowLabel}</button>`
         + `</div>`;
 
       let panelHtml = `<div class="hwfit-serve-panel">${_slotsHtml}`;
@@ -622,11 +628,15 @@ function _rerenderCachedModels() {
         panel.querySelector(`.cookbook-slot-btn[data-slot="${slotIdx}"]`)?.classList.add('active');
       }
 
-      // Keep the arrow button's count in sync with the stored presets.
+      // Keep the arrow button's count + tooltip in sync with stored presets.
       function _updateSavedToggleLabel() {
         const n = _presetsForModel(_loadPresets(), repo).length;
         const t = panel.querySelector('.cookbook-saved-arrow');
-        if (t) t.textContent = n > 0 ? `${n} ▾` : '▾';
+        if (!t) return;
+        t.textContent = n > 0 ? `${n} ▾` : '▾';
+        t.title = n > 0
+          ? `${n} saved launch config${n === 1 ? '' : 's'} for ${_repoShort} — click ▾ to load or delete`
+          : `No saved launch configs for ${_repoShort} yet — click Save to add one`;
       }
 
       // Save the current panel fields as a new named preset (shared by the menu's

--- a/static/style.css
+++ b/static/style.css
@@ -20098,6 +20098,19 @@ body.gallery-selecting .gallery-dl-btn,
   display: inline-flex;
   align-items: center;
   gap: 3px;
+  /* Cap chip width so a long label (e.g. heterogeneous GPU group
+     "1× RTX 4090 + 1× RTX 3060") wraps to the next row instead of
+     overflowing the modal. Full text stays in the tooltip. */
+  max-width: 100%;
+}
+.hwfit-hw-chip-toggle {
+  /* Allow the chip body to truncate with an ellipsis when the chip
+     itself is capped at its container's width. Without this, the
+     toggle button keeps its intrinsic width and pushes the × button
+     off-screen on narrow viewports. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .hwfit-hw-chip button,
 .hwfit-hw-chip-dismiss,


### PR DESCRIPTION
## What

Two small polish items in the Cookbook Serve panel, plus a layout fix that fell out of the screenshot pass on the second one.

### 1. Saved-config badge tooltip

The little count badge next to the **Save** button (e.g. `3 ▾`) had a generic `"Saved launch configs"` tooltip, so the number reads like an unread-notification dot rather than a count of saved presets. Spell out what it is and what clicking does:

- With saves: `"3 saved launch configs for <model> — click ▾ to load or delete"`
- Empty: `"No saved launch configs for <model> yet — click Save to add one"`

Tooltip stays in sync via `_updateSavedToggleLabel` so save/delete updates both the count and the hint.

**Before / after**

| Empty | Populated |
|---|---|
|<img width="655" height="131" alt="shotty_20260602_125919" src="https://github.com/user-attachments/assets/55d463d1-9054-46d3-87f6-a3a44a95373f" />| <img width="659" height="142" alt="shotty_20260602_125939" src="https://github.com/user-attachments/assets/ab16e17c-8ed1-47f7-ac07-58e0e0117b73" /> |


### 2. GPU chip on mixed-GPU boxes (refs #711)

The hardware-row GPU chip label was `${gpuCount}x ${gpu_name}`, where `gpu_name` is just `gpus[0].name` — so a 4090 + 3060 reads as `"2x RTX 4090"`. The backend already emits `gpu_groups` (identical cards grouped, used by the serve flow to pin `CUDA_VISIBLE_DEVICES`) plus a per-card `gpus[]` array, so use them:

- Label renders each homogeneous pool: `"1× RTX 4090 + 1× RTX 3060"`. Homogeneous setups keep the existing `"NVIDIA GeForce RTX 4090"` form.
- Tooltip lists each GPU with its index + full vendor name + VRAM, useful for picking the right device when launching.
- Vendor prefixes (`NVIDIA GeForce`, `AMD Radeon`, `Intel`) are stripped from the chip label only when there are 2+ groups, so the multi-group label actually fits the chip row. Full names stay in the tooltip.

**Per-GPU tooltip + mixed-GPU label (narrow viewport)**

| Tooltip | Label |
|---|---|
| <img width="612" height="396" alt="shotty_20260602_131403" src="https://github.com/user-attachments/assets/6359dd03-ff7e-4f22-bb46-2f9228e51b29" />| <img width="462" height="361" alt="shotty_20260602_131342" src="https://github.com/user-attachments/assets/f88b59e2-0ede-45b1-a22b-b5aad65c674d" />|


### 3. Chip overflow safety

While taking the screenshots above I noticed the chip row clipped past the modal's right edge on narrow viewports (the chip strip's container wraps, but each chip had `white-space: nowrap` and no width cap). Added `max-width: 100%` on `.hwfit-hw-chip` and `overflow: hidden; text-overflow: ellipsis` on `.hwfit-hw-chip-toggle` so chips that still exceed the row width fall back to ellipsis rather than overflowing. Full text stays accessible via the tooltip.

## Files

- `static/js/cookbookServe.js` — saved-config badge title (initial render + live update path)
- `static/js/cookbook-hwfit.js` — GPU chip label, vendor-prefix shortener for multi-group, per-GPU tooltip
- `static/style.css` — chip width cap + ellipsis on the toggle button

## Testing

- `node --check` on both JS files
- Verified on a single-GPU (RTX 4090) host: chip reads `"NVIDIA GeForce RTX 4090"`, tooltip `"GPU 0: NVIDIA GeForce RTX 4090 · 24.0 GB"`; saved-config badge title updates on save/delete.
- Mixed-GPU case verified by stubbing `gpu_groups` via devtools (screenshot D); label reads `"1× RTX 4090 + 1× RTX 3060"`, tooltip lists both cards with full vendor names + VRAM.
- Narrow viewport (~400 px): chip strip wraps cleanly, no overflow.

## Related cookbook PRs

Part of a small stream of cookbook polish — flagging the others for visibility while reviewers are in this area:

- **#387** — Cookbook: context as a dropdown with a hardware-aware recommendation. Just refactored the math into a pure helper module + added a pytest harness pinning the KV-bytes/tok calibration and recommended-context for known model+GPU combos.
- **#580** — Cookbook: pick the right vLLM `--tool-call-parser` for Qwen2.5. _Merged._
- **#594** — Cookbook: make the GPU process popup actually visible. _Merged._
