### PR TITLE
fix: longest-match in _lookup_known so o1-mini isn't shadowed by o1

### DIFF
--- a/src/model_context.py
+++ b/src/model_context.py
@@ -184,14 +184,22 @@ def get_context_length(endpoint_url: str, model: str) -> int:
 
 
 def _lookup_known(model: str) -> Optional[int]:
-    """Check known context windows by substring match."""
+    """Check known context windows by substring match.
+
+    Picks the LONGEST matching key so a short key never shadows a more specific
+    one. Without this, 'o1' (200k) precedes 'o1-mini' (128k) in the table and a
+    first-match return would report o1-mini's window as 200k.
+    """
     name = model.lower()
     basename = name.split("/")[-1] if "/" in name else name
     basename = basename.split(":")[0]  # strip :free, :extended etc.
+    best_key: Optional[str] = None
+    best_ctx: Optional[int] = None
     for key, ctx in KNOWN_CONTEXT_WINDOWS.items():
         if key in basename or key in name:
-            return ctx
-    return None
+            if best_key is None or len(key) > len(best_key):
+                best_key, best_ctx = key, ctx
+    return best_ctx
 
 
 def _query_context_length(endpoint_url: str, model: str) -> int:

--- a/tests/test_model_context.py
+++ b/tests/test_model_context.py
@@ -109,6 +109,19 @@ class TestLookupKnown:
         result = _lookup_known("deepseek-r1:free")
         assert result == 64000
 
+    def test_o1_mini_not_shadowed_by_o1(self):
+        """'o1' (200k) precedes 'o1-mini' (128k) in the table; longest match wins."""
+        assert _lookup_known("o1-mini") == 128000
+
+    def test_o1_full(self):
+        assert _lookup_known("o1") == 200000
+
+    def test_gpt4o_mini_not_shadowed_by_gpt4(self):
+        assert _lookup_known("gpt-4o-mini") == 128000
+
+    def test_gpt4_base(self):
+        assert _lookup_known("gpt-4") == 8192
+
 
 class TestGetContextLength:
     def setup_method(self):


### PR DESCRIPTION
Split out from #752 (one fix per PR, as the maintainer requested).

## Problem

`_lookup_known()` (`src/model_context.py`) returned the context window of the **first** `KNOWN_CONTEXT_WINDOWS` key found as a substring of the model name. The table lists `'o1'` (200000) before `'o1-mini'` (128000), so `"o1-mini"` matched `'o1'` first and was reported as a 200k-token window — overstating o1-mini's real 128k limit, which can lead to oversized requests being built for that model.

## Fix

Scan all keys and keep the **longest** matching key, so the most specific entry wins regardless of table order. This also protects against the same class of shadowing for `gpt-4` vs `gpt-4o-mini`, etc.

## Tests

`tests/test_model_context.py` — adds cases asserting `o1-mini → 128000`, `o1 → 200000`, `gpt-4o-mini → 128000`, and `gpt-4 → 8192`. The `o1-mini` case fails before the change (returns 200000) and passes after.
