### PR TITLE
Fix remote download setup pip fallback in venvs

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -175,7 +175,7 @@ def _pip_install_fallback_chain(package: str, *, python_cmd: str = "python3 -m p
 
 def _remote_linux_download_setup_script() -> str:
     """Build the SSH Linux setup script used before remote HF downloads."""
-    hf_setup = _pip_install_fallback_chain("huggingface_hub hf_transfer", python_cmd="pip")
+    hf_setup = _pip_install_fallback_chain("huggingface_hub hf_transfer")
     return (
         # Install tmux if missing — try common package managers; skip if no sudo
         "if ! command -v tmux >/dev/null 2>&1; then "

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -173,6 +173,25 @@ def _pip_install_fallback_chain(package: str, *, python_cmd: str = "python3 -m p
     return f"{base} || {{ {venv_check} || {user}; }}"
 
 
+def _remote_linux_download_setup_script() -> str:
+    """Build the SSH Linux setup script used before remote HF downloads."""
+    hf_setup = _pip_install_fallback_chain("huggingface_hub hf_transfer", python_cmd="pip")
+    return (
+        # Install tmux if missing — try common package managers; skip if no sudo
+        "if ! command -v tmux >/dev/null 2>&1; then "
+        "  if command -v apt-get >/dev/null 2>&1; then sudo -n apt-get install -y tmux 2>/dev/null; "
+        "  elif command -v pacman >/dev/null 2>&1; then sudo -n pacman -S --noconfirm tmux 2>/dev/null; "
+        "  elif command -v dnf >/dev/null 2>&1; then sudo -n dnf install -y tmux 2>/dev/null; "
+        "  elif command -v apk >/dev/null 2>&1; then sudo -n apk add --no-interactive tmux 2>/dev/null; "
+        "  elif command -v zypper >/dev/null 2>&1; then sudo -n zypper --non-interactive install tmux 2>/dev/null; "
+        "  fi; "
+        "fi; "
+        "command -v tmux >/dev/null 2>&1 || echo 'WARNING: tmux missing and auto-install failed (need passwordless sudo). Install manually.'; "
+        f"{hf_setup}; "
+        "python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")'"
+    )
+
+
 def _cached_model_scan_script(model_dirs: list[str] | None = None) -> str:
     """Build the standalone Python scanner used by /api/model/cached."""
     lines = [

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -38,7 +38,7 @@ from routes.cookbook_helpers import (
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
     _safe_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
     _append_serve_exit_code_lines, _cached_model_scan_script, _ollama_bind_from_cmd,
-    _pip_install_fallback_chain, ModelDownloadRequest, ServeRequest,
+    _pip_install_fallback_chain, _remote_linux_download_setup_script, ModelDownloadRequest, ServeRequest,
 )
 
 _HF_TOKEN_STATUS_SNIPPET = (
@@ -1244,26 +1244,7 @@ def setup_cookbook_routes() -> APIRouter:
             )
             cmd = f"ssh {pf}{host} '{setup_script}'"
         else:
-            # Linux: auto-install tmux (via whichever package manager is available)
-            # and huggingface_hub + hf_transfer (falling back to --user/--break-system-packages
-            # on PEP-668 locked distros like Arch / newer Debian).
-            setup_script = (
-                # Install tmux if missing — try common package managers; skip if no sudo
-                "if ! command -v tmux >/dev/null 2>&1; then "
-                "  if command -v apt-get >/dev/null 2>&1; then sudo -n apt-get install -y tmux 2>/dev/null; "
-                "  elif command -v pacman >/dev/null 2>&1; then sudo -n pacman -S --noconfirm tmux 2>/dev/null; "
-                "  elif command -v dnf >/dev/null 2>&1; then sudo -n dnf install -y tmux 2>/dev/null; "
-                "  elif command -v apk >/dev/null 2>&1; then sudo -n apk add --no-interactive tmux 2>/dev/null; "
-                "  elif command -v zypper >/dev/null 2>&1; then sudo -n zypper --non-interactive install tmux 2>/dev/null; "
-                "  fi; "
-                "fi; "
-                "command -v tmux >/dev/null 2>&1 || echo 'WARNING: tmux missing and auto-install failed (need passwordless sudo). Install manually.'; "
-                # Install Python bits. Try system install first; fall back to --user --break-system-packages on PEP 668 systems.
-                "pip install -q huggingface_hub hf_transfer 2>/dev/null || "
-                "pip install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null || "
-                "pip3 install --user --break-system-packages -q huggingface_hub hf_transfer 2>/dev/null; "
-                "python3 -c 'from huggingface_hub import snapshot_download; print(\"OK\")'"
-            )
+            setup_script = _remote_linux_download_setup_script()
             cmd = f"ssh {pf}{host} '{setup_script}'"
 
         try:

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -104,10 +104,10 @@ def test_pip_install_fallback_chain_allows_custom_python_command():
 def test_remote_linux_download_setup_avoids_user_install_inside_venv():
     script = _remote_linux_download_setup_script()
 
-    assert "pip install -q huggingface_hub hf_transfer" in script
-    assert 'python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"' in script
-    assert "|| pip install --user --break-system-packages -q huggingface_hub hf_transfer" in script
-    assert script.index('python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"') < script.index("|| pip install --user")
+    assert "python3 -m pip install -q huggingface_hub hf_transfer" in script
+    assert 'python3 -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"' in script
+    assert "|| python3 -m pip install --user --break-system-packages -q huggingface_hub hf_transfer" in script
+    assert script.index('python3 -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"') < script.index("|| python3 -m pip install --user")
 
 
 def test_serve_preflight_failure_keeps_tmux_pane_visible():

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -11,6 +11,7 @@ from routes.cookbook_helpers import (
     _append_serve_preflight_exit_lines,
     _local_tooling_path_export,
     _pip_install_fallback_chain,
+    _remote_linux_download_setup_script,
     _ollama_bind_from_cmd,
     _safe_env_prefix,
     _validate_gpus,
@@ -98,6 +99,15 @@ def test_pip_install_fallback_chain_allows_custom_python_command():
         'python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"'
         ' || pip install --user --break-system-packages -q hf_transfer 2>/dev/null; }'
     )
+
+
+def test_remote_linux_download_setup_avoids_user_install_inside_venv():
+    script = _remote_linux_download_setup_script()
+
+    assert "pip install -q huggingface_hub hf_transfer" in script
+    assert 'python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"' in script
+    assert "|| pip install --user --break-system-packages -q huggingface_hub hf_transfer" in script
+    assert script.index('python -c "import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)"') < script.index("|| pip install --user")
 
 
 def test_serve_preflight_failure_keeps_tmux_pane_visible():


### PR DESCRIPTION
## Summary
- move the remote Linux download setup script into a testable helper
- reuse the venv-aware pip fallback chain for remote huggingface_hub/hf_transfer setup
- prevent failed venv installs from falling through to invalid pip --user installs

Fixes #885

## Validation
- .venv/bin/python -m pytest tests/test_cookbook_helpers.py -k 'pip_install_fallback_chain or remote_linux_download_setup' -q
- .venv/bin/python -m py_compile routes/cookbook_helpers.py routes/cookbook_routes.py tests/test_cookbook_helpers.py