### PR TITLE
Add WebAuthn passkey support for 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,12 @@ SEARXNG_INSTANCE=http://localhost:8080
 # by a trusted reverse proxy or private access gateway.
 # SECURE_COOKIES=true
 
+# WebAuthn / security-key 2FA.
+# RP ID is a hostname only, so localhost:7000 uses RP ID "localhost".
+WEBAUTHN_ORIGIN=http://localhost:7000
+WEBAUTHN_RP_ID=localhost
+WEBAUTHN_RP_NAME=odysseus
+
 # Optional: pre-seed the first admin password during setup.
 # Do not commit a real password.
 # ODYSSEUS_ADMIN_PASSWORD=change_me_before_first_boot

--- a/core/auth.py
+++ b/core/auth.py
@@ -9,6 +9,7 @@ import secrets
 import threading
 import time
 import logging
+import base64
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -39,6 +40,7 @@ DEFAULT_AUTH_PATH = os.path.join(
     Path(__file__).parent.parent, "data", "auth.json"
 )
 TOKEN_TTL = 60 * 60 * 24 * 7  # 7 days
+WEBAUTHN_CHALLENGE_TTL = 60 * 5  # 5 minutes
 
 # Usernames the auth + middleware layer reserve as internal "synthetic owner"
 # sentinels; they must never belong to a real account. The most dangerous is
@@ -55,6 +57,19 @@ TOKEN_TTL = 60 * 60 * 24 * 7  # 7 days
 # Refuse to create or rename into any of them so the sentinels can't be
 # impersonated. (Keep this in sync with that synthetic-owner set.)
 RESERVED_USERNAMES = frozenset({"internal-tool", "api", "demo", "system"})
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    raw = (data or "").encode("ascii")
+    return base64.urlsafe_b64decode(raw + b"=" * (-len(raw) % 4))
+
+
+def _new_webauthn_user_id() -> str:
+    return _b64url_encode(secrets.token_bytes(32))
 
 
 def _hash_password(password: str) -> str:
@@ -207,6 +222,7 @@ class AuthManager:
             "created": time.time(),
             "is_admin": is_admin,
             "privileges": dict(ADMIN_PRIVILEGES if is_admin else DEFAULT_PRIVILEGES),
+            "webauthn_user_id": _new_webauthn_user_id(),
         }
         self._save()
         logger.info(f"Created user '{username}' (admin={is_admin})")
@@ -282,7 +298,12 @@ class AuthManager:
 
     def list_users(self) -> List[Dict[str, Any]]:
         return [
-            {"username": u, "is_admin": d.get("is_admin", False), "privileges": self.get_privileges(u)}
+            {
+                "username": u,
+                "is_admin": d.get("is_admin", False),
+                "privileges": self.get_privileges(u),
+                "webauthn_credentials": len(d.get("webauthn_credentials") or []),
+            }
             for u, d in self.users.items()
         ]
 
@@ -398,6 +419,283 @@ class AuthManager:
         self._config["users"][username]["totp_enabled"] = False
         self._save()
         logger.info(f"2FA disabled for '{username}'")
