### PR TITLE
fix(research): gate /api/research/spinoff on session ownership (cross-user report disclosure)

### DIFF
--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -492,8 +492,14 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         injects a single system message containing the report and sources so
         the user can ask follow-up questions in a clean conversation.
         """
-        _require_user(request)
+        user = _require_user(request)
         _validate_session_id(session_id)
+        # SECURITY: gate on ownership before reading the persisted research —
+        # otherwise any authenticated user could spin off (and thereby read)
+        # another user's report by guessing its session ID. Mirrors every other
+        # endpoint in this file (see result_peek above).
+        if not _owns_in_memory(session_id, user):
+            raise HTTPException(404, "No research found for this session")
         if session_manager is None:
             raise HTTPException(500, "session_manager not configured")
 
@@ -574,7 +580,6 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
 
         # Create new session
         new_sid = str(uuid.uuid4())
-        user = get_current_user(request)
 
         title_query = (query or "research").strip()
         if len(title_query) > 60:

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -177,6 +177,35 @@ def test_research_delete_rejects_anonymous():
     assert exc.value.status_code == 401
 
 
+def test_research_spinoff_rejects_anonymous():
+    """spinoff must 401 before reading any research data."""
+    from routes.research_routes import setup_research_routes
+    rh = MagicMock()
+    router = setup_research_routes(rh, session_manager=MagicMock())
+    target = next(r.endpoint for r in router.routes if getattr(r, "path", "") == "/api/research/spinoff/{session_id}")
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(target(session_id="x", request=_fake_request(user=None)))
+    assert exc.value.status_code == 401
+
+
+def test_research_spinoff_rejects_wrong_owner():
+    """A user must not be able to spin off (and thereby read) another user's
+    research report. The ownership gate must 404 before any data is read or a
+    new session is created. Regression for the cross-user disclosure IDOR."""
+    from routes.research_routes import setup_research_routes
+    sm = MagicMock()
+    rh = MagicMock()
+    rh._active_tasks = {"x": {"owner": "alice"}}
+    rh.get_result.return_value = "TOP SECRET REPORT"
+    router = setup_research_routes(rh, session_manager=sm)
+    target = next(r.endpoint for r in router.routes if getattr(r, "path", "") == "/api/research/spinoff/{session_id}")
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(target(session_id="x", request=_fake_request(user="bob")))
+    assert exc.value.status_code == 404
+    # The attacker must never get a session created on their behalf.
+    sm.create_session.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # pop_notifications owner filter
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`POST /api/research/spinoff/{session_id}` authenticated the caller but **never verified the research session belonged to them** before reading the persisted report and seeding it into a new chat session owned by the caller. Any authenticated user who knew or guessed another user's research `session_id` could exfiltrate that user's **full research report** into their own session — a cross-user data disclosure (IDOR).

Every other endpoint in `routes/research_routes.py` gates on `_owns_in_memory` / `_assert_owns_research` immediately after `_validate_session_id`. `spinoff` was the lone exception.

## The bug

```python
@router.post("/api/research/spinoff/{session_id}")
async def research_spinoff(session_id: str, request: Request):
    _require_user(request)          # only blocks anonymous access
    _validate_session_id(session_id)  # only checks ID *format*
    ...
    result = research_handler.get_result(session_id)   # <-- any user's report
    ...
    disk = json.loads(path.read_text(...))             # data/deep_research/{session_id}.json
    ...
    new_sess = session_manager.create_session(..., owner=user)  # attacker-owned
    new_sess.add_message(ChatMessage(role="system", content=primer))  # full report injected
```

`_require_user` itself documents the gap: *"Multi-tenant deploys should additionally verify the session belongs to this user."* — which the sibling endpoints do and this one didn't.

## Fix

Add the same `_owns_in_memory` check (covers both the in-memory task and the on-disk JSON) right after `_validate_session_id`, so a non-owner gets a `404` before any data is read or a session is created. Also drops a now-redundant re-fetch of `user`.

## Tests

Added regression tests in `tests/test_auth_regressions.py`:
- `test_research_spinoff_rejects_anonymous` → 401
- `test_research_spinoff_rejects_wrong_owner` → 404, and asserts `create_session` is never called

Verified the wrong-owner test **fails on the unpatched code** (bob successfully spins off alice's report) and **passes with the fix**. Full `test_auth_regressions.py` + `test_research_service.py` suite green (22 passed).

## Impact

- **Severity:** High — authenticated cross-user confidentiality breach, low attacker complexity (needs only a valid session ID).
- No schema/API changes; non-owners now get the same `404` as every other research endpoint.
