### PR TITLE
Document Helm chart deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,21 @@ Local GPU *serving* of vLLM/SGLang needs Linux/WSL2; for a local model on Window
 Open `http://localhost:7000`, log in with the generated admin password,
 and configure everything else inside **Settings**.
 
+### Helm Chart
+
+A Helm chart is available in `charts/odysseus`. Build an Odysseus image from
+source and push it to a registry first, then install:
+
+```bash
+helm install odysseus ./charts/odysseus \
+  --set image.repository=ghcr.io/YOUR_OWNER/odysseus \
+  --set image.tag=latest
+```
+
+The chart can deploy bundled ChromaDB and SearXNG services, runs first-time
+setup as an init container, and persists app data on PVCs. See
+`charts/odysseus/README.md` for values and examples.
+
 ## Security Notes
 Odysseus is a self-hosted workspace with powerful local tools: shell access, file uploads, model downloads, web research, email/calendar integrations, and API tokens. Treat it like an admin console.
 

--- a/charts/odysseus/README.md
+++ b/charts/odysseus/README.md
@@ -1,0 +1,97 @@
+# Odysseus Helm Chart
+
+This chart deploys Odysseus plus optional in-cluster ChromaDB, SearXNG, and
+ntfy services.
+
+## Install
+
+Build an Odysseus image from source and push it to a registry first, then point
+the chart at it:
+
+```bash
+helm install odysseus ./charts/odysseus \
+  --set image.repository=ghcr.io/YOUR_OWNER/odysseus \
+  --set image.tag=latest
+```
+
+For local testing with the default ClusterIP service:
+
+```bash
+kubectl port-forward svc/odysseus 7000:7000
+```
+
+Then open `http://127.0.0.1:7000`.
+
+## Secrets
+
+Pass sensitive values through `secretEnv.values`:
+
+```bash
+helm install odysseus ./charts/odysseus \
+  --set image.repository=ghcr.io/YOUR_OWNER/odysseus \
+  --set image.tag=latest \
+  --set secretEnv.values.OPENAI_API_KEY=sk-... \
+  --set secretEnv.values.ODYSSEUS_ADMIN_PASSWORD=change-me
+```
+
+Or point at an existing Secret:
+
+```yaml
+secretEnv:
+  existingSecret: odysseus-env
+```
+
+## Bundled Services
+
+By default:
+
+- `chromadb.enabled=true`
+- `searxng.enabled=true`
+- `ntfy.enabled=false`
+
+When ChromaDB or SearXNG are enabled, the chart automatically sets
+`CHROMADB_HOST`, `CHROMADB_PORT`, and `SEARXNG_INSTANCE` for the Odysseus pod.
+Disable either service if you want to use an external instance and set the
+corresponding values under `env`.
+
+## Persistence
+
+The app uses one PVC and mounts separate subpaths for:
+
+- `/app/data`
+- `/app/logs`
+- `/app/.ssh`
+- `/app/.cache/huggingface`
+- `/app/.local`
+
+The bundled ChromaDB, SearXNG, and ntfy deployments each have their own PVCs.
+
+## First Run Setup
+
+`setup.enabled=true` runs `python setup.py` as an init container before the app
+starts. This initializes the SQLite database and creates the first admin user if
+`auth.json` does not already exist.
+
+If you do not provide `ODYSSEUS_ADMIN_PASSWORD`, setup generates a temporary
+password in the init container logs:
+
+```bash
+kubectl logs deploy/odysseus -c setup
+```
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: odysseus.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: odysseus-tls
+      hosts:
+        - odysseus.example.com
+```


### PR DESCRIPTION
## Summary

Documents the Helm chart deployment path.

## Details

- Adds a root README pointer to `charts/odysseus`.
- Adds chart README install, secrets, bundled service, persistence, setup, and ingress examples.
- Keeps the v1 install guidance centered on building an Odysseus image from source and pushing it to a registry before installing the chart.
- Leaves prebuilt image publishing out of the docs until that path has release-owner review and end-to-end testing.

## Release Note

This PR is docs-only. It is split from the chart implementation and the GHCR publishing workflow so each surface can be reviewed separately.

## Validation

- Reviewed the docs diff for scope.
- Confirmed this branch only changes `README.md` and `charts/odysseus/README.md`.
