### PR TITLE
Fix companion pairing admin guard import

### DIFF
--- a/companion/routes.py
+++ b/companion/routes.py
@@ -21,6 +21,7 @@ import html
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
+from core.middleware import require_admin
 from src.auth_helpers import get_current_user
 
 from companion import pairing as _pairing

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -62,6 +62,7 @@ for _name, _attrs in {
 from fastapi import HTTPException  # noqa: E402
 
 import companion.pairing as P  # noqa: E402
+import companion.routes as companion_routes  # noqa: E402
 from companion.routes import mint_pairing_token, setup_companion_routes  # noqa: E402
 from core.middleware import require_admin  # noqa: E402
 
@@ -148,9 +149,24 @@ def _pair_methods():
     return methods
 
 
+def _pair_endpoint(method):
+    router = setup_companion_routes()
+    for r in router.routes:
+        if getattr(r, "path", "").endswith("/pair") and method in getattr(r, "methods", set()):
+            return r.endpoint
+    raise AssertionError(f"{method} /api/companion/pair route not found")
+
+
 def test_pair_is_minted_via_post_not_get():
     methods = _pair_methods()
     assert "POST" in methods, "pairing must accept POST (the mint)"
     assert "GET" in methods, "GET should render the form page"
     # The distinction is enforced in the handlers: GET renders a form and never
     # mints; only POST calls mint_pairing_token.
+
+
+def test_pair_page_uses_imported_admin_gate(monkeypatch):
+    monkeypatch.setattr(companion_routes, "require_admin", lambda request: None)
+    response = _pair_endpoint("GET")(SimpleNamespace())
+
+    assert "Pair a device" in str(getattr(response, "body", response))


### PR DESCRIPTION
## Summary

Fixes a runtime `NameError` in the companion pairing routes.

`/api/companion/pair` calls `require_admin(request)` but `companion/routes.py` did not import `require_admin`, so the pairing page/create handlers could fail when reached.

## Changes

- Import `require_admin` from `core.middleware`.
- Add a regression test that calls the companion pairing GET handler with the admin guard patched.

## Testing

- `.venv/bin/python -m pytest tests/test_companion_pairing.py -q`
- `python -m py_compile companion/routes.py tests/test_companion_pairing.py`
- `git diff --check`