### PR TITLE
fix(stt): always remove the temp audio file, even when transcription fails

### DIFF
--- a/services/stt/stt_service.py
+++ b/services/stt/stt_service.py
@@ -91,6 +91,7 @@ class STTService:
         model = self._get_whisper()
         if not model:
             return None
+        tmp_path = None
         try:
             # Write to temp file (faster-whisper needs a file path or file-like)
             with tempfile.NamedTemporaryFile(suffix=".webm", delete=False) as tmp:
@@ -104,14 +105,14 @@ class STTService:
             segments, info = model.transcribe(tmp_path, **kwargs)
             text = " ".join(seg.text.strip() for seg in segments)
 
-            # Cleanup
-            Path(tmp_path).unlink(missing_ok=True)
-
             logger.info(f"Local STT: {len(text)} chars, lang={info.language}, prob={info.language_probability:.2f}")
             return text
         except Exception as e:
             logger.error(f"Local STT transcription failed: {e}", exc_info=True)
             return None
+        finally:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
 
     # ── API endpoint ──
 

--- a/tests/test_stt_leak.py
+++ b/tests/test_stt_leak.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+from services.stt.stt_service import STTService
+
+
+def test_stt_local_transcribe_leak_on_error():
+    service = STTService()
+
+    class MockWhisper:
+        def transcribe(self, *args, **kwargs):
+            raise ValueError("Simulated transcribe error")
+
+    service._get_whisper = lambda: MockWhisper()
+
+    # Track WebM files in the temp directory before running transcription
+    temp_dir = tempfile.gettempdir()
+    webm_before = {f for f in os.listdir(temp_dir) if f.endswith(".webm")}
+
+    # Run transcription, which will raise ValueError internally
+    result = service._transcribe_local(b"dummy_audio_data")
+
+    # Track WebM files in the temp directory after running transcription
+    webm_after = {f for f in os.listdir(temp_dir) if f.endswith(".webm")}
+
+    # Assert that it returned None (failure)
+    assert result is None
+
+    # Assert that no new temp files were leaked
+    leaked = webm_after - webm_before
+    assert len(leaked) == 0, f"Leaked files: {leaked}"


### PR DESCRIPTION
## Problem

`STTService._transcribe_local` writes the incoming audio to a temp file (faster-whisper needs a path) and then unlinks it — but the unlink is on the **success path only**, before the `except`:

```python
try:
    with tempfile.NamedTemporaryFile(suffix=".webm", delete=False) as tmp:
        tmp.write(audio_bytes); tmp_path = tmp.name
    segments, info = model.transcribe(tmp_path, **kwargs)
    text = " ".join(seg.text.strip() for seg in segments)
    Path(tmp_path).unlink(missing_ok=True)   # <-- only runs if nothing above raised
    ...
    return text
except Exception as e:
    logger.error(...); return None           # <-- temp file leaks here
```

If `model.transcribe()` raises (corrupt/short audio, model or runtime error, etc.), the function returns `None` and the `.webm` temp file is never removed. So **every failed local transcription leaks a file** in the system temp dir.

Verified with a stubbed model that raises: `_transcribe_local` returns `None` and leaves one `.webm` behind.

## Fix

Initialize `tmp_path = None` before the `try`, and move the unlink into a `finally` so cleanup runs whether transcription succeeds or raises:

```python
finally:
    if tmp_path:
        Path(tmp_path).unlink(missing_ok=True)
```

## Test

`tests/test_stt_leak.py` stubs the whisper model to raise during `transcribe`, runs `_transcribe_local`, and asserts it returns `None` and leaves **no** new `.webm` file in the temp dir. Real filesystem, no mocking. Fails before this change.