+        return True
+
+    # ------------------------------------------------------------------
+    # WebAuthn two-factor authentication
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _require_webauthn():
+        try:
+            from webauthn import (  # type: ignore
+                generate_authentication_options,
+                generate_registration_options,
+                options_to_json,
+                verify_authentication_response,
+                verify_registration_response,
+            )
+            from webauthn.helpers.structs import (  # type: ignore
+                AttestationConveyancePreference,
+                AuthenticatorSelectionCriteria,
+                PublicKeyCredentialDescriptor,
+                ResidentKeyRequirement,
+                UserVerificationRequirement,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "WebAuthn support requires the 'webauthn' Python package. "
+                "Install the project requirements and restart Odysseus."
+            ) from exc
+
+        return {
+            "generate_authentication_options": generate_authentication_options,
+            "generate_registration_options": generate_registration_options,
+            "options_to_json": options_to_json,
+            "verify_authentication_response": verify_authentication_response,
+            "verify_registration_response": verify_registration_response,
+            "AttestationConveyancePreference": AttestationConveyancePreference,
+            "AuthenticatorSelectionCriteria": AuthenticatorSelectionCriteria,
+            "PublicKeyCredentialDescriptor": PublicKeyCredentialDescriptor,
+            "ResidentKeyRequirement": ResidentKeyRequirement,
+            "UserVerificationRequirement": UserVerificationRequirement,
+        }
+
+    def _ensure_webauthn_user_id(self, username: str) -> Optional[str]:
+        username = username.strip().lower()
+        if username not in self.users:
+            return None
+        user = self._config["users"][username]
+        user_id = user.get("webauthn_user_id")
+        if not user_id:
+            user_id = _new_webauthn_user_id()
+            user["webauthn_user_id"] = user_id
+            self._save()
+        return user_id
+
+    def webauthn_enabled(self, username: str) -> bool:
+        """Check if WebAuthn 2FA is enabled for a user."""
+        user = self.users.get(username.strip().lower(), {})
+        return bool(user.get("webauthn_credentials"))
+
+    def webauthn_list_credentials(self, username: str) -> List[Dict[str, Any]]:
+        """Return public metadata for a user's registered WebAuthn credentials."""
+        user = self.users.get(username.strip().lower(), {})
+        credentials = user.get("webauthn_credentials") or []
+        return [
+            {
+                "id": c.get("credential_id"),
+                "name": c.get("name") or "Security key",
+                "created": c.get("created"),
+                "last_used": c.get("last_used"),
+                "transports": list(c.get("transports") or []),
+                "backed_up": bool(c.get("backed_up", False)),
+            }
+            for c in credentials
+            if c.get("credential_id")
+        ]
+
+    def webauthn_begin_registration(
+        self,
+        username: str,
+        credential_name: str,
+        rp_id: str,
+        rp_name: str = "Odysseus",
+    ) -> Optional[Dict[str, Any]]:
+        """Generate PublicKeyCredentialCreationOptions for the current user."""
+        username = username.strip().lower()
+        if username not in self.users:
+            return None
+        modules = self._require_webauthn()
+        user_id = self._ensure_webauthn_user_id(username)
+        if not user_id:
+            return None
+
+        credentials = self.users[username].get("webauthn_credentials") or []
+        descriptor = modules["PublicKeyCredentialDescriptor"]
+        exclude_credentials = [
+            descriptor(id=_b64url_decode(c["credential_id"]))
+            for c in credentials
+            if c.get("credential_id")
+        ]
+        selection = modules["AuthenticatorSelectionCriteria"](
+            resident_key=modules["ResidentKeyRequirement"].DISCOURAGED,
+            user_verification=modules["UserVerificationRequirement"].PREFERRED,
+        )
+        options = modules["generate_registration_options"](
+            rp_id=rp_id,
+            rp_name=rp_name,
+            user_id=_b64url_decode(user_id),
+            user_name=username,
+            user_display_name=username,
+            exclude_credentials=exclude_credentials,
+            attestation=modules["AttestationConveyancePreference"].NONE,
+            authenticator_selection=selection,
+        )
+        options_dict = json.loads(modules["options_to_json"](options))
+        name = (credential_name or "").strip()[:80]
+        if not name:
+            name = f"Security key {len(credentials) + 1}"
+        self._config["users"][username]["webauthn_registration_pending"] = {
+            "challenge": options_dict.get("challenge"),
+            "name": name,
+            "rp_id": rp_id,
+            "created": time.time(),
+        }
+        self._save()
+        return options_dict
+
+    def webauthn_finish_registration(
+        self,
+        username: str,
+        credential: Dict[str, Any],
+        expected_origin: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Verify registration response and store a new security key."""
+        username = username.strip().lower()
+        user = self.users.get(username, {})
+        pending = user.get("webauthn_registration_pending") or {}
+        if not pending or time.time() - float(pending.get("created", 0)) > WEBAUTHN_CHALLENGE_TTL:
+            return None
+        modules = self._require_webauthn()
+        try:
+            verification = modules["verify_registration_response"](
+                credential=credential,
+                expected_challenge=_b64url_decode(pending["challenge"]),
+                expected_origin=expected_origin,
+                expected_rp_id=pending["rp_id"],
+                require_user_verification=False,
+            )
+        except Exception as exc:
+            logger.warning("WebAuthn registration verification failed for '%s': %s", username, exc)
+            return None
+
+        credential_id = _b64url_encode(verification.credential_id)
+        credentials = list(user.get("webauthn_credentials") or [])
+        if any(c.get("credential_id") == credential_id for c in credentials):
+            return None
+
+        transports = credential.get("transports")
+        if transports is None:
+            transports = (credential.get("response") or {}).get("transports")
+        stored = {
+            "credential_id": credential_id,
+            "public_key": _b64url_encode(verification.credential_public_key),
+            "sign_count": int(verification.sign_count or 0),
+            "name": pending.get("name") or f"Security key {len(credentials) + 1}",
+            "created": time.time(),
+            "last_used": None,
+            "transports": [str(t) for t in (transports or []) if isinstance(t, str)],
+            "device_type": str(getattr(verification, "credential_device_type", "") or ""),
+            "backed_up": bool(getattr(verification, "credential_backed_up", False)),
+        }
+        credentials.append(stored)
+        self._config["users"][username]["webauthn_credentials"] = credentials
+        self._config["users"][username].pop("webauthn_registration_pending", None)
+        self._save()
+        logger.info("WebAuthn credential added for '%s' (%s)", username, stored["name"])
+        return {
+            "id": stored["credential_id"],
+            "name": stored["name"],
+            "created": stored["created"],
+            "last_used": stored["last_used"],
+            "transports": stored["transports"],
+            "backed_up": stored["backed_up"],
+        }
+
+    def webauthn_begin_authentication(self, username: str, rp_id: str) -> Optional[Dict[str, Any]]:
+        """Generate PublicKeyCredentialRequestOptions for login 2FA."""
+        username = username.strip().lower()
+        if username not in self.users:
+            return None
+        credentials = self.users[username].get("webauthn_credentials") or []
+        if not credentials:
+            return None
+        modules = self._require_webauthn()
+        descriptor = modules["PublicKeyCredentialDescriptor"]
+        allow_credentials = [
+            descriptor(id=_b64url_decode(c["credential_id"]))
+            for c in credentials
+            if c.get("credential_id")
+        ]
+        options = modules["generate_authentication_options"](
+            rp_id=rp_id,
+            allow_credentials=allow_credentials,
+            user_verification=modules["UserVerificationRequirement"].PREFERRED,
+        )
+        options_dict = json.loads(modules["options_to_json"](options))
+        self._config["users"][username]["webauthn_authentication_pending"] = {
+            "challenge": options_dict.get("challenge"),
+            "rp_id": rp_id,
+            "created": time.time(),
+        }
+        self._save()
+        return options_dict
+
+    def webauthn_finish_authentication(
+        self,
+        username: str,
+        credential: Dict[str, Any],
+        expected_origin: str,
+    ) -> bool:
+        """Verify a WebAuthn assertion for login."""
+        username = username.strip().lower()
+        user = self.users.get(username, {})
+        pending = user.get("webauthn_authentication_pending") or {}
+        if not pending or time.time() - float(pending.get("created", 0)) > WEBAUTHN_CHALLENGE_TTL:
+            return False
+        raw_credential_id = credential.get("id") or credential.get("rawId") or ""
+        try:
+            credential_id = _b64url_encode(_b64url_decode(raw_credential_id))
+        except Exception:
+            credential_id = raw_credential_id
+        credentials = list(user.get("webauthn_credentials") or [])
+        stored = next((c for c in credentials if c.get("credential_id") == credential_id), None)
+        if not stored:
+            return False
+
+        modules = self._require_webauthn()
+        try:
+            verification = modules["verify_authentication_response"](
+                credential=credential,
+                expected_challenge=_b64url_decode(pending["challenge"]),
+                expected_origin=expected_origin,
+                expected_rp_id=pending["rp_id"],
+                credential_public_key=_b64url_decode(stored["public_key"]),
+                credential_current_sign_count=int(stored.get("sign_count") or 0),
+                require_user_verification=False,
+            )
+        except Exception as exc:
+            logger.warning("WebAuthn authentication verification failed for '%s': %s", username, exc)
+            return False
+
+        stored["sign_count"] = int(getattr(verification, "new_sign_count", stored.get("sign_count") or 0) or 0)
+        stored["last_used"] = time.time()
+        self._config["users"][username]["webauthn_credentials"] = credentials
+        self._config["users"][username].pop("webauthn_authentication_pending", None)
+        self._save()
+        return True
+
+    def webauthn_delete_credential(self, username: str, credential_id: str, password: str) -> bool:
+        """Delete one WebAuthn credential. Requires password confirmation."""
+        username = username.strip().lower()
+        if username not in self.users:
+            return False
+        if not self.verify_password(username, password):
+            return False
+        try:
+            normalized_id = _b64url_encode(_b64url_decode(credential_id))
+        except Exception:
+            normalized_id = credential_id
+        credentials = list(self.users[username].get("webauthn_credentials") or [])
+        remaining = [c for c in credentials if c.get("credential_id") != normalized_id]
+        if len(remaining) == len(credentials):
+            return False
+        self._config["users"][username]["webauthn_credentials"] = remaining
+        if not remaining:
+            self._config["users"][username].pop("webauthn_authentication_pending", None)
+        self._save()
+        logger.info("WebAuthn credential removed for '%s'", username)
         return True
 
     # ------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       - ODYSSEUS_ADMIN_PASSWORD=${ODYSSEUS_ADMIN_PASSWORD:-}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
       - SECURE_COOKIES=${SECURE_COOKIES:-false}
+      - WEBAUTHN_ORIGIN=${WEBAUTHN_ORIGIN:-http://localhost:7000}
+      - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-localhost}
+      - WEBAUTHN_RP_NAME=${WEBAUTHN_RP_NAME:-odysseus}
       - EMBEDDING_URL=${EMBEDDING_URL:-}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
       - FASTEMBED_MODEL=${FASTEMBED_MODEL:-sentence-transformers/all-MiniLM-L6-v2}

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ bcrypt
 mcp
 pyotp
 qrcode[pil]
+webauthn
 croniter
 pytest
 pytest-asyncio

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Request, Response, HTTPException
 from pydantic import BaseModel
-from typing import Optional
+from typing import Any, Dict, Optional
 import asyncio
 import logging
 import os
@@ -37,6 +37,7 @@ class LoginRequest(BaseModel):
     password: str
     remember: bool = True
     totp_code: Optional[str] = None
+    webauthn_credential: Optional[Dict[str, Any]] = None
 
 
 class SetupRequest(BaseModel):
@@ -70,7 +71,22 @@ class RenameUserRequest(BaseModel):
 class SetOpenRegistrationRequest(BaseModel):
     enabled: bool
 
+
+class WebAuthnRegisterOptionsRequest(BaseModel):
+    name: Optional[str] = None
+
+
+class WebAuthnRegisterVerifyRequest(BaseModel):
+    credential: Dict[str, Any]
+
+
+class WebAuthnDeleteCredentialRequest(BaseModel):
+    password: str
+
 SESSION_COOKIE = "odysseus_session"
+DEFAULT_WEBAUTHN_ORIGIN = "http://localhost:7000"
+DEFAULT_WEBAUTHN_RP_ID = "localhost"
+DEFAULT_WEBAUTHN_RP_NAME = "odysseus"
 
 
 def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
@@ -83,6 +99,33 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
     def _get_current_user(request: Request) -> Optional[str]:
         token = request.cookies.get(SESSION_COOKIE)
         return auth_manager.get_username_for_token(token)
+
+    def _request_origin(request: Request) -> str:
+        configured = (os.getenv("WEBAUTHN_ORIGIN") or DEFAULT_WEBAUTHN_ORIGIN).strip().rstrip("/")
+        if configured:
+            return configured
+        scheme = (request.headers.get("x-forwarded-proto") or request.url.scheme or "http").split(",")[0].strip()
+        host = (request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc).split(",")[0].strip()
+        return f"{scheme}://{host}".rstrip("/")
+
+    def _request_rp_id(request: Request) -> str:
+        configured = (os.getenv("WEBAUTHN_RP_ID") or DEFAULT_WEBAUTHN_RP_ID).strip()
+        if configured:
+            return configured
+        host = (request.headers.get("x-forwarded-host") or request.headers.get("host") or request.url.netloc).split(",")[0].strip()
+        if host.startswith("[") and "]" in host:
+            return host[1:host.index("]")]
+        return host.split(":", 1)[0]
+
+    async def _begin_webauthn_login(username: str, request: Request) -> Optional[Dict[str, Any]]:
+        try:
+            return await asyncio.to_thread(
+                auth_manager.webauthn_begin_authentication,
+                username,
+                _request_rp_id(request),
+            )
+        except RuntimeError as exc:
+            raise HTTPException(503, str(exc)) from exc
 
     @router.post("/setup")
     async def first_run_setup(body: SetupRequest, request: Request):
@@ -124,13 +167,54 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         username = body.username.strip().lower()
         if not await asyncio.to_thread(auth_manager.verify_password, username, body.password):
             raise HTTPException(401, "Invalid credentials")
-        # Check 2FA if enabled
-        if auth_manager.totp_enabled(username):
-            if not body.totp_code:
-                # Password OK but need TOTP — tell client to show code input
-                return {"ok": False, "requires_totp": True, "username": username}
+        # Check 2FA if enabled. TOTP and WebAuthn are alternative second
+        # factors: if the user has both, either a valid code or a valid
+        # security-key assertion can finish the login.
+        totp_enabled = auth_manager.totp_enabled(username) is True
+        webauthn_enabled_fn = getattr(auth_manager, "webauthn_enabled", None)
+        webauthn_enabled = (
+            webauthn_enabled_fn(username) is True
+            if callable(webauthn_enabled_fn)
+            else False
+        )
+        second_factor_required = totp_enabled or webauthn_enabled
+        second_factor_ok = not second_factor_required
+
+        if body.totp_code:
+            if not totp_enabled:
+                raise HTTPException(401, "Invalid 2FA method")
             if not auth_manager.totp_verify(username, body.totp_code):
                 raise HTTPException(401, "Invalid 2FA code")
+            second_factor_ok = True
+
+        if body.webauthn_credential:
+            if not webauthn_enabled:
+                raise HTTPException(401, "Invalid 2FA method")
+            try:
+                second_factor_ok = await asyncio.to_thread(
+                    auth_manager.webauthn_finish_authentication,
+                    username,
+                    body.webauthn_credential,
+                    _request_origin(request),
+                )
+            except RuntimeError as exc:
+                raise HTTPException(503, str(exc)) from exc
+            if not second_factor_ok:
+                raise HTTPException(401, "Invalid security key response")
+
+        if second_factor_required and not second_factor_ok:
+            payload = {
+                "ok": False,
+                "requires_2fa": True,
+                "requires_totp": totp_enabled,
+                "requires_webauthn": webauthn_enabled,
+                "username": username,
+            }
+            if webauthn_enabled:
+                options = await _begin_webauthn_login(username, request)
+                if options:
+                    payload["webauthn_options"] = options
+            return payload
         # All checks passed — create session
         token = await asyncio.to_thread(auth_manager.create_session, username, body.password)
         if not token:
@@ -245,6 +329,70 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         if not user:
             raise HTTPException(401, "Not authenticated")
         return {"enabled": auth_manager.totp_enabled(user)}
+
+    @router.get("/webauthn/status")
+    async def webauthn_status(request: Request):
+        """List the current user's registered WebAuthn credentials."""
+        user = _get_current_user(request)
+        if not user:
+            raise HTTPException(401, "Not authenticated")
+        credentials = auth_manager.webauthn_list_credentials(user)
+        return {"enabled": bool(credentials), "credentials": credentials}
+
+    @router.post("/webauthn/register/options")
+    async def webauthn_register_options(body: WebAuthnRegisterOptionsRequest, request: Request):
+        """Start registering a new security key or passkey for the current user."""
+        user = _get_current_user(request)
+        if not user:
+            raise HTTPException(401, "Not authenticated")
+        try:
+            options = await asyncio.to_thread(
+                auth_manager.webauthn_begin_registration,
+                user,
+                body.name or "",
+                _request_rp_id(request),
+                (os.getenv("WEBAUTHN_RP_NAME") or DEFAULT_WEBAUTHN_RP_NAME).strip() or DEFAULT_WEBAUTHN_RP_NAME,
+            )
+        except RuntimeError as exc:
+            raise HTTPException(503, str(exc)) from exc
+        if not options:
+            raise HTTPException(500, "Failed to start WebAuthn registration")
+        return options
+
+    @router.post("/webauthn/register/verify")
+    async def webauthn_register_verify(body: WebAuthnRegisterVerifyRequest, request: Request):
+        """Finish registering a WebAuthn credential."""
+        user = _get_current_user(request)
+        if not user:
+            raise HTTPException(401, "Not authenticated")
+        try:
+            credential = await asyncio.to_thread(
+                auth_manager.webauthn_finish_registration,
+                user,
+                body.credential,
+                _request_origin(request),
+            )
+        except RuntimeError as exc:
+            raise HTTPException(503, str(exc)) from exc
+        if not credential:
+            raise HTTPException(400, "Security key registration failed")
+        return {"ok": True, "credential": credential}
+
+    @router.delete("/webauthn/credentials/{credential_id}")
+    async def webauthn_delete_credential(credential_id: str, body: WebAuthnDeleteCredentialRequest, request: Request):
+        """Remove one WebAuthn credential from the current user."""
+        user = _get_current_user(request)
+        if not user:
+            raise HTTPException(401, "Not authenticated")
+        ok = await asyncio.to_thread(
+            auth_manager.webauthn_delete_credential,
+            user,
+            credential_id,
+            body.password,
+        )
+        if not ok:
+            raise HTTPException(400, "Invalid password or security key not found")
+        return {"ok": True}
 
     # Admin-only routes
     @router.get("/users")

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -14,6 +14,55 @@ let modalEl = null;
 function el(id) { return document.getElementById(id); }
 function esc(s) { return uiModule.esc(s); }
 
+function b64urlToBuffer(value) {
+  const b64 = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+  const bin = atob(padded);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes.buffer;
+}
+
+function bufferToB64url(buffer) {
+  const bytes = new Uint8Array(buffer || new ArrayBuffer(0));
+  let bin = '';
+  bytes.forEach(b => { bin += String.fromCharCode(b); });
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function webauthnCreateOptions(options) {
+  const publicKey = { ...options };
+  publicKey.challenge = b64urlToBuffer(publicKey.challenge);
+  if (publicKey.user && publicKey.user.id) {
+    publicKey.user = { ...publicKey.user, id: b64urlToBuffer(publicKey.user.id) };
+  }
+  if (Array.isArray(publicKey.excludeCredentials)) {
+    publicKey.excludeCredentials = publicKey.excludeCredentials.map(cred => ({
+      ...cred,
+      id: b64urlToBuffer(cred.id),
+    }));
+  }
+  return publicKey;
+}
+
+function webauthnAttestationToJSON(credential) {
+  const transports = credential.response && credential.response.getTransports
+    ? credential.response.getTransports()
+    : [];
+  return {
+    id: credential.id,
+    rawId: bufferToB64url(credential.rawId),
+    type: credential.type,
+    transports,
+    response: {
+      attestationObject: bufferToB64url(credential.response.attestationObject),
+      clientDataJSON: bufferToB64url(credential.response.clientDataJSON),
+      transports,
+    },
+    clientExtensionResults: credential.getClientExtensionResults ? credential.getClientExtensionResults() : {},
+  };
+}
+
 /* ── Tab switching ── */
 const ADMIN_TABS = new Set(['services', 'integrations', 'tools', 'users', 'system']);
 
@@ -2007,6 +2056,125 @@ function initAccount() {
   // ── Two-Factor Authentication ──
   const tfaContent = el('settings-2fa-content');
   if (tfaContent) {
+    async function renderWebAuthnSection() {
+      const supported = !!(window.PublicKeyCredential && navigator.credentials);
+      let data = { credentials: [] };
+      try {
+        const res = await fetch('/api/auth/webauthn/status', { credentials: 'same-origin' });
+        if (!res.ok) throw new Error('Failed');
+        data = await res.json();
+      } catch (_) {
+        tfaContent.insertAdjacentHTML('beforeend', '<div style="font-size:11px;opacity:0.4;margin-top:12px;">Could not load security keys</div>');
+        return;
+      }
+
+      const credentials = data.credentials || [];
+      const rows = credentials.length ? credentials.map(c => {
+        const when = c.last_used ? `last used ${new Date(c.last_used * 1000).toLocaleString()}` : 'not used yet';
+        return `
+          <div style="display:flex;align-items:center;gap:8px;padding:7px 0;border-top:1px solid color-mix(in srgb,var(--border) 45%,transparent);">
+            <div style="flex:1;min-width:0;">
+              <div style="font-size:12px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${esc(c.name || 'Security key')}</div>
+              <div style="font-size:10px;opacity:0.5;">${esc(when)}</div>
+            </div>
+            <button class="admin-btn-sm webauthn-delete-btn" data-credential-id="${esc(c.id || '')}" data-credential-name="${esc(c.name || 'Security key')}" style="opacity:0.65;">Remove</button>
+          </div>`;
+      }).join('') : '<div style="font-size:11px;opacity:0.5;margin:6px 0;">No security keys registered yet.</div>';
+
+      tfaContent.insertAdjacentHTML('beforeend', `
+        <div style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border);">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
+            <span style="font-size:12px;font-weight:600;">Security keys / passkeys</span>
+            ${credentials.length ? `<span style="font-size:11px;opacity:0.5;">${credentials.length} registered</span>` : ''}
+          </div>
+          <div style="font-size:12px;opacity:0.6;margin-bottom:8px;">Use a hardware security key, phone passkey, or platform authenticator as a login second factor.</div>
+          ${rows}
+          <div class="settings-row" style="gap:6px;margin-top:8px;align-items:center;">
+            <input id="webauthn-key-name" type="text" placeholder="Key name (optional)" autocomplete="off" style="flex:1;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--fg);font-family:inherit;font-size:12px;min-width:0;">
+            <button class="admin-btn-add" id="webauthn-add-btn" ${supported ? '' : 'disabled'}>Add Security Key</button>
+          </div>
+          <div id="webauthn-msg" style="font-size:11px;margin-top:6px;${supported ? '' : 'color:var(--red);'}">${supported ? '' : 'This browser does not support WebAuthn.'}</div>
+        </div>`);
+
+      const msg = el('webauthn-msg');
+      const addBtn = el('webauthn-add-btn');
+      if (addBtn && supported) {
+        addBtn.addEventListener('click', async () => {
+          msg.textContent = '';
+          msg.style.color = '';
+          addBtn.disabled = true;
+          try {
+            const name = (el('webauthn-key-name') && el('webauthn-key-name').value.trim()) || '';
+            const optRes = await fetch('/api/auth/webauthn/register/options', {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name }),
+            });
+            const options = await optRes.json();
+            if (!optRes.ok) throw new Error(options.detail || 'Failed to start registration');
+            const credential = await navigator.credentials.create({ publicKey: webauthnCreateOptions(options) });
+            if (!credential) throw new Error('Security key registration was cancelled');
+            const verifyRes = await fetch('/api/auth/webauthn/register/verify', {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ credential: webauthnAttestationToJSON(credential) }),
+            });
+            const verified = await verifyRes.json();
+            if (!verifyRes.ok) throw new Error(verified.detail || 'Security key registration failed');
+            msg.style.color = 'var(--green)';
+            msg.textContent = 'Security key added';
+            render2FA();
+          } catch (e) {
+            msg.style.color = 'var(--red)';
+            msg.textContent = e.message || 'Security key registration failed';
+          } finally {
+            addBtn.disabled = false;
+          }
+        });
+      }
+
+      tfaContent.querySelectorAll('.webauthn-delete-btn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const credentialId = btn.dataset.credentialId;
+          const keyName = btn.dataset.credentialName || 'this passkey';
+          const password = await uiModule.styledPrompt(
+            `Enter your password to remove "${keyName}".`,
+            {
+              title: 'Remove Passkey',
+              placeholder: 'Current password',
+              inputType: 'password',
+              confirmText: 'Remove',
+              cancelText: 'Cancel',
+              maxLength: 256,
+            },
+          );
+          if (!password) return;
+          btn.disabled = true;
+          try {
+            const res = await fetch(`/api/auth/webauthn/credentials/${encodeURIComponent(credentialId)}`, {
+              method: 'DELETE',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ password }),
+            });
+            if (!res.ok) {
+              const d = await res.json();
+              throw new Error(d.detail || 'Failed to remove security key');
+            }
+            render2FA();
+          } catch (e) {
+            if (msg) {
+              msg.style.color = 'var(--red)';
+              msg.textContent = e.message || 'Failed to remove security key';
+            }
+            btn.disabled = false;
+          }
+        });
+      });
+    }
+
     async function render2FA() {
       try {
         const res = await fetch('/api/auth/2fa/status', { credentials: 'same-origin' });
@@ -2093,6 +2261,7 @@ function initAccount() {
             } catch (e) { msg.textContent = e.message; msg.style.color = 'var(--red)'; }
           });
         }
