### PR TITLE
fix(sessions): don't delete a chat when Backspace is pressed while renaming

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -1872,6 +1872,14 @@ export function setCurrentSessionId(id) {
 
 // Session list keyboard navigation: arrows to move, Delete to delete
 function _onSessionListKeydown(e) {
+  // Ignore keys that originate from an inline editable control such as the
+  // session rename input. That input lives *inside* the .list-item row, so its
+  // keydown events bubble up here; without this guard, pressing Backspace (or
+  // Delete/Enter) while renaming would fall through to the delete/select
+  // branches below and remove or switch the very session being renamed
+  // (issue #1007).
+  const t = e.target;
+  if (t && (t.isContentEditable || t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT')) return;
   const item = e.target.closest('.list-item[data-session-id]');
   if (!item) return;
 


### PR DESCRIPTION
## Problem

Fixes #1007.

Renaming a chat and hitting **Backspace** to correct a typo deletes the whole conversation instead of editing a character.

The session list has a container-level keyboard handler, `_onSessionListKeydown`, bound to `#session-list` (`static/js/sessions.js`). It implements list navigation for a focused row: arrows to move, **Enter** to open, **Delete/Backspace** to delete the session under the cursor.

The inline rename `<input>` is created by replacing the row's name `<span>` — so the input lives *inside* the `.list-item[data-session-id]` row. The input's own keydown handler only intercepts `Enter` and `Escape`; every other key (including `Backspace`) bubbles up to the container handler. There, `e.target.closest('.list-item[data-session-id]')` happily matches (the input is inside the row), so the `Delete`/`Backspace` branch runs and deletes the session you were renaming:

```js
function _onSessionListKeydown(e) {
  const item = e.target.closest('.list-item[data-session-id]');
  if (!item) return;
  ...
  if (e.key === 'Delete' || e.key === 'Backspace') {
    e.preventDefault();
    ...
    await fetch(`${API_BASE}/api/session/${s.id}`, { method: 'DELETE' });
```

So Backspace-on-empty-or-mid-word during a rename = the conversation is gone.

## Fix

Bail out of the list-level handler when the key event originates from an editable control (the rename input, or any `input`/`textarea`/`select`/`contenteditable`). Those keys belong to the field being edited, not to list navigation:

```js
const t = e.target;
if (t && (t.isContentEditable || t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT')) return;
```

List navigation still works exactly as before: when a **row** is focused (a `div`, not an input) the guard is false and arrows / Enter / Delete behave normally. Only keystrokes typed into an inline field are now left alone — so Backspace edits the name, as expected. The guard is intentionally general (not just the rename input) so any future inline control in a session row is safe too.

## Tests

This repo has no JavaScript test harness (no jest/vitest, no `*.test.js`), so there's no automated test to add. The change is a minimal, self-contained guard; it can be verified manually: double-click a chat to rename it, press Backspace, and confirm it deletes a character instead of the conversation, while Delete/Backspace on a focused (non-editing) row still deletes the session.
