### PR TITLE
Integrate Codex CLI provider into chat UI and model flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,13 @@ SEARXNG_INSTANCE=http://localhost:8080
 # Do not commit a real password.
 # ODYSSEUS_ADMIN_PASSWORD=change_me_before_first_boot
 
+# Codex / ChatGPT device-code auth.
+# Requires the official Codex CLI (`npm install -g @openai/codex` or equivalent).
+# Odysseus delegates token storage to Codex and never stores ~/.codex/auth.json.
+# CODEX_BIN=codex
+# CODEX_HOME=~/.codex
+# ODYSSEUS_CODEX_AUTH_ENABLED=true
+
 # CORS allowed origins (default: localhost-only; restrict to your public origin in production)
 # ALLOWED_ORIGINS=http://localhost:7000,http://localhost:8000
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,13 @@ dev-docs/
 # Windows-port working docs (local only, not for public repo)
 docs/windows-port/
 
+# Local Codex CLI installs and credential homes
+codex-bin/
+codex-home/
+.codex/
+**/.codex/
+**/codex-home/
+
 # Local config
 compound.config.json
 *.error.log

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Key settings:
 | `LLM_HOST` | `localhost` | Your LLM server (e.g. `llm-host.local:8000`) |
 | `LLM_HOSTS` | -- | Comma-separated list for model discovery |
 | `OPENAI_API_KEY` | -- | Optional OpenAI key. Prefer adding providers in the app unless pre-seeding. |
+| `CODEX_BIN` | `codex` | Optional path/name for the official Codex CLI used by Settings -> Integrations -> Codex / ChatGPT sign-in. |
+| `CODEX_HOME` | Codex default | Optional Codex credential/config home. If unset, the Codex CLI uses its own default, normally `~/.codex`. |
+| `ODYSSEUS_CODEX_AUTH_ENABLED` | `true` | Enables the admin-gated Codex / ChatGPT device-code auth UI. Set to `false` to hide/disable the flow. |
 | `SEARXNG_INSTANCE` | `http://localhost:8080` | SearXNG URL. Docker overrides this to `http://searxng:8080`. |
 | `SEARXNG_SECRET` | generated on first Docker boot | Optional SearXNG cookie/CSRF secret. Leave blank unless you need to pin it. |
 | `AUTH_ENABLED` | `true` | Enable/disable login |
@@ -247,6 +250,25 @@ npx -y @playwright/mcp@latest --version
 ```
 
 That installs `@playwright/mcp` plus Playwright (~300MB total). Restart Odysseus and the server will register at startup.
+
+### Codex / ChatGPT Sign-In
+Admins can link the Odysseus host to Codex from **Settings -> Integrations -> Codex / ChatGPT**. Odysseus starts the official Codex CLI device-code flow, equivalent to:
+
+```bash
+codex login --device-auth
+```
+
+The UI shows the verification URL and one-time device code, polls the CLI process for completion, and then uses `codex login status` / `codex logout` for status checks and unlinking. Install the Codex CLI first (`npm install -g @openai/codex`, or the current official install method), and set `CODEX_BIN` only if `codex` is not on the service user's `PATH`.
+
+Security notes:
+
+- Odysseus does not read, copy, or store Codex access or refresh tokens. Credential storage stays with Codex, normally under `~/.codex`.
+- Treat `~/.codex/auth.json`, any custom `CODEX_HOME`, and Codex login logs as secrets. Do not commit or upload them.
+- The Codex sign-in routes are admin-gated because logout/unlink affects the Codex identity available to the Odysseus host.
+- If you run Odysseus in Docker, mount a persistent, private Codex home and set strict host permissions, or sign-in state will be lost when the container is recreated.
+- Device-code auth can be disabled by a ChatGPT workspace admin. In that case the UI reports the Codex CLI failure and you must use a supported Codex login method outside Odysseus.
+
+MCP is not used for this authentication path. Odysseus MCP settings manage tool servers and are admin-only command execution plumbing; Codex account login belongs with provider/integration setup and should remain isolated from MCP server registration.
 
 ## Architecture
 ```

--- a/app.py
+++ b/app.py
@@ -619,6 +619,9 @@ app.include_router(setup_font_routes())
 from routes.codex_auth_routes import setup_codex_auth_routes
 app.include_router(setup_codex_auth_routes())
 
+from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+app.include_router(setup_codex_model_provider_routes())
+
 
 # MCP (Model Context Protocol)
 from src.mcp_manager import McpManager

--- a/app.py
+++ b/app.py
@@ -616,6 +616,9 @@ app.include_router(setup_backup_routes(memory_manager, preset_manager, skills_ma
 from routes.font_routes import setup_font_routes
 app.include_router(setup_font_routes())
 
+from routes.codex_auth_routes import setup_codex_auth_routes
+app.include_router(setup_codex_auth_routes())
+
 
 # MCP (Model Context Protocol)
 from src.mcp_manager import McpManager

--- a/app.py
+++ b/app.py
@@ -108,16 +108,11 @@ _TIMEOUT_EXEMPT_PREFIXES = (
     "/api/upload",          # large files
     "/api/image",           # diffusion proxies (inpaint/harmonize/upscale/etc.) — own 120s httpx timeout
 )
-_TIMEOUT_EXEMPT_EXACT = {
-    "/api/codex-model-provider/test-chat",  # own bounded Codex CLI timeout
-}
 
 
 class _RequestTimeoutMiddleware(_BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         path = request.url.path or ""
-        if path in _TIMEOUT_EXEMPT_EXACT:
-            return await call_next(request)
         if any(path.startswith(p) for p in _TIMEOUT_EXEMPT_PREFIXES):
             return await call_next(request)
         try:

--- a/app.py
+++ b/app.py
@@ -108,11 +108,16 @@ _TIMEOUT_EXEMPT_PREFIXES = (
     "/api/upload",          # large files
     "/api/image",           # diffusion proxies (inpaint/harmonize/upscale/etc.) — own 120s httpx timeout
 )
+_TIMEOUT_EXEMPT_EXACT = {
+    "/api/codex-model-provider/test-chat",  # own bounded Codex CLI timeout
+}
 
 
 class _RequestTimeoutMiddleware(_BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         path = request.url.path or ""
+        if path in _TIMEOUT_EXEMPT_EXACT:
+            return await call_next(request)
         if any(path.startswith(p) for p in _TIMEOUT_EXEMPT_PREFIXES):
             return await call_next(request)
         try:

--- a/docs/codex_model_provider_design.md
+++ b/docs/codex_model_provider_design.md
@@ -1,0 +1,179 @@
+# Codex Model Provider Draft
+
+Status: research/prototype only. Not ready for PR.
+
+This branch intentionally keeps Codex model/provider work separate from the
+Codex / ChatGPT device-code authentication branch. The auth branch should stay
+focused on sign-in and sign-out. Model picker, chat, and agent integration need
+their own design because a naive `codex exec --json` provider would not match
+Odysseus' streaming, session, or tool-round contracts.
+
+## Current Model Architecture
+
+Odysseus model selection is built around admin-configured `ModelEndpoint` rows.
+The table shape in `core/database.py` is:
+
+- `id`: endpoint identifier used by settings, sessions, and picker payloads.
+- `name`: display label.
+- `base_url`: provider base URL such as `http://localhost:8002/v1` or
+  `https://openrouter.ai/api/v1`.
+- `api_key`: encrypted optional provider API key.
+- `is_enabled`: endpoint visibility switch.
+- `hidden_models`: JSON list of model ids hidden after probe failures.
+- `cached_models`: JSON list of last discovered model ids.
+- `model_type`: `llm` or `image`.
+- `supports_tools`: nullable function-calling capability override.
+- `owner`: optional user scoping; admins see all endpoints.
+
+`routes/model_routes.py` owns the API surface:
+
+- `/api/model-endpoints`: admin CRUD over `ModelEndpoint` rows.
+- `/api/model-endpoints/test`: one-off model-list/ping validation.
+- `/api/model-endpoints/{id}/probe`: SSE probe over chat-capable models.
+- `/api/model-endpoints/{id}/models`: model visibility management.
+- `/api/models`: user-scoped model picker payload. It emits endpoint-shaped
+  items with `url`, `models`, `models_extra`, `endpoint_id`, `endpoint_name`,
+  `category`, `model_type`, and `offline`.
+- `/api/default-chat`: resolves the default chat endpoint/model with per-user
+  scoping and fallback settings.
+
+Provider detection is URL based. `src/llm_core.py` and
+`src/endpoint_resolver.py` infer OpenAI-compatible, Anthropic, OpenRouter,
+Groq, and Ollama behavior from the endpoint URL. HTTP calls are then built as:
+
+- OpenAI-compatible: `{base}/chat/completions`, SSE deltas from
+  `choices[0].delta.content`, accumulated `tool_calls`, optional usage chunks.
+- Anthropic: native `/v1/messages`, translated message/tool schema, native
+  SSE event parsing.
+- Ollama: native `/api/chat`, newline JSON streaming, native tool call
+  accumulation.
+
+The selected model path is:
+
+1. Settings/admin UI creates or updates a `ModelEndpoint`.
+2. `/api/models` returns visible endpoint items.
+3. `static/js/models.js` and `static/js/modelPicker.js` render rows and store
+   `endpoint_url`, `model`, and `endpoint_id` on a session.
+4. `routes/chat_routes.py` receives `/api/chat` or `/api/chat_stream`.
+5. `routes/chat_helpers.py` prepares context, validates privileges, and
+   normalizes model ids.
+6. Plain chat calls `stream_llm_with_fallback`.
+7. Agent mode calls `stream_agent_loop`, which wraps `stream_llm_with_fallback`
+   across multiple tool rounds.
+
+Fallbacks are configured as endpoint/model pairs in settings. The resolver
+turns them into `(chat_url, model, headers)` tuples. Streaming fallback only
+switches before any real content is emitted, so duplicate partial answers are
+avoided.
+
+## Codex CLI Findings
+
+The requested help probes were attempted:
+
+- `codex --help`
+- `codex login status`
+- `codex exec --help`
+
+On this Windows host, `codex.exe` resolves to:
+
+`C:\Program Files\WindowsApps\OpenAI.Codex_26.527.3686.0_x64__2p2nqsd0c76g0\app\resources\codex.exe`
+
+All three commands failed before producing help text with PowerShell reporting
+`Access is denied`. That means this runtime cannot validate `codex exec`
+capabilities directly. The branch must not depend on undocumented behavior from
+this CLI install.
+
+Reliable enough today:
+
+- Existing `src/codex_auth.py` can report CLI presence, executable status, and
+  `codex login status` output when the binary is executable.
+- Auth status does not read, parse, store, log, or expose raw Codex tokens.
+- The integration can safely build capability/status reporting around the auth
+  service.
+
+Not reliable enough today:
+
+- JSON event shape from `codex exec`.
+- Whether true token deltas exist.
+- Session/resume identity and lifecycle.
+- Tool execution controls suitable for a chat-provider mode.
+- Docker runtime behavior, because the current host binary is inaccessible and
+  the project should not bundle the CLI in this branch.
+
+## Proposed Integration
+
+Do not add Codex as a normal `ModelEndpoint` yet. The current endpoint schema is
+URL/API-key oriented and does not have a clean auth mode field such as
+`auth_type = api_key | codex_cli`. Overloading `base_url` with a fake URL would
+make picker selection look like a normal provider while chat routing still has
+different semantics.
+
+Instead, stage the work:
+
+1. Keep Codex sign-in in Settings -> Integrations.
+2. Add a feature-flagged internal Codex model-provider capability probe:
+   `ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=false` by default.
+3. Report a synthetic model only when the feature flag is enabled, the CLI is
+   available, and Codex auth status is authenticated.
+4. Mark chat support, token streaming, session resume, and tool execution as
+   unsupported until each has a concrete implementation and tests.
+5. Only later add schema support for a provider auth type or a first-class
+   non-HTTP provider registry.
+6. Only after that expose Add Models / model picker UI, with clear experimental
+   copy and sign-in-required state.
+
+The Add Models UI should link to the existing Integrations Codex form instead
+of duplicating auth implementation. The sign-in state is host-wide and
+admin-gated, so a second auth card in Add Models would increase security and UX
+surface area without adding capability.
+
+## Hook Points
+
+Minimum clean hook points:
+
+- `src/codex_auth.py`: source of truth for CLI availability and auth state.
+- A new internal provider module for feature flag, capability shape, and
+  eventual adapter boundary.
+- A new admin-gated status route, separate from `/api/models`, until chat
+  behavior is ready.
+
+Future hook points after adapter design:
+
+- Provider registry used by `/api/models`, returning endpoint-shaped entries
+  with explicit metadata such as `experimental`, `requires_sign_in`, and
+  `streaming_supported`.
+- `src/llm_core.py` or a sibling dispatch layer that routes non-HTTP providers
+  without pretending they are OpenAI-compatible URLs.
+- `routes/chat_routes.py` plain-chat branch only after session/resume and
+  streaming semantics are explicit.
+- Agent mode only after tool execution is intentionally disabled or mapped to
+  Odysseus agent rounds.
+
+## Test Plan
+
+Current stage:
+
+- Feature flag disabled returns no synthetic models.
+- Feature flag enabled but unauthenticated returns sign-in-required.
+- Feature flag enabled and authenticated returns a clearly experimental model.
+- Capability responses expose no token fields.
+- CLI unavailable state is reported clearly.
+- Existing Codex auth tests continue passing.
+- Existing model route tests continue passing.
+
+Deferred before PR:
+
+- Mocked Codex CLI adapter success/failure/timeout behavior.
+- No fake token streaming.
+- Session/resume behavior.
+- Explicit tool execution isolation.
+- UI gated behind feature flag.
+- Docker validation with sign-in, model selection, chat call, logout, and
+  failure states.
+
+## Readiness
+
+Not ready for PR. This branch can document the architecture and carry a small
+internal capability probe. It should not claim full Codex-backed chat/provider
+support until streaming, session/resume, tool isolation, and Docker behavior are
+implemented and validated end to end.

--- a/docs/codex_model_provider_docker_validation.md
+++ b/docs/codex_model_provider_docker_validation.md
@@ -30,7 +30,9 @@ The script validates:
 - feature flag enabled plus logged-out Codex returns `status=sign_in_required`
 - feature flag enabled plus logged-in Codex returns `status=available`
 - the synthetic model id is `codex-cli/chatgpt-experimental`
-- chat, streaming, session resume, and tool execution support remain false
+- `POST /api/codex-model-provider/test-chat` returns a completed assistant message
+- status reports chat support only when the adapter passes safety preflight
+- streaming, session resume, and tool execution support remain false
 - response bodies do not include token-like fields such as access or refresh tokens
 - logout returns the provider status to `sign_in_required`
 

--- a/docs/codex_model_provider_docker_validation.md
+++ b/docs/codex_model_provider_docker_validation.md
@@ -1,0 +1,43 @@
+# Codex Model Provider Docker Validation
+
+This validates the experimental status probe in the real Docker deployment
+without exposing Codex in the model picker and without adding a `codex exec`
+chat adapter.
+
+Run on the Proxmox/Docker host:
+
+```bash
+cd /opt/odysseus
+git fetch fork codex-model-provider-draft
+git switch codex-model-provider-draft
+git pull --ff-only fork codex-model-provider-draft
+
+ODYSSEUS_ADMIN_USER=admin \
+ODYSSEUS_ADMIN_PASSWORD='your-admin-password' \
+scripts/validate_codex_model_provider_docker.sh
+```
+
+If the admin account uses TOTP, add:
+
+```bash
+ODYSSEUS_ADMIN_TOTP=123456
+```
+
+The script validates:
+
+- unauthenticated access to `/api/codex-model-provider/status` is rejected
+- feature flag disabled returns `status=disabled`
+- feature flag enabled plus logged-out Codex returns `status=sign_in_required`
+- feature flag enabled plus logged-in Codex returns `status=available`
+- the synthetic model id is `codex-cli/chatgpt-experimental`
+- chat, streaming, session resume, and tool execution support remain false
+- response bodies do not include token-like fields such as access or refresh tokens
+- logout returns the provider status to `sign_in_required`
+
+The script temporarily edits the deployment `.env` file to toggle
+`ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED`, recreates only the `odysseus` service,
+restores `.env` before exit, and removes its temporary `.env` backup. It does
+not modify Dockerfile or Compose files.
+
+It intentionally logs Codex out during validation. That is part of the requested
+state coverage and cannot be undone without signing in again.

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -129,7 +129,6 @@ async def auto_name_session(session_manager, sess):
     """Generate a short title for a session from its first user message."""
     try:
         from src.llm_core import llm_call_async
-        from src.task_endpoint import resolve_task_endpoint
 
         # Find first user message
         first_msg = ""
@@ -147,9 +146,13 @@ async def auto_name_session(session_manager, sess):
         if not first_msg:
             return
 
-        t_url, t_model, t_headers = resolve_task_endpoint(
+        resolved = _resolve_http_task_endpoint(
             sess.endpoint_url, sess.model, sess.headers,
         )
+        if not resolved:
+            logger.debug("Skipping auto-name for synthetic/non-HTTP model session %s", sess.id)
+            return
+        t_url, t_model, t_headers = resolved
 
         # max_tokens big enough that reasoning models (Minimax M2,
         # DeepSeek R1, QwQ, etc.) have headroom for <think>…</think>
@@ -181,6 +184,18 @@ async def auto_name_session(session_manager, sess):
     except Exception as e:
         import traceback
         logger.error(f"Auto-name failed for {sess.id}: {e}\n{traceback.format_exc()}")
+
+
+def _resolve_http_task_endpoint(fallback_url=None, fallback_model=None, fallback_headers=None):
+    """Resolve the background-task endpoint and reject synthetic model providers."""
+    from src.task_endpoint import resolve_task_endpoint
+
+    url, model, headers = resolve_task_endpoint(fallback_url, fallback_model, fallback_headers)
+    if not url or not model:
+        return None
+    if is_codex_model_selection(url, model):
+        return None
+    return url, model, headers
 
 
 def try_fallback_endpoint(sess, session_id: str) -> dict | None:
@@ -748,14 +763,15 @@ def run_post_response_tasks(
     _should_extract = (_msg_count >= 4) and (_msg_count % 4 == 0)
     if not incognito and not compare_mode and _should_extract and uprefs.get("auto_memory", True):
         from services.memory.memory_extractor import extract_and_store
-        from src.task_endpoint import resolve_task_endpoint
-        t_url, t_model, t_headers = resolve_task_endpoint(
+        resolved = _resolve_http_task_endpoint(
             sess.endpoint_url, sess.model, sess.headers,
         )
-        asyncio.create_task(extract_and_store(
-            sess, memory_manager, memory_vector,
-            t_url, t_model, t_headers,
-        ))
+        if resolved:
+            t_url, t_model, t_headers = resolved
+            asyncio.create_task(extract_and_store(
+                sess, memory_manager, memory_vector,
+                t_url, t_model, t_headers,
+            ))
 
     # Skill extraction from complex agent runs. Only when the user actually
     # chose agent mode — not a chat we auto-escalated for a notes/calendar
@@ -785,17 +801,18 @@ def run_post_response_tasks(
             )
         else:
             from services.memory.skill_extractor import maybe_extract_skill
-            from src.task_endpoint import resolve_task_endpoint
-            s_url, s_model, s_headers = resolve_task_endpoint(
+            resolved = _resolve_http_task_endpoint(
                 sess.endpoint_url, sess.model, sess.headers,
             )
-            logger.debug("[skill-extract] dispatching extractor (model=%s)", s_model)
-            asyncio.create_task(maybe_extract_skill(
-                sess, skills_manager,
-                s_url, s_model, s_headers,
-                agent_rounds, agent_tool_calls,
-                owner=owner,
-            ))
+            if resolved:
+                s_url, s_model, s_headers = resolved
+                logger.debug("[skill-extract] dispatching extractor (model=%s)", s_model)
+                asyncio.create_task(maybe_extract_skill(
+                    sess, skills_manager,
+                    s_url, s_model, s_headers,
+                    agent_rounds, agent_tool_calls,
+                    owner=owner,
+                ))
 
     # Token accumulation
     if last_metrics:

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -12,6 +12,7 @@ from core.database import SessionLocal
 from core.database import Session as DBSession, ModelEndpoint
 from src.llm_core import normalize_model_id
 from src.context_compactor import maybe_compact, trim_for_context
+from src.codex_model_provider import is_codex_model_selection
 from src.auth_helpers import get_current_user
 from src.prompt_security import untrusted_context_message
 from routes.prefs_routes import _load_for_user as load_prefs_for_user
@@ -434,19 +435,25 @@ async def build_chat_context(
     for transcript in preprocessed.youtube_transcripts:
         preface.append(untrusted_context_message("youtube transcript", transcript))
 
-    # Normalize model ID
-    norm = normalize_model_id(sess.endpoint_url, sess.model)
-    if norm:
-        sess.model = norm
+    if is_codex_model_selection(sess.endpoint_url, sess.model):
+        messages = preface + sess.get_context_messages()
+        context_length = 32000
+        was_compacted = False
+        messages = trim_for_context(messages, context_length)
+    else:
+        # Normalize model ID
+        norm = normalize_model_id(sess.endpoint_url, sess.model)
+        if norm:
+            sess.model = norm
 
-    # Build messages
-    messages = preface + sess.get_context_messages()
+        # Build messages
+        messages = preface + sess.get_context_messages()
 
-    # Auto-compact
-    messages, context_length, was_compacted = await maybe_compact(
-        sess, sess.endpoint_url, sess.model, messages, sess.headers,
-    )
-    messages = trim_for_context(messages, context_length)
+        # Auto-compact
+        messages, context_length, was_compacted = await maybe_compact(
+            sess, sess.endpoint_url, sess.model, messages, sess.headers,
+        )
+        messages = trim_for_context(messages, context_length)
 
     return ChatContext(
         preface=preface,

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -36,11 +36,22 @@ from routes.chat_helpers import (
     _enforce_chat_privileges,
 )
 from src.action_intents import message_needs_tools as _message_needs_tools
+from src.codex_model_provider import CodexModelProvider, is_codex_virtual_endpoint
 
 logger = logging.getLogger(__name__)
 
 # Track active streams for partial-save safety net
 _active_streams: Dict[str, dict] = {}
+
+
+async def _run_codex_chat(messages: list[dict[str, Any]], session_id: str, model: str) -> dict[str, Any]:
+    provider = CodexModelProvider()
+    return await provider.test_chat(
+        messages,
+        model=model,
+        timeout_seconds=120,
+        odysseus_session_id=session_id,
+    )
 
 
 def _stream_set(session_id: str, **fields) -> None:
@@ -72,6 +83,8 @@ def _session_url_matches_endpoint(session_url: str, endpoint_base: str) -> bool:
 def _clear_orphaned_session_endpoint(sess) -> bool:
     """Clear a session model if its endpoint was deleted from ModelEndpoint."""
     if not getattr(sess, "endpoint_url", ""):
+        return False
+    if is_codex_virtual_endpoint(getattr(sess, "endpoint_url", ""), getattr(sess, "model", "")):
         return False
     db = SessionLocal()
     try:
@@ -167,6 +180,30 @@ def setup_chat_routes(
                 )
             except Exception as e:
                 logger.error(f"Research failed: {e}")
+
+        if is_codex_virtual_endpoint(sess.endpoint_url, sess.model):
+            result = await _run_codex_chat(ctx.messages, session, sess.model)
+            if not result.get("ok"):
+                return {"response": result.get("error") or "Codex / ChatGPT is unavailable."}
+            reply = result.get("message") or ""
+            _clean_reply, _clean_md = clean_thinking_for_save(reply, {
+                "model": sess.model,
+                "streaming_supported": False,
+                "session_resume_supported": bool(result.get("session_resume_supported")),
+                "session_resumed": bool(result.get("session_resumed")),
+            })
+            sess.add_message(ChatMessage("assistant", _clean_reply, metadata=_clean_md))
+
+            from core.database import update_session_last_accessed
+            update_session_last_accessed(session)
+            session_manager.save_sessions()
+            run_post_response_tasks(
+                sess, session_manager, session, message, reply, None,
+                ctx.uprefs, memory_manager, memory_vector, webhook_manager,
+                character_name=ctx.preset.character_name,
+                owner=ctx.user,
+            )
+            return {"response": reply}
 
         reply = await llm_call_async(
             sess.endpoint_url,
@@ -630,6 +667,58 @@ def setup_chat_routes(
             if ctx.preset.character_name:
                 _model_info["character_name"] = ctx.preset.character_name
             yield f'data: {json.dumps(_model_info)}\n\n'
+
+            if is_codex_virtual_endpoint(sess.endpoint_url, sess.model):
+                _chat_start = time.time()
+                result = await _run_codex_chat(messages, session, sess.model)
+                if not result.get("ok"):
+                    msg = result.get("error") or "Codex / ChatGPT is unavailable."
+                    yield f"event: error\ndata: {json.dumps({'error': msg, 'status': 502})}\n\n"
+                    yield "data: [DONE]\n\n"
+                    _stream_set(session, status="done")
+                    _active_streams.pop(session, None)
+                    return
+
+                full_response = result.get("message") or ""
+                if full_response:
+                    yield f"data: {json.dumps({'delta': full_response})}\n\n"
+                elapsed = max(time.time() - _chat_start, 0.001)
+                last_metrics = {
+                    "response_time": round(elapsed, 2),
+                    "input_tokens": estimate_tokens(messages),
+                    "output_tokens": len(full_response) // 4,
+                    "tokens_per_second": round((len(full_response) // 4) / elapsed, 2),
+                    "model": sess.model,
+                    "usage_source": "estimated",
+                    "streaming_supported": False,
+                    "session_resume_supported": bool(result.get("session_resume_supported")),
+                    "session_resumed": bool(result.get("session_resumed")),
+                }
+                yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
+                if full_response and not incognito:
+                    _saved_id = save_assistant_response(
+                        sess, session_manager, session, full_response, last_metrics,
+                        character_name=ctx.preset.character_name,
+                        web_sources=web_sources,
+                        rag_sources=ctx.rag_sources,
+                        research_sources=research_sources,
+                        used_memories=ctx.used_memories,
+                        do_research=do_research,
+                        incognito=incognito,
+                    )
+                    if _saved_id:
+                        yield f'data: {json.dumps({"type": "message_saved", "id": _saved_id})}\n\n'
+                    run_post_response_tasks(
+                        sess, session_manager, session, message, full_response,
+                        last_metrics, ctx.uprefs, memory_manager, memory_vector, webhook_manager,
+                        incognito=incognito, compare_mode=compare_mode,
+                        character_name=ctx.preset.character_name,
+                        owner=_user,
+                    )
+                _stream_set(session, status="done")
+                yield "data: [DONE]\n\n"
+                _active_streams.pop(session, None)
+                return
 
             # Detect image models and route directly to image generation
             _IMAGE_MODEL_PREFIXES = ("gpt-image", "dall-e", "chatgpt-image")

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -254,6 +254,7 @@ def setup_chat_routes(
         compare_mode = str(form_data.get("compare_mode", "")).lower() == "true"
         incognito = str(form_data.get("incognito", "")).lower() == "true"
         chat_mode = str(form_data.get("mode", "")).lower()  # 'chat' or 'agent'
+        codex_reasoning_effort = str(form_data.get("codex_reasoning_effort") or "").strip().lower() or None
         # Did the USER explicitly pick agent mode? (vs. us auto-escalating
         # below). Skill extraction should only learn from real agent sessions,
         # not chats we quietly promoted for a notes/calendar intent.
@@ -714,6 +715,7 @@ def setup_chat_routes(
                 async for event in CodexModelProvider().stream_chat(
                     messages,
                     model=sess.model or CODEX_EXPERIMENTAL_MODEL_ID,
+                    reasoning_effort=codex_reasoning_effort,
                     timeout_seconds=120,
                     odysseus_session_id=session,
                     allow_one_shot_fallback=True,

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -744,7 +744,7 @@ def setup_chat_routes(
                 return
             elif is_codex_model_selection(sess.endpoint_url, sess.model):
                 if chat_mode != "chat":
-                    msg = "Codex / ChatGPT experimental provider is chat-only; Agent tools are not available for this model."
+                    msg = "Codex / ChatGPT provider is chat-only; Agent tools are not available for this model."
                     yield f'event: error\ndata: {json.dumps({"error": msg, "status": 400})}\n\n'
                     yield "data: [DONE]\n\n"
                     _active_streams.pop(session, None)

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Dict, Any, AsyncGenerator, List
 
 from fastapi import APIRouter, Request, HTTPException, Form, Query
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import ValidationError
 
 from core.models import ChatMessage
@@ -20,6 +20,8 @@ from src.model_context import estimate_tokens
 from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_ID,
     CodexModelProvider,
+    codex_model_default_reasoning_effort,
+    is_codex_model_available,
     is_codex_model_selection,
 )
 from src.chat_helpers import coerce_message_and_session
@@ -79,7 +81,25 @@ def _clear_orphaned_session_endpoint(sess) -> bool:
     if not getattr(sess, "endpoint_url", ""):
         return False
     if is_codex_model_selection(sess.endpoint_url, getattr(sess, "model", "")):
-        return False
+        if is_codex_model_available(getattr(sess, "model", "")):
+            return False
+        sess.endpoint_url = ""
+        sess.model = ""
+        sess.headers = {}
+        db = SessionLocal()
+        try:
+            db_session = db.query(DBSession).filter(DBSession.id == sess.id).first()
+            if db_session:
+                db_session.endpoint_url = ""
+                db_session.model = ""
+                db_session.updated_at = datetime.utcnow()
+                db.commit()
+            return True
+        except Exception:
+            db.rollback()
+            return False
+        finally:
+            db.close()
     db = SessionLocal()
     try:
         endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
@@ -294,6 +314,25 @@ def setup_chat_routes(
             raise HTTPException(404, str(e))
         except (ValueError, ValidationError):
             raise HTTPException(400, "Invalid request parameters")
+
+        codex_session = is_codex_model_selection(sess.endpoint_url, sess.model)
+        if codex_session and chat_mode != "chat":
+            if user_requested_agent:
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "code": "agent_mode_unsupported",
+                        "error": "Codex currently supports chat streaming only. Agent tool mode is not enabled for this provider.",
+                        "requested_mode": "agent",
+                        "supported_mode": "chat",
+                        "agent_tools_supported": False,
+                        "tool_execution_allowed": False,
+                    },
+                )
+            chat_mode = "chat"
+            auto_escalated = False
+        if codex_session and not codex_reasoning_effort:
+            codex_reasoning_effort = codex_model_default_reasoning_effort(sess.model)
 
         # ------------------------------------------------------------------ #
         # Privilege gates that must fire BEFORE any LLM work / token spend.
@@ -729,6 +768,14 @@ def setup_chat_routes(
                     elif event_type == "metrics":
                         last_metrics = event.get("data") or {}
                         last_metrics["model"] = sess.model or CODEX_EXPERIMENTAL_MODEL_ID
+                        last_metrics.setdefault("provider", "codex_cli")
+                        last_metrics.setdefault("usage_source", "real")
+                        if ctx.context_length and "input_tokens" in last_metrics:
+                            last_metrics.setdefault(
+                                "context_percent",
+                                min(round((last_metrics["input_tokens"] / ctx.context_length) * 100, 1), 100.0),
+                            )
+                            last_metrics.setdefault("context_length", ctx.context_length)
                         yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
                     elif event_type == "error":
                         yield f'event: error\ndata: {json.dumps({"error": event.get("error") or "Codex provider failed", "status": event.get("status") or "codex_failed"})}\n\n'

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -36,22 +36,11 @@ from routes.chat_helpers import (
     _enforce_chat_privileges,
 )
 from src.action_intents import message_needs_tools as _message_needs_tools
-from src.codex_model_provider import CodexModelProvider, is_codex_virtual_endpoint
 
 logger = logging.getLogger(__name__)
 
 # Track active streams for partial-save safety net
 _active_streams: Dict[str, dict] = {}
-
-
-async def _run_codex_chat(messages: list[dict[str, Any]], session_id: str, model: str) -> dict[str, Any]:
-    provider = CodexModelProvider()
-    return await provider.test_chat(
-        messages,
-        model=model,
-        timeout_seconds=120,
-        odysseus_session_id=session_id,
-    )
 
 
 def _stream_set(session_id: str, **fields) -> None:
@@ -83,8 +72,6 @@ def _session_url_matches_endpoint(session_url: str, endpoint_base: str) -> bool:
 def _clear_orphaned_session_endpoint(sess) -> bool:
     """Clear a session model if its endpoint was deleted from ModelEndpoint."""
     if not getattr(sess, "endpoint_url", ""):
-        return False
-    if is_codex_virtual_endpoint(getattr(sess, "endpoint_url", ""), getattr(sess, "model", "")):
         return False
     db = SessionLocal()
     try:
@@ -180,30 +167,6 @@ def setup_chat_routes(
                 )
             except Exception as e:
                 logger.error(f"Research failed: {e}")
-
-        if is_codex_virtual_endpoint(sess.endpoint_url, sess.model):
-            result = await _run_codex_chat(ctx.messages, session, sess.model)
-            if not result.get("ok"):
-                return {"response": result.get("error") or "Codex / ChatGPT is unavailable."}
-            reply = result.get("message") or ""
-            _clean_reply, _clean_md = clean_thinking_for_save(reply, {
-                "model": sess.model,
-                "streaming_supported": False,
-                "session_resume_supported": bool(result.get("session_resume_supported")),
-                "session_resumed": bool(result.get("session_resumed")),
-            })
-            sess.add_message(ChatMessage("assistant", _clean_reply, metadata=_clean_md))
-
-            from core.database import update_session_last_accessed
-            update_session_last_accessed(session)
-            session_manager.save_sessions()
-            run_post_response_tasks(
-                sess, session_manager, session, message, reply, None,
-                ctx.uprefs, memory_manager, memory_vector, webhook_manager,
-                character_name=ctx.preset.character_name,
-                owner=ctx.user,
-            )
-            return {"response": reply}
 
         reply = await llm_call_async(
             sess.endpoint_url,
@@ -667,58 +630,6 @@ def setup_chat_routes(
             if ctx.preset.character_name:
                 _model_info["character_name"] = ctx.preset.character_name
             yield f'data: {json.dumps(_model_info)}\n\n'
-
-            if is_codex_virtual_endpoint(sess.endpoint_url, sess.model):
-                _chat_start = time.time()
-                result = await _run_codex_chat(messages, session, sess.model)
-                if not result.get("ok"):
-                    msg = result.get("error") or "Codex / ChatGPT is unavailable."
-                    yield f"event: error\ndata: {json.dumps({'error': msg, 'status': 502})}\n\n"
-                    yield "data: [DONE]\n\n"
-                    _stream_set(session, status="done")
-                    _active_streams.pop(session, None)
-                    return
-
-                full_response = result.get("message") or ""
-                if full_response:
-                    yield f"data: {json.dumps({'delta': full_response})}\n\n"
-                elapsed = max(time.time() - _chat_start, 0.001)
-                last_metrics = {
-                    "response_time": round(elapsed, 2),
-                    "input_tokens": estimate_tokens(messages),
-                    "output_tokens": len(full_response) // 4,
-                    "tokens_per_second": round((len(full_response) // 4) / elapsed, 2),
-                    "model": sess.model,
-                    "usage_source": "estimated",
-                    "streaming_supported": False,
-                    "session_resume_supported": bool(result.get("session_resume_supported")),
-                    "session_resumed": bool(result.get("session_resumed")),
-                }
-                yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
-                if full_response and not incognito:
-                    _saved_id = save_assistant_response(
-                        sess, session_manager, session, full_response, last_metrics,
-                        character_name=ctx.preset.character_name,
-                        web_sources=web_sources,
-                        rag_sources=ctx.rag_sources,
-                        research_sources=research_sources,
-                        used_memories=ctx.used_memories,
-                        do_research=do_research,
-                        incognito=incognito,
-                    )
-                    if _saved_id:
-                        yield f'data: {json.dumps({"type": "message_saved", "id": _saved_id})}\n\n'
-                    run_post_response_tasks(
-                        sess, session_manager, session, message, full_response,
-                        last_metrics, ctx.uprefs, memory_manager, memory_vector, webhook_manager,
-                        incognito=incognito, compare_mode=compare_mode,
-                        character_name=ctx.preset.character_name,
-                        owner=_user,
-                    )
-                _stream_set(session, status="done")
-                yield "data: [DONE]\n\n"
-                _active_streams.pop(session, None)
-                return
 
             # Detect image models and route directly to image generation
             _IMAGE_MODEL_PREFIXES = ("gpt-image", "dall-e", "chatgpt-image")

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -17,6 +17,11 @@ from src.llm_core import llm_call_async, stream_llm, stream_llm_with_fallback
 from src.agent_loop import stream_agent_loop
 from src import agent_runs
 from src.model_context import estimate_tokens
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_MODEL_ID,
+    CodexModelProvider,
+    is_codex_model_selection,
+)
 from src.chat_helpers import coerce_message_and_session
 from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url
 from src.prompt_security import untrusted_context_message
@@ -72,6 +77,8 @@ def _session_url_matches_endpoint(session_url: str, endpoint_base: str) -> bool:
 def _clear_orphaned_session_endpoint(sess) -> bool:
     """Clear a session model if its endpoint was deleted from ModelEndpoint."""
     if not getattr(sess, "endpoint_url", ""):
+        return False
+    if is_codex_model_selection(sess.endpoint_url, getattr(sess, "model", "")):
         return False
     db = SessionLocal()
     try:
@@ -168,15 +175,25 @@ def setup_chat_routes(
             except Exception as e:
                 logger.error(f"Research failed: {e}")
 
-        reply = await llm_call_async(
-            sess.endpoint_url,
-            sess.model,
-            ctx.messages,
-            headers=sess.headers,
-            temperature=ctx.preset.temperature,
-            max_tokens=ctx.preset.max_tokens,
-            prompt_type=preset_id,
-        )
+        if is_codex_model_selection(sess.endpoint_url, sess.model):
+            result = await CodexModelProvider().test_chat(
+                ctx.messages,
+                model=sess.model or CODEX_EXPERIMENTAL_MODEL_ID,
+                odysseus_session_id=session,
+            )
+            if not result.get("ok"):
+                raise HTTPException(400, result.get("error") or "Codex provider failed")
+            reply = result.get("message") or ""
+        else:
+            reply = await llm_call_async(
+                sess.endpoint_url,
+                sess.model,
+                ctx.messages,
+                headers=sess.headers,
+                temperature=ctx.preset.temperature,
+                max_tokens=ctx.preset.max_tokens,
+                prompt_type=preset_id,
+            )
         _clean_reply, _clean_md = clean_thinking_for_save(reply, {"model": sess.model})
         sess.add_message(ChatMessage("assistant", _clean_reply, metadata=_clean_md))
 
@@ -682,6 +699,77 @@ def setup_chat_routes(
                     sess.add_message(ChatMessage("assistant", full_response, metadata={"tool_events": [_ev], "model": sess.model}))
                     session_manager.save_sessions()
                 yield f'data: {json.dumps({"type": "metrics", "data": {"total_time": 0}})}\n\n'
+                yield "data: [DONE]\n\n"
+                _active_streams.pop(session, None)
+                return
+            elif is_codex_model_selection(sess.endpoint_url, sess.model):
+                if chat_mode != "chat":
+                    msg = "Codex / ChatGPT experimental provider is chat-only; Agent tools are not available for this model."
+                    yield f'event: error\ndata: {json.dumps({"error": msg, "status": 400})}\n\n'
+                    yield "data: [DONE]\n\n"
+                    _active_streams.pop(session, None)
+                    return
+
+                _codex_start = time.time()
+                async for event in CodexModelProvider().stream_chat(
+                    messages,
+                    model=sess.model or CODEX_EXPERIMENTAL_MODEL_ID,
+                    timeout_seconds=120,
+                    odysseus_session_id=session,
+                    allow_one_shot_fallback=True,
+                ):
+                    event_type = event.get("type")
+                    if event_type == "delta":
+                        delta = event.get("delta") or ""
+                        full_response += delta
+                        _stream_set(session, partial=full_response)
+                        yield f'data: {json.dumps({"delta": delta})}\n\n'
+                    elif event_type == "metrics":
+                        last_metrics = event.get("data") or {}
+                        last_metrics["model"] = sess.model or CODEX_EXPERIMENTAL_MODEL_ID
+                        yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
+                    elif event_type == "error":
+                        yield f'event: error\ndata: {json.dumps({"error": event.get("error") or "Codex provider failed", "status": event.get("status") or "codex_failed"})}\n\n'
+                    elif event_type == "done":
+                        full_response = event.get("message") or full_response
+
+                if full_response and not last_metrics:
+                    _elapsed = time.time() - _codex_start
+                    _est_in = estimate_tokens(messages)
+                    _est_out = len(full_response) // 4
+                    last_metrics = {
+                        "response_time": round(_elapsed, 2),
+                        "input_tokens": _est_in,
+                        "output_tokens": _est_out,
+                        "tokens_per_second": round(_est_out / _elapsed, 2) if _elapsed > 0 else 0,
+                        "context_percent": min(round((_est_in / ctx.context_length) * 100, 1), 100.0) if ctx.context_length else 0,
+                        "context_length": ctx.context_length,
+                        "model": sess.model or CODEX_EXPERIMENTAL_MODEL_ID,
+                        "usage_source": "estimated",
+                        "provider": "codex_cli",
+                    }
+                    yield f'data: {json.dumps({"type": "metrics", "data": last_metrics})}\n\n'
+
+                if full_response:
+                    _saved_id = save_assistant_response(
+                        sess, session_manager, session, full_response, last_metrics,
+                        character_name=ctx.preset.character_name,
+                        web_sources=web_sources,
+                        rag_sources=ctx.rag_sources,
+                        used_memories=ctx.used_memories,
+                        do_research=do_research,
+                        incognito=incognito,
+                    )
+                    if _saved_id:
+                        yield f'data: {json.dumps({"type": "message_saved", "id": _saved_id})}\n\n'
+                    run_post_response_tasks(
+                        sess, session_manager, session, message, full_response,
+                        last_metrics, ctx.uprefs, memory_manager, memory_vector, webhook_manager,
+                        incognito=incognito, compare_mode=compare_mode,
+                        character_name=ctx.preset.character_name,
+                        owner=_user,
+                    )
+                _stream_set(session, status="done")
                 yield "data: [DONE]\n\n"
                 _active_streams.pop(session, None)
                 return

--- a/routes/codex_auth_routes.py
+++ b/routes/codex_auth_routes.py
@@ -1,0 +1,37 @@
+"""Admin-gated Codex / ChatGPT device-code auth routes."""
+
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+from src.codex_auth import get_codex_auth_service
+
+
+def setup_codex_auth_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/codex-auth", tags=["codex-auth"])
+
+    @router.get("/status")
+    async def status(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().status()
+
+    @router.post("/start")
+    async def start(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().start()
+
+    @router.post("/cancel")
+    async def cancel(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().cancel()
+
+    @router.post("/logout")
+    async def logout(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().logout()
+
+    @router.post("/test")
+    async def test(request: Request):
+        require_admin(request)
+        return await get_codex_auth_service().test()
+
+    return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,4 +1,4 @@
-"""Admin-gated experimental Codex model-provider routes."""
+"""Admin-gated Codex model-provider routes."""
 
 import json
 

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,9 +1,18 @@
 """Admin-gated experimental Codex model-provider routes."""
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
+from typing import Any
 
 from core.middleware import require_admin
 from src.codex_model_provider import CodexModelProvider
+
+
+class CodexTestChatRequest(BaseModel):
+    prompt: str | None = None
+    messages: list[dict[str, Any]] | None = None
+    model: str | None = None
+    timeout_seconds: int | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -14,5 +23,23 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
     async def status(request: Request):
         require_admin(request)
         return await provider.status()
+
+    @router.post("/test-chat")
+    async def test_chat(request: Request, body: CodexTestChatRequest):
+        require_admin(request)
+        messages = body.messages or []
+        if not messages and body.prompt:
+            messages = [{"role": "user", "content": body.prompt}]
+        if not messages:
+            return {
+                "ok": False,
+                "status": "invalid_request",
+                "error": "Provide either prompt or messages",
+            }
+        return await provider.test_chat(
+            messages,
+            model=body.model,
+            timeout_seconds=body.timeout_seconds or 120,
+        )
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -13,6 +13,7 @@ class CodexTestChatRequest(BaseModel):
     messages: list[dict[str, Any]] | None = None
     model: str | None = None
     timeout_seconds: int | None = None
+    odysseus_session_id: str | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -40,6 +41,7 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
             messages,
             model=body.model,
             timeout_seconds=body.timeout_seconds or 120,
+            odysseus_session_id=getattr(body, "odysseus_session_id", None),
         )
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -13,6 +13,11 @@ class CodexTestChatRequest(BaseModel):
     messages: list[dict[str, Any]] | None = None
     model: str | None = None
     timeout_seconds: int | None = None
+    session_id: str | None = None
+
+
+class CodexResetSessionRequest(BaseModel):
+    session_id: str | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -40,6 +45,12 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
             messages,
             model=body.model,
             timeout_seconds=body.timeout_seconds or 120,
+            odysseus_session_id=getattr(body, "session_id", None),
         )
+
+    @router.post("/reset-session")
+    async def reset_session(request: Request, body: CodexResetSessionRequest):
+        require_admin(request)
+        return provider.reset_session(body.session_id)
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -13,11 +13,6 @@ class CodexTestChatRequest(BaseModel):
     messages: list[dict[str, Any]] | None = None
     model: str | None = None
     timeout_seconds: int | None = None
-    session_id: str | None = None
-
-
-class CodexResetSessionRequest(BaseModel):
-    session_id: str | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -45,12 +40,6 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
             messages,
             model=body.model,
             timeout_seconds=body.timeout_seconds or 120,
-            odysseus_session_id=getattr(body, "session_id", None),
         )
-
-    @router.post("/reset-session")
-    async def reset_session(request: Request, body: CodexResetSessionRequest):
-        require_admin(request)
-        return provider.reset_session(body.session_id)
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,6 +1,9 @@
 """Admin-gated experimental Codex model-provider routes."""
 
+import json
+
 from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from typing import Any
 
@@ -43,5 +46,28 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
             timeout_seconds=body.timeout_seconds or 120,
             odysseus_session_id=getattr(body, "odysseus_session_id", None),
         )
+
+    @router.post("/test-chat-stream")
+    async def test_chat_stream(request: Request, body: CodexTestChatRequest):
+        require_admin(request)
+        messages = body.messages or []
+        if not messages and body.prompt:
+            messages = [{"role": "user", "content": body.prompt}]
+        if not messages:
+            async def invalid_request():
+                yield 'data: {"type":"error","status":"invalid_request","error":"Provide either prompt or messages"}\n\n'
+
+            return StreamingResponse(invalid_request(), media_type="text/event-stream")
+
+        async def event_stream():
+            async for event in provider.stream_chat(
+                messages,
+                model=body.model,
+                timeout_seconds=body.timeout_seconds or 120,
+                odysseus_session_id=getattr(body, "odysseus_session_id", None),
+            ):
+                yield f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -23,6 +23,7 @@ class CodexTestChatRequest(BaseModel):
 class CodexModelUpdateRequest(BaseModel):
     model_id: str | None = None
     action: str | None = None
+    thinking_effort: str | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -88,7 +89,18 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
         require_admin(request)
         if not (body.model_id or "").strip():
             return {"ok": False, "status": "invalid_request", "error": "Model ID is required"}
-        cfg = update_codex_model_config(add_model=body.model_id)
+        cfg = update_codex_model_config(
+            add_model=body.model_id,
+            thinking_model=body.model_id,
+            thinking_effort=body.thinking_effort,
+            connector_enabled=True,
+        )
+        return {"ok": True, "config": cfg}
+
+    @router.delete("/connector")
+    async def remove_connector(request: Request):
+        require_admin(request)
+        cfg = update_codex_model_config(clear_all_models=True, connector_enabled=False)
         return {"ok": True, "config": cfg}
 
     @router.patch("/models")
@@ -96,14 +108,19 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
         require_admin(request)
         action = (body.action or "").strip().lower()
         kwargs = {}
-        if action in {"hide", "remove"}:
+        if action == "hide":
             kwargs["hide_model"] = body.model_id
+        elif action == "remove":
+            kwargs["remove_model"] = body.model_id
         elif action == "restore":
             kwargs["restore_model"] = body.model_id
         elif action == "disable":
             kwargs["disable_model"] = body.model_id
         elif action == "enable":
             kwargs["enable_model"] = body.model_id
+        elif action == "set_thinking_effort":
+            kwargs["thinking_model"] = body.model_id
+            kwargs["thinking_effort"] = body.thinking_effort
         else:
             return {"ok": False, "status": "invalid_request", "error": "Unsupported model action"}
         if not (body.model_id or "").strip():

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -97,6 +97,12 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
         )
         return {"ok": True, "config": cfg}
 
+    @router.post("/connector")
+    async def add_connector(request: Request):
+        require_admin(request)
+        cfg = update_codex_model_config(connector_enabled=True)
+        return {"ok": True, "config": cfg}
+
     @router.delete("/connector")
     async def remove_connector(request: Request):
         require_admin(request)

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from typing import Any
 
 from core.middleware import require_admin
-from src.codex_model_provider import CodexModelProvider
+from src.codex_model_provider import CodexModelProvider, update_codex_model_config
 
 
 class CodexTestChatRequest(BaseModel):
@@ -17,6 +17,12 @@ class CodexTestChatRequest(BaseModel):
     model: str | None = None
     timeout_seconds: int | None = None
     odysseus_session_id: str | None = None
+    reasoning_effort: str | None = None
+
+
+class CodexModelUpdateRequest(BaseModel):
+    model_id: str | None = None
+    action: str | None = None
 
 
 def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
@@ -43,6 +49,7 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
         return await provider.test_chat(
             messages,
             model=body.model,
+            reasoning_effort=getattr(body, "reasoning_effort", None),
             timeout_seconds=body.timeout_seconds or 120,
             odysseus_session_id=getattr(body, "odysseus_session_id", None),
         )
@@ -63,11 +70,45 @@ def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None
             async for event in provider.stream_chat(
                 messages,
                 model=body.model,
+                reasoning_effort=getattr(body, "reasoning_effort", None),
                 timeout_seconds=body.timeout_seconds or 120,
                 odysseus_session_id=getattr(body, "odysseus_session_id", None),
             ):
                 yield f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    @router.get("/models")
+    async def list_models(request: Request):
+        require_admin(request)
+        return await provider.status()
+
+    @router.post("/models")
+    async def add_model(request: Request, body: CodexModelUpdateRequest):
+        require_admin(request)
+        if not (body.model_id or "").strip():
+            return {"ok": False, "status": "invalid_request", "error": "Model ID is required"}
+        cfg = update_codex_model_config(add_model=body.model_id)
+        return {"ok": True, "config": cfg}
+
+    @router.patch("/models")
+    async def update_model(request: Request, body: CodexModelUpdateRequest):
+        require_admin(request)
+        action = (body.action or "").strip().lower()
+        kwargs = {}
+        if action in {"hide", "remove"}:
+            kwargs["hide_model"] = body.model_id
+        elif action == "restore":
+            kwargs["restore_model"] = body.model_id
+        elif action == "disable":
+            kwargs["disable_model"] = body.model_id
+        elif action == "enable":
+            kwargs["enable_model"] = body.model_id
+        else:
+            return {"ok": False, "status": "invalid_request", "error": "Unsupported model action"}
+        if not (body.model_id or "").strip():
+            return {"ok": False, "status": "invalid_request", "error": "Model ID is required"}
+        cfg = update_codex_model_config(**kwargs)
+        return {"ok": True, "config": cfg}
 
     return router

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,0 +1,18 @@
+"""Admin-gated experimental Codex model-provider routes."""
+
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+from src.codex_model_provider import CodexModelProvider
+
+
+def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
+    router = APIRouter(prefix="/api/codex-model-provider", tags=["codex-model-provider"])
+    provider = provider or CodexModelProvider()
+
+    @router.get("/status")
+    async def status(request: Request):
+        require_admin(request)
+        return await provider.status()
+
+    return router

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -3,6 +3,7 @@
 import re
 import uuid
 import json
+import asyncio
 import time as _time
 import logging
 import httpx
@@ -582,6 +583,33 @@ def setup_model_routes(model_discovery):
                     "model_type": ep_model_type,
                     "offline": True,
                 })
+
+        try:
+            from src.codex_model_provider import (
+                CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+                CODEX_EXPERIMENTAL_MODEL_ID,
+                CODEX_VIRTUAL_ENDPOINT_URL,
+                CodexModelProvider,
+            )
+            codex_status = asyncio.run(CodexModelProvider().status())
+            if codex_status.get("status") == "available" and codex_status.get("chat_supported"):
+                items.append({
+                    "host": "codex",
+                    "port": 0,
+                    "url": CODEX_VIRTUAL_ENDPOINT_URL,
+                    "models": [CODEX_EXPERIMENTAL_MODEL_ID],
+                    "models_display": [CODEX_EXPERIMENTAL_MODEL_DISPLAY],
+                    "models_extra": [],
+                    "models_extra_display": [],
+                    "endpoint_id": "",
+                    "endpoint_name": "Codex / ChatGPT",
+                    "category": "api",
+                    "model_type": "llm",
+                    "virtual": True,
+                    "experimental": True,
+                })
+        except Exception:
+            pass
 
         return {"hosts": [], "items": items}
 

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -3,7 +3,6 @@
 import re
 import uuid
 import json
-import asyncio
 import time as _time
 import logging
 import httpx
@@ -583,33 +582,6 @@ def setup_model_routes(model_discovery):
                     "model_type": ep_model_type,
                     "offline": True,
                 })
-
-        try:
-            from src.codex_model_provider import (
-                CODEX_EXPERIMENTAL_MODEL_DISPLAY,
-                CODEX_EXPERIMENTAL_MODEL_ID,
-                CODEX_VIRTUAL_ENDPOINT_URL,
-                CodexModelProvider,
-            )
-            codex_status = asyncio.run(CodexModelProvider().status())
-            if codex_status.get("status") == "available" and codex_status.get("chat_supported"):
-                items.append({
-                    "host": "codex",
-                    "port": 0,
-                    "url": CODEX_VIRTUAL_ENDPOINT_URL,
-                    "models": [CODEX_EXPERIMENTAL_MODEL_ID],
-                    "models_display": [CODEX_EXPERIMENTAL_MODEL_DISPLAY],
-                    "models_extra": [],
-                    "models_extra_display": [],
-                    "endpoint_id": "",
-                    "endpoint_name": "Codex / ChatGPT",
-                    "category": "api",
-                    "model_type": "llm",
-                    "virtual": True,
-                    "experimental": True,
-                })
-        except Exception:
-            pass
 
         return {"hosts": [], "items": items}
 

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -583,6 +583,14 @@ def setup_model_routes(model_discovery):
                     "offline": True,
                 })
 
+        try:
+            from src.codex_model_provider import codex_model_list_item_if_available
+            codex_item = codex_model_list_item_if_available()
+            if codex_item:
+                items.append(codex_item)
+        except Exception:
+            pass
+
         return {"hosts": [], "items": items}
 
     @router.get("/models")

--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -583,15 +583,22 @@ def setup_model_routes(model_discovery):
                     "offline": True,
                 })
 
+        return {"hosts": [], "items": items}
+
+    def _append_codex_model_item(result: Dict[str, Any]) -> Dict[str, Any]:
+        """Add the dynamic Codex picker item without storing it in /api/models cache."""
+        out = {
+            "hosts": list(result.get("hosts") or []),
+            "items": list(result.get("items") or []),
+        }
         try:
             from src.codex_model_provider import codex_model_list_item_if_available
             codex_item = codex_model_list_item_if_available()
             if codex_item:
-                items.append(codex_item)
+                out["items"].append(codex_item)
         except Exception:
             pass
-
-        return {"hosts": [], "items": items}
+        return out
 
     @router.get("/models")
     def api_models(request: Request, refresh: bool = False):
@@ -629,12 +636,12 @@ def setup_model_routes(model_discovery):
         _cache_key = (owner, _is_admin)
         cache_entry = _models_cache.get(_cache_key)
         if not refresh and cache_entry is not None and (now - cache_entry["time"]) < _MODELS_CACHE_TTL:
-            return cache_entry["data"]
+            return _append_codex_model_item(cache_entry["data"])
         result = _fetch_models(owner=owner, is_admin=_is_admin)
         _models_cache[_cache_key] = {"data": result, "time": now}
         # Kick off background refresh to update caches from live endpoints
         _refresh_caches_bg()
-        return result
+        return _append_codex_model_item(result)
 
     # Brief cache for local-probe results so picker-open doesn't hammer
     # /v1/models every time. 8s TTL — long enough to amortize cost,

--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -11,6 +11,13 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel, Field
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_ENDPOINT_URL,
+    codex_model_provider_enabled,
+    first_enabled_codex_model,
+    is_codex_model_available,
+    is_codex_model_selection,
+)
 from src.endpoint_resolver import resolve_endpoint
 from src.auth_helpers import get_current_user
 
@@ -36,13 +43,57 @@ def _first_chat_model(models) -> str:
 
 def _resolve_research_endpoint(sess) -> tuple:
     """Return (endpoint_url, model, headers) for Deep Research, checking admin overrides."""
+    fallback_url = sess.endpoint_url
+    fallback_model = sess.model
+    fallback_headers = sess.headers
+    if is_codex_model_selection(fallback_url, fallback_model) and not is_codex_model_available(fallback_model):
+        fallback_url, fallback_model, fallback_headers = "", "", {}
     url, model, headers = resolve_endpoint(
         "research",
-        fallback_url=sess.endpoint_url,
-        fallback_model=sess.model,
-        fallback_headers=sess.headers,
+        fallback_url=fallback_url,
+        fallback_model=fallback_model,
+        fallback_headers=fallback_headers,
     )
     return url, model, headers
+
+
+def _resolve_global_research_endpoint() -> tuple[str, str, dict]:
+    ep_url, ep_model, ep_headers = resolve_endpoint("research")
+    if not ep_url:
+        ep_url, ep_model, ep_headers = resolve_endpoint("utility")
+    if not ep_url:
+        ep_url, ep_model, ep_headers = resolve_endpoint("default")
+    if not ep_url:
+        ep_url, ep_model, ep_headers = resolve_endpoint("chat")
+    if not ep_url:
+        from src.database import SessionLocal
+        from src.database import ModelEndpoint
+        from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
+
+        db = SessionLocal()
+        try:
+            ep = db.query(ModelEndpoint).filter(
+                ModelEndpoint.is_enabled == True,
+            ).first()
+            if ep:
+                base = normalize_base(ep.base_url)
+                ep_url = build_chat_url(base)
+                ep_headers = build_headers(ep.api_key, base)
+                ep_model = ""
+                if ep.cached_models:
+                    try:
+                        models = json.loads(ep.cached_models)
+                        if models:
+                            ep_model = _first_chat_model(models)
+                    except Exception:
+                        pass
+        finally:
+            db.close()
+    if not ep_url and codex_model_provider_enabled():
+        codex_model = first_enabled_codex_model()
+        if codex_model:
+            return CODEX_EXPERIMENTAL_ENDPOINT_URL, codex_model, {}
+    return ep_url or "", ep_model or "", ep_headers or {}
 
 
 def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
@@ -298,6 +349,7 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         search_provider: Optional[str] = None
         endpoint_id: Optional[str] = None
         model: Optional[str] = None
+        source_session_id: Optional[str] = None
         max_time: int = Field(default=300, ge=60, le=1800)
         extraction_timeout: Optional[int] = Field(default=None, ge=15, le=600)
         extraction_concurrency: Optional[int] = Field(default=None, ge=1, le=12)
@@ -351,41 +403,18 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
             finally:
                 db.close()
         else:
-            ep_url, ep_model, ep_headers = resolve_endpoint("research")
-            if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("utility")
-            # When neither research nor utility is configured, use the user's
-            # configured DEFAULT model (default_endpoint_id/default_model) rather
-            # than arbitrarily grabbing the first enabled endpoint's first model
-            # (which surfaced gpt-3.5). "Default" should mean the default model.
-            if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("default")
-            if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("chat")
-            if not ep_url:
-                from src.database import SessionLocal
-                from src.database import ModelEndpoint
-                from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
-                db = SessionLocal()
+            ep_url, ep_model, ep_headers = "", "", {}
+            if body.source_session_id and session_manager is not None:
                 try:
-                    ep = db.query(ModelEndpoint).filter(
-                        ModelEndpoint.is_enabled == True,
-                    ).first()
-                    if ep:
-                        base = normalize_base(ep.base_url)
-                        ep_url = build_chat_url(base)
-                        ep_headers = build_headers(ep.api_key, base)
-                        ep_model = ""
-                        if ep.cached_models:
-                            try:
-                                import json as _json
-                                models = _json.loads(ep.cached_models)
-                                if models:
-                                    ep_model = _first_chat_model(models)
-                            except Exception:
-                                pass
-                finally:
-                    db.close()
+                    src_sess = session_manager.get_session(body.source_session_id)
+                    src_owner = getattr(src_sess, "owner", None)
+                    if src_owner and src_owner != user:
+                        raise HTTPException(404, "Source session not found")
+                    ep_url, ep_model, ep_headers = _resolve_research_endpoint(src_sess)
+                except KeyError:
+                    pass
+            if not ep_url:
+                ep_url, ep_model, ep_headers = _resolve_global_research_endpoint()
             if not ep_url:
                 raise HTTPException(400, "No endpoints configured. Add one in Settings first.")
             if body.model:
@@ -482,6 +511,8 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         result = research_handler.get_result(session_id)
         sources = research_handler.get_sources(session_id) or []
         query = ""
+        saved_ep_url = ""
+        saved_ep_model = ""
 
         path = Path("data/deep_research") / f"{session_id}.json"
         if path.exists():
@@ -492,6 +523,8 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                 if not sources:
                     sources = disk.get("sources", []) or []
                 query = disk.get("query", "") or ""
+                saved_ep_url = disk.get("llm_endpoint", "") or ""
+                saved_ep_model = disk.get("llm_model", "") or ""
             except Exception as e:
                 logger.warning(f"Could not read research JSON for spinoff: {e}")
 
@@ -520,6 +553,10 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
             if not ep_headers and r_headers:
                 ep_headers = dict(r_headers)
 
+        if saved_ep_url and saved_ep_model:
+            if not is_codex_model_selection(saved_ep_url, saved_ep_model) or is_codex_model_available(saved_ep_model):
+                _merge(saved_ep_url, saved_ep_model, {})
+
         if not ep_url or not ep_model:
             _merge(*resolve_endpoint("chat"))
         if not ep_url or not ep_model:
@@ -527,28 +564,7 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         if not ep_url or not ep_model:
             _merge(*resolve_endpoint("utility"))
         if not ep_url or not ep_model:
-            # Last resort: any enabled endpoint
-            from src.database import SessionLocal
-            from src.database import ModelEndpoint
-            from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
-            db = SessionLocal()
-            try:
-                ep = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()
-                if ep:
-                    base = normalize_base(ep.base_url)
-                    fallback_url = build_chat_url(base)
-                    fallback_headers = build_headers(ep.api_key, base)
-                    fallback_model = ""
-                    if ep.cached_models:
-                        try:
-                            models = json.loads(ep.cached_models)
-                            if models:
-                                fallback_model = models[0]
-                        except Exception:
-                            pass
-                    _merge(fallback_url, fallback_model, fallback_headers)
-            finally:
-                db.close()
+            _merge(*_resolve_global_research_endpoint())
 
         if not ep_url or not ep_model:
             raise HTTPException(400, "No endpoint configured — add one in Settings first")

--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -236,7 +236,6 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         archived: bool = Query(False),
     ):
         user = _require_user(request)
-        """List all completed research for the Library panel."""
         data_dir = Path("data/deep_research")
         items = []
         for p in data_dir.glob("*.json"):

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -171,13 +171,24 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         endpoint_id: str = Form(""),
     ):
         skip_val = str(skip_validation).lower() == "true"
+        try:
+            from src.codex_model_provider import (
+                CODEX_EXPERIMENTAL_MODEL_ID,
+                is_codex_virtual_endpoint,
+            )
+            is_codex_session = is_codex_virtual_endpoint(endpoint_url, model)
+        except Exception:
+            CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
+            is_codex_session = False
 
         if not endpoint_url and not skip_val:
             raise HTTPException(400, "endpoint_url is required (choose from /api/models)")
 
-        model_to_use = model
+        model_to_use = CODEX_EXPERIMENTAL_MODEL_ID if is_codex_session else model
 
-        if skip_val:
+        if is_codex_session:
+            pass
+        elif skip_val:
             # skip_validation = trust the caller and do NOT probe /v1/models.
             # Used for custom endpoints AND for bare placeholder sessions with no
             # model at all (e.g. an email reply draft just needs a session to live

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -171,24 +171,13 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         endpoint_id: str = Form(""),
     ):
         skip_val = str(skip_validation).lower() == "true"
-        try:
-            from src.codex_model_provider import (
-                CODEX_EXPERIMENTAL_MODEL_ID,
-                is_codex_virtual_endpoint,
-            )
-            is_codex_session = is_codex_virtual_endpoint(endpoint_url, model)
-        except Exception:
-            CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
-            is_codex_session = False
 
         if not endpoint_url and not skip_val:
             raise HTTPException(400, "endpoint_url is required (choose from /api/models)")
 
-        model_to_use = CODEX_EXPERIMENTAL_MODEL_ID if is_codex_session else model
+        model_to_use = model
 
-        if is_codex_session:
-            pass
-        elif skip_val:
+        if skip_val:
             # skip_validation = trust the caller and do NOT probe /v1/models.
             # Used for custom endpoints AND for bare placeholder sessions with no
             # model at all (e.g. an email reply draft just needs a session to live

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -789,6 +789,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         users can clean junk without spending tokens.
         """
         from src.llm_core import llm_call
+        from src.session_actions import session_protected_from_auto_sort
         user = get_current_user(request)
         user_sessions = session_manager.get_sessions_for_user(user)
 
@@ -809,6 +810,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         _THROWAWAY_MAX_MESSAGES = 4  # only delete if <= this many messages
         try:
             rows = db.query(DbSession).filter(DbSession.archived == False, DbSession.owner == user).all()
+            now = datetime.utcnow()
             folder_map = {r.id: r.folder for r in rows}
             # Precompute per-session message counts in TWO aggregate queries
             # instead of 1–3 queries PER session — with many chats the per-row
@@ -822,6 +824,8 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             for row in rows:
                 # Never delete important sessions
                 if getattr(row, 'is_important', False):
+                    continue
+                if session_protected_from_auto_sort(row, now=now):
                     continue
                 # Always delete incognito sessions during cleanup
                 if (row.name or "").strip() == "Incognito":

--- a/scripts/validate_codex_model_provider_docker.sh
+++ b/scripts/validate_codex_model_provider_docker.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Validate the experimental Codex model-provider status probe in a real Docker
+# deployment. Run this on the deployment host, usually:
+#
+#   cd /opt/odysseus
+#   ODYSSEUS_ADMIN_USER=admin ODYSSEUS_ADMIN_PASSWORD='...' \
+#     scripts/validate_codex_model_provider_docker.sh
+#
+# The script edits only the deployment .env file, backs it up, and restores it
+# before exit. It never reads Codex credential files and redirects CLI logout
+# output so token-like material is not printed.
+
+set -euo pipefail
+
+APP_DIR="${1:-/opt/odysseus}"
+SERVICE="${ODYSSEUS_DOCKER_SERVICE:-odysseus}"
+APP_PORT="${APP_PORT:-7000}"
+BASE_URL="${ODYSSEUS_BASE_URL:-http://127.0.0.1:${APP_PORT}}"
+FLAG_KEY="ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
+MODEL_ID="codex-cli/chatgpt-experimental"
+COOKIE_JAR=""
+ENV_BACKUP=""
+RESTORE_DONE=0
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "${COOKIE_JAR}" ] && [ -f "${COOKIE_JAR}" ]; then
+    rm -f "${COOKIE_JAR}"
+  fi
+  if [ "${RESTORE_DONE}" = "0" ] && [ -n "${ENV_BACKUP}" ] && [ -f "${ENV_BACKUP}" ]; then
+    log "Restoring original .env feature-flag state"
+    cp "${ENV_BACKUP}" "${APP_DIR}/.env"
+    rm -f "${ENV_BACKUP}"
+    (cd "${APP_DIR}" && docker compose up -d --force-recreate "${SERVICE}" >/dev/null)
+    RESTORE_DONE=1
+  fi
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+json_get() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+cur = data
+for part in key.split("."):
+    if isinstance(cur, dict):
+        cur = cur.get(part)
+    else:
+        cur = None
+        break
+print("" if cur is None else cur)
+PY
+}
+
+assert_status_payload() {
+  local file="$1"
+  local expected_status="$2"
+  local expected_feature="$3"
+  python3 - "$file" "$expected_status" "$expected_feature" "$MODEL_ID" <<'PY'
+import json, sys
+path, expected_status, expected_feature, model_id = sys.argv[1:5]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+def fail(msg):
+    raise SystemExit(msg)
+
+if data.get("status") != expected_status:
+    fail(f"expected status={expected_status!r}, got {data.get('status')!r}: {data}")
+if bool(data.get("feature_enabled")) != (expected_feature == "true"):
+    fail(f"feature_enabled mismatch: {data}")
+for key in ("chat_supported", "streaming_supported", "session_resume_supported", "tool_execution_allowed"):
+    if data.get(key) is not False:
+        fail(f"{key} must remain false: {data}")
+dump = json.dumps(data).lower()
+for forbidden in ("access_token", "refresh_token", "id_token", "secret", "bearer "):
+    if forbidden in dump:
+        fail(f"response contains forbidden token-like field/text: {forbidden}")
+models = data.get("models") or []
+if expected_status == "available":
+    ids = [m.get("id") for m in models if isinstance(m, dict)]
+    if model_id not in ids:
+        fail(f"missing experimental model {model_id}: {data}")
+else:
+    if models:
+        fail(f"models should be empty for status {expected_status}: {data}")
+print("ok")
+PY
+}
+
+set_flag() {
+  local value="$1"
+  python3 - "${APP_DIR}/.env" "${FLAG_KEY}" "${value}" <<'PY'
+import os, sys
+path, key, value = sys.argv[1:4]
+lines = []
+if os.path.exists(path):
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+out = []
+seen = False
+for line in lines:
+    if line.startswith(key + "=") or line.startswith("#" + key + "="):
+        out.append(f"{key}={value}")
+        seen = True
+    else:
+        out.append(line)
+if not seen:
+    if out and out[-1].strip():
+        out.append("")
+    out.append(f"{key}={value}")
+with open(path, "w", encoding="utf-8") as f:
+    f.write("\n".join(out) + "\n")
+PY
+}
+
+restart_app() {
+  (cd "${APP_DIR}" && docker compose up -d --build --force-recreate "${SERVICE}" >/dev/null)
+  for _ in $(seq 1 60); do
+    if curl -fsS "${BASE_URL}/api/auth/status" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  die "app did not become reachable at ${BASE_URL}"
+}
+
+login_admin() {
+  local body login_file
+  if [ -n "${COOKIE_JAR}" ] && [ -f "${COOKIE_JAR}" ]; then
+    rm -f "${COOKIE_JAR}"
+  fi
+  COOKIE_JAR="$(mktemp)"
+  login_file="$(mktemp)"
+  body="$(python3 - <<'PY'
+import json, os
+body = {
+    "username": os.environ["ODYSSEUS_ADMIN_USER"],
+    "password": os.environ["ODYSSEUS_ADMIN_PASSWORD"],
+    "remember": False,
+}
+totp = os.environ.get("ODYSSEUS_ADMIN_TOTP")
+if totp:
+    body["totp_code"] = totp
+print(json.dumps(body))
+PY
+)"
+  local code
+  code="$(curl -sS -o "${login_file}" -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    -c "${COOKIE_JAR}" \
+    -X POST "${BASE_URL}/api/auth/login" \
+    --data "${body}")"
+  if [ "${code}" != "200" ]; then
+    rm -f "${login_file}"
+    die "admin login failed with HTTP ${code}"
+  fi
+  if [ "$(json_get "${login_file}" ok)" != "True" ]; then
+    rm -f "${login_file}"
+    die "admin login did not return ok=true"
+  fi
+  rm -f "${login_file}"
+}
+
+request_status() {
+  local file="$1"
+  curl -fsS -b "${COOKIE_JAR}" "${BASE_URL}/api/codex-model-provider/status" > "${file}"
+}
+
+request_codex_auth() {
+  local method="$1"
+  local path="$2"
+  local file="$3"
+  curl -fsS -b "${COOKIE_JAR}" -X "${method}" "${BASE_URL}/api/codex-auth/${path}" > "${file}"
+}
+
+poll_until_codex_authenticated() {
+  local status_file
+  status_file="$(mktemp)"
+  for _ in $(seq 1 310); do
+    request_codex_auth GET status "${status_file}"
+    if [ "$(json_get "${status_file}" authenticated)" = "True" ] || [ "$(json_get "${status_file}" codex_authenticated)" = "True" ]; then
+      rm -f "${status_file}"
+      return
+    fi
+    sleep 3
+  done
+  rm -f "${status_file}"
+  die "Codex did not become authenticated before timeout"
+}
+
+main() {
+  need docker
+  need curl
+  need python3
+  [ -d "${APP_DIR}" ] || die "deployment path not found: ${APP_DIR}"
+  [ -f "${APP_DIR}/docker-compose.yml" ] || die "docker-compose.yml not found under ${APP_DIR}"
+  [ -n "${ODYSSEUS_ADMIN_USER:-}" ] || die "set ODYSSEUS_ADMIN_USER in the environment"
+  [ -n "${ODYSSEUS_ADMIN_PASSWORD:-}" ] || die "set ODYSSEUS_ADMIN_PASSWORD in the environment"
+
+  local branch
+  branch="$(git -C "${APP_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [ "${SKIP_GIT_BRANCH_CHECK:-0}" != "1" ] && [ "${branch}" != "codex-model-provider-draft" ]; then
+    die "expected ${APP_DIR} to be on codex-model-provider-draft, got ${branch:-unknown}"
+  fi
+  [ -f "${APP_DIR}/src/codex_model_provider.py" ] || die "provider probe source is missing"
+
+  ENV_BACKUP="${APP_DIR}/.env.codex-provider-validation.$(date +%Y%m%d%H%M%S).bak"
+  if [ -f "${APP_DIR}/.env" ]; then
+    cp "${APP_DIR}/.env" "${ENV_BACKUP}"
+  else
+    : > "${ENV_BACKUP}"
+    : > "${APP_DIR}/.env"
+  fi
+
+  log "State 1: feature flag disabled"
+  set_flag false
+  restart_app
+  login_admin
+  local unauth_code disabled_file logged_out_file logged_in_file after_logout_file start_file logout_file
+  disabled_file="$(mktemp)"
+  unauth_code="$(curl -sS -o /dev/null -w "%{http_code}" "${BASE_URL}/api/codex-model-provider/status")"
+  [ "${unauth_code}" = "403" ] || die "admin gate check failed: unauthenticated status returned HTTP ${unauth_code}, expected 403"
+  request_status "${disabled_file}"
+  assert_status_payload "${disabled_file}" disabled false >/dev/null
+  rm -f "${disabled_file}"
+
+  log "State 2: feature flag enabled, Codex logged out"
+  set_flag true
+  restart_app
+  login_admin
+  (cd "${APP_DIR}" && docker compose exec -T "${SERVICE}" codex logout >/dev/null 2>&1 || true)
+  restart_app
+  login_admin
+  logged_out_file="$(mktemp)"
+  request_status "${logged_out_file}"
+  assert_status_payload "${logged_out_file}" sign_in_required true >/dev/null
+  rm -f "${logged_out_file}"
+
+  log "State 3: feature flag enabled, Codex logged in"
+  start_file="$(mktemp)"
+  request_codex_auth POST start "${start_file}"
+  local st
+  st="$(json_get "${start_file}" status)"
+  if [ "${st}" = "pending" ] || [ "${st}" = "starting" ]; then
+    local url code
+    url="$(json_get "${start_file}" verification_url)"
+    code="$(json_get "${start_file}" user_code)"
+    if [ -n "${url}" ] && [ -n "${code}" ]; then
+      printf 'Open this URL and enter the one-time code:\n%s\n%s\n' "${url}" "${code}"
+    else
+      printf 'Codex login started. Complete verification in the browser.\n'
+    fi
+    poll_until_codex_authenticated
+  elif [ "${st}" = "already_authenticated" ] || [ "$(json_get "${start_file}" authenticated)" = "True" ]; then
+    :
+  else
+    rm -f "${start_file}"
+    die "Codex auth start failed with status ${st}"
+  fi
+  rm -f "${start_file}"
+  logged_in_file="$(mktemp)"
+  request_status "${logged_in_file}"
+  assert_status_payload "${logged_in_file}" available true >/dev/null
+  rm -f "${logged_in_file}"
+
+  log "State 4: logout after login"
+  logout_file="$(mktemp)"
+  request_codex_auth POST logout "${logout_file}"
+  rm -f "${logout_file}"
+  after_logout_file="$(mktemp)"
+  request_status "${after_logout_file}"
+  assert_status_payload "${after_logout_file}" sign_in_required true >/dev/null
+  rm -f "${after_logout_file}"
+
+  log "Restoring original .env"
+  cp "${ENV_BACKUP}" "${APP_DIR}/.env"
+  rm -f "${ENV_BACKUP}"
+  restart_app
+  RESTORE_DONE=1
+
+  log "Codex model-provider Docker validation passed"
+}
+
+main "$@"

--- a/scripts/validate_codex_model_provider_docker.sh
+++ b/scripts/validate_codex_model_provider_docker.sh
@@ -85,7 +85,13 @@ if data.get("status") != expected_status:
     fail(f"expected status={expected_status!r}, got {data.get('status')!r}: {data}")
 if bool(data.get("feature_enabled")) != (expected_feature == "true"):
     fail(f"feature_enabled mismatch: {data}")
-for key in ("chat_supported", "streaming_supported", "session_resume_supported", "tool_execution_allowed"):
+if expected_status == "available":
+    if data.get("chat_supported") is not True:
+        fail(f"chat_supported must be true only for safe available provider: {data}")
+else:
+    if data.get("chat_supported") is not False:
+        fail(f"chat_supported must remain false for status {expected_status}: {data}")
+for key in ("streaming_supported", "session_resume_supported", "tool_execution_allowed"):
     if data.get(key) is not False:
         fail(f"{key} must remain false: {data}")
 dump = json.dumps(data).lower()
@@ -100,6 +106,33 @@ if expected_status == "available":
 else:
     if models:
         fail(f"models should be empty for status {expected_status}: {data}")
+print("ok")
+PY
+}
+
+assert_test_chat_payload() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+def fail(msg):
+    raise SystemExit(msg)
+
+if data.get("ok") is not True:
+    fail(f"expected ok=true from test-chat: {data}")
+message = data.get("message")
+if not isinstance(message, str) or not message.strip():
+    fail(f"test-chat response missing assistant message: {data}")
+for key in ("streaming_supported", "session_resume_supported", "tool_execution_allowed"):
+    if data.get(key) is not False:
+        fail(f"{key} must remain false: {data}")
+dump = json.dumps(data).lower()
+for forbidden in ("access_token", "refresh_token", "id_token", "secret", "bearer "):
+    if forbidden in dump:
+        fail(f"response contains forbidden token-like field/text: {forbidden}")
 print("ok")
 PY
 }
@@ -190,6 +223,15 @@ request_codex_auth() {
   curl -fsS -b "${COOKIE_JAR}" -X "${method}" "${BASE_URL}/api/codex-auth/${path}" > "${file}"
 }
 
+request_test_chat() {
+  local file="$1"
+  curl -fsS -b "${COOKIE_JAR}" \
+    -H "Content-Type: application/json" \
+    -X POST "${BASE_URL}/api/codex-model-provider/test-chat" \
+    --data '{"prompt":"Reply with exactly: codex provider test ok","timeout_seconds":180}' \
+    > "${file}"
+}
+
 poll_until_codex_authenticated() {
   local status_file
   status_file="$(mktemp)"
@@ -233,7 +275,7 @@ main() {
   set_flag false
   restart_app
   login_admin
-  local unauth_code disabled_file logged_out_file logged_in_file after_logout_file start_file logout_file
+  local unauth_code disabled_file logged_out_file logged_in_file test_chat_file after_logout_file start_file logout_file
   disabled_file="$(mktemp)"
   unauth_code="$(curl -sS -o /dev/null -w "%{http_code}" "${BASE_URL}/api/codex-model-provider/status")"
   [ "${unauth_code}" = "403" ] || die "admin gate check failed: unauthenticated status returned HTTP ${unauth_code}, expected 403"
@@ -279,6 +321,10 @@ main() {
   request_status "${logged_in_file}"
   assert_status_payload "${logged_in_file}" available true >/dev/null
   rm -f "${logged_in_file}"
+  test_chat_file="$(mktemp)"
+  request_test_chat "${test_chat_file}"
+  assert_test_chat_payload "${test_chat_file}" >/dev/null
+  rm -f "${test_chat_file}"
 
   log "State 4: logout after login"
   logout_file="$(mktemp)"

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -168,7 +168,7 @@ class CodexAuthService:
         if "not logged in" in lower:
             return False, "", "Not logged in"
         if clean:
-            return False, "", clean[:300]
+            return False, "", "Codex login status returned an unrecognized response"
         return False, "", "Unable to determine Codex login status"
 
     async def _run_command(self, args: list[str], timeout: float = 15.0) -> tuple[int, str]:
@@ -320,7 +320,7 @@ class CodexAuthService:
                 if "device code login is not enabled" in line.lower():
                     last_safe_line = "Device-code login is not enabled for this Codex account or server"
                 elif "error" in line.lower():
-                    last_safe_line = line[:300]
+                    last_safe_line = "Codex CLI reported an error during device-code login"
                 found_url = URL_RE.search(line)
                 if found_url and any(host in found_url.group(0).lower() for host in ("openai.com", "chatgpt.com")):
                     url = found_url.group(0)
@@ -409,10 +409,10 @@ class CodexAuthService:
         rc, out = await self._run_command(["logout"], timeout=20)
         clean = ANSI_RE.sub("", out or "").strip()
         if rc == 0:
-            state = CodexAuthState(status="logged_out", message=clean or "Codex credentials removed")
+            state = CodexAuthState(status="logged_out", message="Codex credentials removed")
         else:
             log.warning("Codex logout failed with rc=%s", rc)
-            state = CodexAuthState(status="failed", message=(clean or "Codex logout failed")[:300], error_code="logout_failed")
+            state = CodexAuthState(status="failed", message="Codex logout failed", error_code="logout_failed")
         async with self._lock:
             self._state = state
         return {**self._base_capabilities(), **state.public()}

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -212,7 +212,7 @@ class CodexAuthService:
                 state["process_running"] = True
                 return {**caps, **state}
             if (
-                self._state.status in {"failed", "timeout", "canceled", "logged_out", "succeeded"}
+                self._state.status in {"failed", "timeout", "canceled", "succeeded"}
                 and time.time() - self._state.updated_at < 300
             ):
                 return {**caps, **state}

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -1,0 +1,354 @@
+"""Codex CLI device-code authentication service.
+
+This deliberately delegates credential storage and token refresh to the
+official Codex CLI. Odysseus only tracks the in-flight login state needed by
+the browser UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import shutil
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+URL_RE = re.compile(r"https?://[^\s]+/codex/device\b")
+CODE_RE = re.compile(r"\b[A-Z0-9]{4,}(?:-[A-Z0-9]{3,})+\b")
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class CodexAuthState:
+    status: str = "idle"
+    message: str = ""
+    authenticated: bool = False
+    auth_mode: str = ""
+    verification_url: str = ""
+    user_code: str = ""
+    started_at: float = 0.0
+    updated_at: float = field(default_factory=time.time)
+    error_code: str = ""
+    process_running: bool = False
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "message": self.message,
+            "authenticated": self.authenticated,
+            "auth_mode": self.auth_mode,
+            "verification_url": self.verification_url,
+            "user_code": self.user_code,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "error_code": self.error_code,
+            "process_running": self.process_running,
+        }
+
+
+class CodexAuthService:
+    """Small async wrapper around `codex login --device-auth`."""
+
+    def __init__(
+        self,
+        *,
+        codex_bin: str | None = None,
+        codex_home: str | None = None,
+        enabled: bool | None = None,
+        login_timeout_seconds: int = 15 * 60 + 30,
+        code_timeout_seconds: int = 45,
+    ) -> None:
+        self.codex_bin = codex_bin or os.getenv("CODEX_BIN", "codex")
+        self.codex_home = codex_home if codex_home is not None else os.getenv("CODEX_HOME", "")
+        self.enabled = (
+            enabled
+            if enabled is not None
+            else not _truthy(os.getenv("ODYSSEUS_CODEX_AUTH_DISABLED"))
+            and _truthy(os.getenv("ODYSSEUS_CODEX_AUTH_ENABLED", "true"))
+        )
+        self.login_timeout_seconds = login_timeout_seconds
+        self.code_timeout_seconds = code_timeout_seconds
+        self._lock = asyncio.Lock()
+        self._state = CodexAuthState()
+        self._process: asyncio.subprocess.Process | None = None
+        self._watch_task: asyncio.Task | None = None
+
+    def _bin_path(self) -> Optional[str]:
+        if os.path.sep in self.codex_bin or (os.path.altsep and os.path.altsep in self.codex_bin):
+            return self.codex_bin if os.path.exists(self.codex_bin) else None
+        return shutil.which(self.codex_bin)
+
+    def _env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        if self.codex_home:
+            env["CODEX_HOME"] = os.path.expanduser(self.codex_home)
+        return env
+
+    def _base_capabilities(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "method": "codex_cli",
+            "sdk_available": False,
+            "sdk_status": "not_available",
+            "codex_cli_available": self._bin_path() is not None,
+            "codex_home": "custom" if self.codex_home else "default",
+            "stores_credentials": "codex_cli",
+        }
+
+    @staticmethod
+    def _classify_status_output(output: str, returncode: int) -> tuple[bool, str, str]:
+        clean = ANSI_RE.sub("", output or "").strip()
+        lower = clean.lower()
+        if returncode == 0 and "logged in using chatgpt" in lower:
+            return True, "ChatGPT", "Logged in using ChatGPT"
+        if returncode == 0 and "logged in using an api key" in lower:
+            return True, "API key", "Logged in using an API key"
+        if returncode == 0 and "logged in using access token" in lower:
+            return True, "access token", "Logged in using access token"
+        if "not logged in" in lower:
+            return False, "", "Not logged in"
+        if clean:
+            return False, "", clean[:300]
+        return False, "", "Unable to determine Codex login status"
+
+    async def _run_command(self, args: list[str], timeout: float = 15.0) -> tuple[int, str]:
+        bin_path = self._bin_path()
+        if not bin_path:
+            return 127, "Codex CLI is not installed or CODEX_BIN is invalid"
+        proc = await asyncio.create_subprocess_exec(
+            bin_path,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=self._env(),
+        )
+        try:
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return 124, "Command timed out"
+        return proc.returncode or 0, (out or b"").decode("utf-8", errors="replace")
+
+    async def status(self) -> dict[str, Any]:
+        caps = self._base_capabilities()
+        if not self.enabled:
+            return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
+        if not caps["codex_cli_available"]:
+            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+
+        async with self._lock:
+            state = self._state.public()
+            running = self._process is not None and self._process.returncode is None
+            if running:
+                state["process_running"] = True
+                return {**caps, **state}
+            if (
+                self._state.status in {"failed", "timeout", "canceled", "logged_out", "succeeded"}
+                and time.time() - self._state.updated_at < 300
+            ):
+                return {**caps, **state}
+
+        rc, out = await self._run_command(["login", "status"], timeout=10)
+        authenticated, mode, msg = self._classify_status_output(out, rc)
+        status = "authenticated" if authenticated else "not_authenticated"
+        return {
+            **caps,
+            **CodexAuthState(
+                status=status,
+                message=msg,
+                authenticated=authenticated,
+                auth_mode=mode,
+            ).public(),
+        }
+
+    async def start(self) -> dict[str, Any]:
+        caps = self._base_capabilities()
+        if not self.enabled:
+            return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
+        bin_path = self._bin_path()
+        if not bin_path:
+            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+
+        current = await self.status()
+        if current.get("authenticated"):
+            current["status"] = "already_authenticated"
+            return current
+
+        async with self._lock:
+            if self._process is not None and self._process.returncode is None:
+                return {**caps, **self._state.public()}
+            self._state = CodexAuthState(
+                status="starting",
+                message="Starting Codex device-code login",
+                started_at=time.time(),
+                process_running=True,
+            )
+            self._process = await asyncio.create_subprocess_exec(
+                bin_path,
+                "login",
+                "--device-auth",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env(),
+            )
+            self._watch_task = asyncio.create_task(self._watch_login(self._process))
+            return {**caps, **self._state.public()}
+
+    async def _watch_login(self, proc: asyncio.subprocess.Process) -> None:
+        url = ""
+        code = ""
+        code_seen_deadline = time.time() + self.code_timeout_seconds
+        overall_deadline = time.time() + self.login_timeout_seconds
+        last_safe_line = ""
+
+        async def _set(**kwargs: Any) -> None:
+            async with self._lock:
+                for k, v in kwargs.items():
+                    setattr(self._state, k, v)
+                self._state.updated_at = time.time()
+                self._state.process_running = proc.returncode is None
+
+        try:
+            assert proc.stdout is not None
+            while True:
+                if time.time() > overall_deadline:
+                    await self._terminate_process(proc)
+                    await _set(status="timeout", message="Codex device auth timed out", error_code="timeout", process_running=False)
+                    return
+                try:
+                    raw = await asyncio.wait_for(proc.stdout.readline(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    if not code and time.time() > code_seen_deadline:
+                        await self._terminate_process(proc)
+                        await _set(status="failed", message="Codex CLI did not produce a device code", error_code="device_code_unavailable", process_running=False)
+                        return
+                    if proc.returncode is not None:
+                        break
+                    continue
+                if not raw:
+                    break
+                line = ANSI_RE.sub("", raw.decode("utf-8", errors="replace")).strip()
+                if not line:
+                    continue
+                if "device code login is not enabled" in line.lower():
+                    last_safe_line = "Device-code login is not enabled for this Codex account or server"
+                elif "error" in line.lower():
+                    last_safe_line = line[:300]
+                found_url = URL_RE.search(line)
+                if found_url:
+                    url = found_url.group(0)
+                found_code = CODE_RE.search(line)
+                if found_code:
+                    code = found_code.group(0)
+                if url and code:
+                    await _set(
+                        status="pending",
+                        message="Waiting for browser verification",
+                        verification_url=url,
+                        user_code=code,
+                        error_code="",
+                    )
+            rc = await proc.wait()
+            if rc == 0:
+                await _set(
+                    status="succeeded",
+                    message="Codex login completed",
+                    authenticated=True,
+                    auth_mode="ChatGPT",
+                    user_code="",
+                    verification_url="",
+                    error_code="",
+                    process_running=False,
+                )
+            else:
+                msg = last_safe_line or "Codex device-code login failed"
+                err_code = "device_auth_disabled" if "not enabled" in msg.lower() else "login_failed"
+                await _set(status="failed", message=msg, error_code=err_code, user_code="", verification_url="", process_running=False)
+        except Exception:
+            await _set(status="failed", message="Codex device-code login failed", error_code="login_failed", user_code="", verification_url="", process_running=False)
+        finally:
+            async with self._lock:
+                if self._process is proc:
+                    self._process = None
+                self._state.process_running = False
+
+    async def _terminate_process(self, proc: asyncio.subprocess.Process) -> None:
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+            await asyncio.wait_for(proc.wait(), timeout=3)
+        except ProcessLookupError:
+            return
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                await proc.wait()
+            except Exception:
+                pass
+
+    async def cancel(self) -> dict[str, Any]:
+        async with self._lock:
+            proc = self._process
+            task = self._watch_task
+        if proc is not None and proc.returncode is None:
+            await self._terminate_process(proc)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        async with self._lock:
+            self._process = None
+            self._watch_task = None
+            self._state = CodexAuthState(status="canceled", message="Codex login canceled")
+            return {**self._base_capabilities(), **self._state.public()}
+
+    async def logout(self) -> dict[str, Any]:
+        await self.cancel()
+        if not self.enabled:
+            return {**self._base_capabilities(), **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
+        if not self._bin_path():
+            return {**self._base_capabilities(), **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+        rc, out = await self._run_command(["logout"], timeout=20)
+        clean = ANSI_RE.sub("", out or "").strip()
+        if rc == 0:
+            state = CodexAuthState(status="logged_out", message=clean or "Codex credentials removed")
+        else:
+            state = CodexAuthState(status="failed", message=(clean or "Codex logout failed")[:300], error_code="logout_failed")
+        async with self._lock:
+            self._state = state
+        return {**self._base_capabilities(), **state.public()}
+
+    async def test(self) -> dict[str, Any]:
+        status = await self.status()
+        if not status.get("authenticated"):
+            return {**status, "ok": False}
+        return {**status, "ok": True}
+
+
+_service: CodexAuthService | None = None
+
+
+def get_codex_auth_service() -> CodexAuthService:
+    global _service
+    if _service is None:
+        _service = CodexAuthService()
+    return _service
+
+
+def set_codex_auth_service(service: CodexAuthService | None) -> None:
+    global _service
+    _service = service

--- a/src/codex_auth.py
+++ b/src/codex_auth.py
@@ -8,6 +8,7 @@ the browser UI.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import re
 import shutil
@@ -17,8 +18,9 @@ from typing import Any, Optional
 
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-URL_RE = re.compile(r"https?://[^\s]+/codex/device\b")
+URL_RE = re.compile(r"https?://[^\s<>'\"]+")
 CODE_RE = re.compile(r"\b[A-Z0-9]{4,}(?:-[A-Z0-9]{3,})+\b")
+log = logging.getLogger(__name__)
 
 
 def _truthy(value: str | None) -> bool:
@@ -43,6 +45,7 @@ class CodexAuthState:
             "status": self.status,
             "message": self.message,
             "authenticated": self.authenticated,
+            "codex_authenticated": self.authenticated,
             "auth_mode": self.auth_mode,
             "verification_url": self.verification_url,
             "user_code": self.user_code,
@@ -50,6 +53,7 @@ class CodexAuthState:
             "updated_at": self.updated_at,
             "error_code": self.error_code,
             "process_running": self.process_running,
+            "device_login_active": self.process_running or self.status in {"starting", "pending"},
         }
 
 
@@ -79,11 +83,44 @@ class CodexAuthService:
         self._state = CodexAuthState()
         self._process: asyncio.subprocess.Process | None = None
         self._watch_task: asyncio.Task | None = None
+        log.debug(
+            "Codex auth service configured: enabled=%s codex_bin=%s codex_bin_from_env=%s codex_home_configured=%s",
+            self.enabled,
+            self.codex_bin,
+            "CODEX_BIN" in os.environ,
+            bool(self.codex_home),
+        )
+
+    def _candidate_bin_path(self) -> Optional[str]:
+        codex_bin = os.path.expanduser(self.codex_bin)
+        if os.path.sep in codex_bin or (os.path.altsep and os.path.altsep in codex_bin):
+            return codex_bin
+        return shutil.which(self.codex_bin)
 
     def _bin_path(self) -> Optional[str]:
-        if os.path.sep in self.codex_bin or (os.path.altsep and os.path.altsep in self.codex_bin):
-            return self.codex_bin if os.path.exists(self.codex_bin) else None
-        return shutil.which(self.codex_bin)
+        path = self._candidate_bin_path()
+        if not path:
+            return None
+        return path if os.path.isfile(path) and os.access(path, os.X_OK) else None
+
+    def _bin_diagnostics(self) -> dict[str, Any]:
+        candidate = self._candidate_bin_path()
+        cli_found = bool(candidate and os.path.isfile(candidate))
+        cli_executable = bool(cli_found and os.access(candidate, os.X_OK))
+        codex_home_path = os.path.expanduser(self.codex_home) if self.codex_home else os.path.expanduser("~/.codex")
+        return {
+            "configured_binary": self.codex_bin,
+            "binary_source": "CODEX_BIN" if "CODEX_BIN" in os.environ else "default",
+            "resolved_binary_path": candidate,
+            "binary_exists": bool(candidate and os.path.exists(candidate)),
+            "binary_is_file": cli_found,
+            "binary_executable": cli_executable,
+            "cli_found": cli_found,
+            "cli_executable": cli_executable,
+            "codex_home_source": "CODEX_HOME" if "CODEX_HOME" in os.environ else "default",
+            "codex_home_configured": bool(self.codex_home),
+            "codex_home_path": codex_home_path,
+        }
 
     def _env(self) -> dict[str, str]:
         env = os.environ.copy()
@@ -100,7 +137,23 @@ class CodexAuthService:
             "codex_cli_available": self._bin_path() is not None,
             "codex_home": "custom" if self.codex_home else "default",
             "stores_credentials": "codex_cli",
+            "codex_authenticated": False,
+            "device_login_active": False,
+            **self._bin_diagnostics(),
         }
+
+    def _cli_unavailable_state(self, caps: dict[str, Any]) -> CodexAuthState:
+        if caps.get("cli_found"):
+            return CodexAuthState(
+                status="cli_not_executable",
+                message="Codex CLI found but CODEX_BIN is not executable",
+                error_code="cli_not_executable",
+            )
+        return CodexAuthState(
+            status="cli_missing",
+            message="Codex CLI missing or CODEX_BIN invalid",
+            error_code="cli_missing",
+        )
 
     @staticmethod
     def _classify_status_output(output: str, returncode: int) -> tuple[bool, str, str]:
@@ -121,28 +174,36 @@ class CodexAuthService:
     async def _run_command(self, args: list[str], timeout: float = 15.0) -> tuple[int, str]:
         bin_path = self._bin_path()
         if not bin_path:
+            log.warning("Codex command skipped because CLI is unavailable: %s", self._bin_diagnostics())
             return 127, "Codex CLI is not installed or CODEX_BIN is invalid"
-        proc = await asyncio.create_subprocess_exec(
-            bin_path,
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=self._env(),
-        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                bin_path,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env(),
+            )
+        except Exception as exc:
+            log.exception("Failed to start Codex command %s", args[:1])
+            return 1, f"Failed to start Codex CLI: {exc.__class__.__name__}"
         try:
             out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
+            log.warning("Codex command timed out: %s", args[:1])
             return 124, "Command timed out"
         return proc.returncode or 0, (out or b"").decode("utf-8", errors="replace")
 
     async def status(self) -> dict[str, Any]:
         caps = self._base_capabilities()
         if not self.enabled:
+            log.info("Codex auth status requested while disabled")
             return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
         if not caps["codex_cli_available"]:
-            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+            log.warning("Codex auth status reports missing CLI: %s", self._bin_diagnostics())
+            return {**caps, **self._cli_unavailable_state(caps).public()}
 
         async with self._lock:
             state = self._state.public()
@@ -157,8 +218,12 @@ class CodexAuthService:
                 return {**caps, **state}
 
         rc, out = await self._run_command(["login", "status"], timeout=10)
+        if rc != 0:
+            log.warning("Codex login status command returned rc=%s", rc)
         authenticated, mode, msg = self._classify_status_output(out, rc)
         status = "authenticated" if authenticated else "not_authenticated"
+        if not authenticated:
+            msg = "Codex CLI ready. Not signed in."
         return {
             **caps,
             **CodexAuthState(
@@ -172,10 +237,12 @@ class CodexAuthService:
     async def start(self) -> dict[str, Any]:
         caps = self._base_capabilities()
         if not self.enabled:
+            log.info("Codex auth start requested while disabled")
             return {**caps, **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
         bin_path = self._bin_path()
         if not bin_path:
-            return {**caps, **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+            log.warning("Codex auth start reports missing CLI: %s", self._bin_diagnostics())
+            return {**caps, **self._cli_unavailable_state(caps).public()}
 
         current = await self.status()
         if current.get("authenticated"):
@@ -191,14 +258,24 @@ class CodexAuthService:
                 started_at=time.time(),
                 process_running=True,
             )
-            self._process = await asyncio.create_subprocess_exec(
-                bin_path,
-                "login",
-                "--device-auth",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                env=self._env(),
-            )
+            try:
+                self._process = await asyncio.create_subprocess_exec(
+                    bin_path,
+                    "login",
+                    "--device-auth",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    env=self._env(),
+                )
+            except Exception as exc:
+                log.exception("Failed to start Codex device auth")
+                self._state = CodexAuthState(
+                    status="failed",
+                    message=f"Failed to start Codex CLI: {exc.__class__.__name__}",
+                    error_code="start_failed",
+                )
+                self._process = None
+                return {**caps, **self._state.public()}
             self._watch_task = asyncio.create_task(self._watch_login(self._process))
             return {**caps, **self._state.public()}
 
@@ -221,6 +298,7 @@ class CodexAuthService:
             while True:
                 if time.time() > overall_deadline:
                     await self._terminate_process(proc)
+                    log.warning("Codex device auth timed out")
                     await _set(status="timeout", message="Codex device auth timed out", error_code="timeout", process_running=False)
                     return
                 try:
@@ -228,6 +306,7 @@ class CodexAuthService:
                 except asyncio.TimeoutError:
                     if not code and time.time() > code_seen_deadline:
                         await self._terminate_process(proc)
+                        log.warning("Codex device auth did not produce a device code")
                         await _set(status="failed", message="Codex CLI did not produce a device code", error_code="device_code_unavailable", process_running=False)
                         return
                     if proc.returncode is not None:
@@ -243,7 +322,7 @@ class CodexAuthService:
                 elif "error" in line.lower():
                     last_safe_line = line[:300]
                 found_url = URL_RE.search(line)
-                if found_url:
+                if found_url and any(host in found_url.group(0).lower() for host in ("openai.com", "chatgpt.com")):
                     url = found_url.group(0)
                 found_code = CODE_RE.search(line)
                 if found_code:
@@ -271,8 +350,10 @@ class CodexAuthService:
             else:
                 msg = last_safe_line or "Codex device-code login failed"
                 err_code = "device_auth_disabled" if "not enabled" in msg.lower() else "login_failed"
+                log.warning("Codex device auth failed with rc=%s error_code=%s", rc, err_code)
                 await _set(status="failed", message=msg, error_code=err_code, user_code="", verification_url="", process_running=False)
         except Exception:
+            log.exception("Codex device auth watcher failed")
             await _set(status="failed", message="Codex device-code login failed", error_code="login_failed", user_code="", verification_url="", process_running=False)
         finally:
             async with self._lock:
@@ -319,14 +400,18 @@ class CodexAuthService:
     async def logout(self) -> dict[str, Any]:
         await self.cancel()
         if not self.enabled:
+            log.info("Codex logout requested while disabled")
             return {**self._base_capabilities(), **CodexAuthState(status="disabled", message="Codex auth is disabled", error_code="disabled").public()}
-        if not self._bin_path():
-            return {**self._base_capabilities(), **CodexAuthState(status="missing_cli", message="Codex CLI is not installed or CODEX_BIN is invalid", error_code="missing_cli").public()}
+        caps = self._base_capabilities()
+        if not caps["codex_cli_available"]:
+            log.warning("Codex logout reports missing CLI: %s", self._bin_diagnostics())
+            return {**caps, **self._cli_unavailable_state(caps).public()}
         rc, out = await self._run_command(["logout"], timeout=20)
         clean = ANSI_RE.sub("", out or "").strip()
         if rc == 0:
             state = CodexAuthState(status="logged_out", message=clean or "Codex credentials removed")
         else:
+            log.warning("Codex logout failed with rc=%s", rc)
             state = CodexAuthState(status="failed", message=(clean or "Codex logout failed")[:300], error_code="logout_failed")
         async with self._lock:
             self._state = state
@@ -335,6 +420,7 @@ class CodexAuthService:
     async def test(self) -> dict[str, Any]:
         status = await self.status()
         if not status.get("authenticated"):
+            log.info("Codex test requested while not authenticated: status=%s error_code=%s", status.get("status"), status.get("error_code"))
             return {**status, "ok": False}
         return {**status, "ok": True}
 

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1408,7 +1408,7 @@ class CodexCliChatAdapter:
 
 
 class CodexModelProvider:
-    """Status/capability adapter for a future Codex CLI provider."""
+    """Status/capability adapter for the Codex CLI provider."""
 
     def __init__(
         self,

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1,8 +1,8 @@
-"""Experimental Codex CLI model-provider capability boundary.
+"""Codex CLI model-provider capability boundary.
 
-This module does not implement chat dispatch. It reports whether a future
-Codex-backed provider can be exposed safely, without treating completed CLI
-output as token streaming or reading Codex credential files.
+This module implements the Codex CLI provider boundary without reading Codex
+credential files or treating completed CLI output as token streaming. Normal
+API-provider behavior remains deliberately out of scope.
 """
 
 from __future__ import annotations
@@ -17,12 +17,48 @@ from dataclasses import dataclass, replace
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
+from src.settings import load_settings, save_settings
 
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
-CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental)"
+CODEX_EXPERIMENTAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
+CODEX_SETTINGS_KEY = "codex_model_provider"
+CODEX_RECOMMENDED_MODELS = (
+    {
+        "id": "gpt-5.5",
+        "label": "GPT-5.5",
+        "description": "newest frontier model for complex coding, computer use, knowledge work, and research workflows",
+        "default": True,
+    },
+    {
+        "id": "gpt-5.4",
+        "label": "GPT-5.4",
+        "description": "flagship frontier model for professional work, stronger reasoning, tool use, and agentic workflows",
+    },
+    {
+        "id": "gpt-5.4-mini",
+        "label": "GPT-5.4 Mini",
+        "description": "fast and efficient model for responsive coding tasks and subagents",
+    },
+    {
+        "id": "gpt-5.3-codex",
+        "label": "GPT-5.3 Codex",
+        "description": "coding model for complex software engineering",
+    },
+    {
+        "id": "gpt-5.3-codex-spark",
+        "label": "GPT-5.3 Codex Spark",
+        "description": "research preview for near-instant real-time coding iteration; availability may depend on plan",
+    },
+    {
+        "id": "gpt-5.2",
+        "label": "GPT-5.2",
+        "description": "previous general-purpose coding and agentic model",
+    },
+)
+_CODEX_RECOMMENDED_BY_ID = {item["id"]: item for item in CODEX_RECOMMENDED_MODELS}
 
 _TOKEN_PATTERNS = (
     re.compile(r"(?i)(access_token|refresh_token|id_token)\s*[:=]\s*['\"]?[^'\"\s,}]+"),
@@ -30,19 +66,34 @@ _TOKEN_PATTERNS = (
 )
 
 _BASE_LIMITATIONS = [
-    "Normal chat integration is not implemented.",
+    "Chat picker integration only; not a normal API endpoint.",
     "Stateless: session/resume is not implemented.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
     "The adapter requires Codex CLI sandbox support and runs with read-only sandbox mode.",
+    "Thinking controls stay hidden unless the CLI explicitly advertises supported reasoning levels.",
 ]
 
 _APPROVAL_FLAGS = ("--ask-for-approval", "--approval-policy", "--approval")
 _DANGEROUS_FLAGS = ("--dangerously-bypass-approvals-and-sandbox", "--yolo")
 _SKIP_GIT_REPO_CHECK_FLAG = "--skip-git-repo-check"
 _JSON_OUTPUT_FLAG = "--json"
-_STREAM_TEXT_KEYS = ("delta", "text", "content", "message")
-_STREAM_NESTED_KEYS = ("event", "type", "item", "output", "data")
+_MODEL_FLAGS = ("--model", "-m")
+_REASONING_FLAGS = ("--reasoning-effort", "--effort", "--thinking-level")
+_REASONING_LEVELS = ("low", "medium", "high", "maximum")
+_STREAM_CONTAINER_KEYS = ("message", "item", "data", "response")
+_STREAM_NESTED_KEYS = (*_STREAM_CONTAINER_KEYS, "output")
 _STREAM_METRIC_KEYS = ("metrics", "usage")
+_LIFECYCLE_EVENT_NAMES = {
+    "started",
+    "completed",
+    "failed",
+    "thread.started",
+    "thread.completed",
+    "turn.started",
+    "turn.completed",
+    "turn.failed",
+}
+_LIFECYCLE_EVENT_SUFFIXES = (".started", ".completed", ".failed")
 _TRUST_DIRECTORY_PATTERNS = (
     re.compile(r"not\s+(inside\s+)?(a\s+)?trusted\s+(directory|git\s+repository)", re.I),
     re.compile(r"trust(ed)?\s+directory", re.I),
@@ -56,6 +107,346 @@ def _truthy(value: str | None) -> bool:
 
 def codex_model_provider_enabled() -> bool:
     return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
+
+
+def is_codex_model_selection(endpoint_url: str | None, _model: str | None = None) -> bool:
+    return (endpoint_url or "").strip() == CODEX_EXPERIMENTAL_ENDPOINT_URL
+
+
+def _sanitize_model_id(model_id: Any) -> str:
+    text = str(model_id or "").strip()
+    if not text or len(text) > 160:
+        return ""
+    if any(ch.isspace() for ch in text):
+        return ""
+    if any(ord(ch) < 32 for ch in text):
+        return ""
+    return text
+
+
+def _unique_model_ids(values: Any) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        model_id = _sanitize_model_id(value)
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            out.append(model_id)
+    return out
+
+
+def _sanitize_optional_text(value: Any, *, limit: int = 300) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if any(ord(ch) < 32 for ch in text):
+        return ""
+    return text[:limit]
+
+
+def _sanitize_thinking_effort(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    return text if text in _REASONING_LEVELS else None
+
+
+def codex_recommended_models() -> list[dict[str, Any]]:
+    return [dict(item) for item in CODEX_RECOMMENDED_MODELS]
+
+
+def _recommended_model_meta(model_id: str) -> dict[str, Any]:
+    item = _CODEX_RECOMMENDED_BY_ID.get(model_id) or {}
+    return {
+        "id": model_id,
+        "label": item.get("label") or _model_display(model_id),
+        "description": item.get("description") or "",
+        "source": "recommended" if item else "custom",
+        "default": bool(item.get("default")),
+    }
+
+
+def _selected_model_entry(
+    model_id: str,
+    *,
+    enabled: bool = True,
+    hidden: bool = False,
+    thinking_effort: str | None = None,
+    source: str | None = None,
+    label: str | None = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    meta = _recommended_model_meta(model_id)
+    return {
+        "id": model_id,
+        "label": label or meta["label"],
+        "description": description or meta["description"],
+        "source": source or meta["source"],
+        "enabled": enabled,
+        "hidden": hidden,
+        "thinking_effort": thinking_effort,
+    }
+
+
+def _sanitize_selected_model_entry(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        value = {"id": value}
+    model_id = _sanitize_model_id(value.get("id") or value.get("model_id"))
+    if not model_id:
+        return None
+    recommended = _recommended_model_meta(model_id)
+    source = str(value.get("source") or recommended["source"]).strip().lower()
+    if source not in {"recommended", "custom", "manual", "codex_cli"}:
+        source = recommended["source"]
+    source = "recommended" if source in {"recommended", "codex_cli"} and model_id in _CODEX_RECOMMENDED_BY_ID else "custom"
+    label = _sanitize_optional_text(value.get("label")) or recommended["label"]
+    description = _sanitize_optional_text(value.get("description")) or recommended["description"]
+    return _selected_model_entry(
+        model_id,
+        enabled=bool(value.get("enabled", True)),
+        hidden=bool(value.get("hidden", False)),
+        thinking_effort=_sanitize_thinking_effort(value.get("thinking_effort")),
+        source=source,
+        label=label,
+        description=description,
+    )
+
+
+def _normalize_selected_models(values: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        item = _sanitize_selected_model_entry(value)
+        if not item:
+            continue
+        if item["id"] in seen:
+            continue
+        seen.add(item["id"])
+        out.append(item)
+    return out
+
+
+def _legacy_selected_models(cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    manual = _unique_model_ids(cfg.get("manual_models"))
+    hidden = set(_unique_model_ids(cfg.get("hidden_models")))
+    disabled = set(_unique_model_ids(cfg.get("disabled_models")))
+    out: list[dict[str, Any]] = []
+    for model_id in manual:
+        out.append(_selected_model_entry(
+            model_id,
+            enabled=model_id not in disabled,
+            hidden=model_id in hidden,
+        ))
+    return out
+
+
+def _config_projections(selected_models: list[dict[str, Any]]) -> dict[str, Any]:
+    selected_ids = [item["id"] for item in selected_models]
+    hidden_ids = [item["id"] for item in selected_models if item.get("hidden")]
+    disabled_ids = [item["id"] for item in selected_models if not item.get("enabled", True)]
+    custom_models = [item["id"] for item in selected_models if item.get("source") == "custom"]
+    return {
+        "manual_models": selected_ids,
+        "hidden_models": hidden_ids,
+        "disabled_models": disabled_ids,
+        "custom_models": custom_models,
+        "hidden_model_ids": hidden_ids,
+    }
+
+
+def load_codex_model_config() -> dict[str, Any]:
+    cfg = load_settings().get(CODEX_SETTINGS_KEY) or {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    selected_models = _normalize_selected_models(cfg.get("selected_models"))
+    if not selected_models:
+        selected_models = _legacy_selected_models(cfg)
+    connector_enabled = cfg.get("connector_enabled")
+    if connector_enabled is None:
+        connector_enabled = bool(selected_models)
+    else:
+        connector_enabled = bool(connector_enabled)
+    task_defaults = cfg.get("task_defaults") or {}
+    if not isinstance(task_defaults, dict):
+        task_defaults = {}
+    projections = _config_projections(selected_models)
+    return {
+        "connector_enabled": connector_enabled,
+        "selected_models": selected_models,
+        **projections,
+        "task_defaults": task_defaults,
+    }
+
+
+def save_codex_model_config(config: dict[str, Any]) -> dict[str, Any]:
+    selected_models = _normalize_selected_models(config.get("selected_models"))
+    projections = _config_projections(selected_models)
+    clean = {
+        "connector_enabled": bool(config.get("connector_enabled")) or bool(selected_models),
+        "selected_models": selected_models,
+        **projections,
+        "task_defaults": config.get("task_defaults") if isinstance(config.get("task_defaults"), dict) else {},
+    }
+    settings = load_settings()
+    settings[CODEX_SETTINGS_KEY] = clean
+    save_settings(settings)
+    return load_codex_model_config()
+
+
+def update_codex_model_config(
+    *,
+    add_model: str | None = None,
+    hide_model: str | None = None,
+    restore_model: str | None = None,
+    enable_model: str | None = None,
+    disable_model: str | None = None,
+    remove_model: str | None = None,
+    thinking_model: str | None = None,
+    thinking_effort: str | None = None,
+    clear_all_models: bool = False,
+    connector_enabled: bool | None = None,
+) -> dict[str, Any]:
+    cfg = load_codex_model_config()
+    selected = [dict(item) for item in cfg["selected_models"]]
+
+    def _find(model_id: str) -> dict[str, Any] | None:
+        for item in selected:
+            if item["id"] == model_id:
+                return item
+        return None
+
+    if clear_all_models:
+        selected = []
+        cfg["connector_enabled"] = False
+
+    if connector_enabled is not None:
+        cfg["connector_enabled"] = bool(connector_enabled)
+
+    model_id = _sanitize_model_id(add_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["hidden"] = False
+            item["enabled"] = True
+        else:
+            selected.append(_selected_model_entry(model_id))
+        cfg["connector_enabled"] = True
+
+    model_id = _sanitize_model_id(remove_model)
+    if model_id:
+        selected = [item for item in selected if item["id"] != model_id]
+
+    model_id = _sanitize_model_id(hide_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["hidden"] = True
+            item["enabled"] = True
+
+    model_id = _sanitize_model_id(restore_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["hidden"] = False
+
+    model_id = _sanitize_model_id(enable_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["enabled"] = True
+            item["hidden"] = False
+
+    model_id = _sanitize_model_id(disable_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["enabled"] = False
+
+    model_id = _sanitize_model_id(thinking_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["thinking_effort"] = _sanitize_thinking_effort(thinking_effort)
+
+    if not selected and connector_enabled is None and not clear_all_models:
+        cfg["connector_enabled"] = False
+
+    cfg["selected_models"] = selected
+    return save_codex_model_config(cfg)
+
+
+def _model_display(model_id: str) -> str:
+    return model_id.rsplit("/", 1)[-1] or model_id
+
+
+def first_enabled_codex_model(config: dict[str, Any] | None = None) -> str:
+    cfg = config or load_codex_model_config()
+    if not cfg.get("connector_enabled"):
+        return ""
+    for item in cfg.get("selected_models") or []:
+        if item.get("enabled", True) and not item.get("hidden"):
+            return item.get("id") or ""
+    return ""
+
+
+def codex_model_default_reasoning_effort(model_id: str, config: dict[str, Any] | None = None) -> str | None:
+    target = _sanitize_model_id(model_id)
+    if not target:
+        return None
+    cfg = config or load_codex_model_config()
+    for item in cfg.get("selected_models") or []:
+        if item.get("id") == target:
+            return _sanitize_thinking_effort(item.get("thinking_effort"))
+    return None
+
+
+def is_codex_model_available(model_id: str | None, *, public_only: bool = True, config: dict[str, Any] | None = None) -> bool:
+    target = _sanitize_model_id(model_id)
+    if not target:
+        return False
+    cfg = config or load_codex_model_config()
+    if not cfg.get("connector_enabled"):
+        return False
+    for item in cfg.get("selected_models") or []:
+        if item.get("id") != target:
+            continue
+        if not public_only:
+            return True
+        return bool(item.get("enabled", True)) and not bool(item.get("hidden"))
+    return False
+
+
+def codex_model_list_item(models: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    public_models = [m for m in (models or []) if m.get("enabled", True) and not m.get("hidden")]
+    model_ids = [m["id"] for m in public_models if m.get("id")]
+    return {
+        "host": "codex",
+        "port": 0,
+        "url": CODEX_EXPERIMENTAL_ENDPOINT_URL,
+        "models": model_ids,
+        "models_display": [m.get("display") or _model_display(m["id"]) for m in public_models if m.get("id")],
+        "models_extra": [],
+        "models_extra_display": [],
+        "endpoint_id": None,
+        "endpoint_name": "Codex / ChatGPT",
+        "category": "api",
+        "model_type": "llm",
+        "experimental": True,
+        "provider": "codex_cli",
+        "capabilities": {
+            "chat_supported": True,
+            "streaming_supported": any(m.get("streaming_supported") for m in public_models),
+            "tool_calling_supported": False,
+            "agent_tools_supported": False,
+        },
+    }
+
+
+def _looks_like_lifecycle_event_name(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    return bool(text) and (text in _LIFECYCLE_EVENT_NAMES or text.endswith(_LIFECYCLE_EVENT_SUFFIXES))
 
 
 def _sanitize_text(text: str | None, limit: int = 2000, *, strip: bool = True) -> str:
@@ -77,6 +468,9 @@ class CodexCliCapabilities:
     skip_git_repo_check_flag: str | None = None
     supports_json: bool = False
     supports_model: bool = False
+    model_flag: str | None = None
+    reasoning_flag: str | None = None
+    reasoning_levels: tuple[str, ...] = ()
     resume_supported: bool = False
     resume_last_supported: bool = False
     resume_session_id_supported: bool = False
@@ -97,11 +491,17 @@ class CodexCliCapabilities:
     def limitations(self) -> list[str]:
         out = list(_BASE_LIMITATIONS)
         if self.streaming_supported:
-            out.append("Experimental SSE test route can stream real Codex CLI JSON events.")
+            out.append("Codex CLI JSON event streaming is available for chat streaming.")
         else:
             out.append("Streaming is not available because Codex CLI JSON event output is not advertised.")
+        if self.reasoning_flag and self.reasoning_levels:
+            out.append(
+                "Codex CLI advertises reasoning-effort levels, but Odysseus only exposes them when the CLI makes the supported levels explicit."
+            )
+        else:
+            out.append("Thinking controls are not advertised because this Codex CLI did not expose explicit supported levels.")
         if self.approval_flag:
-            out.append(f"Approval prompts are suppressed with Codex CLI {self.approval_flag}.")
+            out.append(f"Codex CLI advertises {self.approval_flag}, but this provider does not pass approval flags.")
         else:
             out.append(
                 "Approval-control flag is not available on this Codex CLI; "
@@ -125,19 +525,37 @@ class CodexCliCapabilities:
             "json_output_supported": self.supports_json,
             "streaming_supported": self.streaming_supported,
             "model_flag_supported": self.supports_model,
+            "model_flag": self.model_flag,
+            "reasoning_effort_supported": bool(self.reasoning_flag and self.reasoning_levels),
+            "reasoning_effort_flag": self.reasoning_flag,
+            "reasoning_effort_levels": list(self.reasoning_levels),
             "dangerous_flags_advertised": list(self.dangerous_flags),
         }
 
-    def build_exec_args(self, bin_path: str, prompt: str, *, json_output: bool = False) -> list[str]:
+    def build_exec_args(
+        self,
+        bin_path: str,
+        prompt: str,
+        *,
+        json_output: bool = False,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+    ) -> list[str]:
         if not self.sandbox_flag:
             raise ValueError("Codex CLI sandbox support is required")
         if json_output and not self.supports_json:
             raise ValueError("Codex CLI JSON output support is required for streaming")
         args = [bin_path, "exec", self.sandbox_flag, "read-only"]
+        selected_model = _sanitize_model_id(model)
+        if selected_model and selected_model != CODEX_EXPERIMENTAL_MODEL_ID:
+            if not self.supports_model or not self.model_flag:
+                raise ValueError("Codex CLI model selection is not supported")
+            args.extend([self.model_flag, selected_model])
+        selected_effort = str(reasoning_effort or "").strip().lower()
+        if selected_effort and self.reasoning_flag and selected_effort in self.reasoning_levels:
+            args.extend([self.reasoning_flag, selected_effort])
         if self.skip_git_repo_check_flag:
             args.append(self.skip_git_repo_check_flag)
-        if self.approval_flag:
-            args.extend([self.approval_flag, "never"])
         if json_output:
             args.append(_JSON_OUTPUT_FLAG)
         args.append(prompt)
@@ -149,8 +567,6 @@ class CodexCliCapabilities:
 def _detect_sandbox_flag(help_text: str) -> str | None:
     if "--sandbox" in help_text:
         return "--sandbox"
-    if re.search(r"(^|\s)-s([,\s]|$)", help_text):
-        return "-s"
     return None
 
 
@@ -167,6 +583,35 @@ def _detect_approval_flag(help_text: str) -> str | None:
     return None
 
 
+def _detect_model_flag(help_text: str) -> str | None:
+    if "--model" in help_text:
+        return "--model"
+    if re.search(r"(^|\s)-m([,\s]|$)", help_text):
+        return "-m"
+    return None
+
+
+def _detect_reasoning_flag(help_text: str) -> str | None:
+    for flag in _REASONING_FLAGS:
+        if flag in help_text:
+            return flag
+    return None
+
+
+def _detect_reasoning_levels(help_text: str, flag: str | None) -> tuple[str, ...]:
+    if not flag:
+        return ()
+    found: list[str] = []
+    for line in (help_text or "").splitlines():
+        if flag not in line:
+            continue
+        lowered = line.lower()
+        for level in _REASONING_LEVELS:
+            if re.search(rf"\b{re.escape(level)}\b", lowered) and level not in found:
+                found.append(level)
+    return tuple(found)
+
+
 def _detect_cli_capabilities_from_help(
     exec_help: str,
     root_help: str = "",
@@ -174,6 +619,8 @@ def _detect_cli_capabilities_from_help(
 ) -> CodexCliCapabilities:
     combined = "\n".join([exec_help or "", root_help or "", resume_help or ""])
     resume_text = "\n".join([exec_help or "", root_help or ""])
+    model_flag = _detect_model_flag(exec_help or "")
+    reasoning_flag = _detect_reasoning_flag(exec_help or "")
     return CodexCliCapabilities(
         sandbox_flag=_detect_sandbox_flag(exec_help or ""),
         sandbox_modes=tuple(
@@ -183,12 +630,60 @@ def _detect_cli_capabilities_from_help(
         approval_flag=_detect_approval_flag(exec_help or ""),
         skip_git_repo_check_flag=_detect_skip_git_repo_check_flag(combined),
         supports_json=_JSON_OUTPUT_FLAG in exec_help,
-        supports_model="--model" in exec_help or " -m" in exec_help,
+        supports_model=bool(model_flag),
+        model_flag=model_flag,
+        reasoning_flag=reasoning_flag,
+        reasoning_levels=_detect_reasoning_levels(exec_help or "", reasoning_flag),
         resume_supported=bool(re.search(r"\bresume\b", resume_text)),
         resume_last_supported="--last" in resume_help,
         resume_session_id_supported=bool(re.search(r"\b(session|SESSION)(_ID| id| id)?\b", resume_help, re.I)),
         dangerous_flags=tuple(flag for flag in _DANGEROUS_FLAGS if flag in combined),
     )
+
+
+def _advertised_model_list_commands(root_help: str) -> list[list[str]]:
+    commands: list[list[str]] = []
+    if re.search(r"(?im)^\s+models?\s+", root_help or ""):
+        commands.extend([["models", "--json"], ["models"], ["model", "list", "--json"], ["model", "list"]])
+    elif re.search(r"(?im)^\s+model\s+", root_help or ""):
+        commands.extend([["model", "list", "--json"], ["model", "list"]])
+    return commands
+
+
+def _extract_model_ids_from_payload(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [_sanitize_model_id(value)]
+    if isinstance(value, list):
+        out: list[str] = []
+        for item in value:
+            out.extend(_extract_model_ids_from_payload(item))
+        return [model_id for model_id in out if model_id]
+    if isinstance(value, dict):
+        for key in ("id", "name", "model"):
+            model_id = _sanitize_model_id(value.get(key))
+            if model_id:
+                return [model_id]
+        out: list[str] = []
+        for key in ("data", "models", "items"):
+            out.extend(_extract_model_ids_from_payload(value.get(key)))
+        return [model_id for model_id in out if model_id]
+    return []
+
+
+def _parse_model_list_output(output: str) -> list[str]:
+    text = output or ""
+    parsed: list[str] = []
+    try:
+        parsed = _extract_model_ids_from_payload(json.loads(text))
+    except Exception:
+        parsed = []
+    if not parsed:
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.lower().startswith(("usage:", "error", "warning")):
+                continue
+            parsed.append(stripped.split()[0])
+    return _unique_model_ids(parsed)
 
 
 class CodexCliChatAdapter:
@@ -227,6 +722,8 @@ class CodexCliChatAdapter:
             "tool_execution_allowed": False,
             "supports_json": capabilities.supports_json,
             "supports_model": capabilities.supports_model,
+            "discovered_models": help_result.get("discovered_models") or [],
+            "model_discovery": help_result.get("model_discovery") or {},
             "cli_capabilities": capabilities.to_public_dict(),
             "limitations": capabilities.limitations(),
             "_preflight": preflight,
@@ -237,6 +734,7 @@ class CodexCliChatAdapter:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
@@ -256,7 +754,15 @@ class CodexCliChatAdapter:
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
 
         with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
-            args = capabilities.build_exec_args(preflight["bin_path"], prompt)
+            try:
+                args = capabilities.build_exec_args(
+                    preflight["bin_path"],
+                    prompt,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
+            except ValueError as exc:
+                return self._error("unsupported_option", str(exc), round((time.time() - started) * 1000), model, capabilities)
             rc, out, err = await self._run(
                 args,
                 timeout=timeout,
@@ -265,7 +771,12 @@ class CodexCliChatAdapter:
             )
             if rc != 0 and _is_trust_directory_error(err or out) and not capabilities.skip_git_repo_check_supported:
                 capabilities = replace(capabilities, skip_git_repo_check_flag=_SKIP_GIT_REPO_CHECK_FLAG)
-                args = capabilities.build_exec_args(preflight["bin_path"], prompt)
+                args = capabilities.build_exec_args(
+                    preflight["bin_path"],
+                    prompt,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
                 rc, out, err = await self._run(
                     args,
                     timeout=timeout,
@@ -298,6 +809,13 @@ class CodexCliChatAdapter:
             "message": message,
             "duration_ms": duration_ms,
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "reasoning_effort": (
+                reasoning_effort
+                if capabilities.reasoning_flag
+                and capabilities.reasoning_levels
+                and reasoning_effort in capabilities.reasoning_levels
+                else None
+            ),
             "limitations": capabilities.limitations(),
             "cli_capabilities": capabilities.to_public_dict(),
             "streaming_supported": capabilities.streaming_supported,
@@ -309,8 +827,10 @@ class CodexCliChatAdapter:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
+        allow_one_shot_fallback: bool = False,
     ):
         started = time.time()
         availability = await self._available_internal()
@@ -325,6 +845,27 @@ class CodexCliChatAdapter:
         preflight = availability["_preflight"]
         capabilities = availability["_capabilities"]
         if not capabilities.streaming_supported:
+            if allow_one_shot_fallback:
+                result = await self.complete(
+                    messages,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                    timeout_seconds=timeout_seconds,
+                    odysseus_session_id=odysseus_session_id,
+                )
+                if result.get("ok"):
+                    message = result.get("message") or ""
+                    if message:
+                        yield {"type": "delta", "delta": message}
+                    yield {
+                        "type": "done",
+                        "message": message,
+                        "model": result.get("model") or model or CODEX_EXPERIMENTAL_MODEL_ID,
+                        "duration_ms": result.get("duration_ms"),
+                    }
+                else:
+                    yield self._stream_error_event(result, started=started, model=model)
+                return
             yield self._stream_error_event(
                 {
                     "ok": False,
@@ -341,13 +882,28 @@ class CodexCliChatAdapter:
         prompt = self._build_prompt(messages)
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
         with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-stream-") as workdir:
-            args = capabilities.build_exec_args(preflight["bin_path"], prompt, json_output=True)
+            try:
+                args = capabilities.build_exec_args(
+                    preflight["bin_path"],
+                    prompt,
+                    json_output=True,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
+            except ValueError as exc:
+                yield self._stream_error_event(
+                    self._error("unsupported_option", str(exc), round((time.time() - started) * 1000), model, capabilities),
+                    started=started,
+                    model=model,
+                )
+                return
             async for event in self._stream_exec(
                 args,
                 timeout=timeout,
                 cwd=workdir,
                 env=preflight["env"],
                 model=model,
+                reasoning_effort=reasoning_effort,
                 capabilities=capabilities,
             ):
                 yield event
@@ -406,6 +962,20 @@ class CodexCliChatAdapter:
             if resume_rc == 0:
                 resume_help = resume_out or ""
         capabilities = _detect_cli_capabilities_from_help(exec_help, root_help, resume_help)
+        discovered_models: list[str] = []
+        model_discovery = {"source": "none", "commands_tried": []}
+        for command in _advertised_model_list_commands(root_help):
+            model_discovery["commands_tried"].append(" ".join(command))
+            model_rc, model_out, _ = await self._run([bin_path, *command], timeout=20, env=env)
+            if model_rc != 0:
+                continue
+            discovered_models = _parse_model_list_output(model_out or "")
+            if discovered_models:
+                model_discovery["source"] = "codex_cli"
+                model_discovery["command"] = " ".join(command)
+                break
+        if not discovered_models and capabilities.supports_model:
+            model_discovery["source"] = "manual"
         if not capabilities.ok:
             return {
                 "ok": False,
@@ -418,6 +988,8 @@ class CodexCliChatAdapter:
             "ok": True,
             "status": "exec_help_ok",
             "cli_capabilities": capabilities.to_public_dict(),
+            "discovered_models": discovered_models,
+            "model_discovery": model_discovery,
             "_capabilities": capabilities,
         }
 
@@ -434,6 +1006,7 @@ class CodexCliChatAdapter:
         env: dict[str, str],
         model: str | None,
         capabilities: CodexCliCapabilities,
+        reasoning_effort: str | None = None,
         allow_trust_retry: bool = True,
     ):
         started = time.time()
@@ -509,13 +1082,20 @@ class CodexCliChatAdapter:
             detail = _sanitize_text(stderr_text or "".join(stdout_lines), limit=500)
             if _is_trust_directory_error(detail) and not capabilities.skip_git_repo_check_supported and allow_trust_retry:
                 retry_capabilities = replace(capabilities, skip_git_repo_check_flag=_SKIP_GIT_REPO_CHECK_FLAG)
-                retry_args = retry_capabilities.build_exec_args(args[0], args[-1], json_output=True)
+                retry_args = retry_capabilities.build_exec_args(
+                    args[0],
+                    args[-1],
+                    json_output=True,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
                 async for event in self._stream_exec(
                     retry_args,
                     timeout=timeout,
                     cwd=cwd,
                     env=env,
                     model=model,
+                    reasoning_effort=reasoning_effort,
                     capabilities=retry_capabilities,
                     allow_trust_retry=False,
                 ):
@@ -582,34 +1162,88 @@ class CodexCliChatAdapter:
         return events
 
     @classmethod
-    def _extract_delta(cls, value: Any, depth: int = 0) -> str:
+    def _is_lifecycle_event(cls, value: Any) -> bool:
+        if isinstance(value, list):
+            return bool(value) and all(cls._is_lifecycle_event(item) for item in value)
+        if not isinstance(value, dict):
+            return _looks_like_lifecycle_event_name(value)
+        for key in ("type", "event"):
+            event_name = value.get(key)
+            if isinstance(event_name, str) and _looks_like_lifecycle_event_name(event_name):
+                content = cls._extract_delta(value)
+                metrics = cls._extract_metrics(value)
+                return not content and not metrics
+        return False
+
+    @classmethod
+    def _is_reasoning_event(cls, value: Any) -> bool:
+        if not isinstance(value, dict):
+            return False
+        if value.get("thinking") is True:
+            return True
+        for key in ("type", "event", "kind", "channel", "name"):
+            text = str(value.get(key) or "").strip().lower()
+            if "reasoning" in text or "thinking" in text:
+                return True
+        return False
+
+    @classmethod
+    def _extract_delta(cls, value: Any, depth: int = 0, *, in_content: bool = False) -> str:
         if depth > 6:
             return ""
         if isinstance(value, str):
-            return value if depth > 0 else ""
-        if isinstance(value, list):
-            for item in value:
-                found = cls._extract_delta(item, depth + 1)
-                if found:
-                    return found
+            if in_content and cls._is_assistant_text(value):
+                return value
             return ""
+        if isinstance(value, list):
+            parts: list[str] = []
+            for item in value:
+                found = cls._extract_delta(item, depth + 1, in_content=in_content)
+                if found:
+                    parts.append(found)
+            return "".join(parts)
         if not isinstance(value, dict):
             return ""
-        for key in _STREAM_TEXT_KEYS:
+        if cls._is_reasoning_event(value):
+            return ""
+
+        event_type = str(value.get("type") or "").strip().lower()
+        if event_type in {"text", "output_text"}:
+            for key in ("text", "output_text", "content"):
+                text = value.get(key)
+                if isinstance(text, str) and cls._is_assistant_text(text):
+                    return text
+
+        for key in ("delta", "output_text", "text"):
             text = value.get(key)
-            if isinstance(text, str) and text.strip():
+            if isinstance(text, str) and cls._is_assistant_text(text):
                 return text
-        for key in _STREAM_NESTED_KEYS:
+
+        content = value.get("content")
+        if isinstance(content, str) and cls._is_assistant_text(content):
+            return content
+        if isinstance(content, (dict, list)):
+            found = cls._extract_delta(content, depth + 1, in_content=True)
+            if found:
+                return found
+
+        for key in _STREAM_CONTAINER_KEYS:
             nested = value.get(key)
             if isinstance(nested, (dict, list)):
                 found = cls._extract_delta(nested, depth + 1)
                 if found:
                     return found
-        for nested in value.values():
+        for key, nested in value.items():
+            if key in {"type", "event", "status"} or not isinstance(nested, (dict, list)):
+                continue
             found = cls._extract_delta(nested, depth + 1)
             if found:
                 return found
         return ""
+
+    @staticmethod
+    def _is_assistant_text(value: str) -> bool:
+        return bool(value.strip()) and not _looks_like_lifecycle_event_name(value)
 
     @classmethod
     def _extract_metrics(cls, value: Any, depth: int = 0) -> dict[str, Any]:
@@ -624,8 +1258,6 @@ class CodexCliChatAdapter:
         if not isinstance(value, dict):
             return {}
         event_type = str(value.get("type") or value.get("event") or "").lower()
-        if event_type in {"metrics", "metric", "usage"}:
-            return cls._sanitize_metrics(value)
         for key in _STREAM_METRIC_KEYS:
             metrics = value.get(key)
             if isinstance(metrics, dict):
@@ -634,6 +1266,12 @@ class CodexCliChatAdapter:
             found = cls._extract_metrics(value.get(key), depth + 1)
             if found:
                 return found
+        if event_type in {"metrics", "metric", "usage"}:
+            return cls._sanitize_metrics({
+                key: metric_value
+                for key, metric_value in value.items()
+                if key not in {"type", "event"}
+            })
         return {}
 
     @staticmethod
@@ -691,10 +1329,10 @@ class CodexCliChatAdapter:
     @staticmethod
     def _build_prompt(messages: list[dict[str, Any]]) -> str:
         parts = [
-            "You are replying through Odysseus' experimental Codex CLI provider.",
+            "You are replying through Odysseus' Codex CLI provider.",
             "Return only the final assistant response.",
             "Do not run tools, shell commands, file edits, or web requests.",
-            "If a request requires tools, say that this experimental provider does not support tools yet.",
+            "If a request requires tools, say that this provider does not support tools yet.",
             "",
             "Conversation:",
         ]
@@ -714,18 +1352,37 @@ class CodexCliChatAdapter:
         if not text:
             return ""
         # If a future CLI emits JSONL, prefer common completed-message fields.
+        parsed_json = False
+        non_json_lines: list[str] = []
         for line in text.splitlines():
             line = line.strip()
             if not line.startswith("{"):
+                if line:
+                    non_json_lines.append(line)
                 continue
             try:
                 data = json.loads(line)
             except Exception:
+                non_json_lines.append(line)
+                continue
+            parsed_json = True
+            if CodexCliChatAdapter._is_lifecycle_event(data):
+                continue
+            delta = CodexCliChatAdapter._extract_delta(data)
+            if delta:
+                return _sanitize_text(delta)
+            if CodexCliChatAdapter._extract_metrics(data):
                 continue
             for key in ("message", "content", "text", "output"):
                 value = data.get(key) if isinstance(data, dict) else None
-                if isinstance(value, str) and value.strip():
+                if (
+                    isinstance(value, str)
+                    and value.strip()
+                    and not _looks_like_lifecycle_event_name(value)
+                ):
                     return _sanitize_text(value)
+        if parsed_json:
+            return _sanitize_text("\n".join(non_json_lines))
         return text
 
     @staticmethod
@@ -774,6 +1431,16 @@ class CodexModelProvider:
             "session_resume_supported": False,
             "tool_execution_allowed": False,
             "limitations": list(_BASE_LIMITATIONS),
+            "model_discovery": {"source": "disabled"},
+            "recommended_models": codex_recommended_models(),
+            "connector_enabled": False,
+            "selected_models": [],
+            "manual_models": [],
+            "hidden_models": [],
+            "disabled_models": [],
+            "thinking_supported": False,
+            "thinking_effort_levels": [],
+            "thinking_activity_supported": False,
         }
         if not enabled:
             return {
@@ -814,7 +1481,13 @@ class CodexModelProvider:
             status = "available"
             requires_sign_in = False
 
-        models = []
+        cfg = load_codex_model_config()
+        base["connector_enabled"] = cfg["connector_enabled"]
+        base["selected_models"] = [dict(item) for item in cfg["selected_models"]]
+        base["manual_models"] = cfg["manual_models"]
+        base["hidden_models"] = cfg["hidden_models"]
+        base["disabled_models"] = cfg["disabled_models"]
+        models: list[dict[str, Any]] = []
         chat_available = {"ok": False}
         if status == "available":
             chat_available = await self._chat_adapter.available()
@@ -825,13 +1498,31 @@ class CodexModelProvider:
                 base["streaming_supported"] = bool(chat_available.get("streaming_supported"))
                 base["limitations"] = chat_available.get("limitations") or base["limitations"]
                 base["cli_capabilities"] = chat_available.get("cli_capabilities") or {}
-                models.append({
-                    "id": CODEX_EXPERIMENTAL_MODEL_ID,
-                    "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
-                    "experimental": True,
-                    "streaming_supported": bool(chat_available.get("streaming_supported")),
-                    "session_resume_supported": False,
-                })
+                base["model_discovery"] = chat_available.get("model_discovery") or {"source": "manual"}
+                cap = base["cli_capabilities"]
+                base["thinking_supported"] = bool(cap.get("reasoning_effort_supported")) and bool(cap.get("reasoning_effort_levels"))
+                base["thinking_effort_levels"] = cap.get("reasoning_effort_levels") or []
+                base["thinking_activity_supported"] = False
+
+        for item in cfg["selected_models"]:
+            models.append({
+                "id": item["id"],
+                "display": item.get("label") or _model_display(item["id"]),
+                "label": item.get("label") or _model_display(item["id"]),
+                "description": item.get("description") or "",
+                "source": item.get("source") or "custom",
+                "experimental": True,
+                "hidden": bool(item.get("hidden")),
+                "enabled": bool(item.get("enabled", True)) and not bool(item.get("hidden")),
+                "thinking_effort": item.get("thinking_effort"),
+                "streaming_supported": bool(base["streaming_supported"]),
+                "thinking_supported": bool(base["thinking_supported"]),
+                "thinking_effort_levels": list(base["thinking_effort_levels"]),
+                "thinking_activity_supported": bool(base["thinking_activity_supported"]),
+                "session_resume_supported": False,
+                "tool_calling_supported": False,
+                "agent_tools_supported": False,
+            })
 
         return {
             **base,
@@ -852,12 +1543,14 @@ class CodexModelProvider:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
         return await self._chat_adapter.complete(
             messages,
             model=model,
+            reasoning_effort=reasoning_effort,
             timeout_seconds=timeout_seconds,
             odysseus_session_id=odysseus_session_id,
         )
@@ -866,16 +1559,43 @@ class CodexModelProvider:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
+        allow_one_shot_fallback: bool = False,
     ):
         async for event in self._chat_adapter.stream_chat(
             messages,
             model=model,
+            reasoning_effort=reasoning_effort,
             timeout_seconds=timeout_seconds,
             odysseus_session_id=odysseus_session_id,
+            allow_one_shot_fallback=allow_one_shot_fallback,
         ):
             yield event
+
+
+def codex_model_list_item_if_available(provider: CodexModelProvider | None = None) -> dict[str, Any] | None:
+    """Return the picker item only when Codex has at least one enabled model."""
+    if not codex_model_provider_enabled():
+        return None
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = False
+    else:
+        running_loop = True
+    if running_loop:
+        return None
+    try:
+        status = asyncio.run((provider or CodexModelProvider()).status())
+    except Exception:
+        return None
+    if status.get("status") == "available" and status.get("chat_supported") is True:
+        item = codex_model_list_item(status.get("models") or [])
+        if item.get("models"):
+            return item
+    return None
 
 
 def _is_trust_directory_error(text: str | None) -> bool:

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,7 +13,6 @@ import os
 import re
 import tempfile
 import time
-from pathlib import Path
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
@@ -22,7 +21,6 @@ from src.codex_auth import get_codex_auth_service
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
 CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental, non-streaming)"
-CODEX_VIRTUAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
 
 _TOKEN_PATTERNS = (
@@ -32,15 +30,10 @@ _TOKEN_PATTERNS = (
 
 _LIMITATIONS = [
     "Non-streaming: returns one completed assistant message.",
-    "Session resume depends on the installed Codex CLI.",
+    "Stateless: session/resume is not implemented.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
     "The adapter requires Codex CLI sandbox/approval flags before running.",
 ]
-
-_UNSAFE_FLAGS = (
-    "--dangerously-bypass-approvals-and-sandbox",
-    "--yolo",
-)
 
 
 def _truthy(value: str | None) -> bool:
@@ -58,12 +51,6 @@ def _sanitize_text(text: str | None, limit: int = 2000) -> str:
     return safe.strip()[:limit]
 
 
-def is_codex_virtual_endpoint(endpoint_url: str | None, model: str | None = None) -> bool:
-    return (endpoint_url or "").strip() == CODEX_VIRTUAL_ENDPOINT_URL or (
-        (model or "").strip() == CODEX_EXPERIMENTAL_MODEL_ID
-    )
-
-
 class CodexCliChatAdapter:
     """Admin-only, non-streaming adapter boundary for `codex exec`.
 
@@ -76,13 +63,9 @@ class CodexCliChatAdapter:
         self,
         auth_service_getter: Callable[[], Any] | None = None,
         runner: Callable[..., Any] | None = None,
-        session_root: str | Path | None = None,
     ) -> None:
         self._auth_service_getter = auth_service_getter or get_codex_auth_service
         self._runner = runner
-        self._session_root = Path(session_root) if session_root else Path(tempfile.gettempdir()) / "odysseus-codex-sessions"
-        self._session_map: dict[str, dict[str, Any]] = {}
-        self._reset_versions: dict[str, int] = {}
 
     async def available(self) -> dict[str, Any]:
         preflight = await self._preflight()
@@ -96,7 +79,7 @@ class CodexCliChatAdapter:
             "status": "available",
             "chat_supported": True,
             "streaming_supported": False,
-            "session_resume_supported": bool(help_result.get("session_resume_supported", False)),
+            "session_resume_supported": False,
             "tool_execution_allowed": False,
             "supports_json": help_result.get("supports_json", False),
             "limitations": list(_LIMITATIONS),
@@ -107,7 +90,6 @@ class CodexCliChatAdapter:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
-        odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
         started = time.time()
         availability = await self.available()
@@ -122,21 +104,23 @@ class CodexCliChatAdapter:
         preflight = await self._preflight()
         prompt = self._build_prompt(messages)
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
-        resume_supported = bool(availability.get("session_resume_supported", False))
-        session_key = self._session_key(odysseus_session_id)
-        args, resume_mode = self._build_exec_args(
-            preflight["bin_path"],
-            prompt,
-            odysseus_session_key=session_key,
-            resume_supported=resume_supported,
-        )
-        workdir = self._ensure_workdir_for_session(session_key)
-        rc, out, err = await self._run(
-            args,
-            timeout=timeout,
-            cwd=str(workdir),
-            env=preflight["env"],
-        )
+
+        with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
+            args = [
+                preflight["bin_path"],
+                "exec",
+                "--sandbox",
+                "read-only",
+                "--ask-for-approval",
+                "never",
+                prompt,
+            ]
+            rc, out, err = await self._run(
+                args,
+                timeout=timeout,
+                cwd=workdir,
+                env=preflight["env"],
+            )
 
         duration_ms = round((time.time() - started) * 1000)
         if rc == 124:
@@ -144,14 +128,6 @@ class CodexCliChatAdapter:
         if rc != 0:
             detail = _sanitize_text(err or out, limit=500)
             return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model)
-
-        codex_session_id = self._extract_session_id("\n".join([out or "", err or ""]))
-        if session_key:
-            self._session_map[session_key] = {
-                "codex_session_id": codex_session_id or (self._session_map.get(session_key) or {}).get("codex_session_id", ""),
-                "workdir": str(workdir),
-                "updated_at": time.time(),
-            }
 
         message = self._extract_message(out)
         if not message:
@@ -165,20 +141,9 @@ class CodexCliChatAdapter:
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
             "limitations": list(_LIMITATIONS),
             "streaming_supported": False,
-            "session_resume_supported": resume_supported,
-            "session_resumed": resume_mode != "new",
-            "codex_resume_mode": resume_mode,
+            "session_resume_supported": False,
             "tool_execution_allowed": False,
         }
-
-    def reset_session(self, odysseus_session_id: str | None) -> dict[str, Any]:
-        session_key = self._session_key(odysseus_session_id)
-        if not session_key:
-            return {"ok": False, "status": "invalid_request", "error": "session_id is required"}
-        existed = session_key in self._session_map
-        self._session_map.pop(session_key, None)
-        self._reset_versions[session_key] = self._reset_versions.get(session_key, 0) + 1
-        return {"ok": True, "status": "reset", "session_mapping_cleared": existed}
 
     async def _preflight(self) -> dict[str, Any]:
         if not codex_model_provider_enabled():
@@ -218,17 +183,14 @@ class CodexCliChatAdapter:
 
     async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
         rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
-        top_rc, top_out, top_err = 1, "", ""
-        if rc != 0 or "--sandbox" not in (out or "") or "--ask-for-approval" not in (out or ""):
-            top_rc, top_out, top_err = await self._run([bin_path, "--help"], timeout=20, env=env)
-        help_text = "\n".join([out or "", top_out or ""])
-        if rc != 0 and top_rc != 0:
+        if rc != 0:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
                 "error": "Unable to inspect codex exec safety flags",
-                "detail": _sanitize_text(err or out or top_err or top_out, limit=500),
+                "detail": _sanitize_text(err or out, limit=500),
             }
+        help_text = out or ""
         missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
         if missing:
             return {
@@ -237,77 +199,12 @@ class CodexCliChatAdapter:
                 "error": "Codex CLI does not advertise required safety flags",
                 "missing_flags": missing,
             }
-        resume_supported = await self._detect_resume_support(bin_path, env, help_text)
         return {
             "ok": True,
             "status": "exec_help_ok",
             "supports_json": "--json" in help_text,
             "supports_model": "--model" in help_text or " -m" in help_text,
-            "session_resume_supported": resume_supported,
         }
-
-    async def _detect_resume_support(self, bin_path: str, env: dict[str, str], help_text: str) -> bool:
-        rc, out, err = await self._run([bin_path, "exec", "resume", "--help"], timeout=20, env=env)
-        text = "\n".join([help_text or "", out or "", err or ""]).lower()
-        if rc == 0 and "resume" in text:
-            return True
-        return bool(re.search(r"\bresume\b", text) and "exec" in text)
-
-    def _build_exec_args(
-        self,
-        bin_path: str,
-        prompt: str,
-        *,
-        odysseus_session_key: str,
-        resume_supported: bool,
-    ) -> tuple[list[str], str]:
-        safety = ["--sandbox", "read-only", "--ask-for-approval", "never"]
-        args = [bin_path, "exec"]
-        resume_mode = "new"
-        if resume_supported and odysseus_session_key:
-            mapped = self._session_map.get(odysseus_session_key) or {}
-            codex_session_id = str(mapped.get("codex_session_id") or "").strip()
-            if codex_session_id:
-                args.extend(["resume", codex_session_id])
-                resume_mode = "session_id"
-            else:
-                mapped_workdir_raw = str(mapped.get("workdir") or "")
-                can_resume_last = bool(mapped_workdir_raw and Path(mapped_workdir_raw).exists())
-                if can_resume_last:
-                    args.extend(["resume", "--last"])
-                    resume_mode = "last_in_workdir"
-        args.extend([*safety, prompt])
-        self._assert_safe_args(args)
-        return args, resume_mode
-
-    def _assert_safe_args(self, args: list[str]) -> None:
-        if "exec" not in args:
-            raise ValueError("Codex provider must use codex exec")
-        for unsafe in _UNSAFE_FLAGS:
-            if unsafe in args:
-                raise ValueError("Unsafe Codex CLI flag blocked")
-        if "--sandbox" not in args or "read-only" not in args:
-            raise ValueError("Codex provider requires read-only sandbox")
-        if "--ask-for-approval" not in args or "never" not in args:
-            raise ValueError("Codex provider requires approvals disabled")
-        if CODEX_EXPERIMENTAL_MODEL_ID in args:
-            raise ValueError("Internal Codex model id must not be passed to Codex CLI")
-
-    def _session_key(self, odysseus_session_id: str | None) -> str:
-        value = (odysseus_session_id or "").strip()
-        if not value:
-            return ""
-        return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)[:120]
-
-    def _workdir_path_for_session(self, session_key: str) -> Path:
-        version = self._reset_versions.get(session_key, 0)
-        safe = session_key or "one-shot"
-        return self._session_root / f"{safe}-{version}"
-
-    def _ensure_workdir_for_session(self, session_key: str) -> Path:
-        workdir = self._workdir_path_for_session(session_key)
-        workdir.mkdir(parents=True, exist_ok=True)
-        return workdir
 
     async def _run(
         self,
@@ -380,26 +277,6 @@ class CodexCliChatAdapter:
                 if isinstance(value, str) and value.strip():
                     return _sanitize_text(value)
         return text
-
-    @staticmethod
-    def _extract_session_id(output: str) -> str:
-        text = _sanitize_text(output, limit=8000)
-        for line in text.splitlines():
-            line = line.strip()
-            if line.startswith("{"):
-                try:
-                    data = json.loads(line)
-                except Exception:
-                    data = None
-                if isinstance(data, dict):
-                    for key in ("session_id", "conversation_id", "id"):
-                        value = data.get(key)
-                        if isinstance(value, str) and re.match(r"^[A-Za-z0-9_.:-]{8,}$", value):
-                            return value[:200]
-            match = re.search(r"(?i)\b(?:session|conversation)[ _-]?id\b[:= ]+([A-Za-z0-9_.:-]{8,})", line)
-            if match:
-                return match.group(1)[:200]
-        return ""
 
     @staticmethod
     def _error(status: str, error: str, duration_ms: int, model: str | None) -> dict[str, Any]:
@@ -488,13 +365,12 @@ class CodexModelProvider:
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
             else:
                 base["chat_supported"] = True
-                base["session_resume_supported"] = bool(chat_available.get("session_resume_supported", False))
                 models.append({
                     "id": CODEX_EXPERIMENTAL_MODEL_ID,
                     "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
                     "experimental": True,
                     "streaming_supported": False,
-                    "session_resume_supported": bool(chat_available.get("session_resume_supported", False)),
+                    "session_resume_supported": False,
                 })
 
         return {
@@ -517,14 +393,5 @@ class CodexModelProvider:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
-        odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
-        return await self._chat_adapter.complete(
-            messages,
-            model=model,
-            timeout_seconds=timeout_seconds,
-            odysseus_session_id=odysseus_session_id,
-        )
-
-    def reset_session(self, odysseus_session_id: str | None) -> dict[str, Any]:
-        return self._chat_adapter.reset_session(odysseus_session_id)
+        return await self._chat_adapter.complete(messages, model=model, timeout_seconds=timeout_seconds)

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -41,8 +41,8 @@ _APPROVAL_FLAGS = ("--ask-for-approval", "--approval-policy", "--approval")
 _DANGEROUS_FLAGS = ("--dangerously-bypass-approvals-and-sandbox", "--yolo")
 _SKIP_GIT_REPO_CHECK_FLAG = "--skip-git-repo-check"
 _JSON_OUTPUT_FLAG = "--json"
-_STREAM_TEXT_KEYS = ("delta", "text", "content", "message")
-_STREAM_NESTED_KEYS = ("event", "type", "item", "output", "data")
+_STREAM_CONTAINER_KEYS = ("message", "item", "data", "response")
+_STREAM_NESTED_KEYS = (*_STREAM_CONTAINER_KEYS, "output")
 _STREAM_METRIC_KEYS = ("metrics", "usage")
 _LIFECYCLE_EVENT_NAMES = {
     "started",
@@ -633,8 +633,6 @@ class CodexCliChatAdapter:
             data = json.loads(stripped)
         except Exception:
             return []
-        if cls._is_lifecycle_event(data):
-            return []
 
         events: list[dict[str, Any]] = []
         metrics = cls._extract_metrics(data)
@@ -648,48 +646,72 @@ class CodexCliChatAdapter:
     @classmethod
     def _is_lifecycle_event(cls, value: Any) -> bool:
         if isinstance(value, list):
-            return any(cls._is_lifecycle_event(item) for item in value)
+            return bool(value) and all(cls._is_lifecycle_event(item) for item in value)
         if not isinstance(value, dict):
             return _looks_like_lifecycle_event_name(value)
         for key in ("type", "event"):
             event_name = value.get(key)
             if isinstance(event_name, str) and _looks_like_lifecycle_event_name(event_name):
-                return True
+                content = cls._extract_delta(value)
+                metrics = cls._extract_metrics(value)
+                return not content and not metrics
         return False
 
     @classmethod
-    def _extract_delta(cls, value: Any, depth: int = 0) -> str:
+    def _extract_delta(cls, value: Any, depth: int = 0, *, in_content: bool = False) -> str:
         if depth > 6:
             return ""
         if isinstance(value, str):
-            if depth > 0 and not _looks_like_lifecycle_event_name(value):
+            if in_content and cls._is_assistant_text(value):
                 return value
             return ""
         if isinstance(value, list):
+            parts: list[str] = []
             for item in value:
-                found = cls._extract_delta(item, depth + 1)
+                found = cls._extract_delta(item, depth + 1, in_content=in_content)
                 if found:
-                    return found
-            return ""
+                    parts.append(found)
+            return "".join(parts)
         if not isinstance(value, dict):
             return ""
-        for key in _STREAM_TEXT_KEYS:
+
+        event_type = str(value.get("type") or "").strip().lower()
+        if event_type in {"text", "output_text"}:
+            for key in ("text", "output_text", "content"):
+                text = value.get(key)
+                if isinstance(text, str) and cls._is_assistant_text(text):
+                    return text
+
+        for key in ("delta", "output_text", "text"):
             text = value.get(key)
-            if isinstance(text, str) and text.strip() and not _looks_like_lifecycle_event_name(text):
+            if isinstance(text, str) and cls._is_assistant_text(text):
                 return text
-        for key in _STREAM_NESTED_KEYS:
+
+        content = value.get("content")
+        if isinstance(content, str) and cls._is_assistant_text(content):
+            return content
+        if isinstance(content, (dict, list)):
+            found = cls._extract_delta(content, depth + 1, in_content=True)
+            if found:
+                return found
+
+        for key in _STREAM_CONTAINER_KEYS:
             nested = value.get(key)
             if isinstance(nested, (dict, list)):
                 found = cls._extract_delta(nested, depth + 1)
                 if found:
                     return found
         for key, nested in value.items():
-            if key in {"type", "event"} or not isinstance(nested, (dict, list)):
+            if key in {"type", "event", "status"} or not isinstance(nested, (dict, list)):
                 continue
             found = cls._extract_delta(nested, depth + 1)
             if found:
                 return found
         return ""
+
+    @staticmethod
+    def _is_assistant_text(value: str) -> bool:
+        return bool(value.strip()) and not _looks_like_lifecycle_event_name(value)
 
     @classmethod
     def _extract_metrics(cls, value: Any, depth: int = 0) -> dict[str, Any]:
@@ -704,8 +726,6 @@ class CodexCliChatAdapter:
         if not isinstance(value, dict):
             return {}
         event_type = str(value.get("type") or value.get("event") or "").lower()
-        if event_type in {"metrics", "metric", "usage"}:
-            return cls._sanitize_metrics(value)
         for key in _STREAM_METRIC_KEYS:
             metrics = value.get(key)
             if isinstance(metrics, dict):
@@ -714,6 +734,12 @@ class CodexCliChatAdapter:
             found = cls._extract_metrics(value.get(key), depth + 1)
             if found:
                 return found
+        if event_type in {"metrics", "metric", "usage"}:
+            return cls._sanitize_metrics({
+                key: metric_value
+                for key, metric_value in value.items()
+                if key not in {"type", "event"}
+            })
         return {}
 
     @staticmethod
@@ -813,6 +839,8 @@ class CodexCliChatAdapter:
             delta = CodexCliChatAdapter._extract_delta(data)
             if delta:
                 return _sanitize_text(delta)
+            if CodexCliChatAdapter._extract_metrics(data):
+                continue
             for key in ("message", "content", "text", "output"):
                 value = data.get(key) if isinstance(data, dict) else None
                 if (

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,7 +13,7 @@ import os
 import re
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
@@ -21,7 +21,7 @@ from src.codex_auth import get_codex_auth_service
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
-CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental, non-streaming)"
+CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental)"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
 
 _TOKEN_PATTERNS = (
@@ -30,7 +30,7 @@ _TOKEN_PATTERNS = (
 )
 
 _BASE_LIMITATIONS = [
-    "Non-streaming: returns one completed assistant message.",
+    "Normal chat integration is not implemented.",
     "Stateless: session/resume is not implemented.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
     "The adapter requires Codex CLI sandbox support and runs with read-only sandbox mode.",
@@ -38,6 +38,16 @@ _BASE_LIMITATIONS = [
 
 _APPROVAL_FLAGS = ("--ask-for-approval", "--approval-policy", "--approval")
 _DANGEROUS_FLAGS = ("--dangerously-bypass-approvals-and-sandbox", "--yolo")
+_SKIP_GIT_REPO_CHECK_FLAG = "--skip-git-repo-check"
+_JSON_OUTPUT_FLAG = "--json"
+_STREAM_TEXT_KEYS = ("delta", "text", "content", "message")
+_STREAM_NESTED_KEYS = ("event", "type", "item", "output", "data")
+_STREAM_METRIC_KEYS = ("metrics", "usage")
+_TRUST_DIRECTORY_PATTERNS = (
+    re.compile(r"not\s+(inside\s+)?(a\s+)?trusted\s+(directory|git\s+repository)", re.I),
+    re.compile(r"trust(ed)?\s+directory", re.I),
+    re.compile(r"--skip-git-repo-check", re.I),
+)
 
 
 def _truthy(value: str | None) -> bool:
@@ -48,11 +58,13 @@ def codex_model_provider_enabled() -> bool:
     return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
 
 
-def _sanitize_text(text: str | None, limit: int = 2000) -> str:
+def _sanitize_text(text: str | None, limit: int = 2000, *, strip: bool = True) -> str:
     safe = text or ""
     for pattern in _TOKEN_PATTERNS:
         safe = pattern.sub("<redacted-token>", safe)
-    return safe.strip()[:limit]
+    if strip:
+        safe = safe.strip()
+    return safe[:limit]
 
 
 @dataclass(frozen=True)
@@ -62,6 +74,7 @@ class CodexCliCapabilities:
     sandbox_flag: str | None
     sandbox_modes: tuple[str, ...] = ()
     approval_flag: str | None = None
+    skip_git_repo_check_flag: str | None = None
     supports_json: bool = False
     supports_model: bool = False
     resume_supported: bool = False
@@ -73,8 +86,20 @@ class CodexCliCapabilities:
     def ok(self) -> bool:
         return bool(self.sandbox_flag)
 
+    @property
+    def skip_git_repo_check_supported(self) -> bool:
+        return bool(self.skip_git_repo_check_flag)
+
+    @property
+    def streaming_supported(self) -> bool:
+        return self.ok and self.supports_json
+
     def limitations(self) -> list[str]:
         out = list(_BASE_LIMITATIONS)
+        if self.streaming_supported:
+            out.append("Experimental SSE test route can stream real Codex CLI JSON events.")
+        else:
+            out.append("Streaming is not available because Codex CLI JSON event output is not advertised.")
         if self.approval_flag:
             out.append(f"Approval prompts are suppressed with Codex CLI {self.approval_flag}.")
         else:
@@ -92,20 +117,29 @@ class CodexCliCapabilities:
             "sandbox_mode": "read-only",
             "approval_control_supported": bool(self.approval_flag),
             "approval_flag": self.approval_flag,
+            "skip_git_repo_check_supported": self.skip_git_repo_check_supported,
+            "skip_git_repo_check_flag": self.skip_git_repo_check_flag,
             "resume_supported": self.resume_supported,
             "resume_last_supported": self.resume_last_supported,
             "resume_session_id_supported": self.resume_session_id_supported,
             "json_output_supported": self.supports_json,
+            "streaming_supported": self.streaming_supported,
             "model_flag_supported": self.supports_model,
             "dangerous_flags_advertised": list(self.dangerous_flags),
         }
 
-    def build_exec_args(self, bin_path: str, prompt: str) -> list[str]:
+    def build_exec_args(self, bin_path: str, prompt: str, *, json_output: bool = False) -> list[str]:
         if not self.sandbox_flag:
             raise ValueError("Codex CLI sandbox support is required")
+        if json_output and not self.supports_json:
+            raise ValueError("Codex CLI JSON output support is required for streaming")
         args = [bin_path, "exec", self.sandbox_flag, "read-only"]
+        if self.skip_git_repo_check_flag:
+            args.append(self.skip_git_repo_check_flag)
         if self.approval_flag:
             args.extend([self.approval_flag, "never"])
+        if json_output:
+            args.append(_JSON_OUTPUT_FLAG)
         args.append(prompt)
         if any(flag in args for flag in _DANGEROUS_FLAGS):
             raise ValueError("Unsafe Codex CLI flag refused")
@@ -117,6 +151,12 @@ def _detect_sandbox_flag(help_text: str) -> str | None:
         return "--sandbox"
     if re.search(r"(^|\s)-s([,\s]|$)", help_text):
         return "-s"
+    return None
+
+
+def _detect_skip_git_repo_check_flag(help_text: str) -> str | None:
+    if _SKIP_GIT_REPO_CHECK_FLAG in help_text:
+        return _SKIP_GIT_REPO_CHECK_FLAG
     return None
 
 
@@ -141,7 +181,8 @@ def _detect_cli_capabilities_from_help(
             if mode in (exec_help or "")
         ),
         approval_flag=_detect_approval_flag(exec_help or ""),
-        supports_json="--json" in exec_help,
+        skip_git_repo_check_flag=_detect_skip_git_repo_check_flag(combined),
+        supports_json=_JSON_OUTPUT_FLAG in exec_help,
         supports_model="--model" in exec_help or " -m" in exec_help,
         resume_supported=bool(re.search(r"\bresume\b", resume_text)),
         resume_last_supported="--last" in resume_help,
@@ -181,7 +222,7 @@ class CodexCliChatAdapter:
             "ok": True,
             "status": "available",
             "chat_supported": True,
-            "streaming_supported": False,
+            "streaming_supported": capabilities.streaming_supported,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
             "supports_json": capabilities.supports_json,
@@ -222,12 +263,29 @@ class CodexCliChatAdapter:
                 cwd=workdir,
                 env=preflight["env"],
             )
+            if rc != 0 and _is_trust_directory_error(err or out) and not capabilities.skip_git_repo_check_supported:
+                capabilities = replace(capabilities, skip_git_repo_check_flag=_SKIP_GIT_REPO_CHECK_FLAG)
+                args = capabilities.build_exec_args(preflight["bin_path"], prompt)
+                rc, out, err = await self._run(
+                    args,
+                    timeout=timeout,
+                    cwd=workdir,
+                    env=preflight["env"],
+                )
 
         duration_ms = round((time.time() - started) * 1000)
         if rc == 124:
             return self._error("timeout", "Codex CLI timed out", duration_ms, model, capabilities)
         if rc != 0:
             detail = _sanitize_text(err or out, limit=500)
+            if _is_trust_directory_error(detail) and not capabilities.skip_git_repo_check_supported:
+                return self._error(
+                    "trusted_directory_required",
+                    "Codex CLI requires --skip-git-repo-check, but this CLI did not advertise that flag.",
+                    duration_ms,
+                    model,
+                    capabilities,
+                )
             return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model, capabilities)
 
         message = self._extract_message(out)
@@ -242,10 +300,57 @@ class CodexCliChatAdapter:
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
             "limitations": capabilities.limitations(),
             "cli_capabilities": capabilities.to_public_dict(),
-            "streaming_supported": False,
+            "streaming_supported": capabilities.streaming_supported,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
         }
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        odysseus_session_id: str | None = None,
+    ):
+        started = time.time()
+        availability = await self._available_internal()
+        if not availability.get("ok"):
+            yield self._stream_error_event(
+                self._public_result(availability),
+                started=started,
+                model=model,
+            )
+            return
+
+        preflight = availability["_preflight"]
+        capabilities = availability["_capabilities"]
+        if not capabilities.streaming_supported:
+            yield self._stream_error_event(
+                {
+                    "ok": False,
+                    "status": "streaming_not_supported",
+                    "error": "Codex CLI does not advertise JSON event output; use test-chat one-shot fallback.",
+                    "cli_capabilities": capabilities.to_public_dict(),
+                    "limitations": capabilities.limitations(),
+                },
+                started=started,
+                model=model,
+            )
+            return
+
+        prompt = self._build_prompt(messages)
+        timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
+        with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-stream-") as workdir:
+            args = capabilities.build_exec_args(preflight["bin_path"], prompt, json_output=True)
+            async for event in self._stream_exec(
+                args,
+                timeout=timeout,
+                cwd=workdir,
+                env=preflight["env"],
+                model=model,
+                capabilities=capabilities,
+            ):
+                yield event
 
     async def _preflight(self) -> dict[str, Any]:
         if not codex_model_provider_enabled():
@@ -319,6 +424,237 @@ class CodexCliChatAdapter:
     @staticmethod
     def _public_result(result: dict[str, Any]) -> dict[str, Any]:
         return {k: v for k, v in result.items() if not k.startswith("_")}
+
+    async def _stream_exec(
+        self,
+        args: list[str],
+        *,
+        timeout: int,
+        cwd: str,
+        env: dict[str, str],
+        model: str | None,
+        capabilities: CodexCliCapabilities,
+        allow_trust_retry: bool = True,
+    ):
+        started = time.time()
+        stdout_lines: list[str] = []
+        stderr_text = ""
+        response_parts: list[str] = []
+        emitted_delta = False
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+        except Exception as exc:
+            yield self._stream_error_event(
+                {
+                    "ok": False,
+                    "status": "cli_start_failed",
+                    "error": f"Failed to start Codex CLI: {exc.__class__.__name__}",
+                    "cli_capabilities": capabilities.to_public_dict(),
+                    "limitations": capabilities.limitations(),
+                },
+                started=started,
+                model=model,
+            )
+            return
+
+        async def read_stderr() -> str:
+            if not proc.stderr:
+                return ""
+            raw = await proc.stderr.read()
+            return (raw or b"").decode("utf-8", errors="replace")
+
+        stderr_task = asyncio.create_task(read_stderr())
+        try:
+            while True:
+                if not proc.stdout:
+                    break
+                line_bytes = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+                if not line_bytes:
+                    break
+                line = line_bytes.decode("utf-8", errors="replace")
+                stdout_lines.append(line)
+                for event in self._events_from_json_line(line):
+                    if event["type"] == "delta":
+                        emitted_delta = True
+                        response_parts.append(event["delta"])
+                    yield event
+            return_code = await asyncio.wait_for(proc.wait(), timeout=5)
+            stderr_text = await asyncio.wait_for(stderr_task, timeout=5)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            if not stderr_task.done():
+                stderr_task.cancel()
+            yield self._stream_error_event(
+                {
+                    "ok": False,
+                    "status": "timeout",
+                    "error": "Codex CLI timed out",
+                    "cli_capabilities": capabilities.to_public_dict(),
+                    "limitations": capabilities.limitations(),
+                },
+                started=started,
+                model=model,
+            )
+            return
+
+        if return_code != 0:
+            detail = _sanitize_text(stderr_text or "".join(stdout_lines), limit=500)
+            if _is_trust_directory_error(detail) and not capabilities.skip_git_repo_check_supported and allow_trust_retry:
+                retry_capabilities = replace(capabilities, skip_git_repo_check_flag=_SKIP_GIT_REPO_CHECK_FLAG)
+                retry_args = retry_capabilities.build_exec_args(args[0], args[-1], json_output=True)
+                async for event in self._stream_exec(
+                    retry_args,
+                    timeout=timeout,
+                    cwd=cwd,
+                    env=env,
+                    model=model,
+                    capabilities=retry_capabilities,
+                    allow_trust_retry=False,
+                ):
+                    yield event
+                return
+            status = "trusted_directory_required" if _is_trust_directory_error(detail) else "cli_failed"
+            yield self._stream_error_event(
+                {
+                    "ok": False,
+                    "status": status,
+                    "error": detail or "Codex CLI failed",
+                    "cli_capabilities": capabilities.to_public_dict(),
+                    "limitations": capabilities.limitations(),
+                },
+                started=started,
+                model=model,
+            )
+            return
+
+        full_response = "".join(response_parts)
+        if not emitted_delta:
+            full_response = self._extract_message("".join(stdout_lines))
+            if full_response:
+                yield {"type": "delta", "delta": full_response}
+        if not full_response:
+            yield self._stream_error_event(
+                {
+                    "ok": False,
+                    "status": "empty_response",
+                    "error": "Codex CLI returned no assistant message",
+                    "cli_capabilities": capabilities.to_public_dict(),
+                    "limitations": capabilities.limitations(),
+                },
+                started=started,
+                model=model,
+            )
+            return
+        yield {
+            "type": "done",
+            "message": full_response,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "duration_ms": round((time.time() - started) * 1000),
+        }
+
+    @classmethod
+    def _events_from_json_line(cls, line: str) -> list[dict[str, Any]]:
+        stripped = line.strip()
+        if stripped.startswith("data:"):
+            stripped = stripped[5:].strip()
+        if not stripped or stripped == "[DONE]" or not stripped.startswith("{"):
+            return []
+        try:
+            data = json.loads(stripped)
+        except Exception:
+            return []
+
+        events: list[dict[str, Any]] = []
+        metrics = cls._extract_metrics(data)
+        if metrics:
+            events.append({"type": "metrics", "data": metrics})
+        delta = cls._extract_delta(data)
+        if delta:
+            events.append({"type": "delta", "delta": _sanitize_text(delta, limit=2000, strip=False)})
+        return events
+
+    @classmethod
+    def _extract_delta(cls, value: Any, depth: int = 0) -> str:
+        if depth > 6:
+            return ""
+        if isinstance(value, str):
+            return value if depth > 0 else ""
+        if isinstance(value, list):
+            for item in value:
+                found = cls._extract_delta(item, depth + 1)
+                if found:
+                    return found
+            return ""
+        if not isinstance(value, dict):
+            return ""
+        for key in _STREAM_TEXT_KEYS:
+            text = value.get(key)
+            if isinstance(text, str) and text.strip():
+                return text
+        for key in _STREAM_NESTED_KEYS:
+            nested = value.get(key)
+            if isinstance(nested, (dict, list)):
+                found = cls._extract_delta(nested, depth + 1)
+                if found:
+                    return found
+        for nested in value.values():
+            found = cls._extract_delta(nested, depth + 1)
+            if found:
+                return found
+        return ""
+
+    @classmethod
+    def _extract_metrics(cls, value: Any, depth: int = 0) -> dict[str, Any]:
+        if depth > 4:
+            return {}
+        if isinstance(value, list):
+            for item in value:
+                found = cls._extract_metrics(item, depth + 1)
+                if found:
+                    return found
+            return {}
+        if not isinstance(value, dict):
+            return {}
+        event_type = str(value.get("type") or value.get("event") or "").lower()
+        if event_type in {"metrics", "metric", "usage"}:
+            return cls._sanitize_metrics(value)
+        for key in _STREAM_METRIC_KEYS:
+            metrics = value.get(key)
+            if isinstance(metrics, dict):
+                return cls._sanitize_metrics(metrics)
+        for key in _STREAM_NESTED_KEYS:
+            found = cls._extract_metrics(value.get(key), depth + 1)
+            if found:
+                return found
+        return {}
+
+    @staticmethod
+    def _sanitize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+        safe: dict[str, Any] = {}
+        for key, value in metrics.items():
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                safe[str(key)] = _sanitize_text(str(value), limit=200) if isinstance(value, str) else value
+        return safe
+
+    @staticmethod
+    def _stream_error_event(result: dict[str, Any], *, started: float, model: str | None) -> dict[str, Any]:
+        return {
+            "type": "error",
+            "status": result.get("status") or "error",
+            "error": _sanitize_text(result.get("error") or "Codex CLI streaming failed", limit=500),
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "duration_ms": round((time.time() - started) * 1000),
+            "cli_capabilities": result.get("cli_capabilities") or {},
+            "limitations": result.get("limitations") or list(_BASE_LIMITATIONS),
+        }
 
     async def _run(
         self,
@@ -486,13 +822,14 @@ class CodexModelProvider:
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
             else:
                 base["chat_supported"] = True
+                base["streaming_supported"] = bool(chat_available.get("streaming_supported"))
                 base["limitations"] = chat_available.get("limitations") or base["limitations"]
                 base["cli_capabilities"] = chat_available.get("cli_capabilities") or {}
                 models.append({
                     "id": CODEX_EXPERIMENTAL_MODEL_ID,
                     "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
                     "experimental": True,
-                    "streaming_supported": False,
+                    "streaming_supported": bool(chat_available.get("streaming_supported")),
                     "session_resume_supported": False,
                 })
 
@@ -524,3 +861,23 @@ class CodexModelProvider:
             timeout_seconds=timeout_seconds,
             odysseus_session_id=odysseus_session_id,
         )
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        odysseus_session_id: str | None = None,
+    ):
+        async for event in self._chat_adapter.stream_chat(
+            messages,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            odysseus_session_id=odysseus_session_id,
+        ):
+            yield event
+
+
+def _is_trust_directory_error(text: str | None) -> bool:
+    detail = text or ""
+    return any(pattern.search(detail) for pattern in _TRUST_DIRECTORY_PATTERNS)

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1,0 +1,113 @@
+"""Experimental Codex CLI model-provider capability boundary.
+
+This module does not implement chat dispatch. It reports whether a future
+Codex-backed provider can be exposed safely, without treating completed CLI
+output as token streaming or reading Codex credential files.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+from src.codex_auth import get_codex_auth_service
+
+
+CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
+CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def codex_model_provider_enabled() -> bool:
+    return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
+
+
+class CodexModelProvider:
+    """Status/capability adapter for a future Codex CLI provider."""
+
+    def __init__(self, auth_service_getter: Callable[[], Any] | None = None) -> None:
+        self._auth_service_getter = auth_service_getter or get_codex_auth_service
+
+    async def status(self) -> dict[str, Any]:
+        enabled = codex_model_provider_enabled()
+        base = {
+            "feature_enabled": enabled,
+            "feature_flag": CODEX_MODEL_PROVIDER_FLAG,
+            "provider": "codex_cli",
+            "experimental": True,
+            "models": [],
+            "chat_supported": False,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "limitations": [
+                "Chat dispatch is not implemented.",
+                "True token streaming has not been validated.",
+                "Session/resume behavior has not been designed.",
+                "Codex tool execution is not enabled for Odysseus chat mode.",
+            ],
+        }
+        if not enabled:
+            return {
+                **base,
+                "status": "disabled",
+                "cli_available": False,
+                "authenticated": False,
+                "requires_sign_in": False,
+            }
+
+        try:
+            auth = await self._auth_service_getter().status()
+        except Exception as exc:
+            return {
+                **base,
+                "status": "auth_status_failed",
+                "cli_available": False,
+                "authenticated": False,
+                "requires_sign_in": False,
+                "error": exc.__class__.__name__,
+            }
+
+        cli_available = bool(
+            auth.get("codex_cli_available")
+            or (auth.get("cli_found") and auth.get("cli_executable"))
+        )
+        authenticated = bool(auth.get("codex_authenticated") or auth.get("authenticated"))
+        auth_status = str(auth.get("status") or "")
+        auth_mode = str(auth.get("auth_mode") or "")
+
+        if not cli_available:
+            status = "cli_unavailable"
+            requires_sign_in = False
+        elif not authenticated:
+            status = "sign_in_required"
+            requires_sign_in = True
+        else:
+            status = "available"
+            requires_sign_in = False
+
+        models = []
+        if status == "available":
+            models.append({
+                "id": CODEX_EXPERIMENTAL_MODEL_ID,
+                "display": "codex-cli/chatgpt (experimental)",
+                "experimental": True,
+            })
+
+        return {
+            **base,
+            "status": status,
+            "cli_available": cli_available,
+            "authenticated": authenticated,
+            "requires_sign_in": requires_sign_in,
+            "sign_in_route": "/api/codex-auth/start",
+            "auth": {
+                "status": auth_status,
+                "auth_mode": auth_mode,
+                "codex_home": auth.get("codex_home", ""),
+            },
+            "models": models,
+        }

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1,8 +1,8 @@
 """Experimental Codex CLI model-provider capability boundary.
 
-This module does not implement chat dispatch. It reports whether a future
-Codex-backed provider can be exposed safely, without treating completed CLI
-output as token streaming or reading Codex credential files.
+This module implements the experimental Codex CLI provider boundary without
+reading Codex credential files or treating completed CLI output as token
+streaming. Normal API-provider behavior remains deliberately out of scope.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from src.codex_auth import get_codex_auth_service
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
 CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental)"
+CODEX_EXPERIMENTAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
 
 _TOKEN_PATTERNS = (
@@ -30,7 +31,7 @@ _TOKEN_PATTERNS = (
 )
 
 _BASE_LIMITATIONS = [
-    "Normal chat integration is not implemented.",
+    "Experimental chat picker integration only; not a normal API endpoint.",
     "Stateless: session/resume is not implemented.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
     "The adapter requires Codex CLI sandbox support and runs with read-only sandbox mode.",
@@ -43,6 +44,17 @@ _JSON_OUTPUT_FLAG = "--json"
 _STREAM_TEXT_KEYS = ("delta", "text", "content", "message")
 _STREAM_NESTED_KEYS = ("event", "type", "item", "output", "data")
 _STREAM_METRIC_KEYS = ("metrics", "usage")
+_LIFECYCLE_EVENT_NAMES = {
+    "started",
+    "completed",
+    "failed",
+    "thread.started",
+    "thread.completed",
+    "turn.started",
+    "turn.completed",
+    "turn.failed",
+}
+_LIFECYCLE_EVENT_SUFFIXES = (".started", ".completed", ".failed")
 _TRUST_DIRECTORY_PATTERNS = (
     re.compile(r"not\s+(inside\s+)?(a\s+)?trusted\s+(directory|git\s+repository)", re.I),
     re.compile(r"trust(ed)?\s+directory", re.I),
@@ -56,6 +68,35 @@ def _truthy(value: str | None) -> bool:
 
 def codex_model_provider_enabled() -> bool:
     return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
+
+
+def is_codex_model_selection(endpoint_url: str | None, model: str | None = None) -> bool:
+    return (endpoint_url or "").strip() == CODEX_EXPERIMENTAL_ENDPOINT_URL or (
+        (model or "").strip() == CODEX_EXPERIMENTAL_MODEL_ID
+    )
+
+
+def codex_model_list_item() -> dict[str, Any]:
+    return {
+        "host": "codex",
+        "port": 0,
+        "url": CODEX_EXPERIMENTAL_ENDPOINT_URL,
+        "models": [CODEX_EXPERIMENTAL_MODEL_ID],
+        "models_display": ["Codex / ChatGPT"],
+        "models_extra": [],
+        "models_extra_display": [],
+        "endpoint_id": None,
+        "endpoint_name": "Codex / ChatGPT",
+        "category": "api",
+        "model_type": "llm",
+        "experimental": True,
+        "provider": "codex_cli",
+    }
+
+
+def _looks_like_lifecycle_event_name(value: Any) -> bool:
+    text = str(value or "").strip().lower()
+    return bool(text) and (text in _LIFECYCLE_EVENT_NAMES or text.endswith(_LIFECYCLE_EVENT_SUFFIXES))
 
 
 def _sanitize_text(text: str | None, limit: int = 2000, *, strip: bool = True) -> str:
@@ -311,6 +352,7 @@ class CodexCliChatAdapter:
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
+        allow_one_shot_fallback: bool = False,
     ):
         started = time.time()
         availability = await self._available_internal()
@@ -325,6 +367,26 @@ class CodexCliChatAdapter:
         preflight = availability["_preflight"]
         capabilities = availability["_capabilities"]
         if not capabilities.streaming_supported:
+            if allow_one_shot_fallback:
+                result = await self.complete(
+                    messages,
+                    model=model,
+                    timeout_seconds=timeout_seconds,
+                    odysseus_session_id=odysseus_session_id,
+                )
+                if result.get("ok"):
+                    message = result.get("message") or ""
+                    if message:
+                        yield {"type": "delta", "delta": message}
+                    yield {
+                        "type": "done",
+                        "message": message,
+                        "model": result.get("model") or model or CODEX_EXPERIMENTAL_MODEL_ID,
+                        "duration_ms": result.get("duration_ms"),
+                    }
+                else:
+                    yield self._stream_error_event(result, started=started, model=model)
+                return
             yield self._stream_error_event(
                 {
                     "ok": False,
@@ -571,6 +633,8 @@ class CodexCliChatAdapter:
             data = json.loads(stripped)
         except Exception:
             return []
+        if cls._is_lifecycle_event(data):
+            return []
 
         events: list[dict[str, Any]] = []
         metrics = cls._extract_metrics(data)
@@ -582,11 +646,25 @@ class CodexCliChatAdapter:
         return events
 
     @classmethod
+    def _is_lifecycle_event(cls, value: Any) -> bool:
+        if isinstance(value, list):
+            return any(cls._is_lifecycle_event(item) for item in value)
+        if not isinstance(value, dict):
+            return _looks_like_lifecycle_event_name(value)
+        for key in ("type", "event"):
+            event_name = value.get(key)
+            if isinstance(event_name, str) and _looks_like_lifecycle_event_name(event_name):
+                return True
+        return False
+
+    @classmethod
     def _extract_delta(cls, value: Any, depth: int = 0) -> str:
         if depth > 6:
             return ""
         if isinstance(value, str):
-            return value if depth > 0 else ""
+            if depth > 0 and not _looks_like_lifecycle_event_name(value):
+                return value
+            return ""
         if isinstance(value, list):
             for item in value:
                 found = cls._extract_delta(item, depth + 1)
@@ -597,7 +675,7 @@ class CodexCliChatAdapter:
             return ""
         for key in _STREAM_TEXT_KEYS:
             text = value.get(key)
-            if isinstance(text, str) and text.strip():
+            if isinstance(text, str) and text.strip() and not _looks_like_lifecycle_event_name(text):
                 return text
         for key in _STREAM_NESTED_KEYS:
             nested = value.get(key)
@@ -605,7 +683,9 @@ class CodexCliChatAdapter:
                 found = cls._extract_delta(nested, depth + 1)
                 if found:
                     return found
-        for nested in value.values():
+        for key, nested in value.items():
+            if key in {"type", "event"} or not isinstance(nested, (dict, list)):
+                continue
             found = cls._extract_delta(nested, depth + 1)
             if found:
                 return found
@@ -714,18 +794,35 @@ class CodexCliChatAdapter:
         if not text:
             return ""
         # If a future CLI emits JSONL, prefer common completed-message fields.
+        parsed_json = False
+        non_json_lines: list[str] = []
         for line in text.splitlines():
             line = line.strip()
             if not line.startswith("{"):
+                if line:
+                    non_json_lines.append(line)
                 continue
             try:
                 data = json.loads(line)
             except Exception:
+                non_json_lines.append(line)
                 continue
+            parsed_json = True
+            if CodexCliChatAdapter._is_lifecycle_event(data):
+                continue
+            delta = CodexCliChatAdapter._extract_delta(data)
+            if delta:
+                return _sanitize_text(delta)
             for key in ("message", "content", "text", "output"):
                 value = data.get(key) if isinstance(data, dict) else None
-                if isinstance(value, str) and value.strip():
+                if (
+                    isinstance(value, str)
+                    and value.strip()
+                    and not _looks_like_lifecycle_event_name(value)
+                ):
                     return _sanitize_text(value)
+        if parsed_json:
+            return _sanitize_text("\n".join(non_json_lines))
         return text
 
     @staticmethod
@@ -868,14 +965,41 @@ class CodexModelProvider:
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
+        allow_one_shot_fallback: bool = False,
     ):
         async for event in self._chat_adapter.stream_chat(
             messages,
             model=model,
             timeout_seconds=timeout_seconds,
             odysseus_session_id=odysseus_session_id,
+            allow_one_shot_fallback=allow_one_shot_fallback,
         ):
             yield event
+
+
+def codex_model_list_item_if_available(provider: CodexModelProvider | None = None) -> dict[str, Any] | None:
+    """Return the synthetic picker item only when Codex is actually usable."""
+    if not codex_model_provider_enabled():
+        return None
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = False
+    else:
+        running_loop = True
+    if running_loop:
+        return None
+    try:
+        status = asyncio.run((provider or CodexModelProvider()).status())
+    except Exception:
+        return None
+    if (
+        status.get("status") == "available"
+        and status.get("chat_supported") is True
+        and status.get("models")
+    ):
+        return codex_model_list_item()
+    return None
 
 
 def _is_trust_directory_error(text: str | None) -> bool:

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,6 +13,7 @@ import os
 import re
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -34,7 +35,7 @@ _LIMITATIONS = [
     "Non-streaming: returns one completed assistant message.",
     "Session resume depends on the installed Codex CLI.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
-    "The adapter requires Codex CLI sandbox/approval flags before running.",
+    "The adapter requires Codex CLI read-only sandbox support before running.",
 ]
 
 _UNSAFE_FLAGS = (
@@ -64,12 +65,63 @@ def is_codex_virtual_endpoint(endpoint_url: str | None, model: str | None = None
     )
 
 
+@dataclass(frozen=True)
+class CodexCliCapabilities:
+    sandbox_flag: str = ""
+    sandbox_read_only_supported: bool = False
+    sandbox_modes_visible: bool = False
+    approval_flag: str = ""
+    approval_never_value: str = "never"
+    supports_json: bool = False
+    supports_model: bool = False
+    session_resume_supported: bool = False
+    resume_last_supported: bool = False
+    resume_session_id_supported: bool = False
+
+    @property
+    def sandbox_supported(self) -> bool:
+        return bool(self.sandbox_flag)
+
+    @property
+    def approval_control_supported(self) -> bool:
+        return bool(self.approval_flag)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sandbox_supported": self.sandbox_supported,
+            "sandbox_flag": self.sandbox_flag,
+            "sandbox_read_only_supported": self.sandbox_read_only_supported,
+            "sandbox_modes_visible": self.sandbox_modes_visible,
+            "approval_control_supported": self.approval_control_supported,
+            "approval_flag": self.approval_flag,
+            "supports_json": self.supports_json,
+            "supports_model": self.supports_model,
+            "session_resume_supported": self.session_resume_supported,
+            "resume_last_supported": self.resume_last_supported,
+            "resume_session_id_supported": self.resume_session_id_supported,
+        }
+
+
+def _limitations_for_capabilities(capabilities: CodexCliCapabilities | dict[str, Any] | None = None) -> list[str]:
+    limitations = list(_LIMITATIONS)
+    approval_supported = False
+    if isinstance(capabilities, CodexCliCapabilities):
+        approval_supported = capabilities.approval_control_supported
+    elif isinstance(capabilities, dict):
+        approval_supported = bool(capabilities.get("approval_control_supported"))
+    if capabilities is not None and not approval_supported:
+        limitations.append(
+            "This Codex CLI does not expose an approval-control flag; Odysseus relies on read-only sandbox mode."
+        )
+    return limitations
+
+
 class CodexCliChatAdapter:
     """Admin-only, non-streaming adapter boundary for `codex exec`.
 
     This intentionally does not provide a normal chat-provider hook yet. It
-    refuses to run unless the installed CLI advertises the sandbox and approval
-    flags needed for a constrained one-shot completion probe.
+    refuses to run unless the installed CLI advertises read-only sandbox support
+    for a constrained one-shot completion probe.
     """
 
     def __init__(
@@ -88,18 +140,22 @@ class CodexCliChatAdapter:
         preflight = await self._preflight()
         if not preflight.get("ok"):
             return preflight
-        help_result = await self._exec_help(preflight["bin_path"], preflight["env"])
-        if not help_result.get("ok"):
-            return help_result
+        capabilities_result = await self._detect_cli_capabilities(preflight["bin_path"], preflight["env"])
+        if not capabilities_result.get("ok"):
+            return capabilities_result
+        capabilities = capabilities_result["capabilities"]
         return {
             "ok": True,
             "status": "available",
             "chat_supported": True,
             "streaming_supported": False,
-            "session_resume_supported": bool(help_result.get("session_resume_supported", False)),
+            "session_resume_supported": capabilities.session_resume_supported,
             "tool_execution_allowed": False,
-            "supports_json": help_result.get("supports_json", False),
-            "limitations": list(_LIMITATIONS),
+            "supports_json": capabilities.supports_json,
+            "supports_model": capabilities.supports_model,
+            "approval_control_supported": capabilities.approval_control_supported,
+            "capabilities": capabilities.as_dict(),
+            "limitations": _limitations_for_capabilities(capabilities),
         }
 
     async def complete(
@@ -128,7 +184,7 @@ class CodexCliChatAdapter:
             preflight["bin_path"],
             prompt,
             odysseus_session_key=session_key,
-            resume_supported=resume_supported,
+            capabilities=availability.get("capabilities") or {},
         )
         workdir = self._ensure_workdir_for_session(session_key)
         rc, out, err = await self._run(
@@ -163,7 +219,7 @@ class CodexCliChatAdapter:
             "message": message,
             "duration_ms": duration_ms,
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
-            "limitations": list(_LIMITATIONS),
+            "limitations": _limitations_for_capabilities(availability.get("capabilities")),
             "streaming_supported": False,
             "session_resume_supported": resume_supported,
             "session_resumed": resume_mode != "new",
@@ -216,42 +272,106 @@ class CodexCliChatAdapter:
 
         return {"ok": True, "status": "preflight_ok", "bin_path": bin_path, "env": env}
 
-    async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
+    async def _detect_cli_capabilities(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
         rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
-        top_rc, top_out, top_err = 1, "", ""
-        if rc != 0 or "--sandbox" not in (out or "") or "--ask-for-approval" not in (out or ""):
-            top_rc, top_out, top_err = await self._run([bin_path, "--help"], timeout=20, env=env)
-        help_text = "\n".join([out or "", top_out or ""])
+        top_rc, top_out, top_err = await self._run([bin_path, "--help"], timeout=20, env=env)
         if rc != 0 and top_rc != 0:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
-                "error": "Unable to inspect codex exec safety flags",
+                "error": "Unable to inspect Codex CLI safety capabilities",
                 "detail": _sanitize_text(err or out or top_err or top_out, limit=500),
             }
-        missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
-        if missing:
+        help_text = "\n".join([out or "", err or "", top_out or "", top_err or ""])
+        resume = await self._detect_resume_support(bin_path, env, help_text)
+        capabilities = self._parse_cli_capabilities(help_text, resume)
+        if not capabilities.sandbox_supported or not capabilities.sandbox_read_only_supported:
+            missing = []
+            if not capabilities.sandbox_supported:
+                missing.append("--sandbox/-s")
+            if capabilities.sandbox_supported and not capabilities.sandbox_read_only_supported:
+                missing.append("read-only sandbox mode")
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
-                "error": "Codex CLI does not advertise required safety flags",
+                "error": "Codex CLI does not advertise required read-only sandbox support",
                 "missing_flags": missing,
+                "capabilities": capabilities.as_dict(),
             }
-        resume_supported = await self._detect_resume_support(bin_path, env, help_text)
         return {
             "ok": True,
-            "status": "exec_help_ok",
-            "supports_json": "--json" in help_text,
-            "supports_model": "--model" in help_text or " -m" in help_text,
-            "session_resume_supported": resume_supported,
+            "status": "capabilities_ok",
+            "capabilities": capabilities,
         }
 
-    async def _detect_resume_support(self, bin_path: str, env: dict[str, str], help_text: str) -> bool:
+    async def _detect_resume_support(self, bin_path: str, env: dict[str, str], help_text: str) -> dict[str, bool]:
         rc, out, err = await self._run([bin_path, "exec", "resume", "--help"], timeout=20, env=env)
         text = "\n".join([help_text or "", out or "", err or ""]).lower()
-        if rc == 0 and "resume" in text:
-            return True
-        return bool(re.search(r"\bresume\b", text) and "exec" in text)
+        resume_supported = bool((rc == 0 and "resume" in text) or (re.search(r"\bresume\b", text) and "exec" in text))
+        resume_last_supported = bool(re.search(r"(?<!\w)--last\b", text))
+        resume_session_id_supported = bool(
+            re.search(r"<\s*(session|conversation)[_-]?id\s*>", text, re.IGNORECASE)
+            or re.search(r"\[\s*(session|conversation)[_-]?id\s*\]", text, re.IGNORECASE)
+            or re.search(r"\b(session|conversation)[_-]?id\b", text, re.IGNORECASE)
+        )
+        return {
+            "session_resume_supported": resume_supported and (resume_last_supported or resume_session_id_supported),
+            "resume_last_supported": resume_last_supported,
+            "resume_session_id_supported": resume_session_id_supported,
+        }
+
+    @staticmethod
+    def _parse_cli_capabilities(help_text: str, resume: dict[str, bool]) -> CodexCliCapabilities:
+        text = help_text or ""
+        lower = text.lower()
+        sandbox_flag = ""
+        if "--sandbox" in text:
+            sandbox_flag = "--sandbox"
+        elif re.search(r"(^|[\s,])-s([,\s]|$)", text):
+            sandbox_flag = "-s"
+
+        sandbox_modes_visible = bool(
+            "read-only" in lower
+            or "read only" in lower
+            or "workspace-write" in lower
+            or "danger-full-access" in lower
+            or "sandbox_mode" in lower
+        )
+        sandbox_read_only_supported = bool(sandbox_flag and ("read-only" in lower or "read only" in lower))
+        if sandbox_flag and not sandbox_modes_visible:
+            # Older/current help can show only "--sandbox <SANDBOX_MODE>". The
+            # CLI will reject an unknown mode, so keeping read-only here is a
+            # fail-closed probe while still supporting terse help output.
+            sandbox_read_only_supported = True
+
+        approval_flag = ""
+        approval_candidates = (
+            "--ask-for-approval",
+            "--approval-policy",
+            "--approval",
+            "--approval-mode",
+            "--approval_policy",
+        )
+        for candidate in approval_candidates:
+            if candidate in text:
+                approval_flag = candidate
+                break
+        if not approval_flag:
+            match = re.search(r"--[A-Za-z0-9][A-Za-z0-9_-]*approval[A-Za-z0-9_-]*", text)
+            if match and match.group(0) not in _UNSAFE_FLAGS:
+                approval_flag = match.group(0)
+
+        return CodexCliCapabilities(
+            sandbox_flag=sandbox_flag,
+            sandbox_read_only_supported=sandbox_read_only_supported,
+            sandbox_modes_visible=sandbox_modes_visible,
+            approval_flag=approval_flag,
+            supports_json=bool("--json" in text or "--output-format" in text),
+            supports_model=bool("--model" in text or re.search(r"(^|[\s,])-m([,\s]|$)", text)),
+            session_resume_supported=bool(resume.get("session_resume_supported")),
+            resume_last_supported=bool(resume.get("resume_last_supported")),
+            resume_session_id_supported=bool(resume.get("resume_session_id_supported")),
+        )
 
     def _build_exec_args(
         self,
@@ -259,26 +379,52 @@ class CodexCliChatAdapter:
         prompt: str,
         *,
         odysseus_session_key: str,
-        resume_supported: bool,
+        capabilities: CodexCliCapabilities | dict[str, Any],
     ) -> tuple[list[str], str]:
-        safety = ["--sandbox", "read-only", "--ask-for-approval", "never"]
+        caps = self._coerce_capabilities(capabilities)
+        safety = self._safety_args(caps)
         args = [bin_path, "exec"]
         resume_mode = "new"
-        if resume_supported and odysseus_session_key:
+        if caps.session_resume_supported and odysseus_session_key:
             mapped = self._session_map.get(odysseus_session_key) or {}
             codex_session_id = str(mapped.get("codex_session_id") or "").strip()
-            if codex_session_id:
+            if codex_session_id and caps.resume_session_id_supported:
                 args.extend(["resume", codex_session_id])
                 resume_mode = "session_id"
             else:
                 mapped_workdir_raw = str(mapped.get("workdir") or "")
                 can_resume_last = bool(mapped_workdir_raw and Path(mapped_workdir_raw).exists())
-                if can_resume_last:
+                if can_resume_last and caps.resume_last_supported:
                     args.extend(["resume", "--last"])
                     resume_mode = "last_in_workdir"
         args.extend([*safety, prompt])
         self._assert_safe_args(args)
         return args, resume_mode
+
+    @staticmethod
+    def _coerce_capabilities(capabilities: CodexCliCapabilities | dict[str, Any]) -> CodexCliCapabilities:
+        if isinstance(capabilities, CodexCliCapabilities):
+            return capabilities
+        return CodexCliCapabilities(
+            sandbox_flag=str(capabilities.get("sandbox_flag") or ""),
+            sandbox_read_only_supported=bool(capabilities.get("sandbox_read_only_supported")),
+            sandbox_modes_visible=bool(capabilities.get("sandbox_modes_visible")),
+            approval_flag=str(capabilities.get("approval_flag") or ""),
+            supports_json=bool(capabilities.get("supports_json")),
+            supports_model=bool(capabilities.get("supports_model")),
+            session_resume_supported=bool(capabilities.get("session_resume_supported")),
+            resume_last_supported=bool(capabilities.get("resume_last_supported")),
+            resume_session_id_supported=bool(capabilities.get("resume_session_id_supported")),
+        )
+
+    @staticmethod
+    def _safety_args(capabilities: CodexCliCapabilities) -> list[str]:
+        if not capabilities.sandbox_supported or not capabilities.sandbox_read_only_supported:
+            raise ValueError("Codex provider requires read-only sandbox support")
+        args = [capabilities.sandbox_flag, "read-only"]
+        if capabilities.approval_control_supported:
+            args.extend([capabilities.approval_flag, capabilities.approval_never_value])
+        return args
 
     def _assert_safe_args(self, args: list[str]) -> None:
         if "exec" not in args:
@@ -286,10 +432,8 @@ class CodexCliChatAdapter:
         for unsafe in _UNSAFE_FLAGS:
             if unsafe in args:
                 raise ValueError("Unsafe Codex CLI flag blocked")
-        if "--sandbox" not in args or "read-only" not in args:
+        if ("--sandbox" not in args and "-s" not in args) or "read-only" not in args:
             raise ValueError("Codex provider requires read-only sandbox")
-        if "--ask-for-approval" not in args or "never" not in args:
-            raise ValueError("Codex provider requires approvals disabled")
         if CODEX_EXPERIMENTAL_MODEL_ID in args:
             raise ValueError("Internal Codex model id must not be passed to Codex CLI")
 
@@ -482,13 +626,22 @@ class CodexModelProvider:
 
         models = []
         chat_available = {"ok": False}
+        availability_details: dict[str, Any] = {}
         if status == "available":
             chat_available = await self._chat_adapter.available()
             if not chat_available.get("ok"):
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
+                for key in ("error", "missing_flags", "capabilities"):
+                    if key in chat_available:
+                        availability_details[key] = chat_available[key]
             else:
                 base["chat_supported"] = True
                 base["session_resume_supported"] = bool(chat_available.get("session_resume_supported", False))
+                base["limitations"] = chat_available.get("limitations") or base["limitations"]
+                availability_details["capabilities"] = chat_available.get("capabilities", {})
+                availability_details["approval_control_supported"] = bool(
+                    chat_available.get("approval_control_supported", False)
+                )
                 models.append({
                     "id": CODEX_EXPERIMENTAL_MODEL_ID,
                     "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
@@ -510,6 +663,7 @@ class CodexModelProvider:
                 "codex_home": auth.get("codex_home", ""),
             },
             "models": models,
+            **availability_details,
         }
 
     async def test_chat(

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,7 +13,6 @@ import os
 import re
 import tempfile
 import time
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -35,7 +34,7 @@ _LIMITATIONS = [
     "Non-streaming: returns one completed assistant message.",
     "Session resume depends on the installed Codex CLI.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
-    "The adapter requires Codex CLI read-only sandbox support before running.",
+    "The adapter requires Codex CLI sandbox/approval flags before running.",
 ]
 
 _UNSAFE_FLAGS = (
@@ -65,63 +64,12 @@ def is_codex_virtual_endpoint(endpoint_url: str | None, model: str | None = None
     )
 
 
-@dataclass(frozen=True)
-class CodexCliCapabilities:
-    sandbox_flag: str = ""
-    sandbox_read_only_supported: bool = False
-    sandbox_modes_visible: bool = False
-    approval_flag: str = ""
-    approval_never_value: str = "never"
-    supports_json: bool = False
-    supports_model: bool = False
-    session_resume_supported: bool = False
-    resume_last_supported: bool = False
-    resume_session_id_supported: bool = False
-
-    @property
-    def sandbox_supported(self) -> bool:
-        return bool(self.sandbox_flag)
-
-    @property
-    def approval_control_supported(self) -> bool:
-        return bool(self.approval_flag)
-
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "sandbox_supported": self.sandbox_supported,
-            "sandbox_flag": self.sandbox_flag,
-            "sandbox_read_only_supported": self.sandbox_read_only_supported,
-            "sandbox_modes_visible": self.sandbox_modes_visible,
-            "approval_control_supported": self.approval_control_supported,
-            "approval_flag": self.approval_flag,
-            "supports_json": self.supports_json,
-            "supports_model": self.supports_model,
-            "session_resume_supported": self.session_resume_supported,
-            "resume_last_supported": self.resume_last_supported,
-            "resume_session_id_supported": self.resume_session_id_supported,
-        }
-
-
-def _limitations_for_capabilities(capabilities: CodexCliCapabilities | dict[str, Any] | None = None) -> list[str]:
-    limitations = list(_LIMITATIONS)
-    approval_supported = False
-    if isinstance(capabilities, CodexCliCapabilities):
-        approval_supported = capabilities.approval_control_supported
-    elif isinstance(capabilities, dict):
-        approval_supported = bool(capabilities.get("approval_control_supported"))
-    if capabilities is not None and not approval_supported:
-        limitations.append(
-            "This Codex CLI does not expose an approval-control flag; Odysseus relies on read-only sandbox mode."
-        )
-    return limitations
-
-
 class CodexCliChatAdapter:
     """Admin-only, non-streaming adapter boundary for `codex exec`.
 
     This intentionally does not provide a normal chat-provider hook yet. It
-    refuses to run unless the installed CLI advertises read-only sandbox support
-    for a constrained one-shot completion probe.
+    refuses to run unless the installed CLI advertises the sandbox and approval
+    flags needed for a constrained one-shot completion probe.
     """
 
     def __init__(
@@ -140,22 +88,18 @@ class CodexCliChatAdapter:
         preflight = await self._preflight()
         if not preflight.get("ok"):
             return preflight
-        capabilities_result = await self._detect_cli_capabilities(preflight["bin_path"], preflight["env"])
-        if not capabilities_result.get("ok"):
-            return capabilities_result
-        capabilities = capabilities_result["capabilities"]
+        help_result = await self._exec_help(preflight["bin_path"], preflight["env"])
+        if not help_result.get("ok"):
+            return help_result
         return {
             "ok": True,
             "status": "available",
             "chat_supported": True,
             "streaming_supported": False,
-            "session_resume_supported": capabilities.session_resume_supported,
+            "session_resume_supported": bool(help_result.get("session_resume_supported", False)),
             "tool_execution_allowed": False,
-            "supports_json": capabilities.supports_json,
-            "supports_model": capabilities.supports_model,
-            "approval_control_supported": capabilities.approval_control_supported,
-            "capabilities": capabilities.as_dict(),
-            "limitations": _limitations_for_capabilities(capabilities),
+            "supports_json": help_result.get("supports_json", False),
+            "limitations": list(_LIMITATIONS),
         }
 
     async def complete(
@@ -184,7 +128,7 @@ class CodexCliChatAdapter:
             preflight["bin_path"],
             prompt,
             odysseus_session_key=session_key,
-            capabilities=availability.get("capabilities") or {},
+            resume_supported=resume_supported,
         )
         workdir = self._ensure_workdir_for_session(session_key)
         rc, out, err = await self._run(
@@ -219,7 +163,7 @@ class CodexCliChatAdapter:
             "message": message,
             "duration_ms": duration_ms,
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
-            "limitations": _limitations_for_capabilities(availability.get("capabilities")),
+            "limitations": list(_LIMITATIONS),
             "streaming_supported": False,
             "session_resume_supported": resume_supported,
             "session_resumed": resume_mode != "new",
@@ -272,106 +216,42 @@ class CodexCliChatAdapter:
 
         return {"ok": True, "status": "preflight_ok", "bin_path": bin_path, "env": env}
 
-    async def _detect_cli_capabilities(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
+    async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
         rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
-        top_rc, top_out, top_err = await self._run([bin_path, "--help"], timeout=20, env=env)
+        top_rc, top_out, top_err = 1, "", ""
+        if rc != 0 or "--sandbox" not in (out or "") or "--ask-for-approval" not in (out or ""):
+            top_rc, top_out, top_err = await self._run([bin_path, "--help"], timeout=20, env=env)
+        help_text = "\n".join([out or "", top_out or ""])
         if rc != 0 and top_rc != 0:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
-                "error": "Unable to inspect Codex CLI safety capabilities",
+                "error": "Unable to inspect codex exec safety flags",
                 "detail": _sanitize_text(err or out or top_err or top_out, limit=500),
             }
-        help_text = "\n".join([out or "", err or "", top_out or "", top_err or ""])
-        resume = await self._detect_resume_support(bin_path, env, help_text)
-        capabilities = self._parse_cli_capabilities(help_text, resume)
-        if not capabilities.sandbox_supported or not capabilities.sandbox_read_only_supported:
-            missing = []
-            if not capabilities.sandbox_supported:
-                missing.append("--sandbox/-s")
-            if capabilities.sandbox_supported and not capabilities.sandbox_read_only_supported:
-                missing.append("read-only sandbox mode")
+        missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
+        if missing:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
-                "error": "Codex CLI does not advertise required read-only sandbox support",
+                "error": "Codex CLI does not advertise required safety flags",
                 "missing_flags": missing,
-                "capabilities": capabilities.as_dict(),
             }
+        resume_supported = await self._detect_resume_support(bin_path, env, help_text)
         return {
             "ok": True,
-            "status": "capabilities_ok",
-            "capabilities": capabilities,
+            "status": "exec_help_ok",
+            "supports_json": "--json" in help_text,
+            "supports_model": "--model" in help_text or " -m" in help_text,
+            "session_resume_supported": resume_supported,
         }
 
-    async def _detect_resume_support(self, bin_path: str, env: dict[str, str], help_text: str) -> dict[str, bool]:
+    async def _detect_resume_support(self, bin_path: str, env: dict[str, str], help_text: str) -> bool:
         rc, out, err = await self._run([bin_path, "exec", "resume", "--help"], timeout=20, env=env)
         text = "\n".join([help_text or "", out or "", err or ""]).lower()
-        resume_supported = bool((rc == 0 and "resume" in text) or (re.search(r"\bresume\b", text) and "exec" in text))
-        resume_last_supported = bool(re.search(r"(?<!\w)--last\b", text))
-        resume_session_id_supported = bool(
-            re.search(r"<\s*(session|conversation)[_-]?id\s*>", text, re.IGNORECASE)
-            or re.search(r"\[\s*(session|conversation)[_-]?id\s*\]", text, re.IGNORECASE)
-            or re.search(r"\b(session|conversation)[_-]?id\b", text, re.IGNORECASE)
-        )
-        return {
-            "session_resume_supported": resume_supported and (resume_last_supported or resume_session_id_supported),
-            "resume_last_supported": resume_last_supported,
-            "resume_session_id_supported": resume_session_id_supported,
-        }
-
-    @staticmethod
-    def _parse_cli_capabilities(help_text: str, resume: dict[str, bool]) -> CodexCliCapabilities:
-        text = help_text or ""
-        lower = text.lower()
-        sandbox_flag = ""
-        if "--sandbox" in text:
-            sandbox_flag = "--sandbox"
-        elif re.search(r"(^|[\s,])-s([,\s]|$)", text):
-            sandbox_flag = "-s"
-
-        sandbox_modes_visible = bool(
-            "read-only" in lower
-            or "read only" in lower
-            or "workspace-write" in lower
-            or "danger-full-access" in lower
-            or "sandbox_mode" in lower
-        )
-        sandbox_read_only_supported = bool(sandbox_flag and ("read-only" in lower or "read only" in lower))
-        if sandbox_flag and not sandbox_modes_visible:
-            # Older/current help can show only "--sandbox <SANDBOX_MODE>". The
-            # CLI will reject an unknown mode, so keeping read-only here is a
-            # fail-closed probe while still supporting terse help output.
-            sandbox_read_only_supported = True
-
-        approval_flag = ""
-        approval_candidates = (
-            "--ask-for-approval",
-            "--approval-policy",
-            "--approval",
-            "--approval-mode",
-            "--approval_policy",
-        )
-        for candidate in approval_candidates:
-            if candidate in text:
-                approval_flag = candidate
-                break
-        if not approval_flag:
-            match = re.search(r"--[A-Za-z0-9][A-Za-z0-9_-]*approval[A-Za-z0-9_-]*", text)
-            if match and match.group(0) not in _UNSAFE_FLAGS:
-                approval_flag = match.group(0)
-
-        return CodexCliCapabilities(
-            sandbox_flag=sandbox_flag,
-            sandbox_read_only_supported=sandbox_read_only_supported,
-            sandbox_modes_visible=sandbox_modes_visible,
-            approval_flag=approval_flag,
-            supports_json=bool("--json" in text or "--output-format" in text),
-            supports_model=bool("--model" in text or re.search(r"(^|[\s,])-m([,\s]|$)", text)),
-            session_resume_supported=bool(resume.get("session_resume_supported")),
-            resume_last_supported=bool(resume.get("resume_last_supported")),
-            resume_session_id_supported=bool(resume.get("resume_session_id_supported")),
-        )
+        if rc == 0 and "resume" in text:
+            return True
+        return bool(re.search(r"\bresume\b", text) and "exec" in text)
 
     def _build_exec_args(
         self,
@@ -379,52 +259,26 @@ class CodexCliChatAdapter:
         prompt: str,
         *,
         odysseus_session_key: str,
-        capabilities: CodexCliCapabilities | dict[str, Any],
+        resume_supported: bool,
     ) -> tuple[list[str], str]:
-        caps = self._coerce_capabilities(capabilities)
-        safety = self._safety_args(caps)
+        safety = ["--sandbox", "read-only", "--ask-for-approval", "never"]
         args = [bin_path, "exec"]
         resume_mode = "new"
-        if caps.session_resume_supported and odysseus_session_key:
+        if resume_supported and odysseus_session_key:
             mapped = self._session_map.get(odysseus_session_key) or {}
             codex_session_id = str(mapped.get("codex_session_id") or "").strip()
-            if codex_session_id and caps.resume_session_id_supported:
+            if codex_session_id:
                 args.extend(["resume", codex_session_id])
                 resume_mode = "session_id"
             else:
                 mapped_workdir_raw = str(mapped.get("workdir") or "")
                 can_resume_last = bool(mapped_workdir_raw and Path(mapped_workdir_raw).exists())
-                if can_resume_last and caps.resume_last_supported:
+                if can_resume_last:
                     args.extend(["resume", "--last"])
                     resume_mode = "last_in_workdir"
         args.extend([*safety, prompt])
         self._assert_safe_args(args)
         return args, resume_mode
-
-    @staticmethod
-    def _coerce_capabilities(capabilities: CodexCliCapabilities | dict[str, Any]) -> CodexCliCapabilities:
-        if isinstance(capabilities, CodexCliCapabilities):
-            return capabilities
-        return CodexCliCapabilities(
-            sandbox_flag=str(capabilities.get("sandbox_flag") or ""),
-            sandbox_read_only_supported=bool(capabilities.get("sandbox_read_only_supported")),
-            sandbox_modes_visible=bool(capabilities.get("sandbox_modes_visible")),
-            approval_flag=str(capabilities.get("approval_flag") or ""),
-            supports_json=bool(capabilities.get("supports_json")),
-            supports_model=bool(capabilities.get("supports_model")),
-            session_resume_supported=bool(capabilities.get("session_resume_supported")),
-            resume_last_supported=bool(capabilities.get("resume_last_supported")),
-            resume_session_id_supported=bool(capabilities.get("resume_session_id_supported")),
-        )
-
-    @staticmethod
-    def _safety_args(capabilities: CodexCliCapabilities) -> list[str]:
-        if not capabilities.sandbox_supported or not capabilities.sandbox_read_only_supported:
-            raise ValueError("Codex provider requires read-only sandbox support")
-        args = [capabilities.sandbox_flag, "read-only"]
-        if capabilities.approval_control_supported:
-            args.extend([capabilities.approval_flag, capabilities.approval_never_value])
-        return args
 
     def _assert_safe_args(self, args: list[str]) -> None:
         if "exec" not in args:
@@ -432,8 +286,10 @@ class CodexCliChatAdapter:
         for unsafe in _UNSAFE_FLAGS:
             if unsafe in args:
                 raise ValueError("Unsafe Codex CLI flag blocked")
-        if ("--sandbox" not in args and "-s" not in args) or "read-only" not in args:
+        if "--sandbox" not in args or "read-only" not in args:
             raise ValueError("Codex provider requires read-only sandbox")
+        if "--ask-for-approval" not in args or "never" not in args:
+            raise ValueError("Codex provider requires approvals disabled")
         if CODEX_EXPERIMENTAL_MODEL_ID in args:
             raise ValueError("Internal Codex model id must not be passed to Codex CLI")
 
@@ -626,22 +482,13 @@ class CodexModelProvider:
 
         models = []
         chat_available = {"ok": False}
-        availability_details: dict[str, Any] = {}
         if status == "available":
             chat_available = await self._chat_adapter.available()
             if not chat_available.get("ok"):
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
-                for key in ("error", "missing_flags", "capabilities"):
-                    if key in chat_available:
-                        availability_details[key] = chat_available[key]
             else:
                 base["chat_supported"] = True
                 base["session_resume_supported"] = bool(chat_available.get("session_resume_supported", False))
-                base["limitations"] = chat_available.get("limitations") or base["limitations"]
-                availability_details["capabilities"] = chat_available.get("capabilities", {})
-                availability_details["approval_control_supported"] = bool(
-                    chat_available.get("approval_control_supported", False)
-                )
                 models.append({
                     "id": CODEX_EXPERIMENTAL_MODEL_ID,
                     "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
@@ -663,7 +510,6 @@ class CodexModelProvider:
                 "codex_home": auth.get("codex_home", ""),
             },
             "models": models,
-            **availability_details,
         }
 
     async def test_chat(

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
+from src.settings import load_settings, save_settings
 
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
@@ -24,6 +25,7 @@ CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
 CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental)"
 CODEX_EXPERIMENTAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
+CODEX_SETTINGS_KEY = "codex_model_provider"
 
 _TOKEN_PATTERNS = (
     re.compile(r"(?i)(access_token|refresh_token|id_token)\s*[:=]\s*['\"]?[^'\"\s,}]+"),
@@ -41,6 +43,9 @@ _APPROVAL_FLAGS = ("--ask-for-approval", "--approval-policy", "--approval")
 _DANGEROUS_FLAGS = ("--dangerously-bypass-approvals-and-sandbox", "--yolo")
 _SKIP_GIT_REPO_CHECK_FLAG = "--skip-git-repo-check"
 _JSON_OUTPUT_FLAG = "--json"
+_MODEL_FLAGS = ("--model", "-m")
+_REASONING_FLAGS = ("--reasoning-effort", "--effort", "--thinking", "--thinking-level")
+_REASONING_LEVELS = ("low", "medium", "high", "maximum")
 _STREAM_CONTAINER_KEYS = ("message", "item", "data", "response")
 _STREAM_NESTED_KEYS = (*_STREAM_CONTAINER_KEYS, "output")
 _STREAM_METRIC_KEYS = ("metrics", "usage")
@@ -71,18 +76,117 @@ def codex_model_provider_enabled() -> bool:
 
 
 def is_codex_model_selection(endpoint_url: str | None, model: str | None = None) -> bool:
-    return (endpoint_url or "").strip() == CODEX_EXPERIMENTAL_ENDPOINT_URL or (
-        (model or "").strip() == CODEX_EXPERIMENTAL_MODEL_ID
-    )
+    return (endpoint_url or "").strip() == CODEX_EXPERIMENTAL_ENDPOINT_URL
 
 
-def codex_model_list_item() -> dict[str, Any]:
+def _sanitize_model_id(model_id: Any) -> str:
+    text = str(model_id or "").strip()
+    if not text or len(text) > 160:
+        return ""
+    if any(ch.isspace() for ch in text):
+        return ""
+    if any(ord(ch) < 32 for ch in text):
+        return ""
+    return text
+
+
+def _unique_model_ids(values: Any) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        model_id = _sanitize_model_id(value)
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            out.append(model_id)
+    return out
+
+
+def load_codex_model_config() -> dict[str, Any]:
+    cfg = load_settings().get(CODEX_SETTINGS_KEY) or {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    task_defaults = cfg.get("task_defaults") or {}
+    if not isinstance(task_defaults, dict):
+        task_defaults = {}
+    return {
+        "manual_models": _unique_model_ids(cfg.get("manual_models")),
+        "hidden_models": _unique_model_ids(cfg.get("hidden_models")),
+        "disabled_models": _unique_model_ids(cfg.get("disabled_models")),
+        "task_defaults": task_defaults,
+    }
+
+
+def save_codex_model_config(config: dict[str, Any]) -> dict[str, Any]:
+    clean = {
+        "manual_models": _unique_model_ids(config.get("manual_models")),
+        "hidden_models": _unique_model_ids(config.get("hidden_models")),
+        "disabled_models": _unique_model_ids(config.get("disabled_models")),
+        "task_defaults": config.get("task_defaults") if isinstance(config.get("task_defaults"), dict) else {},
+    }
+    settings = load_settings()
+    settings[CODEX_SETTINGS_KEY] = clean
+    save_settings(settings)
+    return clean
+
+
+def update_codex_model_config(
+    *,
+    add_model: str | None = None,
+    hide_model: str | None = None,
+    restore_model: str | None = None,
+    enable_model: str | None = None,
+    disable_model: str | None = None,
+) -> dict[str, Any]:
+    cfg = load_codex_model_config()
+    manual = set(cfg["manual_models"])
+    hidden = set(cfg["hidden_models"])
+    disabled = set(cfg["disabled_models"])
+
+    model_id = _sanitize_model_id(add_model)
+    if model_id:
+        manual.add(model_id)
+        hidden.discard(model_id)
+        disabled.discard(model_id)
+
+    model_id = _sanitize_model_id(hide_model)
+    if model_id:
+        hidden.add(model_id)
+        disabled.discard(model_id)
+
+    model_id = _sanitize_model_id(restore_model)
+    if model_id:
+        hidden.discard(model_id)
+
+    model_id = _sanitize_model_id(enable_model)
+    if model_id:
+        disabled.discard(model_id)
+        hidden.discard(model_id)
+
+    model_id = _sanitize_model_id(disable_model)
+    if model_id:
+        disabled.add(model_id)
+
+    cfg["manual_models"] = sorted(manual)
+    cfg["hidden_models"] = sorted(hidden)
+    cfg["disabled_models"] = sorted(disabled)
+    return save_codex_model_config(cfg)
+
+
+def _model_display(model_id: str) -> str:
+    return model_id.rsplit("/", 1)[-1] or model_id
+
+
+def codex_model_list_item(models: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    public_models = [m for m in (models or []) if m.get("enabled", True) and not m.get("hidden")]
+    model_ids = [m["id"] for m in public_models if m.get("id")]
     return {
         "host": "codex",
         "port": 0,
         "url": CODEX_EXPERIMENTAL_ENDPOINT_URL,
-        "models": [CODEX_EXPERIMENTAL_MODEL_ID],
-        "models_display": ["Codex / ChatGPT"],
+        "models": model_ids,
+        "models_display": [m.get("display") or _model_display(m["id"]) for m in public_models if m.get("id")],
         "models_extra": [],
         "models_extra_display": [],
         "endpoint_id": None,
@@ -91,6 +195,12 @@ def codex_model_list_item() -> dict[str, Any]:
         "model_type": "llm",
         "experimental": True,
         "provider": "codex_cli",
+        "capabilities": {
+            "chat_supported": True,
+            "streaming_supported": any(m.get("streaming_supported") for m in public_models),
+            "tool_calling_supported": False,
+            "agent_tools_supported": False,
+        },
     }
 
 
@@ -118,6 +228,9 @@ class CodexCliCapabilities:
     skip_git_repo_check_flag: str | None = None
     supports_json: bool = False
     supports_model: bool = False
+    model_flag: str | None = None
+    reasoning_flag: str | None = None
+    reasoning_levels: tuple[str, ...] = ()
     resume_supported: bool = False
     resume_last_supported: bool = False
     resume_session_id_supported: bool = False
@@ -142,7 +255,7 @@ class CodexCliCapabilities:
         else:
             out.append("Streaming is not available because Codex CLI JSON event output is not advertised.")
         if self.approval_flag:
-            out.append(f"Approval prompts are suppressed with Codex CLI {self.approval_flag}.")
+            out.append(f"Codex CLI advertises {self.approval_flag}, but this provider does not pass approval flags.")
         else:
             out.append(
                 "Approval-control flag is not available on this Codex CLI; "
@@ -166,19 +279,39 @@ class CodexCliCapabilities:
             "json_output_supported": self.supports_json,
             "streaming_supported": self.streaming_supported,
             "model_flag_supported": self.supports_model,
+            "model_flag": self.model_flag,
+            "reasoning_effort_supported": bool(self.reasoning_flag),
+            "reasoning_effort_flag": self.reasoning_flag,
+            "reasoning_effort_levels": list(self.reasoning_levels),
             "dangerous_flags_advertised": list(self.dangerous_flags),
         }
 
-    def build_exec_args(self, bin_path: str, prompt: str, *, json_output: bool = False) -> list[str]:
+    def build_exec_args(
+        self,
+        bin_path: str,
+        prompt: str,
+        *,
+        json_output: bool = False,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+    ) -> list[str]:
         if not self.sandbox_flag:
             raise ValueError("Codex CLI sandbox support is required")
         if json_output and not self.supports_json:
             raise ValueError("Codex CLI JSON output support is required for streaming")
         args = [bin_path, "exec", self.sandbox_flag, "read-only"]
+        selected_model = _sanitize_model_id(model)
+        if selected_model and selected_model != CODEX_EXPERIMENTAL_MODEL_ID:
+            if not self.supports_model or not self.model_flag:
+                raise ValueError("Codex CLI model selection is not supported")
+            args.extend([self.model_flag, selected_model])
+        selected_effort = str(reasoning_effort or "").strip().lower()
+        if selected_effort:
+            if not self.reasoning_flag or selected_effort not in self.reasoning_levels:
+                raise ValueError("Codex CLI reasoning effort selection is not supported")
+            args.extend([self.reasoning_flag, selected_effort])
         if self.skip_git_repo_check_flag:
             args.append(self.skip_git_repo_check_flag)
-        if self.approval_flag:
-            args.extend([self.approval_flag, "never"])
         if json_output:
             args.append(_JSON_OUTPUT_FLAG)
         args.append(prompt)
@@ -190,8 +323,6 @@ class CodexCliCapabilities:
 def _detect_sandbox_flag(help_text: str) -> str | None:
     if "--sandbox" in help_text:
         return "--sandbox"
-    if re.search(r"(^|\s)-s([,\s]|$)", help_text):
-        return "-s"
     return None
 
 
@@ -208,6 +339,31 @@ def _detect_approval_flag(help_text: str) -> str | None:
     return None
 
 
+def _detect_model_flag(help_text: str) -> str | None:
+    if "--model" in help_text:
+        return "--model"
+    if re.search(r"(^|\s)-m([,\s]|$)", help_text):
+        return "-m"
+    return None
+
+
+def _detect_reasoning_flag(help_text: str) -> str | None:
+    for flag in _REASONING_FLAGS:
+        if flag in help_text:
+            return flag
+    return None
+
+
+def _detect_reasoning_levels(help_text: str, flag: str | None) -> tuple[str, ...]:
+    if not flag:
+        return ()
+    text = help_text.lower()
+    found = [level for level in _REASONING_LEVELS if level in text]
+    if found:
+        return tuple(found)
+    return ("low", "medium", "high")
+
+
 def _detect_cli_capabilities_from_help(
     exec_help: str,
     root_help: str = "",
@@ -215,6 +371,8 @@ def _detect_cli_capabilities_from_help(
 ) -> CodexCliCapabilities:
     combined = "\n".join([exec_help or "", root_help or "", resume_help or ""])
     resume_text = "\n".join([exec_help or "", root_help or ""])
+    model_flag = _detect_model_flag(exec_help or "")
+    reasoning_flag = _detect_reasoning_flag(exec_help or "")
     return CodexCliCapabilities(
         sandbox_flag=_detect_sandbox_flag(exec_help or ""),
         sandbox_modes=tuple(
@@ -224,12 +382,60 @@ def _detect_cli_capabilities_from_help(
         approval_flag=_detect_approval_flag(exec_help or ""),
         skip_git_repo_check_flag=_detect_skip_git_repo_check_flag(combined),
         supports_json=_JSON_OUTPUT_FLAG in exec_help,
-        supports_model="--model" in exec_help or " -m" in exec_help,
+        supports_model=bool(model_flag),
+        model_flag=model_flag,
+        reasoning_flag=reasoning_flag,
+        reasoning_levels=_detect_reasoning_levels(exec_help or "", reasoning_flag),
         resume_supported=bool(re.search(r"\bresume\b", resume_text)),
         resume_last_supported="--last" in resume_help,
         resume_session_id_supported=bool(re.search(r"\b(session|SESSION)(_ID| id| id)?\b", resume_help, re.I)),
         dangerous_flags=tuple(flag for flag in _DANGEROUS_FLAGS if flag in combined),
     )
+
+
+def _advertised_model_list_commands(root_help: str) -> list[list[str]]:
+    commands: list[list[str]] = []
+    if re.search(r"(?im)^\s+models?\s+", root_help or ""):
+        commands.extend([["models", "--json"], ["models"], ["model", "list", "--json"], ["model", "list"]])
+    elif re.search(r"(?im)^\s+model\s+", root_help or ""):
+        commands.extend([["model", "list", "--json"], ["model", "list"]])
+    return commands
+
+
+def _extract_model_ids_from_payload(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [_sanitize_model_id(value)]
+    if isinstance(value, list):
+        out: list[str] = []
+        for item in value:
+            out.extend(_extract_model_ids_from_payload(item))
+        return [model_id for model_id in out if model_id]
+    if isinstance(value, dict):
+        for key in ("id", "name", "model"):
+            model_id = _sanitize_model_id(value.get(key))
+            if model_id:
+                return [model_id]
+        out: list[str] = []
+        for key in ("data", "models", "items"):
+            out.extend(_extract_model_ids_from_payload(value.get(key)))
+        return [model_id for model_id in out if model_id]
+    return []
+
+
+def _parse_model_list_output(output: str) -> list[str]:
+    text = output or ""
+    parsed: list[str] = []
+    try:
+        parsed = _extract_model_ids_from_payload(json.loads(text))
+    except Exception:
+        parsed = []
+    if not parsed:
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.lower().startswith(("usage:", "error", "warning")):
+                continue
+            parsed.append(stripped.split()[0])
+    return _unique_model_ids(parsed)
 
 
 class CodexCliChatAdapter:
@@ -268,6 +474,8 @@ class CodexCliChatAdapter:
             "tool_execution_allowed": False,
             "supports_json": capabilities.supports_json,
             "supports_model": capabilities.supports_model,
+            "discovered_models": help_result.get("discovered_models") or [],
+            "model_discovery": help_result.get("model_discovery") or {},
             "cli_capabilities": capabilities.to_public_dict(),
             "limitations": capabilities.limitations(),
             "_preflight": preflight,
@@ -278,6 +486,7 @@ class CodexCliChatAdapter:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
@@ -297,7 +506,15 @@ class CodexCliChatAdapter:
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
 
         with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
-            args = capabilities.build_exec_args(preflight["bin_path"], prompt)
+            try:
+                args = capabilities.build_exec_args(
+                    preflight["bin_path"],
+                    prompt,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
+            except ValueError as exc:
+                return self._error("unsupported_option", str(exc), round((time.time() - started) * 1000), model, capabilities)
             rc, out, err = await self._run(
                 args,
                 timeout=timeout,
@@ -306,7 +523,12 @@ class CodexCliChatAdapter:
             )
             if rc != 0 and _is_trust_directory_error(err or out) and not capabilities.skip_git_repo_check_supported:
                 capabilities = replace(capabilities, skip_git_repo_check_flag=_SKIP_GIT_REPO_CHECK_FLAG)
-                args = capabilities.build_exec_args(preflight["bin_path"], prompt)
+                args = capabilities.build_exec_args(
+                    preflight["bin_path"],
+                    prompt,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
                 rc, out, err = await self._run(
                     args,
                     timeout=timeout,
@@ -339,6 +561,7 @@ class CodexCliChatAdapter:
             "message": message,
             "duration_ms": duration_ms,
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "reasoning_effort": reasoning_effort if capabilities.reasoning_flag else None,
             "limitations": capabilities.limitations(),
             "cli_capabilities": capabilities.to_public_dict(),
             "streaming_supported": capabilities.streaming_supported,
@@ -350,6 +573,7 @@ class CodexCliChatAdapter:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
         allow_one_shot_fallback: bool = False,
@@ -371,6 +595,7 @@ class CodexCliChatAdapter:
                 result = await self.complete(
                     messages,
                     model=model,
+                    reasoning_effort=reasoning_effort,
                     timeout_seconds=timeout_seconds,
                     odysseus_session_id=odysseus_session_id,
                 )
@@ -403,13 +628,28 @@ class CodexCliChatAdapter:
         prompt = self._build_prompt(messages)
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
         with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-stream-") as workdir:
-            args = capabilities.build_exec_args(preflight["bin_path"], prompt, json_output=True)
+            try:
+                args = capabilities.build_exec_args(
+                    preflight["bin_path"],
+                    prompt,
+                    json_output=True,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
+            except ValueError as exc:
+                yield self._stream_error_event(
+                    self._error("unsupported_option", str(exc), round((time.time() - started) * 1000), model, capabilities),
+                    started=started,
+                    model=model,
+                )
+                return
             async for event in self._stream_exec(
                 args,
                 timeout=timeout,
                 cwd=workdir,
                 env=preflight["env"],
                 model=model,
+                reasoning_effort=reasoning_effort,
                 capabilities=capabilities,
             ):
                 yield event
@@ -468,6 +708,20 @@ class CodexCliChatAdapter:
             if resume_rc == 0:
                 resume_help = resume_out or ""
         capabilities = _detect_cli_capabilities_from_help(exec_help, root_help, resume_help)
+        discovered_models: list[str] = []
+        model_discovery = {"source": "none", "commands_tried": []}
+        for command in _advertised_model_list_commands(root_help):
+            model_discovery["commands_tried"].append(" ".join(command))
+            model_rc, model_out, _ = await self._run([bin_path, *command], timeout=20, env=env)
+            if model_rc != 0:
+                continue
+            discovered_models = _parse_model_list_output(model_out or "")
+            if discovered_models:
+                model_discovery["source"] = "codex_cli"
+                model_discovery["command"] = " ".join(command)
+                break
+        if not discovered_models and capabilities.supports_model:
+            model_discovery["source"] = "manual"
         if not capabilities.ok:
             return {
                 "ok": False,
@@ -480,6 +734,8 @@ class CodexCliChatAdapter:
             "ok": True,
             "status": "exec_help_ok",
             "cli_capabilities": capabilities.to_public_dict(),
+            "discovered_models": discovered_models,
+            "model_discovery": model_discovery,
             "_capabilities": capabilities,
         }
 
@@ -496,6 +752,7 @@ class CodexCliChatAdapter:
         env: dict[str, str],
         model: str | None,
         capabilities: CodexCliCapabilities,
+        reasoning_effort: str | None = None,
         allow_trust_retry: bool = True,
     ):
         started = time.time()
@@ -571,13 +828,20 @@ class CodexCliChatAdapter:
             detail = _sanitize_text(stderr_text or "".join(stdout_lines), limit=500)
             if _is_trust_directory_error(detail) and not capabilities.skip_git_repo_check_supported and allow_trust_retry:
                 retry_capabilities = replace(capabilities, skip_git_repo_check_flag=_SKIP_GIT_REPO_CHECK_FLAG)
-                retry_args = retry_capabilities.build_exec_args(args[0], args[-1], json_output=True)
+                retry_args = retry_capabilities.build_exec_args(
+                    args[0],
+                    args[-1],
+                    json_output=True,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
                 async for event in self._stream_exec(
                     retry_args,
                     timeout=timeout,
                     cwd=cwd,
                     env=env,
                     model=model,
+                    reasoning_effort=reasoning_effort,
                     capabilities=retry_capabilities,
                     allow_trust_retry=False,
                 ):
@@ -899,6 +1163,12 @@ class CodexModelProvider:
             "session_resume_supported": False,
             "tool_execution_allowed": False,
             "limitations": list(_BASE_LIMITATIONS),
+            "model_discovery": {"source": "disabled"},
+            "manual_models": [],
+            "hidden_models": [],
+            "disabled_models": [],
+            "thinking_supported": False,
+            "thinking_effort_levels": [],
         }
         if not enabled:
             return {
@@ -939,7 +1209,8 @@ class CodexModelProvider:
             status = "available"
             requires_sign_in = False
 
-        models = []
+        cfg = load_codex_model_config()
+        models: list[dict[str, Any]] = []
         chat_available = {"ok": False}
         if status == "available":
             chat_available = await self._chat_adapter.available()
@@ -950,13 +1221,34 @@ class CodexModelProvider:
                 base["streaming_supported"] = bool(chat_available.get("streaming_supported"))
                 base["limitations"] = chat_available.get("limitations") or base["limitations"]
                 base["cli_capabilities"] = chat_available.get("cli_capabilities") or {}
-                models.append({
-                    "id": CODEX_EXPERIMENTAL_MODEL_ID,
-                    "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
-                    "experimental": True,
-                    "streaming_supported": bool(chat_available.get("streaming_supported")),
-                    "session_resume_supported": False,
-                })
+                base["model_discovery"] = chat_available.get("model_discovery") or {"source": "manual"}
+                cap = base["cli_capabilities"]
+                base["thinking_supported"] = bool(cap.get("reasoning_effort_supported"))
+                base["thinking_effort_levels"] = cap.get("reasoning_effort_levels") or []
+                source_ids = _unique_model_ids(
+                    list(chat_available.get("discovered_models") or [])
+                    + cfg["manual_models"]
+                    + cfg["hidden_models"]
+                    + cfg["disabled_models"]
+                )
+                hidden = set(cfg["hidden_models"])
+                disabled = set(cfg["disabled_models"])
+                for model_id in source_ids:
+                    is_hidden = model_id in hidden
+                    models.append({
+                        "id": model_id,
+                        "display": _model_display(model_id),
+                        "source": "manual" if model_id in cfg["manual_models"] else "codex_cli",
+                        "experimental": True,
+                        "hidden": is_hidden,
+                        "enabled": (not is_hidden) and model_id not in disabled,
+                        "streaming_supported": bool(chat_available.get("streaming_supported")),
+                        "thinking_supported": bool(base["thinking_supported"]),
+                        "thinking_effort_levels": list(base["thinking_effort_levels"]),
+                        "session_resume_supported": False,
+                        "tool_calling_supported": False,
+                        "agent_tools_supported": False,
+                    })
 
         return {
             **base,
@@ -970,6 +1262,9 @@ class CodexModelProvider:
                 "auth_mode": auth_mode,
                 "codex_home": auth.get("codex_home", ""),
             },
+            "manual_models": cfg["manual_models"],
+            "hidden_models": cfg["hidden_models"],
+            "disabled_models": cfg["disabled_models"],
             "models": models,
         }
 
@@ -977,12 +1272,14 @@ class CodexModelProvider:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
         return await self._chat_adapter.complete(
             messages,
             model=model,
+            reasoning_effort=reasoning_effort,
             timeout_seconds=timeout_seconds,
             odysseus_session_id=odysseus_session_id,
         )
@@ -991,6 +1288,7 @@ class CodexModelProvider:
         self,
         messages: list[dict[str, Any]],
         model: str | None = None,
+        reasoning_effort: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
         odysseus_session_id: str | None = None,
         allow_one_shot_fallback: bool = False,
@@ -998,6 +1296,7 @@ class CodexModelProvider:
         async for event in self._chat_adapter.stream_chat(
             messages,
             model=model,
+            reasoning_effort=reasoning_effort,
             timeout_seconds=timeout_seconds,
             odysseus_session_id=odysseus_session_id,
             allow_one_shot_fallback=allow_one_shot_fallback,
@@ -1006,7 +1305,7 @@ class CodexModelProvider:
 
 
 def codex_model_list_item_if_available(provider: CodexModelProvider | None = None) -> dict[str, Any] | None:
-    """Return the synthetic picker item only when Codex is actually usable."""
+    """Return the picker item only when Codex has at least one enabled model."""
     if not codex_model_provider_enabled():
         return None
     try:
@@ -1021,12 +1320,10 @@ def codex_model_list_item_if_available(provider: CodexModelProvider | None = Non
         status = asyncio.run((provider or CodexModelProvider()).status())
     except Exception:
         return None
-    if (
-        status.get("status") == "available"
-        and status.get("chat_supported") is True
-        and status.get("models")
-    ):
-        return codex_model_list_item()
+    if status.get("status") == "available" and status.get("chat_supported") is True:
+        item = codex_model_list_item(status.get("models") or [])
+        if item.get("models"):
+            return item
     return None
 
 

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -26,6 +26,40 @@ CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental)"
 CODEX_EXPERIMENTAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
 CODEX_SETTINGS_KEY = "codex_model_provider"
+CODEX_RECOMMENDED_MODELS = (
+    {
+        "id": "gpt-5.5",
+        "label": "GPT-5.5",
+        "description": "newest frontier model for complex coding, computer use, knowledge work, and research workflows",
+        "default": True,
+    },
+    {
+        "id": "gpt-5.4",
+        "label": "GPT-5.4",
+        "description": "flagship frontier model for professional work, stronger reasoning, tool use, and agentic workflows",
+    },
+    {
+        "id": "gpt-5.4-mini",
+        "label": "GPT-5.4 Mini",
+        "description": "fast and efficient model for responsive coding tasks and subagents",
+    },
+    {
+        "id": "gpt-5.3-codex",
+        "label": "GPT-5.3 Codex",
+        "description": "coding model for complex software engineering",
+    },
+    {
+        "id": "gpt-5.3-codex-spark",
+        "label": "GPT-5.3 Codex Spark",
+        "description": "research preview for near-instant real-time coding iteration; availability may depend on plan",
+    },
+    {
+        "id": "gpt-5.2",
+        "label": "GPT-5.2",
+        "description": "previous general-purpose coding and agentic model",
+    },
+)
+_CODEX_RECOMMENDED_BY_ID = {item["id"]: item for item in CODEX_RECOMMENDED_MODELS}
 
 _TOKEN_PATTERNS = (
     re.compile(r"(?i)(access_token|refresh_token|id_token)\s*[:=]\s*['\"]?[^'\"\s,}]+"),
@@ -103,32 +137,145 @@ def _unique_model_ids(values: Any) -> list[str]:
     return out
 
 
+def _sanitize_optional_text(value: Any, *, limit: int = 300) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if any(ord(ch) < 32 for ch in text):
+        return ""
+    return text[:limit]
+
+
+def _sanitize_thinking_effort(value: Any) -> str | None:
+    text = str(value or "").strip().lower()
+    return text if text in _REASONING_LEVELS else None
+
+
+def codex_recommended_models() -> list[dict[str, Any]]:
+    return [dict(item) for item in CODEX_RECOMMENDED_MODELS]
+
+
+def _recommended_model_meta(model_id: str) -> dict[str, Any]:
+    item = _CODEX_RECOMMENDED_BY_ID.get(model_id) or {}
+    return {
+        "id": model_id,
+        "label": item.get("label") or _model_display(model_id),
+        "description": item.get("description") or "",
+        "source": "recommended" if item else "custom",
+        "default": bool(item.get("default")),
+    }
+
+
+def _sanitize_selected_model_entry(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        value = {"id": value}
+    model_id = _sanitize_model_id(value.get("id") or value.get("model_id"))
+    if not model_id:
+        return None
+    recommended = _recommended_model_meta(model_id)
+    source = str(value.get("source") or recommended["source"]).strip().lower()
+    if source not in {"recommended", "custom", "manual", "codex_cli"}:
+        source = recommended["source"]
+    source = "recommended" if source in {"recommended", "codex_cli"} and model_id in _CODEX_RECOMMENDED_BY_ID else "custom"
+    label = _sanitize_optional_text(value.get("label")) or recommended["label"]
+    description = _sanitize_optional_text(value.get("description")) or recommended["description"]
+    return {
+        "id": model_id,
+        "label": label,
+        "description": description,
+        "source": source,
+        "enabled": bool(value.get("enabled", True)),
+        "hidden": bool(value.get("hidden", False)),
+        "thinking_effort": _sanitize_thinking_effort(value.get("thinking_effort")),
+    }
+
+
+def _normalize_selected_models(values: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        item = _sanitize_selected_model_entry(value)
+        if not item:
+            continue
+        if item["id"] in seen:
+            continue
+        seen.add(item["id"])
+        out.append(item)
+    return out
+
+
+def _legacy_selected_models(cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    manual = _unique_model_ids(cfg.get("manual_models"))
+    hidden = set(_unique_model_ids(cfg.get("hidden_models")))
+    disabled = set(_unique_model_ids(cfg.get("disabled_models")))
+    out: list[dict[str, Any]] = []
+    for model_id in manual:
+        meta = _recommended_model_meta(model_id)
+        out.append({
+            "id": model_id,
+            "label": meta["label"],
+            "description": meta["description"],
+            "source": meta["source"],
+            "enabled": model_id not in disabled,
+            "hidden": model_id in hidden,
+            "thinking_effort": None,
+        })
+    return out
+
+
+def _config_projections(selected_models: list[dict[str, Any]]) -> dict[str, Any]:
+    selected_ids = [item["id"] for item in selected_models]
+    hidden_ids = [item["id"] for item in selected_models if item.get("hidden")]
+    disabled_ids = [item["id"] for item in selected_models if not item.get("enabled", True)]
+    custom_models = [item["id"] for item in selected_models if item.get("source") == "custom"]
+    return {
+        "manual_models": selected_ids,
+        "hidden_models": hidden_ids,
+        "disabled_models": disabled_ids,
+        "custom_models": custom_models,
+        "hidden_model_ids": hidden_ids,
+    }
+
+
 def load_codex_model_config() -> dict[str, Any]:
     cfg = load_settings().get(CODEX_SETTINGS_KEY) or {}
     if not isinstance(cfg, dict):
         cfg = {}
+    selected_models = _normalize_selected_models(cfg.get("selected_models"))
+    if not selected_models:
+        selected_models = _legacy_selected_models(cfg)
+    connector_enabled = cfg.get("connector_enabled")
+    if connector_enabled is None:
+        connector_enabled = bool(selected_models)
+    else:
+        connector_enabled = bool(connector_enabled)
     task_defaults = cfg.get("task_defaults") or {}
     if not isinstance(task_defaults, dict):
         task_defaults = {}
+    projections = _config_projections(selected_models)
     return {
-        "manual_models": _unique_model_ids(cfg.get("manual_models")),
-        "hidden_models": _unique_model_ids(cfg.get("hidden_models")),
-        "disabled_models": _unique_model_ids(cfg.get("disabled_models")),
+        "connector_enabled": connector_enabled,
+        "selected_models": selected_models,
+        **projections,
         "task_defaults": task_defaults,
     }
 
 
 def save_codex_model_config(config: dict[str, Any]) -> dict[str, Any]:
+    selected_models = _normalize_selected_models(config.get("selected_models"))
+    projections = _config_projections(selected_models)
     clean = {
-        "manual_models": _unique_model_ids(config.get("manual_models")),
-        "hidden_models": _unique_model_ids(config.get("hidden_models")),
-        "disabled_models": _unique_model_ids(config.get("disabled_models")),
+        "connector_enabled": bool(config.get("connector_enabled")) or bool(selected_models),
+        "selected_models": selected_models,
+        **projections,
         "task_defaults": config.get("task_defaults") if isinstance(config.get("task_defaults"), dict) else {},
     }
     settings = load_settings()
     settings[CODEX_SETTINGS_KEY] = clean
     save_settings(settings)
-    return clean
+    return load_codex_model_config()
 
 
 def update_codex_model_config(
@@ -138,44 +285,129 @@ def update_codex_model_config(
     restore_model: str | None = None,
     enable_model: str | None = None,
     disable_model: str | None = None,
+    remove_model: str | None = None,
+    thinking_model: str | None = None,
+    thinking_effort: str | None = None,
+    clear_all_models: bool = False,
+    connector_enabled: bool | None = None,
 ) -> dict[str, Any]:
     cfg = load_codex_model_config()
-    manual = set(cfg["manual_models"])
-    hidden = set(cfg["hidden_models"])
-    disabled = set(cfg["disabled_models"])
+    selected = [dict(item) for item in cfg["selected_models"]]
+
+    def _find(model_id: str) -> dict[str, Any] | None:
+        for item in selected:
+            if item["id"] == model_id:
+                return item
+        return None
+
+    if clear_all_models:
+        selected = []
+        cfg["connector_enabled"] = False
+
+    if connector_enabled is not None:
+        cfg["connector_enabled"] = bool(connector_enabled)
 
     model_id = _sanitize_model_id(add_model)
     if model_id:
-        manual.add(model_id)
-        hidden.discard(model_id)
-        disabled.discard(model_id)
+        item = _find(model_id)
+        if item:
+            item["hidden"] = False
+            item["enabled"] = True
+        else:
+            meta = _recommended_model_meta(model_id)
+            selected.append({
+                "id": model_id,
+                "label": meta["label"],
+                "description": meta["description"],
+                "source": meta["source"],
+                "enabled": True,
+                "hidden": False,
+                "thinking_effort": None,
+            })
+        cfg["connector_enabled"] = True
+
+    model_id = _sanitize_model_id(remove_model)
+    if model_id:
+        selected = [item for item in selected if item["id"] != model_id]
 
     model_id = _sanitize_model_id(hide_model)
     if model_id:
-        hidden.add(model_id)
-        disabled.discard(model_id)
+        item = _find(model_id)
+        if item:
+            item["hidden"] = True
+            item["enabled"] = True
 
     model_id = _sanitize_model_id(restore_model)
     if model_id:
-        hidden.discard(model_id)
+        item = _find(model_id)
+        if item:
+            item["hidden"] = False
 
     model_id = _sanitize_model_id(enable_model)
     if model_id:
-        disabled.discard(model_id)
-        hidden.discard(model_id)
+        item = _find(model_id)
+        if item:
+            item["enabled"] = True
+            item["hidden"] = False
 
     model_id = _sanitize_model_id(disable_model)
     if model_id:
-        disabled.add(model_id)
+        item = _find(model_id)
+        if item:
+            item["enabled"] = False
 
-    cfg["manual_models"] = sorted(manual)
-    cfg["hidden_models"] = sorted(hidden)
-    cfg["disabled_models"] = sorted(disabled)
+    model_id = _sanitize_model_id(thinking_model)
+    if model_id:
+        item = _find(model_id)
+        if item:
+            item["thinking_effort"] = _sanitize_thinking_effort(thinking_effort)
+
+    if not selected and connector_enabled is None and not clear_all_models:
+        cfg["connector_enabled"] = False
+
+    cfg["selected_models"] = selected
     return save_codex_model_config(cfg)
 
 
 def _model_display(model_id: str) -> str:
     return model_id.rsplit("/", 1)[-1] or model_id
+
+
+def first_enabled_codex_model(config: dict[str, Any] | None = None) -> str:
+    cfg = config or load_codex_model_config()
+    if not cfg.get("connector_enabled"):
+        return ""
+    for item in cfg.get("selected_models") or []:
+        if item.get("enabled", True) and not item.get("hidden"):
+            return item.get("id") or ""
+    return ""
+
+
+def codex_model_default_reasoning_effort(model_id: str, config: dict[str, Any] | None = None) -> str | None:
+    target = _sanitize_model_id(model_id)
+    if not target:
+        return None
+    cfg = config or load_codex_model_config()
+    for item in cfg.get("selected_models") or []:
+        if item.get("id") == target:
+            return _sanitize_thinking_effort(item.get("thinking_effort"))
+    return None
+
+
+def is_codex_model_available(model_id: str | None, *, public_only: bool = True, config: dict[str, Any] | None = None) -> bool:
+    target = _sanitize_model_id(model_id)
+    if not target:
+        return False
+    cfg = config or load_codex_model_config()
+    if not cfg.get("connector_enabled"):
+        return False
+    for item in cfg.get("selected_models") or []:
+        if item.get("id") != target:
+            continue
+        if not public_only:
+            return True
+        return bool(item.get("enabled", True)) and not bool(item.get("hidden"))
+    return False
 
 
 def codex_model_list_item(models: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -922,6 +1154,18 @@ class CodexCliChatAdapter:
         return False
 
     @classmethod
+    def _is_reasoning_event(cls, value: Any) -> bool:
+        if not isinstance(value, dict):
+            return False
+        if value.get("thinking") is True:
+            return True
+        for key in ("type", "event", "kind", "channel", "name"):
+            text = str(value.get(key) or "").strip().lower()
+            if "reasoning" in text or "thinking" in text:
+                return True
+        return False
+
+    @classmethod
     def _extract_delta(cls, value: Any, depth: int = 0, *, in_content: bool = False) -> str:
         if depth > 6:
             return ""
@@ -937,6 +1181,8 @@ class CodexCliChatAdapter:
                     parts.append(found)
             return "".join(parts)
         if not isinstance(value, dict):
+            return ""
+        if cls._is_reasoning_event(value):
             return ""
 
         event_type = str(value.get("type") or "").strip().lower()
@@ -1164,11 +1410,15 @@ class CodexModelProvider:
             "tool_execution_allowed": False,
             "limitations": list(_BASE_LIMITATIONS),
             "model_discovery": {"source": "disabled"},
+            "recommended_models": codex_recommended_models(),
+            "connector_enabled": False,
+            "selected_models": [],
             "manual_models": [],
             "hidden_models": [],
             "disabled_models": [],
             "thinking_supported": False,
             "thinking_effort_levels": [],
+            "thinking_activity_supported": False,
         }
         if not enabled:
             return {
@@ -1210,6 +1460,11 @@ class CodexModelProvider:
             requires_sign_in = False
 
         cfg = load_codex_model_config()
+        base["connector_enabled"] = cfg["connector_enabled"]
+        base["selected_models"] = [dict(item) for item in cfg["selected_models"]]
+        base["manual_models"] = cfg["manual_models"]
+        base["hidden_models"] = cfg["hidden_models"]
+        base["disabled_models"] = cfg["disabled_models"]
         models: list[dict[str, Any]] = []
         chat_available = {"ok": False}
         if status == "available":
@@ -1225,30 +1480,27 @@ class CodexModelProvider:
                 cap = base["cli_capabilities"]
                 base["thinking_supported"] = bool(cap.get("reasoning_effort_supported"))
                 base["thinking_effort_levels"] = cap.get("reasoning_effort_levels") or []
-                source_ids = _unique_model_ids(
-                    list(chat_available.get("discovered_models") or [])
-                    + cfg["manual_models"]
-                    + cfg["hidden_models"]
-                    + cfg["disabled_models"]
-                )
-                hidden = set(cfg["hidden_models"])
-                disabled = set(cfg["disabled_models"])
-                for model_id in source_ids:
-                    is_hidden = model_id in hidden
-                    models.append({
-                        "id": model_id,
-                        "display": _model_display(model_id),
-                        "source": "manual" if model_id in cfg["manual_models"] else "codex_cli",
-                        "experimental": True,
-                        "hidden": is_hidden,
-                        "enabled": (not is_hidden) and model_id not in disabled,
-                        "streaming_supported": bool(chat_available.get("streaming_supported")),
-                        "thinking_supported": bool(base["thinking_supported"]),
-                        "thinking_effort_levels": list(base["thinking_effort_levels"]),
-                        "session_resume_supported": False,
-                        "tool_calling_supported": False,
-                        "agent_tools_supported": False,
-                    })
+                base["thinking_activity_supported"] = bool(chat_available.get("streaming_supported"))
+
+        for item in cfg["selected_models"]:
+            models.append({
+                "id": item["id"],
+                "display": item.get("label") or _model_display(item["id"]),
+                "label": item.get("label") or _model_display(item["id"]),
+                "description": item.get("description") or "",
+                "source": item.get("source") or "custom",
+                "experimental": True,
+                "hidden": bool(item.get("hidden")),
+                "enabled": bool(item.get("enabled", True)) and not bool(item.get("hidden")),
+                "thinking_effort": item.get("thinking_effort"),
+                "streaming_supported": bool(base["streaming_supported"]),
+                "thinking_supported": bool(base["thinking_supported"]),
+                "thinking_effort_levels": list(base["thinking_effort_levels"]),
+                "thinking_activity_supported": bool(base["thinking_activity_supported"]),
+                "session_resume_supported": False,
+                "tool_calling_supported": False,
+                "agent_tools_supported": False,
+            })
 
         return {
             **base,
@@ -1262,9 +1514,6 @@ class CodexModelProvider:
                 "auth_mode": auth_mode,
                 "codex_home": auth.get("codex_home", ""),
             },
-            "manual_models": cfg["manual_models"],
-            "hidden_models": cfg["hidden_models"],
-            "disabled_models": cfg["disabled_models"],
             "models": models,
         }
 

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -552,13 +552,8 @@ class CodexCliCapabilities:
                 raise ValueError("Codex CLI model selection is not supported")
             args.extend([self.model_flag, selected_model])
         selected_effort = str(reasoning_effort or "").strip().lower()
-        if selected_effort and self.reasoning_flag:
-            if not self.reasoning_levels:
-                pass
-            elif selected_effort in self.reasoning_levels:
-                args.extend([self.reasoning_flag, selected_effort])
-            else:
-                raise ValueError("Codex CLI reasoning effort selection is not supported")
+        if selected_effort and self.reasoning_flag and selected_effort in self.reasoning_levels:
+            args.extend([self.reasoning_flag, selected_effort])
         if self.skip_git_repo_check_flag:
             args.append(self.skip_git_repo_check_flag)
         if json_output:

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,6 +13,7 @@ import os
 import re
 import tempfile
 import time
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
@@ -28,12 +29,15 @@ _TOKEN_PATTERNS = (
     re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+"),
 )
 
-_LIMITATIONS = [
+_BASE_LIMITATIONS = [
     "Non-streaming: returns one completed assistant message.",
     "Stateless: session/resume is not implemented.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
-    "The adapter requires Codex CLI sandbox/approval flags before running.",
+    "The adapter requires Codex CLI sandbox support and runs with read-only sandbox mode.",
 ]
+
+_APPROVAL_FLAGS = ("--ask-for-approval", "--approval-policy", "--approval")
+_DANGEROUS_FLAGS = ("--dangerously-bypass-approvals-and-sandbox", "--yolo")
 
 
 def _truthy(value: str | None) -> bool:
@@ -51,12 +55,107 @@ def _sanitize_text(text: str | None, limit: int = 2000) -> str:
     return safe.strip()[:limit]
 
 
+@dataclass(frozen=True)
+class CodexCliCapabilities:
+    """Detected Codex CLI command surface for the installed binary."""
+
+    sandbox_flag: str | None
+    sandbox_modes: tuple[str, ...] = ()
+    approval_flag: str | None = None
+    supports_json: bool = False
+    supports_model: bool = False
+    resume_supported: bool = False
+    resume_last_supported: bool = False
+    resume_session_id_supported: bool = False
+    dangerous_flags: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.sandbox_flag)
+
+    def limitations(self) -> list[str]:
+        out = list(_BASE_LIMITATIONS)
+        if self.approval_flag:
+            out.append(f"Approval prompts are suppressed with Codex CLI {self.approval_flag}.")
+        else:
+            out.append(
+                "Approval-control flag is not available on this Codex CLI; "
+                "Odysseus relies on read-only sandbox mode."
+            )
+        return out
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "sandbox_supported": bool(self.sandbox_flag),
+            "sandbox_flag": self.sandbox_flag,
+            "sandbox_modes": list(self.sandbox_modes),
+            "sandbox_mode": "read-only",
+            "approval_control_supported": bool(self.approval_flag),
+            "approval_flag": self.approval_flag,
+            "resume_supported": self.resume_supported,
+            "resume_last_supported": self.resume_last_supported,
+            "resume_session_id_supported": self.resume_session_id_supported,
+            "json_output_supported": self.supports_json,
+            "model_flag_supported": self.supports_model,
+            "dangerous_flags_advertised": list(self.dangerous_flags),
+        }
+
+    def build_exec_args(self, bin_path: str, prompt: str) -> list[str]:
+        if not self.sandbox_flag:
+            raise ValueError("Codex CLI sandbox support is required")
+        args = [bin_path, "exec", self.sandbox_flag, "read-only"]
+        if self.approval_flag:
+            args.extend([self.approval_flag, "never"])
+        args.append(prompt)
+        if any(flag in args for flag in _DANGEROUS_FLAGS):
+            raise ValueError("Unsafe Codex CLI flag refused")
+        return args
+
+
+def _detect_sandbox_flag(help_text: str) -> str | None:
+    if "--sandbox" in help_text:
+        return "--sandbox"
+    if re.search(r"(^|\s)-s([,\s]|$)", help_text):
+        return "-s"
+    return None
+
+
+def _detect_approval_flag(help_text: str) -> str | None:
+    for flag in _APPROVAL_FLAGS:
+        if flag in help_text:
+            return flag
+    return None
+
+
+def _detect_cli_capabilities_from_help(
+    exec_help: str,
+    root_help: str = "",
+    resume_help: str = "",
+) -> CodexCliCapabilities:
+    combined = "\n".join([exec_help or "", root_help or "", resume_help or ""])
+    resume_text = "\n".join([exec_help or "", root_help or ""])
+    return CodexCliCapabilities(
+        sandbox_flag=_detect_sandbox_flag(exec_help or ""),
+        sandbox_modes=tuple(
+            mode for mode in ("read-only", "workspace-write", "danger-full-access")
+            if mode in (exec_help or "")
+        ),
+        approval_flag=_detect_approval_flag(exec_help or ""),
+        supports_json="--json" in exec_help,
+        supports_model="--model" in exec_help or " -m" in exec_help,
+        resume_supported=bool(re.search(r"\bresume\b", resume_text)),
+        resume_last_supported="--last" in resume_help,
+        resume_session_id_supported=bool(re.search(r"\b(session|SESSION)(_ID| id| id)?\b", resume_help, re.I)),
+        dangerous_flags=tuple(flag for flag in _DANGEROUS_FLAGS if flag in combined),
+    )
+
+
 class CodexCliChatAdapter:
     """Admin-only, non-streaming adapter boundary for `codex exec`.
 
     This intentionally does not provide a normal chat-provider hook yet. It
-    refuses to run unless the installed CLI advertises the sandbox and approval
-    flags needed for a constrained one-shot completion probe.
+    refuses to run unless the installed CLI advertises sandbox support needed
+    for a constrained one-shot completion probe.
     """
 
     def __init__(
@@ -68,12 +167,16 @@ class CodexCliChatAdapter:
         self._runner = runner
 
     async def available(self) -> dict[str, Any]:
+        return self._public_result(await self._available_internal())
+
+    async def _available_internal(self) -> dict[str, Any]:
         preflight = await self._preflight()
         if not preflight.get("ok"):
             return preflight
-        help_result = await self._exec_help(preflight["bin_path"], preflight["env"])
+        help_result = await self._detect_cli_capabilities(preflight["bin_path"], preflight["env"])
         if not help_result.get("ok"):
             return help_result
+        capabilities = help_result["_capabilities"]
         return {
             "ok": True,
             "status": "available",
@@ -81,8 +184,12 @@ class CodexCliChatAdapter:
             "streaming_supported": False,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
-            "supports_json": help_result.get("supports_json", False),
-            "limitations": list(_LIMITATIONS),
+            "supports_json": capabilities.supports_json,
+            "supports_model": capabilities.supports_model,
+            "cli_capabilities": capabilities.to_public_dict(),
+            "limitations": capabilities.limitations(),
+            "_preflight": preflight,
+            "_capabilities": capabilities,
         }
 
     async def complete(
@@ -90,31 +197,25 @@ class CodexCliChatAdapter:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
         started = time.time()
-        availability = await self.available()
+        availability = await self._available_internal()
         if not availability.get("ok"):
             return {
-                **availability,
+                **self._public_result(availability),
                 "ok": False,
                 "duration_ms": round((time.time() - started) * 1000),
                 "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
             }
 
-        preflight = await self._preflight()
+        preflight = availability["_preflight"]
+        capabilities = availability["_capabilities"]
         prompt = self._build_prompt(messages)
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
 
         with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
-            args = [
-                preflight["bin_path"],
-                "exec",
-                "--sandbox",
-                "read-only",
-                "--ask-for-approval",
-                "never",
-                prompt,
-            ]
+            args = capabilities.build_exec_args(preflight["bin_path"], prompt)
             rc, out, err = await self._run(
                 args,
                 timeout=timeout,
@@ -124,14 +225,14 @@ class CodexCliChatAdapter:
 
         duration_ms = round((time.time() - started) * 1000)
         if rc == 124:
-            return self._error("timeout", "Codex CLI timed out", duration_ms, model)
+            return self._error("timeout", "Codex CLI timed out", duration_ms, model, capabilities)
         if rc != 0:
             detail = _sanitize_text(err or out, limit=500)
-            return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model)
+            return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model, capabilities)
 
         message = self._extract_message(out)
         if not message:
-            return self._error("empty_response", "Codex CLI returned no assistant message", duration_ms, model)
+            return self._error("empty_response", "Codex CLI returned no assistant message", duration_ms, model, capabilities)
 
         return {
             "ok": True,
@@ -139,7 +240,8 @@ class CodexCliChatAdapter:
             "message": message,
             "duration_ms": duration_ms,
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
-            "limitations": list(_LIMITATIONS),
+            "limitations": capabilities.limitations(),
+            "cli_capabilities": capabilities.to_public_dict(),
             "streaming_supported": False,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
@@ -181,30 +283,42 @@ class CodexCliChatAdapter:
 
         return {"ok": True, "status": "preflight_ok", "bin_path": bin_path, "env": env}
 
-    async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
+    async def _detect_cli_capabilities(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
         rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
         if rc != 0:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
-                "error": "Unable to inspect codex exec safety flags",
+                "error": "Unable to inspect codex exec safety capabilities",
                 "detail": _sanitize_text(err or out, limit=500),
             }
-        help_text = out or ""
-        missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
-        if missing:
+        exec_help = out or ""
+        root_rc, root_out, _ = await self._run([bin_path, "--help"], timeout=20, env=env)
+        root_help = root_out if root_rc == 0 else ""
+        resume_help = ""
+        if re.search(r"\bresume\b", "\n".join([exec_help, root_help])):
+            resume_rc, resume_out, _ = await self._run([bin_path, "exec", "resume", "--help"], timeout=20, env=env)
+            if resume_rc == 0:
+                resume_help = resume_out or ""
+        capabilities = _detect_cli_capabilities_from_help(exec_help, root_help, resume_help)
+        if not capabilities.ok:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
-                "error": "Codex CLI does not advertise required safety flags",
-                "missing_flags": missing,
+                "error": "Codex CLI does not advertise required sandbox support",
+                "missing_flags": ["--sandbox"],
+                "cli_capabilities": capabilities.to_public_dict(),
             }
         return {
             "ok": True,
             "status": "exec_help_ok",
-            "supports_json": "--json" in help_text,
-            "supports_model": "--model" in help_text or " -m" in help_text,
+            "cli_capabilities": capabilities.to_public_dict(),
+            "_capabilities": capabilities,
         }
+
+    @staticmethod
+    def _public_result(result: dict[str, Any]) -> dict[str, Any]:
+        return {k: v for k, v in result.items() if not k.startswith("_")}
 
     async def _run(
         self,
@@ -279,14 +393,21 @@ class CodexCliChatAdapter:
         return text
 
     @staticmethod
-    def _error(status: str, error: str, duration_ms: int, model: str | None) -> dict[str, Any]:
+    def _error(
+        status: str,
+        error: str,
+        duration_ms: int,
+        model: str | None,
+        capabilities: CodexCliCapabilities | None = None,
+    ) -> dict[str, Any]:
         return {
             "ok": False,
             "status": status,
             "error": _sanitize_text(error, limit=500),
             "duration_ms": duration_ms,
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
-            "limitations": list(_LIMITATIONS),
+            "limitations": capabilities.limitations() if capabilities else list(_BASE_LIMITATIONS),
+            "cli_capabilities": capabilities.to_public_dict() if capabilities else {},
             "streaming_supported": False,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
@@ -316,7 +437,7 @@ class CodexModelProvider:
             "streaming_supported": False,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
-            "limitations": list(_LIMITATIONS),
+            "limitations": list(_BASE_LIMITATIONS),
         }
         if not enabled:
             return {
@@ -365,6 +486,8 @@ class CodexModelProvider:
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
             else:
                 base["chat_supported"] = True
+                base["limitations"] = chat_available.get("limitations") or base["limitations"]
+                base["cli_capabilities"] = chat_available.get("cli_capabilities") or {}
                 models.append({
                     "id": CODEX_EXPERIMENTAL_MODEL_ID,
                     "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
@@ -393,5 +516,11 @@ class CodexModelProvider:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
-        return await self._chat_adapter.complete(messages, model=model, timeout_seconds=timeout_seconds)
+        return await self._chat_adapter.complete(
+            messages,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            odysseus_session_id=odysseus_session_id,
+        )

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1,8 +1,8 @@
-"""Experimental Codex CLI model-provider capability boundary.
+"""Codex CLI model-provider capability boundary.
 
-This module implements the experimental Codex CLI provider boundary without
-reading Codex credential files or treating completed CLI output as token
-streaming. Normal API-provider behavior remains deliberately out of scope.
+This module implements the Codex CLI provider boundary without reading Codex
+credential files or treating completed CLI output as token streaming. Normal
+API-provider behavior remains deliberately out of scope.
 """
 
 from __future__ import annotations
@@ -22,7 +22,6 @@ from src.settings import load_settings, save_settings
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
-CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental)"
 CODEX_EXPERIMENTAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
 CODEX_SETTINGS_KEY = "codex_model_provider"
@@ -67,7 +66,7 @@ _TOKEN_PATTERNS = (
 )
 
 _BASE_LIMITATIONS = [
-    "Experimental chat picker integration only; not a normal API endpoint.",
+    "Chat picker integration only; not a normal API endpoint.",
     "Stateless: session/resume is not implemented.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
     "The adapter requires Codex CLI sandbox support and runs with read-only sandbox mode.",
@@ -483,7 +482,7 @@ class CodexCliCapabilities:
     def limitations(self) -> list[str]:
         out = list(_BASE_LIMITATIONS)
         if self.streaming_supported:
-            out.append("Experimental SSE test route can stream real Codex CLI JSON events.")
+            out.append("Codex CLI JSON event streaming is available for chat streaming.")
         else:
             out.append("Streaming is not available because Codex CLI JSON event output is not advertised.")
         if self.approval_flag:
@@ -1307,10 +1306,10 @@ class CodexCliChatAdapter:
     @staticmethod
     def _build_prompt(messages: list[dict[str, Any]]) -> str:
         parts = [
-            "You are replying through Odysseus' experimental Codex CLI provider.",
+            "You are replying through Odysseus' Codex CLI provider.",
             "Return only the final assistant response.",
             "Do not run tools, shell commands, file edits, or web requests.",
-            "If a request requires tools, say that this experimental provider does not support tools yet.",
+            "If a request requires tools, say that this provider does not support tools yet.",
             "",
             "Conversation:",
         ]

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -13,6 +13,7 @@ import os
 import re
 import tempfile
 import time
+from pathlib import Path
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
@@ -21,6 +22,7 @@ from src.codex_auth import get_codex_auth_service
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
 CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental, non-streaming)"
+CODEX_VIRTUAL_ENDPOINT_URL = "odysseus://codex-cli"
 CODEX_CHAT_TIMEOUT_SECONDS = 120
 
 _TOKEN_PATTERNS = (
@@ -30,10 +32,15 @@ _TOKEN_PATTERNS = (
 
 _LIMITATIONS = [
     "Non-streaming: returns one completed assistant message.",
-    "Stateless: session/resume is not implemented.",
+    "Session resume depends on the installed Codex CLI.",
     "Codex tool execution is not mapped into Odysseus agent rounds.",
     "The adapter requires Codex CLI sandbox/approval flags before running.",
 ]
+
+_UNSAFE_FLAGS = (
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--yolo",
+)
 
 
 def _truthy(value: str | None) -> bool:
@@ -51,6 +58,12 @@ def _sanitize_text(text: str | None, limit: int = 2000) -> str:
     return safe.strip()[:limit]
 
 
+def is_codex_virtual_endpoint(endpoint_url: str | None, model: str | None = None) -> bool:
+    return (endpoint_url or "").strip() == CODEX_VIRTUAL_ENDPOINT_URL or (
+        (model or "").strip() == CODEX_EXPERIMENTAL_MODEL_ID
+    )
+
+
 class CodexCliChatAdapter:
     """Admin-only, non-streaming adapter boundary for `codex exec`.
 
@@ -63,9 +76,13 @@ class CodexCliChatAdapter:
         self,
         auth_service_getter: Callable[[], Any] | None = None,
         runner: Callable[..., Any] | None = None,
+        session_root: str | Path | None = None,
     ) -> None:
         self._auth_service_getter = auth_service_getter or get_codex_auth_service
         self._runner = runner
+        self._session_root = Path(session_root) if session_root else Path(tempfile.gettempdir()) / "odysseus-codex-sessions"
+        self._session_map: dict[str, dict[str, Any]] = {}
+        self._reset_versions: dict[str, int] = {}
 
     async def available(self) -> dict[str, Any]:
         preflight = await self._preflight()
@@ -79,7 +96,7 @@ class CodexCliChatAdapter:
             "status": "available",
             "chat_supported": True,
             "streaming_supported": False,
-            "session_resume_supported": False,
+            "session_resume_supported": bool(help_result.get("session_resume_supported", False)),
             "tool_execution_allowed": False,
             "supports_json": help_result.get("supports_json", False),
             "limitations": list(_LIMITATIONS),
@@ -90,6 +107,7 @@ class CodexCliChatAdapter:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
         started = time.time()
         availability = await self.available()
@@ -104,23 +122,21 @@ class CodexCliChatAdapter:
         preflight = await self._preflight()
         prompt = self._build_prompt(messages)
         timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
-
-        with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
-            args = [
-                preflight["bin_path"],
-                "exec",
-                "--sandbox",
-                "read-only",
-                "--ask-for-approval",
-                "never",
-                prompt,
-            ]
-            rc, out, err = await self._run(
-                args,
-                timeout=timeout,
-                cwd=workdir,
-                env=preflight["env"],
-            )
+        resume_supported = bool(availability.get("session_resume_supported", False))
+        session_key = self._session_key(odysseus_session_id)
+        args, resume_mode = self._build_exec_args(
+            preflight["bin_path"],
+            prompt,
+            odysseus_session_key=session_key,
+            resume_supported=resume_supported,
+        )
+        workdir = self._ensure_workdir_for_session(session_key)
+        rc, out, err = await self._run(
+            args,
+            timeout=timeout,
+            cwd=str(workdir),
+            env=preflight["env"],
+        )
 
         duration_ms = round((time.time() - started) * 1000)
         if rc == 124:
@@ -128,6 +144,14 @@ class CodexCliChatAdapter:
         if rc != 0:
             detail = _sanitize_text(err or out, limit=500)
             return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model)
+
+        codex_session_id = self._extract_session_id("\n".join([out or "", err or ""]))
+        if session_key:
+            self._session_map[session_key] = {
+                "codex_session_id": codex_session_id or (self._session_map.get(session_key) or {}).get("codex_session_id", ""),
+                "workdir": str(workdir),
+                "updated_at": time.time(),
+            }
 
         message = self._extract_message(out)
         if not message:
@@ -141,9 +165,20 @@ class CodexCliChatAdapter:
             "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
             "limitations": list(_LIMITATIONS),
             "streaming_supported": False,
-            "session_resume_supported": False,
+            "session_resume_supported": resume_supported,
+            "session_resumed": resume_mode != "new",
+            "codex_resume_mode": resume_mode,
             "tool_execution_allowed": False,
         }
+
+    def reset_session(self, odysseus_session_id: str | None) -> dict[str, Any]:
+        session_key = self._session_key(odysseus_session_id)
+        if not session_key:
+            return {"ok": False, "status": "invalid_request", "error": "session_id is required"}
+        existed = session_key in self._session_map
+        self._session_map.pop(session_key, None)
+        self._reset_versions[session_key] = self._reset_versions.get(session_key, 0) + 1
+        return {"ok": True, "status": "reset", "session_mapping_cleared": existed}
 
     async def _preflight(self) -> dict[str, Any]:
         if not codex_model_provider_enabled():
@@ -183,14 +218,17 @@ class CodexCliChatAdapter:
 
     async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
         rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
-        if rc != 0:
+        top_rc, top_out, top_err = 1, "", ""
+        if rc != 0 or "--sandbox" not in (out or "") or "--ask-for-approval" not in (out or ""):
+            top_rc, top_out, top_err = await self._run([bin_path, "--help"], timeout=20, env=env)
+        help_text = "\n".join([out or "", top_out or ""])
+        if rc != 0 and top_rc != 0:
             return {
                 "ok": False,
                 "status": "unsupported_unsafe_cli_mode",
                 "error": "Unable to inspect codex exec safety flags",
-                "detail": _sanitize_text(err or out, limit=500),
+                "detail": _sanitize_text(err or out or top_err or top_out, limit=500),
             }
-        help_text = out or ""
         missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
         if missing:
             return {
@@ -199,12 +237,77 @@ class CodexCliChatAdapter:
                 "error": "Codex CLI does not advertise required safety flags",
                 "missing_flags": missing,
             }
+        resume_supported = await self._detect_resume_support(bin_path, env, help_text)
         return {
             "ok": True,
             "status": "exec_help_ok",
             "supports_json": "--json" in help_text,
             "supports_model": "--model" in help_text or " -m" in help_text,
+            "session_resume_supported": resume_supported,
         }
+
+    async def _detect_resume_support(self, bin_path: str, env: dict[str, str], help_text: str) -> bool:
+        rc, out, err = await self._run([bin_path, "exec", "resume", "--help"], timeout=20, env=env)
+        text = "\n".join([help_text or "", out or "", err or ""]).lower()
+        if rc == 0 and "resume" in text:
+            return True
+        return bool(re.search(r"\bresume\b", text) and "exec" in text)
+
+    def _build_exec_args(
+        self,
+        bin_path: str,
+        prompt: str,
+        *,
+        odysseus_session_key: str,
+        resume_supported: bool,
+    ) -> tuple[list[str], str]:
+        safety = ["--sandbox", "read-only", "--ask-for-approval", "never"]
+        args = [bin_path, "exec"]
+        resume_mode = "new"
+        if resume_supported and odysseus_session_key:
+            mapped = self._session_map.get(odysseus_session_key) or {}
+            codex_session_id = str(mapped.get("codex_session_id") or "").strip()
+            if codex_session_id:
+                args.extend(["resume", codex_session_id])
+                resume_mode = "session_id"
+            else:
+                mapped_workdir_raw = str(mapped.get("workdir") or "")
+                can_resume_last = bool(mapped_workdir_raw and Path(mapped_workdir_raw).exists())
+                if can_resume_last:
+                    args.extend(["resume", "--last"])
+                    resume_mode = "last_in_workdir"
+        args.extend([*safety, prompt])
+        self._assert_safe_args(args)
+        return args, resume_mode
+
+    def _assert_safe_args(self, args: list[str]) -> None:
+        if "exec" not in args:
+            raise ValueError("Codex provider must use codex exec")
+        for unsafe in _UNSAFE_FLAGS:
+            if unsafe in args:
+                raise ValueError("Unsafe Codex CLI flag blocked")
+        if "--sandbox" not in args or "read-only" not in args:
+            raise ValueError("Codex provider requires read-only sandbox")
+        if "--ask-for-approval" not in args or "never" not in args:
+            raise ValueError("Codex provider requires approvals disabled")
+        if CODEX_EXPERIMENTAL_MODEL_ID in args:
+            raise ValueError("Internal Codex model id must not be passed to Codex CLI")
+
+    def _session_key(self, odysseus_session_id: str | None) -> str:
+        value = (odysseus_session_id or "").strip()
+        if not value:
+            return ""
+        return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)[:120]
+
+    def _workdir_path_for_session(self, session_key: str) -> Path:
+        version = self._reset_versions.get(session_key, 0)
+        safe = session_key or "one-shot"
+        return self._session_root / f"{safe}-{version}"
+
+    def _ensure_workdir_for_session(self, session_key: str) -> Path:
+        workdir = self._workdir_path_for_session(session_key)
+        workdir.mkdir(parents=True, exist_ok=True)
+        return workdir
 
     async def _run(
         self,
@@ -277,6 +380,26 @@ class CodexCliChatAdapter:
                 if isinstance(value, str) and value.strip():
                     return _sanitize_text(value)
         return text
+
+    @staticmethod
+    def _extract_session_id(output: str) -> str:
+        text = _sanitize_text(output, limit=8000)
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                try:
+                    data = json.loads(line)
+                except Exception:
+                    data = None
+                if isinstance(data, dict):
+                    for key in ("session_id", "conversation_id", "id"):
+                        value = data.get(key)
+                        if isinstance(value, str) and re.match(r"^[A-Za-z0-9_.:-]{8,}$", value):
+                            return value[:200]
+            match = re.search(r"(?i)\b(?:session|conversation)[ _-]?id\b[:= ]+([A-Za-z0-9_.:-]{8,})", line)
+            if match:
+                return match.group(1)[:200]
+        return ""
 
     @staticmethod
     def _error(status: str, error: str, duration_ms: int, model: str | None) -> dict[str, Any]:
@@ -365,12 +488,13 @@ class CodexModelProvider:
                 status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
             else:
                 base["chat_supported"] = True
+                base["session_resume_supported"] = bool(chat_available.get("session_resume_supported", False))
                 models.append({
                     "id": CODEX_EXPERIMENTAL_MODEL_ID,
                     "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
                     "experimental": True,
                     "streaming_supported": False,
-                    "session_resume_supported": False,
+                    "session_resume_supported": bool(chat_available.get("session_resume_supported", False)),
                 })
 
         return {
@@ -393,5 +517,14 @@ class CodexModelProvider:
         messages: list[dict[str, Any]],
         model: str | None = None,
         timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+        odysseus_session_id: str | None = None,
     ) -> dict[str, Any]:
-        return await self._chat_adapter.complete(messages, model=model, timeout_seconds=timeout_seconds)
+        return await self._chat_adapter.complete(
+            messages,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            odysseus_session_id=odysseus_session_id,
+        )
+
+    def reset_session(self, odysseus_session_id: str | None) -> dict[str, Any]:
+        return self._chat_adapter.reset_session(odysseus_session_id)

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -7,7 +7,12 @@ output as token streaming or reading Codex credential files.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
+import re
+import tempfile
+import time
 from typing import Any, Callable
 
 from src.codex_auth import get_codex_auth_service
@@ -15,6 +20,20 @@ from src.codex_auth import get_codex_auth_service
 
 CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
 CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
+CODEX_EXPERIMENTAL_MODEL_DISPLAY = "Codex CLI / ChatGPT (experimental, non-streaming)"
+CODEX_CHAT_TIMEOUT_SECONDS = 120
+
+_TOKEN_PATTERNS = (
+    re.compile(r"(?i)(access_token|refresh_token|id_token)\s*[:=]\s*['\"]?[^'\"\s,}]+"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+"),
+)
+
+_LIMITATIONS = [
+    "Non-streaming: returns one completed assistant message.",
+    "Stateless: session/resume is not implemented.",
+    "Codex tool execution is not mapped into Odysseus agent rounds.",
+    "The adapter requires Codex CLI sandbox/approval flags before running.",
+]
 
 
 def _truthy(value: str | None) -> bool:
@@ -25,11 +44,265 @@ def codex_model_provider_enabled() -> bool:
     return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
 
 
+def _sanitize_text(text: str | None, limit: int = 2000) -> str:
+    safe = text or ""
+    for pattern in _TOKEN_PATTERNS:
+        safe = pattern.sub("<redacted-token>", safe)
+    return safe.strip()[:limit]
+
+
+class CodexCliChatAdapter:
+    """Admin-only, non-streaming adapter boundary for `codex exec`.
+
+    This intentionally does not provide a normal chat-provider hook yet. It
+    refuses to run unless the installed CLI advertises the sandbox and approval
+    flags needed for a constrained one-shot completion probe.
+    """
+
+    def __init__(
+        self,
+        auth_service_getter: Callable[[], Any] | None = None,
+        runner: Callable[..., Any] | None = None,
+    ) -> None:
+        self._auth_service_getter = auth_service_getter or get_codex_auth_service
+        self._runner = runner
+
+    async def available(self) -> dict[str, Any]:
+        preflight = await self._preflight()
+        if not preflight.get("ok"):
+            return preflight
+        help_result = await self._exec_help(preflight["bin_path"], preflight["env"])
+        if not help_result.get("ok"):
+            return help_result
+        return {
+            "ok": True,
+            "status": "available",
+            "chat_supported": True,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "supports_json": help_result.get("supports_json", False),
+            "limitations": list(_LIMITATIONS),
+        }
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        started = time.time()
+        availability = await self.available()
+        if not availability.get("ok"):
+            return {
+                **availability,
+                "ok": False,
+                "duration_ms": round((time.time() - started) * 1000),
+                "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            }
+
+        preflight = await self._preflight()
+        prompt = self._build_prompt(messages)
+        timeout = max(1, min(int(timeout_seconds or CODEX_CHAT_TIMEOUT_SECONDS), 300))
+
+        with tempfile.TemporaryDirectory(prefix="odysseus-codex-chat-") as workdir:
+            args = [
+                preflight["bin_path"],
+                "exec",
+                "--sandbox",
+                "read-only",
+                "--ask-for-approval",
+                "never",
+                prompt,
+            ]
+            rc, out, err = await self._run(
+                args,
+                timeout=timeout,
+                cwd=workdir,
+                env=preflight["env"],
+            )
+
+        duration_ms = round((time.time() - started) * 1000)
+        if rc == 124:
+            return self._error("timeout", "Codex CLI timed out", duration_ms, model)
+        if rc != 0:
+            detail = _sanitize_text(err or out, limit=500)
+            return self._error("cli_failed", detail or "Codex CLI failed", duration_ms, model)
+
+        message = self._extract_message(out)
+        if not message:
+            return self._error("empty_response", "Codex CLI returned no assistant message", duration_ms, model)
+
+        return {
+            "ok": True,
+            "status": "ok",
+            "message": message,
+            "duration_ms": duration_ms,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "limitations": list(_LIMITATIONS),
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+        }
+
+    async def _preflight(self) -> dict[str, Any]:
+        if not codex_model_provider_enabled():
+            return {"ok": False, "status": "disabled", "error": "Codex model provider is disabled"}
+
+        service = self._auth_service_getter()
+        try:
+            auth = await service.status()
+        except Exception as exc:
+            return {"ok": False, "status": "auth_status_failed", "error": exc.__class__.__name__}
+
+        cli_available = bool(
+            auth.get("codex_cli_available")
+            or (auth.get("cli_found") and auth.get("cli_executable"))
+        )
+        if not cli_available:
+            return {"ok": False, "status": "cli_unavailable", "error": "Codex CLI is unavailable"}
+
+        authenticated = bool(auth.get("codex_authenticated") or auth.get("authenticated"))
+        if not authenticated:
+            return {"ok": False, "status": "sign_in_required", "error": "Sign in with Codex / ChatGPT first"}
+
+        bin_path = ""
+        try:
+            bin_path = service._bin_path()  # Existing auth service owns CLI resolution.
+        except Exception:
+            bin_path = auth.get("resolved_binary_path") or ""
+        if not bin_path:
+            bin_path = auth.get("resolved_binary_path") or os.getenv("CODEX_BIN", "codex")
+
+        try:
+            env = service._env()
+        except Exception:
+            env = os.environ.copy()
+
+        return {"ok": True, "status": "preflight_ok", "bin_path": bin_path, "env": env}
+
+    async def _exec_help(self, bin_path: str, env: dict[str, str]) -> dict[str, Any]:
+        rc, out, err = await self._run([bin_path, "exec", "--help"], timeout=20, env=env)
+        if rc != 0:
+            return {
+                "ok": False,
+                "status": "unsupported_unsafe_cli_mode",
+                "error": "Unable to inspect codex exec safety flags",
+                "detail": _sanitize_text(err or out, limit=500),
+            }
+        help_text = out or ""
+        missing = [flag for flag in ("--sandbox", "--ask-for-approval") if flag not in help_text]
+        if missing:
+            return {
+                "ok": False,
+                "status": "unsupported_unsafe_cli_mode",
+                "error": "Codex CLI does not advertise required safety flags",
+                "missing_flags": missing,
+            }
+        return {
+            "ok": True,
+            "status": "exec_help_ok",
+            "supports_json": "--json" in help_text,
+            "supports_model": "--model" in help_text or " -m" in help_text,
+        }
+
+    async def _run(
+        self,
+        args: list[str],
+        *,
+        timeout: int,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if self._runner:
+            return await self._runner(args=args, timeout=timeout, cwd=cwd, env=env)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            try:
+                out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return 124, "", "Command timed out"
+            return (
+                proc.returncode or 0,
+                (out or b"").decode("utf-8", errors="replace"),
+                (err or b"").decode("utf-8", errors="replace"),
+            )
+        except Exception as exc:
+            return 1, "", f"Failed to start Codex CLI: {exc.__class__.__name__}"
+
+    @staticmethod
+    def _build_prompt(messages: list[dict[str, Any]]) -> str:
+        parts = [
+            "You are replying through Odysseus' experimental Codex CLI provider.",
+            "Return only the final assistant response.",
+            "Do not run tools, shell commands, file edits, or web requests.",
+            "If a request requires tools, say that this experimental provider does not support tools yet.",
+            "",
+            "Conversation:",
+        ]
+        for msg in messages or []:
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role") or "user").strip() or "user"
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = " ".join(str(part.get("text", part)) if isinstance(part, dict) else str(part) for part in content)
+            parts.append(f"{role}: {content}")
+        return "\n".join(parts).strip()
+
+    @staticmethod
+    def _extract_message(output: str) -> str:
+        text = _sanitize_text(output)
+        if not text:
+            return ""
+        # If a future CLI emits JSONL, prefer common completed-message fields.
+        for line in text.splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                data = json.loads(line)
+            except Exception:
+                continue
+            for key in ("message", "content", "text", "output"):
+                value = data.get(key) if isinstance(data, dict) else None
+                if isinstance(value, str) and value.strip():
+                    return _sanitize_text(value)
+        return text
+
+    @staticmethod
+    def _error(status: str, error: str, duration_ms: int, model: str | None) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "status": status,
+            "error": _sanitize_text(error, limit=500),
+            "duration_ms": duration_ms,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "limitations": list(_LIMITATIONS),
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+        }
+
+
 class CodexModelProvider:
     """Status/capability adapter for a future Codex CLI provider."""
 
-    def __init__(self, auth_service_getter: Callable[[], Any] | None = None) -> None:
+    def __init__(
+        self,
+        auth_service_getter: Callable[[], Any] | None = None,
+        chat_adapter: CodexCliChatAdapter | None = None,
+    ) -> None:
         self._auth_service_getter = auth_service_getter or get_codex_auth_service
+        self._chat_adapter = chat_adapter or CodexCliChatAdapter(self._auth_service_getter)
 
     async def status(self) -> dict[str, Any]:
         enabled = codex_model_provider_enabled()
@@ -43,12 +316,7 @@ class CodexModelProvider:
             "streaming_supported": False,
             "session_resume_supported": False,
             "tool_execution_allowed": False,
-            "limitations": [
-                "Chat dispatch is not implemented.",
-                "True token streaming has not been validated.",
-                "Session/resume behavior has not been designed.",
-                "Codex tool execution is not enabled for Odysseus chat mode.",
-            ],
+            "limitations": list(_LIMITATIONS),
         }
         if not enabled:
             return {
@@ -90,12 +358,20 @@ class CodexModelProvider:
             requires_sign_in = False
 
         models = []
+        chat_available = {"ok": False}
         if status == "available":
-            models.append({
-                "id": CODEX_EXPERIMENTAL_MODEL_ID,
-                "display": "codex-cli/chatgpt (experimental)",
-                "experimental": True,
-            })
+            chat_available = await self._chat_adapter.available()
+            if not chat_available.get("ok"):
+                status = chat_available.get("status") or "unsupported_unsafe_cli_mode"
+            else:
+                base["chat_supported"] = True
+                models.append({
+                    "id": CODEX_EXPERIMENTAL_MODEL_ID,
+                    "display": CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+                    "experimental": True,
+                    "streaming_supported": False,
+                    "session_resume_supported": False,
+                })
 
         return {
             **base,
@@ -111,3 +387,11 @@ class CodexModelProvider:
             },
             "models": models,
         }
+
+    async def test_chat(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        timeout_seconds: int = CODEX_CHAT_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        return await self._chat_adapter.complete(messages, model=model, timeout_seconds=timeout_seconds)

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -189,7 +189,6 @@ def add_integration(data: Dict[str, Any]) -> Dict[str, Any]:
     integration.setdefault("api_key", "")
     integration.setdefault("name", "")
     integration.setdefault("base_url", "")
-    integration.setdefault("integration_type", "api")
 
     integrations = load_integrations()
     integrations.append(integration)
@@ -259,9 +258,6 @@ async def execute_api_call(
     integration = _find_integration(integration_id)
     if not integration:
         return {"error": f"Integration not found: {integration_id}", "exit_code": 1}
-
-    if integration.get("integration_type") == "codex":
-        return {"error": "Codex / ChatGPT is not an HTTP API integration", "exit_code": 1}
 
     if not integration.get("enabled", True):
         return {"error": f"Integration '{integration.get('name')}' is disabled", "exit_code": 1}
@@ -385,10 +381,7 @@ def get_integrations_prompt() -> str:
     Returns empty string if no integrations are enabled.
     """
     integrations = load_integrations()
-    enabled = [
-        i for i in integrations
-        if i.get("enabled", True) and i.get("integration_type", "api") != "codex"
-    ]
+    enabled = [i for i in integrations if i.get("enabled", True)]
     if not enabled:
         return ""
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -189,6 +189,7 @@ def add_integration(data: Dict[str, Any]) -> Dict[str, Any]:
     integration.setdefault("api_key", "")
     integration.setdefault("name", "")
     integration.setdefault("base_url", "")
+    integration.setdefault("integration_type", "api")
 
     integrations = load_integrations()
     integrations.append(integration)
@@ -258,6 +259,9 @@ async def execute_api_call(
     integration = _find_integration(integration_id)
     if not integration:
         return {"error": f"Integration not found: {integration_id}", "exit_code": 1}
+
+    if integration.get("integration_type") == "codex":
+        return {"error": "Codex / ChatGPT is not an HTTP API integration", "exit_code": 1}
 
     if not integration.get("enabled", True):
         return {"error": f"Integration '{integration.get('name')}' is disabled", "exit_code": 1}
@@ -381,7 +385,10 @@ def get_integrations_prompt() -> str:
     Returns empty string if no integrations are enabled.
     """
     integrations = load_integrations()
-    enabled = [i for i in integrations if i.get("enabled", True)]
+    enabled = [
+        i for i in integrations
+        if i.get("enabled", True) and i.get("integration_type", "api") != "codex"
+    ]
     if not enabled:
         return ""
 

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -522,6 +522,8 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
              max_tokens: int = LLMConfig.DEFAULT_MAX_TOKENS, headers: Optional[Dict] = None, 
              timeout: int = LLMConfig.DEFAULT_TIMEOUT, prompt_type: Optional[str] = None) -> str:
     """Synchronous LLM call with optional prompt type enhancement."""
+    from src.codex_model_provider import CodexModelProvider, is_codex_model_selection
+
     h = _provider_headers(_detect_provider(url))
     # Tolerate headers that arrive as a JSON string (some sessions stored them
     # double-encoded) — otherwise h.update() throws "dictionary update sequence
@@ -555,6 +557,20 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
     if cached_response:
         logger.debug(f"Returning cached response for key: {cache_key}")
         return cached_response
+
+    if is_codex_model_selection(url, model):
+        result = asyncio.run(
+            CodexModelProvider().test_chat(
+                messages_copy,
+                model=model,
+                timeout_seconds=timeout,
+            )
+        )
+        if not result.get("ok"):
+            raise HTTPException(502, result.get("error") or "Codex provider failed")
+        response = result.get("message") or ""
+        _set_cached_response(cache_key, response)
+        return response
 
     if provider == "anthropic":
         target_url = _normalize_anthropic_url(url)
@@ -646,6 +662,8 @@ async def llm_call_async(
     prompt_type: Optional[str] = None
 ) -> str:
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
+    from src.codex_model_provider import CodexModelProvider, is_codex_model_selection
+
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
 
@@ -667,6 +685,18 @@ async def llm_call_async(
     if cached_response:
         logger.debug(f"Returning cached response for key: {cache_key}")
         return cached_response
+
+    if is_codex_model_selection(url, model):
+        result = await CodexModelProvider().test_chat(
+            messages_copy,
+            model=model,
+            timeout_seconds=timeout,
+        )
+        if not result.get("ok"):
+            raise HTTPException(502, result.get("error") or "Codex provider failed")
+        response = result.get("message") or ""
+        _set_cached_response(cache_key, response)
+        return response
 
     if provider == "anthropic":
         target_url = _normalize_anthropic_url(url)

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -192,6 +192,8 @@ class ResearchHandler:
             "task": None,
             "researcher": None,
             "query": query,
+            "llm_endpoint": llm_endpoint,
+            "llm_model": llm_model,
             "status": "running",
             "progress": {},
             "result": None,
@@ -469,6 +471,8 @@ class ResearchHandler:
             path = RESEARCH_DATA_DIR / f"{session_id}.json"
             data = {
                 "query": entry["query"],
+                "llm_endpoint": entry.get("llm_endpoint", ""),
+                "llm_model": entry.get("llm_model", ""),
                 "status": entry["status"],
                 "result": entry["result"],
                 "raw_report": entry.get("raw_report", ""),

--- a/src/session_actions.py
+++ b/src/session_actions.py
@@ -8,7 +8,7 @@ and the task scheduler / builtin actions system.
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,23 @@ _THROWAWAY_NAMES = {
     "ok", "lol", "bruh", "hmm", "hm", "meh",
 }
 _THROWAWAY_MAX_MESSAGES = 4
+_AUTO_SORT_GRACE_PERIOD = timedelta(minutes=2)
+
+
+def session_protected_from_auto_sort(row, *, now: datetime | None = None) -> bool:
+    name = (getattr(row, "name", "") or "").strip()
+    if name.startswith("[GRP]"):
+        return True
+    created_at = getattr(row, "created_at", None) or getattr(row, "updated_at", None)
+    if not created_at:
+        return False
+    now = now or datetime.utcnow()
+    try:
+        created_cmp = created_at.replace(tzinfo=None) if getattr(created_at, "tzinfo", None) else created_at
+        now_cmp = now.replace(tzinfo=None) if getattr(now, "tzinfo", None) else now
+    except Exception:
+        return False
+    return (now_cmp - created_cmp) < _AUTO_SORT_GRACE_PERIOD
 
 
 async def run_auto_sort(owner: str, skip_llm: bool = False) -> str:
@@ -49,9 +66,12 @@ async def run_auto_sort(owner: str, skip_llm: bool = False) -> str:
             DbSession.archived == False,
             *([DbSession.owner == owner] if owner else []),
         ).all()
+        now = datetime.utcnow()
 
         for row in rows:
             if getattr(row, 'is_important', False):
+                continue
+            if session_protected_from_auto_sort(row, now=now):
                 continue
             if (row.name or "").strip() == "Incognito":
                 deleted_throwaway += 1

--- a/static/index.html
+++ b/static/index.html
@@ -2108,14 +2108,18 @@
                   <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
                   <div id="adm-codexProviderModels" class="admin-ep-detail" style="white-space:normal;"></div>
                   <div class="adm-codex-model-add" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
-                    <input id="adm-codexManualModelId" type="text" placeholder="Manual Codex model ID" style="min-width:220px;flex:1;">
-                    <button type="button" class="admin-btn-sm" id="adm-codexAddModelBtn">Add Model</button>
+                    <select id="adm-codexPresetSelect" style="min-width:200px;flex:1;">
+                      <option value="">Recommended Codex model</option>
+                    </select>
+                    <input id="adm-codexManualModelId" type="text" placeholder="Custom Codex model ID" style="min-width:220px;flex:1;display:none;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexAddModelBtn">+ Add model</button>
                   </div>
                   <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
                     <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexStreamTestBtn">Stream Test</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexRemoveConnectorBtn" style="opacity:0.75;">Remove connector</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexSignOutBtn" style="opacity:0.75;">Sign out</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexResetBtn" style="opacity:0.75;">Reset</button>
                   </div>

--- a/static/index.html
+++ b/static/index.html
@@ -2043,6 +2043,7 @@
                   <option value="https://api.anthropic.com" data-logo="anthropic">Anthropic</option>
                   <option value="https://api.deepseek.com/v1" data-logo="deepseek" selected>DeepSeek</option>
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>
+                  <option value="__codex_cli__" data-logo="openai">Codex / ChatGPT (Experimental)</option>
                   <option value="https://openrouter.ai/api/v1" data-logo="openrouter">OpenRouter</option>
                   <option value="https://ollama.com/api" data-logo="ollama">Ollama Cloud</option>
                   <option value="https://api.groq.com/openai/v1" data-logo="groq">Groq</option>
@@ -2064,27 +2065,6 @@
                   <button class="admin-btn-add" id="adm-epAddBtn" style="width:55px;text-align:center;">Add</button>
                 </div>
                 <div id="adm-epApiMsg" class="adm-ep-inline-msg"></div>
-                <div id="adm-codexProviderCard" class="admin-user-row" style="display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-top:10px;">
-                  <div style="display:flex;align-items:flex-start;gap:10px;">
-                    <div style="flex:1;min-width:0;">
-                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
-                        <span>Codex / ChatGPT</span>
-                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
-                      </div>
-                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                        Experimental, non-streaming, stateless provider using Codex CLI auth. Not added to the default model picker yet.
-                      </div>
-                    </div>
-                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
-                  </div>
-                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
-                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
-                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
-                  </div>
-                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
-                </div>
               </div>
             </div>
           </div>
@@ -2102,6 +2082,36 @@
               <div class="adm-ep-section-head">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:4px;"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
                 <span>API</span>
+              </div>
+              <div id="adm-codexProviderCard" class="admin-user-row" style="display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-bottom:8px;">
+                <div id="adm-codexProviderHeader" style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;">
+                  <div style="flex:1;min-width:0;">
+                    <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
+                      <span>Codex / ChatGPT</span>
+                      <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
+                      <span style="font-size:10px;opacity:0.4;">Click to configure</span>
+                    </div>
+                    <div id="adm-codexProviderSummary" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                      Uses Codex CLI auth. Experimental chat model picker entry.
+                    </div>
+                  </div>
+                  <div style="display:flex;gap:6px;align-items:center;">
+                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
+                    <svg id="adm-codexProviderChevron" class="admin-user-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;transition:transform 0.2s,opacity 0.2s;"><polyline points="6 9 12 15 18 9"/></svg>
+                  </div>
+                </div>
+                <div id="adm-codexProviderBody" style="display:none;flex-direction:column;gap:8px;">
+                  <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                    Experimental, one-shot only, stateless provider using Codex CLI auth.
+                  </div>
+                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                  </div>
+                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
+                </div>
               </div>
               <div id="adm-epList-api"></div>
             </div>

--- a/static/index.html
+++ b/static/index.html
@@ -2104,11 +2104,20 @@
                   <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
                     Experimental, one-shot only, stateless provider using Codex CLI auth.
                   </div>
+                  <div id="adm-codexProviderCapabilities" class="admin-ep-detail" style="white-space:normal;line-height:1.35;"></div>
                   <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div id="adm-codexProviderModels" class="admin-ep-detail" style="white-space:normal;"></div>
+                  <div class="adm-codex-model-add" style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                    <input id="adm-codexManualModelId" type="text" placeholder="Manual Codex model ID" style="min-width:220px;flex:1;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexAddModelBtn">Add Model</button>
+                  </div>
                   <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
                     <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexStreamTestBtn">Stream Test</button>
                     <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexSignOutBtn" style="opacity:0.75;">Sign out</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexResetBtn" style="opacity:0.75;">Reset</button>
                   </div>
                   <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
                 </div>

--- a/static/index.html
+++ b/static/index.html
@@ -2087,11 +2087,11 @@
                 <div id="adm-codexProviderHeader" style="display:flex;align-items:flex-start;gap:10px;cursor:pointer;">
                   <div style="flex:1;min-width:0;">
                     <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
-                      <span>Codex / ChatGPT</span>
+                      <span>Codex connector</span>
                       <span style="font-size:10px;opacity:0.4;">Click to configure</span>
                     </div>
                     <div id="adm-codexProviderSummary" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                      Codex connector uses Codex CLI auth. Chat model picker entry.
+                      Codex connector uses Codex CLI auth. Connector card entry.
                     </div>
                   </div>
                   <div style="display:flex;gap:6px;align-items:center;">

--- a/static/index.html
+++ b/static/index.html
@@ -2043,6 +2043,7 @@
                   <option value="https://api.anthropic.com" data-logo="anthropic">Anthropic</option>
                   <option value="https://api.deepseek.com/v1" data-logo="deepseek" selected>DeepSeek</option>
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>
+                  <option value="codex-cli" data-logo="openai" data-experimental="true">Codex / ChatGPT (experimental)</option>
                   <option value="https://openrouter.ai/api/v1" data-logo="openrouter">OpenRouter</option>
                   <option value="https://ollama.com/api" data-logo="ollama">Ollama Cloud</option>
                   <option value="https://api.groq.com/openai/v1" data-logo="groq">Groq</option>
@@ -2053,7 +2054,29 @@
                   <option value="https://api.x.ai/v1" data-logo="grok">xAI Grok</option>
                   <option value="https://api.z.ai/api/paas/v4" data-logo="zhipu">Z.AI (Zhipu)</option>
                 </select>
-                <div class="admin-model-form-row">
+                <div id="adm-codexProviderPanel" class="adm-codex-provider-panel hidden">
+                  <div style="display:flex;align-items:flex-start;gap:10px;">
+                    <div style="flex:1;min-width:0;">
+                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
+                        <span>Codex / ChatGPT</span>
+                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
+                      </div>
+                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                        Uses the Codex CLI sign-in you manage in Settings -> Integrations. Runs non-streaming test chats with a read-only sandbox.
+                      </div>
+                    </div>
+                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
+                  </div>
+                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexResetBtn" style="opacity:0.75;">Reset Codex session</button>
+                  </div>
+                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
+                </div>
+                <div class="admin-model-form-row" id="adm-epApiNormalRow">
                   <input id="adm-epApiKey" type="password" placeholder="API key">
                   <select id="adm-epType" style="padding:5px;width:80px;">
                     <option value="llm">LLM</option>
@@ -2064,27 +2087,6 @@
                   <button class="admin-btn-add" id="adm-epAddBtn" style="width:55px;text-align:center;">Add</button>
                 </div>
                 <div id="adm-epApiMsg" class="adm-ep-inline-msg"></div>
-                <div id="adm-codexProviderCard" class="admin-user-row" style="display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-top:10px;">
-                  <div style="display:flex;align-items:flex-start;gap:10px;">
-                    <div style="flex:1;min-width:0;">
-                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
-                        <span>Codex / ChatGPT</span>
-                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
-                      </div>
-                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                        Experimental, non-streaming, stateless provider using Codex CLI auth. Not added to the default model picker yet.
-                      </div>
-                    </div>
-                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
-                  </div>
-                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
-                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
-                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
-                  </div>
-                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
-                </div>
               </div>
             </div>
           </div>

--- a/static/index.html
+++ b/static/index.html
@@ -2090,24 +2090,6 @@
         <!-- ═══ TOOLS TAB ═══ -->
         <!-- ═══ INTEGRATIONS TAB ═══ -->
         <div data-settings-panel="integrations" class="hidden">
-          <div class="admin-card" id="codex-auth-card">
-            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M12 2v20"/><path d="M2 12h20"/><path d="m16 6 2 2-2 2"/><path d="m8 18-2-2 2-2"/></svg>Codex / ChatGPT</h2>
-            <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
-            <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
-            <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">
-              <div style="font-size:11px;opacity:0.65;margin-bottom:6px;">Open the verification URL, sign in, then enter this one-time code.</div>
-              <div style="display:grid;grid-template-columns:90px minmax(0,1fr);gap:6px 10px;align-items:center;font-size:12px;">
-                <span style="opacity:0.55;">URL</span><a id="codex-auth-url" href="#" target="_blank" rel="noopener noreferrer" style="color:var(--accent,var(--red));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></a>
-                <span style="opacity:0.55;">Code</span><code id="codex-auth-code" style="font-size:18px;letter-spacing:1px;"></code>
-              </div>
-            </div>
-            <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
-              <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
-              <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
-              <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
-              <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
-            </div>
-          </div>
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>Connections</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">All external service connections in one place.</div>

--- a/static/index.html
+++ b/static/index.html
@@ -2043,7 +2043,7 @@
                   <option value="https://api.anthropic.com" data-logo="anthropic">Anthropic</option>
                   <option value="https://api.deepseek.com/v1" data-logo="deepseek" selected>DeepSeek</option>
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>
-                  <option value="__codex_cli__" data-logo="openai">Codex / ChatGPT (Experimental)</option>
+                  <option value="__codex_cli__" data-logo="openai">Codex / ChatGPT</option>
                   <option value="https://openrouter.ai/api/v1" data-logo="openrouter">OpenRouter</option>
                   <option value="https://ollama.com/api" data-logo="ollama">Ollama Cloud</option>
                   <option value="https://api.groq.com/openai/v1" data-logo="groq">Groq</option>
@@ -2088,11 +2088,10 @@
                   <div style="flex:1;min-width:0;">
                     <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
                       <span>Codex / ChatGPT</span>
-                      <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
                       <span style="font-size:10px;opacity:0.4;">Click to configure</span>
                     </div>
                     <div id="adm-codexProviderSummary" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                      Uses Codex CLI auth. Experimental chat model picker entry.
+                      Codex connector uses Codex CLI auth. Chat model picker entry.
                     </div>
                   </div>
                   <div style="display:flex;gap:6px;align-items:center;">
@@ -2100,10 +2099,10 @@
                     <svg id="adm-codexProviderChevron" class="admin-user-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;transition:transform 0.2s,opacity 0.2s;"><polyline points="6 9 12 15 18 9"/></svg>
                   </div>
                 </div>
-                <div id="adm-codexProviderBody" style="display:none;flex-direction:column;gap:8px;">
-                  <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                    Experimental, one-shot only, stateless provider using Codex CLI auth.
-                  </div>
+                  <div id="adm-codexProviderBody" style="display:none;flex-direction:column;gap:8px;">
+                    <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                    One-shot only, stateless provider using Codex CLI auth.
+                    </div>
                   <div id="adm-codexProviderCapabilities" class="admin-ep-detail" style="white-space:normal;line-height:1.35;"></div>
                   <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
                   <div id="adm-codexProviderModels" class="admin-ep-detail" style="white-space:normal;"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -2090,6 +2090,24 @@
         <!-- ═══ TOOLS TAB ═══ -->
         <!-- ═══ INTEGRATIONS TAB ═══ -->
         <div data-settings-panel="integrations" class="hidden">
+          <div class="admin-card" id="codex-auth-card">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M12 2v20"/><path d="M2 12h20"/><path d="m16 6 2 2-2 2"/><path d="m8 18-2-2 2-2"/></svg>Codex / ChatGPT</h2>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
+            <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
+            <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">
+              <div style="font-size:11px;opacity:0.65;margin-bottom:6px;">Open the verification URL, sign in, then enter this one-time code.</div>
+              <div style="display:grid;grid-template-columns:90px minmax(0,1fr);gap:6px 10px;align-items:center;font-size:12px;">
+                <span style="opacity:0.55;">URL</span><a id="codex-auth-url" href="#" target="_blank" rel="noopener noreferrer" style="color:var(--accent,var(--red));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></a>
+                <span style="opacity:0.55;">Code</span><code id="codex-auth-code" style="font-size:18px;letter-spacing:1px;"></code>
+              </div>
+            </div>
+            <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+              <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
+              <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
+              <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
+              <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
+            </div>
+          </div>
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>Connections</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">All external service connections in one place.</div>

--- a/static/index.html
+++ b/static/index.html
@@ -2043,7 +2043,6 @@
                   <option value="https://api.anthropic.com" data-logo="anthropic">Anthropic</option>
                   <option value="https://api.deepseek.com/v1" data-logo="deepseek" selected>DeepSeek</option>
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>
-                  <option value="codex-cli" data-logo="openai" data-experimental="true">Codex / ChatGPT (experimental)</option>
                   <option value="https://openrouter.ai/api/v1" data-logo="openrouter">OpenRouter</option>
                   <option value="https://ollama.com/api" data-logo="ollama">Ollama Cloud</option>
                   <option value="https://api.groq.com/openai/v1" data-logo="groq">Groq</option>
@@ -2054,29 +2053,7 @@
                   <option value="https://api.x.ai/v1" data-logo="grok">xAI Grok</option>
                   <option value="https://api.z.ai/api/paas/v4" data-logo="zhipu">Z.AI (Zhipu)</option>
                 </select>
-                <div id="adm-codexProviderPanel" class="adm-codex-provider-panel hidden">
-                  <div style="display:flex;align-items:flex-start;gap:10px;">
-                    <div style="flex:1;min-width:0;">
-                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
-                        <span>Codex / ChatGPT</span>
-                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
-                      </div>
-                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
-                        Uses the Codex CLI sign-in you manage in Settings -> Integrations. Runs non-streaming test chats with a read-only sandbox.
-                      </div>
-                    </div>
-                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
-                  </div>
-                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
-                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
-                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
-                    <button type="button" class="admin-btn-sm" id="adm-codexResetBtn" style="opacity:0.75;">Reset Codex session</button>
-                  </div>
-                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
-                </div>
-                <div class="admin-model-form-row" id="adm-epApiNormalRow">
+                <div class="admin-model-form-row">
                   <input id="adm-epApiKey" type="password" placeholder="API key">
                   <select id="adm-epType" style="padding:5px;width:80px;">
                     <option value="llm">LLM</option>
@@ -2087,6 +2064,27 @@
                   <button class="admin-btn-add" id="adm-epAddBtn" style="width:55px;text-align:center;">Add</button>
                 </div>
                 <div id="adm-epApiMsg" class="adm-ep-inline-msg"></div>
+                <div id="adm-codexProviderCard" class="admin-user-row" style="display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-top:10px;">
+                  <div style="display:flex;align-items:flex-start;gap:10px;">
+                    <div style="flex:1;min-width:0;">
+                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
+                        <span>Codex / ChatGPT</span>
+                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
+                      </div>
+                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                        Experimental, non-streaming, stateless provider using Codex CLI auth. Not added to the default model picker yet.
+                      </div>
+                    </div>
+                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
+                  </div>
+                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                  </div>
+                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
+                </div>
               </div>
             </div>
           </div>

--- a/static/index.html
+++ b/static/index.html
@@ -2064,6 +2064,27 @@
                   <button class="admin-btn-add" id="adm-epAddBtn" style="width:55px;text-align:center;">Add</button>
                 </div>
                 <div id="adm-epApiMsg" class="adm-ep-inline-msg"></div>
+                <div id="adm-codexProviderCard" class="admin-user-row" style="display:flex;flex-direction:column;align-items:stretch;gap:8px;margin-top:10px;">
+                  <div style="display:flex;align-items:flex-start;gap:10px;">
+                    <div style="flex:1;min-width:0;">
+                      <div class="admin-ep-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
+                        <span>Codex / ChatGPT</span>
+                        <span class="admin-badge" style="background:color-mix(in srgb, var(--accent) 18%, transparent);color:var(--accent);">Experimental</span>
+                      </div>
+                      <div id="adm-codexProviderDetails" class="admin-ep-detail" style="white-space:normal;line-height:1.35;">
+                        Experimental, non-streaming, stateless provider using Codex CLI auth. Not added to the default model picker yet.
+                      </div>
+                    </div>
+                    <span id="adm-codexProviderStatus" class="admin-badge admin-badge-off" style="white-space:nowrap;">Checking</span>
+                  </div>
+                  <div id="adm-codexProviderModel" class="admin-ep-detail" style="display:none;white-space:normal;"></div>
+                  <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+                    <button type="button" class="admin-btn-sm" id="adm-codexSignInBtn">Open Codex sign-in</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexTestBtn">Test Chat</button>
+                    <button type="button" class="admin-btn-sm" id="adm-codexRefreshBtn" style="opacity:0.75;">Refresh</button>
+                  </div>
+                  <div id="adm-codexProviderMsg" class="adm-ep-inline-msg"></div>
+                </div>
               </div>
             </div>
           </div>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -637,8 +637,6 @@ async function _saveEpModelState(epId, panel) {
 function initEndpointForm() {
   const provider = el('adm-epProvider');
   const urlInput = el('adm-epUrl');
-  const CODEX_PROVIDER_VALUE = 'codex-cli';
-  const CODEX_TEST_SESSION_ID = 'admin-add-models-codex-test';
 
   // Custom provider picker — mirrors the (now hidden) <select id="adm-epProvider">
   // so the rest of this function (which reads provider.value and dispatches
@@ -647,21 +645,14 @@ function initEndpointForm() {
   const pickerBtn = el('adm-provider-btn');
   const pickerMenu = el('adm-provider-menu');
   const pickerCurrent = picker ? picker.querySelector('.adm-provider-current') : null;
-  const apiNormalRow = el('adm-epApiNormalRow');
-  const codexPanel = el('adm-codexProviderPanel');
-  function _isCodexProviderSelected() {
-    return provider && provider.value === CODEX_PROVIDER_VALUE;
-  }
   function _renderPickerMenu() {
     if (!pickerMenu) return;
     pickerMenu.innerHTML = Array.from(provider.options).map(o => {
       const logo = o.dataset.logo ? (providerLogo(o.dataset.logo) || '') : '';
       const active = o.value === provider.value ? ' active' : '';
-      const experimental = o.dataset.experimental === 'true' ? '<span class="admin-badge" style="margin-left:auto;">Experimental</span>' : '';
       return `<div class="adm-provider-item${active}" role="option" data-value="${o.value.replace(/"/g, '&quot;')}">
         <span class="adm-provider-logo">${logo}</span>
         <span>${o.textContent}</span>
-        ${experimental}
       </div>`;
     }).join('');
   }
@@ -694,43 +685,15 @@ function initEndpointForm() {
     });
   }
 
-  function _syncCodexProviderMode() {
-    const isCodex = _isCodexProviderSelected();
-    if (codexPanel) codexPanel.classList.toggle('hidden', !isCodex);
-    if (apiNormalRow) apiNormalRow.classList.toggle('hidden', isCodex);
-    if (urlInput) {
-      urlInput.classList.toggle('hidden', isCodex);
-      if (isCodex) {
-        urlInput.value = '';
-      } else {
-        urlInput.placeholder = 'Base URL or pick provider';
-      }
-    }
-    if (picker) picker.classList.toggle('adm-provider-codex-selected', isCodex);
-    const apiMsg = el('adm-epApiMsg');
-    if (apiMsg && isCodex) {
-      apiMsg.textContent = '';
-      apiMsg.className = 'adm-ep-inline-msg';
-    }
-    if (isCodex) _refreshCodexProviderStatus();
-  }
-
   provider.addEventListener('change', () => {
-    if (_isCodexProviderSelected()) {
-      urlInput.value = '';
-    } else if (provider.value) {
-      urlInput.value = provider.value;
-    } else {
-      urlInput.value = '';
-    }
-    _syncCodexProviderMode();
+    if (provider.value) urlInput.value = provider.value;
+    else urlInput.value = '';
   });
   urlInput.addEventListener('input', () => {
     if (provider.value && urlInput.value.trim() !== provider.value) {
       provider.value = '';
       _renderPickerMenu();
       _syncPickerCurrent();
-      _syncCodexProviderMode();
     }
   });
   function _normalizeBaseUrl(raw) {
@@ -802,6 +765,7 @@ function initEndpointForm() {
     return el(kind === 'local' ? 'adm-epLocalMsg' : 'adm-epApiMsg') || el('adm-epMsg');
   }
 
+  const codexCard = el('adm-codexProviderCard');
   const codexStatusEl = el('adm-codexProviderStatus');
   const codexDetailsEl = el('adm-codexProviderDetails');
   const codexModelEl = el('adm-codexProviderModel');
@@ -809,7 +773,6 @@ function initEndpointForm() {
   const codexSignInBtn = el('adm-codexSignInBtn');
   const codexTestBtn = el('adm-codexTestBtn');
   const codexRefreshBtn = el('adm-codexRefreshBtn');
-  const codexResetBtn = el('adm-codexResetBtn');
   let codexProviderStatus = null;
 
   function _setCodexMsg(text, cls) {
@@ -829,7 +792,7 @@ function initEndpointForm() {
   }
 
   function _renderCodexProviderStatus(data) {
-    if (!codexPanel || !codexStatusEl || !codexDetailsEl) return;
+    if (!codexCard || !codexStatusEl || !codexDetailsEl) return;
     const status = data && data.status ? data.status : 'unavailable';
     const model = Array.isArray(data?.models) && data.models.length ? data.models[0] : null;
     const available = status === 'available' && data.chat_supported === true && !!model;
@@ -841,9 +804,7 @@ function initEndpointForm() {
     codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
     codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
 
-    let details = 'Uses Settings -> Integrations -> Codex / ChatGPT sign-in. Test chat runs through Codex CLI with read-only sandbox and no approval prompts.';
-    if (available && data.session_resume_supported) details += ' Follow-up chats in the same Odysseus session can resume the Codex CLI session.';
-    else if (available) details += ' Session resume is not available with this Codex CLI, so follow-ups fall back safely.';
+    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
@@ -864,7 +825,7 @@ function initEndpointForm() {
   }
 
   async function _refreshCodexProviderStatus() {
-    if (!codexPanel) return;
+    if (!codexCard) return;
     if (codexStatusEl) {
       codexStatusEl.textContent = 'Checking';
       codexStatusEl.className = 'admin-badge admin-badge-off';
@@ -917,7 +878,6 @@ function initEndpointForm() {
           model,
           prompt: 'Reply with exactly: Codex provider UI test ok',
           timeout_seconds: 60,
-          session_id: CODEX_TEST_SESSION_ID,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -936,41 +896,18 @@ function initEndpointForm() {
     if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
   }
 
-  async function _resetCodexProviderSession() {
-    if (!codexResetBtn) return;
-    codexResetBtn.disabled = true;
-    codexResetBtn.textContent = 'Resetting...';
-    _setCodexMsg('', '');
-    try {
-      const res = await fetch('/api/codex-model-provider/reset-session', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_id: CODEX_TEST_SESSION_ID }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (res.ok && data.ok) _setCodexMsg('Codex session mapping reset for this provider test.', 'admin-success');
-      else _setCodexMsg(data.error || 'Could not reset Codex session.', 'admin-error');
-    } catch (e) {
-      _setCodexMsg('Reset failed: ' + (e && e.message ? e.message : 'request failed'), 'admin-error');
-    }
-    codexResetBtn.disabled = false;
-    codexResetBtn.textContent = 'Reset Codex session';
-  }
-
   if (codexSignInBtn) {
     codexSignInBtn.addEventListener('click', () => {
       if (settingsModule && typeof settingsModule.open === 'function') settingsModule.open('integrations');
       setTimeout(() => {
         document.dispatchEvent(new CustomEvent('odysseus:open-codex-auth'));
       }, 50);
-      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this provider after sign-in completes.', '');
+      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this card after sign-in completes.', '');
     });
   }
   if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
   if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
-  if (codexResetBtn) codexResetBtn.addEventListener('click', _resetCodexProviderSession);
-  _syncCodexProviderMode();
+  _refreshCodexProviderStatus();
 
   let apiTestController = null;
   const apiTestBtn = el('adm-epApiTestBtn');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -562,17 +562,19 @@ async function loadEndpoints() {
             const hiddenSet = new Set(sortedModels.filter(m => m.is_hidden).map(m => m.id));
             const showSearch = sortedModels.length >= 8;
             panel.innerHTML = `<div class="mcp-tools-header">
-              <span>Models</span>
+              <span>Models <span class="adm-model-source-note">discovered from provider</span></span>
               <span style="display:flex;gap:8px;align-items:center;">
-                <span class="mcp-tools-count">${sortedModels.length - hiddenSet.size}/${sortedModels.length} enabled</span>
-                <a href="#" data-ep-select-all="${epId}">All</a>
-                <a href="#" data-ep-select-none="${epId}">None</a>
+                <span class="mcp-tools-count">${sortedModels.length - hiddenSet.size}/${sortedModels.length} visible</span>
+                <a href="#" data-ep-select-all="${epId}">Restore all</a>
+                <a href="#" data-ep-select-none="${epId}">Hide all</a>
               </span>
             </div>${showSearch ? `<input type="search" class="mcp-tools-search" placeholder="Search ${sortedModels.length} models..." data-ep-search="${epId}">` : ''}<div class="mcp-tools-list">` + sortedModels.map(m =>
-              `<label title="${esc(m.id)}" data-ep-model-row data-search="${esc((m.display + ' ' + m.id).toLowerCase())}" class="adm-model-row">
+              `<label title="${esc(m.id)}" data-ep-model-row data-search="${esc((m.display + ' ' + m.id).toLowerCase())}" class="adm-model-row${m.is_hidden ? ' adm-model-row-hidden' : ''}">
                 <input type="checkbox" class="adm-cb-hidden" data-ep-model-id="${esc(m.id)}" ${!m.is_hidden ? 'checked' : ''}>
                 <span class="adm-check-dot" aria-hidden="true"></span>
                 <span>${esc(m.display)}</span>
+                <span class="adm-model-source-badge">${m.source === 'manual' ? 'manual' : 'discovered'}</span>
+                <span class="adm-model-hide-label">${m.is_hidden ? 'hidden - restore' : 'visible - hide'}</span>
               </label>`
             ).join('') + '</div>';
             const filterRows = (q) => {
@@ -613,6 +615,12 @@ async function _saveEpModelState(epId, panel) {
   const hidden = [];
   panel.querySelectorAll('input[type=checkbox]').forEach(cb => {
     if (!cb.checked) hidden.push(cb.dataset.epModelId);
+    const row = cb.closest('[data-ep-model-row]');
+    if (row) {
+      row.classList.toggle('adm-model-row-hidden', !cb.checked);
+      const label = row.querySelector('.adm-model-hide-label');
+      if (label) label.textContent = cb.checked ? 'visible - hide' : 'hidden - restore';
+    }
   });
   const total = panel.querySelectorAll('input[type=checkbox]').length;
   try {
@@ -623,7 +631,7 @@ async function _saveEpModelState(epId, panel) {
       body: JSON.stringify({ hidden }),
     });
     const countLabel = panel.querySelector('.mcp-tools-count');
-    if (countLabel) countLabel.textContent = `${total - hidden.length}/${total} enabled`;
+    if (countLabel) countLabel.textContent = `${total - hidden.length}/${total} visible`;
     const row = panel.closest('[data-adm-ep-id]');
     if (row) {
       const badge = row.querySelector('.admin-badge');
@@ -778,14 +786,21 @@ function initEndpointForm() {
   const codexStatusEl = el('adm-codexProviderStatus');
   const codexDetailsEl = el('adm-codexProviderDetails');
   const codexSummaryEl = el('adm-codexProviderSummary');
+  const codexCapabilitiesEl = el('adm-codexProviderCapabilities');
   const codexModelEl = el('adm-codexProviderModel');
+  const codexModelsEl = el('adm-codexProviderModels');
+  const codexManualModelInput = el('adm-codexManualModelId');
+  const codexAddModelBtn = el('adm-codexAddModelBtn');
   const codexMsgEl = el('adm-codexProviderMsg');
   const codexHeader = el('adm-codexProviderHeader');
   const codexBody = el('adm-codexProviderBody');
   const codexChevron = el('adm-codexProviderChevron');
   const codexSignInBtn = el('adm-codexSignInBtn');
   const codexTestBtn = el('adm-codexTestBtn');
+  const codexStreamTestBtn = el('adm-codexStreamTestBtn');
   const codexRefreshBtn = el('adm-codexRefreshBtn');
+  const codexSignOutBtn = el('adm-codexSignOutBtn');
+  const codexResetBtn = el('adm-codexResetBtn');
   let codexProviderStatus = null;
   let codexOpen = false;
 
@@ -808,7 +823,11 @@ function initEndpointForm() {
     const apiKey = el('adm-epApiKey');
     const type = el('adm-epType');
     const apiTestBtn = el('adm-epApiTestBtn');
+    const apiCancelTestBtn = el('adm-epApiCancelTestBtn');
     const addBtn = el('adm-epAddBtn');
+    const apiForm = urlInput ? urlInput.closest('.admin-model-form') : null;
+    if (picker) picker.classList.toggle('adm-provider-codex-selected', isCodex);
+    if (apiForm) apiForm.classList.toggle('adm-provider-codex-selected', isCodex);
     if (urlInput) {
       urlInput.disabled = isCodex;
       urlInput.placeholder = isCodex ? 'Codex uses CLI auth, not an API endpoint URL' : 'Base URL or pick provider';
@@ -821,10 +840,11 @@ function initEndpointForm() {
     }
     if (type) type.disabled = isCodex;
     if (apiTestBtn) apiTestBtn.disabled = isCodex;
+    if (apiCancelTestBtn) apiCancelTestBtn.disabled = isCodex;
     if (addBtn) addBtn.disabled = isCodex;
     if (isCodex) {
       _setCodexOpen(true);
-      _setCodexMsg('Selected in the provider dropdown. Use this experimental card; Codex is not added as a normal endpoint yet.', '');
+      _setCodexMsg('Selected in the provider dropdown. Use the Codex card below; it is not added as a normal endpoint.', '');
     }
   }
 
@@ -852,13 +872,52 @@ function initEndpointForm() {
     return 'Unavailable';
   }
 
+  function _codexEnabledModels(data) {
+    return (Array.isArray(data?.models) ? data.models : []).filter(m => m && m.id && m.enabled !== false && !m.hidden);
+  }
+
+  function _renderCodexModels(data) {
+    if (!codexModelsEl) return;
+    const models = Array.isArray(data?.models) ? data.models : [];
+    const discovery = data?.model_discovery?.source || 'none';
+    if (!models.length) {
+      const reason = discovery === 'manual'
+        ? 'This Codex CLI exposes a model flag but no model list. Add exact model IDs manually.'
+        : 'No Codex models are available yet. Add a manual model ID if this CLI cannot list models.';
+      codexModelsEl.innerHTML = `<div class="adm-codex-model-empty">${esc(reason)}</div>`;
+      return;
+    }
+    codexModelsEl.innerHTML = `<div class="mcp-tools-header">
+      <span>Codex models <span class="adm-model-source-note">${esc(discovery)}</span></span>
+      <span class="mcp-tools-count">${_codexEnabledModels(data).length}/${models.length} enabled</span>
+    </div><div class="mcp-tools-list adm-codex-model-list">` + models.map(m => {
+      const state = m.hidden ? 'hidden' : (m.enabled === false ? 'disabled' : 'enabled');
+      const source = m.source === 'manual' ? 'manual' : 'discovered';
+      const primaryAction = m.hidden
+        ? `<button type="button" class="admin-btn-sm" data-codex-model-action="restore" data-model-id="${esc(m.id)}">Restore</button>`
+        : `<button type="button" class="admin-btn-sm" data-codex-model-action="${m.enabled === false ? 'enable' : 'disable'}" data-model-id="${esc(m.id)}">${m.enabled === false ? 'Enable' : 'Disable'}</button>`;
+      const hideAction = !m.hidden
+        ? `<button type="button" class="admin-btn-sm" data-codex-model-action="hide" data-model-id="${esc(m.id)}" style="opacity:0.75;">Hide</button>`
+        : '';
+      return `<div class="adm-model-row adm-codex-model-row adm-model-row-${state}" title="${esc(m.id)}">
+        <span style="min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;"><code>${esc(m.id)}</code></span>
+        <span class="adm-model-source-badge">${esc(source)}</span>
+        <span class="adm-model-hide-label">${esc(state)}</span>
+        ${primaryAction}${hideAction}
+      </div>`;
+    }).join('') + '</div>';
+  }
+
   function _renderCodexProviderStatus(data) {
     if (!codexCard || !codexStatusEl || !codexDetailsEl) return;
     const status = data && data.status ? data.status : 'unavailable';
-    const model = Array.isArray(data?.models) && data.models.length ? data.models[0] : null;
+    const enabledModels = _codexEnabledModels(data);
+    const model = enabledModels.length ? enabledModels[0] : null;
     const available = status === 'available' && data.chat_supported === true && !!model;
     const signInRequired = status === 'sign_in_required';
     const disabled = status === 'disabled' || data?.feature_enabled === false;
+    const authenticated = !!data?.authenticated;
+    const cliAvailable = !!data?.cli_available;
     codexProviderStatus = data || null;
 
     codexStatusEl.textContent = _codexStatusLabel(status);
@@ -866,16 +925,31 @@ function initEndpointForm() {
     codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
 
     const streaming = data?.streaming_supported === true;
+    const enabledCount = enabledModels.length;
+    const totalCount = Array.isArray(data?.models) ? data.models.length : 0;
     let details = streaming
       ? 'Experimental. Chat picker uses the Codex CLI JSON event stream when available. Stateless. Uses Codex CLI auth. Not added as a normal API endpoint.'
       : 'Experimental, one-shot fallback only, stateless. Uses Codex CLI auth. Not added as a normal API endpoint.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
-    else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
+    else if (signInRequired) details += ' Signed out. Sign in with Codex / ChatGPT before running provider tests or showing it in the chat picker.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
     else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
     codexDetailsEl.textContent = details;
+    if (codexCapabilitiesEl) {
+      const authText = authenticated ? 'signed in' : 'signed out';
+      const streamText = streaming ? 'yes' : 'no';
+      const levels = Array.isArray(data?.thinking_effort_levels) ? data.thinking_effort_levels : [];
+      const thinkText = data?.thinking_supported ? `supported (${levels.join(', ') || 'provider default'})` : 'not advertised by CLI';
+      codexCapabilitiesEl.innerHTML = [
+        `CLI: <strong>${cliAvailable ? 'available' : 'unavailable'}</strong>`,
+        `Auth: <strong>${authText}</strong>`,
+        `Models: <strong>${enabledCount}/${totalCount}</strong>`,
+        `Streaming: <strong>${streamText}</strong>`,
+        `Thinking control: <strong>${esc(thinkText)}</strong>`,
+      ].join(' &middot; ');
+    }
     if (codexSummaryEl) {
-      const pickerState = disabled ? 'Hidden from chat picker while disabled.' : 'Visible in the chat model picker as an experimental model.';
+      const pickerState = available ? 'Visible in the chat model picker as an experimental model.' : 'Hidden from the chat model picker until available.';
       codexSummaryEl.textContent = `${pickerState} Uses Codex CLI auth; no API key is stored.`;
     }
 
@@ -889,7 +963,18 @@ function initEndpointForm() {
       }
     }
     if (codexTestBtn) codexTestBtn.disabled = !available;
-    if (codexSignInBtn) codexSignInBtn.disabled = disabled;
+    if (codexStreamTestBtn) codexStreamTestBtn.disabled = !available || !streaming;
+    if (codexSignInBtn) {
+      codexSignInBtn.disabled = disabled || !cliAvailable;
+      codexSignInBtn.style.display = authenticated ? 'none' : '';
+    }
+    if (codexSignOutBtn) {
+      codexSignOutBtn.disabled = disabled || !authenticated;
+      codexSignOutBtn.style.display = authenticated ? '' : 'none';
+    }
+    if (codexResetBtn) codexResetBtn.disabled = disabled;
+    if (codexAddModelBtn) codexAddModelBtn.disabled = disabled;
+    _renderCodexModels(data || {});
   }
 
   async function _refreshCodexProviderStatus() {
@@ -900,6 +985,7 @@ function initEndpointForm() {
       codexStatusEl.style.color = '';
     }
     if (codexTestBtn) codexTestBtn.disabled = true;
+    if (codexStreamTestBtn) codexStreamTestBtn.disabled = true;
     _setCodexMsg('', '');
     try {
       const res = await fetch('/api/codex-model-provider/status', { credentials: 'same-origin' });
@@ -931,8 +1017,9 @@ function initEndpointForm() {
 
   async function _testCodexProviderChat() {
     if (!codexTestBtn) return;
-    const model = Array.isArray(codexProviderStatus?.models) && codexProviderStatus.models.length
-      ? codexProviderStatus.models[0].id
+    const chatModels = _codexEnabledModels(codexProviderStatus);
+    const model = chatModels.length
+      ? chatModels[0].id
       : 'codex-cli/chatgpt-experimental';
     codexTestBtn.disabled = true;
     codexTestBtn.textContent = 'Testing...';
@@ -964,6 +1051,159 @@ function initEndpointForm() {
     if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
   }
 
+  function _readSseEvents(text, onEvent) {
+    const chunks = String(text || '').split(/\n\n+/);
+    chunks.forEach(chunk => {
+      const line = chunk.split(/\n/).find(l => l.startsWith('data:'));
+      if (!line) return;
+      let event = null;
+      try { event = JSON.parse(line.slice(5).trim()); } catch (_) { return; }
+      onEvent(event);
+    });
+  }
+
+  async function _testCodexProviderStream() {
+    if (!codexStreamTestBtn) return;
+    const streamModels = _codexEnabledModels(codexProviderStatus);
+    const model = streamModels.length
+      ? streamModels[0].id
+      : 'codex-cli/chatgpt-experimental';
+    codexStreamTestBtn.disabled = true;
+    codexStreamTestBtn.textContent = 'Streaming...';
+    _setCodexMsg('Running Codex streaming provider test...', '');
+    let buffer = '';
+    let responseText = '';
+    try {
+      const res = await fetch('/api/codex-model-provider/test-chat-stream', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          prompt: 'Reply with exactly: Codex provider stream ok',
+          timeout_seconds: 90,
+        }),
+      });
+      if (!res.ok || !res.body) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split(/\n\n+/);
+        buffer = parts.pop() || '';
+        _readSseEvents(parts.join('\n\n'), (event) => {
+          if (event.type === 'delta') responseText += event.delta || '';
+          if (event.type === 'error') throw new Error(event.error || event.status || 'stream error');
+        });
+        if (codexMsgEl && responseText) {
+          codexMsgEl.className = 'admin-success';
+          codexMsgEl.innerHTML = `Streaming response: ${esc(responseText)}`;
+        }
+      }
+      _readSseEvents(buffer, (event) => {
+        if (event.type === 'delta') responseText += event.delta || '';
+      });
+      if (codexMsgEl) {
+        codexMsgEl.className = responseText ? 'admin-success' : 'admin-error';
+        codexMsgEl.innerHTML = responseText ? `Streaming response: ${esc(responseText)}` : 'Stream completed without text.';
+      }
+    } catch (e) {
+      _setCodexMsg('Stream test failed: ' + (e && e.message ? e.message : 'request failed'), 'admin-error');
+    }
+    codexStreamTestBtn.textContent = 'Stream Test';
+    if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+  }
+
+  async function _signOutCodexProvider() {
+    if (codexSignOutBtn) codexSignOutBtn.disabled = true;
+    _setCodexMsg('Signing out of Codex...', '');
+    try {
+      await fetch('/api/codex-auth/logout', { method: 'POST', credentials: 'same-origin' });
+      await _refreshCodexProviderStatus();
+      await _refreshAfterEndpointChange();
+      _setCodexMsg('Signed out. Codex is hidden from the model picker until you sign in again.', 'admin-success');
+    } catch (_) {
+      _setCodexMsg('Could not sign out of Codex.', 'admin-error');
+      if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+    }
+  }
+
+  async function _resetCodexProviderUi() {
+    if (codexResetBtn) codexResetBtn.disabled = true;
+    _setCodexMsg('Resetting Codex sign-in state...', '');
+    try {
+      await fetch('/api/codex-auth/cancel', { method: 'POST', credentials: 'same-origin' }).catch(() => {});
+      await _refreshCodexProviderStatus();
+      _setCodexMsg('Codex status refreshed. Active device sign-in was canceled if one was running.', 'admin-success');
+    } catch (_) {
+      _setCodexMsg('Could not reset Codex status.', 'admin-error');
+    } finally {
+      if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+    }
+  }
+
+  async function _updateCodexModel(action, modelId) {
+    if (!modelId) return;
+    _setCodexMsg('Updating Codex model list...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/models', {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, model_id: modelId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.ok === false) {
+        _setCodexMsg(data.error || 'Could not update Codex model.', 'admin-error');
+        return;
+      }
+      await _refreshCodexProviderStatus();
+      await _refreshAfterEndpointChange();
+      _setCodexMsg('Codex model list updated.', 'admin-success');
+    } catch (e) {
+      _setCodexMsg('Could not update Codex model: ' + (e?.message || 'request failed'), 'admin-error');
+    }
+  }
+
+  async function _addCodexManualModel() {
+    const modelId = (codexManualModelInput?.value || '').trim();
+    if (!modelId) {
+      _setCodexMsg('Enter an exact Codex model ID first.', 'admin-error');
+      return;
+    }
+    if (/\s/.test(modelId)) {
+      _setCodexMsg('Model IDs cannot contain spaces.', 'admin-error');
+      return;
+    }
+    if (codexAddModelBtn) codexAddModelBtn.disabled = true;
+    _setCodexMsg('Adding Codex model...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/models', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model_id: modelId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.ok === false) {
+        _setCodexMsg(data.error || 'Could not add Codex model.', 'admin-error');
+        return;
+      }
+      if (codexManualModelInput) codexManualModelInput.value = '';
+      await _refreshCodexProviderStatus();
+      await _refreshAfterEndpointChange();
+      _setCodexMsg('Manual Codex model added.', 'admin-success');
+    } catch (e) {
+      _setCodexMsg('Could not add Codex model: ' + (e?.message || 'request failed'), 'admin-error');
+    } finally {
+      if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+    }
+  }
+
   if (codexSignInBtn) {
     codexSignInBtn.addEventListener('click', () => {
       if (settingsModule && typeof settingsModule.open === 'function') settingsModule.open('integrations');
@@ -982,7 +1222,27 @@ function initEndpointForm() {
     });
   }
   if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
+  if (codexStreamTestBtn) codexStreamTestBtn.addEventListener('click', _testCodexProviderStream);
   if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
+  if (codexSignOutBtn) codexSignOutBtn.addEventListener('click', _signOutCodexProvider);
+  if (codexResetBtn) codexResetBtn.addEventListener('click', _resetCodexProviderUi);
+  if (codexAddModelBtn) codexAddModelBtn.addEventListener('click', _addCodexManualModel);
+  if (codexManualModelInput) {
+    codexManualModelInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        _addCodexManualModel();
+      }
+    });
+  }
+  if (codexModelsEl) {
+    codexModelsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-codex-model-action]');
+      if (!btn) return;
+      e.preventDefault();
+      _updateCodexModel(btn.dataset.codexModelAction, btn.dataset.modelId);
+    });
+  }
   _setEndpointProviderControls();
   _refreshCodexProviderStatus();
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -846,7 +846,7 @@ function initEndpointForm() {
     else if (available) details += ' Session resume is not available with this Codex CLI, so follow-ups fall back safely.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
-    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
+    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI exposes read-only sandbox support.';
     else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
     codexDetailsEl.textContent = details;
 
@@ -892,7 +892,7 @@ function initEndpointForm() {
     if (status === 'disabled') return 'Codex provider test is disabled. Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true.';
     if (status === 'sign_in_required') return 'Sign-in required before Codex provider test chat can run.';
     if (status === 'cli_unavailable') return 'Codex CLI is unavailable in this runtime.';
-    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked: this Codex CLI does not expose the required sandbox/approval flags for UI test chat.';
+    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked: this Codex CLI does not expose read-only sandbox support for UI test chat.';
     if (status === 'timeout') return 'Codex CLI test timed out.';
     if (status === 'empty_response') return 'Codex CLI returned no assistant message.';
     if (status === 'cli_failed') return 'Codex CLI test failed. No raw CLI output is shown in the UI.';

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -843,10 +843,10 @@ function initEndpointForm() {
     if (type) type.disabled = isCodex;
     if (apiTestBtn) apiTestBtn.disabled = isCodex;
     if (apiCancelTestBtn) apiCancelTestBtn.disabled = isCodex;
-    if (addBtn) addBtn.disabled = isCodex;
-    if (isCodex) {
-      _setCodexOpen(true);
-      _setCodexMsg('Selected in the provider dropdown. Use the Codex card below; it is not added as a normal endpoint.', '');
+    if (addBtn) {
+      addBtn.disabled = false;
+      addBtn.textContent = 'Add';
+      addBtn.title = isCodex ? 'Add the Codex connector' : '';
     }
   }
 
@@ -911,7 +911,7 @@ function initEndpointForm() {
     const discovery = data?.model_discovery?.source || 'manual';
     _renderCodexPresetOptions(data);
     if (!models.length) {
-      const reason = (data?.connector_enabled || _isCodexProviderSelected())
+      const reason = data?.connector_enabled
         ? 'No Codex models are selected yet. Start with GPT-5.5 or add a custom model ID.'
         : 'Connector removed. Pick Codex / ChatGPT in the provider dropdown to set it up again.';
       codexModelsEl.innerHTML = `<div class="adm-codex-model-empty">${esc(reason)}</div>`;
@@ -964,7 +964,7 @@ function initEndpointForm() {
     const cliAvailable = !!data?.cli_available;
     codexProviderStatus = data || null;
     const totalCount = Array.isArray(data?.models) ? data.models.length : 0;
-    const shouldShowCard = _isCodexProviderSelected() || !!data?.connector_enabled || totalCount > 0;
+    const shouldShowCard = !!data?.connector_enabled || totalCount > 0;
     if (codexCard) codexCard.style.display = shouldShowCard ? 'flex' : 'none';
 
     codexStatusEl.textContent = _codexStatusLabel(status);
@@ -1244,6 +1244,31 @@ function initEndpointForm() {
     }
   }
 
+  async function _addCodexConnector() {
+    _setCodexMsg('Adding Codex connector...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/connector', {
+        method: 'POST',
+        credentials: 'same-origin',
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.ok === false) {
+        _setCodexMsg(data.error || 'Could not add Codex connector.', 'admin-error');
+        return false;
+      }
+      await _refreshCodexProviderStatus();
+      await _refreshAfterEndpointChange();
+      if (codexCard) codexCard.style.display = 'flex';
+      _setCodexOpen(true);
+      _focusCodexProviderCard();
+      _setCodexMsg('Codex connector added. Add a recommended model or a custom model ID below.', 'admin-success');
+      return true;
+    } catch (e) {
+      _setCodexMsg('Could not add Codex connector: ' + (e?.message || 'request failed'), 'admin-error');
+      return false;
+    }
+  }
+
   async function _addCodexManualModel() {
     const selectedPreset = (codexPresetSelect?.value || '').trim();
     const modelId = selectedPreset === '__custom__'
@@ -1390,8 +1415,14 @@ function initEndpointForm() {
     const msg = _endpointMsg('api');
     msg.textContent = ''; msg.className = '';
     if (_isCodexProviderSelected()) {
-      _focusCodexProviderCard();
-      _setCodexMsg('Codex is not added as a normal API endpoint yet. Use the experimental card for status and Test Chat.', '');
+      const added = await _addCodexConnector();
+      if (added) {
+        msg.textContent = 'Added Codex connector';
+        msg.className = 'admin-success';
+      } else {
+        msg.textContent = 'Could not add Codex connector';
+        msg.className = 'admin-error';
+      }
       return;
     }
     const rawUrl = (urlInput.value || provider.value).trim();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -637,6 +637,8 @@ async function _saveEpModelState(epId, panel) {
 function initEndpointForm() {
   const provider = el('adm-epProvider');
   const urlInput = el('adm-epUrl');
+  const CODEX_PROVIDER_VALUE = 'codex-cli';
+  const CODEX_TEST_SESSION_ID = 'admin-add-models-codex-test';
 
   // Custom provider picker — mirrors the (now hidden) <select id="adm-epProvider">
   // so the rest of this function (which reads provider.value and dispatches
@@ -645,14 +647,21 @@ function initEndpointForm() {
   const pickerBtn = el('adm-provider-btn');
   const pickerMenu = el('adm-provider-menu');
   const pickerCurrent = picker ? picker.querySelector('.adm-provider-current') : null;
+  const apiNormalRow = el('adm-epApiNormalRow');
+  const codexPanel = el('adm-codexProviderPanel');
+  function _isCodexProviderSelected() {
+    return provider && provider.value === CODEX_PROVIDER_VALUE;
+  }
   function _renderPickerMenu() {
     if (!pickerMenu) return;
     pickerMenu.innerHTML = Array.from(provider.options).map(o => {
       const logo = o.dataset.logo ? (providerLogo(o.dataset.logo) || '') : '';
       const active = o.value === provider.value ? ' active' : '';
+      const experimental = o.dataset.experimental === 'true' ? '<span class="admin-badge" style="margin-left:auto;">Experimental</span>' : '';
       return `<div class="adm-provider-item${active}" role="option" data-value="${o.value.replace(/"/g, '&quot;')}">
         <span class="adm-provider-logo">${logo}</span>
         <span>${o.textContent}</span>
+        ${experimental}
       </div>`;
     }).join('');
   }
@@ -685,15 +694,43 @@ function initEndpointForm() {
     });
   }
 
+  function _syncCodexProviderMode() {
+    const isCodex = _isCodexProviderSelected();
+    if (codexPanel) codexPanel.classList.toggle('hidden', !isCodex);
+    if (apiNormalRow) apiNormalRow.classList.toggle('hidden', isCodex);
+    if (urlInput) {
+      urlInput.classList.toggle('hidden', isCodex);
+      if (isCodex) {
+        urlInput.value = '';
+      } else {
+        urlInput.placeholder = 'Base URL or pick provider';
+      }
+    }
+    if (picker) picker.classList.toggle('adm-provider-codex-selected', isCodex);
+    const apiMsg = el('adm-epApiMsg');
+    if (apiMsg && isCodex) {
+      apiMsg.textContent = '';
+      apiMsg.className = 'adm-ep-inline-msg';
+    }
+    if (isCodex) _refreshCodexProviderStatus();
+  }
+
   provider.addEventListener('change', () => {
-    if (provider.value) urlInput.value = provider.value;
-    else urlInput.value = '';
+    if (_isCodexProviderSelected()) {
+      urlInput.value = '';
+    } else if (provider.value) {
+      urlInput.value = provider.value;
+    } else {
+      urlInput.value = '';
+    }
+    _syncCodexProviderMode();
   });
   urlInput.addEventListener('input', () => {
     if (provider.value && urlInput.value.trim() !== provider.value) {
       provider.value = '';
       _renderPickerMenu();
       _syncPickerCurrent();
+      _syncCodexProviderMode();
     }
   });
   function _normalizeBaseUrl(raw) {
@@ -765,7 +802,6 @@ function initEndpointForm() {
     return el(kind === 'local' ? 'adm-epLocalMsg' : 'adm-epApiMsg') || el('adm-epMsg');
   }
 
-  const codexCard = el('adm-codexProviderCard');
   const codexStatusEl = el('adm-codexProviderStatus');
   const codexDetailsEl = el('adm-codexProviderDetails');
   const codexModelEl = el('adm-codexProviderModel');
@@ -773,6 +809,7 @@ function initEndpointForm() {
   const codexSignInBtn = el('adm-codexSignInBtn');
   const codexTestBtn = el('adm-codexTestBtn');
   const codexRefreshBtn = el('adm-codexRefreshBtn');
+  const codexResetBtn = el('adm-codexResetBtn');
   let codexProviderStatus = null;
 
   function _setCodexMsg(text, cls) {
@@ -792,7 +829,7 @@ function initEndpointForm() {
   }
 
   function _renderCodexProviderStatus(data) {
-    if (!codexCard || !codexStatusEl || !codexDetailsEl) return;
+    if (!codexPanel || !codexStatusEl || !codexDetailsEl) return;
     const status = data && data.status ? data.status : 'unavailable';
     const model = Array.isArray(data?.models) && data.models.length ? data.models[0] : null;
     const available = status === 'available' && data.chat_supported === true && !!model;
@@ -804,7 +841,9 @@ function initEndpointForm() {
     codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
     codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
 
-    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
+    let details = 'Uses Settings -> Integrations -> Codex / ChatGPT sign-in. Test chat runs through Codex CLI with read-only sandbox and no approval prompts.';
+    if (available && data.session_resume_supported) details += ' Follow-up chats in the same Odysseus session can resume the Codex CLI session.';
+    else if (available) details += ' Session resume is not available with this Codex CLI, so follow-ups fall back safely.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
@@ -825,7 +864,7 @@ function initEndpointForm() {
   }
 
   async function _refreshCodexProviderStatus() {
-    if (!codexCard) return;
+    if (!codexPanel) return;
     if (codexStatusEl) {
       codexStatusEl.textContent = 'Checking';
       codexStatusEl.className = 'admin-badge admin-badge-off';
@@ -878,6 +917,7 @@ function initEndpointForm() {
           model,
           prompt: 'Reply with exactly: Codex provider UI test ok',
           timeout_seconds: 60,
+          session_id: CODEX_TEST_SESSION_ID,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -896,18 +936,41 @@ function initEndpointForm() {
     if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
   }
 
+  async function _resetCodexProviderSession() {
+    if (!codexResetBtn) return;
+    codexResetBtn.disabled = true;
+    codexResetBtn.textContent = 'Resetting...';
+    _setCodexMsg('', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/reset-session', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: CODEX_TEST_SESSION_ID }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok) _setCodexMsg('Codex session mapping reset for this provider test.', 'admin-success');
+      else _setCodexMsg(data.error || 'Could not reset Codex session.', 'admin-error');
+    } catch (e) {
+      _setCodexMsg('Reset failed: ' + (e && e.message ? e.message : 'request failed'), 'admin-error');
+    }
+    codexResetBtn.disabled = false;
+    codexResetBtn.textContent = 'Reset Codex session';
+  }
+
   if (codexSignInBtn) {
     codexSignInBtn.addEventListener('click', () => {
       if (settingsModule && typeof settingsModule.open === 'function') settingsModule.open('integrations');
       setTimeout(() => {
         document.dispatchEvent(new CustomEvent('odysseus:open-codex-auth'));
       }, 50);
-      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this card after sign-in completes.', '');
+      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this provider after sign-in completes.', '');
     });
   }
   if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
   if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
-  _refreshCodexProviderStatus();
+  if (codexResetBtn) codexResetBtn.addEventListener('click', _resetCodexProviderSession);
+  _syncCodexProviderMode();
 
   let apiTestController = null;
   const apiTestBtn = el('adm-epApiTestBtn');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -912,23 +912,23 @@ function initEndpointForm() {
     _renderCodexPresetOptions(data);
     if (!models.length) {
       const reason = data?.connector_enabled
-        ? 'No Codex models are selected yet. Start with GPT-5.5 or add a custom model ID.'
-        : 'Connector removed. Pick Codex / ChatGPT in the provider dropdown to set it up again.';
+        ? 'No selected models yet. Start with GPT-5.5 or add a custom model ID.'
+        : 'Codex connector removed. Pick Codex / ChatGPT in the provider dropdown to set it up again.';
       codexModelsEl.innerHTML = `<div class="adm-codex-model-empty">${esc(reason)}</div>`;
       return;
     }
     codexModelsEl.innerHTML = `<div class="mcp-tools-header">
-      <span>Codex models <span class="adm-model-source-note">${esc(discovery)}</span></span>
+      <span>Selected models <span class="adm-model-source-note">${esc(discovery)}</span></span>
       <span class="mcp-tools-count">${_codexEnabledModels(data).length}/${models.length} enabled</span>
     </div><div class="mcp-tools-list adm-codex-model-list">` + models.map(m => {
       const state = m.hidden ? 'hidden' : (m.enabled === false ? 'disabled' : 'enabled');
       const source = m.source === 'recommended' ? 'recommended' : 'custom';
       const levels = Array.isArray(m?.thinking_effort_levels) ? m.thinking_effort_levels : [];
       const canThink = !!m?.thinking_supported && levels.length > 0;
-      const thinkSelect = `<select data-codex-thinking-model="${esc(m.id)}" ${canThink ? '' : 'disabled'} style="min-width:136px;">
-        <option value="">${canThink ? 'Provider default' : 'Thinking unavailable'}</option>
+      const thinkSelect = canThink ? `<select data-codex-thinking-model="${esc(m.id)}" style="min-width:136px;">
+        <option value="">Provider default</option>
         ${levels.map(level => `<option value="${esc(level)}" ${m.thinking_effort === level ? 'selected' : ''}>${esc(level)}</option>`).join('')}
-      </select>`;
+      </select>` : '';
       const primaryAction = m.hidden
         ? `<button type="button" class="admin-btn-sm" data-codex-model-action="restore" data-model-id="${esc(m.id)}">Restore</button>`
         : `<button type="button" class="admin-btn-sm" data-codex-model-action="${m.enabled === false ? 'enable' : 'disable'}" data-model-id="${esc(m.id)}">${m.enabled === false ? 'Enable' : 'Disable'}</button>`;
@@ -964,7 +964,9 @@ function initEndpointForm() {
     const cliAvailable = !!data?.cli_available;
     codexProviderStatus = data || null;
     const totalCount = Array.isArray(data?.models) ? data.models.length : 0;
-    const shouldShowCard = !!data?.connector_enabled || totalCount > 0;
+    const shouldShowCard = disabled
+      ? totalCount > 0
+      : !!data?.connector_enabled || totalCount > 0 || authenticated || signInRequired || cliAvailable;
     if (codexCard) codexCard.style.display = shouldShowCard ? 'flex' : 'none';
 
     codexStatusEl.textContent = _codexStatusLabel(status);
@@ -974,8 +976,8 @@ function initEndpointForm() {
     const streaming = data?.streaming_supported === true;
     const enabledCount = enabledModels.length;
     let details = streaming
-      ? 'Chat picker uses the Codex CLI JSON event stream when available. Stateless. Uses Codex CLI auth. Not added as a normal API endpoint.'
-      : 'One-shot fallback only, stateless. Uses Codex CLI auth. Not added as a normal API endpoint.';
+      ? 'Chat picker uses the Codex CLI JSON event stream when available. Stateless. Codex connector uses Codex CLI auth. Not added as a normal API endpoint.'
+      : 'One-shot fallback only, stateless. Codex connector uses Codex CLI auth. Not added as a normal API endpoint.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Signed out. Sign in with Codex / ChatGPT before running provider tests or showing it in the chat picker.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
@@ -1000,7 +1002,7 @@ function initEndpointForm() {
     }
     if (codexSummaryEl) {
       const pickerState = available ? 'Visible in the chat model picker once at least one enabled model is available.' : 'Hidden from the chat model picker until at least one enabled model is available.';
-      codexSummaryEl.textContent = `${pickerState} Uses Codex CLI auth; no API key is stored.`;
+      codexSummaryEl.textContent = `${pickerState} Codex connector uses Codex CLI auth; no API key is stored.`;
     }
 
     if (codexModelEl) {
@@ -1024,7 +1026,7 @@ function initEndpointForm() {
     }
     if (codexResetBtn) codexResetBtn.disabled = disabled;
     if (codexAddModelBtn) codexAddModelBtn.disabled = disabled;
-    if (codexRemoveConnectorBtn) codexRemoveConnectorBtn.disabled = disabled || totalCount === 0;
+    if (codexRemoveConnectorBtn) codexRemoveConnectorBtn.disabled = disabled || !data?.connector_enabled;
     _renderCodexModels(data || {});
   }
 
@@ -1261,7 +1263,7 @@ function initEndpointForm() {
       if (codexCard) codexCard.style.display = 'flex';
       _setCodexOpen(true);
       _focusCodexProviderCard();
-      _setCodexMsg('Codex connector added. Add a recommended model or a custom model ID below.', 'admin-success');
+      _setCodexMsg('Codex connector added. Add a selected model or a custom model ID below.', 'admin-success');
       return true;
     } catch (e) {
       _setCodexMsg('Could not add Codex connector: ' + (e?.message || 'request failed'), 'admin-error');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -913,7 +913,7 @@ function initEndpointForm() {
     if (!models.length) {
       const reason = data?.connector_enabled
         ? 'No selected models yet. Start with GPT-5.5 or add a custom model ID.'
-        : 'Codex connector removed. Pick Codex / ChatGPT in the provider dropdown to set it up again.';
+        : 'Codex connector removed. Pick the Codex connector in the provider dropdown to set it up again.';
       codexModelsEl.innerHTML = `<div class="adm-codex-model-empty">${esc(reason)}</div>`;
       return;
     }
@@ -979,7 +979,7 @@ function initEndpointForm() {
       ? 'Chat picker uses the Codex CLI JSON event stream when available. Stateless. Codex connector uses Codex CLI auth. Not added as a normal API endpoint.'
       : 'One-shot fallback only, stateless. Codex connector uses Codex CLI auth. Not added as a normal API endpoint.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
-    else if (signInRequired) details += ' Signed out. Sign in with Codex / ChatGPT before running provider tests or showing it in the chat picker.';
+    else if (signInRequired) details += ' Signed out. Sign in with the Codex connector before running provider tests or showing it in the chat picker.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
     else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
     codexDetailsEl.textContent = details;
@@ -1316,7 +1316,7 @@ function initEndpointForm() {
       setTimeout(() => {
         document.dispatchEvent(new CustomEvent('odysseus:open-codex-auth'));
       }, 50);
-      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this card after sign-in completes.', '');
+      _setCodexMsg('Opened Settings -> Integrations -> Codex connector. Refresh this card after sign-in completes.', '');
     });
   }
   try { codexOpen = localStorage.getItem('odysseus.addModels.codex.open') === '1'; } catch { codexOpen = false; }

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -846,7 +846,7 @@ function initEndpointForm() {
     else if (available) details += ' Session resume is not available with this Codex CLI, so follow-ups fall back safely.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
-    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI exposes read-only sandbox support.';
+    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
     else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
     codexDetailsEl.textContent = details;
 
@@ -892,7 +892,7 @@ function initEndpointForm() {
     if (status === 'disabled') return 'Codex provider test is disabled. Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true.';
     if (status === 'sign_in_required') return 'Sign-in required before Codex provider test chat can run.';
     if (status === 'cli_unavailable') return 'Codex CLI is unavailable in this runtime.';
-    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked: this Codex CLI does not expose read-only sandbox support for UI test chat.';
+    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked: this Codex CLI does not expose the required sandbox/approval flags for UI test chat.';
     if (status === 'timeout') return 'Codex CLI test timed out.';
     if (status === 'empty_response') return 'Codex CLI returned no assistant message.';
     if (status === 'cli_failed') return 'Codex CLI test failed. No raw CLI output is shown in the UI.';

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -789,6 +789,7 @@ function initEndpointForm() {
   const codexCapabilitiesEl = el('adm-codexProviderCapabilities');
   const codexModelEl = el('adm-codexProviderModel');
   const codexModelsEl = el('adm-codexProviderModels');
+  const codexPresetSelect = el('adm-codexPresetSelect');
   const codexManualModelInput = el('adm-codexManualModelId');
   const codexAddModelBtn = el('adm-codexAddModelBtn');
   const codexMsgEl = el('adm-codexProviderMsg');
@@ -799,6 +800,7 @@ function initEndpointForm() {
   const codexTestBtn = el('adm-codexTestBtn');
   const codexStreamTestBtn = el('adm-codexStreamTestBtn');
   const codexRefreshBtn = el('adm-codexRefreshBtn');
+  const codexRemoveConnectorBtn = el('adm-codexRemoveConnectorBtn');
   const codexSignOutBtn = el('adm-codexSignOutBtn');
   const codexResetBtn = el('adm-codexResetBtn');
   let codexProviderStatus = null;
@@ -876,14 +878,42 @@ function initEndpointForm() {
     return (Array.isArray(data?.models) ? data.models : []).filter(m => m && m.id && m.enabled !== false && !m.hidden);
   }
 
+  function _selectedCodexModelIds(data) {
+    return (Array.isArray(data?.models) ? data.models : []).map(m => m && m.id).filter(Boolean);
+  }
+
+  function _toggleCodexCustomInput() {
+    if (!codexManualModelInput) return;
+    const isCustom = codexPresetSelect && codexPresetSelect.value === '__custom__';
+    codexManualModelInput.style.display = isCustom ? '' : 'none';
+    if (!isCustom) codexManualModelInput.value = '';
+  }
+
+  function _renderCodexPresetOptions(data) {
+    if (!codexPresetSelect) return;
+    const selected = new Set(_selectedCodexModelIds(data));
+    const recommended = Array.isArray(data?.recommended_models) ? data.recommended_models : [];
+    const current = codexPresetSelect.value;
+    const options = recommended.filter(m => !selected.has(m.id));
+    codexPresetSelect.innerHTML =
+      `<option value="">Recommended Codex model</option>` +
+      options.map(m => `<option value="${esc(m.id)}">${esc(m.label || m.id)}</option>`).join('') +
+      `<option value="__custom__">Custom model ID…</option>`;
+    if (current === '__custom__') codexPresetSelect.value = '__custom__';
+    else if (current && [...codexPresetSelect.options].some(o => o.value === current)) codexPresetSelect.value = current;
+    else if (options.length) codexPresetSelect.value = options[0].id;
+    _toggleCodexCustomInput();
+  }
+
   function _renderCodexModels(data) {
     if (!codexModelsEl) return;
     const models = Array.isArray(data?.models) ? data.models : [];
-    const discovery = data?.model_discovery?.source || 'none';
+    const discovery = data?.model_discovery?.source || 'manual';
+    _renderCodexPresetOptions(data);
     if (!models.length) {
-      const reason = discovery === 'manual'
-        ? 'This Codex CLI exposes a model flag but no model list. Add exact model IDs manually.'
-        : 'No Codex models are available yet. Add a manual model ID if this CLI cannot list models.';
+      const reason = (data?.connector_enabled || _isCodexProviderSelected())
+        ? 'No Codex models are selected yet. Start with GPT-5.5 or add a custom model ID.'
+        : 'Connector removed. Pick Codex / ChatGPT in the provider dropdown to set it up again.';
       codexModelsEl.innerHTML = `<div class="adm-codex-model-empty">${esc(reason)}</div>`;
       return;
     }
@@ -892,18 +922,32 @@ function initEndpointForm() {
       <span class="mcp-tools-count">${_codexEnabledModels(data).length}/${models.length} enabled</span>
     </div><div class="mcp-tools-list adm-codex-model-list">` + models.map(m => {
       const state = m.hidden ? 'hidden' : (m.enabled === false ? 'disabled' : 'enabled');
-      const source = m.source === 'manual' ? 'manual' : 'discovered';
+      const source = m.source === 'recommended' ? 'recommended' : 'custom';
+      const levels = Array.isArray(m?.thinking_effort_levels) ? m.thinking_effort_levels : [];
+      const canThink = !!m?.thinking_supported && levels.length > 0;
+      const thinkSelect = `<select data-codex-thinking-model="${esc(m.id)}" ${canThink ? '' : 'disabled'} style="min-width:136px;">
+        <option value="">${canThink ? 'Provider default' : 'Thinking unavailable'}</option>
+        ${levels.map(level => `<option value="${esc(level)}" ${m.thinking_effort === level ? 'selected' : ''}>${esc(level)}</option>`).join('')}
+      </select>`;
       const primaryAction = m.hidden
         ? `<button type="button" class="admin-btn-sm" data-codex-model-action="restore" data-model-id="${esc(m.id)}">Restore</button>`
         : `<button type="button" class="admin-btn-sm" data-codex-model-action="${m.enabled === false ? 'enable' : 'disable'}" data-model-id="${esc(m.id)}">${m.enabled === false ? 'Enable' : 'Disable'}</button>`;
       const hideAction = !m.hidden
         ? `<button type="button" class="admin-btn-sm" data-codex-model-action="hide" data-model-id="${esc(m.id)}" style="opacity:0.75;">Hide</button>`
         : '';
+      const removeAction = `<button type="button" class="admin-btn-sm" data-codex-model-action="remove" data-model-id="${esc(m.id)}" style="opacity:0.75;">Remove</button>`;
       return `<div class="adm-model-row adm-codex-model-row adm-model-row-${state}" title="${esc(m.id)}">
-        <span style="min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;"><code>${esc(m.id)}</code></span>
-        <span class="adm-model-source-badge">${esc(source)}</span>
-        <span class="adm-model-hide-label">${esc(state)}</span>
-        ${primaryAction}${hideAction}
+        <div style="min-width:0;flex:1;display:flex;flex-direction:column;gap:2px;">
+          <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
+            <strong>${esc(m.label || m.display || m.id)}</strong>
+            <code>${esc(m.id)}</code>
+            <span class="adm-model-source-badge">${esc(source)}</span>
+            <span class="adm-model-hide-label">${esc(state)}</span>
+          </div>
+          ${m.description ? `<div class="admin-ep-detail" style="white-space:normal;">${esc(m.description)}</div>` : ''}
+        </div>
+        ${thinkSelect}
+        ${primaryAction}${hideAction}${removeAction}
       </div>`;
     }).join('') + '</div>';
   }
@@ -919,6 +963,9 @@ function initEndpointForm() {
     const authenticated = !!data?.authenticated;
     const cliAvailable = !!data?.cli_available;
     codexProviderStatus = data || null;
+    const totalCount = Array.isArray(data?.models) ? data.models.length : 0;
+    const shouldShowCard = _isCodexProviderSelected() || !!data?.connector_enabled || totalCount > 0;
+    if (codexCard) codexCard.style.display = shouldShowCard ? 'flex' : 'none';
 
     codexStatusEl.textContent = _codexStatusLabel(status);
     codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
@@ -926,7 +973,6 @@ function initEndpointForm() {
 
     const streaming = data?.streaming_supported === true;
     const enabledCount = enabledModels.length;
-    const totalCount = Array.isArray(data?.models) ? data.models.length : 0;
     let details = streaming
       ? 'Experimental. Chat picker uses the Codex CLI JSON event stream when available. Stateless. Uses Codex CLI auth. Not added as a normal API endpoint.'
       : 'Experimental, one-shot fallback only, stateless. Uses Codex CLI auth. Not added as a normal API endpoint.';
@@ -940,16 +986,20 @@ function initEndpointForm() {
       const streamText = streaming ? 'yes' : 'no';
       const levels = Array.isArray(data?.thinking_effort_levels) ? data.thinking_effort_levels : [];
       const thinkText = data?.thinking_supported ? `supported (${levels.join(', ') || 'provider default'})` : 'not advertised by CLI';
+      const activityText = data?.thinking_activity_supported ? 'safe metrics only' : 'not available';
       codexCapabilitiesEl.innerHTML = [
         `CLI: <strong>${cliAvailable ? 'available' : 'unavailable'}</strong>`,
         `Auth: <strong>${authText}</strong>`,
         `Models: <strong>${enabledCount}/${totalCount}</strong>`,
         `Streaming: <strong>${streamText}</strong>`,
         `Thinking control: <strong>${esc(thinkText)}</strong>`,
+        `Reasoning activity: <strong>${esc(activityText)}</strong>`,
+        `Tool calling: <strong>unsupported</strong>`,
+        `Agent mode: <strong>chat only</strong>`,
       ].join(' &middot; ');
     }
     if (codexSummaryEl) {
-      const pickerState = available ? 'Visible in the chat model picker as an experimental model.' : 'Hidden from the chat model picker until available.';
+      const pickerState = available ? 'Visible in the chat model picker as an experimental model.' : 'Hidden from the chat model picker until at least one enabled model is available.';
       codexSummaryEl.textContent = `${pickerState} Uses Codex CLI auth; no API key is stored.`;
     }
 
@@ -974,6 +1024,7 @@ function initEndpointForm() {
     }
     if (codexResetBtn) codexResetBtn.disabled = disabled;
     if (codexAddModelBtn) codexAddModelBtn.disabled = disabled;
+    if (codexRemoveConnectorBtn) codexRemoveConnectorBtn.disabled = disabled || totalCount === 0;
     _renderCodexModels(data || {});
   }
 
@@ -1146,7 +1197,7 @@ function initEndpointForm() {
     }
   }
 
-  async function _updateCodexModel(action, modelId) {
+  async function _updateCodexModel(action, modelId, extras = {}) {
     if (!modelId) return;
     _setCodexMsg('Updating Codex model list...', '');
     try {
@@ -1154,7 +1205,7 @@ function initEndpointForm() {
         method: 'PATCH',
         credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action, model_id: modelId }),
+        body: JSON.stringify({ action, model_id: modelId, ...extras }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || data.ok === false) {
@@ -1169,10 +1220,37 @@ function initEndpointForm() {
     }
   }
 
+  async function _removeCodexConnector() {
+    const ok = window.styledConfirm
+      ? await window.styledConfirm('Remove Codex connector from Odysseus? This removes selected Codex models from the picker but does not sign out of Codex CLI.', { confirmText: 'Remove', danger: true })
+      : window.confirm('Remove Codex connector from Odysseus? This removes selected Codex models from the picker but does not sign out of Codex CLI.');
+    if (!ok) return;
+    _setCodexMsg('Removing Codex connector...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/connector', {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.ok === false) {
+        _setCodexMsg(data.error || 'Could not remove Codex connector.', 'admin-error');
+        return;
+      }
+      await _refreshCodexProviderStatus();
+      await _refreshAfterEndpointChange();
+      _setCodexMsg('Codex connector removed. CLI sign-in was left unchanged.', 'admin-success');
+    } catch (e) {
+      _setCodexMsg('Could not remove Codex connector: ' + (e?.message || 'request failed'), 'admin-error');
+    }
+  }
+
   async function _addCodexManualModel() {
-    const modelId = (codexManualModelInput?.value || '').trim();
+    const selectedPreset = (codexPresetSelect?.value || '').trim();
+    const modelId = selectedPreset === '__custom__'
+      ? (codexManualModelInput?.value || '').trim()
+      : selectedPreset;
     if (!modelId) {
-      _setCodexMsg('Enter an exact Codex model ID first.', 'admin-error');
+      _setCodexMsg('Choose a recommended Codex model or enter a custom model ID first.', 'admin-error');
       return;
     }
     if (/\s/.test(modelId)) {
@@ -1194,9 +1272,10 @@ function initEndpointForm() {
         return;
       }
       if (codexManualModelInput) codexManualModelInput.value = '';
+      if (codexPresetSelect) codexPresetSelect.value = '';
       await _refreshCodexProviderStatus();
       await _refreshAfterEndpointChange();
-      _setCodexMsg('Manual Codex model added.', 'admin-success');
+      _setCodexMsg('Codex model added.', 'admin-success');
     } catch (e) {
       _setCodexMsg('Could not add Codex model: ' + (e?.message || 'request failed'), 'admin-error');
     } finally {
@@ -1224,9 +1303,11 @@ function initEndpointForm() {
   if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
   if (codexStreamTestBtn) codexStreamTestBtn.addEventListener('click', _testCodexProviderStream);
   if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
+  if (codexRemoveConnectorBtn) codexRemoveConnectorBtn.addEventListener('click', _removeCodexConnector);
   if (codexSignOutBtn) codexSignOutBtn.addEventListener('click', _signOutCodexProvider);
   if (codexResetBtn) codexResetBtn.addEventListener('click', _resetCodexProviderUi);
   if (codexAddModelBtn) codexAddModelBtn.addEventListener('click', _addCodexManualModel);
+  if (codexPresetSelect) codexPresetSelect.addEventListener('change', _toggleCodexCustomInput);
   if (codexManualModelInput) {
     codexManualModelInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {
@@ -1241,6 +1322,11 @@ function initEndpointForm() {
       if (!btn) return;
       e.preventDefault();
       _updateCodexModel(btn.dataset.codexModelAction, btn.dataset.modelId);
+    });
+    codexModelsEl.addEventListener('change', (e) => {
+      const sel = e.target.closest('[data-codex-thinking-model]');
+      if (!sel) return;
+      _updateCodexModel('set_thinking_effort', sel.dataset.codexThinkingModel, { thinking_effort: sel.value || null });
     });
   }
   _setEndpointProviderControls();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -974,8 +974,8 @@ function initEndpointForm() {
     const streaming = data?.streaming_supported === true;
     const enabledCount = enabledModels.length;
     let details = streaming
-      ? 'Experimental. Chat picker uses the Codex CLI JSON event stream when available. Stateless. Uses Codex CLI auth. Not added as a normal API endpoint.'
-      : 'Experimental, one-shot fallback only, stateless. Uses Codex CLI auth. Not added as a normal API endpoint.';
+      ? 'Chat picker uses the Codex CLI JSON event stream when available. Stateless. Uses Codex CLI auth. Not added as a normal API endpoint.'
+      : 'One-shot fallback only, stateless. Uses Codex CLI auth. Not added as a normal API endpoint.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Signed out. Sign in with Codex / ChatGPT before running provider tests or showing it in the chat picker.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
@@ -999,7 +999,7 @@ function initEndpointForm() {
       ].join(' &middot; ');
     }
     if (codexSummaryEl) {
-      const pickerState = available ? 'Visible in the chat model picker as an experimental model.' : 'Hidden from the chat model picker until at least one enabled model is available.';
+      const pickerState = available ? 'Visible in the chat model picker once at least one enabled model is available.' : 'Hidden from the chat model picker until at least one enabled model is available.';
       codexSummaryEl.textContent = `${pickerState} Uses Codex CLI auth; no API key is stored.`;
     }
 
@@ -1366,7 +1366,7 @@ function initEndpointForm() {
       msg.textContent = ''; msg.className = '';
       if (_isCodexProviderSelected()) {
         _focusCodexProviderCard();
-        _setCodexMsg('Codex test chat runs from this experimental card, not the generic endpoint tester.', '');
+        _setCodexMsg('Codex test chat runs from this Codex card, not the generic endpoint tester.', '');
         return;
       }
       const rawUrl = (urlInput.value || provider.value).trim();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -804,7 +804,10 @@ function initEndpointForm() {
     codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
     codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
 
-    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
+    const streaming = data?.streaming_supported === true;
+    let details = streaming
+      ? 'Experimental. Test Chat remains one-shot; JSON event streaming is only available through the experimental SSE test route. Stateless. Uses Codex CLI auth. Not added to the default model picker yet.'
+      : 'Experimental, one-shot only, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -437,8 +437,9 @@ async function loadEndpoints() {
     const _renderInto = (container, indices) => {
       if (!container) return;
       const section = container.closest('.adm-ep-section');
+      const keepForCodex = container.id === 'adm-epList-api' && !!el('adm-codexProviderCard');
       if (!indices.length) {
-        if (section) section.style.display = 'none';
+        if (section) section.style.display = keepForCodex ? '' : 'none';
         container.innerHTML = '';
         return;
       }
@@ -637,6 +638,7 @@ async function _saveEpModelState(epId, panel) {
 function initEndpointForm() {
   const provider = el('adm-epProvider');
   const urlInput = el('adm-epUrl');
+  const CODEX_PROVIDER_VALUE = '__codex_cli__';
 
   // Custom provider picker — mirrors the (now hidden) <select id="adm-epProvider">
   // so the rest of this function (which reads provider.value and dispatches
@@ -666,7 +668,7 @@ function initEndpointForm() {
   if (picker && pickerBtn && pickerMenu && pickerCurrent) {
     _renderPickerMenu();
     _syncPickerCurrent();
-    if (provider.value && !urlInput.value) urlInput.value = provider.value;
+    if (provider.value && provider.value !== CODEX_PROVIDER_VALUE && !urlInput.value) urlInput.value = provider.value;
     pickerBtn.addEventListener('click', (e) => {
       e.stopPropagation();
       pickerMenu.classList.toggle('hidden');
@@ -686,8 +688,15 @@ function initEndpointForm() {
   }
 
   provider.addEventListener('change', () => {
+    if (provider.value === CODEX_PROVIDER_VALUE) {
+      urlInput.value = '';
+      _setEndpointProviderControls();
+      _focusCodexProviderCard();
+      return;
+    }
     if (provider.value) urlInput.value = provider.value;
     else urlInput.value = '';
+    _setEndpointProviderControls();
   });
   urlInput.addEventListener('input', () => {
     if (provider.value && urlInput.value.trim() !== provider.value) {
@@ -768,12 +777,64 @@ function initEndpointForm() {
   const codexCard = el('adm-codexProviderCard');
   const codexStatusEl = el('adm-codexProviderStatus');
   const codexDetailsEl = el('adm-codexProviderDetails');
+  const codexSummaryEl = el('adm-codexProviderSummary');
   const codexModelEl = el('adm-codexProviderModel');
   const codexMsgEl = el('adm-codexProviderMsg');
+  const codexHeader = el('adm-codexProviderHeader');
+  const codexBody = el('adm-codexProviderBody');
+  const codexChevron = el('adm-codexProviderChevron');
   const codexSignInBtn = el('adm-codexSignInBtn');
   const codexTestBtn = el('adm-codexTestBtn');
   const codexRefreshBtn = el('adm-codexRefreshBtn');
   let codexProviderStatus = null;
+  let codexOpen = false;
+
+  function _isCodexProviderSelected() {
+    return provider && provider.value === CODEX_PROVIDER_VALUE;
+  }
+
+  function _setCodexOpen(open) {
+    codexOpen = !!open;
+    try { localStorage.setItem('odysseus.addModels.codex.open', codexOpen ? '1' : '0'); } catch {}
+    if (codexBody) codexBody.style.display = codexOpen ? 'flex' : 'none';
+    if (codexChevron) {
+      codexChevron.style.transform = codexOpen ? 'rotate(180deg)' : '';
+      codexChevron.style.opacity = codexOpen ? '0.7' : '0.3';
+    }
+  }
+
+  function _setEndpointProviderControls() {
+    const isCodex = _isCodexProviderSelected();
+    const apiKey = el('adm-epApiKey');
+    const type = el('adm-epType');
+    const apiTestBtn = el('adm-epApiTestBtn');
+    const addBtn = el('adm-epAddBtn');
+    if (urlInput) {
+      urlInput.disabled = isCodex;
+      urlInput.placeholder = isCodex ? 'Codex uses CLI auth, not an API endpoint URL' : 'Base URL or pick provider';
+      if (isCodex) urlInput.value = '';
+    }
+    if (apiKey) {
+      apiKey.disabled = isCodex;
+      apiKey.placeholder = isCodex ? 'Uses Codex CLI auth' : 'API key';
+      if (isCodex) apiKey.value = '';
+    }
+    if (type) type.disabled = isCodex;
+    if (apiTestBtn) apiTestBtn.disabled = isCodex;
+    if (addBtn) addBtn.disabled = isCodex;
+    if (isCodex) {
+      _setCodexOpen(true);
+      _setCodexMsg('Selected in the provider dropdown. Use this experimental card; Codex is not added as a normal endpoint yet.', '');
+    }
+  }
+
+  function _focusCodexProviderCard() {
+    if (!codexCard) return;
+    _setCodexOpen(true);
+    codexCard.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    codexCard.style.boxShadow = '0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent)';
+    setTimeout(() => { codexCard.style.boxShadow = ''; }, 1200);
+  }
 
   function _setCodexMsg(text, cls) {
     if (!codexMsgEl) return;
@@ -806,13 +867,17 @@ function initEndpointForm() {
 
     const streaming = data?.streaming_supported === true;
     let details = streaming
-      ? 'Experimental. Test Chat remains one-shot; JSON event streaming is only available through the experimental SSE test route. Stateless. Uses Codex CLI auth. Not added to the default model picker yet.'
-      : 'Experimental, one-shot only, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
+      ? 'Experimental. Chat picker uses the Codex CLI JSON event stream when available. Stateless. Uses Codex CLI auth. Not added as a normal API endpoint.'
+      : 'Experimental, one-shot fallback only, stateless. Uses Codex CLI auth. Not added as a normal API endpoint.';
     if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
     else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
     else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
     else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
     codexDetailsEl.textContent = details;
+    if (codexSummaryEl) {
+      const pickerState = disabled ? 'Hidden from chat picker while disabled.' : 'Visible in the chat model picker as an experimental model.';
+      codexSummaryEl.textContent = `${pickerState} Uses Codex CLI auth; no API key is stored.`;
+    }
 
     if (codexModelEl) {
       if (model && model.id) {
@@ -908,8 +973,17 @@ function initEndpointForm() {
       _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this card after sign-in completes.', '');
     });
   }
+  try { codexOpen = localStorage.getItem('odysseus.addModels.codex.open') === '1'; } catch { codexOpen = false; }
+  _setCodexOpen(codexOpen);
+  if (codexHeader) {
+    codexHeader.addEventListener('click', (e) => {
+      if (e.target.closest('button')) return;
+      _setCodexOpen(!codexOpen);
+    });
+  }
   if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
   if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
+  _setEndpointProviderControls();
   _refreshCodexProviderStatus();
 
   let apiTestController = null;
@@ -919,6 +993,11 @@ function initEndpointForm() {
     apiTestBtn.addEventListener('click', async () => {
       const msg = _endpointMsg('api');
       msg.textContent = ''; msg.className = '';
+      if (_isCodexProviderSelected()) {
+        _focusCodexProviderCard();
+        _setCodexMsg('Codex test chat runs from this experimental card, not the generic endpoint tester.', '');
+        return;
+      }
       const rawUrl = (urlInput.value || provider.value).trim();
       const apiKey = el('adm-epApiKey').value.trim();
       if (!rawUrl) { msg.textContent = 'Select a provider or enter a base URL'; msg.className = 'admin-error'; return; }
@@ -964,6 +1043,11 @@ function initEndpointForm() {
   el('adm-epAddBtn').addEventListener('click', async () => {
     const msg = _endpointMsg('api');
     msg.textContent = ''; msg.className = '';
+    if (_isCodexProviderSelected()) {
+      _focusCodexProviderCard();
+      _setCodexMsg('Codex is not added as a normal API endpoint yet. Use the experimental card for status and Test Chat.', '');
+      return;
+    }
     const rawUrl = (urlInput.value || provider.value).trim();
     const apiKey = el('adm-epApiKey').value.trim();
     if (!rawUrl) { msg.textContent = 'Select a provider or enter a base URL'; msg.className = 'admin-error'; return; }

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -765,6 +765,150 @@ function initEndpointForm() {
     return el(kind === 'local' ? 'adm-epLocalMsg' : 'adm-epApiMsg') || el('adm-epMsg');
   }
 
+  const codexCard = el('adm-codexProviderCard');
+  const codexStatusEl = el('adm-codexProviderStatus');
+  const codexDetailsEl = el('adm-codexProviderDetails');
+  const codexModelEl = el('adm-codexProviderModel');
+  const codexMsgEl = el('adm-codexProviderMsg');
+  const codexSignInBtn = el('adm-codexSignInBtn');
+  const codexTestBtn = el('adm-codexTestBtn');
+  const codexRefreshBtn = el('adm-codexRefreshBtn');
+  let codexProviderStatus = null;
+
+  function _setCodexMsg(text, cls) {
+    if (!codexMsgEl) return;
+    codexMsgEl.textContent = text || '';
+    codexMsgEl.className = cls || 'adm-ep-inline-msg';
+  }
+
+  function _codexStatusLabel(status) {
+    if (status === 'disabled') return 'Disabled';
+    if (status === 'sign_in_required') return 'Sign-in required';
+    if (status === 'available') return 'Available';
+    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked';
+    if (status === 'cli_unavailable') return 'CLI unavailable';
+    if (status === 'auth_status_failed') return 'Status unavailable';
+    return 'Unavailable';
+  }
+
+  function _renderCodexProviderStatus(data) {
+    if (!codexCard || !codexStatusEl || !codexDetailsEl) return;
+    const status = data && data.status ? data.status : 'unavailable';
+    const model = Array.isArray(data?.models) && data.models.length ? data.models[0] : null;
+    const available = status === 'available' && data.chat_supported === true && !!model;
+    const signInRequired = status === 'sign_in_required';
+    const disabled = status === 'disabled' || data?.feature_enabled === false;
+    codexProviderStatus = data || null;
+
+    codexStatusEl.textContent = _codexStatusLabel(status);
+    codexStatusEl.className = available ? 'admin-badge' : 'admin-badge admin-badge-off';
+    codexStatusEl.style.color = available ? 'var(--green,#50fa7b)' : '';
+
+    let details = 'Experimental, non-streaming, stateless. Uses Codex CLI auth. Not added to the default model picker yet.';
+    if (disabled) details += ' Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true to test this provider.';
+    else if (signInRequired) details += ' Sign in with Codex / ChatGPT before running the provider test.';
+    else if (status === 'unsupported_unsafe_cli_mode') details += ' Test chat is blocked until the Codex CLI safety flags are available.';
+    else if (status === 'cli_unavailable') details += ' Install or expose the Codex CLI in this runtime before testing.';
+    codexDetailsEl.textContent = details;
+
+    if (codexModelEl) {
+      if (model && model.id) {
+        codexModelEl.style.display = '';
+        codexModelEl.innerHTML = `Model id: <code>${esc(model.id)}</code>`;
+      } else {
+        codexModelEl.style.display = 'none';
+        codexModelEl.textContent = '';
+      }
+    }
+    if (codexTestBtn) codexTestBtn.disabled = !available;
+    if (codexSignInBtn) codexSignInBtn.disabled = disabled;
+  }
+
+  async function _refreshCodexProviderStatus() {
+    if (!codexCard) return;
+    if (codexStatusEl) {
+      codexStatusEl.textContent = 'Checking';
+      codexStatusEl.className = 'admin-badge admin-badge-off';
+      codexStatusEl.style.color = '';
+    }
+    if (codexTestBtn) codexTestBtn.disabled = true;
+    _setCodexMsg('', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/status', { credentials: 'same-origin' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        _renderCodexProviderStatus({ status: res.status === 403 ? 'admin_required' : 'unavailable' });
+        _setCodexMsg(res.status === 403 ? 'Admin access is required to view Codex provider status.' : 'Could not load Codex provider status.', 'admin-error');
+        return;
+      }
+      _renderCodexProviderStatus(data);
+    } catch (_) {
+      _renderCodexProviderStatus({ status: 'unavailable' });
+      _setCodexMsg('Could not load Codex provider status.', 'admin-error');
+    }
+  }
+
+  function _codexTestFailureMessage(data, httpStatus) {
+    const status = data && data.status ? data.status : '';
+    if (status === 'disabled') return 'Codex provider test is disabled. Enable ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED=true.';
+    if (status === 'sign_in_required') return 'Sign-in required before Codex provider test chat can run.';
+    if (status === 'cli_unavailable') return 'Codex CLI is unavailable in this runtime.';
+    if (status === 'unsupported_unsafe_cli_mode') return 'Safety blocked: this Codex CLI does not expose the required sandbox/approval flags for UI test chat.';
+    if (status === 'timeout') return 'Codex CLI test timed out.';
+    if (status === 'empty_response') return 'Codex CLI returned no assistant message.';
+    if (status === 'cli_failed') return 'Codex CLI test failed. No raw CLI output is shown in the UI.';
+    if (status === 'invalid_request') return 'Codex provider test request was invalid.';
+    return `Test failed (${httpStatus})`;
+  }
+
+  async function _testCodexProviderChat() {
+    if (!codexTestBtn) return;
+    const model = Array.isArray(codexProviderStatus?.models) && codexProviderStatus.models.length
+      ? codexProviderStatus.models[0].id
+      : 'codex-cli/chatgpt-experimental';
+    codexTestBtn.disabled = true;
+    codexTestBtn.textContent = 'Testing...';
+    _setCodexMsg('Running non-streaming Codex provider test...', '');
+    try {
+      const res = await fetch('/api/codex-model-provider/test-chat', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model,
+          prompt: 'Reply with exactly: Codex provider UI test ok',
+          timeout_seconds: 60,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok) {
+        if (codexMsgEl) {
+          codexMsgEl.className = 'admin-success';
+          codexMsgEl.innerHTML = `Response: ${esc(data.message || '')}`;
+        }
+      } else {
+        _setCodexMsg(_codexTestFailureMessage(data, res.status), 'admin-error');
+      }
+    } catch (e) {
+      _setCodexMsg('Test failed: ' + (e && e.message ? e.message : 'request failed'), 'admin-error');
+    }
+    codexTestBtn.textContent = 'Test Chat';
+    if (codexProviderStatus) _renderCodexProviderStatus(codexProviderStatus);
+  }
+
+  if (codexSignInBtn) {
+    codexSignInBtn.addEventListener('click', () => {
+      if (settingsModule && typeof settingsModule.open === 'function') settingsModule.open('integrations');
+      setTimeout(() => {
+        document.dispatchEvent(new CustomEvent('odysseus:open-codex-auth'));
+      }, 50);
+      _setCodexMsg('Opened Settings -> Integrations -> Codex / ChatGPT. Refresh this card after sign-in completes.', '');
+    });
+  }
+  if (codexTestBtn) codexTestBtn.addEventListener('click', _testCodexProviderChat);
+  if (codexRefreshBtn) codexRefreshBtn.addEventListener('click', _refreshCodexProviderStatus);
+  _refreshCodexProviderStatus();
+
   let apiTestController = null;
   const apiTestBtn = el('adm-epApiTestBtn');
   const apiCancelTestBtn = el('adm-epApiCancelTestBtn');

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1150,8 +1150,8 @@ import createResearchSynapse from './researchSynapse.js';
           // Don't show beforeThink text during streaming — it'll appear in the final render
           // This prevents the "split into two" duplication
           contentEl.innerHTML =
-            '<div class="thinking-section"><div class="thinking-header"><div class="thinking-header-left">Thinking' +
-            (lines > 1 ? ` (${lines} lines)` : '') + '</div></div></div>';
+            '<div class="thinking-section"><div class="thinking-header"><div class="thinking-header-left"><span>Reasoning activity' +
+            (lines > 1 ? ` (${lines} hidden lines)` : '') + '</span></div></div></div>';
           contentEl._prevTextLen = 0;
           uiModule.scrollHistory();
           return;
@@ -1463,13 +1463,13 @@ import createResearchSynapse from './researchSynapse.js';
                   thinkContent.innerHTML = `
                     <div class="thinking-section">
                       <div class="thinking-header" data-thinking-id="${_liveThinkDomId}">
-                        <div class="thinking-header-left"><span class="live-think-header-text">Thinking\u2026</span></div>
+                        <div class="thinking-header-left"><span class="live-think-header-text" data-label="reasoning activity">Reasoning activity...</span></div>
                         <span class="live-think-spinner-slot" style="flex-shrink:0;margin-left:auto;"></span>
                         <span class="live-think-timer" style="font-size:11px;opacity:0.4;font-variant-numeric:tabular-nums;margin-left:6px;margin-right:5px;"></span>
                         <span class="thinking-toggle live-think-toggle" id="${_liveThinkDomId}-toggle"></span>
                       </div>
                       <div class="thinking-content" id="${_liveThinkDomId}">
-                        <div class="thinking-content-inner live-think-inner"></div>
+                        <div class="thinking-content-inner live-think-inner is-redacted">Reasoning activity is being captured. Raw hidden chain-of-thought is not displayed.</div>
                       </div>
                     </div>`;
                   _liveThinkSection = thinkContent.querySelector('.thinking-section');
@@ -1503,7 +1503,10 @@ import createResearchSynapse from './researchSynapse.js';
                     // Extract raw thinking text (strip all <think>/<thinking> open/close tags and prefixes)
                     var thinkText = roundText.replace(/<\/?think(?:ing)?>/gi, '');
                     thinkText = thinkText.replace(/^\s*Thinking(?:\s+Process)?:\s*/i, '');
-                    _liveThinkInner.innerHTML = markdownModule.mdToHtml(thinkText);
+                    var _hiddenLines = thinkText.trim() ? thinkText.trim().split('\n').length : 0;
+                    _liveThinkInner.textContent = _hiddenLines > 1
+                      ? 'Reasoning activity captured (' + _hiddenLines + ' hidden lines). Raw hidden chain-of-thought is not displayed.'
+                      : 'Reasoning activity is being captured. Raw hidden chain-of-thought is not displayed.';
                     // Keep thinking box scrolled to bottom
                     var thinkBox = _liveThinkInner.closest('.thinking-content');
                     if (thinkBox) thinkBox.scrollTop = thinkBox.scrollHeight;

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -726,12 +726,36 @@ import createResearchSynapse from './researchSynapse.js';
         try { await documentModule.saveDocument({ silent: true }); } catch (_e) { /* best-effort */ }
         fd.append('active_doc_id', documentModule.getCurrentDocId());
       }
+      function _setChatModeUi() {
+        const _ab = document.getElementById('mode-agent-btn');
+        const _cb = document.getElementById('mode-chat-btn');
+        if (_ab && _cb) {
+          _ab.classList.remove('active');
+          _cb.classList.add('active');
+          const _toggle = _ab.closest('.mode-toggle');
+          if (_toggle) _toggle.classList.add('mode-chat');
+        }
+        if (typeof Storage !== 'undefined' && Storage.KEYS) {
+          const _st = Storage.getJSON(Storage.KEYS.TOGGLES, {});
+          _st.mode = 'chat';
+          Storage.setJSON(Storage.KEYS.TOGGLES, _st);
+        }
+      }
       // Web toggle: pre-search in Chat mode, tool permission in Agent mode
       const toggleState = Storage.loadToggleState();
       let isAgentMode = (toggleState.mode || 'chat') === 'agent';
+      const _currentSessionMeta = sessionModule && sessionModule.getSessions
+        ? sessionModule.getSessions().find(s => s.id === streamSessionId)
+        : null;
+      const _pendingChatModel = sessionModule && sessionModule.getPendingChat
+        ? sessionModule.getPendingChat()
+        : null;
+      const _isCodexSelection =
+        ((_currentSessionMeta && _currentSessionMeta.endpoint_url === 'odysseus://codex-cli')
+          || (!_currentSessionMeta && _pendingChatModel && _pendingChatModel.url === 'odysseus://codex-cli'));
       // Auto-escalate to agent mode when a document is open — the user expects
       // the AI to see the document and have tools to edit it
-      if (!isAgentMode && documentModule && documentModule.isPanelOpen() && documentModule.getCurrentDocId()) {
+      if (!isAgentMode && !_isCodexSelection && documentModule && documentModule.isPanelOpen() && documentModule.getCurrentDocId()) {
         isAgentMode = true;
       }
       fd.append('mode', isAgentMode ? 'agent' : 'chat');
@@ -921,29 +945,27 @@ import createResearchSynapse from './researchSynapse.js';
           return;
         }
         let errText = `Error ${res.status}`;
+        let errJson = null;
         try {
           const errBody = await res.text();
+          try { errJson = JSON.parse(errBody); } catch {}
+          if (errJson && typeof errJson === 'object') {
+            const detail = errJson.detail && typeof errJson.detail === 'object' ? errJson.detail : {};
+            errText = detail.error || errJson.error || errJson.detail || errText;
+            if ((detail.code || errJson.code) === 'agent_mode_unsupported') {
+              errText = detail.error || errJson.error || 'This model supports chat streaming only — switched to Chat mode. Try again.';
+              _setChatModeUi();
+            }
+          }
           // Parse nested JSON error if present
           const m = errBody.match(/"message"\s*:\s*"([^"]+)"/);
-          if (m) errText = m[1].replace(/\\"/g, '"');
+          if (!errJson && m) errText = m[1].replace(/\\"/g, '"');
           else if (errBody.length < 200) errText = errBody;
         } catch {}
         // Auto-switch to chat mode for tool-related errors
         if (errText.includes('tool') || errText.includes('auto')) {
           errText = 'This model doesn\'t support agent tools — switched to Chat mode. Try again.';
-          const _ab = document.getElementById('mode-agent-btn');
-          const _cb = document.getElementById('mode-chat-btn');
-          if (_ab && _cb) {
-            _ab.classList.remove('active');
-            _cb.classList.add('active');
-            const _toggle = _ab.closest('.mode-toggle');
-            if (_toggle) _toggle.classList.add('mode-chat');
-          }
-          if (typeof Storage !== 'undefined' && Storage.KEYS) {
-            const _st = Storage.getJSON(Storage.KEYS.TOGGLES, {});
-            _st.mode = 'chat';
-            Storage.setJSON(Storage.KEYS.TOGGLES, _st);
-          }
+          _setChatModeUi();
         }
         typewriterInto(holder.querySelector('.body'), errText);
         enableResearchBtn();
@@ -1328,7 +1350,11 @@ import createResearchSynapse from './researchSynapse.js';
               // Handle SSE error events (e.g. HTTP 404 from provider)
               if (_nextIsError || json.status >= 400) {
                 _nextIsError = false;
-                const errMsg = json.text || json.error?.message || `Error ${json.status || 'unknown'}`;
+                let errMsg = json.text || json.error?.message || json.error || `Error ${json.status || 'unknown'}`;
+                if ((json.code || '') === 'agent_mode_unsupported' || /chat-only|agent tools are not available/i.test(String(errMsg || ''))) {
+                  errMsg = 'This model supports chat streaming only — switched to Chat mode. Try again.';
+                  _setChatModeUi();
+                }
                 console.error('Stream error:', errMsg);
                 if (spinner && spinner.element) spinner.destroy();
                 typewriterInto(roundHolder.querySelector('.body'), errMsg);

--- a/static/js/group.js
+++ b/static/js/group.js
@@ -794,8 +794,15 @@ async function _streamToHolder(modelIdx, sessionId, msg, holderEl, abortCtrl) {
       credentials: 'same-origin',
       signal: abortCtrl.signal,
     });
+    if (!res.ok || !res.body) {
+      let errText = `[HTTP ${res.status}]`;
+      try { errText = await res.text() || errText; } catch {}
+      bodyEl.innerHTML = `<i style="color:var(--color-error);">${uiModule.esc(errText)}</i>`;
+      return;
+    }
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
+    let _nextIsError = false;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -807,11 +814,24 @@ async function _streamToHolder(modelIdx, sessionId, msg, holderEl, abortCtrl) {
       _buffer = lines.pop(); // keep incomplete last line
 
       for (const line of lines) {
+        if (line.startsWith('event: ')) {
+          if (line.slice(7).trim() === 'error') _nextIsError = true;
+          continue;
+        }
         if (!line.startsWith('data: ')) continue;
         if (line === 'data: [DONE]') continue;
 
         try {
           const json = JSON.parse(line.slice(6));
+          if (_nextIsError || json.status >= 400 || json.code === 'agent_mode_unsupported') {
+            _nextIsError = false;
+            const errMsg = json.error || json.text || `[Error ${json.status || 'unknown'}]`;
+            const errDiv = document.createElement('div');
+            errDiv.style.cssText = 'color:var(--color-error);font-style:italic;padding:4px 0;';
+            errDiv.textContent = `[Error: ${errMsg}]`;
+            bodyEl.appendChild(errDiv);
+            continue;
+          }
 
           // Text delta (OpenAI format)
           if (json.choices?.[0]?.delta?.content) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -178,11 +178,13 @@ export function extractThinkingBlocks(text) {
 function createThinkingSection(thinkingContent, index = 0, thinkingTime = null) {
   const id = `thinking-${Date.now()}-${index}`;
   const timeHtml = thinkingTime ? `<span style="font-size:11px;opacity:0.4;font-variant-numeric:tabular-nums;">${thinkingTime}s</span>` : '';
+  const approxLines = String(thinkingContent || '').split('\n').filter(Boolean).length;
+  const activity = approxLines > 1 ? `Reasoning activity captured (${approxLines} lines hidden).` : 'Reasoning activity captured.';
   return `
     <div class="thinking-section">
       <div class="thinking-header" data-thinking-id="${id}">
         <div class="thinking-header-left">
-          <span>View thinking process</span>
+          <span data-label="reasoning activity">View reasoning activity</span>
         </div>
         <div style="display:flex;align-items:center;gap:6px;">
           ${timeHtml}
@@ -190,8 +192,8 @@ function createThinkingSection(thinkingContent, index = 0, thinkingTime = null) 
         </div>
       </div>
       <div class="thinking-content" id="${id}">
-        <div class="thinking-content-inner">
-          ${mdToHtml(thinkingContent)}
+        <div class="thinking-content-inner is-redacted">
+          ${activity} Raw hidden chain-of-thought is not displayed.
         </div>
       </div>
     </div>

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -143,9 +143,9 @@ function _initModelPickerDropdown() {
       const probeResult = item.endpoint_id ? _localProbe[item.endpoint_id] : null;
       const isLocalDead = !!(probeResult && probeResult.alive === false);
       allModels.forEach((mid, i) => {
-        // Deduplicate by model ID — prefer DB endpoints over env-discovered
-        if (seen.has(mid)) return;
-        seen.add(mid);
+        const dedupeKey = `${item.url || ''}::${mid}`;
+        if (seen.has(dedupeKey)) return;
+        seen.add(dedupeKey);
         result.push({
           mid,
           display: (allDisplay[i] || mid).split('/').pop(),
@@ -154,6 +154,9 @@ function _initModelPickerDropdown() {
           epName: item.endpoint_name || '',
           stale: isLocalDead,
           staleReason: isLocalDead ? (probeResult.error || 'not responding') : '',
+          provider: item.provider || '',
+          experimental: !!item.experimental,
+          capabilities: item.capabilities || {},
         });
       });
     });
@@ -268,7 +271,13 @@ function _initModelPickerDropdown() {
     }
     if (!currentSessionId && _pendingChat) {
       // Already have a deferred session — just update the model
-      _deps.setPendingChat({ url: m.url, modelId: m.mid, endpointId: m.endpointId });
+      _deps.setPendingChat({
+        url: m.url,
+        modelId: m.mid,
+        endpointId: m.endpointId,
+        capabilities: m.capabilities || {},
+        provider: m.provider || '',
+      });
       // Header stays as session name — model switch only updates picker
       updateModelPicker();
       uiModule.showToast(`Using ${m.display}`);

--- a/static/js/models.js
+++ b/static/js/models.js
@@ -213,6 +213,9 @@ export async function refreshModels(force = false) {
             endpointId: item.endpoint_id || null,
             offline: isOffline,
             modelType: epModelType,
+            provider: item.provider || '',
+            experimental: !!item.experimental,
+            capabilities: item.capabilities || {},
           });
         });
         // Extra (non-curated) models from server
@@ -224,6 +227,9 @@ export async function refreshModels(force = false) {
             endpointId: item.endpoint_id || null,
             offline: isOffline,
             modelType: epModelType,
+            provider: item.provider || '',
+            experimental: !!item.experimental,
+            capabilities: item.capabilities || {},
           });
         });
       });

--- a/static/js/research/panel.js
+++ b/static/js/research/panel.js
@@ -474,6 +474,9 @@ function _readSettings() {
     model: document.getElementById('research-model')?.value || undefined,
     category: category || undefined,
   };
+  if (!settings.endpoint_id && _sessionModule && typeof _sessionModule.getCurrentSessionId === 'function') {
+    settings.source_session_id = _sessionModule.getCurrentSessionId() || undefined;
+  }
   const epSel = document.getElementById('research-endpoint');
   if (epSel && epSel.value) {
     const opt = epSel.options[epSel.selectedIndex];

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3072,13 +3072,6 @@ function initCodexAuth(root) {
     diagEl.classList.remove('hidden');
   }
 
-  function safeCodexLogBody(data) {
-    if (!data || typeof data !== 'object') return data;
-    const copy = { ...data };
-    if (copy.user_code) copy.user_code = '[redacted]';
-    return copy;
-  }
-
   function render(data) {
     const st = data.status || 'unknown';
     const codexAuthed = !!(data.codex_authenticated || data.authenticated);
@@ -3124,7 +3117,6 @@ function initCodexAuth(root) {
     try {
       const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
       const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
-      console.debug(`codex ${path} response`, { status: res.status, body: safeCodexLogBody(data) });
       if (res.status === 401 || res.status === 403) {
         data.status = 'auth_required';
         data.error_code = 'auth_required';
@@ -3137,7 +3129,6 @@ function initCodexAuth(root) {
       render(data);
       return data;
     } catch (e) {
-      console.debug(`codex ${path} request failed`, e);
       const data = { status: 'failed', message: `Request failed: ${e.message || e}` };
       render(data);
       return data;
@@ -3157,8 +3148,6 @@ function initCodexAuth(root) {
   }
 
   startBtn.addEventListener('click', async () => {
-    console.debug('codex sign-in clicked');
-    console.debug('calling /api/codex-auth/start');
     const data = await request('start', 'POST', 'Requesting Codex device code...');
     if (data.status === 'pending' && data.verification_url && data.user_code) {
       setResult('Device code ready. Complete sign-in in the browser.', 'var(--green,#50fa7b)');
@@ -3172,8 +3161,6 @@ function initCodexAuth(root) {
     if (!pollTimer) pollTimer = setInterval(refresh, 2500);
   });
   testBtn?.addEventListener('click', async () => {
-    console.debug('codex test clicked');
-    console.debug('calling /api/codex-auth/test');
     const data = await request('test', 'POST', 'Testing Codex connection...');
     if (data.ok) {
       statusEl.textContent = 'Codex connection is available';
@@ -3216,7 +3203,7 @@ async function initUnifiedIntegrations() {
   }
 
   async function fetchAll() {
-    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes] = await Promise.all([
+    const [apiRes, calRes, cardRes, contactsRes, emailAccountsRes, mcpRes, vaultRes, codexRes] = await Promise.all([
       fetch('/api/auth/integrations', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { integrations: [] }).catch(() => ({ integrations: [] })),
       fetch('/api/calendar/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
       fetch('/api/contacts/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
@@ -3224,16 +3211,21 @@ async function initUnifiedIntegrations() {
       fetch('/api/email/accounts', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : { accounts: [] }).catch(() => ({ accounts: [] })),
       fetch('/api/mcp/servers', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : []).catch(() => []),
       fetch('/api/vault/config', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
+      fetch('/api/codex-auth/status', { credentials: 'same-origin' }).then(r => r.ok ? r.json() : {}).catch(() => ({})),
     ]);
     const items = [];
     // API integrations
     for (const intg of (apiRes.integrations || [])) {
-      if ((intg.integration_type || 'api') === 'codex') {
-        items.push({ type: 'codex', id: intg.id, name: intg.name || 'Codex / ChatGPT', detail: 'ChatGPT sign-in through the Codex CLI', enabled: intg.enabled !== false, data: intg });
-      } else {
-        items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
-      }
+      items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
     }
+    items.push({
+      type: 'codex',
+      id: '__codex__',
+      name: 'Codex / ChatGPT',
+      detail: codexRes.message || 'ChatGPT sign-in through the Codex CLI',
+      enabled: !!(codexRes.codex_authenticated || codexRes.authenticated),
+      data: codexRes,
+    });
     // CalDAV
     if (calRes.url) {
       items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
@@ -3344,7 +3336,7 @@ async function initUnifiedIntegrations() {
           else if (type === 'email') await fetch(`/api/email/accounts/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'mcp') await fetch(`/api/mcp/servers/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'vault') await fetch('/api/vault/logout', { method: 'POST', credentials: 'same-origin' });
-          else if (type === 'codex') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
+          else if (type === 'codex') await fetch('/api/codex-auth/logout', { method: 'POST', credentials: 'same-origin' });
         } catch (_) {}
         formEl.style.display = 'none';
         await renderList();
@@ -4406,65 +4398,7 @@ async function initUnifiedIntegrations() {
   }
 
   // ── Add button with type picker ──
-  async function findCodexIntegration() {
-    try {
-      const r = await fetch('/api/auth/integrations', { credentials: 'same-origin' });
-      const d = await r.json();
-      return (d.integrations || []).find(i => (i.integration_type || 'api') === 'codex') || null;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  async function showCodexForm(editId) {
-    const isEdit = editId && editId !== 'new';
-    if (!isEdit) {
-      const existing = await findCodexIntegration();
-      if (existing?.id) {
-        await showCodexForm(existing.id);
-        return;
-      }
-      formEl.innerHTML = `
-        <div class="admin-card" style="margin-top:8px">
-          <h2 style="font-size:13px">Add Codex / ChatGPT</h2>
-          <div class="admin-toggle-sub" style="margin-bottom:8px">Adds host-level ChatGPT sign-in through the official Codex CLI device-code flow.</div>
-          <div class="settings-row" style="margin-top:4px;flex-wrap:wrap;gap:6px">
-            <button type="button" class="admin-btn-sm" id="uf-codex-add">Add Codex / ChatGPT</button>
-            <button type="button" class="admin-btn-sm" id="uf-codex-cancel" style="opacity:0.75">Cancel</button>
-            <span id="uf-codex-msg" style="font-size:11px"></span>
-          </div>
-        </div>`;
-      el('uf-codex-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
-      el('uf-codex-add').addEventListener('click', async () => {
-        const msg = el('uf-codex-msg');
-        msg.textContent = 'Adding...';
-        msg.style.color = '';
-        try {
-          const r = await fetch('/api/auth/integrations', {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              integration_type: 'codex',
-              name: 'Codex / ChatGPT',
-              auth_type: 'none',
-              enabled: true,
-              description: 'ChatGPT sign-in through the official Codex CLI device-code flow.',
-            }),
-          });
-          const d = await r.json().catch(() => ({}));
-          if (!r.ok || !d.integration?.id) throw new Error(d.detail || d.error || `HTTP ${r.status}`);
-          await renderList();
-          notifyIntegrationsChanged();
-          await showCodexForm(d.integration.id);
-        } catch (e) {
-          msg.textContent = `Failed: ${e.message || e}`;
-          msg.style.color = 'var(--red)';
-        }
-      });
-      return;
-    }
-
+  async function showCodexForm() {
     formEl.innerHTML = `
       <div class="admin-card" id="codex-auth-card" style="margin-top:8px">
         <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex / ChatGPT</h2>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2115,7 +2115,6 @@ function initAll() {
   initEmailSettings();
   initEmailAccountsSettings();
   initReminderSettings();
-  initCodexAuth();
   initUnifiedIntegrations();
 }
 
@@ -3019,23 +3018,27 @@ const INTG_TYPES = {
   email:   { label: 'Email',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>' },
   mcp:     { label: 'MCP',     icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>' },
   vault:   { label: 'Vault',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>' },
+  codex:   { label: 'Codex',   icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="M2 12h20"/><path d="m16 6 2 2-2 2"/><path d="m8 18-2-2 2-2"/></svg>' },
 };
 
 let _unifiedInited = false;
-let _codexAuthInited = false;
 
-function initCodexAuth() {
-  if (_codexAuthInited) return;
-  _codexAuthInited = true;
-  const statusEl = el('codex-auth-status');
-  const deviceEl = el('codex-auth-device');
-  const urlEl = el('codex-auth-url');
-  const codeEl = el('codex-auth-code');
-  const startBtn = el('codex-auth-start');
-  const testBtn = el('codex-auth-test');
-  const cancelBtn = el('codex-auth-cancel');
-  const logoutBtn = el('codex-auth-logout');
+function initCodexAuth(root) {
+  const scope = root || document;
+  const q = (id) => scope.querySelector ? scope.querySelector(`#${id}`) : el(id);
+  const statusEl = q('codex-auth-status');
+  const deviceEl = q('codex-auth-device');
+  const urlEl = q('codex-auth-url');
+  const codeEl = q('codex-auth-code');
+  const startBtn = q('codex-auth-start');
+  const testBtn = q('codex-auth-test');
+  const cancelBtn = q('codex-auth-cancel');
+  const logoutBtn = q('codex-auth-logout');
+  const resultEl = q('codex-auth-result');
+  const diagEl = q('codex-auth-diagnostics');
   if (!statusEl || !startBtn) return;
+  if (startBtn.dataset.codexAuthInited === '1') return;
+  startBtn.dataset.codexAuthInited = '1';
 
   let pollTimer = null;
 
@@ -3045,16 +3048,56 @@ function initCodexAuth() {
     btn.style.opacity = busy ? '0.45' : '';
   }
 
+  function setResult(text, color) {
+    if (!resultEl) return;
+    resultEl.textContent = text || '';
+    resultEl.style.color = color || '';
+  }
+
+  function renderDiagnostics(data) {
+    if (!diagEl) return;
+    if (!data) {
+      diagEl.classList.add('hidden');
+      diagEl.textContent = '';
+      return;
+    }
+    const parts = [
+      `CLI installed: ${data.cli_found === false ? 'no' : 'yes'}`,
+      `executable: ${data.cli_executable === false ? 'no' : 'yes'}`,
+      `CODEX_BIN: ${data.configured_binary || 'codex'}`,
+      `resolved: ${data.resolved_binary_path || 'not found'}`,
+    ];
+    if (data.codex_home_path) parts.push(`CODEX_HOME: ${data.codex_home_path}`);
+    diagEl.textContent = parts.join('  ');
+    diagEl.classList.remove('hidden');
+  }
+
+  function safeCodexLogBody(data) {
+    if (!data || typeof data !== 'object') return data;
+    const copy = { ...data };
+    if (copy.user_code) copy.user_code = '[redacted]';
+    return copy;
+  }
+
   function render(data) {
     const st = data.status || 'unknown';
+    const codexAuthed = !!(data.codex_authenticated || data.authenticated);
+    const cliMissing = st === 'missing_cli' || st === 'cli_missing' || st === 'cli_not_executable'
+      || data.error_code === 'missing_cli' || data.error_code === 'cli_missing' || data.error_code === 'cli_not_executable'
+      || data.cli_found === false || data.cli_executable === false;
+    const authRequired = st === 'auth_required' || data.error_code === 'auth_required';
     let text = data.message || st;
-    if (data.authenticated && data.auth_mode) text = `${text} (${data.auth_mode})`;
+    if (authRequired) text = 'Odysseus session expired or admin auth required.';
+    else if (cliMissing) text = 'Codex CLI missing or CODEX_BIN invalid.';
+    else if (st === 'not_authenticated' || st === 'logged_out' || st === 'canceled') text = 'Codex CLI ready. Not signed in.';
+    else if (codexAuthed && data.auth_mode) text = `${text} (${data.auth_mode})`;
     if (st === 'pending') text = 'Waiting for browser verification...';
     if (st === 'starting') text = 'Starting device-code login...';
     statusEl.textContent = text;
-    statusEl.style.color = (st === 'failed' || st === 'timeout' || st === 'missing_cli' || st === 'disabled') ? 'var(--red)' : '';
+    statusEl.style.color = (st === 'failed' || st === 'timeout' || cliMissing || st === 'disabled' || authRequired) ? 'var(--red)' : '';
+    renderDiagnostics(data);
 
-    const hasDevice = !!(data.verification_url && data.user_code && (st === 'pending' || st === 'starting'));
+    const hasDevice = !!(data.verification_url && data.user_code && (st === 'pending' || st === 'starting' || data.device_login_active));
     deviceEl?.classList.toggle('hidden', !hasDevice);
     if (hasDevice) {
       urlEl.textContent = data.verification_url;
@@ -3064,19 +3107,41 @@ function initCodexAuth() {
       codeEl.textContent = '';
     }
 
-    const running = st === 'starting' || st === 'pending' || data.process_running;
+    const running = st === 'starting' || st === 'pending' || data.process_running || data.device_login_active;
     cancelBtn?.classList.toggle('hidden', !running);
-    startBtn.textContent = data.authenticated ? 'Sign in again' : 'Sign in with Codex';
+    startBtn.textContent = codexAuthed ? 'Sign in again' : 'Sign in with Codex';
     setBusy(startBtn, running);
     setBusy(testBtn, running);
     setBusy(logoutBtn, running);
   }
 
-  async function request(path, method) {
-    const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
-    const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
-    render(data);
-    return data;
+  async function request(path, method, busyText) {
+    if (busyText) {
+      statusEl.textContent = busyText;
+      statusEl.style.color = '';
+      setResult('', '');
+    }
+    try {
+      const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
+      const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
+      console.debug(`codex ${path} response`, { status: res.status, body: safeCodexLogBody(data) });
+      if (res.status === 401 || res.status === 403) {
+        data.status = 'auth_required';
+        data.error_code = 'auth_required';
+        data.message = 'Odysseus session expired or admin auth required.';
+      }
+      if (!res.ok) {
+        data.status = data.status || 'failed';
+        data.message = data.message || data.detail || `HTTP ${res.status}`;
+      }
+      render(data);
+      return data;
+    } catch (e) {
+      console.debug(`codex ${path} request failed`, e);
+      const data = { status: 'failed', message: `Request failed: ${e.message || e}` };
+      render(data);
+      return data;
+    }
   }
 
   async function refresh() {
@@ -3092,23 +3157,44 @@ function initCodexAuth() {
   }
 
   startBtn.addEventListener('click', async () => {
-    await request('start', 'POST');
+    console.debug('codex sign-in clicked');
+    console.debug('calling /api/codex-auth/start');
+    const data = await request('start', 'POST', 'Requesting Codex device code...');
+    if (data.status === 'pending' && data.verification_url && data.user_code) {
+      setResult('Device code ready. Complete sign-in in the browser.', 'var(--green,#50fa7b)');
+    } else if (data.status === 'starting' || data.device_login_active) {
+      setResult('Waiting for Codex CLI to provide a device code...', '');
+    } else if (data.status === 'already_authenticated' || data.authenticated) {
+      setResult('Codex is already authenticated.', 'var(--green,#50fa7b)');
+    } else if (data.error_code) {
+      setResult(data.message || 'Codex sign-in could not start', 'var(--red)');
+    }
     if (!pollTimer) pollTimer = setInterval(refresh, 2500);
   });
   testBtn?.addEventListener('click', async () => {
-    const data = await request('test', 'POST');
+    console.debug('codex test clicked');
+    console.debug('calling /api/codex-auth/test');
+    const data = await request('test', 'POST', 'Testing Codex connection...');
     if (data.ok) {
       statusEl.textContent = 'Codex connection is available';
       statusEl.style.color = 'var(--green,#50fa7b)';
+      setResult('Test passed', 'var(--green,#50fa7b)');
+    } else {
+      const cliReady = data.cli_found !== false && data.cli_executable !== false;
+      const message = cliReady && (data.status === 'not_authenticated' || data.status === 'logged_out')
+        ? 'Codex CLI ready. Not signed in.'
+        : (data.message || 'Test failed');
+      setResult(message, 'var(--red)');
     }
   });
   cancelBtn?.addEventListener('click', async () => {
-    await request('cancel', 'POST');
+    await request('cancel', 'POST', 'Canceling Codex sign-in...');
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
   });
   logoutBtn?.addEventListener('click', async () => {
     if (!await window.styledConfirm('Logout from Codex on this Odysseus host?', { confirmText: 'Logout', danger: true })) return;
-    await request('logout', 'POST');
+    const data = await request('logout', 'POST', 'Logging out from Codex...');
+    setResult(data.status === 'logged_out' ? 'Logged out' : (data.message || 'Logout finished'), data.status === 'logged_out' ? 'var(--green,#50fa7b)' : '');
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
   });
 
@@ -3142,7 +3228,11 @@ async function initUnifiedIntegrations() {
     const items = [];
     // API integrations
     for (const intg of (apiRes.integrations || [])) {
-      items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
+      if ((intg.integration_type || 'api') === 'codex') {
+        items.push({ type: 'codex', id: intg.id, name: intg.name || 'Codex / ChatGPT', detail: 'ChatGPT sign-in through the Codex CLI', enabled: intg.enabled !== false, data: intg });
+      } else {
+        items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
+      }
     }
     // CalDAV
     if (calRes.url) {
@@ -3254,6 +3344,7 @@ async function initUnifiedIntegrations() {
           else if (type === 'email') await fetch(`/api/email/accounts/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'mcp') await fetch(`/api/mcp/servers/${id}`, { method: 'DELETE', credentials: 'same-origin' });
           else if (type === 'vault') await fetch('/api/vault/logout', { method: 'POST', credentials: 'same-origin' });
+          else if (type === 'codex') await fetch(`/api/auth/integrations/${id}`, { method: 'DELETE', credentials: 'same-origin' });
         } catch (_) {}
         formEl.style.display = 'none';
         await renderList();
@@ -3270,6 +3361,7 @@ async function initUnifiedIntegrations() {
     else if (type === 'email') showEmailForm(editId);
     else if (type === 'mcp') showMcpForm(editId);
     else if (type === 'vault') showVaultForm();
+    else if (type === 'codex') showCodexForm(editId);
   }
 
   // ── API form ──
@@ -4314,6 +4406,91 @@ async function initUnifiedIntegrations() {
   }
 
   // ── Add button with type picker ──
+  async function findCodexIntegration() {
+    try {
+      const r = await fetch('/api/auth/integrations', { credentials: 'same-origin' });
+      const d = await r.json();
+      return (d.integrations || []).find(i => (i.integration_type || 'api') === 'codex') || null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async function showCodexForm(editId) {
+    const isEdit = editId && editId !== 'new';
+    if (!isEdit) {
+      const existing = await findCodexIntegration();
+      if (existing?.id) {
+        await showCodexForm(existing.id);
+        return;
+      }
+      formEl.innerHTML = `
+        <div class="admin-card" style="margin-top:8px">
+          <h2 style="font-size:13px">Add Codex / ChatGPT</h2>
+          <div class="admin-toggle-sub" style="margin-bottom:8px">Adds host-level ChatGPT sign-in through the official Codex CLI device-code flow.</div>
+          <div class="settings-row" style="margin-top:4px;flex-wrap:wrap;gap:6px">
+            <button type="button" class="admin-btn-sm" id="uf-codex-add">Add Codex / ChatGPT</button>
+            <button type="button" class="admin-btn-sm" id="uf-codex-cancel" style="opacity:0.75">Cancel</button>
+            <span id="uf-codex-msg" style="font-size:11px"></span>
+          </div>
+        </div>`;
+      el('uf-codex-cancel').addEventListener('click', () => { formEl.style.display = 'none'; });
+      el('uf-codex-add').addEventListener('click', async () => {
+        const msg = el('uf-codex-msg');
+        msg.textContent = 'Adding...';
+        msg.style.color = '';
+        try {
+          const r = await fetch('/api/auth/integrations', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              integration_type: 'codex',
+              name: 'Codex / ChatGPT',
+              auth_type: 'none',
+              enabled: true,
+              description: 'ChatGPT sign-in through the official Codex CLI device-code flow.',
+            }),
+          });
+          const d = await r.json().catch(() => ({}));
+          if (!r.ok || !d.integration?.id) throw new Error(d.detail || d.error || `HTTP ${r.status}`);
+          await renderList();
+          notifyIntegrationsChanged();
+          await showCodexForm(d.integration.id);
+        } catch (e) {
+          msg.textContent = `Failed: ${e.message || e}`;
+          msg.style.color = 'var(--red)';
+        }
+      });
+      return;
+    }
+
+    formEl.innerHTML = `
+      <div class="admin-card" id="codex-auth-card" style="margin-top:8px">
+        <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex / ChatGPT</h2>
+        <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
+        <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
+        <div id="codex-auth-diagnostics" class="hidden" style="font-size:10px;opacity:0.65;margin:-2px 0 8px 0;line-height:1.35;word-break:break-word;"></div>
+        <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">
+          <div style="font-size:11px;opacity:0.65;margin-bottom:6px;">Open the verification URL, sign in, then enter this one-time code.</div>
+          <div style="display:grid;grid-template-columns:90px minmax(0,1fr);gap:6px 10px;align-items:center;font-size:12px;">
+            <span style="opacity:0.55;">URL</span><a id="codex-auth-url" href="#" target="_blank" rel="noopener noreferrer" style="color:var(--accent,var(--red));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"></a>
+            <span style="opacity:0.55;">Code</span><code id="codex-auth-code" style="font-size:18px;letter-spacing:1px;"></code>
+          </div>
+        </div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;">
+          <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
+          <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
+          <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
+          <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
+          <button type="button" class="admin-btn-sm" id="uf-codex-close" style="opacity:0.75;">Close</button>
+          <span id="codex-auth-result" style="font-size:11px"></span>
+        </div>
+      </div>`;
+    el('uf-codex-close').addEventListener('click', () => { formEl.style.display = 'none'; });
+    initCodexAuth(formEl);
+  }
+
   if (addBtn) {
     addBtn.addEventListener('click', () => {
       formEl.style.display = '';
@@ -4330,6 +4507,7 @@ async function initUnifiedIntegrations() {
                 <option value="carddav">Contacts (CardDAV)</option>
                 <option value="email">Email (IMAP/SMTP)</option>
                 <option value="mcp">MCP Tool Server</option>
+                <option value="codex">Codex / ChatGPT</option>
               </select>
             </div>
           </div>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -4458,7 +4458,7 @@ async function initUnifiedIntegrations() {
           <button type="button" class="admin-btn-sm" id="codex-auth-start">Sign in with Codex</button>
           <button type="button" class="admin-btn-sm" id="codex-auth-test" style="opacity:0.75;">Test</button>
           <button type="button" class="admin-btn-sm hidden" id="codex-auth-cancel" style="opacity:0.75;">Cancel</button>
-          <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Logout / Unlink</button>
+          <button type="button" class="admin-btn-sm" id="codex-auth-logout" style="opacity:0.75;">Sign out</button>
           <button type="button" class="admin-btn-sm" id="uf-codex-close" style="opacity:0.75;">Close</button>
           <span id="codex-auth-result" style="font-size:11px"></span>
         </div>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -4467,6 +4467,11 @@ async function initUnifiedIntegrations() {
     initCodexAuth(formEl, () => renderList());
   }
 
+  document.addEventListener('odysseus:open-codex-auth', () => {
+    formEl.style.display = '';
+    showCodexForm();
+  });
+
   if (addBtn) {
     addBtn.addEventListener('click', () => {
       formEl.style.display = '';

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3262,7 +3262,7 @@ async function initUnifiedIntegrations() {
       items.push({
         type: 'codex',
         id: '__codex__',
-        name: 'Codex connector',
+        name: 'Codex / ChatGPT',
         detail: codexDetail,
         enabled: codexAuthed,
         data: codexRes,
@@ -4443,8 +4443,8 @@ async function initUnifiedIntegrations() {
   async function showCodexForm() {
     formEl.innerHTML = `
       <div class="admin-card" id="codex-auth-card" style="margin-top:8px">
-        <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex connector</h2>
-        <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in through the official Codex CLI device-code flow.</div>
+        <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex / ChatGPT</h2>
+        <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
         <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
         <div id="codex-auth-diagnostics" class="hidden" style="font-size:10px;opacity:0.65;margin:-2px 0 8px 0;line-height:1.35;word-break:break-word;"></div>
         <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3023,7 +3023,7 @@ const INTG_TYPES = {
 
 let _unifiedInited = false;
 
-function initCodexAuth(root) {
+function initCodexAuth(root, onStateChange) {
   const scope = root || document;
   const q = (id) => scope.querySelector ? scope.querySelector(`#${id}`) : el(id);
   const statusEl = q('codex-auth-status');
@@ -3041,6 +3041,30 @@ function initCodexAuth(root) {
   startBtn.dataset.codexAuthInited = '1';
 
   let pollTimer = null;
+  let lastListState = null;
+
+  function codexListState(data) {
+    const authenticated = !!(data?.codex_authenticated || data?.authenticated);
+    const running = !!(
+      data?.device_login_active
+      || data?.process_running
+      || data?.status === 'starting'
+      || data?.status === 'pending'
+    );
+    return `${authenticated ? '1' : '0'}:${running ? '1' : '0'}`;
+  }
+
+  function notifyStateChange(data) {
+    if (typeof onStateChange !== 'function') return;
+    const next = codexListState(data);
+    if (lastListState === null) {
+      lastListState = next;
+      return;
+    }
+    if (next === lastListState) return;
+    lastListState = next;
+    onStateChange(data);
+  }
 
   function setBusy(btn, busy) {
     if (!btn) return;
@@ -3127,10 +3151,12 @@ function initCodexAuth(root) {
         data.message = data.message || data.detail || `HTTP ${res.status}`;
       }
       render(data);
+      notifyStateChange(data);
       return data;
     } catch (e) {
       const data = { status: 'failed', message: `Request failed: ${e.message || e}` };
       render(data);
+      notifyStateChange(data);
       return data;
     }
   }
@@ -3218,14 +3244,30 @@ async function initUnifiedIntegrations() {
     for (const intg of (apiRes.integrations || [])) {
       items.push({ type: 'api', id: intg.id, name: intg.name || 'Unnamed', detail: intg.base_url || '', enabled: intg.enabled !== false, data: intg });
     }
-    items.push({
-      type: 'codex',
-      id: '__codex__',
-      name: 'Codex / ChatGPT',
-      detail: codexRes.message || 'ChatGPT sign-in through the Codex CLI',
-      enabled: !!(codexRes.codex_authenticated || codexRes.authenticated),
-      data: codexRes,
-    });
+    const codexAuthed = !!(codexRes.codex_authenticated || codexRes.authenticated);
+    const codexRunning = !!(
+      codexRes.device_login_active
+      || codexRes.process_running
+      || codexRes.status === 'starting'
+      || codexRes.status === 'pending'
+    );
+    const codexVisible = codexAuthed || codexRunning;
+    if (codexVisible) {
+      let codexDetail = 'ChatGPT sign-in through the Codex CLI';
+      if (codexAuthed && codexRes.auth_mode) codexDetail = `Signed in with ${codexRes.auth_mode}`;
+      else if (codexRunning) codexDetail = 'Device-code sign-in in progress';
+      else if (['not_authenticated', 'logged_out', 'canceled'].includes(codexRes.status)) codexDetail = 'Not signed in';
+      else if (codexRes.status === 'cli_missing' || codexRes.status === 'cli_not_executable') codexDetail = 'Codex CLI unavailable';
+      else if (codexRes.message && !/credential/i.test(codexRes.message)) codexDetail = codexRes.message;
+      items.push({
+        type: 'codex',
+        id: '__codex__',
+        name: 'Codex / ChatGPT',
+        detail: codexDetail,
+        enabled: codexAuthed,
+        data: codexRes,
+      });
+    }
     // CalDAV
     if (calRes.url) {
       items.push({ type: 'caldav', id: '__caldav__', name: 'Calendar (CalDAV)', detail: calRes.url, enabled: true, data: calRes });
@@ -4422,7 +4464,7 @@ async function initUnifiedIntegrations() {
         </div>
       </div>`;
     el('uf-codex-close').addEventListener('click', () => { formEl.style.display = 'none'; });
-    initCodexAuth(formEl);
+    initCodexAuth(formEl, () => renderList());
   }
 
   if (addBtn) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3262,7 +3262,7 @@ async function initUnifiedIntegrations() {
       items.push({
         type: 'codex',
         id: '__codex__',
-        name: 'Codex / ChatGPT',
+        name: 'Codex connector',
         detail: codexDetail,
         enabled: codexAuthed,
         data: codexRes,
@@ -4443,8 +4443,8 @@ async function initUnifiedIntegrations() {
   async function showCodexForm() {
     formEl.innerHTML = `
       <div class="admin-card" id="codex-auth-card" style="margin-top:8px">
-        <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex / ChatGPT</h2>
-        <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in with ChatGPT through the official Codex CLI device-code flow.</div>
+        <h2 style="font-size:13px">${INTG_TYPES.codex.icon} Codex connector</h2>
+        <div class="admin-toggle-sub" style="margin-bottom:8px">Sign in through the official Codex CLI device-code flow.</div>
         <div id="codex-auth-status" style="font-size:12px;opacity:0.75;margin-bottom:8px;">Checking status...</div>
         <div id="codex-auth-diagnostics" class="hidden" style="font-size:10px;opacity:0.65;margin:-2px 0 8px 0;line-height:1.35;word-break:break-word;"></div>
         <div id="codex-auth-device" class="hidden" style="border:1px solid var(--border);border-radius:6px;padding:10px;margin-bottom:8px;background:color-mix(in srgb, var(--panel) 70%, transparent);">

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2115,6 +2115,7 @@ function initAll() {
   initEmailSettings();
   initEmailAccountsSettings();
   initReminderSettings();
+  initCodexAuth();
   initUnifiedIntegrations();
 }
 
@@ -3021,6 +3022,98 @@ const INTG_TYPES = {
 };
 
 let _unifiedInited = false;
+let _codexAuthInited = false;
+
+function initCodexAuth() {
+  if (_codexAuthInited) return;
+  _codexAuthInited = true;
+  const statusEl = el('codex-auth-status');
+  const deviceEl = el('codex-auth-device');
+  const urlEl = el('codex-auth-url');
+  const codeEl = el('codex-auth-code');
+  const startBtn = el('codex-auth-start');
+  const testBtn = el('codex-auth-test');
+  const cancelBtn = el('codex-auth-cancel');
+  const logoutBtn = el('codex-auth-logout');
+  if (!statusEl || !startBtn) return;
+
+  let pollTimer = null;
+
+  function setBusy(btn, busy) {
+    if (!btn) return;
+    btn.disabled = !!busy;
+    btn.style.opacity = busy ? '0.45' : '';
+  }
+
+  function render(data) {
+    const st = data.status || 'unknown';
+    let text = data.message || st;
+    if (data.authenticated && data.auth_mode) text = `${text} (${data.auth_mode})`;
+    if (st === 'pending') text = 'Waiting for browser verification...';
+    if (st === 'starting') text = 'Starting device-code login...';
+    statusEl.textContent = text;
+    statusEl.style.color = (st === 'failed' || st === 'timeout' || st === 'missing_cli' || st === 'disabled') ? 'var(--red)' : '';
+
+    const hasDevice = !!(data.verification_url && data.user_code && (st === 'pending' || st === 'starting'));
+    deviceEl?.classList.toggle('hidden', !hasDevice);
+    if (hasDevice) {
+      urlEl.textContent = data.verification_url;
+      urlEl.href = data.verification_url;
+      codeEl.textContent = data.user_code;
+    } else if (codeEl) {
+      codeEl.textContent = '';
+    }
+
+    const running = st === 'starting' || st === 'pending' || data.process_running;
+    cancelBtn?.classList.toggle('hidden', !running);
+    startBtn.textContent = data.authenticated ? 'Sign in again' : 'Sign in with Codex';
+    setBusy(startBtn, running);
+    setBusy(testBtn, running);
+    setBusy(logoutBtn, running);
+  }
+
+  async function request(path, method) {
+    const res = await fetch(`/api/codex-auth/${path}`, { method: method || 'GET', credentials: 'same-origin' });
+    const data = await res.json().catch(() => ({ status: 'failed', message: `HTTP ${res.status}` }));
+    render(data);
+    return data;
+  }
+
+  async function refresh() {
+    try {
+      const data = await request('status');
+      const running = data.status === 'starting' || data.status === 'pending' || data.process_running;
+      if (running && !pollTimer) pollTimer = setInterval(refresh, 2500);
+      if (!running && pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    } catch (e) {
+      statusEl.textContent = 'Failed to check Codex status';
+      statusEl.style.color = 'var(--red)';
+    }
+  }
+
+  startBtn.addEventListener('click', async () => {
+    await request('start', 'POST');
+    if (!pollTimer) pollTimer = setInterval(refresh, 2500);
+  });
+  testBtn?.addEventListener('click', async () => {
+    const data = await request('test', 'POST');
+    if (data.ok) {
+      statusEl.textContent = 'Codex connection is available';
+      statusEl.style.color = 'var(--green,#50fa7b)';
+    }
+  });
+  cancelBtn?.addEventListener('click', async () => {
+    await request('cancel', 'POST');
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  });
+  logoutBtn?.addEventListener('click', async () => {
+    if (!await window.styledConfirm('Logout from Codex on this Odysseus host?', { confirmText: 'Logout', danger: true })) return;
+    await request('logout', 'POST');
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  });
+
+  refresh();
+}
 
 async function initUnifiedIntegrations() {
   if (_unifiedInited) return;

--- a/static/style.css
+++ b/static/style.css
@@ -13340,24 +13340,6 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
 }
 .adm-provider-item:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
 .adm-provider-item.active { background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); }
-.adm-provider-codex-selected input { display: none; }
-.adm-provider-codex-selected .adm-provider-btn {
-  width: 100%;
-  border-left: 1px solid var(--border);
-  border-radius: 6px;
-}
-.adm-codex-provider-panel {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px;
-  margin-bottom: 6px;
-  background: color-mix(in srgb, var(--fg) 3%, transparent);
-}
-.adm-codex-provider-panel.hidden { display: none; }
 
 /* When the Appearance tab is open, the #settings-modal-opacity slider (in
    the header) fades the modal so the user can see the rest of the UI react

--- a/static/style.css
+++ b/static/style.css
@@ -8056,6 +8056,10 @@ body.hide-thinking .thinking-section { display: none !important; }
   opacity: 0.9;
   line-height: 1.5;
 }
+.thinking-content-inner.is-redacted {
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+  opacity: 1;
+}
 .live-reply-content {
   animation: fadeSlideIn 0.3s ease-out;
 }
@@ -13279,6 +13283,37 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
 .adm-quickstart-section.collapsed .adm-quickstart-body { display: none; }
 .adm-quickstart-section.collapsed .adm-section-caret { transform: rotate(-90deg); }
 
+.adm-codex-model-list {
+  gap: 4px;
+}
+.adm-codex-model-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.adm-codex-model-empty {
+  padding: 7px 8px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--fg) 68%, transparent);
+}
+.adm-model-row-disabled,
+.adm-model-row-hidden {
+  opacity: 0.62;
+}
+.adm-model-source-badge,
+.adm-model-hide-label {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+}
+.adm-model-source-note {
+  margin-left: 4px;
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 48%, transparent);
+  font-weight: 400;
+}
+
 /* Custom provider picker (logo + name) replacing the native <select> */
 .adm-provider-picker { position: relative; margin-bottom: 6px; }
 .adm-provider-combo {
@@ -13340,6 +13375,13 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
 }
 .adm-provider-item:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
 .adm-provider-item.active { background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); }
+.adm-provider-codex-selected #adm-epUrl,
+.adm-provider-codex-selected #adm-epApiKey,
+.adm-provider-codex-selected #adm-epType,
+.adm-provider-codex-selected #adm-epApiTestBtn,
+.adm-provider-codex-selected #adm-epAddBtn {
+  opacity: 0.55;
+}
 
 /* When the Appearance tab is open, the #settings-modal-opacity slider (in
    the header) fades the modal so the user can see the rest of the UI react
@@ -13567,6 +13609,29 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
   display: flex;
   gap: 4px;
   flex-shrink: 0;
+}
+.adm-model-source-note {
+  font-size: 10px;
+  font-weight: 400;
+  opacity: 0.45;
+  margin-left: 4px;
+}
+.adm-model-row {
+  gap: 6px;
+}
+.adm-model-row-hidden {
+  opacity: 0.58;
+}
+.adm-model-source-badge,
+.adm-model-hide-label {
+  margin-left: auto;
+  font-size: 10px;
+  opacity: 0.45;
+  white-space: nowrap;
+}
+.adm-model-hide-label {
+  margin-left: 6px;
+  color: color-mix(in srgb, var(--fg) 56%, transparent);
 }
 
 /* Status messages */

--- a/static/style.css
+++ b/static/style.css
@@ -13340,6 +13340,24 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
 }
 .adm-provider-item:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
 .adm-provider-item.active { background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); }
+.adm-provider-codex-selected input { display: none; }
+.adm-provider-codex-selected .adm-provider-btn {
+  width: 100%;
+  border-left: 1px solid var(--border);
+  border-radius: 6px;
+}
+.adm-codex-provider-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px;
+  margin-bottom: 6px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+}
+.adm-codex-provider-panel.hidden { display: none; }
 
 /* When the Appearance tab is open, the #settings-modal-opacity slider (in
    the header) fades the modal so the user can see the rest of the UI react

--- a/tests/test_codex_auth_routes.py
+++ b/tests/test_codex_auth_routes.py
@@ -1,0 +1,79 @@
+import asyncio
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+if "core" not in sys.modules:
+    core_pkg = types.ModuleType("core")
+    core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
+    sys.modules["core"] = core_pkg
+
+from routes.codex_auth_routes import setup_codex_auth_routes
+from src.codex_auth import set_codex_auth_service
+
+
+class _AuthManager:
+    is_configured = True
+
+    def is_admin(self, user):
+        return user == "admin"
+
+
+def _request(user="admin"):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=_AuthManager())),
+    )
+
+
+class _FakeService:
+    async def status(self):
+        return {"status": "not_authenticated"}
+
+    async def start(self):
+        return {"status": "pending", "verification_url": "https://auth.openai.com/codex/device", "user_code": "CODE-12345"}
+
+    async def cancel(self):
+        return {"status": "canceled"}
+
+    async def logout(self):
+        return {"status": "logged_out"}
+
+    async def test(self):
+        return {"ok": False, "status": "not_authenticated"}
+
+
+def _endpoint(router, path, method):
+    for route in router.routes:
+        if getattr(route, "path", "") == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_codex_auth_routes_use_service():
+    set_codex_auth_service(_FakeService())
+    try:
+        router = setup_codex_auth_routes()
+        start = _endpoint(router, "/api/codex-auth/start", "POST")
+        out = asyncio.run(start(_request()))
+        assert out["status"] == "pending"
+        assert out["user_code"] == "CODE-12345"
+    finally:
+        set_codex_auth_service(None)
+
+
+def test_codex_auth_routes_admin_gated():
+    set_codex_auth_service(_FakeService())
+    try:
+        router = setup_codex_auth_routes()
+        status = _endpoint(router, "/api/codex-auth/status", "GET")
+        try:
+            asyncio.run(status(_request(user="bob")))
+        except Exception as exc:
+            assert getattr(exc, "status_code", None) == 403
+        else:
+            raise AssertionError("non-admin request should fail")
+    finally:
+        set_codex_auth_service(None)

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 from src.codex_auth import CodexAuthService
 
@@ -34,6 +35,37 @@ def test_status_parses_chatgpt_login(monkeypatch):
     assert out["authenticated"] is True
     assert out["codex_authenticated"] is True
     assert out["auth_mode"] == "ChatGPT"
+
+
+def test_status_does_not_echo_unrecognized_cli_output(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 0, "access_token=secret refresh_token=secret"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.status())
+    assert out["status"] == "not_authenticated"
+    assert "secret" not in out["message"]
+    assert "token" not in out["message"].lower()
+
+
+def test_codex_home_delegated_without_auth_file_access(monkeypatch, tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"access_token":"secret"}')
+    real_open = open
+
+    def guarded_open(path, *args, **kwargs):
+        if os.fspath(path) == os.fspath(auth_file):
+            raise AssertionError("Odysseus must not read or write Codex auth.json")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", guarded_open)
+    svc = CodexAuthService(codex_bin="definitely-not-codex", codex_home=str(tmp_path), enabled=True)
+    out = run(svc.status())
+    assert out["status"] == "cli_missing"
+    assert out["codex_home_configured"] is True
 
 
 def test_disabled_state():
@@ -170,7 +202,22 @@ def test_logout_runs_codex_logout(monkeypatch):
     monkeypatch.setattr(svc, "_run_command", fake_run)
     out = run(svc.logout())
     assert out["status"] == "logged_out"
+    assert out["message"] == "Codex credentials removed"
     assert ["logout"] in calls
+
+
+def test_logout_failure_does_not_echo_cli_output(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "refresh_token=secret"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.logout())
+    assert out["status"] == "failed"
+    assert out["message"] == "Codex logout failed"
+    assert "secret" not in str(out)
 
 
 def test_test_requires_authenticated_status(monkeypatch):

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -1,0 +1,179 @@
+import asyncio
+
+from src.codex_auth import CodexAuthService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_status_reports_missing_cli():
+    svc = CodexAuthService(codex_bin="definitely-not-codex", enabled=True)
+    out = run(svc.status())
+    assert out["status"] == "missing_cli"
+    assert out["error_code"] == "missing_cli"
+    assert out["codex_cli_available"] is False
+
+
+def test_status_parses_chatgpt_login(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 0, "Logged in using ChatGPT\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.status())
+    assert out["status"] == "authenticated"
+    assert out["authenticated"] is True
+    assert out["auth_mode"] == "ChatGPT"
+
+
+def test_disabled_state():
+    svc = CodexAuthService(enabled=False)
+    out = run(svc.start())
+    assert out["status"] == "disabled"
+    assert out["error_code"] == "disabled"
+
+
+class _FakeStdout:
+    def __init__(self, lines):
+        self._lines = [line.encode() for line in lines]
+
+    async def readline(self):
+        await asyncio.sleep(0)
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+
+class _FakeProcess:
+    def __init__(self, lines, returncode=0):
+        self.stdout = _FakeStdout(lines)
+        self.returncode = None
+        self._final_returncode = returncode
+        self.terminated = False
+
+    async def wait(self):
+        self.returncode = self._final_returncode
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.terminated = True
+        self.returncode = -9
+
+
+class _SlowStdout:
+    async def readline(self):
+        await asyncio.sleep(2)
+        return b""
+
+
+def test_start_device_flow_success(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    fake_proc = _FakeProcess([
+        "Open https://auth.openai.com/codex/device\n",
+        "Enter code CODE-12345\n",
+        "Successfully logged in\n",
+    ])
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    async def scenario():
+        first = await svc.start()
+        assert first["status"] == "starting"
+        await asyncio.sleep(0.05)
+        assert svc._state.status == "succeeded"
+        assert svc._state.authenticated is True
+
+    run(scenario())
+
+
+def test_start_device_flow_times_out_waiting_for_code(monkeypatch):
+    svc = CodexAuthService(enabled=True, code_timeout_seconds=0)
+    fake_proc = _FakeProcess([], returncode=1)
+    fake_proc.stdout = _SlowStdout()
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    async def scenario():
+        await svc.start()
+        await asyncio.sleep(1.1)
+        assert svc._state.status == "failed"
+        assert svc._state.error_code == "device_code_unavailable"
+        assert fake_proc.terminated is True
+
+    run(scenario())
+
+
+def test_start_device_flow_reports_cli_failure(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    fake_proc = _FakeProcess([
+        "Error logging in with device code: device code login is not enabled for this Codex server\n",
+    ], returncode=1)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    async def fake_exec(*args, **kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    async def scenario():
+        await svc.start()
+        await asyncio.sleep(0.05)
+        assert svc._state.status == "failed"
+        assert svc._state.error_code == "device_auth_disabled"
+
+    run(scenario())
+
+
+def test_logout_runs_codex_logout(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    calls = []
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        calls.append(args)
+        return 0, "Successfully logged out\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.logout())
+    assert out["status"] == "logged_out"
+    assert ["logout"] in calls
+
+
+def test_test_requires_authenticated_status(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        return 1, "Not logged in\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.test())
+    assert out["ok"] is False
+    assert out["authenticated"] is False

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -10,9 +10,15 @@ def run(coro):
 def test_status_reports_missing_cli():
     svc = CodexAuthService(codex_bin="definitely-not-codex", enabled=True)
     out = run(svc.status())
-    assert out["status"] == "missing_cli"
-    assert out["error_code"] == "missing_cli"
+    assert out["status"] == "cli_missing"
+    assert out["error_code"] == "cli_missing"
     assert out["codex_cli_available"] is False
+    assert out["configured_binary"] == "definitely-not-codex"
+    assert out["resolved_binary_path"] is None
+    assert out["binary_exists"] is False
+    assert out["binary_executable"] is False
+    assert out["cli_found"] is False
+    assert out["cli_executable"] is False
 
 
 def test_status_parses_chatgpt_login(monkeypatch):
@@ -26,6 +32,7 @@ def test_status_parses_chatgpt_login(monkeypatch):
     out = run(svc.status())
     assert out["status"] == "authenticated"
     assert out["authenticated"] is True
+    assert out["codex_authenticated"] is True
     assert out["auth_mode"] == "ChatGPT"
 
 
@@ -177,3 +184,6 @@ def test_test_requires_authenticated_status(monkeypatch):
     out = run(svc.test())
     assert out["ok"] is False
     assert out["authenticated"] is False
+    assert out["codex_authenticated"] is False
+    assert out["status"] == "not_authenticated"
+    assert out["message"] == "Codex CLI ready. Not signed in."

--- a/tests/test_codex_auth_service.py
+++ b/tests/test_codex_auth_service.py
@@ -206,6 +206,27 @@ def test_logout_runs_codex_logout(monkeypatch):
     assert ["logout"] in calls
 
 
+def test_status_after_logout_rechecks_codex_login_status(monkeypatch):
+    svc = CodexAuthService(enabled=True)
+    calls = []
+    monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")
+
+    async def fake_run(args, timeout=15.0):
+        calls.append(args)
+        if args == ["logout"]:
+            return 0, "Successfully logged out\n"
+        return 1, "Not logged in\n"
+
+    monkeypatch.setattr(svc, "_run_command", fake_run)
+    out = run(svc.logout())
+    assert out["status"] == "logged_out"
+
+    status = run(svc.status())
+    assert status["status"] == "not_authenticated"
+    assert status["message"] == "Codex CLI ready. Not signed in."
+    assert calls == [["logout"], ["login", "status"]]
+
+
 def test_logout_failure_does_not_echo_cli_output(monkeypatch):
     svc = CodexAuthService(enabled=True)
     monkeypatch.setattr(svc, "_bin_path", lambda: "/usr/bin/codex")

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -52,7 +52,7 @@ class _FakeAdapter:
             "limitations": [],
         }
 
-    async def complete(self, messages, model=None, timeout_seconds=120):
+    async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
         return {
             "ok": True,
             "status": "ok",
@@ -69,6 +69,41 @@ class _FakeAdapter:
 def _provider(payload):
     svc = _FakeService(payload)
     return CodexModelProvider(lambda: svc, chat_adapter=_FakeAdapter()), svc
+
+
+CODEX_0135_EXEC_HELP = """Usage: codex exec [OPTIONS] [PROMPT]
+
+Options:
+  -s, --sandbox <SANDBOX_MODE>
+  --json
+
+Commands:
+  resume
+"""
+
+CODEX_0135_ROOT_HELP = """Usage: codex [OPTIONS] <COMMAND>
+
+Commands:
+  exec
+"""
+
+CODEX_0135_RESUME_HELP = """Usage: codex exec resume [OPTIONS] [SESSION_ID]
+
+Options:
+  --last
+"""
+
+CODEX_OLD_EXEC_HELP = "Usage: codex exec --sandbox <MODE> --ask-for-approval <POLICY> --json --model <MODEL>"
+
+
+async def _codex_help_runner(args, timeout, cwd=None, env=None, exec_help=CODEX_0135_EXEC_HELP):
+    if args[1:] == ["exec", "--help"]:
+        return 0, exec_help, ""
+    if args[1:] == ["--help"]:
+        return 0, CODEX_0135_ROOT_HELP, ""
+    if args[1:] == ["exec", "resume", "--help"]:
+        return 0, CODEX_0135_RESUME_HELP, ""
+    return 0, "codex provider test ok", ""
 
 
 def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
@@ -226,8 +261,10 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
 
     async def runner(args, timeout, cwd=None, env=None):
         calls.append((args, cwd, env))
-        if args[-1] == "--help":
-            return 0, "Usage: codex exec --sandbox <MODE> --ask-for-approval <POLICY> --json", ""
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_OLD_EXEC_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
         return 0, "codex provider test ok", ""
 
     adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
@@ -238,11 +275,70 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
     assert out["streaming_supported"] is False
     assert out["session_resume_supported"] is False
     assert out["tool_execution_allowed"] is False
-    assert calls[1][1]
-    assert "--sandbox" in calls[1][0]
-    assert "read-only" in calls[1][0]
-    assert "--ask-for-approval" in calls[1][0]
-    assert "never" in calls[1][0]
+    exec_args = calls[-1][0]
+    assert calls[-1][1]
+    assert "--sandbox" in exec_args
+    assert "read-only" in exec_args
+    assert "--ask-for-approval" in exec_args
+    assert "never" in exec_args
+
+
+def test_adapter_accepts_current_cli_without_approval_flag(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        return await _codex_help_runner(args, timeout, cwd=cwd, env=env)
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete(
+        [{"role": "user", "content": "Say ok"}],
+        model=CODEX_EXPERIMENTAL_MODEL_ID,
+        odysseus_session_id="test-session",
+    ))
+
+    assert out["ok"] is True
+    assert out["message"] == "codex provider test ok"
+    assert out["cli_capabilities"]["sandbox_supported"] is True
+    assert out["cli_capabilities"]["approval_control_supported"] is False
+    assert out["cli_capabilities"]["resume_supported"] is True
+    assert out["cli_capabilities"]["resume_last_supported"] is True
+    exec_args = calls[-1]
+    assert exec_args[:4] == ["/usr/bin/codex", "exec", "--sandbox", "read-only"]
+    assert "--ask-for-approval" not in exec_args
+    assert "--approval-policy" not in exec_args
+    assert "--approval" not in exec_args
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_args
+    assert "--yolo" not in exec_args
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in exec_args
+    assert any("Approval-control flag is not available" in item for item in out["limitations"])
+
+
+def test_status_available_with_current_cli_help(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    adapter = CodexCliChatAdapter(lambda: svc, runner=_codex_help_runner)
+    provider = CodexModelProvider(lambda: svc, chat_adapter=adapter)
+
+    out = run(provider.status())
+
+    assert out["status"] == "available"
+    assert out["chat_supported"] is True
+    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert out["cli_capabilities"]["sandbox_supported"] is True
+    assert out["cli_capabilities"]["approval_control_supported"] is False
 
 
 def test_adapter_handles_timeout(monkeypatch):
@@ -250,8 +346,10 @@ def test_adapter_handles_timeout(monkeypatch):
     svc = _FakeService({"codex_cli_available": True, "authenticated": True})
 
     async def runner(args, timeout, cwd=None, env=None):
-        if args[-1] == "--help":
-            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_OLD_EXEC_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
         return 124, "", "access_token=secret"
 
     adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
@@ -267,8 +365,10 @@ def test_adapter_handles_cli_nonzero_and_redacts(monkeypatch):
     svc = _FakeService({"codex_cli_available": True, "authenticated": True})
 
     async def runner(args, timeout, cwd=None, env=None):
-        if args[-1] == "--help":
-            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_OLD_EXEC_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
         return 2, "", "refresh_token=secret failed"
 
     adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
@@ -293,7 +393,29 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
     assert out["ok"] is False
     assert out["status"] == "unsupported_unsafe_cli_mode"
     assert "--sandbox" in out["missing_flags"]
-    assert "--ask-for-approval" in out["missing_flags"]
+
+
+def test_adapter_never_uses_advertised_dangerous_flags(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    calls = []
+    dangerous_help = CODEX_0135_EXEC_HELP + "\n  --dangerously-bypass-approvals-and-sandbox\n  --yolo\n"
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        return await _codex_help_runner(args, timeout, cwd=cwd, env=env, exec_help=dangerous_help)
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "hello"}]))
+
+    assert out["ok"] is True
+    assert out["cli_capabilities"]["dangerous_flags_advertised"] == [
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--yolo",
+    ]
+    exec_args = calls[-1]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_args
+    assert "--yolo" not in exec_args
 
 
 def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -2,16 +2,24 @@ import asyncio
 import os
 import sys
 import types
+from pathlib import Path
 from types import SimpleNamespace
 
 from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_ENDPOINT_URL,
     CODEX_EXPERIMENTAL_MODEL_ID,
     CODEX_MODEL_PROVIDER_FLAG,
     CODEX_EXPERIMENTAL_MODEL_DISPLAY,
     CodexCliChatAdapter,
     CodexModelProvider,
+    codex_model_list_item_if_available,
+    codex_model_list_item,
+    is_codex_model_selection,
 )
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 if "core" not in sys.modules:
@@ -65,7 +73,14 @@ class _FakeAdapter:
             "tool_execution_allowed": False,
         }
 
-    async def stream_chat(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+    async def stream_chat(
+        self,
+        messages,
+        model=None,
+        timeout_seconds=120,
+        odysseus_session_id=None,
+        allow_one_shot_fallback=False,
+    ):
         yield {"type": "delta", "delta": "mock stream"}
         yield {"type": "done", "message": "mock stream", "model": model or CODEX_EXPERIMENTAL_MODEL_ID}
 
@@ -164,6 +179,38 @@ def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
     assert out["status"] == "disabled"
     assert out["models"] == []
     assert svc.calls == 0
+
+
+def test_codex_model_list_item_is_synthetic_not_db_endpoint():
+    item = codex_model_list_item()
+
+    assert item["url"] == CODEX_EXPERIMENTAL_ENDPOINT_URL
+    assert item["models"] == [CODEX_EXPERIMENTAL_MODEL_ID]
+    assert item["endpoint_id"] is None
+    assert item["experimental"] is True
+    assert is_codex_model_selection(item["url"], item["models"][0]) is True
+
+
+def test_codex_model_list_item_if_available_requires_available_status(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+
+    available_provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    signed_out_provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": False,
+        "status": "not_authenticated",
+    })
+
+    assert codex_model_list_item_if_available(available_provider)["url"] == CODEX_EXPERIMENTAL_ENDPOINT_URL
+    assert codex_model_list_item_if_available(signed_out_provider) is None
+
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "false")
+    assert codex_model_list_item_if_available(available_provider) is None
 
 
 def test_codex_model_provider_requires_sign_in_when_unauthenticated(monkeypatch):
@@ -526,6 +573,99 @@ def test_adapter_streams_json_events_with_safe_args(monkeypatch):
     assert "--yolo" not in exec_args
 
 
+def test_adapter_stream_ignores_lifecycle_events(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        return await _codex_help_runner(
+            args,
+            timeout,
+            cwd=cwd,
+            env=env,
+            exec_help=CODEX_0135_EXEC_HELP_WITH_SKIP,
+        )
+
+    async def fake_create_subprocess_exec(*args, stdout=None, stderr=None, cwd=None, env=None):
+        return _FakeProcess([
+            b'{"type":"thread.started"}\n',
+            b'{"event":"turn.started"}\n',
+            b'{"type":"response.output_text.delta","delta":"clean "}\n',
+            b'{"type":"turn.completed"}\n',
+            b'{"event":"request.completed"}\n',
+            b'{"type":"delta","data":{"text":"answer"}}\n',
+            b'{"type":"metrics","usage":{"input_tokens":1,"output_tokens":2}}\n',
+        ])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    events = run(_collect(adapter.stream_chat([{"role": "user", "content": "Say ok"}], timeout_seconds=5)))
+
+    assert [event["type"] for event in events] == ["delta", "delta", "metrics", "done"]
+    assert [event["delta"] for event in events if event["type"] == "delta"] == ["clean ", "answer"]
+    assert events[-1]["message"] == "clean answer"
+    assert "thread.started" not in str(events)
+    assert "turn.started" not in str(events)
+    assert "turn.completed" not in str(events)
+
+
+def test_extract_message_ignores_lifecycle_json_lines():
+    output = "\n".join([
+        '{"type":"thread.started"}',
+        '{"event":"turn.started"}',
+        '{"type":"request.completed"}',
+        '{"message":"final answer"}',
+        '{"type":"turn.completed"}',
+    ])
+
+    assert CodexCliChatAdapter._extract_message(output) == "final answer"
+
+
+def test_adapter_stream_signed_out_returns_clean_error(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": False,
+        "status": "not_authenticated",
+    })
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=_codex_help_runner)
+    events = run(_collect(adapter.stream_chat(
+        [{"role": "user", "content": "Say ok"}],
+        timeout_seconds=5,
+        allow_one_shot_fallback=True,
+    )))
+
+    assert events[0]["type"] == "error"
+    assert events[0]["status"] == "sign_in_required"
+    assert "sign in" in events[0]["error"].lower()
+    assert "503" not in str(events[0])
+
+
+def test_normal_chat_routes_use_explicit_codex_branches_before_generic_llm():
+    source = (REPO_ROOT / "routes" / "chat_routes.py").read_text(encoding="utf-8")
+
+    non_stream_branch = source.index("if is_codex_model_selection(sess.endpoint_url, sess.model):")
+    generic_non_stream = source.index("reply = await llm_call_async(", non_stream_branch)
+    assert non_stream_branch < generic_non_stream
+    assert "CodexModelProvider().test_chat(" in source[non_stream_branch:generic_non_stream]
+
+    stream_branch = source.index("elif is_codex_model_selection(sess.endpoint_url, sess.model):")
+    generic_stream = source.index("elif chat_mode == \"chat\":", stream_branch)
+    assert stream_branch < generic_stream
+    branch_source = source[stream_branch:generic_stream]
+    assert "if chat_mode != \"chat\":" in branch_source
+    assert "Agent tools are not available" in branch_source
+    assert "CodexModelProvider().stream_chat(" in branch_source
+    assert "allow_one_shot_fallback=True" in branch_source
+
+
 def test_adapter_stream_falls_back_to_completed_stdout_when_no_deltas(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
     svc = _FakeService({
@@ -575,6 +715,34 @@ def test_adapter_stream_reports_not_supported_without_json(monkeypatch):
     assert available["cli_capabilities"]["json_output_supported"] is False
     assert events[0]["type"] == "error"
     assert events[0]["status"] == "streaming_not_supported"
+
+
+def test_adapter_stream_can_use_one_shot_fallback_without_json(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[1:] == ["exec", "--help"]:
+            return 0, "Usage: codex exec --sandbox <MODE>", ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "one shot response", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    events = run(_collect(adapter.stream_chat(
+        [{"role": "user", "content": "Say ok"}],
+        timeout_seconds=5,
+        allow_one_shot_fallback=True,
+    )))
+
+    assert [event["type"] for event in events] == ["delta", "done"]
+    assert events[0]["delta"] == "one shot response"
+    assert events[1]["message"] == "one shot response"
 
 
 def test_adapter_handles_timeout(monkeypatch):

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_ID,
     CODEX_MODEL_PROVIDER_FLAG,
+    CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+    CodexCliChatAdapter,
     CodexModelProvider,
 )
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
@@ -31,10 +33,42 @@ class _FakeService:
         self.calls += 1
         return dict(self.payload)
 
+    def _bin_path(self):
+        return "/usr/bin/codex"
+
+    def _env(self):
+        return {"PATH": "/usr/bin"}
+
+
+class _FakeAdapter:
+    async def available(self):
+        return {
+            "ok": True,
+            "status": "available",
+            "chat_supported": True,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "limitations": [],
+        }
+
+    async def complete(self, messages, model=None, timeout_seconds=120):
+        return {
+            "ok": True,
+            "status": "ok",
+            "message": "mock response",
+            "duration_ms": 1,
+            "model": model or CODEX_EXPERIMENTAL_MODEL_ID,
+            "limitations": [],
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+        }
+
 
 def _provider(payload):
     svc = _FakeService(payload)
-    return CodexModelProvider(lambda: svc), svc
+    return CodexModelProvider(lambda: svc, chat_adapter=_FakeAdapter()), svc
 
 
 def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
@@ -83,7 +117,12 @@ def test_codex_model_provider_reports_experimental_model_when_authenticated(monk
     assert out["status"] == "available"
     assert out["authenticated"] is True
     assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert out["models"][0]["display"] == CODEX_EXPERIMENTAL_MODEL_DISPLAY
     assert out["models"][0]["experimental"] is True
+    assert out["chat_supported"] is True
+    assert out["streaming_supported"] is False
+    assert out["session_resume_supported"] is False
+    assert out["tool_execution_allowed"] is False
     assert "secret" not in str(out)
     assert "access_token" not in str(out)
     assert "refresh_token" not in str(out)
@@ -142,3 +181,133 @@ def test_codex_model_provider_route_is_admin_gated(monkeypatch):
         assert getattr(exc, "status_code", None) == 403
     else:
         raise AssertionError("non-admin request should fail")
+
+
+def test_codex_model_provider_test_chat_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    test_chat = _endpoint(router, "/api/codex-model-provider/test-chat", "POST")
+
+    body = SimpleNamespace(prompt="hello", messages=None, model=None, timeout_seconds=None)
+    out = run(test_chat(_request(user="admin"), body))
+    assert out["ok"] is True
+    assert out["message"] == "mock response"
+
+    try:
+        run(test_chat(_request(user="bob"), body))
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 403
+    else:
+        raise AssertionError("non-admin request should fail")
+
+
+def test_codex_model_provider_test_chat_requires_body(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    test_chat = _endpoint(router, "/api/codex-model-provider/test-chat", "POST")
+
+    body = SimpleNamespace(prompt="", messages=None, model=None, timeout_seconds=None)
+    out = run(test_chat(_request(user="admin"), body))
+    assert out["ok"] is False
+    assert out["status"] == "invalid_request"
+
+
+def test_adapter_success_from_mocked_subprocess(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append((args, cwd, env))
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox <MODE> --ask-for-approval <POLICY> --json", ""
+        return 0, "codex provider test ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "Say ok"}]))
+
+    assert out["ok"] is True
+    assert out["message"] == "codex provider test ok"
+    assert out["streaming_supported"] is False
+    assert out["session_resume_supported"] is False
+    assert out["tool_execution_allowed"] is False
+    assert calls[1][1]
+    assert "--sandbox" in calls[1][0]
+    assert "read-only" in calls[1][0]
+    assert "--ask-for-approval" in calls[1][0]
+    assert "never" in calls[1][0]
+
+
+def test_adapter_handles_timeout(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        return 124, "", "access_token=secret"
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "hello"}], timeout_seconds=1))
+
+    assert out["ok"] is False
+    assert out["status"] == "timeout"
+    assert "secret" not in str(out)
+
+
+def test_adapter_handles_cli_nonzero_and_redacts(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[-1] == "--help":
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        return 2, "", "refresh_token=secret failed"
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "hello"}]))
+
+    assert out["ok"] is False
+    assert out["status"] == "cli_failed"
+    assert "secret" not in str(out)
+    assert "refresh_token" not in str(out)
+
+
+def test_adapter_refuses_unsafe_cli_help(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        return 0, "Usage: codex exec --json", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.available())
+
+    assert out["ok"] is False
+    assert out["status"] == "unsupported_unsafe_cli_mode"
+    assert "--sandbox" in out["missing_flags"]
+    assert "--ask-for-approval" in out["missing_flags"]
+
+
+def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+
+    class UnsafeAdapter:
+        async def available(self):
+            return {"ok": False, "status": "unsupported_unsafe_cli_mode"}
+
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    provider = CodexModelProvider(lambda: svc, chat_adapter=UnsafeAdapter())
+
+    out = run(provider.status())
+
+    assert out["status"] == "unsupported_unsafe_cli_mode"
+    assert out["models"] == []
+    assert out["chat_supported"] is False

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -21,6 +21,34 @@ from src.codex_model_provider import (
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
 
 
+CODEX_0135_EXEC_HELP = """
+Usage: codex exec [OPTIONS] [PROMPT] [COMMAND]
+
+Commands:
+  resume  Resume a previous exec session
+
+Options:
+  -s, --sandbox <SANDBOX_MODE>
+          Sandbox mode to use when executing commands
+          [possible values: read-only, workspace-write, danger-full-access]
+      --json
+          Emit events as JSONL
+  -h, --help
+          Print help
+"""
+
+
+CODEX_0135_RESUME_HELP = """
+Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
+
+Options:
+      --last
+          Resume the most recent session in the current working directory
+  -h, --help
+          Print help
+"""
+
+
 def run(coro):
     return asyncio.run(coro)
 
@@ -237,20 +265,95 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
 
     adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
     out = run(adapter.complete([{"role": "user", "content": "Say ok"}]))
+    exec_call = next(call for call in calls if call[0][-1] != "--help")
 
     assert out["ok"] is True
     assert out["message"] == "codex provider test ok"
     assert out["streaming_supported"] is False
     assert out["session_resume_supported"] is False
     assert out["tool_execution_allowed"] is False
-    assert calls[2][1]
-    assert "--sandbox" in calls[2][0]
-    assert "read-only" in calls[2][0]
-    assert "--ask-for-approval" in calls[2][0]
-    assert "never" in calls[2][0]
-    assert "--yolo" not in calls[2][0]
-    assert "--dangerously-bypass-approvals-and-sandbox" not in calls[2][0]
-    assert CODEX_EXPERIMENTAL_MODEL_ID not in calls[2][0]
+    assert exec_call[1]
+    assert "--sandbox" in exec_call[0]
+    assert "read-only" in exec_call[0]
+    assert "--ask-for-approval" in exec_call[0]
+    assert "never" in exec_call[0]
+    assert "--yolo" not in exec_call[0]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_call[0]
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in exec_call[0]
+
+
+def test_adapter_supports_0135_style_sandbox_without_approval_flag(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    exec_calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, CODEX_0135_EXEC_HELP, ""
+        if args == ["/usr/bin/codex", "--help"]:
+            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 0, CODEX_0135_RESUME_HELP, ""
+        exec_calls.append(args)
+        return 0, "codex direct ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    available = run(adapter.available())
+    out = run(adapter.complete([{"role": "user", "content": "Reply exactly: codex direct ok"}]))
+
+    assert available["ok"] is True
+    assert available["status"] == "available"
+    assert available["approval_control_supported"] is False
+    assert available["capabilities"]["sandbox_flag"] == "--sandbox"
+    assert available["capabilities"]["session_resume_supported"] is True
+    assert "approval-control flag" in " ".join(available["limitations"])
+    assert out["ok"] is True
+    assert out["message"] == "codex direct ok"
+    assert exec_calls
+    assert exec_calls[0][0:2] == ["/usr/bin/codex", "exec"]
+    assert "--sandbox" in exec_calls[0]
+    assert "read-only" in exec_calls[0]
+    assert "--ask-for-approval" not in exec_calls[0]
+    assert "--approval-policy" not in exec_calls[0]
+    assert "--approval" not in exec_calls[0]
+    assert "--yolo" not in exec_calls[0]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_calls[0]
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in exec_calls[0]
+
+
+def test_status_available_with_0135_style_sandbox_without_approval_flag(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, CODEX_0135_EXEC_HELP, ""
+        if args == ["/usr/bin/codex", "--help"]:
+            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 0, CODEX_0135_RESUME_HELP, ""
+        return 0, "ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    provider = CodexModelProvider(lambda: svc, chat_adapter=adapter)
+    out = run(provider.status())
+
+    assert out["status"] == "available"
+    assert out["chat_supported"] is True
+    assert out["approval_control_supported"] is False
+    assert out["capabilities"]["sandbox_supported"] is True
+    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert "approval-control flag" in " ".join(out["limitations"])
 
 
 def test_codex_virtual_endpoint_detection():
@@ -306,8 +409,18 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
 
     assert out["ok"] is False
     assert out["status"] == "unsupported_unsafe_cli_mode"
-    assert "--sandbox" in out["missing_flags"]
-    assert "--ask-for-approval" in out["missing_flags"]
+    assert "--sandbox/-s" in out["missing_flags"]
+
+
+def test_adapter_blocks_forbidden_cli_flags():
+    adapter = CodexCliChatAdapter()
+    for flag in ("--yolo", "--dangerously-bypass-approvals-and-sandbox"):
+        try:
+            adapter._assert_safe_args(["/usr/bin/codex", "exec", "--sandbox", "read-only", flag, "prompt"])
+        except ValueError as exc:
+            assert "Unsafe Codex CLI flag blocked" in str(exc)
+        else:
+            raise AssertionError(f"{flag} should be blocked")
 
 
 def test_adapter_detects_safety_flags_from_top_level_help(monkeypatch):
@@ -376,6 +489,8 @@ def test_same_odysseus_session_resumes_codex_session(monkeypatch, tmp_path):
     async def runner(args, timeout, cwd=None, env=None):
         if args == ["/usr/bin/codex", "exec", "--help"]:
             return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "--help"]:
+            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
         if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
             return 0, "Usage: codex exec resume <SESSION_ID>", ""
         exec_calls.append((args, cwd))
@@ -407,6 +522,8 @@ def test_different_odysseus_sessions_do_not_share_codex_mapping(monkeypatch, tmp
     async def runner(args, timeout, cwd=None, env=None):
         if args == ["/usr/bin/codex", "exec", "--help"]:
             return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "--help"]:
+            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
         if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
             return 0, "Usage: codex exec resume <SESSION_ID>", ""
         exec_calls.append(args)
@@ -430,6 +547,8 @@ def test_reset_clears_only_selected_codex_session_mapping(monkeypatch, tmp_path)
     async def runner(args, timeout, cwd=None, env=None):
         if args == ["/usr/bin/codex", "exec", "--help"]:
             return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "--help"]:
+            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
         if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
             return 0, "Usage: codex exec resume <SESSION_ID>", ""
         exec_calls.append(args)

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -4,12 +4,14 @@ import sys
 import types
 from types import SimpleNamespace
 
+import pytest
+
 from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_ID,
     CODEX_MODEL_PROVIDER_FLAG,
-    CODEX_EXPERIMENTAL_MODEL_DISPLAY,
     CodexCliChatAdapter,
     CodexModelProvider,
+    update_codex_model_config,
 )
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
 
@@ -22,6 +24,18 @@ if "core" not in sys.modules:
 
 def run(coro):
     return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codex_settings(monkeypatch, tmp_path):
+    import src.settings as settings_module
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(settings_module, "SETTINGS_FILE", str(settings_file))
+    settings_module._invalidate_caches()
+    yield
+    settings_module._invalidate_caches()
 
 
 class _FakeService:
@@ -52,7 +66,7 @@ class _FakeAdapter:
             "limitations": [],
         }
 
-    async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+    async def complete(self, messages, model=None, reasoning_effort=None, timeout_seconds=120, odysseus_session_id=None):
         return {
             "ok": True,
             "status": "ok",
@@ -65,7 +79,15 @@ class _FakeAdapter:
             "tool_execution_allowed": False,
         }
 
-    async def stream_chat(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+    async def stream_chat(
+        self,
+        messages,
+        model=None,
+        reasoning_effort=None,
+        timeout_seconds=120,
+        odysseus_session_id=None,
+        allow_one_shot_fallback=False,
+    ):
         yield {"type": "delta", "delta": "mock stream"}
         yield {"type": "done", "message": "mock stream", "model": model or CODEX_EXPERIMENTAL_MODEL_ID}
 
@@ -103,6 +125,13 @@ Options:
 """
 
 CODEX_OLD_EXEC_HELP = "Usage: codex exec --sandbox <MODE> --ask-for-approval <POLICY> --json --model <MODEL>"
+CODEX_THINKING_TOGGLE_HELP = """Usage: codex exec [OPTIONS] [PROMPT]
+
+Options:
+  -s, --sandbox <SANDBOX_MODE>
+  --json
+  --thinking
+"""
 
 
 async def _codex_help_runner(args, timeout, cwd=None, env=None, exec_help=CODEX_0135_EXEC_HELP):
@@ -185,6 +214,7 @@ def test_codex_model_provider_requires_sign_in_when_unauthenticated(monkeypatch)
 
 def test_codex_model_provider_reports_experimental_model_when_authenticated(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    update_codex_model_config(add_model="gpt-5.2-codex")
     provider, _ = _provider({
         "codex_cli_available": True,
         "authenticated": True,
@@ -199,8 +229,8 @@ def test_codex_model_provider_reports_experimental_model_when_authenticated(monk
 
     assert out["status"] == "available"
     assert out["authenticated"] is True
-    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
-    assert out["models"][0]["display"] == CODEX_EXPERIMENTAL_MODEL_DISPLAY
+    assert out["models"][0]["id"] == "gpt-5.2-codex"
+    assert out["models"][0]["display"] == "gpt-5.2-codex"
     assert out["models"][0]["experimental"] is True
     assert out["chat_supported"] is True
     assert out["streaming_supported"] is False
@@ -348,8 +378,10 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
     assert calls[-1][1]
     assert "--sandbox" in exec_args
     assert "read-only" in exec_args
-    assert "--ask-for-approval" in exec_args
-    assert "never" in exec_args
+    assert "--ask-for-approval" not in exec_args
+    assert "--approval-policy" not in exec_args
+    assert "--approval" not in exec_args
+    assert "never" not in exec_args
 
 
 def test_adapter_accepts_current_cli_without_approval_flag(monkeypatch):
@@ -471,14 +503,74 @@ def test_status_available_with_current_cli_help(monkeypatch):
     assert out["status"] == "available"
     assert out["chat_supported"] is True
     assert out["streaming_supported"] is True
-    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
-    assert out["models"][0]["streaming_supported"] is True
+    assert out["models"] == []
+    assert out["model_discovery"]["source"] == "none"
     assert out["cli_capabilities"]["sandbox_supported"] is True
     assert out["cli_capabilities"]["approval_control_supported"] is False
     assert out["cli_capabilities"]["json_output_supported"] is True
     assert out["cli_capabilities"]["streaming_supported"] is True
     assert out["cli_capabilities"]["skip_git_repo_check_supported"] is False
     assert out["cli_capabilities"]["sandbox_mode"] == "read-only"
+    assert out["thinking_supported"] is False
+    assert out["thinking_effort_levels"] == []
+    assert out["thinking_activity_supported"] is False
+
+
+def test_status_does_not_advertise_thinking_from_toggle_only_help(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_THINKING_TOGGLE_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "codex provider test ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    provider = CodexModelProvider(lambda: svc, chat_adapter=adapter)
+
+    out = run(provider.status())
+
+    assert out["status"] == "available"
+    assert out["cli_capabilities"]["reasoning_effort_supported"] is False
+    assert out["cli_capabilities"]["reasoning_effort_levels"] == []
+    assert out["thinking_supported"] is False
+    assert out["thinking_effort_levels"] == []
+
+
+def test_adapter_ignores_unsupported_reasoning_effort(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_THINKING_TOGGLE_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "codex provider test ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete(
+        [{"role": "user", "content": "Say ok"}],
+        reasoning_effort="low",
+    ))
+
+    assert out["ok"] is True
+    assert out["reasoning_effort"] is None
+    assert "--thinking" not in calls[-1]
 
 
 def test_adapter_streams_json_events_with_safe_args(monkeypatch):

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -169,6 +169,33 @@ class _FakeProcess:
         self.killed = True
 
 
+def _stream_events_from_lines(monkeypatch, lines):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        return await _codex_help_runner(
+            args,
+            timeout,
+            cwd=cwd,
+            env=env,
+            exec_help=CODEX_0135_EXEC_HELP_WITH_SKIP,
+        )
+
+    async def fake_create_subprocess_exec(*args, stdout=None, stderr=None, cwd=None, env=None):
+        return _FakeProcess([line if isinstance(line, bytes) else line.encode("utf-8") for line in lines])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    return run(_collect(adapter.stream_chat([{"role": "user", "content": "Say ok"}], timeout_seconds=5)))
+
+
 def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
     monkeypatch.delenv(CODEX_MODEL_PROVIDER_FLAG, raising=False)
     provider, svc = _provider({"codex_cli_available": True, "authenticated": True})
@@ -613,6 +640,87 @@ def test_adapter_stream_ignores_lifecycle_events(monkeypatch):
     assert "thread.started" not in str(events)
     assert "turn.started" not in str(events)
     assert "turn.completed" not in str(events)
+
+
+def test_adapter_streams_prompt_sample_delta_and_metrics(monkeypatch):
+    events = _stream_events_from_lines(monkeypatch, [
+        '{"type":"thread.started"}\n',
+        '{"type":"turn.started"}\n',
+        '{"type":"message.delta","delta":"odysseus streaming ok"}\n',
+        '{"type":"metrics","usage":{"input_tokens":10,"output_tokens":3}}\n',
+        '{"type":"turn.completed"}\n',
+    ])
+
+    assert [event["type"] for event in events] == ["delta", "metrics", "done"]
+    assert events[0]["delta"] == "odysseus streaming ok"
+    assert events[1]["data"] == {"input_tokens": 10, "output_tokens": 3}
+    assert events[-1]["message"] == "odysseus streaming ok"
+    assert "thread.started" not in events[-1]["message"]
+    assert "turn.started" not in events[-1]["message"]
+    assert "turn.completed" not in events[-1]["message"]
+
+
+def test_adapter_streams_event_data_delta_shape(monkeypatch):
+    events = _stream_events_from_lines(monkeypatch, [
+        '{"event":"response.output_text.delta","data":{"delta":"odysseus streaming ok"}}\n',
+    ])
+
+    assert [event["type"] for event in events] == ["delta", "done"]
+    assert events[0]["delta"] == "odysseus streaming ok"
+    assert events[-1]["message"] == "odysseus streaming ok"
+
+
+def test_adapter_streams_final_only_message_completed_content(monkeypatch):
+    events = _stream_events_from_lines(monkeypatch, [
+        '{"type":"message.completed","message":{"content":[{"type":"text","text":"odysseus streaming ok"}]}}\n',
+    ])
+
+    assert [event["type"] for event in events] == ["delta", "done"]
+    assert events[0]["delta"] == "odysseus streaming ok"
+    assert events[-1]["message"] == "odysseus streaming ok"
+
+
+def test_adapter_streams_nested_content_on_lifecycle_event(monkeypatch):
+    events = _stream_events_from_lines(monkeypatch, [
+        '{"type":"turn.completed","item":{"content":[{"type":"output_text","text":"odysseus streaming ok"}]}}\n',
+    ])
+
+    assert [event["type"] for event in events] == ["delta", "done"]
+    assert events[0]["delta"] == "odysseus streaming ok"
+    assert events[-1]["message"] == "odysseus streaming ok"
+    assert "turn.completed" not in events[-1]["message"]
+
+
+def test_adapter_stream_malformed_json_lines_do_not_crash(monkeypatch):
+    events = _stream_events_from_lines(monkeypatch, [
+        '{"type":"thread.started"}\n',
+        '{"type":"message.delta","delta":\n',
+        '{"type":"message.delta","delta":"odysseus streaming ok"}\n',
+    ])
+
+    assert [event["type"] for event in events] == ["delta", "done"]
+    assert events[0]["delta"] == "odysseus streaming ok"
+    assert events[-1]["message"] == "odysseus streaming ok"
+
+
+def test_adapter_stream_lifecycle_only_returns_empty_response(monkeypatch):
+    events = _stream_events_from_lines(monkeypatch, [
+        '{"type":"thread.started"}\n',
+        '{"event":"turn.started"}\n',
+        '{"type":"turn.completed"}\n',
+    ])
+
+    assert [event["type"] for event in events] == ["error"]
+    assert events[0]["status"] == "empty_response"
+    assert "thread.started" not in str(events[0])
+    assert "turn.started" not in str(events[0])
+    assert "turn.completed" not in str(events[0])
+
+
+def test_stream_parser_ignores_lifecycle_values_in_text_like_fields():
+    assert CodexCliChatAdapter._events_from_json_line(
+        '{"type":"message.delta","message":"thread.started","text":"turn.started","delta":"turn.completed"}'
+    ) == []
 
 
 def test_extract_message_ignores_lifecycle_json_lines():

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -65,6 +65,10 @@ class _FakeAdapter:
             "tool_execution_allowed": False,
         }
 
+    async def stream_chat(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+        yield {"type": "delta", "delta": "mock stream"}
+        yield {"type": "done", "message": "mock stream", "model": model or CODEX_EXPERIMENTAL_MODEL_ID}
+
 
 def _provider(payload):
     svc = _FakeService(payload)
@@ -80,6 +84,11 @@ Options:
 Commands:
   resume
 """
+
+CODEX_0135_EXEC_HELP_WITH_SKIP = CODEX_0135_EXEC_HELP.replace(
+    "  --json\n",
+    "  --json\n  --skip-git-repo-check\n",
+)
 
 CODEX_0135_ROOT_HELP = """Usage: codex [OPTIONS] <COMMAND>
 
@@ -104,6 +113,45 @@ async def _codex_help_runner(args, timeout, cwd=None, env=None, exec_help=CODEX_
     if args[1:] == ["exec", "resume", "--help"]:
         return 0, CODEX_0135_RESUME_HELP, ""
     return 0, "codex provider test ok", ""
+
+
+async def _collect(agen):
+    out = []
+    async for event in agen:
+        out.append(event)
+    return out
+
+
+class _FakeStdout:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    async def readline(self):
+        if not self._lines:
+            return b""
+        return self._lines.pop(0)
+
+
+class _FakeStderr:
+    def __init__(self, payload=b""):
+        self._payload = payload
+
+    async def read(self):
+        return self._payload
+
+
+class _FakeProcess:
+    def __init__(self, stdout_lines, stderr=b"", returncode=0):
+        self.stdout = _FakeStdout(stdout_lines)
+        self.stderr = _FakeStderr(stderr)
+        self.returncode = returncode
+        self.killed = False
+
+    async def wait(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
 
 
 def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
@@ -237,6 +285,27 @@ def test_codex_model_provider_test_chat_route_is_admin_gated(monkeypatch):
         raise AssertionError("non-admin request should fail")
 
 
+def test_codex_model_provider_test_chat_stream_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    test_chat_stream = _endpoint(router, "/api/codex-model-provider/test-chat-stream", "POST")
+
+    body = SimpleNamespace(prompt="hello", messages=None, model=None, timeout_seconds=None)
+    response = run(test_chat_stream(_request(user="admin"), body))
+    chunks = run(_collect(response.body_iterator))
+    payload = "".join(chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk for chunk in chunks)
+    assert '"type":"delta"' in payload or '"type": "delta"' in payload
+    assert "mock stream" in payload
+
+    try:
+        run(test_chat_stream(_request(user="bob"), body))
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 403
+    else:
+        raise AssertionError("non-admin request should fail")
+
+
 def test_codex_model_provider_test_chat_requires_body(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
     provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
@@ -272,7 +341,7 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
 
     assert out["ok"] is True
     assert out["message"] == "codex provider test ok"
-    assert out["streaming_supported"] is False
+    assert out["streaming_supported"] is True
     assert out["session_resume_supported"] is False
     assert out["tool_execution_allowed"] is False
     exec_args = calls[-1][0]
@@ -321,6 +390,71 @@ def test_adapter_accepts_current_cli_without_approval_flag(monkeypatch):
     assert any("Approval-control flag is not available" in item for item in out["limitations"])
 
 
+def test_adapter_uses_skip_git_repo_check_when_advertised(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        return await _codex_help_runner(
+            args,
+            timeout,
+            cwd=cwd,
+            env=env,
+            exec_help=CODEX_0135_EXEC_HELP_WITH_SKIP,
+        )
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "Say ok"}]))
+
+    assert out["ok"] is True
+    assert out["cli_capabilities"]["skip_git_repo_check_supported"] is True
+    assert out["cli_capabilities"]["skip_git_repo_check_flag"] == "--skip-git-repo-check"
+    exec_args = calls[-1]
+    assert exec_args[:4] == ["/usr/bin/codex", "exec", "--sandbox", "read-only"]
+    assert "--skip-git-repo-check" in exec_args
+    assert "--json" not in exec_args
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_args
+    assert "--yolo" not in exec_args
+
+
+def test_adapter_retries_with_skip_git_repo_check_when_trust_error_requires_it(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_0135_EXEC_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        if "--skip-git-repo-check" not in args:
+            return 2, "", "not inside a trusted directory; retry with --skip-git-repo-check"
+        return 0, "codex provider test ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "Say ok"}]))
+
+    assert out["ok"] is True
+    exec_calls = [args for args in calls if args[1] == "exec" and "--help" not in args and args[2] != "resume"]
+    assert "--skip-git-repo-check" not in exec_calls[0]
+    assert "--skip-git-repo-check" in exec_calls[1]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_calls[1]
+    assert "--yolo" not in exec_calls[1]
+
+
 def test_status_available_with_current_cli_help(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
     svc = _FakeService({
@@ -336,9 +470,111 @@ def test_status_available_with_current_cli_help(monkeypatch):
 
     assert out["status"] == "available"
     assert out["chat_supported"] is True
+    assert out["streaming_supported"] is True
     assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert out["models"][0]["streaming_supported"] is True
     assert out["cli_capabilities"]["sandbox_supported"] is True
     assert out["cli_capabilities"]["approval_control_supported"] is False
+    assert out["cli_capabilities"]["json_output_supported"] is True
+    assert out["cli_capabilities"]["streaming_supported"] is True
+    assert out["cli_capabilities"]["skip_git_repo_check_supported"] is False
+    assert out["cli_capabilities"]["sandbox_mode"] == "read-only"
+
+
+def test_adapter_streams_json_events_with_safe_args(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    created = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        return await _codex_help_runner(
+            args,
+            timeout,
+            cwd=cwd,
+            env=env,
+            exec_help=CODEX_0135_EXEC_HELP_WITH_SKIP,
+        )
+
+    async def fake_create_subprocess_exec(*args, stdout=None, stderr=None, cwd=None, env=None):
+        created.append({"args": list(args), "cwd": cwd, "env": env})
+        return _FakeProcess([
+            b'{"type":"response.output_text.delta","delta":"hello "}\n',
+            b'{"type":"delta","data":{"text":"world"}}\n',
+            b'{"usage":{"input_tokens":1,"output_tokens":2}}\n',
+        ])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    events = run(_collect(adapter.stream_chat([{"role": "user", "content": "Say ok"}], timeout_seconds=5)))
+
+    assert [event["type"] for event in events] == ["delta", "delta", "metrics", "done"]
+    assert events[0]["delta"] == "hello "
+    assert events[1]["delta"] == "world"
+    assert events[2]["data"]["input_tokens"] == 1
+    assert events[-1]["message"] == "hello world"
+    exec_args = created[0]["args"]
+    assert exec_args[:4] == ["/usr/bin/codex", "exec", "--sandbox", "read-only"]
+    assert "--skip-git-repo-check" in exec_args
+    assert "--json" in exec_args
+    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_args
+    assert "--yolo" not in exec_args
+
+
+def test_adapter_stream_falls_back_to_completed_stdout_when_no_deltas(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        return await _codex_help_runner(args, timeout, cwd=cwd, env=env)
+
+    async def fake_create_subprocess_exec(*args, stdout=None, stderr=None, cwd=None, env=None):
+        return _FakeProcess([b"plain completed response\n"])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    events = run(_collect(adapter.stream_chat([{"role": "user", "content": "Say ok"}], timeout_seconds=5)))
+
+    assert [event["type"] for event in events] == ["delta", "done"]
+    assert events[0]["delta"] == "plain completed response"
+    assert events[1]["message"] == "plain completed response"
+
+
+def test_adapter_stream_reports_not_supported_without_json(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[1:] == ["exec", "--help"]:
+            return 0, "Usage: codex exec --sandbox <MODE>", ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    available = run(adapter.available())
+    events = run(_collect(adapter.stream_chat([{"role": "user", "content": "Say ok"}], timeout_seconds=5)))
+
+    assert available["streaming_supported"] is False
+    assert available["cli_capabilities"]["json_output_supported"] is False
+    assert events[0]["type"] == "error"
+    assert events[0]["status"] == "streaming_not_supported"
 
 
 def test_adapter_handles_timeout(monkeypatch):

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -1488,5 +1488,5 @@ def test_admin_source_keeps_codex_setup_reachable_when_provider_selected():
     source = (REPO_ROOT / "static" / "js" / "admin.js").read_text(encoding="utf-8")
 
     assert "fetch('/api/codex-model-provider/connector'" in source
-    assert "const shouldShowCard = !!data?.connector_enabled || totalCount > 0;" in source
-    assert "msg.textContent = 'Added Codex connector';" in source
+    assert "const shouldShowCard = disabled" in source
+    assert "Codex connector added. Add a selected model or a custom model ID below." in source

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -4,21 +4,20 @@ import sys
 import types
 from types import SimpleNamespace
 
-if "core" not in sys.modules:
-    core_pkg = types.ModuleType("core")
-    core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
-    sys.modules["core"] = core_pkg
-
 from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_ID,
     CODEX_MODEL_PROVIDER_FLAG,
     CODEX_EXPERIMENTAL_MODEL_DISPLAY,
-    CODEX_VIRTUAL_ENDPOINT_URL,
     CodexCliChatAdapter,
     CodexModelProvider,
-    is_codex_virtual_endpoint,
 )
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+
+
+if "core" not in sys.modules:
+    core_pkg = types.ModuleType("core")
+    core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
+    sys.modules["core"] = core_pkg
 
 
 def run(coro):
@@ -53,7 +52,7 @@ class _FakeAdapter:
             "limitations": [],
         }
 
-    async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+    async def complete(self, messages, model=None, timeout_seconds=120):
         return {
             "ok": True,
             "status": "ok",
@@ -63,12 +62,8 @@ class _FakeAdapter:
             "limitations": [],
             "streaming_supported": False,
             "session_resume_supported": False,
-            "session_resumed": False,
             "tool_execution_allowed": False,
         }
-
-    def reset_session(self, session_id):
-        return {"ok": True, "status": "reset", "session_mapping_cleared": False}
 
 
 def _provider(payload):
@@ -243,20 +238,11 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
     assert out["streaming_supported"] is False
     assert out["session_resume_supported"] is False
     assert out["tool_execution_allowed"] is False
-    assert calls[2][1]
-    assert "--sandbox" in calls[2][0]
-    assert "read-only" in calls[2][0]
-    assert "--ask-for-approval" in calls[2][0]
-    assert "never" in calls[2][0]
-    assert "--yolo" not in calls[2][0]
-    assert "--dangerously-bypass-approvals-and-sandbox" not in calls[2][0]
-    assert CODEX_EXPERIMENTAL_MODEL_ID not in calls[2][0]
-
-
-def test_codex_virtual_endpoint_detection():
-    assert is_codex_virtual_endpoint(CODEX_VIRTUAL_ENDPOINT_URL, CODEX_EXPERIMENTAL_MODEL_ID) is True
-    assert is_codex_virtual_endpoint(CODEX_VIRTUAL_ENDPOINT_URL, "") is True
-    assert is_codex_virtual_endpoint("https://api.openai.com/v1/chat/completions", "gpt-4o") is False
+    assert calls[1][1]
+    assert "--sandbox" in calls[1][0]
+    assert "read-only" in calls[1][0]
+    assert "--ask-for-approval" in calls[1][0]
+    assert "never" in calls[1][0]
 
 
 def test_adapter_handles_timeout(monkeypatch):
@@ -310,47 +296,6 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
     assert "--ask-for-approval" in out["missing_flags"]
 
 
-def test_adapter_detects_safety_flags_from_top_level_help(monkeypatch):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
-    calls = []
-
-    async def runner(args, timeout, cwd=None, env=None):
-        calls.append(args)
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, "Usage: codex exec", ""
-        if args == ["/usr/bin/codex", "--help"]:
-            return 0, "Options: --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 1, "", "unknown"
-        return 0, "ok", ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
-    out = run(adapter.available())
-
-    assert out["ok"] is True
-    assert out["session_resume_supported"] is False
-    assert ["/usr/bin/codex", "--help"] in calls
-
-
-def test_adapter_detects_resume_support(monkeypatch):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
-
-    async def runner(args, timeout, cwd=None, env=None):
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 0, "Usage: codex exec resume <SESSION_ID>", ""
-        return 0, "ok", ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
-    out = run(adapter.available())
-
-    assert out["ok"] is True
-    assert out["session_resume_supported"] is True
-
-
 def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
 
@@ -366,125 +311,3 @@ def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
     assert out["status"] == "unsupported_unsafe_cli_mode"
     assert out["models"] == []
     assert out["chat_supported"] is False
-
-
-def test_same_odysseus_session_resumes_codex_session(monkeypatch, tmp_path):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
-    exec_calls = []
-
-    async def runner(args, timeout, cwd=None, env=None):
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 0, "Usage: codex exec resume <SESSION_ID>", ""
-        exec_calls.append((args, cwd))
-        if "resume" in args:
-            return 0, "resumed response", ""
-        return 0, '{"session_id":"codex-session-1","message":"first response"}', ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner, session_root=tmp_path)
-    first = run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-1"))
-    second = run(adapter.complete([{"role": "user", "content": "two"}], odysseus_session_id="ody-1"))
-
-    assert first["ok"] is True
-    assert second["ok"] is True
-    assert second["session_resumed"] is True
-    assert exec_calls[1][0][0:4] == ["/usr/bin/codex", "exec", "resume", "codex-session-1"]
-    assert "--sandbox" in exec_calls[1][0]
-    assert "read-only" in exec_calls[1][0]
-    assert "--ask-for-approval" in exec_calls[1][0]
-    assert "never" in exec_calls[1][0]
-    assert "--all" not in exec_calls[1][0]
-
-
-def test_different_odysseus_sessions_do_not_share_codex_mapping(monkeypatch, tmp_path):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
-    exec_calls = []
-    next_id = {"n": 0}
-
-    async def runner(args, timeout, cwd=None, env=None):
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 0, "Usage: codex exec resume <SESSION_ID>", ""
-        exec_calls.append(args)
-        next_id["n"] += 1
-        return 0, f'{{"session_id":"codex-session-{next_id["n"]}","message":"ok"}}', ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner, session_root=tmp_path)
-    run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-1"))
-    run(adapter.complete([{"role": "user", "content": "two"}], odysseus_session_id="ody-2"))
-
-    assert "resume" not in exec_calls[0]
-    assert "resume" not in exec_calls[1]
-
-
-def test_reset_clears_only_selected_codex_session_mapping(monkeypatch, tmp_path):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
-    exec_calls = []
-    ids = iter(["codex-a-1", "codex-b-1", "codex-a-2"])
-
-    async def runner(args, timeout, cwd=None, env=None):
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 0, "Usage: codex exec resume <SESSION_ID>", ""
-        exec_calls.append(args)
-        if "resume" in args:
-            return 0, "resumed", ""
-        return 0, f'{{"session_id":"{next(ids)}","message":"ok"}}', ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner, session_root=tmp_path)
-    run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-a"))
-    run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-b"))
-
-    reset = adapter.reset_session("ody-a")
-    assert reset["ok"] is True
-
-    run(adapter.complete([{"role": "user", "content": "again"}], odysseus_session_id="ody-a"))
-    run(adapter.complete([{"role": "user", "content": "again"}], odysseus_session_id="ody-b"))
-
-    assert "resume" not in exec_calls[2]
-    assert exec_calls[3][0:4] == ["/usr/bin/codex", "exec", "resume", "codex-b-1"]
-
-
-def test_test_chat_route_accepts_session_id_for_reuse(monkeypatch):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    seen = {}
-
-    class CapturingAdapter(_FakeAdapter):
-        async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
-            seen["session_id"] = odysseus_session_id
-            return await super().complete(messages, model=model, timeout_seconds=timeout_seconds, odysseus_session_id=odysseus_session_id)
-
-    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
-    provider = CodexModelProvider(lambda: svc, chat_adapter=CapturingAdapter())
-    router = setup_codex_model_provider_routes(provider)
-    test_chat = _endpoint(router, "/api/codex-model-provider/test-chat", "POST")
-    body = SimpleNamespace(prompt="hello", messages=None, model=None, timeout_seconds=None, session_id="ody-test")
-
-    out = run(test_chat(_request(user="admin"), body))
-
-    assert out["ok"] is True
-    assert seen["session_id"] == "ody-test"
-
-
-def test_reset_session_route_is_admin_gated(monkeypatch):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
-    router = setup_codex_model_provider_routes(provider)
-    reset = _endpoint(router, "/api/codex-model-provider/reset-session", "POST")
-    body = SimpleNamespace(session_id="ody-test")
-
-    out = run(reset(_request(user="admin"), body))
-    assert out["ok"] is True
-
-    try:
-        run(reset(_request(user="bob"), body))
-    except Exception as exc:
-        assert getattr(exc, "status_code", None) == 403
-    else:
-        raise AssertionError("non-admin request should fail")

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -12,6 +12,8 @@ from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_DISPLAY,
     CodexCliChatAdapter,
     CodexModelProvider,
+    load_codex_model_config,
+    update_codex_model_config,
     codex_model_list_item_if_available,
     codex_model_list_item,
     is_codex_model_selection,
@@ -58,9 +60,17 @@ class _FakeAdapter:
             "session_resume_supported": False,
             "tool_execution_allowed": False,
             "limitations": [],
+            "supports_model": True,
+            "discovered_models": ["gpt-5.2-codex"],
+            "model_discovery": {"source": "codex_cli", "command": "models"},
+            "cli_capabilities": {
+                "model_flag_supported": True,
+                "reasoning_effort_supported": False,
+                "reasoning_effort_levels": [],
+            },
         }
 
-    async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+    async def complete(self, messages, model=None, reasoning_effort=None, timeout_seconds=120, odysseus_session_id=None):
         return {
             "ok": True,
             "status": "ok",
@@ -77,6 +87,7 @@ class _FakeAdapter:
         self,
         messages,
         model=None,
+        reasoning_effort=None,
         timeout_seconds=120,
         odysseus_session_id=None,
         allow_one_shot_fallback=False,
@@ -209,13 +220,44 @@ def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
 
 
 def test_codex_model_list_item_is_synthetic_not_db_endpoint():
-    item = codex_model_list_item()
+    item = codex_model_list_item([{
+        "id": "gpt-5.2-codex",
+        "display": "gpt-5.2-codex",
+        "enabled": True,
+        "streaming_supported": True,
+    }])
 
     assert item["url"] == CODEX_EXPERIMENTAL_ENDPOINT_URL
-    assert item["models"] == [CODEX_EXPERIMENTAL_MODEL_ID]
+    assert item["models"] == ["gpt-5.2-codex"]
     assert item["endpoint_id"] is None
     assert item["experimental"] is True
     assert is_codex_model_selection(item["url"], item["models"][0]) is True
+    assert is_codex_model_selection(None, item["models"][0]) is False
+    assert is_codex_model_selection("https://api.openai.com/v1/chat/completions", item["models"][0]) is False
+
+
+def test_codex_manual_model_config_persists_hide_disable_restore(monkeypatch, tmp_path):
+    import src.settings as settings_module
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(settings_module, "SETTINGS_FILE", str(settings_file))
+    settings_module._invalidate_caches()
+
+    cfg = update_codex_model_config(add_model="gpt-5.2-codex")
+    assert cfg["manual_models"] == ["gpt-5.2-codex"]
+    assert load_codex_model_config()["manual_models"] == ["gpt-5.2-codex"]
+
+    cfg = update_codex_model_config(disable_model="gpt-5.2-codex")
+    assert cfg["disabled_models"] == ["gpt-5.2-codex"]
+
+    cfg = update_codex_model_config(hide_model="gpt-5.2-codex")
+    assert cfg["hidden_models"] == ["gpt-5.2-codex"]
+    assert cfg["disabled_models"] == []
+
+    cfg = update_codex_model_config(restore_model="gpt-5.2-codex")
+    assert cfg["hidden_models"] == []
+    settings_module._invalidate_caches()
 
 
 def test_codex_model_list_item_if_available_requires_available_status(monkeypatch):
@@ -273,8 +315,8 @@ def test_codex_model_provider_reports_experimental_model_when_authenticated(monk
 
     assert out["status"] == "available"
     assert out["authenticated"] is True
-    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
-    assert out["models"][0]["display"] == CODEX_EXPERIMENTAL_MODEL_DISPLAY
+    assert out["models"][0]["id"] == "gpt-5.2-codex"
+    assert out["models"][0]["display"] == "gpt-5.2-codex"
     assert out["models"][0]["experimental"] is True
     assert out["chat_supported"] is True
     assert out["streaming_supported"] is False
@@ -422,8 +464,10 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
     assert calls[-1][1]
     assert "--sandbox" in exec_args
     assert "read-only" in exec_args
-    assert "--ask-for-approval" in exec_args
-    assert "never" in exec_args
+    assert "--ask-for-approval" not in exec_args
+    assert "--approval-policy" not in exec_args
+    assert "--approval" not in exec_args
+    assert "never" not in exec_args
 
 
 def test_adapter_accepts_current_cli_without_approval_flag(monkeypatch):
@@ -498,6 +542,59 @@ def test_adapter_uses_skip_git_repo_check_when_advertised(monkeypatch):
     assert "--yolo" not in exec_args
 
 
+def test_adapter_passes_custom_model_only_when_model_flag_supported(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_OLD_EXEC_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "codex provider test ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "Say ok"}], model="gpt-5.2-codex"))
+
+    assert out["ok"] is True
+    exec_args = calls[-1]
+    assert "--model" in exec_args
+    assert exec_args[exec_args.index("--model") + 1] == "gpt-5.2-codex"
+
+
+def test_adapter_rejects_custom_model_without_model_flag(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+    })
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        if args[1:] == ["exec", "--help"]:
+            return 0, CODEX_0135_EXEC_HELP, ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "should not run", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.complete([{"role": "user", "content": "Say ok"}], model="gpt-5.2-codex"))
+
+    assert out["ok"] is False
+    assert out["status"] == "unsupported_option"
+    assert not any(args[1] == "exec" and "--help" not in args for args in calls)
+
+
 def test_adapter_retries_with_skip_git_repo_check_when_trust_error_requires_it(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
     svc = _FakeService({
@@ -545,8 +642,8 @@ def test_status_available_with_current_cli_help(monkeypatch):
     assert out["status"] == "available"
     assert out["chat_supported"] is True
     assert out["streaming_supported"] is True
-    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
-    assert out["models"][0]["streaming_supported"] is True
+    assert out["models"] == []
+    assert out["model_discovery"]["source"] == "none"
     assert out["cli_capabilities"]["sandbox_supported"] is True
     assert out["cli_capabilities"]["approval_control_supported"] is False
     assert out["cli_capabilities"]["json_output_supported"] is True
@@ -774,6 +871,75 @@ def test_normal_chat_routes_use_explicit_codex_branches_before_generic_llm():
     assert "allow_one_shot_fallback=True" in branch_source
 
 
+def test_codex_auto_name_does_not_call_generic_llm(monkeypatch):
+    from routes import chat_helpers
+    import src.task_endpoint as task_endpoint
+    import src.llm_core as llm_core
+
+    monkeypatch.setattr(
+        task_endpoint,
+        "resolve_task_endpoint",
+        lambda fallback_url=None, fallback_model=None, fallback_headers=None: (
+            CODEX_EXPERIMENTAL_ENDPOINT_URL,
+            CODEX_EXPERIMENTAL_MODEL_ID,
+            {},
+        ),
+    )
+
+    async def fail_llm_call(*args, **kwargs):
+        raise AssertionError("auto-name must not POST to odysseus://codex-cli")
+
+    monkeypatch.setattr(llm_core, "llm_call_async", fail_llm_call)
+    sess = SimpleNamespace(
+        id="codex-session",
+        endpoint_url=CODEX_EXPERIMENTAL_ENDPOINT_URL,
+        model=CODEX_EXPERIMENTAL_MODEL_ID,
+        headers={},
+        history=[SimpleNamespace(role="user", content="hello codex")],
+    )
+
+    run(chat_helpers.auto_name_session(SimpleNamespace(update_session_name=lambda *a: None), sess))
+
+
+def test_codex_post_response_skips_generic_background_llm_tasks(monkeypatch):
+    from routes import chat_helpers
+
+    created = []
+    monkeypatch.setattr(chat_helpers, "_resolve_http_task_endpoint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_helpers.asyncio, "create_task", lambda coro: created.append(coro))
+    sess = SimpleNamespace(
+        id="codex-session",
+        name="Already Named",
+        endpoint_url=CODEX_EXPERIMENTAL_ENDPOINT_URL,
+        model=CODEX_EXPERIMENTAL_MODEL_ID,
+        headers={},
+        history=[
+            SimpleNamespace(role="user", content="one"),
+            SimpleNamespace(role="assistant", content="two"),
+            SimpleNamespace(role="user", content="three"),
+            SimpleNamespace(role="assistant", content="four"),
+        ],
+    )
+
+    chat_helpers.run_post_response_tasks(
+        sess,
+        session_manager=SimpleNamespace(),
+        session_id=sess.id,
+        message="three",
+        full_response="four",
+        last_metrics=None,
+        uprefs={"auto_memory": True, "auto_skills": True},
+        memory_manager=object(),
+        memory_vector=object(),
+        webhook_manager=None,
+        agent_rounds=2,
+        agent_tool_calls=2,
+        skills_manager=object(),
+    )
+
+    assert created == []
+
+
 def test_adapter_stream_falls_back_to_completed_stdout_when_no_deltas(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
     svc = _FakeService({
@@ -905,6 +1071,25 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
     assert out["ok"] is False
     assert out["status"] == "unsupported_unsafe_cli_mode"
     assert "--sandbox" in out["missing_flags"]
+
+
+def test_adapter_requires_long_sandbox_flag(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args[1:] == ["exec", "--help"]:
+            return 0, "Usage: codex exec -s <MODE> --json", ""
+        if args[1:] == ["--help"]:
+            return 0, CODEX_0135_ROOT_HELP, ""
+        return 0, "", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.available())
+
+    assert out["ok"] is False
+    assert out["status"] == "unsupported_unsafe_cli_mode"
+    assert out["cli_capabilities"]["sandbox_supported"] is False
 
 
 def test_adapter_never_uses_advertised_dangerous_flags(monkeypatch):

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -1,9 +1,14 @@
 import asyncio
+import json
 import os
 import sys
 import types
+from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 
 from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_ENDPOINT_URL,
@@ -12,12 +17,15 @@ from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_MODEL_DISPLAY,
     CodexCliChatAdapter,
     CodexModelProvider,
+    codex_recommended_models,
     load_codex_model_config,
     update_codex_model_config,
     codex_model_list_item_if_available,
     codex_model_list_item,
+    first_enabled_codex_model,
     is_codex_model_selection,
 )
+from src.llm_core import llm_call_async
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
 
 
@@ -32,6 +40,27 @@ if "core" not in sys.modules:
 
 def run(coro):
     return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codex_settings(monkeypatch, tmp_path):
+    import src.settings as settings_module
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(settings_module, "SETTINGS_FILE", str(settings_file))
+    settings_module._invalidate_caches()
+    yield
+    settings_module._invalidate_caches()
+
+
+def _fake_request(user="alice"):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=None)),
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
 
 
 class _FakeService:
@@ -260,8 +289,35 @@ def test_codex_manual_model_config_persists_hide_disable_restore(monkeypatch, tm
     settings_module._invalidate_caches()
 
 
+def test_codex_model_config_remove_and_clear_connector():
+    update_codex_model_config(add_model="gpt-5.5")
+    update_codex_model_config(add_model="gpt-5.4")
+
+    cfg = update_codex_model_config(remove_model="gpt-5.4")
+    assert cfg["manual_models"] == ["gpt-5.5"]
+    assert first_enabled_codex_model(cfg) == "gpt-5.5"
+
+    cfg = update_codex_model_config(clear_all_models=True, connector_enabled=False)
+    assert cfg["connector_enabled"] is False
+    assert cfg["manual_models"] == []
+    assert cfg["selected_models"] == []
+
+
+def test_codex_recommended_presets_default_to_gpt_5_5_and_dedupe_selection():
+    presets = codex_recommended_models()
+
+    assert presets[0]["id"] == "gpt-5.5"
+    assert presets[0]["label"] == "GPT-5.5"
+
+    update_codex_model_config(add_model="gpt-5.5")
+    cfg = update_codex_model_config(add_model="gpt-5.5")
+
+    assert [item["id"] for item in cfg["selected_models"]] == ["gpt-5.5"]
+
+
 def test_codex_model_list_item_if_available_requires_available_status(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    update_codex_model_config(add_model="gpt-5.2-codex")
 
     available_provider, _ = _provider({
         "codex_cli_available": True,
@@ -301,6 +357,7 @@ def test_codex_model_provider_requires_sign_in_when_unauthenticated(monkeypatch)
 
 def test_codex_model_provider_reports_experimental_model_when_authenticated(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    update_codex_model_config(add_model="gpt-5.2-codex")
     provider, _ = _provider({
         "codex_cli_available": True,
         "authenticated": True,
@@ -820,6 +877,14 @@ def test_stream_parser_ignores_lifecycle_values_in_text_like_fields():
     ) == []
 
 
+def test_stream_parser_drops_reasoning_deltas_but_keeps_metrics():
+    events = CodexCliChatAdapter._events_from_json_line(
+        '{"type":"reasoning.delta","delta":"secret","usage":{"reasoning_output_tokens":41}}'
+    )
+
+    assert events == [{"type": "metrics", "data": {"reasoning_output_tokens": 41}}]
+
+
 def test_extract_message_ignores_lifecycle_json_lines():
     output = "\n".join([
         '{"type":"thread.started"}',
@@ -1129,4 +1194,204 @@ def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
 
     assert out["status"] == "unsupported_unsafe_cli_mode"
     assert out["models"] == []
-    assert out["chat_supported"] is False
+
+
+def test_group_sessions_are_protected_from_auto_sort():
+    from src.session_actions import session_protected_from_auto_sort
+
+    now = datetime.now()
+
+    assert session_protected_from_auto_sort(SimpleNamespace(
+        name="[GRP] Roundtable",
+        created_at=now - timedelta(minutes=10),
+        updated_at=None,
+    ), now=now) is True
+
+    assert session_protected_from_auto_sort(SimpleNamespace(
+        name="Fresh chat",
+        created_at=now - timedelta(seconds=30),
+        updated_at=None,
+    ), now=now) is True
+
+    assert session_protected_from_auto_sort(SimpleNamespace(
+        name="Old chat",
+        created_at=now - timedelta(minutes=5),
+        updated_at=None,
+    ), now=now) is False
+
+
+def test_llm_call_async_uses_codex_provider_for_sentinel(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+
+    calls = []
+
+    async def fake_test_chat(self, messages, model=None, reasoning_effort=None, timeout_seconds=120, odysseus_session_id=None):
+        calls.append({
+            "messages": messages,
+            "model": model,
+            "timeout_seconds": timeout_seconds,
+        })
+        return {"ok": True, "message": "codex async ok"}
+
+    monkeypatch.setattr(CodexModelProvider, "test_chat", fake_test_chat)
+
+    out = run(llm_call_async(
+        CODEX_EXPERIMENTAL_ENDPOINT_URL,
+        "gpt-5.5",
+        [{"role": "user", "content": "Say ok"}],
+        timeout=42,
+    ))
+
+    assert out == "codex async ok"
+    assert calls == [{
+        "messages": [{"role": "user", "content": "Say ok"}],
+        "model": "gpt-5.5",
+        "timeout_seconds": 42,
+    }]
+
+
+def test_research_start_same_as_chat_uses_codex_sentinel(monkeypatch):
+    from routes import research_routes
+    import src.auth_helpers as auth_helpers
+
+    update_codex_model_config(add_model="gpt-5.5")
+
+    research_handler = SimpleNamespace(
+        _active_tasks={},
+        start_research=MagicMock(),
+    )
+    session_manager = SimpleNamespace(
+        get_session=lambda sid: SimpleNamespace(
+            endpoint_url=CODEX_EXPERIMENTAL_ENDPOINT_URL,
+            model="gpt-5.5",
+            headers={},
+            owner="alice",
+        )
+    )
+
+    monkeypatch.setattr(auth_helpers, "require_privilege", lambda request, privilege: "alice")
+    monkeypatch.setattr(
+        research_routes,
+        "resolve_endpoint",
+        lambda purpose, fallback_url="", fallback_model="", fallback_headers=None: (
+            fallback_url,
+            fallback_model,
+            fallback_headers or {},
+        ),
+    )
+
+    router = research_routes.setup_research_routes(research_handler, session_manager=session_manager)
+    target = next(r.endpoint for r in router.routes if getattr(r, "path", "") == "/api/research/start")
+    body = SimpleNamespace(
+        query="Investigate Codex routing",
+        max_rounds=0,
+        search_provider=None,
+        endpoint_id=None,
+        model=None,
+        source_session_id="chat-1",
+        max_time=300,
+        extraction_timeout=None,
+        extraction_concurrency=None,
+        category=None,
+    )
+
+    out = run(target(body=body, request=_fake_request("alice")))
+
+    assert out["status"] == "running"
+    kwargs = research_handler.start_research.call_args.kwargs
+    assert kwargs["llm_endpoint"] == CODEX_EXPERIMENTAL_ENDPOINT_URL
+    assert kwargs["llm_model"] == "gpt-5.5"
+
+
+def test_research_spinoff_reuses_saved_codex_sentinel(monkeypatch, tmp_path):
+    from routes import research_routes
+
+    update_codex_model_config(add_model="gpt-5.5")
+    monkeypatch.chdir(tmp_path)
+
+    data_dir = tmp_path / "data" / "deep_research"
+    data_dir.mkdir(parents=True)
+    (data_dir / "rp-123.json").write_text(json.dumps({
+        "owner": "alice",
+        "query": "Codex research",
+        "result": "Saved report",
+        "sources": ["https://example.test"],
+        "llm_endpoint": CODEX_EXPERIMENTAL_ENDPOINT_URL,
+        "llm_model": "gpt-5.5",
+    }), encoding="utf-8")
+
+    core_models = types.ModuleType("core.models")
+
+    class _ChatMessage:
+        def __init__(self, role, content, metadata=None):
+            self.role = role
+            self.content = content
+            self.metadata = metadata or {}
+
+    core_models.ChatMessage = _ChatMessage
+    monkeypatch.setitem(sys.modules, "core.models", core_models)
+    if "core" in sys.modules:
+        setattr(sys.modules["core"], "models", core_models)
+
+    event_bus = types.ModuleType("src.event_bus")
+    event_bus.fire_event = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "src.event_bus", event_bus)
+
+    created = {}
+
+    class _FakeSession:
+        def __init__(self):
+            self.headers = {}
+            self.messages = []
+
+        def add_message(self, msg):
+            self.messages.append(msg)
+
+    class _SessionManager:
+        def get_session(self, sid):
+            raise KeyError(sid)
+
+        def create_session(self, session_id, name, endpoint_url, model, rag, owner):
+            created.update({
+                "session_id": session_id,
+                "name": name,
+                "endpoint_url": endpoint_url,
+                "model": model,
+                "owner": owner,
+            })
+            sess = _FakeSession()
+            created["session"] = sess
+            return sess
+
+        def save_sessions(self):
+            created["saved"] = created.get("saved", 0) + 1
+
+    research_handler = SimpleNamespace(
+        get_result=lambda session_id: None,
+        get_sources=lambda session_id: [],
+    )
+    router = research_routes.setup_research_routes(research_handler, session_manager=_SessionManager())
+    target = next(r.endpoint for r in router.routes if getattr(r, "path", "") == "/api/research/spinoff/{session_id}")
+
+    out = run(target(session_id="rp-123", request=_fake_request("alice")))
+
+    assert out["source_count"] == 1
+    assert created["endpoint_url"] == CODEX_EXPERIMENTAL_ENDPOINT_URL
+    assert created["model"] == "gpt-5.5"
+    assert created["owner"] == "alice"
+    assert created["session"].messages[0].metadata["research_spinoff_from"] == "rp-123"
+
+
+def test_chat_stream_codex_agent_mode_uses_structured_capability_response():
+    source = (REPO_ROOT / "routes" / "chat_routes.py").read_text(encoding="utf-8")
+
+    assert "agent_mode_unsupported" in source
+    assert "status_code=409" in source
+
+
+def test_group_source_uses_chat_stream_and_saves_only_accumulated_text():
+    source = (REPO_ROOT / "static" / "js" / "group.js").read_text(encoding="utf-8")
+
+    assert "/api/chat_stream" in source
+    assert "if (!res.ok || !res.body)" in source
+    assert "content: accumulated" in source

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -14,7 +14,6 @@ from src.codex_model_provider import (
     CODEX_EXPERIMENTAL_ENDPOINT_URL,
     CODEX_EXPERIMENTAL_MODEL_ID,
     CODEX_MODEL_PROVIDER_FLAG,
-    CODEX_EXPERIMENTAL_MODEL_DISPLAY,
     CodexCliChatAdapter,
     CodexModelProvider,
     codex_recommended_models,

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -1,0 +1,144 @@
+import asyncio
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_MODEL_ID,
+    CODEX_MODEL_PROVIDER_FLAG,
+    CodexModelProvider,
+)
+from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+
+
+if "core" not in sys.modules:
+    core_pkg = types.ModuleType("core")
+    core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
+    sys.modules["core"] = core_pkg
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeService:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = 0
+
+    async def status(self):
+        self.calls += 1
+        return dict(self.payload)
+
+
+def _provider(payload):
+    svc = _FakeService(payload)
+    return CodexModelProvider(lambda: svc), svc
+
+
+def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
+    monkeypatch.delenv(CODEX_MODEL_PROVIDER_FLAG, raising=False)
+    provider, svc = _provider({"codex_cli_available": True, "authenticated": True})
+
+    out = run(provider.status())
+
+    assert out["feature_enabled"] is False
+    assert out["status"] == "disabled"
+    assert out["models"] == []
+    assert svc.calls == 0
+
+
+def test_codex_model_provider_requires_sign_in_when_unauthenticated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": False,
+        "status": "not_authenticated",
+    })
+
+    out = run(provider.status())
+
+    assert out["status"] == "sign_in_required"
+    assert out["requires_sign_in"] is True
+    assert out["models"] == []
+    assert out["chat_supported"] is False
+    assert out["streaming_supported"] is False
+
+
+def test_codex_model_provider_reports_experimental_model_when_authenticated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": True,
+        "authenticated": True,
+        "codex_authenticated": True,
+        "status": "authenticated",
+        "auth_mode": "ChatGPT",
+        "access_token": "secret",
+        "refresh_token": "secret",
+    })
+
+    out = run(provider.status())
+
+    assert out["status"] == "available"
+    assert out["authenticated"] is True
+    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert out["models"][0]["experimental"] is True
+    assert "secret" not in str(out)
+    assert "access_token" not in str(out)
+    assert "refresh_token" not in str(out)
+
+
+def test_codex_model_provider_reports_cli_unavailable(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({
+        "codex_cli_available": False,
+        "cli_found": False,
+        "cli_executable": False,
+        "status": "cli_missing",
+    })
+
+    out = run(provider.status())
+
+    assert out["status"] == "cli_unavailable"
+    assert out["cli_available"] is False
+    assert out["models"] == []
+
+
+class _AuthManager:
+    is_configured = True
+
+    def is_admin(self, user):
+        return user == "admin"
+
+
+def _request(user="admin"):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=_AuthManager())),
+    )
+
+
+def _endpoint(router, path, method):
+    for route in router.routes:
+        if getattr(route, "path", "") == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_codex_model_provider_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    status = _endpoint(router, "/api/codex-model-provider/status", "GET")
+
+    out = run(status(_request(user="admin")))
+    assert out["status"] == "available"
+
+    try:
+        run(status(_request(user="bob")))
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 403
+    else:
+        raise AssertionError("non-admin request should fail")

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -4,20 +4,21 @@ import sys
 import types
 from types import SimpleNamespace
 
-from src.codex_model_provider import (
-    CODEX_EXPERIMENTAL_MODEL_ID,
-    CODEX_MODEL_PROVIDER_FLAG,
-    CODEX_EXPERIMENTAL_MODEL_DISPLAY,
-    CodexCliChatAdapter,
-    CodexModelProvider,
-)
-from routes.codex_model_provider_routes import setup_codex_model_provider_routes
-
-
 if "core" not in sys.modules:
     core_pkg = types.ModuleType("core")
     core_pkg.__path__ = [os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")]
     sys.modules["core"] = core_pkg
+
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_MODEL_ID,
+    CODEX_MODEL_PROVIDER_FLAG,
+    CODEX_EXPERIMENTAL_MODEL_DISPLAY,
+    CODEX_VIRTUAL_ENDPOINT_URL,
+    CodexCliChatAdapter,
+    CodexModelProvider,
+    is_codex_virtual_endpoint,
+)
+from routes.codex_model_provider_routes import setup_codex_model_provider_routes
 
 
 def run(coro):
@@ -52,7 +53,7 @@ class _FakeAdapter:
             "limitations": [],
         }
 
-    async def complete(self, messages, model=None, timeout_seconds=120):
+    async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
         return {
             "ok": True,
             "status": "ok",
@@ -62,8 +63,12 @@ class _FakeAdapter:
             "limitations": [],
             "streaming_supported": False,
             "session_resume_supported": False,
+            "session_resumed": False,
             "tool_execution_allowed": False,
         }
+
+    def reset_session(self, session_id):
+        return {"ok": True, "status": "reset", "session_mapping_cleared": False}
 
 
 def _provider(payload):
@@ -238,11 +243,20 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
     assert out["streaming_supported"] is False
     assert out["session_resume_supported"] is False
     assert out["tool_execution_allowed"] is False
-    assert calls[1][1]
-    assert "--sandbox" in calls[1][0]
-    assert "read-only" in calls[1][0]
-    assert "--ask-for-approval" in calls[1][0]
-    assert "never" in calls[1][0]
+    assert calls[2][1]
+    assert "--sandbox" in calls[2][0]
+    assert "read-only" in calls[2][0]
+    assert "--ask-for-approval" in calls[2][0]
+    assert "never" in calls[2][0]
+    assert "--yolo" not in calls[2][0]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in calls[2][0]
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in calls[2][0]
+
+
+def test_codex_virtual_endpoint_detection():
+    assert is_codex_virtual_endpoint(CODEX_VIRTUAL_ENDPOINT_URL, CODEX_EXPERIMENTAL_MODEL_ID) is True
+    assert is_codex_virtual_endpoint(CODEX_VIRTUAL_ENDPOINT_URL, "") is True
+    assert is_codex_virtual_endpoint("https://api.openai.com/v1/chat/completions", "gpt-4o") is False
 
 
 def test_adapter_handles_timeout(monkeypatch):
@@ -296,6 +310,47 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
     assert "--ask-for-approval" in out["missing_flags"]
 
 
+def test_adapter_detects_safety_flags_from_top_level_help(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        calls.append(args)
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, "Usage: codex exec", ""
+        if args == ["/usr/bin/codex", "--help"]:
+            return 0, "Options: --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 1, "", "unknown"
+        return 0, "ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.available())
+
+    assert out["ok"] is True
+    assert out["session_resume_supported"] is False
+    assert ["/usr/bin/codex", "--help"] in calls
+
+
+def test_adapter_detects_resume_support(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 0, "Usage: codex exec resume <SESSION_ID>", ""
+        return 0, "ok", ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
+    out = run(adapter.available())
+
+    assert out["ok"] is True
+    assert out["session_resume_supported"] is True
+
+
 def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
     monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
 
@@ -311,3 +366,125 @@ def test_status_does_not_expose_model_when_adapter_is_unsafe(monkeypatch):
     assert out["status"] == "unsupported_unsafe_cli_mode"
     assert out["models"] == []
     assert out["chat_supported"] is False
+
+
+def test_same_odysseus_session_resumes_codex_session(monkeypatch, tmp_path):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    exec_calls = []
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 0, "Usage: codex exec resume <SESSION_ID>", ""
+        exec_calls.append((args, cwd))
+        if "resume" in args:
+            return 0, "resumed response", ""
+        return 0, '{"session_id":"codex-session-1","message":"first response"}', ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner, session_root=tmp_path)
+    first = run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-1"))
+    second = run(adapter.complete([{"role": "user", "content": "two"}], odysseus_session_id="ody-1"))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert second["session_resumed"] is True
+    assert exec_calls[1][0][0:4] == ["/usr/bin/codex", "exec", "resume", "codex-session-1"]
+    assert "--sandbox" in exec_calls[1][0]
+    assert "read-only" in exec_calls[1][0]
+    assert "--ask-for-approval" in exec_calls[1][0]
+    assert "never" in exec_calls[1][0]
+    assert "--all" not in exec_calls[1][0]
+
+
+def test_different_odysseus_sessions_do_not_share_codex_mapping(monkeypatch, tmp_path):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    exec_calls = []
+    next_id = {"n": 0}
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 0, "Usage: codex exec resume <SESSION_ID>", ""
+        exec_calls.append(args)
+        next_id["n"] += 1
+        return 0, f'{{"session_id":"codex-session-{next_id["n"]}","message":"ok"}}', ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner, session_root=tmp_path)
+    run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-1"))
+    run(adapter.complete([{"role": "user", "content": "two"}], odysseus_session_id="ody-2"))
+
+    assert "resume" not in exec_calls[0]
+    assert "resume" not in exec_calls[1]
+
+
+def test_reset_clears_only_selected_codex_session_mapping(monkeypatch, tmp_path):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    exec_calls = []
+    ids = iter(["codex-a-1", "codex-b-1", "codex-a-2"])
+
+    async def runner(args, timeout, cwd=None, env=None):
+        if args == ["/usr/bin/codex", "exec", "--help"]:
+            return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
+        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
+            return 0, "Usage: codex exec resume <SESSION_ID>", ""
+        exec_calls.append(args)
+        if "resume" in args:
+            return 0, "resumed", ""
+        return 0, f'{{"session_id":"{next(ids)}","message":"ok"}}', ""
+
+    adapter = CodexCliChatAdapter(lambda: svc, runner=runner, session_root=tmp_path)
+    run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-a"))
+    run(adapter.complete([{"role": "user", "content": "one"}], odysseus_session_id="ody-b"))
+
+    reset = adapter.reset_session("ody-a")
+    assert reset["ok"] is True
+
+    run(adapter.complete([{"role": "user", "content": "again"}], odysseus_session_id="ody-a"))
+    run(adapter.complete([{"role": "user", "content": "again"}], odysseus_session_id="ody-b"))
+
+    assert "resume" not in exec_calls[2]
+    assert exec_calls[3][0:4] == ["/usr/bin/codex", "exec", "resume", "codex-b-1"]
+
+
+def test_test_chat_route_accepts_session_id_for_reuse(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    seen = {}
+
+    class CapturingAdapter(_FakeAdapter):
+        async def complete(self, messages, model=None, timeout_seconds=120, odysseus_session_id=None):
+            seen["session_id"] = odysseus_session_id
+            return await super().complete(messages, model=model, timeout_seconds=timeout_seconds, odysseus_session_id=odysseus_session_id)
+
+    svc = _FakeService({"codex_cli_available": True, "authenticated": True})
+    provider = CodexModelProvider(lambda: svc, chat_adapter=CapturingAdapter())
+    router = setup_codex_model_provider_routes(provider)
+    test_chat = _endpoint(router, "/api/codex-model-provider/test-chat", "POST")
+    body = SimpleNamespace(prompt="hello", messages=None, model=None, timeout_seconds=None, session_id="ody-test")
+
+    out = run(test_chat(_request(user="admin"), body))
+
+    assert out["ok"] is True
+    assert seen["session_id"] == "ody-test"
+
+
+def test_reset_session_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    reset = _endpoint(router, "/api/codex-model-provider/reset-session", "POST")
+    body = SimpleNamespace(session_id="ody-test")
+
+    out = run(reset(_request(user="admin"), body))
+    assert out["ok"] is True
+
+    try:
+        run(reset(_request(user="bob"), body))
+    except Exception as exc:
+        assert getattr(exc, "status_code", None) == 403
+    else:
+        raise AssertionError("non-admin request should fail")

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -303,6 +303,14 @@ def test_codex_model_config_remove_and_clear_connector():
     assert cfg["selected_models"] == []
 
 
+def test_codex_connector_can_exist_without_selected_models():
+    cfg = update_codex_model_config(connector_enabled=True)
+
+    assert cfg["connector_enabled"] is True
+    assert cfg["selected_models"] == []
+    assert cfg["manual_models"] == []
+
+
 def test_codex_recommended_presets_default_to_gpt_5_5_and_dedupe_selection():
     presets = codex_recommended_models()
 
@@ -489,6 +497,19 @@ def test_codex_model_provider_test_chat_requires_body(monkeypatch):
     out = run(test_chat(_request(user="admin"), body))
     assert out["ok"] is False
     assert out["status"] == "invalid_request"
+
+
+def test_codex_model_provider_connector_route_persists_empty_connector(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    provider, _ = _provider({"codex_cli_available": True, "authenticated": True})
+    router = setup_codex_model_provider_routes(provider)
+    add_connector = _endpoint(router, "/api/codex-model-provider/connector", "POST")
+
+    out = run(add_connector(_request(user="admin")))
+
+    assert out["ok"] is True
+    assert out["config"]["connector_enabled"] is True
+    assert out["config"]["selected_models"] == []
 
 
 def test_adapter_success_from_mocked_subprocess(monkeypatch):
@@ -1395,3 +1416,11 @@ def test_group_source_uses_chat_stream_and_saves_only_accumulated_text():
     assert "/api/chat_stream" in source
     assert "if (!res.ok || !res.body)" in source
     assert "content: accumulated" in source
+
+
+def test_admin_source_keeps_codex_setup_reachable_when_provider_selected():
+    source = (REPO_ROOT / "static" / "js" / "admin.js").read_text(encoding="utf-8")
+
+    assert "fetch('/api/codex-model-provider/connector'" in source
+    assert "const shouldShowCard = !!data?.connector_enabled || totalCount > 0;" in source
+    assert "msg.textContent = 'Added Codex connector';" in source

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -21,34 +21,6 @@ from src.codex_model_provider import (
 from routes.codex_model_provider_routes import setup_codex_model_provider_routes
 
 
-CODEX_0135_EXEC_HELP = """
-Usage: codex exec [OPTIONS] [PROMPT] [COMMAND]
-
-Commands:
-  resume  Resume a previous exec session
-
-Options:
-  -s, --sandbox <SANDBOX_MODE>
-          Sandbox mode to use when executing commands
-          [possible values: read-only, workspace-write, danger-full-access]
-      --json
-          Emit events as JSONL
-  -h, --help
-          Print help
-"""
-
-
-CODEX_0135_RESUME_HELP = """
-Usage: codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]
-
-Options:
-      --last
-          Resume the most recent session in the current working directory
-  -h, --help
-          Print help
-"""
-
-
 def run(coro):
     return asyncio.run(coro)
 
@@ -265,95 +237,20 @@ def test_adapter_success_from_mocked_subprocess(monkeypatch):
 
     adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
     out = run(adapter.complete([{"role": "user", "content": "Say ok"}]))
-    exec_call = next(call for call in calls if call[0][-1] != "--help")
 
     assert out["ok"] is True
     assert out["message"] == "codex provider test ok"
     assert out["streaming_supported"] is False
     assert out["session_resume_supported"] is False
     assert out["tool_execution_allowed"] is False
-    assert exec_call[1]
-    assert "--sandbox" in exec_call[0]
-    assert "read-only" in exec_call[0]
-    assert "--ask-for-approval" in exec_call[0]
-    assert "never" in exec_call[0]
-    assert "--yolo" not in exec_call[0]
-    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_call[0]
-    assert CODEX_EXPERIMENTAL_MODEL_ID not in exec_call[0]
-
-
-def test_adapter_supports_0135_style_sandbox_without_approval_flag(monkeypatch):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({
-        "codex_cli_available": True,
-        "authenticated": True,
-        "codex_authenticated": True,
-        "status": "authenticated",
-    })
-    exec_calls = []
-
-    async def runner(args, timeout, cwd=None, env=None):
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, CODEX_0135_EXEC_HELP, ""
-        if args == ["/usr/bin/codex", "--help"]:
-            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 0, CODEX_0135_RESUME_HELP, ""
-        exec_calls.append(args)
-        return 0, "codex direct ok", ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
-    available = run(adapter.available())
-    out = run(adapter.complete([{"role": "user", "content": "Reply exactly: codex direct ok"}]))
-
-    assert available["ok"] is True
-    assert available["status"] == "available"
-    assert available["approval_control_supported"] is False
-    assert available["capabilities"]["sandbox_flag"] == "--sandbox"
-    assert available["capabilities"]["session_resume_supported"] is True
-    assert "approval-control flag" in " ".join(available["limitations"])
-    assert out["ok"] is True
-    assert out["message"] == "codex direct ok"
-    assert exec_calls
-    assert exec_calls[0][0:2] == ["/usr/bin/codex", "exec"]
-    assert "--sandbox" in exec_calls[0]
-    assert "read-only" in exec_calls[0]
-    assert "--ask-for-approval" not in exec_calls[0]
-    assert "--approval-policy" not in exec_calls[0]
-    assert "--approval" not in exec_calls[0]
-    assert "--yolo" not in exec_calls[0]
-    assert "--dangerously-bypass-approvals-and-sandbox" not in exec_calls[0]
-    assert CODEX_EXPERIMENTAL_MODEL_ID not in exec_calls[0]
-
-
-def test_status_available_with_0135_style_sandbox_without_approval_flag(monkeypatch):
-    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
-    svc = _FakeService({
-        "codex_cli_available": True,
-        "authenticated": True,
-        "codex_authenticated": True,
-        "status": "authenticated",
-    })
-
-    async def runner(args, timeout, cwd=None, env=None):
-        if args == ["/usr/bin/codex", "exec", "--help"]:
-            return 0, CODEX_0135_EXEC_HELP, ""
-        if args == ["/usr/bin/codex", "--help"]:
-            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
-        if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
-            return 0, CODEX_0135_RESUME_HELP, ""
-        return 0, "ok", ""
-
-    adapter = CodexCliChatAdapter(lambda: svc, runner=runner)
-    provider = CodexModelProvider(lambda: svc, chat_adapter=adapter)
-    out = run(provider.status())
-
-    assert out["status"] == "available"
-    assert out["chat_supported"] is True
-    assert out["approval_control_supported"] is False
-    assert out["capabilities"]["sandbox_supported"] is True
-    assert out["models"][0]["id"] == CODEX_EXPERIMENTAL_MODEL_ID
-    assert "approval-control flag" in " ".join(out["limitations"])
+    assert calls[2][1]
+    assert "--sandbox" in calls[2][0]
+    assert "read-only" in calls[2][0]
+    assert "--ask-for-approval" in calls[2][0]
+    assert "never" in calls[2][0]
+    assert "--yolo" not in calls[2][0]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in calls[2][0]
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in calls[2][0]
 
 
 def test_codex_virtual_endpoint_detection():
@@ -409,18 +306,8 @@ def test_adapter_refuses_unsafe_cli_help(monkeypatch):
 
     assert out["ok"] is False
     assert out["status"] == "unsupported_unsafe_cli_mode"
-    assert "--sandbox/-s" in out["missing_flags"]
-
-
-def test_adapter_blocks_forbidden_cli_flags():
-    adapter = CodexCliChatAdapter()
-    for flag in ("--yolo", "--dangerously-bypass-approvals-and-sandbox"):
-        try:
-            adapter._assert_safe_args(["/usr/bin/codex", "exec", "--sandbox", "read-only", flag, "prompt"])
-        except ValueError as exc:
-            assert "Unsafe Codex CLI flag blocked" in str(exc)
-        else:
-            raise AssertionError(f"{flag} should be blocked")
+    assert "--sandbox" in out["missing_flags"]
+    assert "--ask-for-approval" in out["missing_flags"]
 
 
 def test_adapter_detects_safety_flags_from_top_level_help(monkeypatch):
@@ -489,8 +376,6 @@ def test_same_odysseus_session_resumes_codex_session(monkeypatch, tmp_path):
     async def runner(args, timeout, cwd=None, env=None):
         if args == ["/usr/bin/codex", "exec", "--help"]:
             return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "--help"]:
-            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
         if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
             return 0, "Usage: codex exec resume <SESSION_ID>", ""
         exec_calls.append((args, cwd))
@@ -522,8 +407,6 @@ def test_different_odysseus_sessions_do_not_share_codex_mapping(monkeypatch, tmp
     async def runner(args, timeout, cwd=None, env=None):
         if args == ["/usr/bin/codex", "exec", "--help"]:
             return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "--help"]:
-            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
         if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
             return 0, "Usage: codex exec resume <SESSION_ID>", ""
         exec_calls.append(args)
@@ -547,8 +430,6 @@ def test_reset_clears_only_selected_codex_session_mapping(monkeypatch, tmp_path)
     async def runner(args, timeout, cwd=None, env=None):
         if args == ["/usr/bin/codex", "exec", "--help"]:
             return 0, "Usage: codex exec --sandbox --ask-for-approval", ""
-        if args == ["/usr/bin/codex", "--help"]:
-            return 0, "Usage: codex [OPTIONS] [COMMAND]", ""
         if args == ["/usr/bin/codex", "exec", "resume", "--help"]:
             return 0, "Usage: codex exec resume <SESSION_ID>", ""
         exec_calls.append(args)

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -1,6 +1,7 @@
 """Tests for model route helper functions — pure logic, no server needed."""
 import sys
 import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import httpx
@@ -26,6 +27,7 @@ if "core.database" not in sys.modules:
 
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
+import src.codex_model_provider as codex_model_provider
 from routes.model_routes import (
     _match_provider_curated,
     _curate_models,
@@ -35,6 +37,7 @@ from routes.model_routes import (
     _truthy,
     _PROVIDER_CURATED,
 )
+from src.codex_model_provider import CODEX_EXPERIMENTAL_ENDPOINT_URL, CODEX_EXPERIMENTAL_MODEL_ID
 from src.llm_core import ANTHROPIC_MODELS
 
 
@@ -296,3 +299,82 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
 
         assert _probe_endpoint("https://api.anthropic.com/v1") == ANTHROPIC_MODELS
+
+
+class _EmptyQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return []
+
+
+class _EmptyDb:
+    def query(self, *args, **kwargs):
+        return _EmptyQuery()
+
+    def close(self):
+        pass
+
+
+def _api_models_endpoint():
+    router = model_routes.setup_model_routes(None)
+    for route in router.routes:
+        if getattr(route, "path", "") == "/api/models" and "GET" in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError("GET /api/models route not found")
+
+
+def _request():
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=""),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=None)),
+    )
+
+
+def test_api_models_excludes_codex_when_feature_flag_off(monkeypatch):
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _EmptyDb())
+    monkeypatch.delenv(codex_model_provider.CODEX_MODEL_PROVIDER_FLAG, raising=False)
+
+    out = _api_models_endpoint()(_request(), refresh=True)
+
+    urls = [item.get("url") for item in out["items"]]
+    models = [model for item in out["items"] for model in item.get("models", [])]
+    assert CODEX_EXPERIMENTAL_ENDPOINT_URL not in urls
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in models
+
+
+def test_api_models_includes_codex_when_feature_enabled_and_available(monkeypatch):
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _EmptyDb())
+    monkeypatch.setenv(codex_model_provider.CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(
+        codex_model_provider,
+        "codex_model_list_item_if_available",
+        lambda: codex_model_provider.codex_model_list_item(),
+    )
+
+    out = _api_models_endpoint()(_request(), refresh=True)
+
+    codex_items = [
+        item for item in out["items"]
+        if item.get("url") == CODEX_EXPERIMENTAL_ENDPOINT_URL
+    ]
+    assert len(codex_items) == 1
+    assert codex_items[0]["models"] == [CODEX_EXPERIMENTAL_MODEL_ID]
+
+
+def test_api_models_excludes_codex_when_feature_enabled_but_signed_out(monkeypatch):
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _EmptyDb())
+    monkeypatch.setenv(codex_model_provider.CODEX_MODEL_PROVIDER_FLAG, "true")
+    monkeypatch.setattr(codex_model_provider, "codex_model_list_item_if_available", lambda: None)
+
+    out = _api_models_endpoint()(_request(), refresh=True)
+
+    urls = [item.get("url") for item in out["items"]]
+    models = [model for item in out["items"] for model in item.get("models", [])]
+    assert CODEX_EXPERIMENTAL_ENDPOINT_URL not in urls
+    assert CODEX_EXPERIMENTAL_MODEL_ID not in models

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -24,15 +24,6 @@ if "core.database" not in sys.modules:
         setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
 
-# Some route regression tests intentionally stub src.endpoint_resolver before
-# importing their target modules. If this file is collected after them in the
-# same process, make sure model_routes sees the real helper module.
-if "src.endpoint_resolver" in sys.modules and isinstance(
-    getattr(sys.modules["src.endpoint_resolver"], "_anthropic_api_root", None),
-    MagicMock,
-):
-    del sys.modules["src.endpoint_resolver"]
-
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 from routes.model_routes import (

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -370,6 +370,8 @@ def test_api_models_includes_codex_when_feature_enabled_and_available(monkeypatc
     ]
     assert len(codex_items) == 1
     assert codex_items[0]["models"] == ["gpt-5.2-codex"]
+    assert codex_items[0]["capabilities"]["chat_supported"] is True
+    assert codex_items[0]["capabilities"]["agent_tools_supported"] is False
 
 
 def test_api_models_excludes_codex_when_feature_enabled_but_signed_out(monkeypatch):

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -24,6 +24,15 @@ if "core.database" not in sys.modules:
         setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
 
+# Some route regression tests intentionally stub src.endpoint_resolver before
+# importing their target modules. If this file is collected after them in the
+# same process, make sure model_routes sees the real helper module.
+if "src.endpoint_resolver" in sys.modules and isinstance(
+    getattr(sys.modules["src.endpoint_resolver"], "_anthropic_api_root", None),
+    MagicMock,
+):
+    del sys.modules["src.endpoint_resolver"]
+
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 from routes.model_routes import (

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -354,7 +354,12 @@ def test_api_models_includes_codex_when_feature_enabled_and_available(monkeypatc
     monkeypatch.setattr(
         codex_model_provider,
         "codex_model_list_item_if_available",
-        lambda: codex_model_provider.codex_model_list_item(),
+        lambda: codex_model_provider.codex_model_list_item([{
+            "id": "gpt-5.2-codex",
+            "display": "gpt-5.2-codex",
+            "enabled": True,
+            "streaming_supported": True,
+        }]),
     )
 
     out = _api_models_endpoint()(_request(), refresh=True)
@@ -364,7 +369,7 @@ def test_api_models_includes_codex_when_feature_enabled_and_available(monkeypatc
         if item.get("url") == CODEX_EXPERIMENTAL_ENDPOINT_URL
     ]
     assert len(codex_items) == 1
-    assert codex_items[0]["models"] == [CODEX_EXPERIMENTAL_MODEL_ID]
+    assert codex_items[0]["models"] == ["gpt-5.2-codex"]
 
 
 def test_api_models_excludes_codex_when_feature_enabled_but_signed_out(monkeypatch):
@@ -378,3 +383,32 @@ def test_api_models_excludes_codex_when_feature_enabled_but_signed_out(monkeypat
     models = [model for item in out["items"] for model in item.get("models", [])]
     assert CODEX_EXPERIMENTAL_ENDPOINT_URL not in urls
     assert CODEX_EXPERIMENTAL_MODEL_ID not in models
+
+
+def test_api_models_does_not_cache_codex_availability_after_sign_out(monkeypatch):
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _EmptyDb())
+    monkeypatch.setenv(codex_model_provider.CODEX_MODEL_PROVIDER_FLAG, "true")
+    available = {"value": True}
+
+    def codex_item_if_available():
+        if available["value"]:
+            return codex_model_provider.codex_model_list_item([{
+                "id": "gpt-5.2-codex",
+                "display": "gpt-5.2-codex",
+                "enabled": True,
+            }])
+        return None
+
+    monkeypatch.setattr(
+        codex_model_provider,
+        "codex_model_list_item_if_available",
+        codex_item_if_available,
+    )
+    endpoint = _api_models_endpoint()
+
+    first = endpoint(_request(), refresh=True)
+    available["value"] = False
+    second = endpoint(_request(), refresh=False)
+
+    assert CODEX_EXPERIMENTAL_ENDPOINT_URL in [item.get("url") for item in first["items"]]
+    assert CODEX_EXPERIMENTAL_ENDPOINT_URL not in [item.get("url") for item in second["items"]]


### PR DESCRIPTION
## Summary

Draft/unstacked fallback PR because GitHub would not allow the intended upstream stacked PR until `codex-model-provider-draft` exists in `pewdiepie-archdaemon/odysseus`.

- Integrates Codex CLI provider into chat/model-flow surfaces.
- Adds connector lifecycle, selected/recommended model handling, chat picker integration, group routing, and Deep Research same-as-chat synthetic-provider handling.
- Keeps Codex synthetic instead of treating it as a generic HTTP endpoint.

## Review / stacking note

- This is intended as a follow-up to the Codex auth/device-code foundation in #183.
- Expect this PR to include more context than the ideal stacked diff.

## Auth separation

- No new backend Codex auth implementation was added for the chat/model-flow layer.
- No token storage behavior is changed by the integration layer.
- Codex credentials remain in Codex CLI storage.
- Remaining auth-adjacent UI uses existing auth state for provider setup.

## Server validation

- Tested commit: `176e4b092ef5f43ac44e7677990e889a1ce19349`
- Docker build/start passed.
- App import passed.
- Direct Codex one-shot passed.
- Direct Codex streaming passed.
- Browser checks passed.

## Safety

- No unsafe Codex flags are passed.
- `danger-full-access` is not passed as an argument.
- Raw chain-of-thought is not displayed.
- Codex credentials remain in Codex CLI storage.
- Codex remains synthetic: `odysseus://codex-cli`.

## Tests

- `python -m pytest -q tests/test_codex_auth_service.py tests/test_codex_auth_routes.py tests/test_codex_model_provider.py` -> `69 passed`
- `python -m pytest -q tests/test_model_routes.py` -> `66 passed`
- `python -m pytest -q tests/test_agent_loop.py` -> `37 passed`
- Python compile checks passed.
- JS `node --check` passed.
- `import app` passed.

## Diff size

Against `main`: `33 files changed, 6202 insertions(+), 138 deletions(-)`.

Ideal stacked PR 2 reference size: `22 files changed, 1950 insertions(+), 171 deletions(-)` against `codex-model-provider-draft`.

## Known limitations

- Full Codex Agent tool mode is not enabled.
- Thinking/reasoning controls remain hidden unless CLI advertises supported levels.
- Raw chain-of-thought is never displayed.
- Shell access through Codex is not claimed.