### PR TITLE
fix(cookbook): mark zero-file HF downloads as failed instead of completed (#839)

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1898,6 +1898,7 @@ def setup_cookbook_routes() -> APIRouter:
             # persists after the process exits, so a finished download still has a
             # snapshot to classify (DOWNLOAD_OK / exit marker) — evaluate it even
             # when the PID is gone instead of blindly reporting "stopped".
+            download_zero_files = False
             status = "unknown"
             if is_alive or (local_win_task and full_snapshot):
                 lower = full_snapshot.lower()
@@ -1914,7 +1915,11 @@ def setup_cookbook_routes() -> APIRouter:
                     # Only download tasks treat 100% as "completed".
                     # Serve tasks log 100%|██████| during inference progress
                     # (diffusion sampling, etc.) — that's "running", not done.
-                    status = "completed"
+                    if re.search(r"Fetching\s+0\s+files", full_snapshot, re.IGNORECASE):
+                        status = "error"
+                        download_zero_files = True
+                    else:
+                        status = "completed"
                 elif "application startup complete" in lower:
                     status = "ready"
                 elif not is_alive:
@@ -1934,6 +1939,8 @@ def setup_cookbook_routes() -> APIRouter:
             diagnosis = _diagnose_serve_output(full_snapshot) if task_type == "serve" and full_snapshot else None
             if diagnosis and status in {"running", "unknown", "stopped"}:
                 status = "error"
+            if download_zero_files:
+                diagnosis = {"message": "No matching files were downloaded. The model repo or filename/quant pattern may be wrong (for example a ':Q4_K_M' tag that does not exist in the repo). Check the repo and the include/quant pattern."}
             output_tail = "\n".join(full_snapshot.splitlines()[-12:]) if full_snapshot else ""
 
             results.append({


### PR DESCRIPTION
## Summary

Fixes #839.

A Cookbook HF model download whose repo/quant selector matched **no files** (for example a `:Q4_K_M` tag that doesn't exist in the repo) was still reported as a successful **✓ Downloaded** / `completed` task. The user thinks the model is downloaded, but nothing was actually fetched.

This matches the maintainer's request: *detect zero-file downloads and mark the task failed with a clear message instead of `✓ Downloaded`.*

## Root cause

In `routes/cookbook_routes.py`, the status block treats any download task whose snapshot contains `100%` or `DOWNLOAD_OK` as `completed`. But the HF CLI prints this even when zero files matched:

```
Fetching 0 files: 0it [00:00, ?it/s]
Download complete: : 0.00B [00:00, ?B/s]   ✓ Downloaded
DOWNLOAD_OK
```

`Fetching 0 files` + `0.00B` still ends with `DOWNLOAD_OK`, so the task was marked `completed`.

## Fix

Inside the existing `download` branch, before marking `completed`, detect the zero-file signature and mark the task as an error with a helpful diagnosis instead:

```python
elif task_type == "download" and ("100%" in full_snapshot or "DOWNLOAD_OK" in full_snapshot):
    if re.search(r"Fetching\s+0\s+files", full_snapshot, re.IGNORECASE):
        status = "error"
        download_zero_files = True
    else:
        status = "completed"
...
if download_zero_files:
    diagnosis = {"message": "No matching files were downloaded. The model repo or filename/quant pattern may be wrong ..."}
```

## Why this is safe (no false positives)

The HF CLI only prints `Fetching 0 files` when the include/quant filter matched nothing on the Hub. A fully-cached re-download still prints `Fetching N files` with **N > 0** (it lists the files, then skips already-cached ones), so a valid cached download is **not** flagged. Normal multi-file downloads are unaffected.

## Checks

- `python -m py_compile routes/cookbook_routes.py` passes.
- Verified the classifier against the exact issue output (→ `error`) and a normal multi-file download (→ `completed`).

Scope: one file, a localized change inside the existing download status branch.
