### PR TITLE
Document self-host system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ python setup.py
 python -m uvicorn app:app --host 127.0.0.1 --port 7000
 ```
 Requirements: Python 3.11+. Cookbook also needs `tmux` for background model
-downloads and serves. Use `--host 0.0.0.0` only when you intentionally want
-LAN/reverse-proxy access.
+downloads and serves. The app itself is lightweight; local model serving is the
+heavy part and depends on the model, runtime, GPU, and VRAM, so small hosts can
+connect to API or remote model servers instead. Use `--host 0.0.0.0` only when
+you intentionally want LAN/reverse-proxy access.
 
 ### Apple Silicon
 Docker on macOS cannot use the Metal GPU. For GPU-accelerated Cookbook on an


### PR DESCRIPTION
Fixes #439.

Trimmed this down after review. The README now only adds a small first-run expectation note: Odysseus itself is lightweight, while local model serving depends on the chosen model, runtime, GPU, and available VRAM. Small hosts can still run the app and connect to API or remote model servers.

I also dropped the README-content test since this is intentionally just docs copy now.

Checked:
- git diff --check
