### PR TITLE
Publish container images to GHCR

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,69 @@
+name: Container Image
+
+# Publishing is intentionally limited to explicit release tags. This avoids
+# publishing a moving `latest` image from every main push until release owners
+# decide the public image naming and distribution policy.
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build, smoke test, and push image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build smoke-test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: odysseus-smoke:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test built image
+        run: docker run --rm --entrypoint python odysseus-smoke:${{ github.sha }} -c "import app; print('app import ok')"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the project Dockerfile, smoke-tests the resulting image, and publishes release-tagged images to GHCR.

## Details

- Publishes only from explicit Git tag pushes.
- Does not publish `latest`.
- Does not publish on every `main` push.
- Publishes tag and semver-derived tags for pushed Git tags.
- Uses `contents: read` and `packages: write` permissions only.
- Uses `secrets.GITHUB_TOKEN` for GHCR login; no custom repository secrets are required.
- Uses GitHub Actions build cache with `cache-from: type=gha` and `cache-to: type=gha,mode=max`.
- Builds a local smoke-test image before GHCR login/push and runs `python -c "import app"` inside the built container.

## Release Decision

This should remain draft/held for an explicit release and distribution decision before merge. Prebuilt GHCR images change the public install path and create artifacts consumers may rely on.

Before merging, release owners should confirm:

- image naming
- release tagging policy
- whether `latest` should exist at all
- whether publishing should ever happen on `main`
- whether the current smoke test is sufficient for v1 image distribution

Docker-from-source remains the canonical v1 path until prebuilt images are tested end-to-end.

## Validation

- Updated workflow to remove `main` publishing and `latest`.
- Added the built-image smoke test step.
- Parsed `.github/workflows/container-image.yml` with Ruby YAML.
