### PR TITLE
fix(ollama): pass num_ctx to prevent silent 2048-token truncation

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -9,6 +9,7 @@ import threading
 from fastapi import HTTPException
 from typing import Optional, Dict, List
 from urllib.parse import urlparse
+from src.model_context import get_context_length
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +239,7 @@ def _build_ollama_payload(
     max_tokens: int,
     stream: bool = False,
     tools: Optional[List[Dict]] = None,
+    context_length: Optional[int] = None,
 ) -> Dict:
     payload: Dict = {
         "model": model,
@@ -249,6 +251,10 @@ def _build_ollama_payload(
         options["temperature"] = temperature
     if max_tokens and max_tokens > 0:
         options["num_predict"] = max_tokens
+    # Ollama defaults num_ctx to 2048 when not specified, silently truncating
+    # any prompt longer than that regardless of the model's actual window.
+    if context_length and context_length > 2048:
+        options["num_ctx"] = context_length
     if options:
         payload["options"] = options
     if tools:
@@ -675,7 +681,8 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        ctx_len = get_context_length(target_url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False, context_length=ctx_len)
     else:
         target_url = url
         payload = {
@@ -790,7 +797,8 @@ async def llm_call_async(
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        ctx_len = get_context_length(target_url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False, context_length=ctx_len)
     else:
         target_url = url
         h = _provider_headers(provider, headers)
@@ -888,7 +896,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
+        ctx_len = get_context_length(target_url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools, context_length=ctx_len)
     else:
         target_url = url
         payload = {

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -2,6 +2,7 @@
 import httpx
 
 from src import llm_core
+from src.model_context import DEFAULT_CONTEXT
 
 
 def test_detects_ollama_cloud_native_provider():
@@ -25,6 +26,7 @@ def test_llm_call_posts_native_ollama_payload(monkeypatch):
         )
 
     monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+    monkeypatch.setattr(llm_core, "get_context_length", lambda url, model: 32768)
 
     result = llm_core.llm_call(
         "https://ollama.com/api",
@@ -40,7 +42,7 @@ def test_llm_call_posts_native_ollama_payload(monkeypatch):
     assert seen["url"] == "https://ollama.com/api/chat"
     assert seen["headers"]["Authorization"] == "Bearer ollama-key"
     assert seen["json"]["stream"] is False
-    assert seen["json"]["options"] == {"temperature": 0.2, "num_predict": 7}
+    assert seen["json"]["options"] == {"temperature": 0.2, "num_predict": 7, "num_ctx": 32768}
 
 
 # ---------------------------------------------------------------------------
@@ -113,3 +115,34 @@ def test_ollama_payload_tolerates_malformed_arguments():
     payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
     # Falls back to an empty object rather than raising.
     assert payload["messages"][0]["tool_calls"][0]["function"]["arguments"] == {}
+
+
+# ---------------------------------------------------------------------------
+# num_ctx — Ollama silently truncates at 2048 when num_ctx is omitted
+# ---------------------------------------------------------------------------
+
+def test_ollama_payload_emits_num_ctx_when_context_length_supplied():
+    """num_ctx must appear in options when a context_length > 2048 is given."""
+    msgs = [{"role": "user", "content": "hi"}]
+    payload = llm_core._build_ollama_payload(
+        "llama3.2", msgs, temperature=0.7, max_tokens=512, context_length=32768,
+    )
+    assert payload["options"]["num_ctx"] == 32768
+
+
+def test_ollama_payload_omits_num_ctx_when_context_length_is_none():
+    """Callers that don't pass context_length must not get a spurious num_ctx key."""
+    msgs = [{"role": "user", "content": "hi"}]
+    payload = llm_core._build_ollama_payload(
+        "llama3.2", msgs, temperature=0.7, max_tokens=512,
+    )
+    assert "num_ctx" not in payload.get("options", {})
+
+
+def test_ollama_payload_omits_num_ctx_at_default_2048():
+    """context_length=2048 is Ollama's built-in default — no need to echo it back."""
+    msgs = [{"role": "user", "content": "hi"}]
+    payload = llm_core._build_ollama_payload(
+        "llama3.2", msgs, temperature=0.7, max_tokens=512, context_length=2048,
+    )
+    assert "num_ctx" not in payload.get("options", {})


### PR DESCRIPTION
Fixes #909 — sibling to #753.

## Problem

Ollama defaults `num_ctx` to **2048** when the field is absent from the API request, silently truncating any prompt longer than that regardless of the model's advertised context window. All three Odysseus → Ollama call paths (`llm_call`, `llm_call_async`, `stream_llm`) were missing this field.

## Fix

Call `get_context_length()` (already cached in `src/model_context.py`) just before building each Ollama payload and emit `options.num_ctx` whenever the returned value exceeds 2048. This threads the actual serving context — queried from Ollama's API or looked up from the known-windows table — through to Ollama on every request.

## Changes

- `src/llm_core.py` — import `get_context_length`; add `context_length` param to `_build_ollama_payload`; emit `num_ctx` when `> 2048`; call `get_context_length` at all three Ollama call sites
- `tests/test_llm_core_ollama.py` — monkeypatch `get_context_length` in the existing integration test for determinism; add 3 new unit tests (emits `num_ctx` when supplied, omits when `None`, omits at exactly 2048)

## Test results

```
tests/test_llm_core_ollama.py — 9 passed
tests/test_model_context.py   — 24 passed
tests/test_llm_core_fallback.py / test_llm_core_concurrency.py — 5 passed
```