### PR TITLE
fix(model_context): query Ollama api/show for serving context

### DIFF
--- a/src/model_context.py
+++ b/src/model_context.py
@@ -29,6 +29,16 @@ def _is_local_endpoint(url: str) -> bool:
     except Exception:
         return False
 
+
+def _is_ollama_endpoint(url: str) -> bool:
+    """Check if URL points to a local Ollama-style endpoint."""
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        return _is_local_endpoint(url) and (parsed.port == 11434 or "ollama" in host.lower())
+    except Exception:
+        return False
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -214,40 +224,59 @@ def _query_context_length(endpoint_url: str, model: str) -> int:
         except Exception:
             pass
 
-    models_url = endpoint_url.replace("/chat/completions", "/models")
-    try:
-        r = httpx.get(models_url, timeout=REQUEST_TIMEOUT)
-        if r.is_success:
-            data = r.json()
-            models_list = data.get("data") or []
-
-            for m in models_list:
-                mid = m.get("id", "")
-                if mid == model or mid.split("/")[-1] == model.split("/")[-1]:
-                    for field in (
-                        "context_length",
-                        "context_window",
-                        "max_model_len",
-                        "max_context_length",
-                        "max_seq_len",
-                    ):
-                        val = m.get(field)
-                        if val and isinstance(val, (int, float)) and val > 0:
-                            api_ctx = int(val)
+    # Try Ollama /api/show for local endpoints. Ollama's OpenAI-compatible
+    # /v1/models response omits context_length, while model_info reports the
+    # serving context it uses by default.
+    if _is_ollama_endpoint(endpoint_url):
+        try:
+            base = endpoint_url.split("/v1")[0] if "/v1" in endpoint_url else endpoint_url.rsplit("/", 1)[0]
+            r = httpx.post(f"{base}/api/show", json={"name": model}, timeout=REQUEST_TIMEOUT)
+            if r.is_success:
+                model_info = (r.json() or {}).get("model_info") or {}
+                if isinstance(model_info, dict):
+                    for key, val in model_info.items():
+                        if key.endswith(".context_length") and isinstance(val, int) and val > 0:
+                            logger.info(f"Ollama /api/show reports context_length={val} for {model}")
+                            api_ctx = val
                             break
+        except Exception:
+            pass
 
-                    if not api_ctx:
-                        meta = m.get("meta") or m.get("model_extra") or {}
-                        if isinstance(meta, dict):
-                            # n_ctx is the actual serving context (set via -c flag in llama.cpp)
-                            for field in ("n_ctx", "context_length", "context_window", "max_model_len"):
-                                val = meta.get(field)
-                                if val and isinstance(val, (int, float)) and val > 0:
-                                    api_ctx = int(val)
-                                    break
-                    break
-    except Exception as e:
-        logger.debug(f"Failed to query context length for {model}: {e}")
+    if api_ctx is None:
+        models_url = endpoint_url.replace("/chat/completions", "/models")
+        try:
+            r = httpx.get(models_url, timeout=REQUEST_TIMEOUT)
+            if r.is_success:
+                data = r.json()
+                models_list = data.get("data") or []
+
+                for m in models_list:
+                    mid = m.get("id", "")
+                    if mid == model or mid.split("/")[-1] == model.split("/")[-1]:
+                        for field in (
+                            "context_length",
+                            "context_window",
+                            "max_model_len",
+                            "max_context_length",
+                            "max_seq_len",
+                        ):
+                            val = m.get(field)
+                            if val and isinstance(val, (int, float)) and val > 0:
+                                api_ctx = int(val)
+                                break
+
+                        if not api_ctx:
+                            meta = m.get("meta") or m.get("model_extra") or {}
+                            if isinstance(meta, dict):
+                                # n_ctx is the actual serving context (set via -c flag in llama.cpp)
+                                for field in ("n_ctx", "context_length", "context_window", "max_model_len"):
+                                    val = meta.get(field)
+                                    if val and isinstance(val, (int, float)) and val > 0:
+                                        api_ctx = int(val)
+                                        break
+                        break
+        except Exception as e:
+            logger.debug(f"Failed to query context length for {model}: {e}")
 
     # For local/self-hosted endpoints, trust the API value (user set --max-model-len)
     # For cloud APIs, use the larger value (API can report low defaults)