+        await renderWebAuthnSection();
       } catch (_) {
         tfaContent.innerHTML = '<div style="font-size:11px;opacity:0.4;">Could not load 2FA status</div>';
       }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -655,6 +655,7 @@ export function styledPrompt(message, {
   title = 'Name',
   defaultValue = '',
   placeholder = '',
+  inputType = 'text',
   confirmText = 'Save',
   cancelText = 'Cancel',
   maxLength = 80,
@@ -691,6 +692,8 @@ export function styledPrompt(message, {
     msgEl.style.display = message ? '' : 'none';
     input.value = defaultValue || '';
     input.placeholder = placeholder || '';
+    input.type = inputType || 'text';
+    input.autocomplete = input.type === 'password' ? 'current-password' : 'off';
     input.maxLength = maxLength;
     okBtn.textContent = confirmText;
     cancelBtn.textContent = cancelText;

--- a/static/login.html
+++ b/static/login.html
@@ -318,6 +318,58 @@
   let mode = 'login'; // 'login' | 'signup' | 'setup'
   let signupAllowed = false;
 
+  function b64urlToBuffer(value) {
+    const b64 = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const bin = atob(padded);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytes.buffer;
+  }
+
+  function bufferToB64url(buffer) {
+    const bytes = new Uint8Array(buffer || new ArrayBuffer(0));
+    let bin = '';
+    bytes.forEach(b => { bin += String.fromCharCode(b); });
+    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  }
+
+  function webauthnGetOptions(options) {
+    const publicKey = { ...options };
+    publicKey.challenge = b64urlToBuffer(publicKey.challenge);
+    if (Array.isArray(publicKey.allowCredentials)) {
+      publicKey.allowCredentials = publicKey.allowCredentials.map(cred => ({
+        ...cred,
+        id: b64urlToBuffer(cred.id),
+      }));
+    }
+    return publicKey;
+  }
+
+  function webauthnAssertionToJSON(credential) {
+    return {
+      id: credential.id,
+      rawId: bufferToB64url(credential.rawId),
+      type: credential.type,
+      response: {
+        authenticatorData: bufferToB64url(credential.response.authenticatorData),
+        clientDataJSON: bufferToB64url(credential.response.clientDataJSON),
+        signature: bufferToB64url(credential.response.signature),
+        userHandle: credential.response.userHandle ? bufferToB64url(credential.response.userHandle) : null,
+      },
+      clientExtensionResults: credential.getClientExtensionResults ? credential.getClientExtensionResults() : {},
+    };
+  }
+
+  async function getWebAuthnAssertion(options) {
+    if (!window.PublicKeyCredential || !navigator.credentials) {
+      throw new Error('Security keys are not supported in this browser');
+    }
+    const credential = await navigator.credentials.get({ publicKey: webauthnGetOptions(options) });
+    if (!credential) throw new Error('Security key verification was cancelled');
+    return webauthnAssertionToJSON(credential);
+  }
+
   const rememberToggle = document.getElementById('rememberToggle');
 
   function setMode(m) {
@@ -379,24 +431,25 @@
 
     const username = document.getElementById('username').value.trim();
     const password = document.getElementById('password').value;
+    const remember = document.getElementById('remember').checked;
 
-    // If in TOTP mode, handle the code submission directly
-    if (form._totpMode) {
-      const totpInput = document.getElementById('totp-input');
-      const code = totpInput ? totpInput.value.trim() : '';
-      if (!code) { totpInput.focus(); submitBtn.disabled = false; return; }
-      const remember = document.getElementById('remember').checked;
+    if (form._secondFactorMode) {
       try {
-        const res = await fetch('/api/auth/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'same-origin',
-          body: JSON.stringify({ username, password, remember, totp_code: code })
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.detail || 'Invalid code');
+        if (form._webauthnOnly) {
+          if (!form._webauthnOptions) throw new Error('Security key challenge is missing');
+          const assertion = await getWebAuthnAssertion(form._webauthnOptions);
+          const data = await doLogin(null, assertion);
+          if (!data.ok) throw new Error('Login failed');
+          form._secondFactorMode = false;
+          finishLogin();
+          return;
+        }
+        const totpInput = document.getElementById('totp-input');
+        const code = totpInput ? totpInput.value.trim() : '';
+        if (!code) { if (totpInput) totpInput.focus(); submitBtn.disabled = false; return; }
+        const data = await doLogin(code, null);
         if (!data.ok) throw new Error('Login failed');
-        form._totpMode = false;
+        form._secondFactorMode = false;
         finishLogin();
       } catch (err) {
         errEl.textContent = err.message;
@@ -444,7 +497,6 @@
     }
 
     // Login (auto-login after setup/signup too)
-    const remember = document.getElementById('remember').checked;
     function finishLogin() {
       const _rem = document.getElementById('remember').checked;
       if (_rem) localStorage.setItem('odysseus-last-user', username);
@@ -462,9 +514,10 @@
         sessionStorage.setItem('ody-prefetch-settings', JSON.stringify(sett));
       }).catch(() => {}).finally(() => { window.location.replace('/'); });
     }
-    async function doLogin(totpCode) {
+    async function doLogin(totpCode, webauthnCredential) {
       const loginBody = { username, password, remember };
       if (totpCode) loginBody.totp_code = totpCode;
+      if (webauthnCredential) loginBody.webauthn_credential = webauthnCredential;
       const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -477,20 +530,53 @@
     }
     try {
       let data = await doLogin();
-      // 2FA required — show TOTP input
-      if (data.requires_totp) {
+      if (data.requires_2fa || data.requires_totp || data.requires_webauthn) {
         submitBtn.disabled = false;
-        // Only add TOTP input once
-        if (document.getElementById('totp-input')) return;
-        form._totpMode = true;
-        const totpWrap = document.createElement('div');
-        totpWrap.style.cssText = 'margin-top:12px;';
-        totpWrap.innerHTML = '<label for="totp-input" style="font-size:0.85em;opacity:0.7;display:block;margin-bottom:4px;">2FA Code</label><input type="text" id="totp-input" placeholder="Enter 6-digit code" aria-label="Two-factor authentication code" autocomplete="one-time-code" inputmode="numeric" maxlength="8" style="width:100%;padding:10px 12px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:8px;font-size:14px;box-sizing:border-box;text-align:center;letter-spacing:4px;">';
+        if (document.getElementById('second-factor-wrap')) return;
+        form._secondFactorMode = true;
+        form._webauthnOptions = data.webauthn_options || null;
+        form._webauthnOnly = !!data.requires_webauthn && !data.requires_totp;
+        const secondFactorWrap = document.createElement('div');
+        secondFactorWrap.id = 'second-factor-wrap';
+        secondFactorWrap.style.cssText = 'margin-top:12px;';
+        let html = '<div style="font-size:0.85em;opacity:0.72;margin-bottom:8px;">Finish signing in with a second factor</div>';
+        if (data.requires_webauthn && data.requires_totp) {
+          html += '<button type="button" id="webauthn-login-btn" style="margin-bottom:10px;">Use Passkey</button>';
+          html += '<div style="display:flex;align-items:center;gap:8px;margin:2px 0 10px;opacity:0.55;font-size:11px;"><span style="height:1px;background:var(--border);flex:1;"></span><span>or use authenticator app</span><span style="height:1px;background:var(--border);flex:1;"></span></div>';
+        } else if (data.requires_webauthn) {
+          html += '<div style="font-size:12px;opacity:0.6;margin-bottom:8px;">Use your passkey, hardware key, or platform authenticator.</div>';
+        }
+        if (data.requires_totp) {
+          html += '<label for="totp-input" style="font-size:0.85em;opacity:0.7;display:block;margin-bottom:4px;">Authenticator code</label><input type="text" id="totp-input" placeholder="Enter 6-digit code" aria-label="Two-factor authentication code" autocomplete="one-time-code" inputmode="numeric" maxlength="8" style="width:100%;padding:10px 12px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:8px;font-size:14px;box-sizing:border-box;text-align:center;letter-spacing:4px;margin-bottom:8px;">';
+        }
+        secondFactorWrap.innerHTML = html;
         const formEl = submitBtn.parentElement;
-        formEl.insertBefore(totpWrap, submitBtn);
+        formEl.insertBefore(secondFactorWrap, submitBtn);
         const totpInput = document.getElementById('totp-input');
-        totpInput.focus();
-        submitBtn.textContent = 'Verify';
+        submitBtn.textContent = form._webauthnOnly ? 'Use Passkey' : 'Verify Authenticator Code';
+        const webauthnBtn = document.getElementById('webauthn-login-btn');
+        if (webauthnBtn) webauthnBtn.focus();
+        else if (totpInput) totpInput.focus();
+        if (webauthnBtn) {
+          webauthnBtn.addEventListener('click', async () => {
+            errEl.style.display = 'none';
+            webauthnBtn.disabled = true;
+            submitBtn.disabled = true;
+            try {
+              if (!form._webauthnOptions) throw new Error('Security key challenge is missing');
+              const assertion = await getWebAuthnAssertion(form._webauthnOptions);
+              const result = await doLogin(null, assertion);
+              if (!result.ok) throw new Error('Login failed');
+              form._secondFactorMode = false;
+              finishLogin();
+            } catch (err) {
+              errEl.textContent = err.message;
+              errEl.style.display = 'block';
+              webauthnBtn.disabled = false;
+              submitBtn.disabled = false;
+            }
+          });
+        }
         return;
       }
       finishLogin();

--- a/static/style.css
+++ b/static/style.css
@@ -5022,6 +5022,9 @@ body.bg-pattern-sparkles {
       outline:none;
       transition: border-color 0.15s, box-shadow 0.15s;
     }
+    .styled-prompt-input[type="password"] {
+      margin-bottom:8px;
+    }
     .styled-prompt-input:focus {
       border-color: var(--accent-primary, var(--red, #4a9eff));
       box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary, var(--red, #4a9eff)) 25%, transparent);

--- a/tests/test_webauthn_2fa.py
+++ b/tests/test_webauthn_2fa.py
@@ -1,0 +1,94 @@
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _real_core_package():
+    root = Path(__file__).resolve().parent.parent
+    core_path = str(root / "core")
+    core = sys.modules.get("core")
+    if core is None:
+        core = types.ModuleType("core")
+        sys.modules["core"] = core
+    core.__path__ = [core_path]
+    if hasattr(core, "auth"):
+        delattr(core, "auth")
+    sys.modules.pop("core.auth", None)
+    return core
+
+
+def _auth_module():
+    _real_core_package()
+    return importlib.import_module("core.auth")
+
+
+def test_webauthn_credentials_are_per_user_and_removable(tmp_path):
+    auth_mod = _auth_module()
+    auth_mod._hash_password = lambda password: f"hash:{password}"
+    auth_mod._verify_password = lambda password, hashed: hashed == f"hash:{password}"
+
+    mgr = auth_mod.AuthManager(str(tmp_path / "auth.json"))
+    assert mgr.create_user("alice", "alice-password") is True
+    assert mgr.create_user("bob", "bob-password") is True
+
+    mgr._config["users"]["alice"]["webauthn_credentials"] = [
+        {"credential_id": "YWxpY2UtMQ", "name": "Alice laptop", "created": 1},
+        {"credential_id": "YWxpY2UtMg", "name": "Alice backup", "created": 2},
+    ]
+    mgr._config["users"]["bob"]["webauthn_credentials"] = [
+        {"credential_id": "Ym9iLTE", "name": "Bob key", "created": 3},
+    ]
+    mgr._save()
+
+    assert mgr.webauthn_enabled("alice") is True
+    assert [c["name"] for c in mgr.webauthn_list_credentials("alice")] == ["Alice laptop", "Alice backup"]
+    assert [c["name"] for c in mgr.webauthn_list_credentials("bob")] == ["Bob key"]
+
+    assert mgr.webauthn_delete_credential("alice", "YWxpY2UtMQ", "wrong-password") is False
+    assert mgr.webauthn_delete_credential("alice", "Ym9iLTE", "alice-password") is False
+    assert mgr.webauthn_delete_credential("alice", "YWxpY2UtMQ", "alice-password") is True
+
+    assert [c["id"] for c in mgr.webauthn_list_credentials("alice")] == ["YWxpY2UtMg"]
+    assert [c["id"] for c in mgr.webauthn_list_credentials("bob")] == ["Ym9iLTE"]
+
+
+def test_login_password_stage_returns_webauthn_challenge():
+    from routes.auth_routes import LoginRequest, setup_auth_routes
+
+    auth = MagicMock()
+    auth.verify_password.return_value = True
+    auth.totp_enabled.return_value = False
+    auth.webauthn_enabled.return_value = True
+    auth.webauthn_begin_authentication.return_value = {
+        "challenge": "abc",
+        "allowCredentials": [{"id": "cred", "type": "public-key"}],
+    }
+
+    router = setup_auth_routes(auth)
+    login = next(
+        r.endpoint
+        for r in router.routes
+        if getattr(r, "path", None) == "/api/auth/login" and "POST" in getattr(r, "methods", set())
+    )
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.10"),
+        cookies={},
+        headers={"host": "localhost:7000"},
+        url=SimpleNamespace(scheme="http", netloc="localhost:7000"),
+    )
+    response = MagicMock()
+    body = LoginRequest(username="alice", password="alice-password", remember=True)
+
+    result = asyncio.run(login(body=body, request=request, response=response))
+
+    assert result["ok"] is False
+    assert result["requires_2fa"] is True
+    assert result["requires_webauthn"] is True
+    assert result["requires_totp"] is False
+    assert result["webauthn_options"]["challenge"] == "abc"
+    auth.create_session.assert_not_called()
+    response.set_cookie.assert_not_called()


### PR DESCRIPTION
## Summary

Adds WebAuthn/passkey support as a two-factor authentication option for Odysseus.

Users can register hardware security keys or platform passkeys, manage multiple credentials from settings, and use a passkey during login as an alternative to an authenticator app code.

## Changed Areas

- Added WebAuthn registration, authentication, credential listing, and removal in the auth backend
- Added per-user storage for multiple WebAuthn credentials in `data/auth.json`
- Added WebAuthn API routes for setup, login verification, status, and credential deletion
- Updated the login 2FA flow so passkeys and authenticator codes are presented more clearly
- Added passkey management UI in settings
- Added default WebAuthn development config for `odysseus` on `localhost:7000`
- Added focused WebAuthn auth tests

## Testing

```bash
python -m py_compile core/auth.py routes/auth_routes.py
node --check static/js/settings.js
node --check static/js/ui.js
git diff --check
```

Recommended before merge:

```bash
python -m pytest tests/test_webauthn_2fa.py tests/test_auth_event_loop.py tests/test_auth_session_revocation.py
docker compose config
```

## Screenshots

Passkey setup in settings:

![Passkey setup](https://github.com/user-attachments/assets/75fdb8ec-b0b9-447b-9b42-9fb427ca92de)

Passkey removal dialog:

![Passkey removal dialog](https://github.com/user-attachments/assets/0d3bb0f4-bce9-48fb-8cf8-4f0bbf69c9b0)

Login with passkey 2FA:

![Passkey login](https://github.com/user-attachments/assets/0f8167f5-1cc6-4cbf-94b8-48f85abb422e)

Enter Passkey (Windows passkey in my case):

![Passkey enter](https://github.com/user-attachments/assets/ed8b202c-65c4-4008-b3d6-02633fa28d9b)

## Related Issues

Resolves #681