### PR TITLE
fix(security): fail closed on null-owner session in /api/v1/chat

### DIFF
--- a/routes/webhook_routes.py
+++ b/routes/webhook_routes.py
@@ -26,6 +26,25 @@ MAX_MESSAGE_LEN = 32_000
 from core.middleware import require_admin as _require_admin
 
 
+def _caller_owns_session(sess_owner, caller) -> bool:
+    """Strict session-ownership gate for the token-authenticated sync-chat
+    endpoint (`POST /api/v1/chat`).
+
+    Mirrors ``_verify_session_owner`` in session_routes.py and the null-owner
+    gates in notes/calendar/gallery: a caller may resume a session ONLY when
+    its owner matches them exactly. A null/empty session owner (legacy or
+    migrated rows) is deliberately NOT resumable by an arbitrary token — the
+    old ``sess_owner and sess_owner != caller`` form skipped the check whenever
+    ``sess_owner`` was falsy, so any chat-scoped token (e.g. a paired mobile
+    device) could resume such a session, inject a message, and read back its
+    history and reuse the owner's endpoint credentials. Fail closed: an
+    unresolvable caller also returns False.
+    """
+    if not caller:
+        return False
+    return sess_owner == caller
+
+
 def setup_webhook_routes(
     webhook_manager: WebhookManager,
     auth_manager,
@@ -228,8 +247,11 @@ def setup_webhook_routes(
                 _tok_user = token_owner or getattr(request.state, "user", None) or _gcu(request)
             except Exception:
                 _tok_user = None
+            # Strict ownership (see _caller_owns_session): fail closed so a
+            # null-owner / cross-owner session can't be resumed by an arbitrary
+            # chat-scoped token.
             _sess_owner = getattr(sess, "owner", None)
-            if _tok_user and _sess_owner and _sess_owner != _tok_user:
+            if not _caller_owns_session(_sess_owner, _tok_user):
                 raise HTTPException(404, "Session not found")
 
         # --- Case 2: Direct API key + model (no pre-configured endpoint needed) ---

--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -165,3 +165,54 @@ def test_gallery_owner_filter_passes_user():
     # logged-in users.
     fake_q.filter.assert_called_once()
     assert out is fake_q.filter.return_value
+
+
+# ---------------------------------------------------------------------------
+# webhook._caller_owns_session  (POST /api/v1/chat sync-chat endpoint)
+# ---------------------------------------------------------------------------
+# This is the FOURTH place the `owner and owner != user` pattern showed up:
+# the token-authenticated sync-chat endpoint let any chat-scoped token resume
+# a null-owner session by passing its id, leaking its history and reusing the
+# owner's endpoint credentials. The gate must fail closed, exactly like the
+# calendar/notes/gallery gates above and _verify_session_owner.
+
+def _import_webhook_helper():
+    """Import routes.webhook_routes without dragging in the real webhook
+    manager / database. Stub src.webhook_manager (only referenced by an
+    import line) and ensure core.database exposes the names the import chain
+    (core/__init__ → session_manager) looks up."""
+    for _name in ("Webhook", "ChatMessage"):
+        setattr(sys.modules["core.database"], _name, MagicMock())
+    if "src.webhook_manager" not in sys.modules:
+        wm = types.ModuleType("src.webhook_manager")
+        wm.WebhookManager = MagicMock()
+        wm.validate_webhook_url = MagicMock()
+        wm.validate_events = MagicMock()
+        sys.modules["src.webhook_manager"] = wm
+    return __import__(
+        "routes.webhook_routes", fromlist=["_caller_owns_session"]
+    )
+
+
+def test_sync_chat_gate_rejects_null_owner_session():
+    wh_mod = _import_webhook_helper()
+    # Legacy/migrated session with no owner must NOT be resumable by a token.
+    assert wh_mod._caller_owns_session(None, "alice") is False
+
+
+def test_sync_chat_gate_rejects_cross_owner_session():
+    wh_mod = _import_webhook_helper()
+    assert wh_mod._caller_owns_session("bob", "alice") is False
+
+
+def test_sync_chat_gate_rejects_unresolvable_caller():
+    wh_mod = _import_webhook_helper()
+    # If the token's owner can't be resolved, fail closed rather than opening
+    # up null-owner sessions.
+    assert wh_mod._caller_owns_session(None, None) is False
+    assert wh_mod._caller_owns_session("alice", None) is False
+
+
+def test_sync_chat_gate_accepts_matching_owner():
+    wh_mod = _import_webhook_helper()
+    assert wh_mod._caller_owns_session("alice", "alice") is True


### PR DESCRIPTION
## Summary

`POST /api/v1/chat` (the sync-chat endpoint used by n8n / Make / Activepieces, in `routes/webhook_routes.py`) gates "resume an existing session" with:

```python
if _tok_user and _sess_owner and _sess_owner != _tok_user:
    raise HTTPException(404, "Session not found")
```

The middle `_sess_owner and` clause means the ownership check is **skipped entirely whenever the session's owner is null/empty**. Sessions created before the `owner` column existed — or any migrated/legacy row — have `owner = None` (`SessionManager.create_session` defaults `owner=None`, and `get_session` reads `getattr(db_session, "owner", None)`).

### Impact
Any **chat-scoped** API token can reach this endpoint (the scope check above only requires `"chat"`, which is the default scope minted for tokens — e.g. tokens minted for a paired mobile device). With the gate bypassed for null-owner sessions, such a token can pass an arbitrary null-owner session id and:

- inject a user message into another account's session,
- read back a reply conditioned on that session's full conversation **history** (trivially exfiltrated by prompting "repeat our conversation so far"), and
- have the call run against the **session owner's endpoint + API credentials** (`sess.headers`).

### Root cause — a known, recurring pattern
This is the same `if owner and owner != user` null-owner-bypass that has already been hardened **three times** elsewhere — gallery, calendar, and notes — and is pinned in `tests/test_null_owner_gates.py`. The canonical web path, `session_routes._verify_session_owner`, is already strict (`if row.owner != user: 404`). The sync-chat endpoint is the fourth instance and was missed.

## Fix
Make the gate **fail closed**, mirroring `_verify_session_owner`: require a resolvable caller **and** an exact owner match. A null-owner or cross-owner session is no longer resumable through this endpoint (consistent with the web routes, which already refuse null-owner sessions for a logged-in user). The decision is extracted into a small pure helper, `_caller_owns_session()`, so it can be unit-tested.

```python
_sess_owner = getattr(sess, "owner", None)
if not _caller_owns_session(_sess_owner, _tok_user):
    raise HTTPException(404, "Session not found")
```

## Tests
Added four regression tests to `tests/test_null_owner_gates.py` (the file that already tracks this bug class): null-owner → 404, cross-owner → 404, unresolvable caller → 404, matching owner → allowed.

```
$ pytest tests/test_null_owner_gates.py -q
13 passed
```

## Notes / compatibility
A token holder's own sessions are unaffected — web-created sessions store `owner=user` and sync-chat-created sessions store `owner=token_owner`, both of which match. The only behavior change is that legacy **null-owner** sessions can no longer be resumed via `/api/v1/chat` — which already matches how `_verify_session_owner` treats them on the web.