### PR TITLE
Keep reasoning (thinking) tokens out of the saved chat reply

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -708,8 +708,13 @@ def setup_chat_routes(
                             try:
                                 data = json.loads(chunk[6:])
                                 if "delta" in data:
-                                    full_response += data["delta"]
-                                    _stream_set(session, partial=full_response)
+                                    # Reasoning tokens arrive flagged thinking:true.
+                                    # Forward them so the client can show a thinking
+                                    # indicator, but don't fold them into the saved
+                                    # reply (mirrors the rewrite path below).
+                                    if not data.get("thinking"):
+                                        full_response += data["delta"]
+                                        _stream_set(session, partial=full_response)
                                     yield chunk
                                 elif data.get("type") == "usage":
                                     last_metrics = data.get("data", {})
@@ -805,8 +810,12 @@ def setup_chat_routes(
                             try:
                                 data = json.loads(chunk[6:])
                                 if "delta" in data:
-                                    full_response += data["delta"]
-                                    _stream_set(session, partial=full_response)
+                                    # Reasoning tokens arrive flagged thinking:true.
+                                    # Forward them for the live indicator, but keep
+                                    # them out of the saved reply (same as chat mode).
+                                    if not data.get("thinking"):
+                                        full_response += data["delta"]
+                                        _stream_set(session, partial=full_response)
                                     yield chunk
                                 elif data.get("type") == "web_sources":
                                     web_sources = data.get("data", [])


### PR DESCRIPTION
## Problem

In the chat stream, deltas flagged `thinking:true` (reasoning-model traces) were appended to `full_response` and persisted via `_stream_set(...)`, so the **saved** assistant message contained the model's chain-of-thought, not just the answer. Reloading the session then showed the raw reasoning.

## Fix

Forward `thinking:true` deltas to the client (so a live "thinking…" indicator still works) but exclude them from the accumulated saved reply, in both the chat and research-stream paths in `routes/chat_routes.py`. This mirrors how the existing rewrite path already handles it.

Found while building a mobile client (https://github.com/mahdi-salmanzade/odysseus-mobile) against reasoning models, but it affects the web UI's saved history too.