### PR TITLE
FIX: use venv-aware pip fallback for Cookbook dependency

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1097,7 +1097,15 @@ def setup_cookbook_routes() -> APIRouter:
                     runner_lines,
                     keep_shell_open=not local_windows,
                 )
-                runner_lines.append(req.cmd)
+                if is_pip_install:
+                    # The client may include --user --break-system-packages,
+                    # which pip refuses inside a virtualenv. Use the venv-aware
+                    # fallback chain instead so installs work regardless of
+                    # whether the serve shell inherits a venv from the user's PATH.
+                    _pip_upgrade = bool(req.cmd and ("-U " in req.cmd or "--upgrade " in req.cmd))
+                    runner_lines.append(_pip_install_fallback_chain(req.repo_id, upgrade=_pip_upgrade))
+                else:
+                    runner_lines.append(req.cmd)
                 if local_windows:
                     # Detached background process — no interactive shell to keep open.
                     # Print the exit marker the status poller looks for, then stop.

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -91,6 +91,26 @@ def test_pip_install_fallback_chain_prefers_venv_safe_install():
     assert "|| python3 -m pip install --user --break-system-packages -q -U huggingface_hub" in chain
 
 
+def test_pip_install_fallback_chain_skips_user_flag_inside_venv():
+    """The fallback chain must not run --user when inside a virtualenv.
+
+    pip refuses --user in a venv with "User site-packages are not visible
+    in this virtualenv." The chain guards the --user attempt with a venv
+    check that exits non-zero when IN a venv, skipping the --user branch.
+    """
+    chain = _pip_install_fallback_chain("vllm")
+    # Plain install must come first (works in venvs and system python alike).
+    bare_idx = chain.index("python3 -m pip install -q vllm")
+    # venv check must appear before the --user fallback.
+    venv_check = 'sys.exit(0 if sys.prefix != sys.base_prefix else 1)'
+    assert venv_check in chain
+    venv_idx = chain.index(venv_check)
+    user_idx = chain.index("--user")
+    assert bare_idx < venv_idx < user_idx, (
+        "Chain must try bare install first, then check for venv, then --user"
+    )
+
+
 def test_pip_install_fallback_chain_allows_custom_python_command():
     chain = _pip_install_fallback_chain("hf_transfer", python_cmd="pip", upgrade=False)
     assert chain == (


### PR DESCRIPTION

When Odysseus runs inside a virtualenv, the Cookbook dependency installer was generating pip commands with --user --break-system-packages based on client-side env detection. pip refuses --user inside a venv with "User site-packages are not visible in this virtualenv", silently breaking vLLM/SGLang/etc installs.

Fix: for is_pip_install serve requests, replace the client-supplied command with _pip_install_fallback_chain, which first tries a plain install (works in both venvs and system python) and only falls back to --user when the python interpreter confirms it is outside a virtualenv.

Adds a test asserting the venv check appears before the --user fallback.

Fixes #885.