### PR TITLE
fix(llm): pass num_ctx to Ollama so prompts are not silently truncated at 2048 (fixes #909)

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 import json
 import logging
+from src.model_context import get_context_length
 import hashlib
 import threading
 from fastapi import HTTPException
@@ -238,6 +239,7 @@ def _build_ollama_payload(
     max_tokens: int,
     stream: bool = False,
     tools: Optional[List[Dict]] = None,
+    context_length: Optional[int] = None,
 ) -> Dict:
     payload: Dict = {
         "model": model,
@@ -249,6 +251,11 @@ def _build_ollama_payload(
         options["temperature"] = temperature
     if max_tokens and max_tokens > 0:
         options["num_predict"] = max_tokens
+    # Tell Ollama to actually use the model context window we expect.
+    # Without this, Ollama silently caps at num_ctx=2048 regardless of
+    # the model's declared capability, and long prompts get truncated.
+    if context_length and context_length > 2048:
+        options["num_ctx"] = context_length
     if options:
         payload["options"] = options
     if tools:
@@ -675,7 +682,8 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        ctx = get_context_length(url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False, context_length=ctx)
     else:
         target_url = url
         payload = {
@@ -790,7 +798,8 @@ async def llm_call_async(
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        ctx = get_context_length(url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False, context_length=ctx)
     else:
         target_url = url
         h = _provider_headers(provider, headers)
@@ -888,7 +897,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
+        ctx = get_context_length(url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools, context_length=ctx)
     else:
         target_url = url
         payload = {

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -25,6 +25,9 @@ def test_llm_call_posts_native_ollama_payload(monkeypatch):
         )
 
     monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+    # `llm_call` looks up the model's context window so it can pass num_ctx
+    # to Ollama. Without a mock, get_context_length would hit the network.
+    monkeypatch.setattr(llm_core, "get_context_length", lambda url, model: 0)
 
     result = llm_core.llm_call(
         "https://ollama.com/api",
@@ -113,3 +116,36 @@ def test_ollama_payload_tolerates_malformed_arguments():
     payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
     # Falls back to an empty object rather than raising.
     assert payload["messages"][0]["tool_calls"][0]["function"]["arguments"] == {}
+
+
+# ---------------------------------------------------------------------------
+# num_ctx must be sent to Ollama so the model gets the full context window
+# it advertises. Without this Ollama silently caps inputs at 2048 tokens
+# regardless of model capability, and long prompts get truncated.
+# ---------------------------------------------------------------------------
+
+def test_ollama_payload_includes_num_ctx_when_provided():
+    payload = llm_core._build_ollama_payload(
+        "minimax-m3", [{"role": "user", "content": "hi"}],
+        temperature=0.0, max_tokens=0, context_length=131072,
+    )
+    assert payload["options"]["num_ctx"] == 131072
+
+
+def test_ollama_payload_omits_num_ctx_when_not_provided():
+    payload = llm_core._build_ollama_payload(
+        "minimax-m3", [{"role": "user", "content": "hi"}],
+        temperature=0.0, max_tokens=0,
+    )
+    assert "num_ctx" not in payload.get("options", {})
+
+
+def test_ollama_payload_omits_num_ctx_at_or_below_default():
+    """Ollama already defaults num_ctx to 2048; setting it explicitly is wasted
+    payload bytes and risks misleading callers."""
+    for ctx in (0, 1024, 2048):
+        payload = llm_core._build_ollama_payload(
+            "m", [{"role": "user", "content": "hi"}],
+            temperature=0.0, max_tokens=0, context_length=ctx,
+        )
+        assert "num_ctx" not in payload.get("options", {}), f"num_ctx leaked for ctx={ctx}"


### PR DESCRIPTION
## Summary

Fixes #909.

`src/llm_core.py:_build_ollama_payload` previously sent only `num_predict` (output cap) to Ollama, never `num_ctx` (input window). Ollama defaults `num_ctx` to **2048 tokens** regardless of the model's advertised window, so every prompt was silently capped at 2K input tokens even for 1M-context models like `minimax-m3` or `kimi-k2`.

## What this PR does

- Threads `context_length` through `_build_ollama_payload`
- Emits `options.num_ctx = context_length` only when `> 2048` (otherwise Ollama's default applies)
- Three chat callers in `src/llm_core.py` look up the value via the existing `get_context_length(url, model)` helper (already cached in `src/model_context.py`)
- The endpoint-test caller in `routes/model_routes.py` is intentionally unchanged — it sends a 5-token connectivity probe where `num_ctx` is irrelevant

## Diff

```
 src/llm_core.py                | 16 ++++++++++++++--
 tests/test_llm_core_ollama.py  | 36 +++++++++++++++++++++++++++++++++++-
 2 files changed, 49 insertions(+), 3 deletions(-)
```

## Tests

`tests/test_llm_core_ollama.py` grows from 6 to 9 cases:

- `test_ollama_payload_includes_num_ctx_when_provided` — explicit `context_length=131072` lands in `options["num_ctx"]`
- `test_ollama_payload_omits_num_ctx_when_not_provided` — default behavior is unchanged
- `test_ollama_payload_omits_num_ctx_at_or_below_default` — values of 0, 1024, 2048 do **not** override Ollama's own default (avoids wasted payload bytes and misleading callers)
- Existing `test_llm_call_posts_native_ollama_payload` updated to mock `get_context_length` (the new caller path would otherwise hit the network in tests)

```
$ python -m pytest tests/test_llm_core_ollama.py -v
========================= 9 passed in 0.15s =========================
```

## End-to-end verified on a real Linux/Docker host

Built this branch from scratch on Ubuntu 24.04 + Docker 29.4.3 + Ollama Cloud (`minimax-m3`, 1M advertised context). Marker-pair test: a long pasted message with `[MARKER-AT-START]` and `[MARKER-AT-END]` ~10KB apart.

- **Before the fix** (current `main`): the model could only quote `MARKER-AT-END`; the start of the message was silently dropped by Ollama before generation.
- **After the fix**: the model quotes both markers verbatim. Full prompt reaches the model.

(Same observation applies to long tool results and large pasted documents that previously caused the agent to "lose track" of context from the front of the message.)

## Relationship to #753

[#753](https://github.com/pewdiepie-archdaemon/odysseus/pull/753) fixes how Odysseus **discovers** the right context length (querying Ollama's `/api/show` for the actual GGUF metadata value). This PR fixes how Odysseus **uses** that value — by passing it explicitly so Ollama actually applies it. The two are sibling halves of the same end-to-end problem; they touch different functions in different files and don't textually conflict.

Either PR can merge first. The combination is what makes the pipeline coherent: #753 ensures the budget is right, this PR ensures Ollama is told to honor that budget.

## Backwards compatibility

- Pure additive: existing calls without `context_length` behave exactly as before
- `num_ctx` only emitted when `> 2048`, so we never push a smaller cap than Ollama's own default
- No new dependencies; uses existing `src.model_context.get_context_length`

## Test plan for the maintainer

- [x] `python -m pytest tests/test_llm_core_ollama.py` — 9 passed
- [x] Diff is exclusively additive in `_build_ollama_payload` and at three caller sites; no semantic change to non-Ollama paths
- [ ] Maintainer: rebuild and exercise an Ollama chat with a long input (markdown table, large paste). Confirm the response references the head of the prompt, not only the tail.