### PR TITLE
fix(cookbook): diagnose 'no GGUF file' serve failures clearly (#811)

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -164,6 +164,11 @@ def setup_cookbook_routes() -> APIRouter:
                 [{"label": "install llama.cpp dependencies or llama-cpp-python[server]", "op": "dependency", "package": "llama-cpp-python[server]"}],
             ),
             (
+                r"No GGUF found on this host|no \.gguf file|No GGUF file found",
+                "No GGUF file found for this model on this host. The llama.cpp backend needs a .gguf file.",
+                [{"label": "download a GGUF build of this model (repo name usually ends in -GGUF, file like Q4_K_M.gguf)", "op": "manual"}],
+            ),
+            (
                 r"No module named 'torch'|No module named torch|No module named 'diffusers'|No module named diffusers",
                 "Diffusion serving requires PyTorch and diffusers.",
                 [{"label": "install diffusers[torch] in Cookbook Dependencies", "op": "dependency", "package": "diffusers[torch]"}],


### PR DESCRIPTION
## Summary

Fixes #811.

When a user tries to **Serve** a model with the **llama.cpp** backend but no `.gguf` file is present on the host, the Cookbook UI just shows a generic "crashed" / error instead of explaining that no GGUF was found. As the maintainer noted: *"if the selected backend is llama.cpp and no `.gguf` exists, Serve should say 'no GGUF file found' instead of just 'crashed'."*

## Root cause

The llama.cpp GGUF launcher prelude (in `static/js/cookbook.js`) already guards the serve command and, when no `.gguf` resolves, exits with:

```
ERROR: No GGUF found on this host. Either download the model here, or switch to the server where it's cached.
```

But `_diagnose_serve_output` in `routes/cookbook_routes.py` had no pattern matching that message, so it fell through to the generic crash/Traceback handling — the user never sees *why*.

## Fix

Add one diagnosis tuple to the existing `(pattern, message, suggestions)` list in `_diagnose_serve_output`, placed before the generic Traceback fallback:

```python
(
    r"No GGUF found on this host|no \.gguf file|No GGUF file found",
    "No GGUF file found for this model on this host. The llama.cpp backend needs a .gguf file.",
    [{"label": "download a GGUF build of this model (repo name usually ends in -GGUF, file like Q4_K_M.gguf)", "op": "manual"}],
),
```

Now a no-GGUF serve failure gets a clear message + a pointer to download a GGUF build, instead of an opaque crash.

## Checks

- `python -m py_compile routes/cookbook_routes.py` passes.
- The regex matches the real prelude error (`No GGUF found on this host`) and does **not** match normal/healthy serve logs (no false positives — verified against typical Uvicorn/llama.cpp startup output).

Scope: one file, a single localized diagnosis entry.
