### PR TITLE
fix: preserve reasoning_content when sanitizing LLM messages (DeepSeek thinking mode)

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -435,6 +435,17 @@ def _detect_provider(url: str) -> str:
     return "openai"
 
 
+def _endpoint_requires_reasoning_content(url: str) -> bool:
+    """Whether this endpoint needs ``reasoning_content`` echoed back on assistant
+    messages. DeepSeek's thinking-mode API (``deepseek-reasoner``) rejects a
+    follow-up request that omits the prior round's ``reasoning_content`` — which
+    ``_append_tool_results`` re-attaches for exactly this reason — so the field
+    must survive sanitization for DeepSeek. Other OpenAI-compatible providers
+    either ignore the field or, like OpenAI itself, reject unknown message keys,
+    so it is stripped for them by default (see ``_sanitize_llm_messages``)."""
+    return _host_match(url, "deepseek.com")
+
+
 def _provider_headers(provider: str, headers: Optional[Dict] = None) -> Dict[str, str]:
     h = {"Content-Type": "application/json"}
     if isinstance(headers, dict):
@@ -799,7 +810,7 @@ def _as_content_blocks(content) -> List[Dict]:
     return []
 
 
-def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
+def _sanitize_llm_messages(messages: List[Dict], *, keep_reasoning: bool = False) -> List[Dict]:
     """Strip Odysseus-only metadata before sending messages to providers.
 
     Per the OpenAI chat format: user/system messages must have content; a tool
@@ -810,12 +821,15 @@ def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
     (content=None, since Gemini/Ollama reject tool_calls alongside ""). Dropping
     it leaves the tool result dangling and breaks the next round.
     """
-    # reasoning_content is preserved on purpose: _append_tool_results echoes the
-    # prior round's reasoning back on the assistant message because DeepSeek's
-    # API rejects follow-up thinking-mode requests that omit it. Other vendors
-    # ignore the extra field.
     allowed = {"role", "content", "name", "tool_call_id", "tool_calls",
-               "function_call", "reasoning_content"}
+               "function_call"}
+    # reasoning_content is provider-specific. _append_tool_results echoes the
+    # prior round's reasoning back on the assistant message because DeepSeek's
+    # thinking-mode API rejects follow-up requests that omit it — but stricter
+    # OpenAI-compatible APIs reject unknown message keys. So keep it only when
+    # the caller says the target endpoint requires it; strip it otherwise.
+    if keep_reasoning:
+        allowed = allowed | {"reasoning_content"}
     cleaned = []
     for msg in messages or []:
         if not isinstance(msg, dict):
@@ -1107,7 +1121,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
     if isinstance(headers, dict):
         h.update(headers)
 
-    messages_copy = _sanitize_llm_messages(messages)
+    messages_copy = _sanitize_llm_messages(messages, keep_reasoning=_endpoint_requires_reasoning_content(url))
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -1254,7 +1268,7 @@ async def llm_call_async(
 ) -> str:
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
     provider = _detect_provider(url)
-    messages_copy = _sanitize_llm_messages(messages)
+    messages_copy = _sanitize_llm_messages(messages, keep_reasoning=_endpoint_requires_reasoning_content(url))
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -1414,7 +1428,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
       - data: [DONE]                       — end of stream
     """
     provider = _detect_provider(url)
-    messages_copy = _sanitize_llm_messages(messages)
+    messages_copy = _sanitize_llm_messages(messages, keep_reasoning=_endpoint_requires_reasoning_content(url))
 
     # Consolidate multiple system messages into one at the start.
     # Some models (e.g. Qwen3.5) reject system messages that aren't first.

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -810,7 +810,12 @@ def _sanitize_llm_messages(messages: List[Dict]) -> List[Dict]:
     (content=None, since Gemini/Ollama reject tool_calls alongside ""). Dropping
     it leaves the tool result dangling and breaks the next round.
     """
-    allowed = {"role", "content", "name", "tool_call_id", "tool_calls", "function_call"}
+    # reasoning_content is preserved on purpose: _append_tool_results echoes the
+    # prior round's reasoning back on the assistant message because DeepSeek's
+    # API rejects follow-up thinking-mode requests that omit it. Other vendors
+    # ignore the extra field.
+    allowed = {"role", "content", "name", "tool_call_id", "tool_calls",
+               "function_call", "reasoning_content"}
     cleaned = []
     for msg in messages or []:
         if not isinstance(msg, dict):