--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -1,9 +1,10 @@
 """Tests for model_context.py — local endpoint detection, token estimation, known model lookup."""
 
+import httpx
 import pytest
 
 import src.model_context as model_context
-from src.model_context import _is_local_endpoint, estimate_tokens, _lookup_known
+from src.model_context import DEFAULT_CONTEXT, _is_local_endpoint, estimate_tokens, _lookup_known
 
 
 class TestIsLocalEndpoint:
@@ -22,6 +23,9 @@ class TestIsLocalEndpoint:
     def test_tailscale_100(self):
         # 100.64.0.0/10 is the CGNAT range Tailscale uses.
         assert _is_local_endpoint("http://100.64.0.1:5000/v1/chat/completions") is True
+
+    def test_host_docker_internal(self):
+        assert _is_local_endpoint("http://host.docker.internal:11434/v1/chat/completions") is True
 
     def test_openai_is_remote(self):
         assert _is_local_endpoint("https://api.openai.com/v1/chat/completions") is False
@@ -109,7 +113,6 @@ class TestLookupKnown:
         result = _lookup_known("deepseek-r1:free")
         assert result == 64000
 
-
 class TestGetContextLength:
     def setup_method(self):
         model_context._context_cache.clear()
@@ -151,3 +154,143 @@ class TestGetContextLength:
         assert first == 200000
         assert second == 200000
         assert len(calls) == 1
