### PR TITLE
docs: Fixed minor spelling errors in documentation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap / Help Wanted
 
-Odysseus is on a voyage, but not home yet. It works great for me (lol), but this is ship is moving fast and feedback/help would be appreciated! (I dont know what I'm doing hlep).
+Odysseus is on a voyage, but not home yet. It works great for me (lol), but this is ship is moving fast and feedback/help would be appreciated! (I dont know what I'm doing help).
 
 If you see weird CSS, strange layout behavior, or a suspiciously murky corner of
 the codebase, you are probably right to stay away.
@@ -71,4 +71,4 @@ the codebase, you are probably right to stay away.
 
 ## Not The Focus Right Now
 
-I prob shouldnt add more themes.
+I probably shouldn't add more themes.


### PR DESCRIPTION
This pull request makes minor improvements to the `ROADMAP.md` file by correcting typos and clarifying language.

- Typo corrections and language improvements:
  * Fixed a typo in the introductory paragraph ("hlep" to "help").
  * Improved clarity in the "Not The Focus Right Now" section ("I prob shouldnt" to "I probably shouldn't").