### PR TITLE
fix(start-macos.sh): use venv Python for pip and uvicorn

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -117,10 +117,11 @@ if [ ! -d venv ]; then
   echo "▶ Creating Python environment…"
   "$PY" -m venv venv
 fi
+VENV_PY="./venv/bin/python3"
 echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$PY" -m pip install --quiet --upgrade pip
+"$VENV_PY" -m pip install --quiet --upgrade pip
 # Not --quiet: this is the slow step, so show progress (and any real errors).
-"$PY" -m pip install -r requirements.txt
+"$VENV_PY" -m pip install -r requirements.txt
 
 # 4. First-run setup: creates data dirs and prints an initial admin password
 #    the first time (idempotent — does nothing if already set up). Suppress its
@@ -179,4 +180,4 @@ if [ -n "$TAILSCALE_URL" ]; then
 fi
 echo "  (this takes a few seconds; press Ctrl+C here to stop)"
 echo
-"$PY" -m uvicorn app:app --host "$HOST" --port "$PORT"
+"$VENV_PY" -m uvicorn app:app --host "$HOST" --port "$PORT"


### PR DESCRIPTION
## What

After `venv/` is created, `$PY` still points to the Homebrew/system interpreter. On modern macOS with PEP 668, using the system interpreter for `pip install` raises `externally-managed-environment` and aborts setup.

This PR introduces `VENV_PY="./venv/bin/python3"` immediately after the venv is created and uses it for:
- `pip install --upgrade pip`
- `pip install -r requirements.txt`
- The final `uvicorn` launch

## Why a new PR

- #581 covers pip installs but not the uvicorn launch
- #615 has the right shape but has merge conflicts and is waiting on a rebase

This is a clean, rebased version against current `main` that covers both.

## Test plan
- [x] Fresh run on macOS with Homebrew Python — no PEP 668 error
- [x] Re-run skips venv creation, still uses `VENV_PY` correctly