### PR TITLE
Add a LAN companion bridge for a native mobile remote (Odysseus Mobile)

### DIFF
--- a/MOBILE_SETUP.md
+++ b/MOBILE_SETUP.md
@@ -1,0 +1,145 @@
+# Odysseus Mobile — server setup & connecting your phone
+
+This guide gets the **Odysseus Mobile** app ([repo](https://github.com/mahdi-salmanzade/odysseus-mobile))
+talking to *this* Odysseus server over your local network. You run Odysseus on a
+machine at home; your phone (on the same Wi-Fi) pairs to it and drives chat,
+agents, sessions, notes, tasks and memory — local-first, nothing leaves your LAN.
+
+```
+ ┌─────────────┐     same Wi-Fi / LAN      ┌──────────────────────────┐
+ │  Odysseus    │   http://<ip>:7860       │   Odysseus Mobile (app)   │
+ │  server      │ ◀──────────────────────▶ │   pair → chat → stream    │
+ └─────────────┘   Authorization: Bearer    └──────────────────────────┘
+                       ody_<token>
+```
+
+The phone authenticates with an `ody_` API token (chat scope). The token lives
+only in the phone's keychain and in your Odysseus token list — revoke it anytime.
+
+---
+
+## 1. Run the server, bound to your LAN
+
+By default Odysseus binds to `127.0.0.1` (loopback), which the phone **can't**
+reach. Bind to `0.0.0.0` so it's reachable on your Wi-Fi. Keep `AUTH_ENABLED=true`.
+
+**macOS (Apple Silicon, native — recommended):**
+```bash
+cd odysseus
+./venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port 7860
+```
+(First-time setup: `./start-macos.sh` once to create the venv + admin password,
+then re-run with `--host 0.0.0.0` as above. Port `7860` because macOS AirPlay
+often holds `7000`.)
+
+**Native Linux / Windows:**
+```bash
+python -m uvicorn app:app --host 0.0.0.0 --port 7000
+```
+
+**Docker:** set `APP_BIND=0.0.0.0` in `.env`, then `docker compose up -d`.
+
+> First boot prints a temporary **admin password** in the terminal
+> (`docker compose logs odysseus` for Docker). Log in once and change it.
+
+### Find your LAN IP (what the phone connects to)
+```bash
+# macOS
+ipconfig getifaddr en0
+# Linux
+hostname -I | awk '{print $1}'
+```
+e.g. `192.168.1.21`. The phone connects to `http://192.168.1.21:7860`.
+
+### Firewall
+Allow inbound connections to the port. macOS: System Settings → Network →
+Firewall → allow the Python/uvicorn process (or disable for a trusted home LAN).
+
+---
+
+## 2. Add a model
+
+The phone chats with whatever models this server has configured. In the web UI
+(**http://localhost:7860**) → **Settings → Add Models**, add an endpoint:
+
+- **Local (Ollama):** Base URL `http://localhost:11434/v1` — start Ollama with
+  `OLLAMA_HOST=0.0.0.0:11434 ollama serve` and `ollama pull llama3.2:3b`.
+- **Local (llama.cpp / vLLM):** point at your `…/v1` server.
+- **Cloud (OpenAI-compatible, e.g. DeepSeek):** Base URL `https://api.deepseek.com`,
+  paste your API key (stored encrypted server-side — it never reaches the phone).
+
+The phone discovers these via the companion bridge and picks one automatically.
+
+---
+
+## 3. Pair your phone
+
+Three ways — all produce the same `{ v, host, port, token }` pairing code:
+
+**A. In the web UI (easiest):**
+**Settings → Mobile App** (Admin section) → **Generate pairing code** → a QR
+appears. Scan it from the app's **Scan QR** screen.
+
+**B. Direct pairing page:** open `http://localhost:7860/api/companion/pair` in the
+browser where you're logged in as admin → scan the QR.
+
+**C. Terminal:**
+```bash
+python scripts/pair_mobile.py
+```
+Prints host / port / token + an ASCII QR.
+
+In the app you can also tap **Enter manually** and type host, port, and token.
+
+Each pairing mints a fresh chat-scoped token. Manage/revoke them under
+**Settings → Account → API tokens**.
+
+---
+
+## 4. Connect & use
+
+Once paired, the app:
+- discovers your models and opens a chat session,
+- streams replies (with **Web search**, **Research**, and **Agent** toggles),
+- lists past **Sessions** (rename / delete),
+- shows your **Notes**, **Tasks**, and **Memory** (read-only) via the sidebar (≡).
+
+---
+
+## The companion bridge (what makes this work)
+
+A small additive layer in [`companion/`](companion/) — it adds **no** LLM logic.
+See [`companion/README.md`](companion/README.md). Endpoints (all token-auth):
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/companion/ping` | pairing health check |
+| GET | `/api/companion/info` | server identity + capability flags |
+| GET | `/api/companion/models` | the token owner's models |
+| GET | `/api/companion/notes` · `/tasks` · `/memory` | owner-scoped read views |
+| GET | `/api/companion/pair` | admin-only QR pairing page (`?format=json` for the in-app tab) |
+
+Chat/session traffic uses the stock Odysseus API (`/api/session`,
+`/api/chat_stream`, `/api/sessions`, `/api/history/{id}`) with the Bearer token.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| App says "Could not reach Odysseus" | Server must be bound to `0.0.0.0`; phone + server on the **same Wi-Fi**; check the firewall and the IP/port. |
+| "Pairing token was rejected" (401) | Token revoked or stale — generate a new code (Settings → Mobile App). |
+| "No models available" | Add and enable a model endpoint in **Settings → Add Models**, then reopen the app. |
+| Notes / Tasks / Memory empty | They're owner-scoped to you — they're just empty until you create some on the server. |
+| Chat errors with a 4xx | Make sure the model endpoint's API key is set on the server (Settings → Add Models). |
+
+---
+
+## Security
+
+Binding to `0.0.0.0` exposes Odysseus to your LAN — keep `AUTH_ENABLED=true`, and
+treat the pairing token as a real credential. For access **beyond** a trusted home
+network (e.g. over the internet), put Odysseus behind a TLS reverse proxy — see the
+main [README](README.md#putting-it-behind-https). The app talks plain HTTP, which
+is fine for a trusted LAN/VPN but not for the public internet.

--- a/app.py
+++ b/app.py
@@ -662,6 +662,9 @@ app.include_router(setup_vault_routes())
 from routes.contacts_routes import setup_contacts_routes
 app.include_router(setup_contacts_routes())
 
+from companion import setup_companion_routes
+app.include_router(setup_companion_routes())
+
 # ========= ROUTES (kept in app.py) =========
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:

--- a/companion/README.md
+++ b/companion/README.md
@@ -1,0 +1,79 @@
+# Odysseus Mobile companion bridge
+
+A thin, additive LAN layer so the [`odysseus-mobile`](https://github.com/mahdi-salmanzade/odysseus-mobile)
+Expo app can pair to this server and drive it over your local network. It adds
+**no** new LLM logic — the phone authenticates with a standard `ody_` API token
+and uses the existing chat/session endpoints.
+
+## Endpoints (`/api/companion/*`)
+
+Every route accepts a bearer `ody_` token or an admin/owner cookie session
+(except `/pair`, which is browser-only). Reads and writes are scoped to the
+token's real owner (plus null-owner shared rows), not the sandboxed `api`
+pseudo-user — that scoping is the whole reason the bridge exists.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/ping` | Pairing health check — confirms host/port/token |
+| GET | `/info` | Server identity, capability flags, and an endpoint map |
+| GET | `/models` | **Owner-scoped** LLM models (read-only; never returns key material) |
+| GET | `/notes` | List the owner's notes |
+| POST | `/notes` | Create a note (text or checklist) |
+| DELETE | `/notes/{note_id}` | Delete a note |
+| POST | `/notes/{note_id}/pin` | Toggle a note's pinned flag |
+| POST | `/notes/{note_id}/items/{index}/toggle` | Toggle one checklist item |
+| GET | `/tasks` | List the owner's scheduled tasks |
+| GET | `/memory` | List the owner's memories |
+| POST | `/memory` | Add a memory (`text`, optional `category`) |
+| DELETE | `/memory/{memory_id}` | Delete a memory |
+| GET | `/pair` | **Admin cookie only** — browser pairing page: mints a token + shows a QR |
+
+> **Models:** use `/api/companion/models`, **not** the stock `/api/models`.
+> The latter scopes to `get_current_user`, which for a bearer token is the
+> sandboxed `api` pseudo-user that owns no endpoints — so it comes back empty.
+> The companion route scopes to the token's real owner instead.
+
+For chat and sessions the phone uses the stock API directly, with
+`Authorization: Bearer ody_…`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/sessions` | List sessions |
+| POST | `/api/session` | Create a session |
+| GET | `/api/history/{session_id}` | Load a session's message history |
+| POST | `/api/chat_stream` | Streaming chat (SSE) |
+| POST | `/api/chat/stop/{session_id}` | Stop an in-flight stream |
+
+## Pairing
+
+**Option A — browser (recommended, instant):** while logged in as admin, open
+
+```
+http://localhost:<port>/api/companion/pair
+```
+
+…where `<port>` is **7000** for the Docker default, or **7860** for the native
+macOS quick start (`start-macos.sh` — macOS AirPlay Receiver holds 7000). Scan
+the QR with the app. The token is minted in-process and the auth cache is
+invalidated immediately, so it works on the next request — no restart.
+
+**Option B — terminal:**
+
+```bash
+python scripts/pair_mobile.py
+```
+
+Prints host/port/token + an ASCII QR. If the server is already running, a token
+minted this way isn't recognized until the token cache refreshes (restart the
+server) — prefer Option A in that case.
+
+## Exposing on the LAN
+
+The phone must reach this server, so bind to the LAN (not just loopback):
+
+- Docker: set `APP_BIND=0.0.0.0` in `.env`, then `docker compose up -d`.
+- Native: launch with `--host 0.0.0.0`.
+
+Keep `AUTH_ENABLED=true`. The pairing token is a real credential — revoke it
+anytime in **Settings → API tokens**. For anything beyond a trusted home LAN,
+put the server behind HTTPS (see the main README).

--- a/companion/__init__.py
+++ b/companion/__init__.py
@@ -1,0 +1,18 @@
+"""Odysseus mobile companion bridge.
+
+A thin, additive LAN layer that lets the `odysseus-mobile` Expo client pair to a
+running Odysseus server and drive it over the local network. It deliberately adds
+NO new LLM logic: the phone authenticates with a standard `ody_` API token (see
+routes/api_token_routes.py) and talks to the existing chat/session endpoints.
+
+This package only adds:
+  - GET /api/companion/ping  — cheap, token-validated pairing health check
+  - GET /api/companion/info  — server identity + capability flags for the client
+
+Pairing tokens are minted out-of-band by an admin (Settings → API tokens, or
+scripts/pair_mobile.py).
+"""
+
+from companion.routes import setup_companion_routes
+
+__all__ = ["setup_companion_routes"]

--- a/companion/pairing.py
+++ b/companion/pairing.py
@@ -1,0 +1,127 @@
+"""Shared pairing helpers for the mobile companion.
+
+Used by both the in-process admin endpoint (companion/routes.py) and the
+standalone CLI (scripts/pair_mobile.py). Keeping the token minting + LAN
+discovery here means the two entry points stay byte-for-byte consistent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import socket
+import uuid
+
+import bcrypt
+
+PAIRING_VERSION = 1
+COMPANION_SCOPE = "chat"
+
+
+def default_port() -> int:
+    """Best guess at the port the server is reachable on. The actual serving
+    port can be overridden at launch (APP_PORT, or 7860 on macOS), so callers
+    that know the real request port should pass it explicitly."""
+    try:
+        return int(os.environ.get("APP_PORT", "7000"))
+    except ValueError:
+        return 7000
+
+
+def lan_ip_candidates() -> list[str]:
+    """Return likely LAN IPv4 addresses for this host, best candidate first.
+
+    The UDP-connect trick reveals the address the OS would use to reach the
+    default gateway — i.e. the one a phone on the same Wi-Fi should target. We
+    also sweep getaddrinfo for any extra private-range addresses (multi-homed
+    hosts, VPNs) and de-dupe, dropping loopback."""
+    candidates: list[str] = []
+
+    def _add(ip: str | None) -> None:
+        if ip and ip not in candidates and not ip.startswith("127."):
+            candidates.append(ip)
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # No packets are actually sent; this just resolves the egress interface.
+        s.connect(("8.8.8.8", 80))
+        _add(s.getsockname()[0])
+    except OSError:
+        pass
+    finally:
+        s.close()
+
+    try:
+        hostname = socket.gethostname()
+        for info in socket.getaddrinfo(hostname, None, socket.AF_INET):
+            _add(info[4][0])
+    except OSError:
+        pass
+
+    return candidates
+
+
+def find_admin_user() -> str | None:
+    """Resolve an admin username from data/auth.json (schema uses is_admin),
+    falling back to the first user. Mirrors core/database.py."""
+    auth_path = os.path.join("data", "auth.json")
+    try:
+        with open(auth_path, "r", encoding="utf-8") as f:
+            users = (json.load(f) or {}).get("users", {})
+    except (OSError, json.JSONDecodeError):
+        return None
+    for uname, udata in users.items():
+        if udata.get("is_admin") is True:
+            return uname
+    return next(iter(users), None)
+
+
+def mint_token(owner: str, name: str = "odysseus-mobile") -> tuple[str, str]:
+    """Create a chat-scoped API token row and return (token_id, raw_token).
+
+    The raw token is shown ONCE — only its bcrypt hash is stored. Matches the
+    minting logic in routes/api_token_routes.py so cookie- and CLI-minted
+    tokens are indistinguishable to the auth middleware.
+    """
+    from core.database import get_db_session, ApiToken
+
+    raw_token = "ody_" + secrets.token_urlsafe(32)
+    token_hash = bcrypt.hashpw(raw_token.encode(), bcrypt.gensalt()).decode()
+    token_id = str(uuid.uuid4())[:8]
+
+    with get_db_session() as db:
+        db.add(ApiToken(
+            id=token_id,
+            owner=owner,
+            name=name,
+            token_hash=token_hash,
+            token_prefix=raw_token[:8],
+            scopes=COMPANION_SCOPE,
+            is_active=True,
+        ))
+    return token_id, raw_token
+
+
+def pairing_payload(host: str, port: int, token: str) -> dict:
+    """The exact JSON the phone scans / accepts. Keep keys stable — the mobile
+    client parses this verbatim."""
+    return {"v": PAIRING_VERSION, "host": host, "port": port, "token": token}
+
+
+def pairing_qr_png_data_uri(payload: dict) -> str | None:
+    """Render the pairing payload as a QR code, returned as a data: URI for an
+    <img>. Returns None if the optional qrcode dep is unavailable."""
+    try:
+        import base64
+        import io
+
+        import qrcode
+
+        img = qrcode.make(json.dumps(payload, separators=(",", ":")))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        b64 = base64.b64encode(buf.getvalue()).decode()
+        return f"data:image/png;base64,{b64}"
+    except Exception:
+        return None

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -1,0 +1,593 @@
+"""Companion bridge routes — /api/companion/*.
+
+These endpoints are reachable with either a logged-in cookie session or, more
+usefully for the mobile app, a Bearer `ody_` API token. Auth is already enforced
+globally by AuthMiddleware in app.py, so reaching a handler here means the caller
+is authenticated.
+
+Surface (all owner-scoped to the token's real owner, NOT the "api" pseudo-user):
+  - ping / info                      pairing health + capability discovery
+  - GET models                       the owner's LLM endpoints (for new chats)
+  - GET/POST/DELETE memory           the owner's memories (read + write)
+  - GET/POST/DELETE notes, pin,
+    items/{i}/toggle                 the owner's notes/checklists (read + write)
+  - GET tasks                        the owner's scheduled tasks (read-only)
+  - GET pair                         admin-only token minting + QR page
+
+So the pairing token is NOT read-only: it grants chat access plus create/delete
+of the owner's notes and memories. Chat/session traffic itself uses the stock
+/api/sessions, /api/session, /api/history, /api/chat_stream endpoints, which are
+owner-aware for bearer tokens via effective_user (see src/auth_helpers.py).
+Mutating endpoints here require the companion scope (_require_companion_scope)
+and a resolvable owner (_require_owner).
+"""
+
+import html
+import json as _json
+import time
+import uuid
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from core.middleware import require_admin
+from src.auth_helpers import effective_user, get_current_user
+from companion import pairing as _pairing
+
+# Categories the phone's memory composer offers. Mirrors the set the desktop
+# memory UI uses (routes/memory_routes.py); anything else falls back to "fact".
+_MEMORY_CATEGORIES = {"fact", "identity", "preference", "contact", "project", "goal"}
+
+# Scope a token must carry to use the companion bridge. The pairing helper mints
+# tokens with exactly this scope (companion/pairing.py), as does the default
+# token route. Enforced on the write endpoints below so a token minted WITHOUT
+# it (e.g. a future read-only scope) can't create/delete the owner's notes or
+# memories even though it can still authenticate.
+_COMPANION_SCOPE = "chat"
+
+
+def _token_owner(request: Request) -> str | None:
+    """Real owner behind the request (shared effective_user logic).
+
+    Cookie sessions resolve to the username; bearer-token callers come through
+    as the pseudo-user "api" but their real owner is stamped on
+    request.state.api_token_owner by the auth middleware (app.py).
+    """
+    return effective_user(request)
+
+
+def _require_owner(request: Request) -> str:
+    """Resolve the real owner, or 401 if it can't be determined.
+
+    Guards against a bearer token whose owner is null (the ApiToken.owner
+    column is nullable). Without this, the `if owner:` filters below would fall
+    through to "no owner filter" and expose / allow mutation of every
+    null-owner shared row to such a token. A token with no resolvable owner is
+    an auth fault — refuse rather than widen scope.
+    """
+    owner = _token_owner(request)
+    if not owner:
+        raise HTTPException(401, "Token owner could not be resolved")
+    return owner
+
+
+def _require_companion_scope(request: Request) -> None:
+    """Bearer tokens must carry the companion scope to mutate data.
+
+    Cookie sessions (the admin/owner in a browser) are exempt — they're already
+    the authenticated owner. Bearer tokens are checked against the scope list
+    the middleware stamped on request.state.api_token_scopes.
+    """
+    if not getattr(request.state, "api_token", False):
+        return
+    scopes = getattr(request.state, "api_token_scopes", None) or []
+    if _COMPANION_SCOPE not in scopes:
+        raise HTTPException(403, f"Token lacks the '{_COMPANION_SCOPE}' scope")
+
+
+def _iso_utc(dt) -> str | None:
+    """Serialize a datetime as a UTC ISO-8601 string with a trailing 'Z'.
+
+    The DB stores last_run as a naive (assumed-UTC) datetime, so plain
+    `isoformat() + "Z"` is right for those — but if a value ever carries tz
+    info, that concatenation produces a malformed `...+00:00Z`. Normalise via
+    timezone-awareness instead so the phone always gets a valid timestamp.
+    """
+    if dt is None:
+        return None
+    from datetime import timezone
+
+    if dt.tzinfo is None:
+        return dt.isoformat() + "Z"
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def setup_companion_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/companion", tags=["companion"])
+
+    @router.get("/ping")
+    def ping(request: Request):
+        """Pairing health check. The phone hits this right after scanning a
+        pairing code to confirm host + port + token are all valid. A 200 with
+        ok=true means the token was accepted; a 401 (from middleware) means it
+        wasn't."""
+        from core.constants import APP_VERSION
+        return {
+            "ok": True,
+            "name": "odysseus",
+            "version": APP_VERSION,
+            "auth": "token" if getattr(request.state, "api_token", False) else "session",
+        }
+
+    @router.get("/info")
+    def info(request: Request):
+        """Server identity + capability flags so the client can tailor its UI
+        without probing every feature route."""
+        from core.constants import APP_VERSION
+        return {
+            "name": "odysseus",
+            "version": APP_VERSION,
+            "owner": _token_owner(request),
+            "capabilities": {
+                "chat": True,
+                "agent": True,
+                "web_search": True,
+                "research": True,
+                "streaming": True,
+                # The phone can now create/delete these, not just read them.
+                "notes_write": True,
+                "memory_write": True,
+            },
+            # The mobile client uses the existing endpoints below; surfaced here
+            # so the contract is discoverable from one place.
+            "endpoints": {
+                "models": "/api/companion/models",
+                "sessions": "/api/sessions",
+                "create_session": "/api/session",
+                "chat_stream": "/api/chat_stream",
+                "chat_stop": "/api/chat/stop/{session_id}",
+                "history": "/api/history/{session_id}",
+            },
+        }
+
+    @router.get("/models")
+    def models(request: Request):
+        """LLM models the TOKEN OWNER can use, so the phone can create a session
+        and chat.
+
+        The normal /api/models route scopes to get_current_user, which for a
+        bearer token is the sandboxed pseudo-user "api" (app.py) — that user owns
+        no endpoints, so it would come back empty. Here we scope to the token's
+        real owner (api_token_owner) instead, plus null-owner shared endpoints,
+        mirroring the owner_filter rule used everywhere else. Read-only; never
+        returns api_key material."""
+        import json as _json
+
+        from core.database import SessionLocal, ModelEndpoint
+        from src.endpoint_resolver import build_chat_url
+
+        owner = _require_owner(request)
+        out = []
+        db = SessionLocal()
+        try:
+            q = db.query(ModelEndpoint).filter(
+                ModelEndpoint.is_enabled == True,  # noqa: E712
+                (ModelEndpoint.model_type == "llm") | (ModelEndpoint.model_type == None),  # noqa: E711
+            )
+            q = q.filter((ModelEndpoint.owner == owner) | (ModelEndpoint.owner == None))  # noqa: E711
+            for ep in q.all():
+                try:
+                    model_ids = _json.loads(ep.cached_models) if ep.cached_models else []
+                except (ValueError, TypeError):
+                    model_ids = []
+                hidden = set()
+                try:
+                    hidden = set(_json.loads(ep.hidden_models)) if ep.hidden_models else set()
+                except (ValueError, TypeError):
+                    hidden = set()
+                model_ids = [m for m in model_ids if m not in hidden]
+                # Return the provider-correct chat URL (…/v1/chat/completions,
+                # Ollama /api/chat, Anthropic /v1/messages), not the bare base —
+                # the phone passes this straight to /api/session, which POSTs to
+                # it verbatim. Falls back to base_url if resolution ever fails.
+                try:
+                    chat_url = build_chat_url(ep.base_url)
+                except Exception:
+                    chat_url = ep.base_url
+                out.append({
+                    "endpoint_id": ep.id,
+                    "name": ep.name,
+                    "endpoint_url": chat_url,
+                    "models": model_ids,
+                    "supports_tools": ep.supports_tools,
+                })
+        finally:
+            db.close()
+        return {"endpoints": out}
+
+    @router.get("/notes")
+    def notes(request: Request):
+        """The TOKEN OWNER's notes (Google Keep-style notes / checklists).
+
+        Same owner-scoping rationale as /models: bearer-token callers arrive as
+        the pseudo-user "api", so we resolve the real owner and filter the notes
+        table to rows they own (plus legacy null-owner shared rows). Read-only;
+        skips archived notes. Degrades to {"items": []} on any error — never
+        500s the phone."""
+        import json as _json
+
+        items = []
+        try:
+            from core.database import SessionLocal, Note
+
+            owner = _require_owner(request)
+            db = SessionLocal()
+            try:
+                q = db.query(Note).filter(Note.archived == False)  # noqa: E712
+                q = q.filter((Note.owner == owner) | (Note.owner == None))  # noqa: E711
+                rows = q.order_by(
+                    Note.pinned.desc(), Note.sort_order.asc(), Note.updated_at.desc()
+                ).all()
+                for n in rows:
+                    checklist = None
+                    if n.items:
+                        try:
+                            checklist = _json.loads(n.items)
+                        except (ValueError, TypeError):
+                            checklist = None
+                    items.append({
+                        "id": n.id,
+                        "title": n.title,
+                        "content": n.content,
+                        "items": checklist,
+                        "pinned": bool(n.pinned),
+                    })
+            finally:
+                db.close()
+        except Exception:
+            return {"items": []}
+        return {"items": items}
+
+    @router.get("/tasks")
+    def tasks(request: Request):
+        """The TOKEN OWNER's scheduled tasks.
+
+        Owner-scoped like /models (real owner behind the bearer token, plus
+        legacy null-owner rows). Read-only summary — id, name, schedule, enabled
+        flag, last_run. Degrades to {"items": []} on any error."""
+        items = []
+        try:
+            from core.database import SessionLocal, ScheduledTask
+
+            owner = _require_owner(request)
+            db = SessionLocal()
+            try:
+                q = db.query(ScheduledTask)
+                q = q.filter(
+                    (ScheduledTask.owner == owner) | (ScheduledTask.owner == None)  # noqa: E711
+                )
+                rows = q.order_by(ScheduledTask.created_at.desc()).all()
+                for t in rows:
+                    items.append({
+                        "id": t.id,
+                        "name": t.name,
+                        # The DB stores the recurrence under `schedule` (daily/
+                        # weekly/…) with the raw cron under `cron_expression`;
+                        # surface the cron when that's the mode so the phone has
+                        # a meaningful schedule string either way.
+                        "schedule": t.cron_expression if t.schedule == "cron" else t.schedule,
+                        "enabled": (t.status == "active"),
+                        "last_run": _iso_utc(t.last_run),
+                    })
+            finally:
+                db.close()
+        except Exception:
+            return {"items": []}
+        return {"items": items}
+
+    @router.get("/memory")
+    def memory(request: Request):
+        """The TOKEN OWNER's memories.
+
+        Memories live in the `memories` SQL table (core.database.Memory),
+        owner-scoped like everything else. Read-only — id, text, category.
+        Degrades to {"items": []} on any error."""
+        items = []
+        try:
+            from core.database import SessionLocal, Memory
+
+            owner = _require_owner(request)
+            db = SessionLocal()
+            try:
+                q = db.query(Memory)
+                q = q.filter((Memory.owner == owner) | (Memory.owner == None))  # noqa: E711
+                rows = q.order_by(Memory.timestamp.desc()).all()
+                for m in rows:
+                    items.append({
+                        "id": m.id,
+                        "text": m.text,
+                        "category": m.category,
+                    })
+            finally:
+                db.close()
+        except Exception:
+            return {"items": []}
+        return {"items": items}
+
+    # ---- Writes -----------------------------------------------------------
+    # The reads above are the established pattern; these mirror it for the
+    # phone's create/delete affordances. Each write resolves the real token
+    # owner and stamps it on new rows, and every mutate/delete enforces strict
+    # ownership (404 — never confirm existence to a non-owner), exactly like the
+    # desktop note/memory routes. Writes go to the same SQL tables the matching
+    # GET reads, so the mobile list stays self-consistent.
+
+    @router.post("/memory")
+    def add_memory(request: Request, text: str = Form(...), category: str = Form("fact")):
+        """Create a memory owned by the token owner. Writes the `memories` table
+        the GET /memory above reads, so it shows up immediately on the phone."""
+        _require_companion_scope(request)
+        owner = _require_owner(request)
+        text = (text or "").strip()
+        if not text:
+            raise HTTPException(400, "empty memory")
+        cat = category if category in _MEMORY_CATEGORIES else "fact"
+
+        from core.database import SessionLocal, Memory
+
+        db = SessionLocal()
+        try:
+            row = Memory(
+                id=str(uuid.uuid4()),
+                text=text,
+                category=cat,
+                source="mobile",
+                owner=owner,
+                timestamp=int(time.time()),
+            )
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            return {"id": row.id, "text": row.text, "category": row.category}
+        finally:
+            db.close()
+
+    @router.delete("/memory/{memory_id}")
+    def delete_memory(request: Request, memory_id: str):
+        """Delete one of the token owner's memories."""
+        _require_companion_scope(request)
+        owner = _require_owner(request)
+
+        from core.database import SessionLocal, Memory
+
+        db = SessionLocal()
+        try:
+            row = db.query(Memory).filter(Memory.id == memory_id).first()
+            if not row:
+                raise HTTPException(404, "Memory not found")
+            if row.owner != owner:
+                raise HTTPException(404, "Memory not found")
+            db.delete(row)
+            db.commit()
+            return {"ok": True}
+        finally:
+            db.close()
+
+    def _serialize_note(n) -> dict:
+        """Same shape the GET /notes endpoint returns."""
+        checklist = None
+        if n.items:
+            try:
+                checklist = _json.loads(n.items)
+            except (ValueError, TypeError):
+                checklist = None
+        return {
+            "id": n.id,
+            "title": n.title,
+            "content": n.content,
+            "items": checklist,
+            "pinned": bool(n.pinned),
+        }
+
+    @router.post("/notes")
+    def add_note(
+        request: Request,
+        title: str = Form(""),
+        content: str = Form(None),
+        items: str = Form(None),
+        pinned: bool = Form(False),
+    ):
+        """Create a note or checklist. `items`, when given, is a JSON array of
+        {text, done} objects (a checklist); otherwise it's a plain text note."""
+        _require_companion_scope(request)
+        owner = _require_owner(request)
+
+        checklist_json = None
+        note_type = "note"
+        if items:
+            try:
+                parsed = _json.loads(items)
+            except (ValueError, TypeError):
+                raise HTTPException(400, "items must be a JSON array")
+            if not isinstance(parsed, list):
+                raise HTTPException(400, "items must be a JSON array")
+            # Normalise to the stored {text, done} shape.
+            norm = [
+                {"text": str(it.get("text", "")), "done": bool(it.get("done", False))}
+                for it in parsed
+                if isinstance(it, dict)
+            ]
+            checklist_json = _json.dumps(norm)
+            note_type = "checklist"
+
+        if not (title or "").strip() and not (content or "") and not checklist_json:
+            raise HTTPException(400, "empty note")
+
+        from core.database import SessionLocal, Note
+
+        db = SessionLocal()
+        try:
+            note = Note(
+                id=str(uuid.uuid4()),
+                owner=owner,
+                title=title or "",
+                content=content,
+                items=checklist_json,
+                note_type=note_type,
+                pinned=bool(pinned),
+                source="mobile",
+            )
+            db.add(note)
+            db.commit()
+            db.refresh(note)
+            return _serialize_note(note)
+        finally:
+            db.close()
+
+    def _owned_note(db, note_id: str, owner):
+        from core.database import Note
+
+        note = db.query(Note).filter(Note.id == note_id).first()
+        if not note:
+            raise HTTPException(404, "Note not found")
+        if note.owner != owner:
+            raise HTTPException(404, "Note not found")
+        return note
+
+    @router.delete("/notes/{note_id}")
+    def delete_note(request: Request, note_id: str):
+        """Delete one of the token owner's notes."""
+        _require_companion_scope(request)
+        owner = _require_owner(request)
+        from core.database import SessionLocal
+
+        db = SessionLocal()
+        try:
+            note = _owned_note(db, note_id, owner)
+            db.delete(note)
+            db.commit()
+            return {"ok": True}
+        finally:
+            db.close()
+
+    @router.post("/notes/{note_id}/pin")
+    def toggle_note_pin(request: Request, note_id: str):
+        """Flip a note's pinned flag."""
+        _require_companion_scope(request)
+        owner = _require_owner(request)
+        from core.database import SessionLocal
+
+        db = SessionLocal()
+        try:
+            note = _owned_note(db, note_id, owner)
+            note.pinned = not note.pinned
+            db.commit()
+            return {"ok": True, "pinned": note.pinned}
+        finally:
+            db.close()
+
+    @router.post("/notes/{note_id}/items/{index}/toggle")
+    def toggle_note_item(request: Request, note_id: str, index: int):
+        """Toggle the done state of one checklist item by index."""
+        _require_companion_scope(request)
+        owner = _require_owner(request)
+        from core.database import SessionLocal
+        from sqlalchemy.orm.attributes import flag_modified
+
+        db = SessionLocal()
+        try:
+            note = _owned_note(db, note_id, owner)
+            if not note.items:
+                raise HTTPException(400, "Note has no checklist items")
+            try:
+                items = _json.loads(note.items)
+            except (ValueError, TypeError):
+                raise HTTPException(400, "Note has no checklist items")
+            if index < 0 or index >= len(items):
+                raise HTTPException(400, f"Item index {index} out of range")
+            items[index]["done"] = not items[index].get("done", False)
+            note.items = _json.dumps(items)
+            flag_modified(note, "items")
+            db.commit()
+            return {"ok": True, "items": items}
+        finally:
+            db.close()
+
+    @router.get("/pair")
+    def pair(request: Request):
+        """Admin-only pairing page. Open this in the browser where you're logged
+        into Odysseus (e.g. http://localhost:7000/api/companion/pair), then scan
+        the QR with the odysseus-mobile app.
+
+        Minting happens in-process so we can invalidate the auth middleware's
+        token cache immediately — the new token works on the very next request,
+        no server restart needed. Returns a dependency-free HTML page (QR is a
+        server-rendered <img>, no inline JS, so CSP stays happy)."""
+        require_admin(request)
+        owner = get_current_user(request)
+
+        token_id, raw_token = _pairing.mint_token(owner)
+
+        # The new token row is invisible to the middleware's in-memory cache
+        # until we flip its dirty flag. Do that now so pairing is instant.
+        invalidate = getattr(request.app.state, "invalidate_token_cache", None)
+        if invalidate:
+            invalidate()
+
+        hosts = _pairing.lan_ip_candidates()
+        host = hosts[0] if hosts else "127.0.0.1"
+        port = request.url.port or _pairing.default_port()
+        payload = _pairing.pairing_payload(host, port, raw_token)
+        qr = _pairing.pairing_qr_png_data_uri(payload)
+
+        import json as _json
+        payload_json = _json.dumps(payload, separators=(",", ":"))
+        alt_hosts = ", ".join(hosts[1:]) if len(hosts) > 1 else "—"
+
+        # JSON variant for the in-app "Mobile App" settings tab, which renders
+        # the QR itself. Same minting + cache-invalidation as the HTML page.
+        if (request.query_params.get("format") or "").lower() == "json":
+            return {
+                "host": host,
+                "port": port,
+                "token": raw_token,
+                "token_id": token_id,
+                "hosts": hosts,
+                "payload": payload,
+                "qr": qr if (qr and qr.startswith("data:image/png;base64,")) else None,
+            }
+        # Only ever emit a known PNG data-URI into the src; never trust the
+        # helper's output shape implicitly (defense in depth vs. the rest of the
+        # page, which html.escapes every interpolation).
+        qr_block = (
+            f'<img src="{html.escape(qr)}" alt="Pairing QR" width="280" height="280">'
+            if qr and qr.startswith("data:image/png;base64,")
+            else "<p><em>QR rendering unavailable — enter the details manually.</em></p>"
+        )
+        page = f"""<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Pair Odysseus Mobile</title>
+<style>
+  body{{font-family:-apple-system,system-ui,sans-serif;max-width:520px;margin:40px auto;padding:0 20px;color:#e8e8e8;background:#16161a}}
+  .card{{background:#1f1f25;border:1px solid #2c2c35;border-radius:14px;padding:24px;text-align:center}}
+  code{{background:#0e0e12;padding:2px 6px;border-radius:6px;word-break:break-all}}
+  .row{{text-align:left;margin:10px 0;font-size:14px;color:#bdbdc7}}
+  .warn{{color:#e0a85e;font-size:13px;margin-top:18px}}
+</style></head>
+<body><div class="card">
+  <h2>Pair Odysseus Mobile</h2>
+  <p>Scan with the <strong>odysseus-mobile</strong> app, or type the details in.</p>
+  {qr_block}
+  <div class="row"><strong>Host:</strong> <code>{html.escape(host)}</code></div>
+  <div class="row"><strong>Port:</strong> <code>{port}</code></div>
+  <div class="row"><strong>Token:</strong> <code>{html.escape(raw_token)}</code></div>
+  <div class="row"><strong>Other addresses:</strong> {html.escape(alt_hosts)}</div>
+  <div class="row"><strong>Payload:</strong> <code>{html.escape(payload_json)}</code></div>
+  <p class="warn">This token grants chat access to your Odysseus. It's shown once.
+  Revoke it anytime in Settings &rarr; API tokens (id <code>{html.escape(token_id)}</code>).
+  The phone must be on the same network, and the server must bind to your LAN
+  (APP_BIND=0.0.0.0 / --host 0.0.0.0).</p>
+</div></body></html>"""
+        return HTMLResponse(page)
+
+    return router

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -11,12 +11,18 @@ from core.session_manager import SessionManager
 from core.models import ChatMessage
 from src.request_models import SessionResponse
 from core.database import Session as DbSession, SessionLocal, Document, GalleryImage
-from src.auth_helpers import get_current_user
+from src.auth_helpers import get_current_user, effective_user
 
 
 def _verify_session_owner(request: Request, session_id: str):
-    """Verify the current user owns the session. Raises 404 if not."""
-    user = get_current_user(request)
+    """Verify the current user owns the session. Raises 404 if not.
+
+    Uses effective_user so a paired mobile (bearer-token) caller is checked
+    against the token's real owner, not the "api" pseudo-user — otherwise the
+    phone could only ever touch sessions it created itself, siloed from the
+    owner's desktop chats. No-op change for cookie sessions.
+    """
+    user = effective_user(request)
     if not user:
         raise HTTPException(403, "Authentication required")
     db = SessionLocal()
@@ -63,7 +69,9 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
     
     @router.get("/sessions")
     def list_sessions(request: Request):
-        user = get_current_user(request)
+        # effective_user: a paired phone lists the token owner's real sessions
+        # (the same ones the desktop UI shows), not the empty "api" silo.
+        user = effective_user(request)
         # Lazy purge: incognito sessions are ephemeral by design — wipe leftovers
         # from the DB and session_manager so they vanish on the next page refresh.
         # BUT: skip sessions that were created within the last 10 minutes.
@@ -217,7 +225,10 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 model_to_use = found
         
         sid = str(uuid.uuid4())
-        user = get_current_user(request)
+        # effective_user: sessions a paired phone creates are owned by the real
+        # token owner, so they show up in (and can be continued from) the
+        # desktop UI too — not stranded under the "api" pseudo-user.
+        user = effective_user(request)
         session = session_manager.create_session(
             session_id=sid,
             name=name or "",

--- a/scripts/pair_mobile.py
+++ b/scripts/pair_mobile.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Pair the odysseus-mobile app from the terminal.
+
+Mints a chat-scoped API token and prints the host / port / token plus an ASCII
+QR code you can scan with the odysseus-mobile app.
+
+Usage (from the repo root, with the venv active):
+    python scripts/pair_mobile.py
+    python scripts/pair_mobile.py --owner alice --port 7860 --name "my phone"
+
+NOTE: if the Odysseus server is ALREADY running, prefer the in-app pairing page
+at  http://localhost:<port>/api/companion/pair  (open it in the browser where
+you're logged in as admin). That mints the token in-process and the server
+accepts it instantly. A token minted by THIS script while the server is running
+won't be recognized until the server's token cache refreshes — restart the
+server, or just mint a fresh token from the pairing page instead.
+"""
+
+import argparse
+import json
+import sys
+
+# Ensure repo root is importable when run as `python scripts/pair_mobile.py`.
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from companion import pairing  # noqa: E402
+
+
+def _ascii_qr(payload: dict) -> None:
+    try:
+        import qrcode
+    except ImportError:
+        print("(install `qrcode` to render a scannable QR here)")
+        return
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(json.dumps(payload, separators=(",", ":")))
+    qr.make(fit=True)
+    qr.print_ascii(invert=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pair the odysseus-mobile app.")
+    parser.add_argument("--owner", help="Token owner username (default: an admin from auth.json)")
+    parser.add_argument("--port", type=int, default=None, help="Port the phone should connect to")
+    parser.add_argument("--host", help="Override the LAN host/IP the phone should use")
+    parser.add_argument("--name", default="odysseus-mobile", help="Label for the token")
+    args = parser.parse_args()
+
+    owner = args.owner or pairing.find_admin_user()
+    if not owner:
+        print("ERROR: no users found in data/auth.json. Start Odysseus once to create an admin.",
+              file=sys.stderr)
+        return 1
+
+    hosts = pairing.lan_ip_candidates()
+    host = args.host or (hosts[0] if hosts else "127.0.0.1")
+    port = args.port or pairing.default_port()
+
+    token_id, raw_token = pairing.mint_token(owner, name=args.name)
+    payload = pairing.pairing_payload(host, port, raw_token)
+
+    print()
+    print("  Odysseus Mobile — pairing code")
+    print("  ──────────────────────────────")
+    print(f"  owner : {owner}")
+    print(f"  host  : {host}")
+    if len(hosts) > 1:
+        print(f"          (other addresses: {', '.join(hosts[1:])})")
+    print(f"  port  : {port}")
+    print(f"  token : {raw_token}")
+    print(f"  id    : {token_id}  (revoke in Settings → API tokens)")
+    print()
+    print(f"  payload: {json.dumps(payload, separators=(',', ':'))}")
+    print()
+    _ascii_qr(payload)
+    print()
+    print("  Scan the QR in odysseus-mobile, or type host/port/token manually.")
+    print("  The server must bind to your LAN (APP_BIND=0.0.0.0 / --host 0.0.0.0)")
+    print("  and the phone must be on the same Wi-Fi.")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/auth_helpers.py
+++ b/src/auth_helpers.py
@@ -9,6 +9,28 @@ def get_current_user(request: Request) -> Optional[str]:
     return getattr(request.state, 'current_user', None)
 
 
+def effective_user(request: Request) -> Optional[str]:
+    """The real human behind the request, for ownership/attribution.
+
+    Cookie sessions resolve to the logged-in username. Bearer `ody_` callers
+    (the mobile app) come through as the sandboxed pseudo-user "api" so they
+    can't wander into cookie/user routes by default — but their token was
+    minted by, and belongs to, a real owner stamped on
+    request.state.api_token_owner. Routes that should attribute a token's
+    actions to that owner (sessions, chat history) call this instead of
+    get_current_user, so the phone sees and creates the SAME data as the
+    owner's desktop UI rather than a separate "api"-owned silo.
+
+    For cookie sessions this is identical to get_current_user, so swapping a
+    route over is a no-op for browser users.
+    """
+    if getattr(request.state, "api_token", False):
+        owner = getattr(request.state, "api_token_owner", None)
+        if owner:
+            return owner
+    return get_current_user(request)
+
+
 def require_user(request: Request) -> str:
     """FastAPI dependency: reject unauthenticated callers, even if upstream
     middleware was bypassed (LOCALHOST_BYPASS, AUTH_ENABLED=false, SSRF from

--- a/static/index.html
+++ b/static/index.html
@@ -1365,8 +1365,27 @@
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
             <span>System</span>
           </button>
+          <button class="settings-nav-item admin-only" data-settings-tab="mobile">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2"/><path d="M12 18h.01"/></svg>
+            <span>Mobile App</span>
+          </button>
         </div>
         <div class="settings-panels">
+
+        <!-- ═══ MOBILE APP TAB ═══ -->
+
+        <div data-settings-panel="mobile" class="hidden">
+          <div class="admin-card">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="5" y="2" width="14" height="20" rx="2"/><path d="M12 18h.01"/></svg>Pair Odysseus Mobile</h2>
+            <div class="admin-toggle-sub" style="margin-bottom:10px">Control this Odysseus from your phone over the local network with the <strong>Odysseus Mobile</strong> app. Scan the QR below from the app's pairing screen, or type the details in by hand.</div>
+            <div id="companion-pair-out" style="text-align:center"></div>
+            <button type="button" class="admin-btn-add" id="companion-pair-btn">Generate pairing code</button>
+            <div class="admin-toggle-sub" style="margin-top:12px;opacity:0.6;font-size:11px;line-height:1.5">
+              Each code mints a new chat-scoped API token (shown once) — manage or revoke them under <strong>Account → API tokens</strong>.
+              The phone must be on the same Wi-Fi, and the server must be bound to your LAN (<code>APP_BIND=0.0.0.0</code> / <code>--host 0.0.0.0</code>).
+            </div>
+          </div>
+        </div>
 
         <!-- ═══ AI TAB ═══ -->
 
@@ -2250,6 +2269,7 @@
 <script type="module" src="/static/js/theme.js"></script>
 <script type="module" src="/static/js/censor.js"></script>
 <script type="module" src="/static/js/settings.js"></script>
+<script type="module" src="/static/js/companionPair.js"></script>
 <script type="module" src="/static/js/admin.js"></script>
 <script type="module" src="/static/js/assistant.js"></script>
 <script type="module" src="/static/app.js"></script>  <!-- app.js must be LAST -->

--- a/static/js/companionPair.js
+++ b/static/js/companionPair.js
@@ -1,0 +1,64 @@
+// Mobile App settings tab — fetches a pairing code from the companion bridge
+// and renders a scannable QR + the host/port/token for manual entry.
+//
+// The endpoint (/api/companion/pair?format=json) is admin-only and mints a
+// fresh chat-scoped token each call, invalidating the auth cache so it works
+// immediately. We render the server-built QR data-URI; no client QR lib needed.
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+async function generatePairingCode(btn, out) {
+  btn.disabled = true;
+  const original = btn.textContent;
+  btn.textContent = 'Generating…';
+  out.innerHTML = '';
+  try {
+    const res = await fetch('/api/companion/pair?format=json', {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+    });
+    if (res.status === 403) throw new Error('Admin only — log in as an admin to pair a device.');
+    if (!res.ok) throw new Error('Server responded ' + res.status + '.');
+    const d = await res.json();
+
+    const qr = d.qr
+      ? `<img src="${esc(d.qr)}" alt="Pairing QR" width="240" height="240" style="border-radius:10px;background:#fff;padding:8px">`
+      : `<p style="opacity:0.7">QR unavailable — enter the details manually.</p>`;
+    const others = (d.hosts || []).slice(1).join(', ') || '—';
+
+    out.innerHTML = `
+      <div style="display:flex;flex-direction:column;align-items:center;gap:14px;margin-bottom:14px">
+        ${qr}
+        <div style="width:100%;max-width:360px;text-align:left;font-size:13px;line-height:1.9">
+          <div><strong>Host</strong><span style="float:right"><code>${esc(d.host)}</code></span></div>
+          <div><strong>Port</strong><span style="float:right"><code>${esc(d.port)}</code></span></div>
+          <div><strong>Token</strong><span style="float:right"><code style="word-break:break-all">${esc(d.token)}</code></span></div>
+          <div style="opacity:0.6"><strong>Other addresses</strong><span style="float:right">${esc(others)}</span></div>
+        </div>
+        <div style="font-size:11px;opacity:0.6">Scan from the Odysseus Mobile app, or type the host / port / token in.</div>
+      </div>`;
+    btn.textContent = 'Generate a new code';
+  } catch (e) {
+    out.innerHTML = `<p style="color:var(--accent-error,#e0685e);font-size:13px">${esc(e.message || 'Could not generate a pairing code.')}</p>`;
+    btn.textContent = original;
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+function init() {
+  const btn = document.getElementById('companion-pair-btn');
+  const out = document.getElementById('companion-pair-out');
+  if (!btn || !out || btn.dataset.wired) return;
+  btn.dataset.wired = '1';
+  btn.addEventListener('click', () => generatePairingCode(btn, out));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}


### PR DESCRIPTION
## What

A thin, **additive** companion bridge so a native phone app can pair to a running Odysseus over the local network and drive it. No new LLM logic: the phone authenticates with a standard chat-scoped `ody_` API token and reuses the existing chat/session endpoints.

Companion app it pairs with: **https://github.com/mahdi-salmanzade/odysseus-mobile** (Expo SDK 56, MIT).

## Why

Odysseus has a great PWA but no native mobile client. This is the minimal server-side surface needed to pair a phone over the LAN and have it behave like the desktop UI, while keeping bearer tokens sandboxed everywhere else.

## Changes

- **`companion/`** — `setup_companion_routes()` adding:
  - `GET /api/companion/ping` — token-validated pairing health check
  - `GET /api/companion/info` — server identity + capability flags
  - `GET /api/companion/models|notes|tasks|memory` — **owner-scoped** reads (so a token caller sees the real owner's data, not the empty `api` set)
  - `GET /api/companion/pair` — admin-only pairing page with a server-rendered QR (`?format=json` for the in-app Settings tab). Mints in-process and invalidates the token cache so the code works immediately.
- **`app.py`** — one `include_router(setup_companion_routes())` line.
- **`scripts/pair_mobile.py`** — terminal pairing helper (mints a token, detects LAN IP, prints an ASCII QR).
- **`static/`** — a **Settings → Mobile App** tab that renders the pairing QR.
- **`effective_user()`** (`src/auth_helpers.py`) + `routes/session_routes.py` — a paired bearer-token caller is attributed to the token's **real owner** for sessions/history, so the phone sees and continues the same chats as the owner's desktop. No-op for cookie sessions.
- **`MOBILE_SETUP.md`** — server setup + pairing + troubleshooting guide.

## Security

- Reuses the existing `Bearer ody_…` auth; nothing bypasses `AUTH_ENABLED`.
- `/pair` is admin-cookie only; bearer callers (the sandboxed `api` user) get 403.
- The QR `data:` URI and all interpolations on the pair page are escaped.
- Token is shown once; only its bcrypt hash + prefix are stored (mirrors `api_token_routes.py`).
- Bind to `0.0.0.0` only for intentional LAN access; keep it off the public internet without a TLS proxy.

Designed to read as an overlay on top of upstream, not a fork of core logic.