### PR TITLE
Appearance: add dedicated chat text size slider

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -84,6 +84,10 @@
       if (t && t.density && t.density !== 'comfortable') {
         document.documentElement.classList.add('density-' + t.density);
       }
+      // Apply chat font scale to avoid a first-paint flash when != 100%
+      if (t && t.chatTextSize && t.chatTextSize !== 100) {
+        s.setProperty('--chat-font-scale', String(t.chatTextSize / 100));
+      }
       // Apply background pattern on body once available
       if (t && t.bgPattern && t.bgPattern !== 'none') {
         document.addEventListener('DOMContentLoaded', function() {
@@ -579,6 +583,12 @@
               <input type="checkbox" id="theme-frosted-toggle">
               <span class="admin-slider"></span>
             </label>
+          </div>
+        </div>
+        <div class="theme-fd-row">
+          <div class="theme-fd-group" style="flex:1 1 0;">
+            <label class="theme-fd-label">Chat Text Size <span id="theme-chat-text-size-label" style="opacity:0.5;font-variant-numeric:tabular-nums">100%</span></label>
+            <input type="range" id="theme-chat-text-size" class="theme-fd-range" min="80" max="120" step="5" value="100">
           </div>
         </div>
         <div class="theme-fd-row">

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -914,6 +914,7 @@ export function initThemeUI() {
       const result = saveCustomTheme(slug, colors, opts);
       if (result === 'limit') { saveError.textContent = 'Max ' + MAX_CUSTOM_THEMES + ' custom themes. Delete one first.'; saveError.style.display = 'block'; return; }
       save(slug, colors, opts);
+      initThemeUI();
       newNameInput.value = '';
       _flashAutosaved('Theme saved');
       uiModule.showToast?.('Theme saved');

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -101,6 +101,7 @@ export function saveCustomTheme(name, colors, opts) {
     if (opts.bgEffectIntensity !== undefined) entry.bgEffectIntensity = opts.bgEffectIntensity;
     if (opts.bgEffectSize !== undefined) entry.bgEffectSize = opts.bgEffectSize;
     if (opts.frosted !== undefined) entry.frosted = !!opts.frosted;
+    if (opts.chatTextSize !== undefined) entry.chatTextSize = opts.chatTextSize;
   }
   ct[name] = entry;
   _saveCustomThemes(ct);
@@ -408,6 +409,14 @@ export function applyBgEffectSize(v) {
   document.documentElement.style.setProperty('--bg-effect-size', String(n));
 }
 
+export function applyChatTextScale(percent) {
+  // percent is 80..120. Default 100 (no change) when missing.
+  const n = (percent === undefined || percent === null || isNaN(percent))
+    ? 100
+    : Math.max(80, Math.min(120, Math.round(Number(percent))));
+  document.documentElement.style.setProperty('--chat-font-scale', String(n / 100));
+}
+
 /** Toggle the global "frosted glass" look — applies a translucent + blurred
  *  treatment to every panel, sidebar, modal, dropdown, and popover via CSS
  *  rules scoped to `body.theme-frosted`. */
@@ -458,6 +467,7 @@ export function save(name, colors, opts) {
     if (opts.bgEffectIntensity !== undefined && opts.bgEffectIntensity !== 1) obj.bgEffectIntensity = opts.bgEffectIntensity;
     if (opts.bgEffectSize !== undefined && opts.bgEffectSize !== 1) obj.bgEffectSize = opts.bgEffectSize;
     if (opts.frosted) obj.frosted = true;
+    if (opts.chatTextSize !== undefined && opts.chatTextSize !== 100) obj.chatTextSize = opts.chatTextSize;
   }
   Storage.setJSON(LS_KEY, obj);
   _syncToServer(obj);
@@ -672,6 +682,8 @@ export function initThemeUI() {
     if (sz) opts.bgEffectSize = parseFloat(sz.value) / 100;
     const fr = document.getElementById('theme-frosted-toggle');
     if (fr) opts.frosted = !!fr.checked;
+    const cs = document.getElementById('theme-chat-text-size');
+    if (cs) opts.chatTextSize = parseInt(cs.value, 10);
     return opts;
   }
   function _saveFull(name, colors) { save(name, colors, _getOpts()); }
@@ -700,12 +712,14 @@ export function initThemeUI() {
         const fr = (ct && ct.frosted !== undefined)
           ? !!ct.frosted
           : (THEME_DEFAULT_FROSTED[name] === true);
+        const cts = (ct && ct.chatTextSize !== undefined) ? ct.chatTextSize : 100;
         applyFontDensity(f, d);
         applyBgEffectColor(ec);
         applyBgEffectIntensity(ei);
         applyBgEffectSize(sz);
         applyFrostedGlass(fr);
         applyBgPattern(p);
+        applyChatTextScale(cts);
         const fs = document.getElementById('theme-font-select');
         const ds = document.getElementById('theme-density-select');
         const ps = document.getElementById('theme-bg-pattern-select');
@@ -713,6 +727,8 @@ export function initThemeUI() {
         const eis = document.getElementById('theme-bg-intensity');
         const szs = document.getElementById('theme-bg-size');
         const frs = document.getElementById('theme-frosted-toggle');
+        const cts_el = document.getElementById('theme-chat-text-size');
+        const cts_lbl = document.getElementById('theme-chat-text-size-label');
         if (fs) fs.value = f;
         if (ds) ds.value = d;
         if (ps) ps.value = p;
@@ -720,7 +736,9 @@ export function initThemeUI() {
         if (eis) eis.value = String(Math.round(ei * 100));
         if (szs) szs.value = String(Math.round(sz * 100));
         if (frs) frs.checked = fr;
-        save(name, colors, { font: f, density: d, bgPattern: p, bgEffectColor: ec, bgEffectIntensity: ei, bgEffectSize: sz, frosted: fr });
+        if (cts_el) cts_el.value = String(cts);
+        if (cts_lbl) cts_lbl.textContent = cts + '%';
+        save(name, colors, { font: f, density: d, bgPattern: p, bgEffectColor: ec, bgEffectIntensity: ei, bgEffectSize: sz, frosted: fr, chatTextSize: cts });
       });
     });
     g.querySelectorAll('.theme-delete-btn').forEach(btn => {
@@ -853,6 +871,7 @@ export function initThemeUI() {
           bgPattern: _activeSaved.bgPattern, bgEffectColor: _activeSaved.bgEffectColor,
           bgEffectIntensity: _activeSaved.bgEffectIntensity,
           bgEffectSize: _activeSaved.bgEffectSize,
+          chatTextSize: _activeSaved.chatTextSize,
         });
         _saveFull(_activeName, colors);
       } else {
@@ -922,12 +941,17 @@ export function initThemeUI() {
       syncPickers(colors);
       applyFontDensity(DEFAULT_FONT, DEFAULT_DENSITY);
       applyBgPattern('none');
+      applyChatTextScale(100);
       const fs = document.getElementById('theme-font-select');
       const ds = document.getElementById('theme-density-select');
       const ps = document.getElementById('theme-bg-pattern-select');
+      const cts_el = document.getElementById('theme-chat-text-size');
+      const cts_lbl = document.getElementById('theme-chat-text-size-label');
       if (fs) fs.value = DEFAULT_FONT;
       if (ds) ds.value = DEFAULT_DENSITY;
       if (ps) ps.value = 'none';
+      if (cts_el) cts_el.value = '100';
+      if (cts_lbl) cts_lbl.textContent = '100%';
       grid.querySelectorAll('.theme-swatch').forEach(s => s.classList.remove('active'));
       const darkSwatch = grid.querySelector('[data-theme="dark"]');
       if (darkSwatch) darkSwatch.classList.add('active');
@@ -1001,6 +1025,7 @@ export function initThemeUI() {
           bgPattern: _activeSaved.bgPattern, bgEffectColor: _activeSaved.bgEffectColor,
           bgEffectIntensity: _activeSaved.bgEffectIntensity,
           bgEffectSize: _activeSaved.bgEffectSize,
+          chatTextSize: _activeSaved.chatTextSize,
         });
         _saveFull(_activeName, base);
       } else {
@@ -1085,12 +1110,14 @@ export function initThemeUI() {
   const _initFrosted = (saved && saved.frosted !== undefined)
     ? !!saved.frosted
     : (saved && THEME_DEFAULT_FROSTED[saved.name] === true);
+  const _initChatTextSize = (saved && saved.chatTextSize) || 100;
   applyFontDensity(_initFont, _initDensity);
   applyBgEffectColor(_initEffectColor);
   applyBgEffectIntensity(_initEffectIntensity);
   applyBgEffectSize(_initEffectSize);
   applyFrostedGlass(_initFrosted);
   applyBgPattern(_initPattern);
+  applyChatTextScale(_initChatTextSize);
 
   const fontSelect = document.getElementById('theme-font-select');
   const densitySelect = document.getElementById('theme-density-select');
@@ -1162,6 +1189,19 @@ export function initThemeUI() {
     sizeSlider.value = String(Math.round(_initEffectSize * 100));
     sizeSlider.addEventListener('input', () => {
       applyBgEffectSize(parseFloat(sizeSlider.value) / 100);
+      const s = getSaved(); if (s) _saveFull(s.name, s.colors);
+    });
+  }
+
+  const chatSizeSlider = document.getElementById('theme-chat-text-size');
+  const chatSizeLabel = document.getElementById('theme-chat-text-size-label');
+  if (chatSizeSlider) {
+    chatSizeSlider.value = String(_initChatTextSize);
+    if (chatSizeLabel) chatSizeLabel.textContent = _initChatTextSize + '%';
+    chatSizeSlider.addEventListener('input', () => {
+      const pct = parseInt(chatSizeSlider.value, 10);
+      applyChatTextScale(pct);
+      if (chatSizeLabel) chatSizeLabel.textContent = pct + '%';
       const s = getSaved(); if (s) _saveFull(s.name, s.colors);
     });
   }
@@ -1252,6 +1292,7 @@ export function initThemeUI() {
       if (cur && cur.density) obj.density = cur.density;
       if (cur && cur.bgPattern) obj.bgPattern = cur.bgPattern;
       if (cur && cur.bgEffectColor) obj.bgEffectColor = cur.bgEffectColor;
+      if (cur && cur.chatTextSize) obj.chatTextSize = cur.chatTextSize;
       const json = JSON.stringify(obj, null, 2);
       const blob = new Blob([json], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -1301,6 +1342,7 @@ export function initThemeUI() {
       if (parsed.density) opts.density = parsed.density;
       if (parsed.bgPattern) opts.bgPattern = parsed.bgPattern;
       if (parsed.bgEffectColor) opts.bgEffectColor = parsed.bgEffectColor;
+      if (parsed.chatTextSize) opts.chatTextSize = parsed.chatTextSize;
       const result = saveCustomTheme(slug, colorData, opts);
       if (result === 'limit') { saveError.textContent = 'Max ' + MAX_CUSTOM_THEMES + ' custom themes. Delete one first.'; saveError.style.display = 'block'; return; }
       save(slug, colorData, opts);
@@ -1308,6 +1350,7 @@ export function initThemeUI() {
       applyFontDensity(opts.font || DEFAULT_FONT, opts.density || DEFAULT_DENSITY);
       applyBgEffectColor(opts.bgEffectColor || '');
       applyBgPattern(opts.bgPattern || 'none');
+      applyChatTextScale(opts.chatTextSize || 100);
       importAreaEl.classList.add('hidden');
       importActionsEl.classList.add('hidden');
     });
@@ -2046,7 +2089,7 @@ function _initEmbers() {
 const themeModule = { initThemeUI, togglePopup, closePopup, makeDraggable,
                        THEMES, applyColors, applyFontDensity, applyBgPattern,
                        applyBgEffectColor, applyBgEffectIntensity, applyBgEffectSize,
-                       applyFrostedGlass,
+                       applyFrostedGlass, applyChatTextScale,
                        save, getSaved, saveCustomTheme, deleteCustomTheme,
                        getCustomThemes };
 

--- a/static/style.css
+++ b/static/style.css
@@ -146,6 +146,7 @@ html {
 /* ── Background Patterns ── */
 
 :root { --bg-effect-intensity: 1; }
+:root { --chat-font-scale: 1; }
 
 /* Canvas-based effects — single source of truth for intensity */
 #synapse-canvas, #rain-canvas, #constellations-canvas,
@@ -1973,7 +1974,7 @@ body.bg-pattern-sparkles {
       word-break: break-word;
       overflow-wrap: anywhere;
       line-height: 1.5;
-      font-size: 0.95em;
+      font-size: calc(0.95em * var(--chat-font-scale, 1));
       margin: 0;
       overflow: hidden;
       max-width: 100%;
@@ -4026,7 +4027,7 @@ body.bg-pattern-sparkles {
       }
       /* Chat bubbles — AI stretches full width, user stays compact */
       .msg { font-size: 0.85em; }
-      .msg .body { font-size: 0.9em; }
+      .msg .body { font-size: calc(0.9em * var(--chat-font-scale, 1)); }
       .msg-user { max-width: 90% !important; margin-left: auto; margin-right: 4px; }
       .msg-ai, .agent-thread { width: 100% !important; max-width: 100% !important; margin: 8px 0; }
       /* Prevent inner scrollable elements from trapping vertical scroll */


### PR DESCRIPTION
## Summary
- Adds a slider (80%–120%, 5% steps) in the theme popup → Customize → Font & Layout for precise control over chat message text size, independent of the global Density setting.
- Implemented via a unitless CSS variable `--chat-font-scale` multiplied into the existing `.msg .body` em-based rules with `calc()` — preserves the desktop/mobile distinction and the density interaction.
- Persists alongside other theme settings in `localStorage['odysseus-theme']` + server sync; omitted from JSON when at the 100% default. Round-trips through swatch switching, reset, export/import, and the color-tweak auto-save (via `_getOpts()`).

## Test plan
- [ ] Fresh localStorage → chat renders at current size; no console errors; JSON has no `chatTextSize` field.
- [ ] Drag slider 80%→120% → bubbles resize live; percent label updates each step.
- [ ] Reload at 80% → persists; localStorage shows `chatTextSize: 80`.
- [ ] Reset to 100% → field removed from localStorage; slider snaps back.
- [ ] Tweak Accent color while at 120% → reload → still 120% (validates `_getOpts()`).
- [ ] Density Compact/Spacious with scale ≠ 100% → text scales proportionally.
- [ ] Click "Reset to Default" → slider returns to 100%; label updates.
- [ ] Built-in preset swatch click → resets to 100%; custom theme swatch click → restores saved scale.
- [ ] Mobile viewport: 0.9em base scales proportionally.
- [ ] Export theme at 120% → JSON contains `"chatTextSize": 120`; import restores it.
- [ ] Hard refresh at 80% → no flash from 100% → 80% on first paint (early-load script).
- [ ] Composer textarea is unaffected at every scale value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)