### PR TITLE
Keep no-prose assistant tool-call messages through _sanitize_llm_messages

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -462,14 +462,37 @@ def _parse_anthropic_response(data: dict) -> str:
 
 
 def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
-    """Strip Odysseus-only metadata before sending messages to providers."""
+    """Strip Odysseus-only metadata before sending messages to providers.
+
+    Per the OpenAI chat format: user/system messages must have content; a tool
+    message needs content + tool_call_id; an assistant message may carry content,
+    tool_calls, or both. The old guard required content on every message, which
+    dropped a valid assistant message that has only tool_calls — e.g. the
+    follow-up message _append_tool_results builds for a no-prose native tool call
+    (content=None, since Gemini/Ollama reject tool_calls alongside ""). Dropping
+    it leaves the tool result dangling and breaks the next round.
+    """
     allowed = {"role", "content", "name", "tool_call_id", "tool_calls", "function_call"}
     cleaned = []
     for msg in messages or []:
         if not isinstance(msg, dict):
             continue
         item = {k: v for k, v in msg.items() if k in allowed and v is not None}
-        if "role" in item and "content" in item:
+        role = item.get("role")
+        if not role:
+            continue
+        if role == "assistant":
+            # Re-add an explicit content=None when the message is tool-calls-only
+            # (the None was stripped above) so the provider gets the spec-correct
+            # `content: null`, not an omitted key.
+            if "content" not in item and item.get("tool_calls"):
+                item["content"] = None
+            if "content" in item or item.get("tool_calls"):
+                cleaned.append(item)
+        elif role == "tool":
+            if "content" in item and "tool_call_id" in item:
+                cleaned.append(item)
+        elif "content" in item:
             cleaned.append(item)
     return cleaned
 

--- a/tests/test_llm_core_sanitize_tool_calls.py
+++ b/tests/test_llm_core_sanitize_tool_calls.py
@@ -1,0 +1,61 @@
+"""Regression test: _sanitize_llm_messages must not drop the no-prose
+assistant tool-call message.
+
+Commit cb13d09 changed _append_tool_results so that when the model emits ONLY
+tool calls (no prose), the follow-up assistant message carries content=None
+(JSON null) instead of "" — Google Gemini's OpenAI-compatible endpoint and
+Ollama reject tool_calls alongside an empty-string content with HTTP 400.
+
+But _sanitize_llm_messages drops None values (`v is not None`) and then required
+"content" to be present, so it dropped that assistant message entirely — leaving
+a dangling role:"tool" result with no parent tool_calls. That re-breaks native
+tool-calling on the follow-up round (and regresses providers that accepted ""
+before, since the message is now removed instead of sent). cb13d09's tests only
+exercised _append_tool_results in isolation, so the sanitizer interaction went
+uncaught.
+
+This test drives the real producer (_append_tool_results) into the sanitizer.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Mock heavy dependencies before importing (mirrors tests/test_agent_loop.py).
+for mod in [
+    'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
+    'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
+    'src.database', 'src.agent_tools', 'core.models', 'core.database',
+]:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+from src.agent_loop import _append_tool_results
+from src.llm_core import _sanitize_llm_messages
+
+
+def test_sanitize_keeps_no_prose_assistant_tool_call_message():
+    native = [{"id": "call_1", "name": "web_fetch",
+               "arguments": '{"url": "https://example.com"}'}]
+    messages = []
+    # Model emitted only a tool call, no prose -> _append_tool_results sets the
+    # assistant message's content to None (cb13d09).
+    _append_tool_results(messages, "", native, [{}], ["page text"],
+                         used_native=True, round_num=1)
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["content"] is None  # producer contract (cb13d09)
+
+    out = _sanitize_llm_messages(messages)
+    roles = [m["role"] for m in out]
+
+    # The assistant tool-call message must survive sanitization, otherwise the
+    # following tool result is dangling and the provider call breaks.
+    assert "assistant" in roles, (
+        "sanitize dropped the no-prose assistant tool-call message; the tool "
+        "result is left dangling"
+    )
+    assistant = next(m for m in out if m["role"] == "assistant")
+    assert assistant.get("tool_calls"), "assistant tool_calls were lost"
+    # Faithful to cb13d09: keep explicit JSON null rather than an omitted key.
+    assert assistant["content"] is None
+    # Pairing intact: the tool result references the assistant's tool_call id.
+    tool = next(m for m in out if m["role"] == "tool")
+    assert tool["tool_call_id"] == assistant["tool_calls"][0]["id"]


### PR DESCRIPTION
## What

Native (OpenAI-style) tool-calling breaks on the follow-up round because
`_sanitize_llm_messages` drops the assistant message that carries only
`tool_calls` and no prose.

cb13d09 ("Fix tool-calling HTTP 400 on Gemini and Ollama: send null, not empty,
assistant content") changed `_append_tool_results` to set that message's
`content` to `None` (JSON null) instead of `""`. But `_sanitize_llm_messages`
strips `None` values and then required `content` on every message:

```python
item = {k: v for k, v in msg.items() if k in allowed and v is not None}  # content=None stripped
if "role" in item and "content" in item:   # content gone -> message dropped
    cleaned.append(item)
```

So the null-content assistant message is removed, leaving the following
`role: "tool"` result dangling with no parent `tool_calls`. The next provider
call then breaks. This regresses **every** provider (ones that accepted `""`
before now get the message removed entirely), not just Gemini/Ollama.

cb13d09's tests exercised `_append_tool_results` in isolation, so the
sanitizer interaction wasn't caught.

### Reproduced end-to-end

Driving the real producer into the sanitizer:

```
_append_tool_results -> [{'role':'assistant','content':None,'tool_calls':[...]},
                         {'role':'tool','content':'result','tool_call_id':'call_1'}]
_sanitize_llm_messages(...) -> roles == ['tool']      # assistant dropped
```

## Fix

Make the sanitizer role-aware (matching the OpenAI chat format):

- **assistant**: kept if it has `content` OR `tool_calls`. A tool-calls-only
  message gets an explicit `content=None` re-added, so the provider receives
  the spec-correct `content: null` cb13d09 intended (not an omitted key).
- **tool**: still requires `content` + `tool_call_id`.
- **user/system**: still require `content`.

Junk metadata stripping and the `function_call`/`tool_calls` passthrough are
unchanged.

## Tests

`tests/test_llm_core_sanitize_tool_calls.py` drives `_append_tool_results` into
`_sanitize_llm_messages` and asserts the assistant tool-call message survives
with its tool result paired. **Red before this change** (`assert 'assistant' in
['tool']`), green after.

Ran on Python 3.12.13:

- `pytest tests/test_llm_core_sanitize_tool_calls.py` -> pass
- `pytest tests/test_agent_loop.py tests/test_llm_core_ollama.py tests/test_llm_core_concurrency.py` -> 44 passed, 1 pre-existing failure (`test_llm_call_posts_native_ollama_payload`, a MagicMock/httpx-stub artifact that fails on `main` without this change too).

## Note

Open PR #752 also touches `_sanitize_llm_messages` (it adds `reasoning_content`
to the allowed-key set). That's a different line from the drop-condition changed
here, so the two are complementary; flagging it for coordination.