### PR TITLE
Fix invalidate_search_cache using a key that never matches stored entries

### DIFF
--- a/services/search/core.py
+++ b/services/search/core.py
@@ -203,7 +203,10 @@ def invalidate_search_cache(query: Optional[str] = None) -> None:
         search_cache_index.clear()
         logger.info("All search cache entries have been cleared.")
     else:
-        cache_key = generate_cache_key(f"{query}|10|None")
+        # Match the key the write path stores: searxng_search_results replaces
+        # the caller's default count with the configured _get_result_count()
+        # (default 5), so a hardcoded "|10|None" never matched a real entry.
+        cache_key = generate_cache_key(f"{query}|{_get_result_count()}|None")
         cache_file = SEARCH_CACHE_DIR / f"{cache_key}.cache"
         if cache_file.exists():
             try:

--- a/src/search/core.py
+++ b/src/search/core.py
@@ -207,7 +207,10 @@ def invalidate_search_cache(query: Optional[str] = None) -> None:
         search_cache_index.clear()
         logger.info("All search cache entries have been cleared.")
     else:
-        cache_key = generate_cache_key(f"{query}|10|None")
+        # Match the key the write path stores: searxng_search_results replaces
+        # the caller's default count with the configured _get_result_count()
+        # (default 5), so a hardcoded "|10|None" never matched a real entry.
+        cache_key = generate_cache_key(f"{query}|{_get_result_count()}|None")
         cache_file = SEARCH_CACHE_DIR / f"{cache_key}.cache"
         if cache_file.exists():
             try:

--- a/tests/test_search_cache_invalidation.py
+++ b/tests/test_search_cache_invalidation.py
@@ -1,0 +1,45 @@
+"""Regression test for invalidate_search_cache key construction.
+
+The write path (`searxng_search_results`) stores a cache entry under
+``generate_cache_key(f"{query}|{count}|{time_filter}")`` where ``count`` is the
+admin-configured result count (``_get_result_count()``, default **5**) — it
+replaces the caller's default of 10 with the configured value before building
+the key.
+
+The original ``invalidate_search_cache`` hardcoded ``f"{query}|10|None"``, so it
+never matched the key the write path actually produced (``|5|None`` by default)
+and silently failed to invalidate anything — a contract violation of its own
+docstring ("invalidate ... just the given query"). The fix derives the count
+from ``_get_result_count()`` so invalidation matches the stored default entry.
+"""
+import pytest
+
+from src.search import core
+from src.search.cache import generate_cache_key
+
+
+def test_invalidate_uses_configured_count_not_hardcoded_10(tmp_path, monkeypatch):
+    query = "python tutorial"
+    result_count = 5  # documented default of _get_result_count()
+
+    # Pin the configured count and redirect the cache dir to keep the test hermetic.
+    monkeypatch.setattr(core, "_get_result_count", lambda: result_count)
+    monkeypatch.setattr(core, "SEARCH_CACHE_DIR", tmp_path)
+
+    # Reproduce exactly what searxng_search_results writes for a default search:
+    # the caller's default count of 10 is replaced by result_count, time_filter=None.
+    write_key = generate_cache_key(f"{query}|{result_count}|None")
+    cache_file = tmp_path / f"{write_key}.cache"
+    cache_file.write_text("{}", encoding="utf-8")
+    core.search_cache_index[write_key] = None
+
+    try:
+        core.invalidate_search_cache(query)
+
+        assert not cache_file.exists(), (
+            "invalidate_search_cache failed to remove the entry the write path "
+            "stored under the configured result count — it used a mismatched key."
+        )
+        assert write_key not in core.search_cache_index
+    finally:
+        core.search_cache_index.pop(write_key, None)


### PR DESCRIPTION
## What

`invalidate_search_cache(query)` builds its lookup key as
`generate_cache_key(f"{query}|10|None")`, but the write path
(`searxng_search_results`) replaces the caller's default count of `10` with the
admin-configured `_get_result_count()` (**default 5**) before building the key:

```python
result_count = _get_result_count()
if count == 10:
    count = result_count
cache_key = generate_cache_key(f"{query}|{count}|{time_filter}")
```

So a default search for `"X"` is stored under `"X|5|None"`, while invalidation
looked for `"X|10|None"`. The keys never match, so `invalidate_search_cache`
silently failed to remove anything in the default configuration — a contract
violation of its own docstring ("invalidate ... just the given query"). It only
matched if an admin had set the result count to exactly `10` and no time filter
was used.

## Fix

Derive the count from `_get_result_count()` so invalidation matches the
default-search entry the write path actually stores. The bug and fix are
identical in both copies of the module, so both are updated:

- `src/search/core.py`
- `services/search/core.py`

## Scope / known limitation

Time-filtered variants (e.g. `"X|5|day"`) still aren't reachable from a
query-only signature: cache keys are opaque SHA-256 hashes and the cache stores
no query string, so clearing every variant of a query would need a broader
cache-index redesign. That's intentionally out of scope here — this fixes the
default (no-filter) path the function was clearly meant to handle.

## Tests

Adds `tests/test_search_cache_invalidation.py`, which reproduces the write-path
key for a default search and asserts `invalidate_search_cache` removes it.
Verified red -> green (fails before the fix, passes after).

Checks run locally (only Python 3.9 was available; the project targets 3.11+, so
11 test modules that use 3.10+ `X | Y` syntax could not be collected — unrelated
to this change):

- `pytest tests/test_search_cache_invalidation.py` -> pass
- `pytest tests/test_search_query.py tests/test_search_ranking.py` -> pass
- Full suite (`--continue-on-collection-errors`): identical pass/fail tally with
  and without this change except for the one new passing test (240 -> 241
  passed), confirming no regressions.