### PR TITLE
fix(macos): use venv Python for pip install and uvicorn launch

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -90,9 +90,9 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$PY" -m pip install --quiet --upgrade pip
+./venv/bin/python -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
-"$PY" -m pip install -r requirements.txt
+./venv/bin/python -m pip install -r requirements.txt
 
 # 4. First-run setup: creates data dirs and prints an initial admin password
 #    the first time (idempotent — does nothing if already set up). Suppress its
@@ -136,4 +136,4 @@ echo
 echo "▶ Starting Odysseus — it will open in your browser at $URL"
 echo "  (this takes a few seconds; press Ctrl+C here to stop)"
 echo
-"$PY" -m uvicorn app:app --host 127.0.0.1 --port "$PORT"
+./venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port "$PORT"


### PR DESCRIPTION
## Summary
- `start-macos.sh` creates a venv but then uses the system `$PY` for `pip install` and `uvicorn`, which fails on newer Homebrew Python installs that enforce PEP 668 (externally-managed-environment)
- Switches to `./venv/bin/python` for pip install, pip upgrade, and uvicorn launch so the script works without `--break-system-packages`

## Test plan
- [ ] Run `./start-macos.sh` on a macOS machine with Homebrew Python 3.12+ (PEP 668 enforced)
- [ ] Verify pip installs into the venv successfully
- [ ] Verify uvicorn starts and Odysseus is accessible at `http://127.0.0.1:7860`
- [ ] Re-run the script to confirm idempotency still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)