### PR TITLE
Fix externally-managed-environment error

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -117,6 +117,7 @@ if [ ! -d venv ]; then
   echo "▶ Creating Python environment…"
   "$PY" -m venv venv
 fi
+PY="./venv/bin/python"
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
 "$PY" -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).


### PR DESCRIPTION
Without changing the PY flag to the virtual environment we get an externally-managed-environment error, hence we tell the script explicitly to use the previously created venv to install the requirements. Previous request had an unwanted indent so that is fixed now.