### PR TITLE
Load .env in start-macos.sh for APP_PORT and APP_BIND

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ ODYSSEUS_HOST=0.0.0.0 ./start-macos.sh
 # then open http://<tailscale-ip>:7860
 ```
 
-Keep auth enabled when binding outside loopback, and do not expose this port directly to the public internet. To build a clickable app wrapper:
+The script also reads `.env` at startup, so `APP_BIND=0.0.0.0` and `APP_PORT`
+set there are picked up automatically without a command-line override each run.
+
+Keep `AUTH_ENABLED=true` (the default) before binding outside loopback. Do not
+expose this port directly to the public internet. To build a clickable app wrapper:
 
 ```bash
 ./build-macos-app.sh

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -16,8 +16,24 @@ set -e
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$REPO_DIR"
 
-PORT="${ODYSSEUS_PORT:-7860}"   # 7860, not 7000 — macOS AirPlay Receiver holds 7000.
-HOST="${ODYSSEUS_HOST:-127.0.0.1}" # Set ODYSSEUS_HOST=0.0.0.0 for LAN/Tailscale access.
+# Load .env so APP_PORT and APP_BIND are available without re-typing them on
+# the command line every run — consistent with how app.py reads them via
+# python-dotenv. Variables already set in the shell take priority over .env.
+if [ -f .env ]; then
+  while IFS='=' read -r key value; do
+    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key// }" ]] && continue
+    value="${value%%#*}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    [ -n "$key" ] && [ -z "${!key+x}" ] && export "$key=$value"
+  done < .env
+fi
+
+# Shell overrides (ODYSSEUS_PORT / ODYSSEUS_HOST) take top priority, then .env
+# values (APP_PORT / APP_BIND), then built-in defaults.
+PORT="${ODYSSEUS_PORT:-${APP_PORT:-7860}}"   # 7860, not 7000 — macOS AirPlay Receiver holds 7000.
+HOST="${ODYSSEUS_HOST:-${APP_BIND:-127.0.0.1}}" # Set APP_BIND=0.0.0.0 in .env for LAN/Tailscale access.
 PROBE_HOST="$HOST"
 if [ "$PROBE_HOST" = "0.0.0.0" ] || [ "$PROBE_HOST" = "::" ]; then
   PROBE_HOST="127.0.0.1"


### PR DESCRIPTION
## Summary

`start-macos.sh` currently ignores `.env` — users who set `APP_PORT` or `APP_BIND` there (as documented and used by Docker Compose) still have to retype them on the command line every run. This PR fixes that by parsing `.env` at startup, consistent with how `app.py` reads it via python-dotenv.

Resolution order (highest to lowest priority):
1. Shell environment (`ODYSSEUS_PORT` / `ODYSSEUS_HOST`) — existing behaviour preserved
2. `.env` values (`APP_PORT` / `APP_BIND`)
3. Built-in defaults (`7860` / `127.0.0.1`)

No behaviour change for users who don't use `.env`.

## Test plan

- [ ] Run `./start-macos.sh` with no `.env` overrides — confirm defaults unchanged (`127.0.0.1:7860`)
- [ ] Set `APP_PORT=7900` in `.env` — confirm script picks it up without a command-line flag
- [ ] Set `APP_BIND=0.0.0.0` in `.env` — confirm server binds to all interfaces
- [ ] Pass `ODYSSEUS_PORT=7800 ./start-macos.sh` with `APP_PORT=7900` in `.env` — confirm shell override wins (`7800`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)