### PR TITLE
fix(windows): prefer Python 3.11+ in launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,15 @@ Or do it by hand:
 ```powershell
 git clone https://github.com/pewdiepie-archdaemon/odysseus.git
 cd odysseus
-python -m venv venv
+py -3.11 -m venv venv
 venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 python setup.py
 python -m uvicorn app:app --host 127.0.0.1 --port 7000
 ```
+
+If `python` points at an older interpreter, use `py -3.12` (or another installed
+3.11+ version) for the venv step.
 
 **Requirements:** Python 3.11+. The core app (chat, agent, memory, documents,
 email, calendar, deep research) runs fully native. For full **Cookbook** background

--- a/launch-windows.ps1
+++ b/launch-windows.ps1
@@ -30,23 +30,60 @@ function Fail($msg) {
     exit 1
 }
 
-# 1. Locate a Python interpreter (3.11+ recommended)
+# 1. Locate a Python interpreter (3.11+ required)
 Write-Step "Checking for Python"
+function Get-PythonVersionText($launcher, $launcherArgs) {
+    try {
+        return (& $launcher @launcherArgs -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>$null).Trim()
+    } catch {
+        return $null
+    }
+}
+
 $pyExe = $null
-foreach ($c in @("python", "py")) {
-    $cmd = Get-Command $c -ErrorAction SilentlyContinue
-    if ($cmd) { $pyExe = $cmd.Source; break }
+$pyArgs = @()
+$pyVersion = $null
+
+$pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+if ($pyLauncher) {
+    foreach ($v in @("-3.13", "-3.12", "-3.11")) {
+        $ver = Get-PythonVersionText $pyLauncher.Source @($v)
+        if ($ver) {
+            $pyExe = $pyLauncher.Source
+            $pyArgs = @($v)
+            $pyVersion = $ver
+            break
+        }
+    }
 }
+
 if (-not $pyExe) {
-    Fail "Python not found on PATH. Install Python 3.11+ from https://www.python.org/downloads/ (check 'Add to PATH'), then re-run this script."
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        $ver = Get-PythonVersionText $pythonCmd.Source @()
+        if ($ver) {
+            $versionParts = $ver.Split('.')
+            $major = [int]$versionParts[0]
+            $minor = [int]$versionParts[1]
+            if ($major -gt 3 -or ($major -eq 3 -and $minor -ge 11)) {
+                $pyExe = $pythonCmd.Source
+                $pyVersion = $ver
+            }
+        }
+    }
 }
-Write-Host ("Using Python: " + $pyExe)
+
+if (-not $pyExe) {
+    Fail "Couldn't find Python 3.11+ for Windows setup. Install Python 3.11+ (or open the Python launcher with 'py -3.11') from https://www.python.org/downloads/, then re-run this script."
+}
+$pythonLabel = ("Using Python {0}: {1} {2}" -f $pyVersion, $pyExe, ($pyArgs -join ' ')).TrimEnd()
+Write-Host $pythonLabel
 
 # 2. Create the virtualenv if missing
 $venvPy = Join-Path $PSScriptRoot "venv\Scripts\python.exe"
 if (-not (Test-Path $venvPy)) {
     Write-Step "Creating virtual environment (venv)"
-    & $pyExe -m venv venv
+    & $pyExe @pyArgs -m venv venv
     if ($LASTEXITCODE -ne 0 -or -not (Test-Path $venvPy)) { Fail "Failed to create the virtual environment." }
 } else {
     Write-Host "venv already exists - skipping creation."


### PR DESCRIPTION
## Summary
- make `launch-windows.ps1` prefer the Windows Python launcher (`py`) and explicitly pick an installed 3.11+ interpreter before creating `venv`
- fail fast with a clearer message when only older Python installs are available
- update the manual Windows setup docs to use `py -3.11 -m venv venv`

## Why
Issue #652 shows the launcher/manual flow can grab an older default Python on Windows, then fail during dependency install with messages like `Could not find a version that satisfies the requirement mcp`. The app requires Python 3.11+, so the Windows entry points should select a compatible interpreter instead of assuming `python` already points at one.

## Scope / non-overlap
- only touches `launch-windows.ps1` and the Windows README instructions
- does **not** replace the Windows app-builder work in #567; it only tightens interpreter selection for the existing launcher/manual install path

## Test Plan
- `git diff --check`
- `git diff --stat origin/main...HEAD`
- inspected the generated script flow to confirm it now prefers `py -3.13/-3.12/-3.11`, falls back to `python` only when it is already 3.11+, and reuses `venv\Scripts\python.exe` after creation
- could not execute the PowerShell launcher end-to-end in this Linux cron environment because `pwsh`/`powershell` is unavailable here

Fixes #652
