### PR TITLE
fix(cookbook): skip pip --user fallback inside virtualenvs (#388)

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -152,13 +152,25 @@ def _pip_install_fallback_chain(package: str, *, python_cmd: str = "python3 -m p
     """Build a bash pip install fallback chain.
 
     Try the active interpreter/environment first. `--user` is invalid inside
-    many venvs, so keep the user-site fallback for PEP-668 system Pythons only
-    after the venv-safe attempt has failed.
+    many venvs, so only attempt the --user fallback when NOT inside a venv.
     """
     upgrade_flag = " -U" if upgrade else ""
     base = f"{python_cmd} install -q{upgrade_flag} {package} 2>/dev/null"
     user = f"{python_cmd} install --user --break-system-packages -q{upgrade_flag} {package} 2>/dev/null"
-    return f"{base} || {user}"
+    # Derive the python executable for the venv detection check.
+    # Must use the same interpreter that pip belongs to; hardcoding
+    # python3 breaks when pip lives in a venv that only has "python".
+    if " -m pip" in python_cmd:
+        python_exe = python_cmd.replace(" -m pip", "")
+    elif python_cmd.strip() == "pip":
+        python_exe = "python"
+    elif python_cmd.strip() == "pip3":
+        python_exe = "python3"
+    else:
+        python_exe = "python3"
+    venv_check = f'{python_exe} -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"'
+    # venv_check exits 0 (true) when IN a venv; --user is only valid outside one.
+    return f"{base} || {{ {venv_check} || {user}; }}"
 
 
 def _cached_model_scan_script(model_dirs: list[str] | None = None) -> str:

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -92,8 +92,9 @@ def test_pip_install_fallback_chain_prefers_venv_safe_install():
 def test_pip_install_fallback_chain_allows_custom_python_command():
     chain = _pip_install_fallback_chain("hf_transfer", python_cmd="pip", upgrade=False)
     assert chain == (
-        "pip install -q hf_transfer 2>/dev/null || "
-        "pip install --user --break-system-packages -q hf_transfer 2>/dev/null"
+        'pip install -q hf_transfer 2>/dev/null || { '
+        'python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"'
+        ' || pip install --user --break-system-packages -q hf_transfer 2>/dev/null; }'
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #388.

The Cookbook dependency-install fallback chain (`_pip_install_fallback_chain` in `routes/cookbook_helpers.py`) unconditionally fell back to `pip install --user`. But `--user` is invalid inside a virtualenv (and when running as root in an LXC/container), so it fails with:

```
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

— which is exactly the error from #388 (the reporter runs Odysseus in an LXC container as root). The function's own docstring already noted "`--user` is invalid inside many venvs", but the code used it anyway. I reproduced the error directly in the app's own venv.

## Fix

Guard the `--user` fallback with a venv check, so it only runs **outside** a venv (where `--user` is legitimately needed for PEP-668 system Pythons):

```
base_install 2>/dev/null || { <venv-check> || user_install; }
```

where the venv check is `python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"` (exit 0 = in a venv → `--user` is skipped).

The probe interpreter is derived from the install command so the check runs in pip's own environment: `python3 -m pip` → `python3`, `pip` → `python`, `pip3` → `python3` (the name-matched python shares pip's env far more reliably than hardcoding `python3`).

Behavior:
- **In a venv / LXC-root:** base install runs; the broken `--user` fallback is skipped (fixes #388).
- **System / PEP-668 python:** unchanged — the `--user --break-system-packages` fallback still runs.

## Checks

- `tests/test_cookbook_helpers.py` updated for the new chain — **15 passed**.
- `python -m py_compile routes/cookbook_helpers.py` passes.
- Verified the generated bash for both the `python3 -m pip` and bare `pip` call styles: `--user` is skipped in a venv and still runs on a system python.

Scope: one helper function + its unit test. The `--user` path is preserved for the system-python case it was meant for.
