### PR TITLE
fix(auth): honor AUTH_ENABLED=false on owner-scoped endpoints (stop /login redirect loop)

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -33,7 +33,7 @@ from fastapi import Query, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional, List
 
-from src.auth_helpers import get_current_user
+from src.auth_helpers import _auth_disabled, get_current_user
 from src.secret_storage import decrypt as _decrypt
 
 logger = logging.getLogger(__name__)
@@ -152,6 +152,8 @@ def _require_auth(request: Request) -> str:
     u = get_current_user(request)
     if u:
         return u
+    if _auth_disabled():
+        return ""
     auth_mgr = getattr(request.app.state, "auth_manager", None)
     if auth_mgr is not None and getattr(auth_mgr, "is_configured", False):
         raise HTTPException(401, "Not authenticated")

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -22,7 +22,7 @@ from src.endpoint_resolver import (
     build_models_url,
     build_headers,
 )
-from src.auth_helpers import owner_filter
+from src.auth_helpers import _auth_disabled, owner_filter
 
 logger = logging.getLogger(__name__)
 
@@ -586,7 +586,7 @@ def setup_model_routes(model_discovery):
         # list to unauthenticated callers.
         try:
             auth_mgr = getattr(request.app.state, "auth_manager", None)
-            if not owner and auth_mgr is not None and getattr(auth_mgr, "is_configured", False):
+            if not owner and not _auth_disabled() and auth_mgr is not None and getattr(auth_mgr, "is_configured", False):
                 raise HTTPException(401, "Not authenticated")
         except HTTPException:
             raise

--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel, Field
 from src.endpoint_resolver import resolve_endpoint
-from src.auth_helpers import get_current_user
+from src.auth_helpers import _auth_disabled, get_current_user
 
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9-]{1,128}$")
 
@@ -58,6 +58,8 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         verify the session belongs to this user."""
         user = get_current_user(request)
         if not user:
+            if _auth_disabled():
+                return ""
             raise HTTPException(401, "Not authenticated")
         return user
 


### PR DESCRIPTION
## Summary

While dogfooding a local install with `AUTH_ENABLED=false`, the SPA kept bouncing to `/login` and never loaded — even though auth was explicitly turned off.

Root cause: three owner-scoped endpoints return **401** for an anonymous caller when the instance is `is_configured`, **without** consulting `_auth_disabled()`. The front-end's fetch wrapper treats those 401s as "session expired" and redirects to `/login`, so the app is unusable.

This is the exact contract `require_user()` in `src/auth_helpers.py` already documents (issue #622):

> *AUTH_ENABLED=false — the operator explicitly turned auth off. The full /login flow is skipped, so route-level checks must let the request through too instead of 401-ing and forcing the browser to /login.*

`require_user` already does `if _auth_disabled(): return ""`, but these endpoints did their own check and missed it.

## Affected endpoints / fix

Each now honors `_auth_disabled()` (anonymous allowed, `owner=""`) **only** when the operator turned auth off — the 401 protection is fully intact when `AUTH_ENABLED=true`:

- **`routes/research_routes.py`** — local `_require_user` returns `""` instead of 401 when auth is disabled.
- **`routes/model_routes.py`** — the `/api/models` anti-leak guard adds `not _auth_disabled()` to its condition (`owner=""` is already treated as "see everything" by `_fetch_models`).
- **`routes/email_helpers.py`** — `_require_auth` returns `""` early when auth is disabled (placed after `if u: return u`, before the `is_configured` 401, so the existing loopback hardening for the auth-enabled path is untouched).

## Verification

End-to-end with a real browser (Playwright) against a local install:

- **Before:** `GET /` → app issues 401 on `/api/models`, `/api/research/active`, `/api/email/list`, `/api/email/urgency-state` → redirected to `/login`.
- **After:** `GET /` stays on `/`, **0** remaining 401/403 responses, the SPA loads.
- `python -m py_compile` passes on all three files.
- The 401 path is unchanged for `AUTH_ENABLED=true` (only an explicit operator opt-out changes behavior).

Scope: three files, each a minimal guard mirroring the existing `require_user` pattern. No change to behavior when auth is enabled.
