### PR TITLE
feat(setup): prompt for admin credentials on first run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,33 @@ def init_database():
     print("  [ok] Database initialized")
 
 
+def _prompt_admin_credentials():
+    """Interactively ask for admin username and password when running in a terminal."""
+    import getpass
+
+    print()
+    print("  Set up your admin account:")
+    print("  (Press Enter to accept defaults)")
+    print()
+
+    username = input("  Username [admin]: ").strip().lower()
+    if not username:
+        username = "admin"
+
+    while True:
+        password = getpass.getpass("  Password: ")
+        if not password:
+            print("  Password cannot be empty.")
+            continue
+        confirm = getpass.getpass("  Confirm password: ")
+        if password != confirm:
+            print("  Passwords don't match. Try again.")
+            continue
+        break
+
+    return username, password
+
+
 def create_default_admin():
     """Create an initial admin user if none exists."""
     auth_path = os.path.join(DATA_DIR, "auth.json")
@@ -54,8 +81,22 @@ def create_default_admin():
         import bcrypt
         import json
 
-        username = os.getenv("ODYSSEUS_ADMIN_USER", "admin").strip().lower() or "admin"
-        password = os.getenv("ODYSSEUS_ADMIN_PASSWORD") or __import__("secrets").token_urlsafe(18)
+        # Priority: env vars > interactive prompt > random password
+        username = os.getenv("ODYSSEUS_ADMIN_USER", "").strip().lower()
+        password = os.getenv("ODYSSEUS_ADMIN_PASSWORD", "").strip()
+
+        if username and password:
+            # Both provided via env — use them directly
+            pass
+        elif sys.stdin.isatty() and not os.getenv("ODYSSEUS_SKIP_ADMIN_PROMPT"):
+            # Interactive terminal — ask the user
+            username, password = _prompt_admin_credentials()
+        else:
+            # Non-interactive (Docker, CI) — fall back to generated password
+            username = username or "admin"
+            password = password or __import__("secrets").token_urlsafe(18)
+
+        username = username or "admin"
         hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
         auth_data = {
             "users": {
@@ -67,9 +108,14 @@ def create_default_admin():
         }
         with open(auth_path, "w", encoding="utf-8") as f:
             json.dump(auth_data, f, indent=2)
-        print(f"  [ok] Initial admin user created ({username})")
-        print(f"        Temporary password: {password}")
-        print(f"        ** Change it after first login. Set ODYSSEUS_ADMIN_PASSWORD to choose your own. **")
+
+        if sys.stdin.isatty() and not os.getenv("ODYSSEUS_ADMIN_PASSWORD"):
+            print(f"  [ok] Admin account created ({username})")
+        else:
+            print(f"  [ok] Initial admin user created ({username})")
+            if not os.getenv("ODYSSEUS_ADMIN_PASSWORD"):
+                print(f"        Temporary password: {password}")
+                print(f"        ** Change it after first login. Set ODYSSEUS_ADMIN_PASSWORD to choose your own. **")
         return "created"
     except ImportError:
         print("  [warn] bcrypt not installed — skipping admin user creation")
@@ -160,7 +206,7 @@ def main():
 
     # Cleaned, action-focused final instruction strings
     if admin_status == "created":
-        print("Login with the admin username and temporary password printed above.\n")
+        print("Login with your admin credentials.\n")
     elif admin_status == "exists":
         print("Login with your existing admin credentials.\n")
     elif admin_status == "skipped":

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -118,9 +118,9 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$PY" -m pip install --quiet --upgrade pip
+./venv/bin/python -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
-"$PY" -m pip install -r requirements.txt
+./venv/bin/python -m pip install -r requirements.txt
 
 # 4. First-run setup: creates data dirs and prints an initial admin password
 #    the first time (idempotent — does nothing if already set up). Suppress its
@@ -179,4 +179,4 @@ if [ -n "$TAILSCALE_URL" ]; then
 fi
 echo "  (this takes a few seconds; press Ctrl+C here to stop)"
 echo
-"$PY" -m uvicorn app:app --host "$HOST" --port "$PORT"
+./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -118,9 +118,9 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-./venv/bin/python -m pip install --quiet --upgrade pip
+"$PY" -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
-./venv/bin/python -m pip install -r requirements.txt
+"$PY" -m pip install -r requirements.txt
 
 # 4. First-run setup: creates data dirs and prints an initial admin password
 #    the first time (idempotent — does nothing if already set up). Suppress its
@@ -179,4 +179,4 @@ if [ -n "$TAILSCALE_URL" ]; then
 fi
 echo "  (this takes a few seconds; press Ctrl+C here to stop)"
 echo
-./venv/bin/python -m uvicorn app:app --host "$HOST" --port "$PORT"
+"$PY" -m uvicorn app:app --host "$HOST" --port "$PORT"


### PR DESCRIPTION
## Summary
- On first run in a terminal, `setup.py` now interactively asks the user to set a username and password instead of generating a random temporary password that easily scrolls off-screen
- Password entry uses `getpass` (hidden input) with a confirmation prompt to catch typos
- Existing non-interactive behavior is fully preserved: env vars (`ODYSSEUS_ADMIN_USER` / `ODYSSEUS_ADMIN_PASSWORD`) take priority, and Docker/CI contexts still get a random password printed to the log
- `ODYSSEUS_SKIP_ADMIN_PROMPT=1` available as an opt-out for scripted installs that want the old random-password behavior in a TTY

## Test plan
- [ ] Delete `data/auth.json` and run `python setup.py` in a terminal — should prompt for username/password
- [ ] Run with `ODYSSEUS_ADMIN_PASSWORD=test python setup.py` — should skip the prompt and use the env var
- [ ] Run with `echo | python setup.py` (non-TTY stdin) — should fall back to random password
- [ ] Run with `ODYSSEUS_SKIP_ADMIN_PROMPT=1 python setup.py` — should fall back to random password
- [ ] Verify re-running when `auth.json` exists prints `[skip]` and doesn't prompt
- [ ] Log in with the credentials you chose

🤖 Generated with [Claude Code](https://claude.com/claude-code)