### PR TITLE
feat: Microsoft OAuth2 (XOAUTH2) auth for personal / Exchange email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,26 @@ SEARXNG_INSTANCE=http://localhost:8080
 # race on the same SQLite.
 # ODYSSEUS_INPROCESS_POLLERS=1
 
+# ── Microsoft email OAuth2 (issue #725) ──
+# Personal Microsoft accounts (@hotmail/@outlook/@live) and Exchange Online no
+# longer allow Basic Auth, so the Email feature signs them in via OAuth2
+# (XOAUTH2, device-code flow). Register your own Azure app and set its client
+# ID here — it is a public client ID, not a secret:
+#   1. https://portal.azure.com -> Microsoft Entra ID -> App registrations -> New
+#   2. Supported account types: "Accounts in any org directory and personal
+#      Microsoft accounts" (or "Personal Microsoft accounts only").
+#   3. Authentication -> Advanced settings -> Allow public client flows: Yes.
+#   4. API permissions -> Add -> APIs my organization uses ->
+#      "Office 365 Exchange Online" -> Delegated -> IMAP.AccessAsUser.All +
+#      SMTP.Send; plus Microsoft Graph -> offline_access, openid, email.
+#   5. Copy the Application (client) ID into MS_OAUTH_CLIENT_ID below.
+# Password accounts (Gmail, etc.) work without this; it only unlocks the
+# "Sign in with Microsoft" button in the email account setup.
+# MS_OAUTH_CLIENT_ID=
+# Tenant: "common" (personal + work, default), "consumers" (personal only),
+# or a tenant GUID for a single-org app.
+# MS_OAUTH_TENANT=common
+
 # In-process scheduled-task runner (default: on). Set to 0 to let an
 # external driver fire scheduled tasks. Calendar reminders are
 # frontend-driven (polling /api/notes from the browser) so no gate is

--- a/core/database.py
+++ b/core/database.py
@@ -316,6 +316,16 @@ class EmailAccount(TimestampMixin, Base):
     smtp_user      = Column(String, default="")
     smtp_password  = Column(String, default="")
 
+    # Authentication. "password" = Basic Auth (imap_password/smtp_password),
+    # the historical default. "oauth2" = XOAUTH2 with a stored refresh token
+    # (Microsoft personal/Exchange accounts, which no longer allow Basic Auth).
+    # The refresh token is Fernet-encrypted at rest, same path as the
+    # passwords; short-lived access tokens are minted on demand and cached
+    # in memory only (see src/oauth_email.py).
+    auth_type           = Column(String, default="password")
+    oauth_provider      = Column(String, default="")   # "microsoft" today
+    oauth_refresh_token = Column(String, default="")   # Fernet-encrypted like *_password
+
     from_address   = Column(String, default="")
 
     __table_args__ = (
@@ -1540,6 +1550,7 @@ def init_db():
     _migrate_seed_email_account()
     _migrate_add_calendar_metadata()
     _migrate_add_calendar_is_utc()
+    _migrate_add_email_oauth_columns()
     _migrate_encrypt_email_passwords()
     _migrate_encrypt_signatures()
     _migrate_encrypt_endpoint_keys()
@@ -1659,6 +1670,33 @@ def _migrate_encrypt_email_passwords():
                 logger.info(f"Encrypted plaintext passwords on {migrated} email account row(s)")
     except Exception as e:
         logger.warning(f"Password migration failed (will retry next start): {e}")
+
+
+def _migrate_add_email_oauth_columns():
+    """Add auth_type / oauth_provider / oauth_refresh_token to email_accounts
+    so accounts can authenticate via OAuth2 (XOAUTH2) instead of Basic Auth —
+    required for personal Microsoft + Exchange Online mailboxes (issue #725).
+    Idempotent; safe on every startup."""
+    import sqlite3
+    db_path = DATABASE_URL.replace("sqlite:///", "")
+    if not os.path.exists(db_path):
+        return
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute("PRAGMA table_info(email_accounts)")
+        columns = [row[1] for row in cursor.fetchall()]
+        if columns:
+            if "auth_type" not in columns:
+                conn.execute("ALTER TABLE email_accounts ADD COLUMN auth_type TEXT DEFAULT 'password'")
+            if "oauth_provider" not in columns:
+                conn.execute("ALTER TABLE email_accounts ADD COLUMN oauth_provider TEXT DEFAULT ''")
+            if "oauth_refresh_token" not in columns:
+                conn.execute("ALTER TABLE email_accounts ADD COLUMN oauth_refresh_token TEXT DEFAULT ''")
+            conn.commit()
+            logging.getLogger(__name__).info("Migrated: added OAuth columns to email_accounts")
+        conn.close()
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"email_accounts OAuth column migration skipped: {e}")
 
 
 def _migrate_add_calendar_is_utc():

--- a/mcp_servers/email_server.py
+++ b/mcp_servers/email_server.py
@@ -72,10 +72,14 @@ def _list_accounts_raw() -> list:
         conn.row_factory = sqlite3.Row
         columns = {r[1] for r in conn.execute("PRAGMA table_info(email_accounts)").fetchall()}
         smtp_security_select = "smtp_security" if "smtp_security" in columns else "'' AS smtp_security"
+        auth_type_select = "auth_type" if "auth_type" in columns else "'password' AS auth_type"
+        oauth_provider_select = "oauth_provider" if "oauth_provider" in columns else "'' AS oauth_provider"
+        oauth_rt_select = "oauth_refresh_token" if "oauth_refresh_token" in columns else "'' AS oauth_refresh_token"
         rows = conn.execute(f"""
             SELECT id, name, is_default, enabled,
                    imap_host, imap_port, imap_user, imap_password, imap_starttls,
-                   smtp_host, smtp_port, {smtp_security_select}, smtp_user, smtp_password, from_address
+                   smtp_host, smtp_port, {smtp_security_select}, smtp_user, smtp_password, from_address,
+                   {auth_type_select}, {oauth_provider_select}, {oauth_rt_select}
             FROM email_accounts WHERE enabled = 1
             ORDER BY is_default DESC, created_at ASC
         """).fetchall()
@@ -152,6 +156,12 @@ def _load_config(account: str | None = None) -> dict:
         "smtp_password": os.environ.get("SMTP_PASSWORD", ""),
         "smtp_starttls": os.environ.get("SMTP_STARTTLS", "false").lower() == "true",
         "smtp_ssl": os.environ.get("SMTP_SSL", "true").lower() == "true",
+        # Auth: "password" (Basic Auth) or "oauth2" (XOAUTH2). The env/settings
+        # fallback path is always Basic Auth; OAuth is account-scoped (DB only).
+        "auth_type": "password",
+        "oauth_provider": "",
+        "oauth_refresh_token": "",
+        "oauth_client_id": "",
         "from_address": os.environ.get("EMAIL_FROM", ""),
         "archive_folder": os.environ.get("ARCHIVE_FOLDER", "Archive"),
         "trash_folder": os.environ.get("TRASH_FOLDER", "Trash"),
@@ -195,6 +205,11 @@ def _load_config(account: str | None = None) -> dict:
         cfg["smtp_security"] = row["smtp_security"] or cfg["smtp_security"] or ("starttls" if int(cfg["smtp_port"]) == 587 else "ssl")
         cfg["smtp_user"] = row["smtp_user"] or cfg["smtp_user"]
         cfg["smtp_password"] = _decrypt(row["smtp_password"]) if row["smtp_password"] else cfg["smtp_password"]
+        # OAuth2 (XOAUTH2) fields — see src/oauth_email.py. Refresh token is
+        # Fernet-encrypted at rest, same as the passwords.
+        cfg["auth_type"] = row.get("auth_type") or "password"
+        cfg["oauth_provider"] = row.get("oauth_provider") or ""
+        cfg["oauth_refresh_token"] = _decrypt(row["oauth_refresh_token"]) if row.get("oauth_refresh_token") else ""
         cfg["from_address"] = row["from_address"] or row["imap_user"] or cfg["from_address"]
     else:
         # Legacy fallback: settings.json flat keys
@@ -217,6 +232,59 @@ def _load_config(account: str | None = None) -> dict:
 
     _ACCOUNT_CACHE[cache_key] = cfg
     return cfg
