### PR TITLE
fix(hwfit): add config.json parameter count estimation fallback (fixes #955)

### DIFF
--- a/scripts/add_hwfit_models.py
+++ b/scripts/add_hwfit_models.py
@@ -21,9 +21,9 @@ import json
 import os
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
-from huggingface_hub import HfApi
+from huggingface_hub import HfApi, hf_hub_download
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), "..", "services", "hwfit", "data", "hf_models.json")
 DATA_PATH = os.path.abspath(DATA_PATH)
@@ -123,6 +123,108 @@ def _arch_from_tags(tags):
     return ""
 
 
+def _estimate_params_from_config(config):
+    """Estimate total and active parameters from config.json structure."""
+    if not isinstance(config, dict):
+        return None, None
+
+    # 1. Get basic model dimensions
+    hidden_size = config.get("hidden_size") or config.get("d_model") or config.get("n_embd")
+    num_layers = config.get("num_hidden_layers") or config.get("num_layers") or config.get("n_layers")
+
+    if not hidden_size or not num_layers:
+        # Check for alternative keys/architectures (e.g. encoder-decoder / t5)
+        hidden_size = config.get("d_model") or config.get("hidden_size")
+        num_layers = config.get("num_layers") or config.get("num_decoder_layers")
+        if not hidden_size or not num_layers:
+            return None, None
+
+    hidden_size = int(hidden_size)
+    num_layers = int(num_layers)
+
+    vocab_size = config.get("vocab_size") or config.get("encoder_vocab_size") or 32000
+    vocab_size = int(vocab_size)
+
+    # 2. Attention parameter estimation
+    num_heads = config.get("num_attention_heads") or config.get("num_heads") or config.get("n_heads")
+    num_kv_heads = config.get("num_key_value_heads")
+    if num_heads:
+        num_heads = int(num_heads)
+        if num_kv_heads is None:
+            num_kv_heads = num_heads
+        else:
+            num_kv_heads = int(num_kv_heads)
+
+        head_dim = config.get("head_dim") or (hidden_size // num_heads)
+        q_size = hidden_size * num_heads * head_dim
+        kv_size = 2 * hidden_size * num_kv_heads * head_dim
+        o_size = num_heads * head_dim * hidden_size
+        attn_params = q_size + kv_size + o_size
+    else:
+        attn_params = 4 * hidden_size * hidden_size
+
+    # 3. MLP parameter estimation
+    intermediate_size = config.get("intermediate_size") or config.get("encoder_ffn_dim") or config.get("decoder_ffn_dim") or config.get("d_ff")
+    if intermediate_size:
+        intermediate_size = int(intermediate_size)
+    else:
+        act = str(config.get("hidden_act", "")).lower()
+        is_gated = any(g in act for g in ["silu", "swiglu", "geglu", "gated"])
+        if is_gated:
+            intermediate_size = int(8 / 3 * hidden_size)
+        else:
+            intermediate_size = 4 * hidden_size
+
+    act = str(config.get("hidden_act", "")).lower()
+    is_gated = any(g in act for g in ["silu", "swiglu", "geglu", "gated"]) or "gated" in str(config.get("mlp_class", "")).lower()
+
+    base_mlp_params = (3 if is_gated else 2) * hidden_size * intermediate_size
+
+    # MoE handling
+    num_experts = config.get("num_local_experts") or config.get("num_experts") or config.get("n_routed_experts")
+    num_active_experts = config.get("num_experts_per_tok") or config.get("num_active_experts")
+
+    if num_experts:
+        num_experts = int(num_experts)
+        # Total MLP parameters in MoE layers
+        mlp_params_total = base_mlp_params * num_experts
+        # Add router parameter count (usually hidden_size * num_experts)
+        mlp_params_total += hidden_size * num_experts
+
+        # Calculate active MLP parameters
+        if num_active_experts:
+            num_active_experts = int(num_active_experts)
+            mlp_params_active = base_mlp_params * num_active_experts
+            # Router is always active
+            mlp_params_active += hidden_size * num_experts
+        else:
+            # Fallback if active experts is not specified
+            mlp_params_active = base_mlp_params
+    else:
+        mlp_params_total = base_mlp_params
+        mlp_params_active = base_mlp_params
+
+    # 4. Total parameter counts
+    # Layer count
+    total_layer_params = attn_params + mlp_params_total
+    active_layer_params = attn_params + mlp_params_active
+
+    # Embedding layers
+    embedding_params = vocab_size * hidden_size
+
+    # Tie word embeddings check
+    tie_word_embeddings = config.get("tie_word_embeddings", True)
+    head_params = 0 if tie_word_embeddings else (vocab_size * hidden_size)
+
+    total_params = embedding_params + head_params + (num_layers * total_layer_params)
+
+    active_params = None
+    if num_experts:
+        active_params = embedding_params + head_params + (num_layers * active_layer_params)
+
+    return total_params, active_params
+
+
 def _entry_from_modelinfo(mi, overrides):
     name = mi.id
     provider = name.split("/")[0]
@@ -139,6 +241,19 @@ def _entry_from_modelinfo(mi, overrides):
                 total = bt
                 if ba and active is None:
                     active = ba
+    # Try config.json fallback when name/tag parsing fails
+    if total is None:
+        try:
+            config_path = hf_hub_download(repo_id=name, filename="config.json")
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            t_est, a_est = _estimate_params_from_config(config)
+            if t_est:
+                total = t_est
+                if a_est and active is None:
+                    active = a_est
+        except Exception:
+            pass
     # Determine quant first — we need it to unpack the safetensors fallback.
     quant = _quant_from_name(name)
     # Last resort: read safetensors element counts. For pre-quantized repos
@@ -174,7 +289,7 @@ def _entry_from_modelinfo(mi, overrides):
         return None  # can't size it — skip
     pb = total / 1e9
     created = getattr(mi, "created_at", None)
-    rel = created.strftime("%Y-%m-%d") if created else datetime.utcnow().strftime("%Y-%m-%d")
+    rel = created.strftime("%Y-%m-%d") if created else datetime.now(timezone.utc).strftime("%Y-%m-%d")
     # Rough RAM/VRAM hints (fit.py recomputes the real requirement from params+quant).
     _BPP = {"AWQ-4bit": 0.58, "GPTQ-Int4": 0.58, "mlx-4bit": 0.55, "mlx-6bit": 0.85,
             "AWQ-8bit": 1.1, "GPTQ-Int8": 1.1, "mlx-8bit": 1.1, "FP8": 1.1,

--- a/tests/test_add_hwfit_models.py
+++ b/tests/test_add_hwfit_models.py
@@ -1,0 +1,159 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Add repository root to python path to import scripts
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.add_hwfit_models import (
+    _estimate_params_from_config,
+    _entry_from_modelinfo,
+)
+
+
+def test_estimate_params_llama2_style():
+    # Standard Llama 2 style (Gated Silu, MHA, tie embeddings=True)
+    config = {
+        "vocab_size": 32000,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "intermediate_size": 11008,
+        "hidden_act": "silu",
+        "tie_word_embeddings": True,
+    }
+    total, active = _estimate_params_from_config(config)
+    # Total layers: 32
+    # Vocab * hidden = 32000 * 4096 = 131,072,000
+    # Q, K, V, O attention = 4 * 4096 * 4096 = 67,108,864
+    # MLP (Gated) = 3 * 4096 * 11008 = 135,266,304
+    # Total per layer = 202,375,168
+    # Total layers = 32 * 202,375,168 = 6,476,005,376
+    # Total = 131,072,000 + 6,476,005,376 = 6,607,077,376 (~6.6B)
+    assert total == 6607077376
+    assert active is None  # Non-MoE has active=None
+
+
+def test_estimate_params_qwen25_style():
+    # Qwen 2.5 7B style (GQA, Gated Silu, tie embeddings=False)
+    config = {
+        "vocab_size": 152064,
+        "hidden_size": 3584,
+        "num_hidden_layers": 28,
+        "num_attention_heads": 28,
+        "num_key_value_heads": 4,
+        "intermediate_size": 18944,
+        "hidden_act": "silu",
+        "tie_word_embeddings": False,
+    }
+    total, active = _estimate_params_from_config(config)
+    # Head dim = 3584 // 28 = 128
+    # Q = 3584 * (28 * 128) = 12845056
+    # K, V = 2 * 3584 * (4 * 128) = 3670016
+    # O = 3584 * 3584 = 12845056
+    # Attn per layer = 29,360,128
+    # MLP (Gated) = 3 * 3584 * 18944 = 203,685,888
+    # Layer total = 233,046,016
+    # Layers total (28) = 6,525,288,448
+    # Embeddings = 152064 * 3584 = 544,997,376
+    # Head = 152064 * 3584 = 544,997,376 (since tie embeddings is False)
+    # Total = 544,997,376 + 544,997,376 + 6,525,288,448 = 7,615,283,200 (~7.6B)
+    assert total == 7615283200
+    assert active is None
+
+
+def test_estimate_params_moe_style():
+    # MoE style model (DeepSeek-like or Mixtral-like)
+    config = {
+        "vocab_size": 32000,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "intermediate_size": 14336,
+        "hidden_act": "silu",
+        "num_local_experts": 8,
+        "num_experts_per_tok": 2,
+        "tie_word_embeddings": True,
+    }
+    total, active = _estimate_params_from_config(config)
+    # Embedding = 32000 * 4096 = 131,072,000
+    # Attn per layer = 4 * 4096 * 4096 = 67,108,864
+    # Base MLP (Gated) = 3 * 4096 * 14336 = 176,160,768
+    # Total MLP (8 experts + router 4096 * 8) = 176,160,768 * 8 + 32,768 = 1,409,318,912
+    # Layer total = 67,108,864 + 1,409,318,912 = 1,476,427,776
+    # Layers total (32) = 32 * 1,476,427,776 = 47,245,688,832
+    # Total parameters = 131,072,000 + 47,245,688,832 = 47,376,760,832 (~47B)
+    assert total == 47376760832
+
+    # Active parameters:
+    # Active MLP = base MLP * 2 experts + router = 176,160,768 * 2 + 32,768 = 352,354,304
+    # Active Layer = 67,108,864 + 352,354,304 = 419,463,168
+    # Active Layers total (32) = 32 * 419,463,168 = 13,422,821,376
+    # Active total = 131,072,000 + 13,422,821,376 = 13,553,893,376 (~13.5B)
+    assert active == 13553893376
+
+
+def test_estimate_params_non_gated():
+    # Standard GPT-2 style non-Gated (GELU, MHA, tie embeddings=True)
+    config = {
+        "vocab_size": 50257,
+        "hidden_size": 768,
+        "num_hidden_layers": 12,
+        "num_attention_heads": 12,
+        "intermediate_size": 3072,
+        "hidden_act": "gelu",
+        "tie_word_embeddings": True,
+    }
+    total, active = _estimate_params_from_config(config)
+    # Embedding = 50257 * 768 = 38,597,376
+    # Attn = 4 * 768 * 768 = 2,359,296
+    # MLP (non-Gated) = 2 * 768 * 3072 = 4,718,592
+    # Layer total = 7,077,888
+    # Layers total (12) = 84,934,656
+    # Total = 38,597,376 + 84,934,656 = 123,532,032 (~123M)
+    assert total == 123532032
+    assert active is None
+
+
+def test_estimate_params_invalid():
+    # Missing hidden_size and num_hidden_layers
+    assert _estimate_params_from_config({}) == (None, None)
+    assert _estimate_params_from_config(None) == (None, None)
+
+
+@patch("scripts.add_hwfit_models.hf_hub_download")
+def test_entry_from_modelinfo_config_fallback(mock_download):
+    # Mock mi (model_info) without size naming or base_model tags
+    mi = MagicMock()
+    mi.id = "user/non-standard-model-name"
+    mi.created_at = None
+    mi.pipeline_tag = "text-generation"
+    mi.tags = []
+    mi.downloads = 100
+    mi.likes = 5
+
+    # Mock the hf_hub_download to write a dummy file
+    dummy_config = {
+        "vocab_size": 32000,
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "intermediate_size": 11008,
+        "hidden_act": "silu",
+        "tie_word_embeddings": True,
+    }
+    
+    mock_download.return_value = "dummy_config.json"
+    
+    import json
+    from unittest.mock import mock_open
+    
+    with patch("builtins.open", mock_open(read_data=json.dumps(dummy_config))):
+        entry = _entry_from_modelinfo(mi, overrides=None)
+        
+    assert entry is not None
+    # Verify parameter count is inferred from config
+    assert entry["parameters_raw"] == 6607077376
+    assert entry["parameter_count"] == "6.6B"
+    assert entry["quantization"] == "Q4_K_M"
+    mock_download.assert_called_once_with(repo_id="user/non-standard-model-name", filename="config.json")

--- a/tests/test_hwfit_macos.py
+++ b/tests/test_hwfit_macos.py
@@ -129,6 +129,10 @@ def test_intel_mac_skipped(monkeypatch):
 def test_detect_system_propagates_unified_memory(monkeypatch):
     """The unified_memory flag set by GPU detection must survive into the
     system dict so the API and UI can report it (it was being dropped)."""
+    monkeypatch.setattr(hardware, "_remote_host", None)
+    monkeypatch.setattr(hardware.os, "name", "posix")
+    monkeypatch.setattr(hardware.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(hardware.platform, "machine", lambda: "arm64")
     monkeypatch.setattr(hardware, "_detect_apple_silicon", lambda: {
         "gpu_name": "Apple M4", "gpu_vram_gb": 10.7, "gpu_count": 1,
         "gpus": [], "gpu_groups": [], "homogeneous": True,


### PR DESCRIPTION
## Summary

This pull request resolves #955 by implementing a robust fallback parameter count estimation mechanism in `scripts/add_hwfit_models.py`. When a repository name does not follow standard naming conventions (i.e. does not encode the model size such as "Qwen3.6-35B-A3B") and lacks size tags, the script now automatically downloads the model's `config.json` via the Hugging Face Hub API and programmatically computes the true parameter count.

Additionally, this PR fixes a platform-dependent bug in `tests/test_hwfit_macos.py` and resolves a Python 3.12 deprecation warning.

## What's included

- **Config Estimation:** Added `_estimate_params_from_config(config)` in `scripts/add_hwfit_models.py` to parse layers, attention heads, intermediate hidden size, expert counts (for MoE), and tie word embeddings variables to calculate parameter size.
- **Fallback Integration:** Integrated the helper inside `_entry_from_modelinfo` using `hf_hub_download` when regex-based parsing returns `None`.
- **Warning Fix:** Replaced the deprecated `datetime.utcnow()` with the timezone-aware `datetime.now(timezone.utc)` to silence Python 3.12 `DeprecationWarning` logs.
- **Test Platform Bypass Fix:** Mocked `os.name`, `platform.system`, `platform.machine`, and `_remote_host` inside `test_detect_system_propagates_unified_memory` (in `tests/test_hwfit_macos.py`) to prevent it from failing when executed on Windows/Linux environments.
- **Comprehensive Unit Tests:** Added `tests/test_add_hwfit_models.py` containing 6 unit tests verifying calculations for standard Llama, Qwen 2.5, MoE (DeepSeek), and GPT-2 style architectures, along with API retrieval mock checks.

## Checks & Test Plan

- [x] `python -m py_compile scripts/add_hwfit_models.py tests/test_add_hwfit_models.py` — clean
- [x] All 19 tests pass successfully on local system:
  ```bash
  python -m pytest tests/test_add_hwfit_models.py tests/test_hwfit_macos.py tests/test_hwfit_quant_formats.py -v
