### PR TITLE
Fix AttributeError on bullet lines in extract_memory_from_chat

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -59,8 +59,12 @@ class MemoryManager:
                     line = line.strip()
                     # Look for bullet points or numbered lists that might contain memories
                     if re.match(r'^[-*•]|\d+\.', line):
-                        # Extract the text after the bullet/number
-                        text_match = re.match(r'^[-*•]|\d+\.\s*(.*)', line)
+                        # Extract the text after the bullet/number. Group both
+                        # markers so the capture applies to either — the previous
+                        # `^[-*•]|\d+\.\s*(.*)` put the group on the numbered branch
+                        # only, so a bullet line matched with group(1)=None and
+                        # crashed on .strip().
+                        text_match = re.match(r'^(?:[-*•]|\d+\.)\s*(.*)', line)
                         if text_match:
                             text = text_match.group(1).strip()
                             if text:

--- a/tests/test_memory_bullet_extraction.py
+++ b/tests/test_memory_bullet_extraction.py
@@ -1,0 +1,26 @@
+"""Regression test: extract_memory_from_chat must not crash on bullet lines.
+
+The fallback memory extractor (invoked by routes/memory_routes.py when the LLM
+extractor fails) matched list items with ``r'^[-*•]|\\d+\\.\\s*(.*)'``. Because
+of alternation precedence that pattern is ``(^[-*•]) | (\\d+\\.\\s*(.*))`` — the
+capture group lives only in the numbered-list branch. A bullet line ("- ...")
+matches the first branch, so ``group(1)`` is ``None`` and ``.strip()`` raised
+``AttributeError``, crashing extraction for any assistant message that contains
+a bullet list (the dominant case).
+"""
+from src.memory import MemoryManager
+
+
+def test_extract_memory_from_chat_handles_bullets(tmp_path):
+    mgr = MemoryManager(str(tmp_path))
+    chat = [{
+        "role": "assistant",
+        "content": "- User likes coffee\n* Prefers tea in winter\n1. Wakes at 6am",
+    }]
+
+    out = mgr.extract_memory_from_chat(chat)
+    texts = [m["text"] for m in out]
+
+    assert "User likes coffee" in texts       # '-' bullet (used to crash)
+    assert "Prefers tea in winter" in texts   # '*' bullet (used to crash)
+    assert "Wakes at 6am" in texts            # numbered list (already worked)


### PR DESCRIPTION
## What

`MemoryManager.extract_memory_from_chat` — the fallback memory extractor invoked
by `routes/memory_routes.py:234` when the LLM extractor fails — crashes on any
assistant message containing a bullet list.

It matched list items with:

```python
text_match = re.match(r'^[-*•]|\d+\.\s*(.*)', line)
text = text_match.group(1).strip()
```

Alternation precedence makes that regex `(^[-*•]) | (\d+\.\s*(.*))`, so the
`(.*)` capture group lives **only** on the numbered-list branch. A bullet line
(`- foo`) matches the first branch, leaving `group(1) == None`:

```
>>> re.match(r'^[-*•]|\d+\.\s*(.*)', "- User likes coffee").group(1)
None
>>> ... .strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

So the fallback extractor raises `AttributeError` for `-`, `*`, or `•` bullets
(numbered lists happened to work). Bullets are the dominant shape of assistant
output, so the fallback effectively always crashes when it's needed.

## Fix

Group both markers so the capture applies to either:

```python
text_match = re.match(r'^(?:[-*•]|\d+\.)\s*(.*)', line)
```

## Tests

Adds `tests/test_memory_bullet_extraction.py`, asserting `-`, `*`, and numbered
items are all extracted. Red before this change (AttributeError), green after.

Ran on Python 3.12.13: `pytest tests/test_memory_bullet_extraction.py` -> pass.