### PR TITLE
Restrict app_api and serve_preset to admins

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -168,6 +168,7 @@ async def _run_subprocess_streaming(
     )
 
 _ADMIN_TOOLS = {
+    "app_api",
     "manage_endpoints",
     "manage_mcp",
     "manage_webhooks",
@@ -175,6 +176,7 @@ _ADMIN_TOOLS = {
     "manage_settings",
     "download_model",
     "serve_model",
+    "serve_preset",
     "stop_served_model",
     "cancel_download",
 }

--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -40,6 +40,7 @@ NON_ADMIN_BLOCKED_TOOLS = {
     "vault_unlock",
     "download_model",
     "serve_model",
+    "serve_preset",
     "stop_served_model",
     "cancel_download",
     "adopt_served_model",

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -399,14 +399,15 @@ async def test_admin_agent_tools_require_admin(monkeypatch):
 
     monkeypatch.setattr(auth_mod, "AuthManager", lambda: FakeAuth())
 
-    desc, result = await execute_tool_block(
-        SimpleNamespace(tool_type="manage_tokens", content='{"action":"create","name":"bad"}'),
-        owner="regular-user",
-    )
+    for tool_name in ("manage_tokens", "app_api", "serve_preset"):
+        desc, result = await execute_tool_block(
+            SimpleNamespace(tool_type=tool_name, content='{"action":"create","name":"bad"}'),
+            owner="regular-user",
+        )
 
-    assert desc == "manage_tokens: BLOCKED"
-    assert result["exit_code"] == 1
-    assert "requires an admin" in result["error"]
+        assert desc == f"{tool_name}: BLOCKED"
+        assert result["exit_code"] == 1
+        assert "requires an admin" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -422,7 +423,7 @@ async def test_public_agent_policy_blocks_sensitive_tools(monkeypatch):
 
     monkeypatch.setattr(auth_mod, "AuthManager", lambda: FakeAuth())
 
-    for tool_name in ("send_email", "read_file", "app_api", "mcp__email__send_email"):
+    for tool_name in ("send_email", "read_file", "mcp__email__send_email"):
         desc, result = await execute_tool_block(
             SimpleNamespace(tool_type=tool_name, content="{}"),
             owner="regular-user",
@@ -449,6 +450,7 @@ def test_public_agent_policy_hides_sensitive_tools(monkeypatch):
     assert "send_email" in blocked
     assert "read_file" in blocked
     assert "app_api" in blocked
+    assert "serve_preset" in blocked
     assert "manage_tasks" in blocked
 
 


### PR DESCRIPTION
## Summary
- require admin context before executing app_api or serve_preset
- hide serve_preset from non-admin/public tool policy
- extend regression coverage for admin execution gates and public tool hiding

## Related
This is an updated split from #734 after maintainer feedback asked for separate vulnerability-class PRs with regression tests. This PR keeps only the app_api/serve_preset admin-tool gating slice and leaves the other bundled fixes out.

## Tests
- python -m pytest tests/test_review_regressions.py -k "admin_agent_tools_require_admin or public_agent_policy"