### PR TITLE
Add AIHubMix as a provider (OpenAI-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A self-hosted AI workspace -- meant to be the self-hosted version of the UI experience you get from ChatGPT and Claude. But with more jank and fun. Running on your own hardware, with your own data -- local-first, privacy-first, and no trojan.
 
 ## Features
-  - **Chat** -- chat with any local model or API; adding them is super simple.<br>　<sub>vLLM · llama.cpp · Ollama · OpenRouter · OpenAI</sub>
+  - **Chat** -- chat with any local model or API; adding them is super simple.<br>　<sub>vLLM · llama.cpp · Ollama · OpenRouter · AIHubMix· OpenAI</sub>
   - **Agent** -- hand it tools and let it run the whole task itself.<br>　<sub>built on [opencode](https://github.com/anomalyco/opencode) · MCP · web · files · shell · skills · memory</sub>
   - **Cookbook** -- Scans your hardware, recommends models, click to download and serve.. easy!<br>　<sub>built on [llmfit](https://github.com/AlexsJones/llmfit) · VRAM-aware · GGUF / FP8 / AWQ · fit scoring · vLLM / llama.cpp serving</sub>
   - **Deep Research** -- multi-step runs that gather, read, and synthesize sources into a nice visual report.<br>　<sub>adapted from [Tongyi DeepResearch](https://github.com/Alibaba-NLP/DeepResearch)</sub>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A self-hosted AI workspace -- meant to be the self-hosted version of the UI experience you get from ChatGPT and Claude. But with more jank and fun. Running on your own hardware, with your own data -- local-first, privacy-first, and no trojan.
 
 ## Features
-  - **Chat** -- chat with any local model or API; adding them is super simple.<br>　<sub>vLLM · llama.cpp · Ollama · OpenRouter · AIHubMix· OpenAI</sub>
+  - **Chat** -- chat with any local model or API; adding them is super simple.<br>　<sub>vLLM · llama.cpp · Ollama · OpenRouter · AIHubMix · OpenAI</sub>
   - **Agent** -- hand it tools and let it run the whole task itself.<br>　<sub>built on [opencode](https://github.com/anomalyco/opencode) · MCP · web · files · shell · skills · memory</sub>
   - **Cookbook** -- Scans your hardware, recommends models, click to download and serve.. easy!<br>　<sub>built on [llmfit](https://github.com/AlexsJones/llmfit) · VRAM-aware · GGUF / FP8 / AWQ · fit scoring · vLLM / llama.cpp serving</sub>
   - **Deep Research** -- multi-step runs that gather, read, and synthesize sources into a nice visual report.<br>　<sub>adapted from [Tongyi DeepResearch](https://github.com/Alibaba-NLP/DeepResearch)</sub>

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -321,6 +321,7 @@ def _provider_label(url: str) -> str:
     if _host_match(url, "x.ai"): return "xAI"
     if _host_match(url, "openai.com"): return "OpenAI"
     if _host_match(url, "openrouter.ai"): return "OpenRouter"
+    if _host_match(url, "aihubmix.com"): return "AIHubMix"
     if _host_match(url, "groq.com"): return "Groq"
     if _host_match(url, "mistral.ai"): return "Mistral"
     if _host_match(url, "deepseek.com"): return "DeepSeek"


### PR DESCRIPTION
### What
Adds a display label for AIHubMix endpoints (`aihubmix.com`) in `_provider_label`, and lists AIHubMix in the supported-providers line in the README.

### Why
AIHubMix is an OpenAI-compatible API gateway, so it already works today via the OpenAI fallback path — users just point a model endpoint at `https://aihubmix.com/v1` with their key. The only gap was cosmetic: endpoints rendered as the bare hostname instead of a friendly name. This makes it show as "AIHubMix", consistent with the other named providers (OpenRouter, DeepSeek, etc.).

### Scope
- One line added to `_provider_label`. No change to `_detect_provider` — AIHubMix intentionally keeps using the OpenAI-compatible default (same `/chat/completions`, `/models`, and `Bearer` auth), so no special handling is needed.
- README provider list updated.

No new dependencies, no behavioral change for existing providers.