+
+
+class TestQueryContextLength:
+    OLLAMA_URL = "http://localhost:11434/v1/chat/completions"
+    REMOTE_URL = "https://api.openai.com/v1/chat/completions"
+
+    def _response(self, method, url, status, body):
+        req = httpx.Request(method, url)
+        return httpx.Response(status, request=req, json=body)
+
+    def test_ollama_api_show_used_for_local_endpoint(self, monkeypatch):
+        post_calls = []
+        get_calls = []
+
+        def fake_get(url, timeout=None):
+            get_calls.append(url)
+            if url.endswith("/slots"):
+                raise httpx.ConnectError("slots unavailable")
+            return self._response("GET", url, 200, {"data": []})
+
+        def fake_post(url, json=None, timeout=None):
+            post_calls.append((url, json))
+            return self._response(
+                "POST",
+                url,
+                200,
+                {"model_info": {"qwen3.context_length": 40960}},
+            )
+
+        monkeypatch.setattr(model_context.httpx, "get", fake_get)
+        monkeypatch.setattr(model_context.httpx, "post", fake_post)
+
+        result = model_context._query_context_length(self.OLLAMA_URL, "qwen3:14b")
+
+        assert result == 40960
+        assert post_calls == [("http://localhost:11434/api/show", {"name": "qwen3:14b"})]
+        assert not any(url.endswith("/models") for url in get_calls)
+
+    def test_api_show_404_falls_through_to_models(self, monkeypatch):
+        def fake_get(url, timeout=None):
+            if url.endswith("/slots"):
+                raise httpx.ConnectError("slots unavailable")
+            return self._response(
+                "GET",
+                url,
+                200,
+                {"data": [{"id": "llama3:8b", "context_length": 8192}]},
+            )
+
+        def fake_post(url, json=None, timeout=None):
+            return self._response("POST", url, 404, {})
+
+        monkeypatch.setattr(model_context.httpx, "get", fake_get)
+        monkeypatch.setattr(model_context.httpx, "post", fake_post)
+
+        result = model_context._query_context_length(
+            "http://localhost:11434/v1/chat/completions",
+            "llama3:8b",
+        )
+
+        assert result == 8192
+
+    def test_api_show_not_tried_for_non_ollama_local_endpoint(self, monkeypatch):
+        post_calls = []
+
+        def fake_get(url, timeout=None):
+            if url.endswith("/slots"):
+                raise httpx.ConnectError("slots unavailable")
+            return self._response(
+                "GET",
+                url,
+                200,
+                {"data": [{"id": "local-model", "context_length": 16384}]},
+            )
+
+        def fake_post(url, json=None, timeout=None):
+            post_calls.append(url)
+            return self._response("POST", url, 200, {})
+
+        monkeypatch.setattr(model_context.httpx, "get", fake_get)
+        monkeypatch.setattr(model_context.httpx, "post", fake_post)
+
+        result = model_context._query_context_length(
+            "http://localhost:8080/v1/chat/completions",
+            "local-model",
+        )
+
+        assert result == 16384
+        assert post_calls == []
+
+    def test_api_show_connection_error_falls_through_to_known_model(self, monkeypatch):
+        def fake_get(url, timeout=None):
+            raise httpx.ConnectError("offline")
+
+        def fake_post(url, json=None, timeout=None):
+            raise httpx.ConnectError("offline")
+
+        monkeypatch.setattr(model_context.httpx, "get", fake_get)
+        monkeypatch.setattr(model_context.httpx, "post", fake_post)
+
+        result = model_context._query_context_length(self.OLLAMA_URL, "qwen3:14b")
+
+        assert result == 131072
+
+    def test_api_show_connection_error_falls_through_to_default_context(self, monkeypatch):
+        def fake_get(url, timeout=None):
+            raise httpx.ConnectError("offline")
+
+        def fake_post(url, json=None, timeout=None):
+            raise httpx.ConnectError("offline")
+
+        monkeypatch.setattr(model_context.httpx, "get", fake_get)
+        monkeypatch.setattr(model_context.httpx, "post", fake_post)
+
+        result = model_context._query_context_length(self.OLLAMA_URL, "unknown-local-model")
+
+        assert result == DEFAULT_CONTEXT
+
+    def test_api_show_not_tried_for_remote_endpoint(self, monkeypatch):
+        post_calls = []
+
+        def fake_get(url, timeout=None):
+            return self._response(
+                "GET",
+                url,
+                200,
+                {"data": [{"id": "gpt-4o", "context_length": 128000}]},
+            )
+
+        def fake_post(url, json=None, timeout=None):
+            post_calls.append(url)
+            return self._response("POST", url, 200, {})
+
+        monkeypatch.setattr(model_context.httpx, "get", fake_get)
+        monkeypatch.setattr(model_context.httpx, "post", fake_post)
+
+        result = model_context._query_context_length(self.REMOTE_URL, "gpt-4o")
+
+        assert result == 128000
+        assert post_calls == []


### PR DESCRIPTION
## Summary

- Add a local Ollama `/api/show` context probe after llama.cpp `/slots` and before `/v1/models`
- Limit `/api/show` to local Ollama-looking endpoints so cloud endpoints and non-Ollama local OpenAI-compatible servers keep existing fallback behavior
- Preserve upstream's local-context cache behavior and add focused regressions for the new probe paths

## Why

Ollama's OpenAI-compatible `/v1/models` response does not expose the serving context length, so known-model fallbacks can overstate the usable context window and delay compaction. Ollama's native `/api/show` reports the actual `model_info.*.context_length` value used for serving.

## Safety / scope

- `/api/show` is only tried for local Ollama-looking endpoints, including port `11434` and Ollama hostnames
- Remote/cloud endpoints never receive the Ollama probe
- Local non-Ollama endpoints fall through through `/slots`, `/v1/models`, known-model lookup, and default context as before
- This branch is rebased onto current `upstream/main` and changes only `src/model_context.py` and `tests/test_model_context.py`
- No dependency, lockfile, docs, deployment, auth, or unrelated UI changes

## Test plan

- [x] `./venv/Scripts/python.exe -m pytest -q tests/test_model_context.py` - 31 passed
- [x] `./venv/Scripts/python.exe -m py_compile src/model_context.py`
- [x] `git diff --check upstream/main...HEAD`