### PR TITLE
fix(cookbook): sort by Fit when the Fit header is clicked (#842)

### DIFF
--- a/static/js/cookbook-hwfit.js
+++ b/static/js/cookbook-hwfit.js
@@ -519,6 +519,11 @@ export async function _hwfitFetch(fresh = false) {
       const asc = sortSel?.dataset.reverse === '1';   // reversed → ascending (lowest first)
       const field = { score: 'score', vram: 'required_gb', speed: 'speed_tps', params: 'params_b', context: 'context' }[sortKey] || 'score';
       data.models.sort((a, b) => {
+        if (sortKey === 'fit') {
+          const rank = { perfect: 4, good: 3, marginal: 2, too_tight: 1, no_fit: 0 };
+          const av = rank[a.fit_level] || 0, bv = rank[b.fit_level] || 0;
+          return asc ? av - bv : bv - av;
+        }
         const av = Number(a[field]) || 0, bv = Number(b[field]) || 0;
         return asc ? av - bv : bv - av;
       });
@@ -717,7 +722,7 @@ function _wireManualHardwareControls(el) {
 export const _fitColors = { perfect: 'var(--green, #50fa7b)', good: 'var(--yellow, #f1fa8c)', marginal: 'var(--orange, #ffb86c)', too_tight: 'var(--red, #ff5555)' };
 
 export const _hwfitColumns = [
-  { key: 'score', label: 'Fit',    cls: 'hwfit-fit' },
+  { key: 'fit', label: 'Fit',    cls: 'hwfit-fit' },
   { key: null,    label: 'Model',  cls: 'hwfit-name' },
   { key: 'params',label: 'Param', cls: 'hwfit-c-params' },
   { key: null,    label: 'Quant',  cls: 'hwfit-c-quant' },

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -1434,7 +1434,7 @@ function _renderRecipes() {
   html += '<button type="button" class="hwfit-gpu-btn" id="hwfit-rescan" title="Re-scan hardware" style="flex-shrink:0;position:relative;top:-3px;left:-1px;">↻ RESCAN</button>';
   html += '<button type="button" class="hwfit-gpu-btn hwfit-hw-manual-btn" id="hwfit-hw-manual-btn" title="Set hardware manually" style="flex-shrink:0;position:relative;top:-3px;left:-1px;">EDIT</button>';
   html += '<select class="cookbook-field-input hwfit-sort" id="hwfit-sort" style="display:none">';
-  html += '<option value="score">Score</option><option value="vram">VRAM</option>';
+  html += '<option value="fit">Fit</option><option value="score">Score</option><option value="vram">VRAM</option>';
   html += '<option value="speed">Speed</option><option value="params">Params</option>';
   html += '<option value="context">Context</option></select>';
   html += '</div>';


### PR DESCRIPTION
## Summary

Fixes #842.

In the Cookbook **Scan / Download (hwfit)** tool, clicking the **Fit** column header sorted the rows by **Score** instead of by fit.

**Root cause:** the Fit column was defined with `key: 'score'` in `_hwfitColumns`, and `'fit'` was not a valid `#hwfit-sort` option — so clicking the Fit header set the sort key to `'score'` and the rows sorted by score. The Fit and Score columns effectively shared one sort key.

## Changes

Per the maintainer's note ("each column should own its own sort key"):

1. **`static/js/cookbook.js`** — add `<option value="fit">Fit</option>` as the first option of the `#hwfit-sort` select, so `'fit'` is a valid sort value.
2. **`static/js/cookbook-hwfit.js`** — give the Fit column its own key: `{ key: 'fit', label: 'Fit', … }` (the separate Score column keeps `key: 'score'`).
3. **`static/js/cookbook-hwfit.js`** — in the client-side sort, handle `sortKey === 'fit'` by ranking `fit_level` (`perfect` > `good` > `marginal` > `too_tight` > `no_fit`). All other keys keep the existing numeric-field sort unchanged.

Default (not reversed) puts the **best fit first**; clicking the header again reverses to **worst fit first**. Score still sorts by score.

## Manual check

With rows where score order and fit order differ:

- Click **Fit** → rows order by fit classification (`perfect` → `good` → `marginal` → `too_tight`), not by score.
- Click **Fit** again → order reverses (worst fit first).
- Click **Score** → still orders by the numeric score, independently of Fit.

The `fit_level` values in the rank map match those produced by `services/hwfit/fit.py` and the image-mode fallback (`fit_level: m.fit || 'no_fit'`). The Python backend ignores an unknown `sort=fit` value (it falls back to `score` via `SORT_KEYS.get(...)`), and the client re-sorts by fit afterwards, so there is no server-side break.

Scope: two front-end files, no unrelated changes.