+
+
+# ── Authentication (Basic Auth + OAuth2 / XOAUTH2) ──
+
+
+def _persist_refresh_token(account_id, new_rt):
+    """Write a rotated OAuth refresh token back to the row (encrypted) and
+    drop the cfg cache so the next read picks up the new token."""
+    if not (account_id and new_rt):
+        return
+    try:
+        from src.secret_storage import encrypt as _enc
+        conn = sqlite3.connect(str(_db_path()))
+        conn.execute(
+            "UPDATE email_accounts SET oauth_refresh_token = ? WHERE id = ?",
+            (_enc(new_rt), account_id),
+        )
+        conn.commit()
+        conn.close()
+        _ACCOUNT_CACHE.clear()
+    except Exception:
+        pass
+
+
+def _oauth_access_token(cfg):
+    from src.oauth_email import get_access_token, resolve_client_id
+    client_id = resolve_client_id(cfg.get("oauth_client_id", ""))
+    acct_id = cfg.get("account_id") or ""
+    return get_access_token(
+        acct_id, client_id, cfg.get("oauth_refresh_token") or "",
+        on_refresh=lambda rt: _persist_refresh_token(acct_id, rt),
+    )
+
+
+def _imap_auth(conn, cfg):
+    if (cfg.get("auth_type") or "password") == "oauth2":
+        from src.oauth_email import xoauth2_string
+        token = _oauth_access_token(cfg)
+        user = cfg.get("imap_user") or cfg.get("from_address") or ""
+        conn.authenticate("XOAUTH2", lambda _: xoauth2_string(user, token).encode())
+    else:
+        conn.login(cfg["imap_user"], cfg["imap_password"])
+
+
+def _smtp_auth(smtp, cfg):
+    if (cfg.get("auth_type") or "password") == "oauth2":
+        from src.oauth_email import xoauth2_string
+        token = _oauth_access_token(cfg)
+        user = cfg.get("smtp_user") or cfg.get("imap_user") or cfg.get("from_address") or ""
+        smtp.ehlo()
+        smtp.auth("XOAUTH2", lambda _=None: xoauth2_string(user, token))
+    elif cfg.get("smtp_user") and cfg.get("smtp_password"):
+        smtp.login(cfg["smtp_user"], cfg["smtp_password"])
 
 
 # ── IMAP helpers ──
@@ -242,7 +310,7 @@ def _imap_connect(account: str | None = None):
             conn.starttls()
     if getattr(conn, "sock", None):
         conn.sock.settimeout(EMAIL_SOCKET_TIMEOUT)
-    conn.login(cfg["imap_user"], cfg["imap_password"])
+    _imap_auth(conn, cfg)
     return conn
 
 
@@ -720,7 +788,12 @@ def _read_email_across_accounts(uid=None, message_id=None, folder="INBOX"):
 
 
 def _smtp_ready(cfg: dict) -> bool:
-    return bool(cfg.get("smtp_host") and cfg.get("smtp_user") and cfg.get("smtp_password"))
+    if not cfg.get("smtp_host"):
+        return False
+    if (cfg.get("auth_type") or "password") == "oauth2":
+        # OAuth accounts send via XOAUTH2 — a refresh token replaces the password.
+        return bool(cfg.get("oauth_refresh_token") and (cfg.get("smtp_user") or cfg.get("from_address")))
+    return bool(cfg.get("smtp_user") and cfg.get("smtp_password"))
 
 
 def _resolve_send_config(account=None):
@@ -765,8 +838,7 @@ def _smtp_connect(account=None, cfg=None):
             port,
             timeout=EMAIL_SOCKET_TIMEOUT,
         )
-    if cfg["smtp_user"] and cfg["smtp_password"]:
-        conn.login(cfg["smtp_user"], cfg["smtp_password"])
+    _smtp_auth(conn, cfg)
     return conn
 
 

--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -48,26 +48,79 @@ def _smtp_security_mode(cfg: dict) -> str:
     return "ssl"
 
 
+# ── Authentication (Basic Auth + OAuth2 / XOAUTH2) ──
+
+def _persist_refresh_token(account_id: str | None, new_rt: str) -> None:
+    """Write a rotated OAuth refresh token back to the account row (encrypted).
+    Best-effort: a failure just means we refresh from the prior token next time."""
+    if not (account_id and new_rt):
+        return
+    try:
+        from core.database import SessionLocal as _SL, EmailAccount as _EA
+        from src.secret_storage import encrypt as _enc
+        db = _SL()
+        try:
+            row = db.get(_EA, account_id)
+            if row is not None:
+                row.oauth_refresh_token = _enc(new_rt)
+                db.commit()
+        finally:
+            db.close()
+    except Exception as e:
+        logger.warning(f"Could not persist rotated refresh token for {account_id!r}: {e}")
+
+
+def _oauth_access_token(cfg: dict) -> str:
+    """Mint/refresh a Microsoft access token for an OAuth account."""
+    from src.oauth_email import get_access_token, resolve_client_id
+    client_id = resolve_client_id(cfg.get("oauth_client_id", ""))
+    acct_id = cfg.get("account_id") or ""
+    return get_access_token(
+        acct_id, client_id, cfg.get("oauth_refresh_token") or "",
+        on_refresh=lambda rt: _persist_refresh_token(acct_id, rt),
+    )
+
+
+def _imap_auth(conn, cfg: dict) -> None:
+    """Authenticate an open imaplib connection per the account's auth_type."""
+    if (cfg.get("auth_type") or "password") == "oauth2":
+        from src.oauth_email import xoauth2_string
+        token = _oauth_access_token(cfg)
+        user = cfg.get("imap_user") or cfg.get("from_address") or ""
+        conn.authenticate("XOAUTH2", lambda _: xoauth2_string(user, token).encode())
+    else:
+        conn.login(cfg["imap_user"], cfg["imap_password"])
+
+
+def _smtp_auth(smtp, cfg: dict) -> None:
+    """Authenticate an open smtplib connection per the account's auth_type.
+    No-op for password accounts that didn't configure SMTP credentials."""
+    if (cfg.get("auth_type") or "password") == "oauth2":
+        from src.oauth_email import xoauth2_string
+        token = _oauth_access_token(cfg)
+        user = cfg.get("smtp_user") or cfg.get("imap_user") or cfg.get("from_address") or ""
+        smtp.ehlo()
+        smtp.auth("XOAUTH2", lambda _=None: xoauth2_string(user, token))
+    elif cfg.get("smtp_user") and cfg.get("smtp_password"):
+        smtp.login(cfg["smtp_user"], cfg["smtp_password"])
+
+
 def _send_smtp_message(cfg: dict, from_addr: str, recipients: list[str], message: str | bytes, timeout: int = 30) -> None:
     """Send through SMTP using the configured transport security mode."""
     host = cfg["smtp_host"]
     port = int(cfg.get("smtp_port") or 465)
-    user = cfg.get("smtp_user") or ""
-    password = cfg.get("smtp_password") or ""
     security = _smtp_security_mode(cfg)
 
     if security == "ssl":
         with smtplib.SMTP_SSL(host, port, timeout=timeout) as smtp:
-            if user and password:
-                smtp.login(user, password)
+            _smtp_auth(smtp, cfg)
             smtp.sendmail(from_addr, recipients, message)
         return
 
     with smtplib.SMTP(host, port, timeout=timeout) as smtp:
         if security == "starttls":
             smtp.starttls()
-        if user and password:
-            smtp.login(user, password)
+        _smtp_auth(smtp, cfg)
         smtp.sendmail(from_addr, recipients, message)
 
 
@@ -547,11 +600,21 @@ def _get_email_config(account_id: str | None = None, owner: str = "") -> dict:
                     "imap_password": _decrypt(row.imap_password or ""),
                     "imap_starttls": bool(row.imap_starttls),
                     "from_address": row.from_address or row.imap_user or "",
+                    "auth_type": getattr(row, "auth_type", None) or "password",
+                    "oauth_provider": getattr(row, "oauth_provider", None) or "",
+                    "oauth_refresh_token": _decrypt(getattr(row, "oauth_refresh_token", None) or ""),
                 }
-                if not (cfg["smtp_host"] and cfg["smtp_user"] and cfg["smtp_password"]):
-                    logger.warning(f"SMTP not configured for account {row.name!r}")
-                if not (cfg["imap_host"] and cfg["imap_user"] and cfg["imap_password"]):
-                    logger.warning(f"IMAP not configured for account {row.name!r}")
+                _is_oauth = cfg["auth_type"] == "oauth2"
+                # OAuth accounts have no SMTP/IMAP password; validate the refresh
+                # token instead so we don't log spurious "not configured" warnings.
+                if _is_oauth:
+                    if not cfg["oauth_refresh_token"]:
+                        logger.warning(f"OAuth account {row.name!r} has no refresh token — needs sign-in")
+                else:
+                    if not (cfg["smtp_host"] and cfg["smtp_user"] and cfg["smtp_password"]):
+                        logger.warning(f"SMTP not configured for account {row.name!r}")
+                    if not (cfg["imap_host"] and cfg["imap_user"] and cfg["imap_password"]):
+                        logger.warning(f"IMAP not configured for account {row.name!r}")
                 return cfg
         finally:
             db.close()
@@ -577,6 +640,11 @@ def _get_email_config(account_id: str | None = None, owner: str = "") -> dict:
         "imap_password": settings.get("imap_password", os.environ.get("IMAP_PASSWORD", "")),
         "imap_starttls": settings.get("imap_starttls", True),
         "from_address": settings.get("email_from", os.environ.get("EMAIL_FROM", "")),
+        # OAuth is account-scoped (DB-only); the env/settings fallback path is
+        # always Basic Auth.
+        "auth_type": "password",
+        "oauth_provider": "",
+        "oauth_refresh_token": "",
     }
     if not (cfg["smtp_host"] and cfg["smtp_user"] and cfg["smtp_password"]):
         logger.warning("SMTP not configured — add an Email Account in Settings or set env vars")
@@ -653,7 +721,7 @@ def _imap_connect(account_id: str | None = None, owner: str = ""):
         starttls=bool(cfg.get("imap_starttls")),
         timeout=_IMAP_TIMEOUT_SECONDS,
     )
