### PR TITLE
Fix Windows NVIDIA VRAM detection in Cookbook

### DIFF
--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -409,7 +409,7 @@ def _detect_windows():
         "    $gpus = @(); "
         "    foreach ($line in $nv -split \"`n\") { "
         "      $p = $line -split ','; "
-        "      if ($p.Count -ge 2) { $gpus += @{name=$p[1].Trim(); vram_mb=[double]$p[0].Trim()} } "
+        "      if ($p.Count -ge 2) { $gpus += [pscustomobject]@{name=$p[1].Trim(); vram_mb=[double]$p[0].Trim()} } "
         "    }; "
         "    $r.gpu_name = $gpus[0].name; "
         "    $r.gpu_vram_gb = [math]::Round(($gpus | Measure-Object -Property vram_mb -Sum).Sum / 1024, 1); "


### PR DESCRIPTION
Summary:
This fixes Windows Cookbook hardware detection for NVIDIA GPUs. The PowerShell probe was adding GPU rows as hashtables, then using Measure-Object -Property vram_mb. Measure-Object does not read hashtable keys as properties, so VRAM could be reported as 0 GB even when nvidia-smi returned valid data.

Change:
- Convert each GPU row to a [pscustomobject] so vram_mb is available as a real property.

Tested:
- Ran: python -m py_compile services/hwfit/hardware.py
- Ran local hardware detection on Windows 10 IoT Enterprise LTSC 21H2.
- Before: RTX 3080 Laptop GPU detected with 0 GB VRAM, Cookbook ranked models as CPU-only.
- After: RTX 3080 Laptop GPU detected with 8 GB VRAM, CUDA backend, Cookbook ranks suitable models as GPU.

Hardware used for test:
- Intel Core i7-12700H
- NVIDIA GeForce RTX 3080 Laptop GPU, 8192 MiB VRAM
- 32 GB RAM
