### PR TITLE
Unwrap DuckDuckGo redirect links so web-search results aren't dropped

### DIFF
--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from typing import List, Optional
+from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -13,6 +14,30 @@ from .analytics import RateLimitError, error_logger
 from .query import build_enhanced_query
 
 logger = logging.getLogger(__name__)
+
+
+def _unwrap_ddg_redirect(url: str) -> str:
+    """Resolve a DuckDuckGo result link to its real target.
+
+    DDG's HTML endpoint returns links as the scheme-less redirect
+    `//duckduckgo.com/l/?uddg=<percent-encoded-target>&rut=...`. Fetching that
+    verbatim fails the downstream SSRF guard (no http/https scheme → "Blocked
+    non-public URL"), so every search result was being dropped. Pull the real
+    URL out of the `uddg` param; also upgrade any other scheme-less `//host`
+    link to https so it can be fetched.
+    """
+    if not url:
+        return url
+    parse_target = "https:" + url if url.startswith("//") else url
+    try:
+        p = urlparse(parse_target)
+        if p.netloc.endswith("duckduckgo.com") and p.path.startswith("/l/"):
+            uddg = parse_qs(p.query).get("uddg", [None])[0]
+            if uddg:
+                return unquote(uddg)
+    except Exception:
+        pass
+    return parse_target if url.startswith("//") else url
 
 REQUEST_TIMEOUT = 20
 
@@ -314,7 +339,7 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
                 link = result.select_one(".result__a")
                 if not link:
                     continue
-                url = link.get("href", "")
+                url = _unwrap_ddg_redirect(link.get("href", ""))
                 if not url:
                     continue
                 snippet_el = result.select_one(".result__snippet")
@@ -345,7 +370,7 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
         raw = ddgs.text(query, max_results=count, timelimit=timelimit)
         results = []
         for item in raw:
-            url = item.get("href", "")
+            url = _unwrap_ddg_redirect(item.get("href", ""))
             if not url:
                 continue
             results.append({

--- a/src/search/providers.py
+++ b/src/search/providers.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from typing import List, Optional
+from urllib.parse import parse_qs, unquote, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -15,6 +16,30 @@ from .query import build_enhanced_query
 logger = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT = 20
+
+
+def _unwrap_ddg_redirect(url: str) -> str:
+    """Resolve a DuckDuckGo result link to its real target.
+
+    DDG's HTML endpoint returns links as the scheme-less redirect
+    `//duckduckgo.com/l/?uddg=<percent-encoded-target>&rut=...`. Fetching that
+    verbatim fails the downstream SSRF guard (no http/https scheme → "Blocked
+    non-public URL"), so every search result was being dropped. Pull the real
+    URL out of the `uddg` param; also upgrade any other scheme-less `//host`
+    link to https so it can be fetched.
+    """
+    if not url:
+        return url
+    parse_target = "https:" + url if url.startswith("//") else url
+    try:
+        p = urlparse(parse_target)
+        if p.netloc.endswith("duckduckgo.com") and p.path.startswith("/l/"):
+            uddg = parse_qs(p.query).get("uddg", [None])[0]
+            if uddg:
+                return unquote(uddg)
+    except Exception:
+        pass
+    return parse_target if url.startswith("//") else url
 
 # Provider registry — maps setting value to (label, needs_key, needs_url)
 PROVIDER_INFO = {
@@ -315,7 +340,7 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
                 link = result.select_one(".result__a")
                 if not link:
                     continue
-                url = link.get("href", "")
+                url = _unwrap_ddg_redirect(link.get("href", ""))
                 if not url:
                     continue
                 snippet_el = result.select_one(".result__snippet")
@@ -346,7 +371,7 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
         raw = ddgs.text(query, max_results=count, timelimit=timelimit)
         results = []
         for item in raw:
-            url = item.get("href", "")
+            url = _unwrap_ddg_redirect(item.get("href", ""))
             if not url:
                 continue
             results.append({


### PR DESCRIPTION
## Problem

DuckDuckGo's HTML endpoint returns each result link as a scheme-less redirect:

```
//duckduckgo.com/l/?uddg=<percent-encoded-target>&rut=...
```

Fetching that verbatim fails the downstream SSRF guard (no `http`/`https` scheme → "Blocked non-public URL"), so in practice **every** DuckDuckGo result was being discarded before it reached the model.

## Fix

Add `_unwrap_ddg_redirect()`:
- pull the real URL out of the `uddg` query param, and
- upgrade any other scheme-less `//host` link to `https` so it passes the guard.

Applied in both `duckduckgo_search` paths (HTML scrape + the `ddgs` library path). The same change lands in `src/search/providers.py` and `services/search/providers.py` to keep the two copies in sync.

Surfaced while testing web-search from a mobile client (https://github.com/mahdi-salmanzade/odysseus-mobile), but it affects any DuckDuckGo search.