-    conn.login(cfg["imap_user"], cfg["imap_password"])
+    _imap_auth(conn, cfg)
     return conn
 
 

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -237,7 +237,13 @@ def _uid_from_fetch_meta(meta_b: bytes) -> str:
 
 
 def _smtp_ready(cfg: dict) -> bool:
-    return bool(cfg.get("smtp_host") and cfg.get("smtp_user") and cfg.get("smtp_password"))
+    if not cfg.get("smtp_host"):
+        return False
+    if (cfg.get("auth_type") or "password") == "oauth2":
+        # OAuth accounts authenticate via XOAUTH2 — a refresh token stands in
+        # for the SMTP password.
+        return bool(cfg.get("oauth_refresh_token") and (cfg.get("smtp_user") or cfg.get("from_address")))
+    return bool(cfg.get("smtp_user") and cfg.get("smtp_password"))
 
 
 def _resolve_send_config(account_id: str | None = None, owner: str = "") -> dict:
@@ -2912,6 +2918,9 @@ def setup_email_routes():
                     "from_address": r.from_address or "",
                     "has_imap_password": bool(r.imap_password),
                     "has_smtp_password": bool(r.smtp_password),
+                    "auth_type": getattr(r, "auth_type", None) or "password",
+                    "oauth_provider": getattr(r, "oauth_provider", None) or "",
+                    "has_oauth": bool(getattr(r, "oauth_refresh_token", None)),
                 })
             return {"accounts": out}
         finally:
@@ -2943,6 +2952,9 @@ def setup_email_routes():
                 smtp_security=_smtp_security_mode({"smtp_security": data.get("smtp_security"), "smtp_port": data.get("smtp_port") or 465}),
                 smtp_user=(data.get("smtp_user") or "").strip(),
                 smtp_password=_enc(data.get("smtp_password") or ""),
+                auth_type=(data.get("auth_type") or "password").strip(),
+                oauth_provider=(data.get("oauth_provider") or "").strip(),
+                oauth_refresh_token=_enc(data.get("oauth_refresh_token") or ""),
                 from_address=(data.get("from_address") or "").strip(),
                 # SECURITY: stamp the creator so all subsequent reads / mutations
                 # can filter by user. Without this every new account leaks to
@@ -2978,7 +2990,8 @@ def setup_email_routes():
             if not row:
                 return {"ok": False, "error": "Account not found"}
             # Simple fields
-            for key in ("name", "imap_host", "imap_user", "smtp_host", "smtp_user", "from_address"):
+            for key in ("name", "imap_host", "imap_user", "smtp_host", "smtp_user",
+                        "from_address", "auth_type", "oauth_provider"):
                 if key in data:
                     setattr(row, key, (data[key] or "").strip())
             for key in ("imap_port", "smtp_port"):
@@ -2996,6 +3009,12 @@ def setup_email_routes():
                 row.imap_password = _enc(data["imap_password"])
             if data.get("smtp_password"):
                 row.smtp_password = _enc(data["smtp_password"])
+            # Refresh token only overwrites when a fresh one is supplied (after
+            # an OAuth sign-in), mirroring the password behaviour.
+            if data.get("oauth_refresh_token"):
+                row.oauth_refresh_token = _enc(data["oauth_refresh_token"])
+                from src.oauth_email import invalidate as _inv
+                _inv(row.id)  # drop any stale cached access token
             db.commit()
             return {"ok": True, "id": row.id}
         finally:
@@ -3073,6 +3092,10 @@ def setup_email_routes():
                     "smtp_security": _smtp_security_mode({"smtp_security": getattr(row, "smtp_security", ""), "smtp_port": row.smtp_port}),
                     "smtp_user": row.smtp_user or "",
                     "smtp_password": _decrypt(row.smtp_password or ""),
+                    "auth_type": getattr(row, "auth_type", None) or "password",
+                    "oauth_provider": getattr(row, "oauth_provider", None) or "",
+                    "oauth_refresh_token": _decrypt(getattr(row, "oauth_refresh_token", None) or ""),
+                    "account_id": row.id,
                 }
                 for key, value in body.items():
                     if key == "account_id":
@@ -3086,22 +3109,43 @@ def setup_email_routes():
         imap_result = {"ok": False}
         smtp_result = None
 
+        auth_type = (body.get("auth_type") or "password").strip()
+        is_oauth = auth_type == "oauth2"
+
+        # OAuth: mint one access token up front, shared by the IMAP + SMTP
+        # checks. The refresh token comes from the saved row or, for a
+        # brand-new account, from the just-completed device-flow sign-in.
+        oauth_token = None
+        oauth_error = None
+        if is_oauth:
+            try:
+                from src.oauth_email import get_access_token, resolve_client_id
+                client_id = resolve_client_id(body.get("oauth_client_id", ""))
+                if not client_id:
+                    oauth_error = "No Microsoft OAuth client ID configured (set MS_OAUTH_CLIENT_ID)"
+                elif not body.get("oauth_refresh_token"):
+                    oauth_error = "Not signed in yet — complete the Microsoft sign-in first"
+                else:
+                    oauth_token = get_access_token(
+                        body.get("account_id") or "test", client_id,
+                        body.get("oauth_refresh_token") or "",
+                    )
+            except Exception as e:
+                oauth_error = str(e)[:200]
+
         imap_host = (body.get("imap_host") or "").strip()
         imap_port = int(body.get("imap_port") or 993)
         imap_user = (body.get("imap_user") or "").strip()
         imap_pass = body.get("imap_password") or ""
         imap_starttls = bool(body.get("imap_starttls"))
 
-        if not (imap_host and imap_user and imap_pass):
+        if is_oauth and oauth_error:
+            imap_result = {"ok": False, "error": oauth_error}
+        elif is_oauth and not (imap_host and imap_user):
+            imap_result = {"ok": False, "error": "Need IMAP host and username"}
+        elif not is_oauth and not (imap_host and imap_user and imap_pass):
             imap_result = {"ok": False, "error": "Need IMAP host, username, and password"}
         else:
-            # Connection mode resolution:
-            #   STARTTLS on  → plain IMAP4 + .starttls() (upgrade)
-            #   STARTTLS off + port 993 → IMAP4_SSL (implicit SSL, "IMAPS")
-            #   STARTTLS off + any other port → plain IMAP4 (no encryption)
-            # Without the last branch, local servers exposed on a non-993
-            # port (Dovecot on 31143, etc.) would always fail the SSL
-            # handshake because they're not actually wrapped in TLS.
             try:
                 conn = _open_imap_connection(
                     imap_host,
@@ -3110,7 +3154,11 @@ def setup_email_routes():
                     timeout=_IMAP_TIMEOUT_SECONDS,
                 )
                 try:
-                    conn.login(imap_user, imap_pass)
+                    if is_oauth:
+                        from src.oauth_email import xoauth2_string
+                        conn.authenticate("XOAUTH2", lambda _: xoauth2_string(imap_user, oauth_token).encode())
+                    else:
+                        conn.login(imap_user, imap_pass)
                     imap_result = {"ok": True}
                 finally:
                     try: conn.logout()
@@ -3132,7 +3180,14 @@ def setup_email_routes():
                     if smtp_security == "starttls":
                         smtp.starttls()
                 try:
-                    smtp.login(smtp_user, smtp_pass)
+                    if is_oauth:
+                        if oauth_error:
+                            raise RuntimeError(oauth_error)
+                        from src.oauth_email import xoauth2_string
+                        smtp.ehlo()
+                        smtp.auth("XOAUTH2", lambda _=None: xoauth2_string(smtp_user, oauth_token))
+                    else:
+                        smtp.login(smtp_user, smtp_pass)
                     smtp_result = {"ok": True}
                 finally:
                     try: smtp.quit()
@@ -3145,6 +3200,45 @@ def setup_email_routes():
             "imap": imap_result,
             "smtp": smtp_result,
         }
+
+    # ═══════════════ Microsoft OAuth2 (device code flow) ═══════════════
+    # Personal Microsoft + Exchange Online accounts can't use Basic Auth. The
+    # device-code flow needs no redirect URI, so it works headless / in Docker
+    # / behind Tailscale. See src/oauth_email.py and issue #725.
+
+    @router.post("/oauth/microsoft/start")
+    async def ms_oauth_start(owner: str = Depends(require_owner)):
+        """Begin Microsoft device-code sign-in. Returns the user_code +
+        verification_uri to display, plus an opaque device_code to poll."""
+        from src.oauth_email import start_device_flow, resolve_client_id
+        client_id = resolve_client_id()
+        if not client_id:
+            return {"ok": False, "error": "No Microsoft OAuth client ID configured. Set MS_OAUTH_CLIENT_ID or the ms_oauth_client_id setting."}
+        try:
+            flow = start_device_flow(client_id)
+        except Exception as e:
+            return {"ok": False, "error": str(e)[:200]}
+        return {
+            "ok": True,
+            "user_code": flow.get("user_code", ""),
+            "verification_uri": flow.get("verification_uri", ""),
+            "device_code": flow.get("device_code", ""),
+            "interval": flow.get("interval", 5),
+            "expires_in": flow.get("expires_in", 900),
+            "message": flow.get("message", ""),
+        }
+
+    @router.post("/oauth/microsoft/poll")
+    async def ms_oauth_poll(data: dict, owner: str = Depends(require_owner)):
+        """Poll for device-flow completion. On success returns the refresh
+        token; the client includes it in the account create/update payload,
+        where it's encrypted at rest (it never leaves this app's origin)."""
+        from src.oauth_email import poll_device_flow, resolve_client_id
+        client_id = resolve_client_id()
+        res = poll_device_flow(client_id, data.get("device_code") or "")
+        if res["status"] == "ok":
+            return {"ok": True, "status": "ok", "refresh_token": res.get("refresh_token", "")}
+        return {"ok": res["status"] == "pending", "status": res["status"], "error": res.get("error", "")}
 
     @router.post("/accounts/{account_id}/set-default")
     async def set_default_account(account_id: str, owner: str = Depends(require_user)):

