### PR TITLE
Add Windows Docker update script

### DIFF
--- a/tests/test_windows_update_script.py
+++ b/tests/test_windows_update_script.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_windows_update_script_uses_safe_docker_update_flow():
+    script = (ROOT / "update_windows.bat").read_text(encoding="utf-8")
+    lowered = script.lower()
+
+    assert 'pushd "%~dp0"' in lowered
+    assert "where git" in lowered
+    assert "where docker" in lowered
+    assert "docker compose version" in lowered
+    assert "git pull --ff-only" in lowered
+    assert "docker compose up -d --build" in lowered
+    assert "docker image prune -f" in lowered
+    assert "pause" in lowered

--- a/update_windows.bat
+++ b/update_windows.bat
@@ -1,0 +1,59 @@
+@echo off
+setlocal
+title Update Odysseus Docker Deployment
+
+pushd "%~dp0" >nul
+
+echo =========================================
+echo Updating Odysseus Docker deployment
+echo =========================================
+echo.
+
+where git >nul 2>nul
+if errorlevel 1 (
+  echo [!] Git was not found on PATH.
+  echo     Install Git for Windows, then run this script again.
+  goto :fail
+)
+
+where docker >nul 2>nul
+if errorlevel 1 (
+  echo [!] Docker was not found on PATH.
+  echo     Start Docker Desktop, then run this script again.
+  goto :fail
+)
+
+docker compose version >nul 2>nul
+if errorlevel 1 (
+  echo [!] Docker Compose is not available.
+  echo     Update Docker Desktop, then run this script again.
+  goto :fail
+)
+
+echo [+] Pulling latest code...
+git pull --ff-only
+if errorlevel 1 goto :fail
+
+echo.
+echo [+] Rebuilding and restarting containers...
+docker compose up -d --build
+if errorlevel 1 goto :fail
+
+echo.
+echo [+] Removing dangling Docker images...
+docker image prune -f
+if errorlevel 1 goto :fail
+
+echo.
+echo =========================================
+echo Update completed successfully.
+echo =========================================
+goto :done
+
+:fail
+echo.
+echo Update failed. Check the message above and try again.
+
+:done
+popd >nul
+pause


### PR DESCRIPTION
Fixes #792.

This adds a small `update_windows.bat` helper for people running the Docker setup on Windows and wanting the usual update flow without typing the same commands every time.

It keeps the script intentionally plain:

- runs from the repo folder via `%~dp0`
- checks that Git, Docker, and Docker Compose are available before doing work
- uses `git pull --ff-only` so it does not create surprise merge commits
- rebuilds/restarts with `docker compose up -d --build`
- prunes dangling Docker images at the end

I kept this out of the README for now to avoid colliding with the larger Windows/native packaging PRs already open. This is just the narrow Docker-update helper requested in the issue.

Checked:
- `python -m py_compile tests/test_windows_update_script.py`
- `python -m pytest -q tests/test_windows_update_script.py`
- `git diff --check`
