### PR TITLE
feat(paths): abstract runtime path logic for frozen distribution packages

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -2,11 +2,14 @@ import os
 import logging
 import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
 from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, func, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import relationship, sessionmaker, backref
+
+from src.runtime_paths import get_app_root
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +32,26 @@ class TimestampMixin:
     def updated_at(cls):
         return Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, nullable=False)
 
-# Get database URL from environment, default to SQLite in DATA_DIR
+# Ensure the writable data directory exists before SQLite connects.
 from src.constants import DATA_DIR, AUTH_FILE, MEMORY_FILE, USER_PREFS_FILE, SETTINGS_FILE
-DATABASE_URL = os.getenv("DATABASE_URL", f"sqlite:///{DATA_DIR}/app.db")
+Path(DATA_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def _default_database_url() -> str:
+    return f"sqlite:///{Path(DATA_DIR) / 'app.db'}"
+
+
+def _normalize_sqlite_url(url: str) -> str:
+    if not url.startswith("sqlite:///"):
+        return url
+    db_path = url.replace("sqlite:///", "", 1)
+    if db_path == ":memory:" or os.path.isabs(db_path):
+        return url
+    return f"sqlite:///{(Path(get_app_root()) / db_path).resolve().as_posix()}"
+
+
+# Get database URL from environment, default to SQLite in DATA_DIR
+DATABASE_URL = _normalize_sqlite_url(os.getenv("DATABASE_URL", _default_database_url()))
 
 # Create engine
 engine = create_engine(

--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Form, Depends
 from core.constants import EMBEDDING_ENDPOINT_FILE, FASTEMBED_CACHE_DIR
 from core.middleware import require_admin
+from src.runtime_paths import get_app_root
 
 logger = logging.getLogger(__name__)
 

--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -13,6 +13,7 @@ import sys
 import asyncio
 
 from core.platform_compat import IS_WINDOWS, which_tool
+from src.runtime_paths import get_app_root
 
 logger = logging.getLogger(__name__)
 
@@ -75,13 +76,14 @@ _BUILTIN_SERVERS = {
 }
 
 # NPX-based built-in servers (run via npx, not Python)
-_BUILTIN_NPX_SERVERS = {
-    "builtin_browser": {
+_BUILTIN_NPX_SERVERS = {}
+
+if os.environ.get("ODYSSEUS_ENABLE_BROWSER_MCP", "").lower() in ("1", "true", "yes", "on"):
+    _BUILTIN_NPX_SERVERS["builtin_browser"] = {
         "name": "Built-in: Browser",
         "command": "npx",
         "args": ["-y", "@playwright/mcp@latest", "--headless", "--caps", "vision"],
-    },
-}
+    }
 
 # Global flag to disable MCP if there are compatibility issues
 MCP_DISABLED = os.environ.get("ODYSSEUS_DISABLE_MCP", "").lower() in ("1", "true", "yes")
@@ -93,7 +95,7 @@ async def register_builtin_servers(mcp_manager):
         logger.info("Built-in MCP servers disabled via ODYSSEUS_DISABLE_MCP")
         return
 
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    base_dir = get_app_root()
     python = sys.executable
 
     async def _connect_python_server(server_id: str, script_path: str, name: str):

--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -76,14 +76,13 @@ _BUILTIN_SERVERS = {
 }
 
 # NPX-based built-in servers (run via npx, not Python)
-_BUILTIN_NPX_SERVERS = {}
-
-if os.environ.get("ODYSSEUS_ENABLE_BROWSER_MCP", "").lower() in ("1", "true", "yes", "on"):
-    _BUILTIN_NPX_SERVERS["builtin_browser"] = {
+_BUILTIN_NPX_SERVERS = {
+    "builtin_browser": {
         "name": "Built-in: Browser",
         "command": "npx",
         "args": ["-y", "@playwright/mcp@latest", "--headless", "--caps", "vision"],
     }
+}
 
 # Global flag to disable MCP if there are compatibility issues
 MCP_DISABLED = os.environ.get("ODYSSEUS_DISABLE_MCP", "").lower() in ("1", "true", "yes")

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field, field_validator
 
 from src.constants import DATA_DIR as _DATA_DIR_CONST
+from src.runtime_paths import get_app_root
 
 # Cross-platform OS flag, exposed here so callers can `from src.config import
 # IS_WINDOWS`. Defined locally (a trivial `os.name == "nt"`) rather than imported
@@ -19,7 +20,7 @@ IS_WINDOWS = os.name == "nt"
 class DataConfig(BaseSettings):
     """Configuration for data storage and file handling."""
     # Base directory
-    base_dir: Path = Field(default=Path(__file__).parent.parent, description="Base directory for the application")
+    base_dir: Path = Field(default=Path(get_app_root()), description="Base directory for the application")
     
     # Data paths
     data_dir: Path = Field(default=Path(_DATA_DIR_CONST), description="Main data directory")
@@ -138,7 +139,7 @@ class AppConfig(BaseSettings):
         if isinstance(v, dict) and "base_dir" in v:
             base_dir = v["base_dir"]
         else:
-            base_dir = Path(__file__).parent.parent
+            base_dir = Path(get_app_root())
         
         # Convert string paths to Path objects relative to base_dir
         data_dir = Path(_DATA_DIR_CONST)

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,10 +2,12 @@
 """Application-wide constants and configuration values."""
 import os
 
+from src.runtime_paths import get_app_root
+
 APP_VERSION = "1.0.0"
 
 # Base paths
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/"
+BASE_DIR = os.path.join(get_app_root(), "")
 STATIC_DIR = os.path.join(BASE_DIR, "static")
 DATA_DIR = os.getenv("ODYSSEUS_DATA_DIR", os.path.join(BASE_DIR, "data"))
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,14 +2,14 @@
 """Application-wide constants and configuration values."""
 import os
 
-from src.runtime_paths import get_app_root
+from src.runtime_paths import get_app_root, get_default_data_dir
 
 APP_VERSION = "1.0.0"
 
 # Base paths
 BASE_DIR = os.path.join(get_app_root(), "")
 STATIC_DIR = os.path.join(BASE_DIR, "static")
-DATA_DIR = os.getenv("ODYSSEUS_DATA_DIR", os.path.join(BASE_DIR, "data"))
+DATA_DIR = os.getenv("ODYSSEUS_DATA_DIR", get_default_data_dir())
 
 # Data file paths
 # Single source of truth: every persisted file/dir lives under DATA_DIR, which

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -31,6 +31,8 @@ import numpy as np
 import httpx
 from typing import List, Optional
 
+from src.runtime_paths import get_app_root
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "all-minilm:l6-v2"

--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -11,6 +11,8 @@ import os
 import re
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from src.runtime_paths import get_app_root
+
 logger = logging.getLogger(__name__)
 
 def _format_mcp_connection_error(name: str, command: str = "", args: Optional[List[str]] = None, error: Exception = None) -> str:
@@ -508,7 +510,7 @@ class McpManager:
             return False
 
         script_rel, name = _BUILTIN_SERVERS[server_id]
-        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        base_dir = get_app_root()
         script_path = os.path.join(base_dir, script_rel)
 
         # Clean up old connection

--- a/src/rag_singleton.py
+++ b/src/rag_singleton.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 from src.constants import RAG_DIR
+from src.runtime_paths import get_app_root
 
 logger = logging.getLogger(__name__)
 

--- a/src/runtime_paths.py
+++ b/src/runtime_paths.py
@@ -1,0 +1,17 @@
+"""Helpers for resolving runtime paths in source and frozen builds."""
+
+import os
+import sys
+
+
+def get_app_root() -> str:
+    """Return the app root directory.
+
+    In normal source runs, this is the repository root. In a frozen Windows
+    build, it is the bundle content root (PyInstaller's internal directory)
+    so bundled runtime folders like `static/`, `scripts/`, and `data/` stay
+    together with the executable payload.
+    """
+    if getattr(sys, "frozen", False):
+        return getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(sys.executable)))
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/src/runtime_paths.py
+++ b/src/runtime_paths.py
@@ -15,3 +15,16 @@ def get_app_root() -> str:
     if getattr(sys, "frozen", False):
         return getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(sys.executable)))
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def get_default_data_dir() -> str:
+    """Return the default path to the data directory.
+
+    In normal runs, this is a 'data' subdirectory under the app root.
+    In frozen builds, it is a persistent user directory (~/.odysseus/data)
+    to prevent SQLite databases and other persistent files from being
+    written to the ephemeral, temporary extraction bundle directory.
+    """
+    if getattr(sys, "frozen", False):
+        return os.path.join(os.path.expanduser("~"), ".odysseus", "data")
+    return os.path.join(get_app_root(), "data")

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -2,7 +2,7 @@ import os
 import sys
 from unittest import mock
 import pytest
