### PR TITLE
fix(db): enable SQLite foreign keys so ondelete cascades actually fire

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -36,6 +36,10 @@ engine = create_engine(
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
+# Listening on the Engine class ensures this listener fires for all Engine
+# instances created within the process, not just the primary application engine.
+# The isinstance(sqlite3.Connection) check ensures that this PRAGMA foreign_keys=ON
+# configuration remains a no-op when using non-SQLite database backends.
 @event.listens_for(Engine, "connect")
 def set_sqlite_pragma(dbapi_connection, connection_record):
     if isinstance(dbapi_connection, sqlite3.Connection):
@@ -1494,6 +1498,10 @@ def _migrate_seed_email_account():
         logging.getLogger(__name__).warning(f"seed email account migration: {e}")
 
 
+# WARNING: Foreign-key enforcement is enabled globally for all SQLite connections.
+# Any future migrations or schema changes that temporarily violate foreign-key
+# constraints will fail. To perform such operations, foreign_keys must be
+# temporarily disabled around the migration workflow.
 def init_db():
     """
     Initialize the database by creating all tables.

--- a/core/database.py
+++ b/core/database.py
@@ -1,7 +1,9 @@
 import os
 import logging
+import sqlite3
 from datetime import datetime
-from sqlalchemy import create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, func, text
+from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, func, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import relationship, sessionmaker, backref
@@ -32,6 +34,14 @@ engine = create_engine(
 
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 
 class EncryptedText(TypeDecorator):

--- a/tests/test_sqlite_foreign_keys.py
+++ b/tests/test_sqlite_foreign_keys.py
@@ -1,0 +1,43 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from core.database import Base, Session, ChatMessage
+from datetime import datetime
+
+def test_sqlite_foreign_keys_cascade():
+    # 1. Create a real SQLite in-memory engine the same way the app does
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    
+    # 2. Create session factory and session
+    TestSessionLocal = sessionmaker(bind=engine)
+    db = TestSessionLocal()
+    
+    # 3. Insert a Session + ChatMessage
+    session_id = "test-session-123"
+    s = Session(
+        id=session_id,
+        name="Test Session",
+        endpoint_url="http://localhost:8000",
+        model="gpt-4",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow()
+    )
+    m = ChatMessage(id="test-msg-123", session_id=session_id, role="user", content="test message")
+    
+    db.add(s)
+    db.add(m)
+    db.commit()
+    
+    # Verify both exist
+    assert db.query(Session).count() == 1
+    assert db.query(ChatMessage).count() == 1
+    
+    # 4. Delete the Session via bulk query().delete() (bypassing ORM-level cascades)
+    db.query(Session).filter(Session.id == session_id).delete()
+    db.commit()
+    
+    # 5. Assert the ChatMessage is automatically deleted by DB-level cascade
+    assert db.query(ChatMessage).count() == 0
+    
+    db.close()

--- a/tests/test_sqlite_foreign_keys.py
+++ b/tests/test_sqlite_foreign_keys.py
@@ -5,15 +5,12 @@ from core.database import Base, Session, ChatMessage
 from datetime import datetime
 
 def test_sqlite_foreign_keys_cascade():
-    # 1. Create a real SQLite in-memory engine the same way the app does
     engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
     Base.metadata.create_all(bind=engine)
     
-    # 2. Create session factory and session
     TestSessionLocal = sessionmaker(bind=engine)
     db = TestSessionLocal()
     
-    # 3. Insert a Session + ChatMessage
     session_id = "test-session-123"
     s = Session(
         id=session_id,
@@ -29,15 +26,13 @@ def test_sqlite_foreign_keys_cascade():
     db.add(m)
     db.commit()
     
-    # Verify both exist
     assert db.query(Session).count() == 1
     assert db.query(ChatMessage).count() == 1
     
-    # 4. Delete the Session via bulk query().delete() (bypassing ORM-level cascades)
     db.query(Session).filter(Session.id == session_id).delete()
     db.commit()
     
-    # 5. Assert the ChatMessage is automatically deleted by DB-level cascade
     assert db.query(ChatMessage).count() == 0
     
     db.close()
+


### PR DESCRIPTION
## Problem

`core/database.py` declares DB-level foreign-key actions throughout — `ondelete="CASCADE"` and `ondelete="SET NULL"` on `ChatMessage`, `DocumentVersion`, `GalleryImage`, `ScheduledTask`, `TaskRun`, calendar/gallery/session links, and more.

But **SQLite disables foreign-key enforcement per connection by default**, and the engine had no connect-event listener turning it on. So every one of those `ondelete` actions is silently dead.

Concrete impact — `src/cleanup_service.py::cleanup_old_sessions()`:

```python
db.query(DbSession).filter(DbSession.id.in_(session_ids)).delete(synchronize_session=False)
```

A bulk `query().delete()` **bypasses** the ORM relationship cascade (`cascade="all, delete-orphan"`) and relies solely on the DB-level `ondelete="CASCADE"` on `ChatMessage.session_id`. With FK enforcement off, the messages are never deleted — they accumulate as orphaned rows in `chat_messages` on every cleanup cycle (a slow storage leak + integrity rot).

Minimal repro (mirrors the app's setup — no listener):

```python
db.add(Session(id="s1")); db.add(ChatMessage(id=1, session_id="s1")); db.commit()
db.query(Session).filter(Session.id.in_(["s1"])).delete(synchronize_session=False); db.commit()
db.query(ChatMessage).count()   # -> 1  (orphaned; should be 0)
```

## Fix

Add the standard SQLAlchemy connect listener that issues `PRAGMA foreign_keys=ON`, guarded so it only runs for SQLite connections and leaves Postgres/other backends untouched:

```python
@event.listens_for(Engine, "connect")
def set_sqlite_pragma(dbapi_connection, connection_record):
    if isinstance(dbapi_connection, sqlite3.Connection):
        cursor = dbapi_connection.cursor()
        cursor.execute("PRAGMA foreign_keys=ON")
        cursor.close()
```

## Test

`tests/test_sqlite_foreign_keys.py` inserts a `Session` + `ChatMessage`, deletes the session via bulk `query().delete()`, and asserts the message is cascade-deleted. Real engine + real models, no mocking. Fails before this change (orphan remains), passes after.

```
1 passed
```

The existing DB/route test suite still passes with FK enforcement enabled.