### PR TITLE
fix(calendar): push CalDAV writes back to remote server

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -740,15 +740,18 @@ def setup_calendar_routes() -> APIRouter:
             db.add(ev)
             db.commit()
 
+            resp = {"ok": True, "uid": uid}
             if cal.source == "caldav":
                 from src.caldav_sync import push_event_create
-                await push_event_create(
+                push_err = await push_event_create(
                     owner, cal.id, uid, data.summary,
                     data.description or "", data.location or "",
                     dtstart, dtend, data.all_day, data.rrule or "",
                 )
+                if push_err:
+                    resp["sync_warning"] = f"Saved locally but remote sync failed: {push_err}"
 
-            return {"ok": True, "uid": uid}
+            return resp
         except HTTPException:
             raise
         except Exception as e:
@@ -795,18 +798,21 @@ def setup_calendar_routes() -> APIRouter:
                 ev.color = data.color if data.color else None
             db.commit()
 
+            resp = {"ok": True}
             cal = db.query(CalendarCal).filter(
                 CalendarCal.id == ev.calendar_id
             ).first()
             if cal and cal.source == "caldav":
                 from src.caldav_sync import push_event_update
-                await push_event_update(
+                push_err = await push_event_update(
                     owner, cal.id, ev.uid, ev.summary,
                     ev.description or "", ev.location or "",
                     ev.dtstart, ev.dtend, ev.all_day, ev.rrule or "",
                 )
+                if push_err:
+                    resp["sync_warning"] = f"Saved locally but remote sync failed: {push_err}"
 
-            return {"ok": True}
+            return resp
         except HTTPException:
             raise
         except Exception as e:
@@ -836,11 +842,14 @@ def setup_calendar_routes() -> APIRouter:
             db.delete(ev)
             db.commit()
 
+            resp = {"ok": True}
             if cal and cal.source == "caldav":
                 from src.caldav_sync import push_event_delete
-                await push_event_delete(owner, cal_id, event_uid)
+                push_err = await push_event_delete(owner, cal_id, event_uid)
+                if push_err:
+                    resp["sync_warning"] = f"Deleted locally but remote sync failed: {push_err}"
 
-            return {"ok": True}
+            return resp
         except HTTPException:
             raise
         except Exception as e:

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -739,6 +739,15 @@ def setup_calendar_routes() -> APIRouter:
             )
             db.add(ev)
             db.commit()
+
+            if cal.source == "caldav":
+                from src.caldav_sync import push_event_create
+                await push_event_create(
+                    owner, cal.id, uid, data.summary,
+                    data.description or "", data.location or "",
+                    dtstart, dtend, data.all_day, data.rrule or "",
+                )
+
             return {"ok": True, "uid": uid}
         except HTTPException:
             raise
@@ -785,6 +794,18 @@ def setup_calendar_routes() -> APIRouter:
             if data.color is not None:
                 ev.color = data.color if data.color else None
             db.commit()
+
+            cal = db.query(CalendarCal).filter(
+                CalendarCal.id == ev.calendar_id
+            ).first()
+            if cal and cal.source == "caldav":
+                from src.caldav_sync import push_event_update
+                await push_event_update(
+                    owner, cal.id, ev.uid, ev.summary,
+                    ev.description or "", ev.location or "",
+                    ev.dtstart, ev.dtend, ev.all_day, ev.rrule or "",
+                )
+
             return {"ok": True}
         except HTTPException:
             raise
@@ -805,8 +826,20 @@ def setup_calendar_routes() -> APIRouter:
         db = SessionLocal()
         try:
             ev = _get_or_404_event(db, base_uid, owner)
+            cal_id = ev.calendar_id
+            event_uid = ev.uid
+
+            cal = db.query(CalendarCal).filter(
+                CalendarCal.id == cal_id
+            ).first()
+
             db.delete(ev)
             db.commit()
+
+            if cal and cal.source == "caldav":
+                from src.caldav_sync import push_event_delete
+                await push_event_delete(owner, cal_id, event_uid)
+
             return {"ok": True}
         except HTTPException:
             raise

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -296,138 +296,167 @@ def _find_remote_calendar(client, cal_id: str):
 def _build_vcal(uid: str, summary: str, description: str, location: str,
                 dtstart: datetime, dtend: datetime, all_day: bool,
                 rrule: str = "") -> str:
-    """Build a minimal iCalendar VCALENDAR string for a single VEVENT."""
-    def _fmt(dt: datetime, all_day: bool) -> str:
-        if all_day:
-            return dt.strftime("%Y%m%d")
-        return dt.strftime("%Y%m%dT%H%M%SZ")
+    """Build a properly escaped iCalendar VCALENDAR string for a single VEVENT.
 
-    start_str = _fmt(dtstart, all_day)
-    end_str = _fmt(dtend, all_day)
-    dt_param = ";VALUE=DATE" if all_day else ""
+    Uses the `icalendar` package (already a project dependency for the pull
+    path) so that SUMMARY, DESCRIPTION, LOCATION, etc. are correctly escaped
+    and folded per RFC 5545 — commas, semicolons, backslashes, newlines, and
+    long lines are all handled automatically."""
+    from icalendar import Calendar as iCal, Event as iEvent, vDate, vDatetime
 
-    lines = [
-        "BEGIN:VCALENDAR",
-        "VERSION:2.0",
-        "PRODID:-//Odysseus//CalDAV Push//EN",
-        "BEGIN:VEVENT",
-        f"UID:{uid}",
-        f"DTSTART{dt_param}:{start_str}",
-        f"DTEND{dt_param}:{end_str}",
-        f"SUMMARY:{summary}",
-    ]
+    cal = iCal()
+    cal.add("prodid", "-//Odysseus//CalDAV Push//EN")
+    cal.add("version", "2.0")
+
+    ev = iEvent()
+    ev.add("uid", uid)
+    ev.add("summary", summary)
     if description:
-        lines.append(f"DESCRIPTION:{description}")
+        ev.add("description", description)
     if location:
-        lines.append(f"LOCATION:{location}")
+        ev.add("location", location)
+
+    if all_day:
+        ev.add("dtstart", dtstart.date())
+        ev.add("dtend", dtend.date())
+    else:
+        ev.add("dtstart", dtstart.replace(tzinfo=timezone.utc))
+        ev.add("dtend", dtend.replace(tzinfo=timezone.utc))
+
     if rrule:
-        lines.append(f"RRULE:{rrule}")
-    lines += ["END:VEVENT", "END:VCALENDAR"]
-    return "\r\n".join(lines)
+        from icalendar import vRecur
+        ev.add("rrule", vRecur.from_ical(rrule))
+
+    cal.add_component(ev)
+    return cal.to_ical().decode("utf-8")
 
 
 def _push_create_blocking(owner: str, cal_id: str, uid: str,
                           summary: str, description: str, location: str,
                           dtstart: datetime, dtend: datetime,
-                          all_day: bool, rrule: str = "") -> None:
-    """Create an event on the remote CalDAV server."""
+                          all_day: bool, rrule: str = "") -> str | None:
+    """Create an event on the remote CalDAV server.
+    Returns None on success, or an error message string on failure."""
     import caldav
 
     creds = _get_caldav_creds(owner)
     if not creds:
-        return
+        return "CalDAV not configured"
     url, user, pw = creds
     client = caldav.DAVClient(url=url, username=user, password=pw)
     remote_cal = _find_remote_calendar(client, cal_id)
     if not remote_cal:
-        logger.warning("CalDAV push-create: no remote calendar for %s", cal_id)
-        return
+        return f"Remote calendar not found for {cal_id}"
 
     vcal = _build_vcal(uid, summary, description, location,
                        dtstart, dtend, all_day, rrule)
     remote_cal.add_event(vcal)
     logger.info("CalDAV push-create: %s on %s", uid, cal_id)
+    return None
 
 
 def _push_update_blocking(owner: str, cal_id: str, uid: str,
                           summary: str, description: str, location: str,
                           dtstart: datetime, dtend: datetime,
-                          all_day: bool, rrule: str = "") -> None:
-    """Update an existing event on the remote CalDAV server."""
+                          all_day: bool, rrule: str = "") -> str | None:
+    """Update an existing event on the remote CalDAV server.
+    Fetches the existing remote event by UID and replaces its data
+    to avoid creating duplicates. Falls back to add_event if the
+    remote event is not found (e.g. locally created, not yet synced).
+    Returns None on success, or an error message string on failure."""
     import caldav
 
     creds = _get_caldav_creds(owner)
     if not creds:
-        return
+        return "CalDAV not configured"
     url, user, pw = creds
     client = caldav.DAVClient(url=url, username=user, password=pw)
     remote_cal = _find_remote_calendar(client, cal_id)
     if not remote_cal:
-        logger.warning("CalDAV push-update: no remote calendar for %s", cal_id)
-        return
+        return f"Remote calendar not found for {cal_id}"
 
-    # CalDAV uses PUT with the same UID to replace an event.
     vcal = _build_vcal(uid, summary, description, location,
                        dtstart, dtend, all_day, rrule)
-    remote_cal.add_event(vcal)
-    logger.info("CalDAV push-update: %s on %s", uid, cal_id)
+
+    # Try to fetch the existing remote event and update in-place
+    # to avoid creating a duplicate resource.
+    try:
+        remote_event = remote_cal.event_by_uid(uid)
+        remote_event.data = vcal
+        remote_event.save()
+        logger.info("CalDAV push-update (in-place): %s on %s", uid, cal_id)
+    except Exception:
+        # Event doesn't exist remotely yet — create it.
+        remote_cal.add_event(vcal)
+        logger.info("CalDAV push-update (created): %s on %s", uid, cal_id)
+    return None
 
 
-def _push_delete_blocking(owner: str, cal_id: str, uid: str) -> None:
-    """Delete an event from the remote CalDAV server by UID."""
+def _push_delete_blocking(owner: str, cal_id: str, uid: str) -> str | None:
+    """Delete an event from the remote CalDAV server by UID.
+    Returns None on success, or an error message string on failure."""
     import caldav
 
     creds = _get_caldav_creds(owner)
     if not creds:
-        return
+        return "CalDAV not configured"
     url, user, pw = creds
     client = caldav.DAVClient(url=url, username=user, password=pw)
     remote_cal = _find_remote_calendar(client, cal_id)
     if not remote_cal:
-        logger.warning("CalDAV push-delete: no remote calendar for %s", cal_id)
-        return
+        return f"Remote calendar not found for {cal_id}"
 
     try:
         event = remote_cal.event_by_uid(uid)
         event.delete()
         logger.info("CalDAV push-delete: %s from %s", uid, cal_id)
+        return None
     except Exception as e:
-        logger.warning("CalDAV push-delete failed for %s: %s", uid, e)
+        return f"Failed to delete remote event {uid}: {e}"
 
 
 async def push_event_create(owner: str, cal_id: str, uid: str,
                             summary: str, description: str, location: str,
                             dtstart: datetime, dtend: datetime,
-                            all_day: bool, rrule: str = "") -> None:
-    """Push a newly created event to the remote CalDAV server (async)."""
+                            all_day: bool, rrule: str = "") -> str | None:
+    """Push a newly created event to the remote CalDAV server (async).
+    Returns None on success, or an error message string on failure."""
     try:
-        await asyncio.to_thread(
+        return await asyncio.to_thread(
             _push_create_blocking, owner, cal_id, uid,
             summary, description, location, dtstart, dtend, all_day, rrule,
         )
     except Exception as e:
-        logger.error("CalDAV push-create failed: %s", e)
+        msg = f"CalDAV push-create failed: {e}"
+        logger.error(msg)
+        return msg
 
 
 async def push_event_update(owner: str, cal_id: str, uid: str,
                             summary: str, description: str, location: str,
                             dtstart: datetime, dtend: datetime,
-                            all_day: bool, rrule: str = "") -> None:
-    """Push an event update to the remote CalDAV server (async)."""
+                            all_day: bool, rrule: str = "") -> str | None:
+    """Push an event update to the remote CalDAV server (async).
+    Returns None on success, or an error message string on failure."""
     try:
-        await asyncio.to_thread(
+        return await asyncio.to_thread(
             _push_update_blocking, owner, cal_id, uid,
             summary, description, location, dtstart, dtend, all_day, rrule,
         )
     except Exception as e:
-        logger.error("CalDAV push-update failed: %s", e)
+        msg = f"CalDAV push-update failed: {e}"
+        logger.error(msg)
+        return msg
 
 
-async def push_event_delete(owner: str, cal_id: str, uid: str) -> None:
-    """Push an event deletion to the remote CalDAV server (async)."""
+async def push_event_delete(owner: str, cal_id: str, uid: str) -> str | None:
+    """Push an event deletion to the remote CalDAV server (async).
+    Returns None on success, or an error message string on failure."""
     try:
-        await asyncio.to_thread(
+        return await asyncio.to_thread(
             _push_delete_blocking, owner, cal_id, uid,
         )
     except Exception as e:
-        logger.error("CalDAV push-delete failed: %s", e)
+        msg = f"CalDAV push-delete failed: {e}"
+        logger.error(msg)
+        return msg

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -1,9 +1,10 @@
-"""CalDAV → local SQLite sync.
+"""CalDAV ↔ local SQLite sync.
 
 The Settings UI lets users save CalDAV credentials, but the original
 sync path was removed when calendar storage was migrated to SQLite.
-This module re-wires that gap as a one-way pull (remote → local),
-called on calendar open and from a periodic scheduler loop.
+This module re-wires that gap as a two-way sync: pull (remote → local)
+on calendar open and periodic scheduler, push (local → remote) on
+event create/update/delete via the API routes.
 
 Design notes:
 - We use the `caldav` lib so PROPFIND discovery + REPORT XML work
@@ -260,3 +261,173 @@ async def sync_caldav(owner: str) -> dict:
     except Exception as e:
         logger.exception("CalDAV sync raised")
         return {"calendars": 0, "events": 0, "deleted": 0, "errors": [str(e)[:200]]}
+
+
+# ---------------------------------------------------------------------------
+# Write-back: push local changes to remote CalDAV server
+# ---------------------------------------------------------------------------
+
+def _get_caldav_creds(owner: str) -> tuple[str, str, str] | None:
+    """Return (url, username, password) for the owner's CalDAV config,
+    or None if not configured."""
+    from routes.prefs_routes import _load_for_user
+
+    cfg = (_load_for_user(owner) or {}).get("caldav", {}) or {}
+    url = (cfg.get("url") or "").strip()
+    user = (cfg.get("username") or "").strip()
+    pw = cfg.get("password") or ""
+    if not (url and user and pw):
+        return None
+    return url, user, pw
+
+
+def _find_remote_calendar(client, cal_id: str):
+    """Locate the remote CalDAV calendar whose URL hashes to `cal_id`."""
+    try:
+        principal = client.principal()
+        for remote_cal in principal.calendars():
+            if _stable_cal_id(str(remote_cal.url)) == cal_id:
+                return remote_cal
+    except Exception as e:
+        logger.warning("CalDAV calendar discovery failed: %s", e)
+    return None
+
+
+def _build_vcal(uid: str, summary: str, description: str, location: str,
+                dtstart: datetime, dtend: datetime, all_day: bool,
+                rrule: str = "") -> str:
+    """Build a minimal iCalendar VCALENDAR string for a single VEVENT."""
+    def _fmt(dt: datetime, all_day: bool) -> str:
+        if all_day:
+            return dt.strftime("%Y%m%d")
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+
+    start_str = _fmt(dtstart, all_day)
+    end_str = _fmt(dtend, all_day)
+    dt_param = ";VALUE=DATE" if all_day else ""
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Odysseus//CalDAV Push//EN",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTART{dt_param}:{start_str}",
+        f"DTEND{dt_param}:{end_str}",
+        f"SUMMARY:{summary}",
+    ]
+    if description:
+        lines.append(f"DESCRIPTION:{description}")
+    if location:
+        lines.append(f"LOCATION:{location}")
+    if rrule:
+        lines.append(f"RRULE:{rrule}")
+    lines += ["END:VEVENT", "END:VCALENDAR"]
+    return "\r\n".join(lines)
+
+
+def _push_create_blocking(owner: str, cal_id: str, uid: str,
+                          summary: str, description: str, location: str,
+                          dtstart: datetime, dtend: datetime,
+                          all_day: bool, rrule: str = "") -> None:
+    """Create an event on the remote CalDAV server."""
+    import caldav
+
+    creds = _get_caldav_creds(owner)
+    if not creds:
+        return
+    url, user, pw = creds
+    client = caldav.DAVClient(url=url, username=user, password=pw)
+    remote_cal = _find_remote_calendar(client, cal_id)
+    if not remote_cal:
+        logger.warning("CalDAV push-create: no remote calendar for %s", cal_id)
+        return
+
+    vcal = _build_vcal(uid, summary, description, location,
+                       dtstart, dtend, all_day, rrule)
+    remote_cal.add_event(vcal)
+    logger.info("CalDAV push-create: %s on %s", uid, cal_id)
+
+
+def _push_update_blocking(owner: str, cal_id: str, uid: str,
+                          summary: str, description: str, location: str,
+                          dtstart: datetime, dtend: datetime,
+                          all_day: bool, rrule: str = "") -> None:
+    """Update an existing event on the remote CalDAV server."""
+    import caldav
+
+    creds = _get_caldav_creds(owner)
+    if not creds:
+        return
+    url, user, pw = creds
+    client = caldav.DAVClient(url=url, username=user, password=pw)
+    remote_cal = _find_remote_calendar(client, cal_id)
+    if not remote_cal:
+        logger.warning("CalDAV push-update: no remote calendar for %s", cal_id)
+        return
+
+    # CalDAV uses PUT with the same UID to replace an event.
+    vcal = _build_vcal(uid, summary, description, location,
+                       dtstart, dtend, all_day, rrule)
+    remote_cal.add_event(vcal)
+    logger.info("CalDAV push-update: %s on %s", uid, cal_id)
+
+
+def _push_delete_blocking(owner: str, cal_id: str, uid: str) -> None:
+    """Delete an event from the remote CalDAV server by UID."""
+    import caldav
+
+    creds = _get_caldav_creds(owner)
+    if not creds:
+        return
+    url, user, pw = creds
+    client = caldav.DAVClient(url=url, username=user, password=pw)
+    remote_cal = _find_remote_calendar(client, cal_id)
+    if not remote_cal:
+        logger.warning("CalDAV push-delete: no remote calendar for %s", cal_id)
+        return
+
+    try:
+        event = remote_cal.event_by_uid(uid)
+        event.delete()
+        logger.info("CalDAV push-delete: %s from %s", uid, cal_id)
+    except Exception as e:
+        logger.warning("CalDAV push-delete failed for %s: %s", uid, e)
+
+
+async def push_event_create(owner: str, cal_id: str, uid: str,
+                            summary: str, description: str, location: str,
+                            dtstart: datetime, dtend: datetime,
+                            all_day: bool, rrule: str = "") -> None:
+    """Push a newly created event to the remote CalDAV server (async)."""
+    try:
+        await asyncio.to_thread(
+            _push_create_blocking, owner, cal_id, uid,
+            summary, description, location, dtstart, dtend, all_day, rrule,
+        )
+    except Exception as e:
+        logger.error("CalDAV push-create failed: %s", e)
+
+
+async def push_event_update(owner: str, cal_id: str, uid: str,
+                            summary: str, description: str, location: str,
+                            dtstart: datetime, dtend: datetime,
+                            all_day: bool, rrule: str = "") -> None:
+    """Push an event update to the remote CalDAV server (async)."""
+    try:
+        await asyncio.to_thread(
+            _push_update_blocking, owner, cal_id, uid,
+            summary, description, location, dtstart, dtend, all_day, rrule,
+        )
+    except Exception as e:
+        logger.error("CalDAV push-update failed: %s", e)
+
+
+async def push_event_delete(owner: str, cal_id: str, uid: str) -> None:
+    """Push an event deletion to the remote CalDAV server (async)."""
+    try:
+        await asyncio.to_thread(
+            _push_delete_blocking, owner, cal_id, uid,
+        )
+    except Exception as e:
+        logger.error("CalDAV push-delete failed: %s", e)


### PR DESCRIPTION
## Summary
- CalDAV sync was read-only — pull (remote → local) worked, but create/update/delete in Odysseus only modified the local DB and never pushed back to the remote CalDAV server
- Adds `push_event_create`, `push_event_update`, and `push_event_delete` to `caldav_sync.py` using the `caldav` library's `add_event`, `save`, and `delete` methods
- Wires push calls into the three calendar route handlers (`POST /events`, `PUT /events/{uid}`, `DELETE /events/{uid}`), only when the parent calendar has `source="caldav"`
- Push runs in a threadpool via `asyncio.to_thread` (same pattern as the existing pull path)
- Local-only calendars are completely unaffected

Fixes #800

## Test plan
- [ ] Configure CalDAV with iCloud (or Radicale/Nextcloud) in Settings
- [ ] Create an event in Odysseus on a CalDAV calendar → verify it appears on the remote (iPhone, web client)
- [ ] Update the event in Odysseus → verify change syncs to remote
- [ ] Delete the event in Odysseus → verify it disappears from remote
- [ ] Create an event on a local-only calendar → verify no CalDAV push attempted (check logs)
- [ ] Verify existing pull sync still works (create event on phone → appears in Odysseus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)