### PR TITLE
fix(text): strip unclosed <think> blocks that appear after leading text

### DIFF
--- a/src/text_helpers.py
+++ b/src/text_helpers.py
@@ -20,9 +20,9 @@ import re
 _THINK_CLOSED_RE = re.compile(r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>\s*", re.IGNORECASE)
 # Orphan opening or closing tags that survive after the closed-pass.
 _THINK_TAG_RE = re.compile(r"</?think(?:ing)?[^>]*>\s*", re.IGNORECASE)
-# Dangling opener at the top of the response with no closer — strip everything
-# from `<think>` up to either `</think>` (if it ever shows) or end of string.
-_THINK_OPEN_RE = re.compile(r"^\s*<think(?:ing)?>.*?(?:</think(?:ing)?>|$)", re.DOTALL | re.IGNORECASE)
+# Dangling opener anywhere in the response with no closer — strip everything
+# from `<think>` to the end of string.
+_THINK_OPEN_RE = re.compile(r"<think(?:ing)?>[\s\S]*$", re.IGNORECASE)
 # Streaming models occasionally emit `<thinking time="0.42">`-style attributes.
 # Normalize to a plain `<think>` so the regexes above catch them.
 _THINK_ATTR_RE = re.compile(r"<think(?:ing)?\s+[^>]*>", re.IGNORECASE)

--- a/tests/test_strip_think.py
+++ b/tests/test_strip_think.py
@@ -1,0 +1,25 @@
+import pytest
+from src.text_helpers import strip_think
+
+def test_strip_think_cases():
+    # 1. Mid-text unclosed leak (fails before fix)
+    assert strip_think("Hello! <think> I am thinking.") == "Hello!"
+    assert strip_think("Sure.\n<think>\nLet me reconsider...") == "Sure."
+    assert strip_think("Sure.\n<thinking>\nLet me reconsider...") == "Sure."
+
+    # 2. Start-anchored unclosed
+    assert strip_think("<think> unclosed from start") == ""
+    assert strip_think("   <thinking> thinking at start") == ""
+
+    # 3. Closed block
+    assert strip_think("Hello! <think> closed </think> Here is the answer.") == "Hello! Here is the answer."
+    assert strip_think("Hello! <thinking> closed </thinking> Here is the answer.") == "Hello! Here is the answer."
+
+    # 4. No-tag passthrough
+    assert strip_think("No tags here.") == "No tags here."
+
+    # 5. Content-before-opener preserved (part of mid-text unclosed)
+    assert strip_think("Prefix text <think> trailing thoughts") == "Prefix text"
+    
+    # 6. Multiple blocks (closed + unclosed)
+    assert strip_think("Hello! <think> closed </think> Here is the answer. <think> unclosed") == "Hello! Here is the answer."


### PR DESCRIPTION
## Problem

`strip_think()` (src/text_helpers.py) removes a dangling, unclosed `<think>` block with `_THINK_OPEN_RE`, but that pattern was anchored to the **start** of the string:

```python
_THINK_OPEN_RE = re.compile(r"^\s*<think(?:ing)?>.*?(?:</think(?:ing)?>|$)", re.DOTALL | re.IGNORECASE)
```

So an unclosed `<think>` / `<thinking>` opener that appears **after** any leading text is only half-handled — the stray tag is removed by `_THINK_TAG_RE`, but the reasoning content after it leaks straight through to the user:

```python
strip_think("Hello! <think> I am thinking.")        # -> "Hello! I am thinking."   (leaked)
strip_think("Sure.\n<think>\nLet me reconsider...")  # -> leaks the reasoning
```

`strip_think` is applied to user-facing output across research, email replies, notes, scheduled tasks, and deep research, so this leaks model chain-of-thought to end users.

## Fix

Un-anchor `_THINK_OPEN_RE` so a dangling opener **anywhere** strips from the opener to end of string — consistent with how the start-of-string case already behaved:

```python
_THINK_OPEN_RE = re.compile(r"<think(?:ing)?>[\s\S]*$", re.IGNORECASE)
```

This runs after the closed-block pass, so:
- closed `<think>...</think>` blocks keep working,
- text before the opener is preserved,
- tag-free text is returned unchanged.

## Test

`tests/test_strip_think.py` covers: the mid-text unclosed leak (fails before this change), start-anchored unclosed, closed blocks (`think` + `thinking`), no-tag passthrough, content-before-opener preserved, and mixed closed+unclosed. Plain assertions on the real function, no mocking. The full existing think-stripping suite still passes (27 passed).