--- a/tests/test_llm_core_sanitize.py
+++ b/tests/test_llm_core_sanitize.py
@@ -1,26 +1,58 @@
-"""Regression test: reasoning_content must survive message sanitization.
+"""Regression tests for message sanitization (PR #968 / DeepSeek thinking mode).
 
-_append_tool_results attaches reasoning_content to the assistant message so
-DeepSeek thinking-mode follow-up requests aren't rejected; the sanitizer used to
-strip it because it wasn't in the allow-list.
+``_append_tool_results`` attaches ``reasoning_content`` to the assistant message
+so DeepSeek thinking-mode follow-up requests aren't rejected. The sanitizer used
+to strip it because it wasn't in the allow-list.
+
+Preserving it *globally* is unsafe: ``_sanitize_llm_messages`` runs before the
+provider-specific payload is built, so a stricter OpenAI-compatible API could
+reject the unknown ``reasoning_content`` key. These tests pin the scoped
+behaviour the maintainer asked for: the field is kept only for endpoints that
+require it (DeepSeek) and stripped for generic providers.
 """
-from src.llm_core import _sanitize_llm_messages
+from src.llm_core import (
+    _sanitize_llm_messages,
+    _endpoint_requires_reasoning_content,
+)
 
 
-def test_reasoning_content_preserved():
-    msgs = [{
-        "role": "assistant",
-        "content": "the answer",
-        "reasoning_content": "step-by-step thinking",
-        "tool_calls": [
-            {"id": "c1", "type": "function",
-             "function": {"name": "x", "arguments": "{}"}}
-        ],
-        "odysseus_internal": "should be dropped",
-    }]
-    out = _sanitize_llm_messages(msgs)
-    assert len(out) == 1
+def _assistant_with_reasoning():
+    # Mirrors what _append_tool_results builds: an assistant turn carrying
+    # reasoning_content + a native tool_call, immediately followed by the tool
+    # result that answers it. The answering tool message is required — the
+    # sanitizer's tool-call adjacency repair strips assistant tool_calls that
+    # have no matching tool response.
+    return [
+        {
+            "role": "assistant",
+            "content": "the answer",
+            "reasoning_content": "step-by-step thinking",
+            "tool_calls": [
+                {"id": "c1", "type": "function",
+                 "function": {"name": "x", "arguments": "{}"}}
+            ],
+            "odysseus_internal": "should be dropped",
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool result"},
+    ]
+
+
+def test_reasoning_content_preserved_for_deepseek():
+    # DeepSeek-style follow-up: keep_reasoning=True keeps the field.
+    out = _sanitize_llm_messages(_assistant_with_reasoning(), keep_reasoning=True)
+    assert len(out) == 2
     assert out[0]["reasoning_content"] == "step-by-step thinking"
+    assert out[0]["tool_calls"][0]["id"] == "c1"
+    assert "odysseus_internal" not in out[0]
+
+
+def test_reasoning_content_stripped_for_generic_provider():
+    # Default (generic / strict OpenAI-compatible provider): the extra key must
+    # NOT be leaked, while the rest of the message is preserved intact.
+    out = _sanitize_llm_messages(_assistant_with_reasoning())
+    assert len(out) == 2
+    assert "reasoning_content" not in out[0]
+    assert out[0]["content"] == "the answer"
     assert out[0]["tool_calls"][0]["id"] == "c1"
     assert "odysseus_internal" not in out[0]
 
@@ -28,3 +60,12 @@ def test_reasoning_content_preserved():
 def test_unknown_keys_still_stripped():
     out = _sanitize_llm_messages([{"role": "user", "content": "hi", "foo": "bar"}])
     assert out == [{"role": "user", "content": "hi"}]
+
+
+def test_endpoint_requires_reasoning_content_routing():
+    # DeepSeek requires the echo; generic OpenAI-compatible endpoints do not.
+    assert _endpoint_requires_reasoning_content("https://api.deepseek.com/v1") is True
+    assert _endpoint_requires_reasoning_content("https://api.openai.com/v1") is False
+    assert _endpoint_requires_reasoning_content("http://localhost:11434/v1") is False
+    # Look-alike host must not be misclassified as DeepSeek.
+    assert _endpoint_requires_reasoning_content("https://api.deepseek.com.evil.test/v1") is False

--- a/tests/test_llm_core_sanitize.py
+++ b/tests/test_llm_core_sanitize.py
@@ -1,0 +1,30 @@
+"""Regression test: reasoning_content must survive message sanitization.
+
+_append_tool_results attaches reasoning_content to the assistant message so
+DeepSeek thinking-mode follow-up requests aren't rejected; the sanitizer used to
+strip it because it wasn't in the allow-list.
+"""
+from src.llm_core import _sanitize_llm_messages
+
+
+def test_reasoning_content_preserved():
+    msgs = [{
+        "role": "assistant",
+        "content": "the answer",
+        "reasoning_content": "step-by-step thinking",
+        "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "x", "arguments": "{}"}}
+        ],
+        "odysseus_internal": "should be dropped",
+    }]
+    out = _sanitize_llm_messages(msgs)
+    assert len(out) == 1
+    assert out[0]["reasoning_content"] == "step-by-step thinking"
+    assert out[0]["tool_calls"][0]["id"] == "c1"
+    assert "odysseus_internal" not in out[0]
+
+
+def test_unknown_keys_still_stripped():
+    out = _sanitize_llm_messages([{"role": "user", "content": "hi", "foo": "bar"}])
+    assert out == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary

`_sanitize_llm_messages()` (`src/llm_core.py`) strips every key not in an allow-list before sending messages upstream, and `reasoning_content` was not allow-listed — so it was dropped from assistant messages. DeepSeek's thinking-mode API (`deepseek-reasoner`) **requires** the prior assistant turn's `reasoning_content` to be echoed back on follow-up requests — `_append_tool_results` re-attaches it for exactly that reason — so stripping it returns HTTP 400 and breaks multi-turn / tool-calling conversations on DeepSeek reasoning models.

Allow-listing the field globally is the wrong fix (flagged in review on the first revision): stricter OpenAI-compatible endpoints — OpenAI itself — reject unknown message keys, so leaking `reasoning_content` to them would break those providers instead.

**Scoped fix (commit `ade5b86`):**
- New helper `_endpoint_requires_reasoning_content(url)` → true only for `deepseek.com` hosts (exact host match, so `deepseek.com.evil.test` is rejected).
- `_sanitize_llm_messages(messages, *, keep_reasoning=False)` adds `reasoning_content` to the allow-list **only** when `keep_reasoning=True`.
- The three call sites (`llm_call`, `llm_call_async`, `stream_llm`) pass `keep_reasoning=_endpoint_requires_reasoning_content(url)`, so DeepSeek keeps the field and every other provider still has it stripped — no behaviour change for them.

## Linked Issue

No separate tracking issue — this was split out of #752 (one fix per PR, per the maintainer's request). The behaviour is discussed in this PR's review thread.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`.
- [x] My changes are limited to the scope described above — no unrelated refactors.
- [ ] I actually ran the app end-to-end. _Not done — verified via the unit tests below + `py_compile`; flagging honestly per CONTRIBUTING._

## How to Test

1. `python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt`
2. Check out `fix/deepseek-reasoning-content`.
3. `PYTHONPATH=. python -m pytest tests/test_llm_core_sanitize.py -q`

`tests/test_llm_core_sanitize.py` pins the scoped behaviour:
- `test_reasoning_content_preserved_for_deepseek` — with `keep_reasoning=True`, `reasoning_content` survives sanitization (DeepSeek path).
- `test_reasoning_content_stripped_for_generic_provider` — by default it is stripped (OpenAI / other providers).
- `test_unknown_keys_still_stripped` — unrelated Odysseus-only keys are still removed.
- `test_endpoint_requires_reasoning_content_routing` — host routing: `api.deepseek.com` → keep, `api.openai.com` / localhost / a spoofed `deepseek.com.evil.test` → strip.

---
Prepared with assistance from Claude Opus 4.8 (Claude Code).