--- a/src/oauth_email.py
+++ b/src/oauth_email.py
@@ -1,0 +1,186 @@
+"""
+oauth_email.py
+
+Microsoft OAuth2 (XOAUTH2) support for IMAP/SMTP — issue #725.
+
+Personal Microsoft accounts (@hotmail / @outlook / @live) and Exchange Online
+mailboxes no longer accept Basic Auth (username + password). This module
+implements the OAuth2 **device code** flow — no redirect URI, so it works
+headless / in Docker / behind Tailscale — plus refresh-token exchange, and
+builds the SASL XOAUTH2 credential string consumed by imaplib/smtplib.
+
+Design:
+  - No new dependency: raw `requests` against the Microsoft identity platform
+    v2.0 endpoints.
+  - The client ID is **user-supplied** — an Azure app registration with
+    "Allow public client flows" enabled and delegated IMAP.AccessAsUser.All +
+    SMTP.Send + offline_access permissions. Provide it via the
+    MS_OAUTH_CLIENT_ID env var or the `ms_oauth_client_id` key in
+    data/settings.json. Tenant defaults to "common" (personal + work);
+    override with MS_OAUTH_TENANT.
+  - Refresh tokens live encrypted in email_accounts.oauth_refresh_token (the
+    same Fernet path as the passwords). They rotate on each refresh, so
+    `get_access_token` takes an `on_refresh` callback to persist the new one.
+  - Access tokens (~1h) are cached in memory only, keyed by account id and
+    guarded by a lock, so the background pollers and web requests don't
+    stampede the token endpoint or race the rotating refresh token.
+
+See docs: https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth
+"""
+
+import os
+import json
+import time
+import logging
+import threading
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _tenant() -> str:
+    return os.environ.get("MS_OAUTH_TENANT", "common").strip() or "common"
+
+
+def _authority() -> str:
+    return f"https://login.microsoftonline.com/{_tenant()}/oauth2/v2.0"
+
+
+# offline_access → refresh token; the outlook.office.com resource scopes are
+# what Exchange Online validates for IMAP/SMTP XOAUTH2. openid/email identify
+# the signed-in mailbox.
+SCOPES = (
+    "https://outlook.office.com/IMAP.AccessAsUser.All "
+    "https://outlook.office.com/SMTP.Send "
+    "offline_access openid email"
+)
+
+_SETTINGS_FILE = Path(__file__).resolve().parent.parent / "data" / "settings.json"
+
+# account_id -> (access_token, expires_at_epoch)
+_token_cache: dict[str, tuple[str, float]] = {}
+_lock = threading.Lock()
+_EXPIRY_SKEW = 300  # refresh 5 min before the token actually expires
+_HTTP_TIMEOUT = 20
+
+
+def resolve_client_id(explicit: str = "") -> str:
+    """Resolve the Azure app client ID: explicit arg → env → settings.json."""
+    if explicit and explicit.strip():
+        return explicit.strip()
+    env = os.environ.get("MS_OAUTH_CLIENT_ID", "").strip()
+    if env:
+        return env
+    try:
+        s = json.loads(_SETTINGS_FILE.read_text(encoding="utf-8"))
+        return (s.get("ms_oauth_client_id") or "").strip()
+    except Exception:
+        return ""
+
+
+def xoauth2_string(user: str, access_token: str) -> str:
+    """Build the SASL XOAUTH2 initial-response string for IMAP/SMTP."""
+    return f"user={user}\x01auth=Bearer {access_token}\x01\x01"
+
+
+def start_device_flow(client_id: str) -> dict:
+    """Begin the device code flow. Returns the raw Microsoft payload:
+    device_code, user_code, verification_uri, expires_in, interval, message."""
+    if not client_id:
+        raise ValueError("No Microsoft OAuth client ID configured (set MS_OAUTH_CLIENT_ID)")
+    r = requests.post(
+        f"{_authority()}/devicecode",
+        data={"client_id": client_id, "scope": SCOPES},
+        timeout=_HTTP_TIMEOUT,
+    )
+    if r.status_code != 200:
+        # Surface the AADSTS error_description from the body — a bare
+        # "400 Bad Request" hides the real cause (public-client flows off,
+        # wrong tenant, unknown client id, etc.).
+        detail = ""
+        try:
+            j = r.json()
+            detail = j.get("error_description") or j.get("error") or ""
+        except Exception:
+            detail = (r.text or "")[:300]
+        # First line of error_description carries the AADSTSxxxxx code.
+        first = detail.splitlines()[0] if detail else f"HTTP {r.status_code}"
+        raise RuntimeError(f"Microsoft sign-in error: {first}")
+    return r.json()
+
+
+def poll_device_flow(client_id: str, device_code: str) -> dict:
+    """Poll once for device-flow completion.
+
+    Returns {"status": "pending"|"ok"|"error", ...}. On "ok" includes
+    "refresh_token". "pending" covers authorization_pending / slow_down."""
+    if not (client_id and device_code):
+        return {"status": "error", "error": "missing client_id or device_code"}
+    r = requests.post(
+        f"{_authority()}/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "client_id": client_id,
+            "device_code": device_code,
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    if r.status_code == 200:
+        tok = r.json()
+        return {"status": "ok", "refresh_token": tok.get("refresh_token", "")}
+    try:
+        err = (r.json() or {}).get("error", "")
+    except Exception:
+        err = ""
+    if err in ("authorization_pending", "slow_down"):
+        return {"status": "pending", "error": err}
+    return {"status": "error", "error": err or f"HTTP {r.status_code}"}
+
+
+def _refresh(client_id: str, refresh_token: str) -> dict:
+    r = requests.post(
+        f"{_authority()}/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "refresh_token": refresh_token,
+            "scope": SCOPES,
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()  # access_token, refresh_token (rotated), expires_in
+
+
+def get_access_token(account_id: str, client_id: str, refresh_token: str, on_refresh=None) -> str:
+    """Return a valid access token, refreshing via the stored refresh token if
+    the cached one is missing or near expiry. Caches per account in memory.
+
+    `on_refresh(new_refresh_token)` is called when the refresh token rotates so
+    the caller can persist the replacement (Microsoft rotates refresh tokens)."""
+    if not (client_id and refresh_token):
+        raise ValueError("OAuth is not configured for this account (missing client ID or refresh token)")
+    key = account_id or ""
+    with _lock:
+        cached = _token_cache.get(key)
+        if cached and time.time() < cached[1] - _EXPIRY_SKEW:
+            return cached[0]
+        tok = _refresh(client_id, refresh_token)
+        access = tok["access_token"]
+        expires_at = time.time() + int(tok.get("expires_in", 3600))
+        _token_cache[key] = (access, expires_at)
+        new_rt = tok.get("refresh_token")
+        if new_rt and new_rt != refresh_token and on_refresh:
+            try:
+                on_refresh(new_rt)
+            except Exception as e:
+                logger.warning(f"Failed to persist rotated refresh token for {key!r}: {e}")
+        return access
+
+
+def invalidate(account_id: str) -> None:
+    """Drop the cached access token for an account (e.g. after re-auth)."""
+    with _lock:
+        _token_cache.pop(account_id or "", None)

--- a/static/js/document.js
+++ b/static/js/document.js
@@ -87,7 +87,11 @@ import * as Modals from './modalManager.js';
   }
 
   function _accountCanSend(account) {
-    return !!(account && account.smtp_host && account.smtp_user && account.has_smtp_password);
+    if (!account || !account.smtp_host) return false;
+    // OAuth accounts send via XOAUTH2 — a stored refresh token replaces the
+    // SMTP password.
+    const hasCreds = account.has_smtp_password || (account.auth_type === 'oauth2' && account.has_oauth);
+    return !!((account.smtp_user || account.from_address) && hasCreds);
   }
 
   async function _resolveComposeSendAccountId() {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2246,7 +2246,7 @@ async function initReminderSettings() {
     const res = await fetch('/api/email/accounts', { credentials: 'same-origin' });
     if (res.ok) {
       const d = await res.json();
-      emailAccounts = (d.accounts || []).filter(a => a.smtp_host && a.smtp_user && a.has_smtp_password);
+      emailAccounts = (d.accounts || []).filter(a => a.smtp_host && (a.smtp_user || a.from_address) && (a.has_smtp_password || (a.auth_type === 'oauth2' && a.has_oauth)));
     }
   } catch (_) {}
   let smtpConfigured = emailAccounts.length > 0;
@@ -2316,7 +2316,7 @@ async function initReminderSettings() {
       const res = await fetch('/api/email/accounts', { credentials: 'same-origin' });
       if (res.ok) {
         const d = await res.json();
-        emailAccounts = (d.accounts || []).filter(a => a.smtp_host && a.smtp_user && a.has_smtp_password);
+        emailAccounts = (d.accounts || []).filter(a => a.smtp_host && (a.smtp_user || a.from_address) && (a.has_smtp_password || (a.auth_type === 'oauth2' && a.has_oauth)));
       }
     } catch (_) {}
     smtpConfigured = emailAccounts.length > 0;
@@ -2604,7 +2604,7 @@ async function initEmailAccountsSettings() {
       gmail:    { label: 'Gmail',                  imap: { host: 'imap.gmail.com',           port: 993, starttls: false }, smtp: { host: 'smtp.gmail.com',            port: 465 } },
       migadu:   { label: 'Migadu',                 imap: { host: 'imap.migadu.com',          port: 993, starttls: false }, smtp: { host: 'smtp.migadu.com',           port: 465 } },
       icloud:   { label: 'iCloud',                 imap: { host: 'imap.mail.me.com',         port: 993, starttls: false }, smtp: { host: 'smtp.mail.me.com',          port: 587 } },
-      outlook:  { label: 'Outlook / Office 365',   imap: { host: 'outlook.office365.com',    port: 993, starttls: false }, smtp: { host: 'smtp.office365.com',        port: 587 } },
+      outlook:  { label: 'Outlook / Microsoft 365', imap: { host: 'outlook.office365.com',    port: 993, starttls: false }, smtp: { host: 'smtp.office365.com',        port: 587 }, oauth: true },
       fastmail: { label: 'Fastmail',               imap: { host: 'imap.fastmail.com',        port: 993, starttls: false }, smtp: { host: 'smtp.fastmail.com',         port: 465 } },
       yahoo:    { label: 'Yahoo',                  imap: { host: 'imap.mail.yahoo.com',      port: 993, starttls: false }, smtp: { host: 'smtp.mail.yahoo.com',       port: 465 } },
       dovecot:  { label: 'Dovecot IMAP (no SMTP)',  imap: { host: '',                        port: 31143, starttls: false }, smtp: { host: '',                          port: 465 } },
@@ -2619,17 +2619,26 @@ async function initEmailAccountsSettings() {
         <div class="settings-row"><label class="settings-label">Provider${_hint('Pick a known provider to auto-fill the IMAP and SMTP host/port. Choose Custom to type your own.')}</label><select id="eaf-provider" class="settings-select"><option value="">Custom…</option>${_providerOptions}</select></div>
         <div class="settings-row"><label class="settings-label">Name${_hint('Optional label for this account (e.g. “Work” or “Personal”). Leave blank to use the email address.')}</label><input id="eaf-name" class="settings-input" placeholder="(optional — leave blank to use email)" value="${esc(a.name || '')}"></div>
         <div class="settings-row"><label class="settings-label">Email${_hint('Your email address. Used as the From: header on outgoing mail and as the display label when Name is blank.')}</label><input id="eaf-from" class="settings-input" placeholder="you@example.com" value="${esc(a.from_address || '')}"></div>
+        <div class="settings-row"><label class="settings-label">Authentication${_hint('Password = classic IMAP/SMTP login (Gmail app password, etc.). Microsoft (OAuth2) = sign in with your Microsoft account — required for personal @hotmail/@outlook and Exchange Online, which no longer allow passwords.')}</label><select id="eaf-auth" class="settings-select"><option value="password" ${(a.auth_type === 'oauth2') ? '' : 'selected'}>Password</option><option value="oauth2" ${(a.auth_type === 'oauth2') ? 'selected' : ''}>Microsoft (OAuth2)</option></select></div>
+        <div id="eaf-oauth-panel" style="display:none;border:1px solid var(--border);border-radius:6px;padding:10px;margin:2px 0 4px">
+          <div style="font-size:11px;opacity:0.75;margin-bottom:7px">Sign in with your Microsoft account to authorize IMAP + SMTP. ${isEdit && a.has_oauth ? 'Already signed in — only re-authorize if sending/receiving stopped working.' : 'Needs an Azure app client ID configured on the server (MS_OAUTH_CLIENT_ID).'}</div>
+          <button type="button" class="admin-btn-add" id="eaf-oauth-btn" style="display:inline-flex;align-items:center;gap:5px;font-weight:600;">
+            <svg width="11" height="11" viewBox="0 0 23 23" aria-hidden="true"><rect x="1" y="1" width="10" height="10" fill="#f25022"/><rect x="12" y="1" width="10" height="10" fill="#7fba00"/><rect x="1" y="12" width="10" height="10" fill="#00a4ef"/><rect x="12" y="12" width="10" height="10" fill="#ffb900"/></svg>
+            Sign in with Microsoft
+          </button>
+          <div id="eaf-oauth-status" style="font-size:11px;margin-top:7px;line-height:1.5"></div>
+        </div>
         <div style="font-size:11px;font-weight:600;opacity:0.6;margin:6px 0 2px">IMAP (Receiving)</div>
         <div class="settings-row"><label class="settings-label">Host${_hint('Your IMAP server, e.g. imap.gmail.com, imap.migadu.com, a LAN host, or a Tailscale IP for Dovecot.')}</label><input id="eaf-imap-host" class="settings-input" value="${esc(a.imap_host || '')}"></div>
         <div class="settings-row"><label class="settings-label">Port${_hint('993 for IMAPS (most providers), 143 for plain or STARTTLS. Local servers often use a custom port like 31143.')}</label><input id="eaf-imap-port" class="settings-input" type="number" value="${esc(a.imap_port || 993)}" style="max-width:100px"></div>
         <div class="settings-row"><label class="settings-label">Username${_hint('Usually your full email address.')}</label><input id="eaf-imap-user" class="settings-input" value="${esc(a.imap_user || '')}"></div>
-        <div class="settings-row"><label class="settings-label">Password${_hint('Your IMAP login password. Use an app-specific password if your provider requires 2FA (Gmail, iCloud, etc.).')}</label><input id="eaf-imap-pass" class="settings-input" type="password" placeholder="${isEdit && a.has_imap_password ? '(unchanged)' : ''}"></div>
+        <div class="settings-row eaf-basic-only"><label class="settings-label">Password${_hint('Your IMAP login password. Use an app-specific password if your provider requires 2FA (Gmail, iCloud, etc.).')}</label><input id="eaf-imap-pass" class="settings-input" type="password" placeholder="${isEdit && a.has_imap_password ? '(unchanged)' : ''}"></div>
         <div class="settings-row"><label class="settings-label">STARTTLS${_hint('Turn ON for port 143/587 to upgrade plain to TLS. Turn OFF for port 993 (IMAPS — already encrypted) or a local server with no TLS configured.')}</label><label class="admin-switch"><input type="checkbox" id="eaf-imap-starttls" ${a.imap_starttls !== false ? 'checked' : ''}><span class="admin-slider"></span></label></div>
         <div style="font-size:11px;font-weight:600;opacity:0.6;margin:8px 0 2px">SMTP (Sending) <span style="font-weight:normal;opacity:0.7">— optional, leave blank for read-only</span></div>
         <div class="settings-row"><label class="settings-label">Host${_hint('Your outgoing-mail server, e.g. smtp.gmail.com, smtp.migadu.com. Leave blank to make this account read-only.')}</label><input id="eaf-smtp-host" class="settings-input" value="${esc(a.smtp_host || '')}"></div>
         <div class="settings-row"><label class="settings-label">Port${_hint('465 for SSL/SMTPS, 587 for STARTTLS. 25 is usually blocked by ISPs.')}</label><input id="eaf-smtp-port" class="settings-input" type="number" value="${esc(a.smtp_port || 465)}" style="max-width:100px"></div>
         <div class="settings-row"><label class="settings-label">Security${_hint('SSL for port 465, STARTTLS for port 587, or None for local SMTP bridges such as Proton Mail Bridge.')}</label><select id="eaf-smtp-security" class="settings-select"><option value="ssl">SSL</option><option value="starttls">STARTTLS</option><option value="none">None</option></select></div>
-        <div class="settings-row"><label class="settings-label">Same as IMAP${_hint('Use the IMAP username and password for SMTP too (this is right for almost every provider). Turn off to enter separate SMTP credentials.')}</label><label class="admin-switch"><input type="checkbox" id="eaf-smtp-same" ${(!isEdit || (a.smtp_user && a.imap_user && a.smtp_user === a.imap_user)) ? 'checked' : ''}><span class="admin-slider"></span></label></div>
+        <div class="settings-row eaf-basic-only"><label class="settings-label">Same as IMAP${_hint('Use the IMAP username and password for SMTP too (this is right for almost every provider). Turn off to enter separate SMTP credentials.')}</label><label class="admin-switch"><input type="checkbox" id="eaf-smtp-same" ${(!isEdit || (a.smtp_user && a.imap_user && a.smtp_user === a.imap_user)) ? 'checked' : ''}><span class="admin-slider"></span></label></div>
         <div class="settings-row eaf-smtp-creds"><label class="settings-label">Username${_hint('Usually the same as your IMAP username (your email address).')}</label><input id="eaf-smtp-user" class="settings-input" value="${esc(a.smtp_user || '')}"></div>
         <div class="settings-row eaf-smtp-creds"><label class="settings-label">Password${_hint('Your SMTP password — often the same as your IMAP password.')}</label><input id="eaf-smtp-pass" class="settings-input" type="password" placeholder="${isEdit && a.has_smtp_password ? '(unchanged)' : ''}"></div>
         <div class="settings-row" style="margin-top:10px;align-items:center;">
@@ -2656,6 +2665,10 @@ async function initEmailAccountsSettings() {
       el('eaf-smtp-host').value = p.smtp.host;
       el('eaf-smtp-port').value = p.smtp.port;
       el('eaf-smtp-security').value = p.smtp.security || ((parseInt(p.smtp.port || 465) === 587) ? 'starttls' : 'ssl');
+      // Microsoft requires OAuth2 — flip the auth selector so the user gets
+      // the sign-in button instead of dead password fields.
+      if (p.oauth) { el('eaf-auth').value = 'oauth2'; }
+      _syncAuthType();
     });
     el('eaf-smtp-security').value = _smtpSecurity(a);
 
@@ -2670,7 +2683,95 @@ async function initEmailAccountsSettings() {
     el('eaf-smtp-same').addEventListener('change', _syncSmtpSame);
     _syncSmtpSame();
 
-    el('eaf-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
+    // ── Auth type: password vs Microsoft OAuth2 ──
+    // For OAuth the password fields are meaningless (we use a refresh token),
+    // so hide them and show the sign-in panel. SMTP uses the same token, so
+    // the per-protocol SMTP creds collapse too.
+    let oauthRefreshToken = null;   // set only after a fresh device-flow sign-in
+    let oauthPolling = false;
+    const _syncAuthType = () => {
+      const oauth = el('eaf-auth').value === 'oauth2';
+      el('eaf-oauth-panel').style.display = oauth ? '' : 'none';
+      formEl.querySelectorAll('.eaf-basic-only').forEach(r => { r.style.display = oauth ? 'none' : ''; });
+      if (oauth) {
+        formEl.querySelectorAll('.eaf-smtp-creds').forEach(r => { r.style.display = 'none'; });
+      } else {
+        _syncSmtpSame();
+      }
+    };
+    el('eaf-auth').addEventListener('change', _syncAuthType);
+    _syncAuthType();
+
+    el('eaf-oauth-btn').addEventListener('click', async () => {
+      const statusEl = el('eaf-oauth-status');
+      const btn = el('eaf-oauth-btn');
+      btn.disabled = true;
+      statusEl.style.color = '';
+      statusEl.textContent = 'Starting sign-in…';
+      let flow;
+      try {
+        const r = await fetch('/api/email/oauth/microsoft/start', { method: 'POST', credentials: 'same-origin' });
+        flow = await r.json();
+      } catch (e) { flow = { ok: false, error: String(e) }; }
+      if (!flow.ok) {
+        statusEl.style.color = 'var(--red)';
+        statusEl.textContent = flow.error || 'Could not start sign-in';
+        btn.disabled = false;
+        return;
+      }
+      statusEl.innerHTML = `Go to <a href="${esc(flow.verification_uri)}" target="_blank" rel="noopener" style="color:var(--accent,#50fa7b)">${esc(flow.verification_uri)}</a> and enter code `
+        + `<span style="display:inline-flex;align-items:center;gap:6px;vertical-align:middle;margin:0 2px">`
+        +   `<b style="font-family:monospace;font-size:13px;letter-spacing:1px">${esc(flow.user_code)}</b>`
+        +   `<button type="button" id="eaf-oauth-copy" class="admin-btn-sm" style="font-size:10px;padding:2px 8px;line-height:1.4">Copy</button>`
+        + `</span>`
+        + `<div style="opacity:0.6;margin-top:3px">Waiting for you to finish in the browser…</div>`;
+      el('eaf-oauth-copy')?.addEventListener('click', (ev) => {
+        try { navigator.clipboard.writeText(flow.user_code); } catch (_) {}
+        const b = ev.currentTarget, t = b.textContent;
+        b.textContent = 'Copied'; setTimeout(() => { b.textContent = t; }, 1200);
+      });
+      try { window.open(flow.verification_uri, '_blank', 'noopener'); } catch (_) {}
+
+      const interval = Math.max(2, flow.interval || 5) * 1000;
+      const deadline = Date.now() + (flow.expires_in || 900) * 1000;
+      oauthPolling = true;
+      const poll = async () => {
+        if (!oauthPolling) return;
+        if (Date.now() > deadline) {
+          statusEl.style.color = 'var(--red)';
+          statusEl.textContent = 'Sign-in timed out — try again';
+          btn.disabled = false;
+          return;
+        }
+        let res;
+        try {
+          const r = await fetch('/api/email/oauth/microsoft/poll', {
+            method: 'POST', credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ device_code: flow.device_code }),
+          });
+          res = await r.json();
+        } catch (e) { res = { status: 'error', error: String(e) }; }
+        if (res.status === 'ok') {
+          oauthRefreshToken = res.refresh_token;
+          oauthPolling = false;
+          statusEl.style.color = 'var(--green,#50fa7b)';
+          statusEl.textContent = '✓ Signed in — click ' + (isEdit ? 'Save' : 'Create') + ' to finish.';
+          btn.disabled = false;
+          // Default the IMAP username to the email if the user left it blank.
+          const email = el('eaf-from').value.trim();
+          if (email && !el('eaf-imap-user').value.trim()) el('eaf-imap-user').value = email;
+          return;
+        }
+        if (res.status === 'pending') { setTimeout(poll, interval); return; }
+        statusEl.style.color = 'var(--red)';
+        statusEl.textContent = res.error || 'Sign-in failed';
+        btn.disabled = false;
+      };
+      setTimeout(poll, interval);
+    });
+
+    el('eaf-cancel').addEventListener('click', () => { oauthPolling = false; formEl.style.display = 'none'; });
     el('eaf-save').addEventListener('click', async () => {
       const body = {
         name: el('eaf-name').value.trim(),
@@ -2693,6 +2794,25 @@ async function initEmailAccountsSettings() {
       if (el('eaf-smtp-same').checked) {
         body.smtp_user = body.imap_user;
         if (body.imap_password) body.smtp_password = body.imap_password;
+      }
+      // Authentication type. OAuth accounts carry a refresh token instead of
+      // passwords; SMTP reuses the IMAP user + the same token.
+      if (el('eaf-auth').value === 'oauth2') {
+        body.auth_type = 'oauth2';
+        body.oauth_provider = 'microsoft';
+        delete body.imap_password;
+        delete body.smtp_password;
+        if (!body.imap_user) body.imap_user = body.from_address;
+        if (!body.smtp_user) body.smtp_user = body.imap_user;
+        if (oauthRefreshToken) body.oauth_refresh_token = oauthRefreshToken;
+        // Must have a token: either a fresh sign-in or one already stored.
+        if (!oauthRefreshToken && !(isEdit && a.has_oauth)) {
+          el('eaf-msg').textContent = 'Sign in with Microsoft first';
+          el('eaf-msg').style.color = 'var(--red)';
+          return;
+        }
+      } else {
+        body.auth_type = 'password';
       }
       // Name is optional — fall back to the From address so the list view
       // still has a label to render. Only refuse if both are blank.
@@ -3697,7 +3817,7 @@ async function initUnifiedIntegrations() {
       gmail:    { label: 'Gmail',                   emailEx: 'you@gmail.com',     imap: { host: 'imap.gmail.com',           port: 993, starttls: false }, smtp: { host: 'smtp.gmail.com',     port: 465 } },
       migadu:   { label: 'Migadu',                  emailEx: 'you@yourdomain.com', imap: { host: 'imap.migadu.com',          port: 993, starttls: false }, smtp: { host: 'smtp.migadu.com',    port: 465 } },
       icloud:   { label: 'iCloud',                  emailEx: 'you@icloud.com',    imap: { host: 'imap.mail.me.com',         port: 993, starttls: false }, smtp: { host: 'smtp.mail.me.com',   port: 587 } },
-      outlook:  { label: 'Outlook / Office 365',    emailEx: 'you@outlook.com',   imap: { host: 'outlook.office365.com',    port: 993, starttls: false }, smtp: { host: 'smtp.office365.com', port: 587 } },
+      outlook:  { label: 'Outlook / Microsoft 365',  emailEx: 'you@outlook.com',   imap: { host: 'outlook.office365.com',    port: 993, starttls: false }, smtp: { host: 'smtp.office365.com', port: 587 }, oauth: true },
       fastmail: { label: 'Fastmail',                emailEx: 'you@fastmail.com',  imap: { host: 'imap.fastmail.com',        port: 993, starttls: false }, smtp: { host: 'smtp.fastmail.com',  port: 465 } },
       yahoo:    { label: 'Yahoo',                   emailEx: 'you@yahoo.com',     imap: { host: 'imap.mail.yahoo.com',      port: 993, starttls: false }, smtp: { host: 'smtp.mail.yahoo.com', port: 465 } },
       dovecot:  { label: 'Dovecot IMAP (no SMTP)',  emailEx: 'you@example.com',   imap: { host: '',                         port: 31143, starttls: false }, smtp: { host: '',                   port: 465 } },
@@ -3713,17 +3833,26 @@ async function initUnifiedIntegrations() {
           <div id="uf-email-provider-note" style="display:none;font-size:11px;line-height:1.5;padding:8px 10px;margin:2px 0 4px;border:1px solid color-mix(in srgb, var(--fg) 15%, transparent);border-left:3px solid var(--accent, var(--red));border-radius:4px;background:color-mix(in srgb, var(--fg) 4%, transparent);"></div>
           <div class="settings-row"><label class="settings-label">Name${_hint('Optional label for this account (e.g. “Work” or “Personal”). Leave blank to use the email address.')}</label><input id="uf-email-name" class="settings-input" placeholder="(optional — leave blank to use email)"></div>
           <div class="settings-row"><label class="settings-label">Email${_hint('Your email address. Used as the From: header on outgoing mail and as the display label when Name is blank.')}</label><input id="uf-email-from" class="settings-input" placeholder="you@example.com"></div>
+          <div class="settings-row"><label class="settings-label">Authentication${_hint('Password = classic IMAP/SMTP login (Gmail app password, etc.). Microsoft (OAuth2) = sign in with your Microsoft account — required for personal @hotmail/@outlook and Exchange Online, which no longer allow passwords.')}</label><select id="uf-email-auth" class="settings-select"><option value="password">Password</option><option value="oauth2">Microsoft (OAuth2)</option></select></div>
+          <div id="uf-oauth-panel" style="display:none;border:1px solid var(--border);border-radius:6px;padding:10px;margin:2px 0 4px">
+            <div id="uf-oauth-intro" style="font-size:11px;opacity:0.75;margin-bottom:7px">Sign in with your Microsoft account to authorize IMAP + SMTP. Needs an Azure app client ID on the server (MS_OAUTH_CLIENT_ID).</div>
+            <button type="button" class="admin-btn-add" id="uf-oauth-btn" style="display:inline-flex;align-items:center;gap:5px;font-weight:600;">
+              <svg width="11" height="11" viewBox="0 0 23 23" aria-hidden="true"><rect x="1" y="1" width="10" height="10" fill="#f25022"/><rect x="12" y="1" width="10" height="10" fill="#7fba00"/><rect x="1" y="12" width="10" height="10" fill="#00a4ef"/><rect x="12" y="12" width="10" height="10" fill="#ffb900"/></svg>
+              Sign in with Microsoft
+            </button>
+            <div id="uf-oauth-status" style="font-size:11px;margin-top:7px;line-height:1.5"></div>
+          </div>
           <div style="font-size:11px;font-weight:600;opacity:0.6;margin:4px 0 2px">IMAP (Receiving)</div>
           <div class="settings-row"><label class="settings-label">Host${_hint('Your IMAP server, e.g. imap.gmail.com, imap.migadu.com, a LAN host, or a Tailscale IP for Dovecot.')}</label><input id="uf-imap-host" class="settings-input" placeholder="imap.example.com"></div>
           <div class="settings-row"><label class="settings-label">Port${_hint('993 for IMAPS (most providers), 143 for plain or STARTTLS. Local servers often use a custom port like 31143.')}</label><input id="uf-imap-port" class="settings-input" type="number" placeholder="993" style="max-width:100px"></div>
           <div class="settings-row"><label class="settings-label">Username${_hint('Yes — your full email address goes here too (e.g. you@gmail.com). Same as the Email field above for almost every provider.')}</label><input id="uf-imap-user" class="settings-input" placeholder="you@example.com"></div>
-          <div class="settings-row"><label class="settings-label">Password${_hint('For Gmail, iCloud, and Yahoo: paste your App Password (NOT your normal account password — those are blocked for IMAP). For Migadu, Fastmail, Outlook, etc.: your regular mailbox password works.')}</label><input id="uf-imap-pass" class="settings-input" type="password" placeholder="${placeholderPass}"></div>
+          <div class="settings-row uf-basic-only"><label class="settings-label">Password${_hint('For Gmail, iCloud, and Yahoo: paste your App Password (NOT your normal account password — those are blocked for IMAP). For Migadu, Fastmail, Outlook, etc.: your regular mailbox password works.')}</label><input id="uf-imap-pass" class="settings-input" type="password" placeholder="${placeholderPass}"></div>
           <div class="settings-row"><label class="settings-label">STARTTLS${_hint('Turn ON for port 143/587 to upgrade plain to TLS. Turn OFF for port 993 (IMAPS — already encrypted) or a local server with no TLS configured.')}</label><label class="admin-switch" style="margin-left:0"><input type="checkbox" id="uf-imap-starttls" checked><span class="admin-slider"></span></label></div>
           <div style="font-size:11px;font-weight:600;opacity:0.6;margin:8px 0 2px">SMTP (Sending) <span style="font-weight:normal;opacity:0.7">— optional, leave blank for read-only</span></div>
           <div class="settings-row"><label class="settings-label">Host${_hint('Your outgoing-mail server, e.g. smtp.gmail.com. Leave blank to make this account read-only.')}</label><input id="uf-smtp-host" class="settings-input" placeholder="smtp.example.com"></div>
           <div class="settings-row"><label class="settings-label">Port${_hint('465 for SSL/SMTPS, 587 for STARTTLS. 25 is usually blocked by ISPs.')}</label><input id="uf-smtp-port" class="settings-input" type="number" placeholder="465" style="max-width:100px"></div>
           <div class="settings-row"><label class="settings-label">Security${_hint('SSL for port 465, STARTTLS for port 587, or None for local SMTP bridges such as Proton Mail Bridge.')}</label><select id="uf-smtp-security" class="settings-select"><option value="ssl">SSL</option><option value="starttls">STARTTLS</option><option value="none">None</option></select></div>
-          <div class="settings-row"><label class="settings-label">Same as IMAP${_hint('Use the IMAP username and password for SMTP too (right for almost every provider). Turn off to enter separate SMTP credentials.')}</label><label class="admin-switch" style="margin-left:0"><input type="checkbox" id="uf-smtp-same" checked><span class="admin-slider"></span></label></div>
+          <div class="settings-row uf-basic-only"><label class="settings-label">Same as IMAP${_hint('Use the IMAP username and password for SMTP too (right for almost every provider). Turn off to enter separate SMTP credentials.')}</label><label class="admin-switch" style="margin-left:0"><input type="checkbox" id="uf-smtp-same" checked><span class="admin-slider"></span></label></div>
           <div class="settings-row uf-smtp-creds"><label class="settings-label">Username${_hint('Usually the same as your IMAP username (your email address).')}</label><input id="uf-smtp-user" class="settings-input"></div>
           <div class="settings-row uf-smtp-creds"><label class="settings-label">Password${_hint('Your SMTP password — often the same as your IMAP password.')}</label><input id="uf-smtp-pass" class="settings-input" type="password" placeholder="${placeholderPass}"></div>
           <div class="settings-row" style="margin-top:4px"><label class="settings-label">Default${_hint('Use this account whenever no specific account is chosen.')}</label><label class="admin-switch" style="margin-left:0"><input type="checkbox" id="uf-email-default"><span class="admin-slider"></span></label><span style="font-size:10px;opacity:0.5;margin-left:6px">Used when nothing else is selected</span></div>
@@ -3855,6 +3984,10 @@ async function initUnifiedIntegrations() {
         el('uf-imap-user').placeholder = p.emailEx;
         el('uf-smtp-user').placeholder = p.emailEx;
       }
+      // Microsoft requires OAuth2 — flip the auth selector so the user gets
+      // the sign-in button instead of dead password fields.
+      if (p.oauth) { el('uf-email-auth').value = 'oauth2'; }
+      _syncAuthType();
     });
 
     // "Same as IMAP" toggle — hide the SMTP creds rows when on.
@@ -3866,6 +3999,87 @@ async function initUnifiedIntegrations() {
     };
     el('uf-smtp-same').addEventListener('change', _syncSmtpSame);
     _syncSmtpSame();
+
+    // ── Auth type: password vs Microsoft OAuth2 ──
+    let oauthRefreshToken = null;   // set only after a fresh device-flow sign-in
+    let oauthPolling = false;
+    const _syncAuthType = () => {
+      const oauth = el('uf-email-auth').value === 'oauth2';
+      el('uf-oauth-panel').style.display = oauth ? '' : 'none';
+      formEl.querySelectorAll('.uf-basic-only').forEach(r => { r.style.display = oauth ? 'none' : ''; });
+      if (oauth) formEl.querySelectorAll('.uf-smtp-creds').forEach(r => { r.style.display = 'none'; });
+      else _syncSmtpSame();
+    };
+    el('uf-email-auth').addEventListener('change', _syncAuthType);
+
+    el('uf-oauth-btn').addEventListener('click', async () => {
+      const statusEl = el('uf-oauth-status');
+      const btn = el('uf-oauth-btn');
+      btn.disabled = true;
+      statusEl.style.color = '';
+      statusEl.textContent = 'Starting sign-in…';
+      let flow;
+      try {
+        const r = await fetch('/api/email/oauth/microsoft/start', { method: 'POST', credentials: 'same-origin' });
+        flow = await r.json();
+      } catch (e) { flow = { ok: false, error: String(e) }; }
+      if (!flow.ok) {
+        statusEl.style.color = 'var(--red)';
+        statusEl.textContent = flow.error || 'Could not start sign-in';
+        btn.disabled = false;
+        return;
+      }
+      statusEl.innerHTML = `Go to <a href="${esc(flow.verification_uri)}" target="_blank" rel="noopener" style="color:var(--accent,#50fa7b)">${esc(flow.verification_uri)}</a> and enter code `
+        + `<span style="display:inline-flex;align-items:center;gap:6px;vertical-align:middle;margin:0 2px">`
+        +   `<b style="font-family:monospace;font-size:13px;letter-spacing:1px">${esc(flow.user_code)}</b>`
+        +   `<button type="button" id="uf-oauth-copy" class="admin-btn-sm" style="font-size:10px;padding:2px 8px;line-height:1.4">Copy</button>`
+        + `</span>`
+        + `<div style="opacity:0.6;margin-top:3px">Waiting for you to finish in the browser…</div>`;
+      el('uf-oauth-copy')?.addEventListener('click', (ev) => {
+        try { navigator.clipboard.writeText(flow.user_code); } catch (_) {}
+        const b = ev.currentTarget, t = b.textContent;
+        b.textContent = 'Copied'; setTimeout(() => { b.textContent = t; }, 1200);
+      });
+      try { window.open(flow.verification_uri, '_blank', 'noopener'); } catch (_) {}
+
+      const interval = Math.max(2, flow.interval || 5) * 1000;
+      const deadline = Date.now() + (flow.expires_in || 900) * 1000;
+      oauthPolling = true;
+      const poll = async () => {
+        if (!oauthPolling) return;
+        if (Date.now() > deadline) {
+          statusEl.style.color = 'var(--red)';
+          statusEl.textContent = 'Sign-in timed out — try again';
+          btn.disabled = false;
+          return;
+        }
+        let res;
+        try {
+          const r = await fetch('/api/email/oauth/microsoft/poll', {
+            method: 'POST', credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ device_code: flow.device_code }),
+          });
+          res = await r.json();
+        } catch (e) { res = { status: 'error', error: String(e) }; }
+        if (res.status === 'ok') {
+          oauthRefreshToken = res.refresh_token;
+          oauthPolling = false;
+          statusEl.style.color = 'var(--green,#50fa7b)';
+          statusEl.textContent = '✓ Signed in — click ' + (isEdit ? 'Save' : 'Create') + ' to finish.';
+          btn.disabled = false;
+          const email = el('uf-email-from').value.trim();
+          if (email && !el('uf-imap-user').value.trim()) el('uf-imap-user').value = email;
+          return;
+        }
+        if (res.status === 'pending') { setTimeout(poll, interval); return; }
+        statusEl.style.color = 'var(--red)';
+        statusEl.textContent = res.error || 'Sign-in failed';
+        btn.disabled = false;
+      };
+      setTimeout(poll, interval);
+    });
+
     if (existing) {
       el('uf-email-name').value = existing.name || '';
       el('uf-email-from').value = existing.from_address || '';
@@ -3884,12 +4098,17 @@ async function initUnifiedIntegrations() {
       const sameCreds = !!(existing.imap_user && existing.smtp_user && existing.imap_user === existing.smtp_user);
       el('uf-smtp-same').checked = sameCreds || !existing.smtp_user;
       _syncSmtpSame();
+      el('uf-email-auth').value = existing.auth_type === 'oauth2' ? 'oauth2' : 'password';
+      if (existing.auth_type === 'oauth2' && existing.has_oauth) {
+        el('uf-oauth-intro').textContent = 'Already signed in — only re-authorize if sending/receiving stopped working.';
+      }
     } else {
       el('uf-imap-port').value = 993;
       el('uf-smtp-port').value = 465;
       el('uf-smtp-security').value = 'ssl';
     }
-    el('uf-email-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
+    _syncAuthType();
+    el('uf-email-cancel').addEventListener('click', () => { oauthPolling = false; formEl.style.display = 'none'; });
 
     // Reset the Test button to neutral when the user edits any field
     // after a test — stale green/red would imply the new values were
@@ -3932,6 +4151,19 @@ async function initUnifiedIntegrations() {
       if (el('uf-smtp-same').checked) {
         body.smtp_user = body.imap_user;
         if (body.imap_password) body.smtp_password = body.imap_password;
+      }
+      // OAuth accounts carry a refresh token instead of passwords; SMTP reuses
+      // the IMAP user + the same token.
+      if (el('uf-email-auth').value === 'oauth2') {
+        body.auth_type = 'oauth2';
+        body.oauth_provider = 'microsoft';
+        delete body.imap_password;
+        delete body.smtp_password;
+        if (!body.imap_user) body.imap_user = body.from_address;
+        if (!body.smtp_user) body.smtp_user = body.imap_user;
+        if (oauthRefreshToken) body.oauth_refresh_token = oauthRefreshToken;
+      } else {
+        body.auth_type = 'password';
       }
       return body;
     };
@@ -4012,6 +4244,12 @@ async function initUnifiedIntegrations() {
       // Name is optional — fall back to Email so the list still has a label.
       if (!body.name) body.name = body.from_address;
       if (!body.name) { el('uf-email-msg').textContent = 'Need at least a Name or Email'; el('uf-email-msg').style.color = 'var(--red)'; return; }
+      // OAuth needs a token: either a fresh sign-in or one already stored.
+      if (body.auth_type === 'oauth2' && !body.oauth_refresh_token && !(isEdit && existing && existing.has_oauth)) {
+        el('uf-email-msg').textContent = 'Sign in with Microsoft first';
+        el('uf-email-msg').style.color = 'var(--red)';
+        return;
+      }
       const saveBtn = el('uf-email-save');
       saveBtn.disabled = true;
       const saveIcoEl = saveBtn.querySelector('.uf-email-save-ico');


### PR DESCRIPTION
## Summary

Personal Microsoft accounts (`@hotmail`/`@outlook`/`@live`) and Exchange Online no longer permit Basic Auth, so they can't be added to the Email feature — IMAP returns `AUTHENTICATE failed` and SMTP returns `535 … basic authentication is disabled`, exactly as reported in #725.

This adds an **OAuth2 (XOAUTH2)** authentication option alongside the existing password auth, using the Microsoft identity platform **device-code flow**.

Fixes #725

## What's included

- **Schema:** `EmailAccount` gains `auth_type` (`password`|`oauth2`), `oauth_provider`, and `oauth_refresh_token` (Fernet-encrypted at rest, like the passwords). Additive, idempotent startup migration; existing accounts default to `password`.
- **`src/oauth_email.py`:** Microsoft device-code flow + refresh-token exchange via raw `requests` (no new dependency), in-memory access-token cache with refresh-token rotation, and the SASL XOAUTH2 string builder.
- **Connection layer:** IMAP/SMTP paths (web routes + MCP email server) branch `password` ↔ XOAUTH2 via stdlib `imaplib.authenticate` / `smtplib.auth`. **TLS transport selection is untouched** — composes cleanly with the new `smtp_security` mode.
- **API:** device-code endpoints (`/api/email/oauth/microsoft/{start,poll}`); OAuth-aware account CRUD, connection test, and send-ready gates.
- **UI:** "Sign in with Microsoft" flow in both email-account forms (Settings → Email and Integrations); the Outlook preset auto-selects OAuth.

## Configuration

The Azure app **client ID is user-supplied** (public client, not a secret) via `MS_OAUTH_CLIENT_ID` (+ optional `MS_OAUTH_TENANT`, default `common`); steps documented in `.env.example`. Register an Azure app with *Allow public client flows* enabled and delegated `IMAP.AccessAsUser.All` + `SMTP.Send` + `offline_access`. Personal-account-only apps use `MS_OAUTH_TENANT=consumers`.

## Testing

- End-to-end against a real personal `@live.com` account: device-code sign-in → consent → inbox loads (IMAP XOAUTH2) and test send works (SMTP XOAUTH2).
- Password accounts (Gmail app-password, etc.) unchanged.
- Unit-checked the XOAUTH2 SASL callbacks (imaplib/smtplib arity + string) and the idempotent migration on a populated DB.
- `tests/test_email_smtp_security.py` still passes — the two features compose.
- JS syntax validation: `node --check` on the changed `static/js/settings.js` and `static/js/document.js` — pass.
- Docker: build not run locally; this PR makes no Dockerfile/compose changes.

## Notes / tradeoffs

- Device-code flow over auth-code+PKCE: no redirect URI, so it works headless / in Docker / behind Tailscale.
- The refresh token transits the browser once (device-flow poll → account save), same-origin, then encrypted at rest.
- Refresh tokens rotate; each process re-reads + persists the rotated token and caches access tokens (~1h) to limit token-endpoint traffic.

## Screenshot
<img width="712" height="998" alt="#725" src="https://github.com/user-attachments/assets/8333e448-9c8d-4cbe-b402-809fbafa75d4" />
