### PR TITLE
fix(youtube): enforce comment-fetch timeout on communicate(), not process spawn

### DIFF
--- a/src/youtube_handler.py
+++ b/src/youtube_handler.py
@@ -198,15 +198,24 @@ async def fetch_youtube_comments(
             f"https://www.youtube.com/watch?v={video_id}",
         ]
 
-        proc = await asyncio.wait_for(
-            asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            ),
-            timeout=timeout,
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await proc.communicate()
+        # Bound the wait on the process actually finishing, not on spawning it.
+        # create_subprocess_exec returns as soon as the child starts, so wrapping
+        # it in wait_for never enforces the timeout — proc.communicate() is the
+        # blocking step. Kill and reap the child if it overruns so it does not
+        # linger after we return.
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
 
         if proc.returncode != 0:
             return {"success": False, "error": f"yt-dlp failed: {stderr.decode()[:200]}", "comments": []}

--- a/tests/test_youtube_comments_timeout.py
+++ b/tests/test_youtube_comments_timeout.py
@@ -1,0 +1,47 @@
+"""Regression: fetch_youtube_comments must actually honour its timeout.
+
+The timeout previously wrapped ``create_subprocess_exec`` (which returns as soon
+as the child is spawned) instead of ``proc.communicate()`` (the step that waits
+for yt-dlp to finish). A hung yt-dlp would therefore block forever and the
+``except asyncio.TimeoutError`` handler was unreachable. The wait must be bound
+to communicate(), and the child killed when it overruns.
+"""
+import asyncio
+
+from src import youtube_handler
+
+
+def test_comment_fetch_honours_timeout(monkeypatch):
+    monkeypatch.setattr(youtube_handler, "_find_ytdlp", lambda: "yt-dlp")
+
+    killed = {"value": False}
+
+    class HangingProc:
+        returncode = None
+
+        async def communicate(self):
+            await asyncio.sleep(30)  # far longer than the test timeout
+            return (b"", b"")
+
+        def kill(self):
+            killed["value"] = True
+
+        async def wait(self):
+            return 0
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return HangingProc()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+
+    result = asyncio.run(
+        youtube_handler.fetch_youtube_comments("vid123", timeout=0.1)
+    )
+
+    assert result["success"] is False
+    assert "timed out" in result["error"].lower()
+    assert result["comments"] == []
+    # The overrunning child must be killed, not left running.
+    assert killed["value"] is True


### PR DESCRIPTION
## Problem

`fetch_youtube_comments()` is meant to give yt-dlp a bounded amount of time (default 30s) to return a video's comments. But the timeout was wrapped around the wrong await:

```python
proc = await asyncio.wait_for(
    asyncio.create_subprocess_exec(*cmd, ...),
    timeout=timeout,
)
stdout, stderr = await proc.communicate()
```

`create_subprocess_exec` returns as soon as the child process is **spawned** — effectively instantly — so `wait_for` almost never has anything to time out. The step that actually waits for yt-dlp to finish is `proc.communicate()`, and that has no timeout at all. If yt-dlp stalls (slow comment pagination, a network hang — both common), `fetch_youtube_comments` hangs indefinitely, and the `except asyncio.TimeoutError` handler below it is unreachable in practice.

## Fix

Spawn the process, then bound the wait on `communicate()` — the step that blocks. Kill and reap the child if it overruns so it doesn't linger after we return:

```python
proc = await asyncio.create_subprocess_exec(*cmd, ...)
try:
    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
except asyncio.TimeoutError:
    proc.kill()
    await proc.wait()
    raise
```

The re-raised `TimeoutError` is caught by the existing handler, which returns the `{"success": False, "error": "Comment fetch timed out"}` result — now reachable.

## Tests

`tests/test_youtube_comments_timeout.py` — stubs the subprocess with a fake whose `communicate()` never returns within the window, then asserts that with a small timeout `fetch_youtube_comments` returns the timed-out result (rather than hanging) and that the overrunning child is killed. With the old code the test hangs on the un-bounded `communicate()`; with the fix it returns at the timeout.