-from src.runtime_paths import get_app_root
+from src.runtime_paths import get_app_root, get_default_data_dir
 
 
 def test_get_app_root_normal_run():
@@ -33,3 +33,18 @@ def test_get_app_root_frozen_without_meipass():
             delattr(sys, "_MEIPASS")
         app_root = get_app_root()
         assert app_root == os.path.abspath("mock_exe_dir")
+
+
+def test_get_default_data_dir_normal():
+    """Verify that get_default_data_dir resolves to get_app_root() / 'data' when not frozen."""
+    with mock.patch.object(sys, "frozen", False, create=True):
+        res = get_default_data_dir()
+        assert res == os.path.join(get_app_root(), "data")
+
+
+def test_get_default_data_dir_frozen():
+    """Verify that get_default_data_dir resolves to a persistent user path under ~ when frozen."""
+    with mock.patch.object(sys, "frozen", True, create=True):
+        res = get_default_data_dir()
+        expected = os.path.join(os.path.expanduser("~"), ".odysseus", "data")
+        assert res == expected

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from unittest import mock
+import pytest
+from src.runtime_paths import get_app_root
+
+
+def test_get_app_root_normal_run():
+    """Verify that get_app_root returns the repository root parent of src/ when not frozen."""
+    with mock.patch.object(sys, "frozen", False, create=True):
+        app_root = get_app_root()
+        # Verify it is a valid directory path and matches expected parent structure
+        assert os.path.isdir(app_root)
+        assert os.path.exists(os.path.join(app_root, "src"))
+
+
+def test_get_app_root_frozen_with_meipass():
+    """Verify that get_app_root returns the sys._MEIPASS directory when frozen by PyInstaller."""
+    mock_meipass = os.path.abspath("mock_meipass_dir")
+    with mock.patch.object(sys, "frozen", True, create=True), \
+         mock.patch.object(sys, "_MEIPASS", mock_meipass, create=True):
+        app_root = get_app_root()
+        assert app_root == mock_meipass
+
+
+def test_get_app_root_frozen_without_meipass():
+    """Verify that get_app_root falls back to the sys.executable parent directory when frozen but _MEIPASS is absent."""
+    mock_exe_path = os.path.join(os.path.abspath("mock_exe_dir"), "Odysseus.exe")
+    with mock.patch.object(sys, "frozen", True, create=True), \
+         mock.patch.object(sys, "executable", mock_exe_path, create=True):
+        # Remove sys._MEIPASS if it exists in the test process environment
+        if hasattr(sys, "_MEIPASS"):
+            delattr(sys, "_MEIPASS")
+        app_root = get_app_root()
+        assert app_root == os.path.abspath("mock_exe_dir")


### PR DESCRIPTION
Uploading this PR by the author's request (Was first #793 but then was split into smaller PRs).

Update - Now a part of the unified launcher/startup workstream (#2475).
This is a prerequisite for the Windows portable launcher PR (https://github.com/pewdiepie-archdaemon/odysseus/pull/976) (which is needed for https://github.com/pewdiepie-archdaemon/odysseus/pull/3660), so it resolves data directories correctly at runtime.

## Summary

Abstracts direct file system path strings into a standardized central helper module (`src/runtime_paths.py`). This guarantees that when the application runs in a frozen environment (such as a compiled PyInstaller executable where static resources are unpacked into `sys._MEIPASS`), configurations, vector databases, and assets resolve correctly. It ensures path consistency across Docker, Linux, macOS, and Windows.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #793

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the newly added path validation suite:
   ```bash
   pytest tests/test_runtime_paths.py
2. Start the backend server (python -m uvicorn app:app) and verify that database and embedding configuration folders initialize inside the root /data directory correctly.

## Visual / UI changes — REQUIRED if you touched anything that renders
_Not applicable (Backend and core paths abstraction only; does not touch any UI or rendering files)._
