### PR TITLE
fix(tts): count .mp3 cache files in get_stats, not just .wav

### DIFF
--- a/services/tts/tts_service.py
+++ b/services/tts/tts_service.py
@@ -188,7 +188,7 @@ class TTSService:
         provider = settings["tts_provider"]
         tts_enabled = settings.get("tts_enabled", True)
 
-        cache_files = list(self.cache_dir.glob("*.wav"))
+        cache_files = list(self.cache_dir.glob("*.wav")) + list(self.cache_dir.glob("*.mp3"))
         cache_size = sum(f.stat().st_size for f in cache_files)
 
         is_available = self.available and tts_enabled

--- a/tests/test_tts_cache_stats.py
+++ b/tests/test_tts_cache_stats.py
@@ -1,0 +1,12 @@
+from services.tts.tts_service import TTSService
+
+
+def test_tts_cache_stats_counts_mp3(tmp_path):
+    service = TTSService(cache_dir=str(tmp_path))
+
+    # Put an MP3-headed blob (starts with b'ID3') into cache, with size > 1MB so cache_size_mb > 0
+    service._put_cache("k", b"ID3" + b"x" * (1024 * 1024))
+
+    stats = service.get_stats()
+    assert stats["cache_entries"] == 1
+    assert stats["cache_size_mb"] > 0


### PR DESCRIPTION
## Problem

`TTSService._put_cache` writes the cache file with an extension based on the audio format:

```python
ext = ".mp3" if (<looks like MP3: ID3 tag or MPEG frame sync>) else ".wav"
(self.cache_dir / f"{key}{ext}").write_bytes(data)
```

and the rest of the class treats both extensions as cache entries — `_get_cache` iterates `(".mp3", ".wav")`, and the eviction path globs `"*.*"`.

But `get_stats()` enumerated the cache with only:

```python
cache_files = list(self.cache_dir.glob("*.wav"))
cache_size = sum(f.stat().st_size for f in cache_files)
```

So both `cache_entries` and `cache_size_mb` undercount — they report **0** whenever the cache holds MP3 files, which is the common case (most TTS providers return MP3).

Repro:

```python
service._put_cache("k", b"ID3" + ...)     # writes k.mp3
service.get_stats()["cache_entries"]       # -> 0   (a k.mp3 file exists on disk)
```

## Fix

Glob both extensions so the reported stats reflect what's actually cached:

```python
cache_files = list(self.cache_dir.glob("*.wav")) + list(self.cache_dir.glob("*.mp3"))
```

`cache_size` is derived from `cache_files`, so it's corrected too. One line in `get_stats`.

## Test

`tests/test_tts_cache_stats.py` constructs a `TTSService` over a throwaway cache dir, writes an MP3-headed blob via `_put_cache`, and asserts `get_stats()` reports one entry with non-zero size. Real filesystem, no mocking. Fails before this change.