### PR TITLE
Add check-only software update status

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Use that for the first login, then change it in **Settings**.
 Contributing? See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and
 pull request guidelines.
 
+For update status, release channels, and manual update commands, see
+[docs/UPDATING.md](docs/UPDATING.md).
+
 ### Docker (recommended)
 ```bash
 git clone https://github.com/pewdiepie-archdaemon/odysseus.git

--- a/app.py
+++ b/app.py
@@ -530,6 +530,8 @@ app.include_router(setup_session_routes(session_manager, session_config, webhook
 # Admin Danger Zone wipes (Settings → System → Danger Zone)
 from routes.admin_wipe_routes import setup_admin_wipe_routes
 app.include_router(setup_admin_wipe_routes(session_manager))
+from routes.update_status_routes import setup_update_status_routes
+app.include_router(setup_update_status_routes())
 
 # Memory
 from routes.memory_routes import setup_memory_routes

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,0 +1,94 @@
+# Updating Odysseus
+
+Odysseus is still early in its release lifecycle. For now, updates are manual.
+
+In-app update status is **check-only** only. The status card in `Settings > System`
+shows observed version/commit state and manual commands, but it does not download,
+apply, or restart automatically.
+
+## Current recommendation: source-based installs
+
+If you installed from source (Docker, Linux/macOS, or Windows), treat updates as
+`git`-driven refreshes.
+
+### 1) Source Docker install (recommended today)
+
+From your checkout:
+
+```bash
+cd /path/to/odysseus
+git fetch --prune
+git pull --ff-only
+docker compose up -d --build
+```
+
+Use `docker compose logs --tail=120 odysseus` to confirm the container restarted
+with the new commit.
+
+### 2) Native source installs (Linux and macOS)
+
+Use the same checkout workflow from your native terminal:
+
+```bash
+cd /path/to/odysseus
+git pull --ff-only
+python -m pip install -r requirements.txt
+python setup.py
+```
+
+Restart your process (`start-macos.sh`, your service manager, or your own
+`uvicorn` command) so the updated code is loaded.
+
+### 3) Native Windows source update
+
+From PowerShell in your checkout:
+
+```powershell
+Set-Location C:\path\to\odysseus
+git pull --ff-only
+powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1
+```
+
+If you need a fully manual flow, run `git pull --ff-only`, update dependencies
+(`python -m pip install -r requirements.txt`), and restart `python -m uvicorn ...`
+with your normal launch command.
+
+## Future/alternate release channels
+
+### 4) Prebuilt Docker image (future)
+
+A release-image path is not the primary flow for this PR scope. When official image
+tags are published, updates should follow:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Watch your compose file for the correct image tag/repository at that time.
+
+### 5) Windows portable/desktop releases
+
+Desktop-focused release artifacts (portable zip / installer) should be handled as
+a separate channel if they are published. For that style of release, the update
+flow is usually:
+
+- Download the latest released package from GitHub Releases.
+- Stop the running app, then replace the app bundle/folder and start the new version.
+- Preserve your `data/` directory and local config when replacing files.
+
+### 6) Package-manager wrappers (later)
+
+Package-manager installers (for example Homebrew, Scoop, Chocolatey, etc.) are
+outside the supported baseline today. They are expected to wrap one of the
+channels above and still require manual update commands after installation.
+
+## Branch and mode notes
+
+For source installs, stick to a branch you track (typically `main`) to keep
+`git pull --ff-only` behavior predictable. If you are on a detached HEAD or a
+custom branch, follow your normal workflow for review and updates instead of
+running a blind pull.
+
+If unsure which path you are on, use the Settings `System` check view to verify
+the current mode before running an update.

--- a/routes/update_status_routes.py
+++ b/routes/update_status_routes.py
@@ -1,0 +1,349 @@
+"""Update-status routes — check-only software update state probes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse, urlunparse
+import os
+import subprocess
+
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+from core.constants import APP_VERSION, BASE_DIR
+
+
+GIT_TIMEOUT_SECONDS = 1.8
+
+_MODE_COMMANDS = {
+    "source_docker": [
+        "git fetch --prune",
+        "git pull --ff-only",
+        "docker compose up -d --build",
+    ],
+    "source_native": [
+        "git pull --ff-only",
+        "python -m pip install -r requirements.txt",
+        "python setup.py",
+    ],
+    "prebuilt_docker": [
+        "docker compose pull",
+        "docker compose up -d",
+    ],
+}
+
+
+def _scrub_remote_url(remote_url: Optional[str]) -> Optional[str]:
+    """Remove credentials from a git remote URL so tokens are never returned."""
+    if not remote_url:
+        return None
+
+    remote_url = remote_url.strip()
+    if "://" not in remote_url:
+        # scp-style URLs like git@host:owner/repo.git are returned untouched.
+        return remote_url
+
+    parsed = urlparse(remote_url)
+    if not (parsed.username or parsed.password):
+        return remote_url
+
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    parsed = parsed._replace(netloc=netloc)
+    return urlunparse(parsed)
+
+
+def _remote_url_allowed(remote_url: Optional[str]) -> bool:
+    """Return True for normal git remotes that are safe to inspect."""
+    if not remote_url:
+        return False
+    value = remote_url.strip()
+    if not value:
+        return False
+    if "://" in value:
+        scheme = urlparse(value).scheme.lower()
+        return scheme in {"https", "http", "ssh", "git"}
+    # SCP-style SSH remotes, for example git@github.com:owner/repo.git.
+    return "@" in value and ":" in value and not value.startswith(("/", "."))
+
+
+def _run_git(cwd: str, args: list[str], timeout: float = GIT_TIMEOUT_SECONDS) -> Dict[str, Any]:
+    """Run a fixed git command against a checkout with a bounded timeout."""
+    try:
+        env = os.environ.copy()
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env.setdefault("GIT_SSH_COMMAND", "ssh -oBatchMode=yes")
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+            env=env,
+        )
+        return {
+            "ok": True,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except FileNotFoundError as exc:
+        return {"ok": False, "error": "git_missing", "details": str(exc)}
+    except subprocess.TimeoutExpired as exc:
+        return {"ok": False, "error": "timeout", "details": str(exc)}
+    except Exception as exc:  # pragma: no cover - defensive.
+        return {"ok": False, "error": "unexpected", "details": str(exc)}
+
+
+def _run_output(cwd: str, args: list[str], *, command_name: str, base: dict[str, Any], timeout_tag: str) -> Optional[str]:
+    """Run a git command and record timeout/error info in `base`."""
+    result = _run_git(cwd, args)
+    if not result.get("ok"):
+        if result.get("error") == "timeout":
+            base["git"]["timeouts"].append(timeout_tag)
+        else:
+            base["git"]["errors"].append(f"{command_name} failed")
+        return None
+    if result.get("returncode") != 0:
+        return None
+    return (result.get("stdout") or "").strip()
+
+
+def _parse_head_offset(raw: Optional[str]) -> tuple[Optional[int], Optional[int]]:
+    """Parse `rev-list --left-right --count` output into (ahead, behind)."""
+    if not raw:
+        return None, None
+    parts = raw.split()
+    if len(parts) != 2:
+        return None, None
+    if not parts[0].isdigit() or not parts[1].isdigit():
+        return None, None
+    return int(parts[0]), int(parts[1])
+
+
+def _parse_for_each_ref(raw: Optional[str]) -> Dict[str, str]:
+    """Parse `for-each-ref --format='%(refname:short) %(upstream:short)'` output."""
+    mapping: Dict[str, str] = {}
+    if not raw:
+        return mapping
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        local, _, upstream = line.partition(" ")
+        if local and upstream:
+            mapping[local] = upstream.strip()
+    return mapping
+
+
+def _detect_install_mode(git_available: bool, repo_dir: str, in_container: bool) -> str:
+    has_compose = os.path.exists(os.path.join(repo_dir, "docker-compose.yml"))
+    if git_available and has_compose:
+        return "source_docker"
+    if git_available:
+        return "source_native"
+    if in_container:
+        return "prebuilt_docker"
+    return "source_native"
+
+
+def _collect_update_status(repo_dir: str | None = None) -> Dict[str, Any]:
+    repo_dir = os.path.abspath(repo_dir or BASE_DIR)
+    in_container = os.path.exists("/.dockerenv")
+
+    base: Dict[str, Any] = {
+        "version": APP_VERSION,
+        "git": {
+            "available": False,
+            "commit": None,
+            "branch": None,
+            "detached_head": False,
+            "dirty": None,
+            "upstream": {
+                "remote": None,
+                "remote_branch": None,
+                "remote_url_scrubbed": None,
+                "tracking_configured": False,
+            },
+            "remote": {
+                "sha": None,
+            },
+            "ahead": None,
+            "behind": None,
+            "warnings": [],
+            "errors": [],
+            "timeouts": [],
+        },
+        "install": {
+            "mode_guess": None,
+            "manual_update_commands": [],
+            "manual_update_commands_by_mode": dict(_MODE_COMMANDS),
+        },
+    }
+
+    toplevel = _run_output(
+        repo_dir,
+        ["rev-parse", "--show-toplevel"],
+        command_name="rev-parse --show-toplevel",
+        base=base,
+        timeout_tag="rev-parse --show-toplevel",
+    )
+    if not toplevel:
+        base["install"]["mode_guess"] = _detect_install_mode(False, repo_dir, in_container)
+        base["install"]["manual_update_commands"] = _MODE_COMMANDS[base["install"]["mode_guess"]]
+        if not base["git"]["errors"]:
+            base["git"]["errors"].append("Repository is not a git checkout.")
+            base["git"]["warnings"].append("Git state unavailable; no repository metadata.")
+        return base
+
+    base["git"]["available"] = True
+
+    commit = _run_output(
+        repo_dir,
+        ["rev-parse", "--short", "HEAD"],
+        command_name="rev-parse --short HEAD",
+        base=base,
+        timeout_tag="rev-parse --short HEAD",
+    )
+    if commit:
+        base["git"]["commit"] = commit
+
+    branch = _run_output(
+        repo_dir,
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        command_name="rev-parse --abbrev-ref HEAD",
+        base=base,
+        timeout_tag="rev-parse --abbrev-ref HEAD",
+    )
+    if branch:
+        base["git"]["branch"] = branch
+        base["git"]["detached_head"] = branch == "HEAD"
+    else:
+        base["git"]["warnings"].append("Unable to resolve current HEAD branch.")
+
+    status = _run_output(
+        repo_dir,
+        ["status", "--porcelain"],
+        command_name="status --porcelain",
+        base=base,
+        timeout_tag="status --porcelain",
+    )
+    if status is not None:
+        base["git"]["dirty"] = bool(status.strip())
+    else:
+        base["git"]["dirty"] = None
+
+    if branch and not base["git"]["detached_head"]:
+        branch_remote = _run_output(
+            repo_dir,
+            ["config", "--get", f"branch.{branch}.remote"],
+            command_name="config --get branch.<branch>.remote",
+            base=base,
+            timeout_tag="config --get branch remote",
+        )
+        branch_merge = _run_output(
+            repo_dir,
+            ["config", "--get", f"branch.{branch}.merge"],
+            command_name="config --get branch.<branch>.merge",
+            base=base,
+            timeout_tag="config --get branch merge",
+        )
+        if branch_merge and branch_merge.startswith("refs/heads/"):
+            branch_merge = branch_merge.replace("refs/heads/", "", 1)
+
+        for_each_ref = _run_output(
+            repo_dir,
+            ["for-each-ref", "--format=%(refname:short) %(upstream:short)", "refs/heads"],
+            command_name="for-each-ref upstream mapping",
+            base=base,
+            timeout_tag="for-each-ref",
+        )
+        for_each_map = _parse_for_each_ref(for_each_ref)
+
+        upstream = None
+        if branch in for_each_map:
+            upstream = for_each_map[branch]
+        if not branch_remote and upstream and "/" in upstream:
+            branch_remote = upstream.split("/", 1)[0]
+            if not branch_merge:
+                branch_merge = upstream.split("/", 1)[1]
+        if branch_remote and branch_merge:
+            upstream = f"{branch_remote}/{branch_merge}"
+
+        if branch_remote:
+            base["git"]["upstream"]["remote"] = branch_remote
+        if upstream:
+            base["git"]["upstream"]["tracking_configured"] = True
+            if branch_merge:
+                base["git"]["upstream"]["remote_branch"] = branch_merge
+            else:
+                base["git"]["upstream"]["remote_branch"] = upstream.split("/", 1)[1] if "/" in upstream else upstream
+
+            remote_url = _run_output(
+                repo_dir,
+                ["config", "--get", f"remote.{branch_remote}.url"],
+                command_name="config --get remote URL",
+                base=base,
+                timeout_tag="config --get remote url",
+            )
+            if remote_url:
+                scrubbed_remote = _scrub_remote_url(remote_url)
+                base["git"]["upstream"]["remote_url_scrubbed"] = scrubbed_remote
+
+            remote_ref = branch_merge or upstream.split("/", 1)[-1]
+            if remote_url and not _remote_url_allowed(remote_url):
+                base["git"]["warnings"].append("Remote URL scheme is not supported for update checks.")
+            elif branch_remote and remote_ref:
+                remote_head = _run_output(
+                    repo_dir,
+                    ["ls-remote", "--heads", branch_remote, remote_ref],
+                    command_name="ls-remote --heads",
+                    base=base,
+                    timeout_tag="ls-remote --heads",
+                )
+                if remote_head:
+                    base["git"]["remote"]["sha"] = remote_head.split()[0]
+
+            ahead_behind = _run_output(
+                repo_dir,
+                ["rev-list", "--left-right", "--count", "HEAD...@{u}"],
+                command_name="rev-list --left-right --count",
+                base=base,
+                timeout_tag="rev-list --left-right --count",
+            )
+            if ahead_behind:
+                ahead, behind = _parse_head_offset(ahead_behind)
+                base["git"]["ahead"] = ahead
+                base["git"]["behind"] = behind
+        else:
+            base["git"]["warnings"].append("No upstream tracking branch configured.")
+    else:
+        if branch:
+            base["git"]["warnings"].append("Detached HEAD; no branch-level update checks available.")
+
+    if not base["git"]["warnings"]:
+        if base["git"]["dirty"]:
+            base["git"]["warnings"].append("Repository contains uncommitted changes.")
+
+    if base["git"]["detached_head"]:
+        base["git"]["upstream"]["tracking_configured"] = False
+
+    base["install"]["mode_guess"] = _detect_install_mode(base["git"]["available"], repo_dir, in_container)
+    base["install"]["manual_update_commands"] = _MODE_COMMANDS[base["install"]["mode_guess"]]
+
+    return base
+
+
+def setup_update_status_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+    @router.get("/update/status")
+    def get_update_status(request: Request) -> Dict[str, Any]:
+        """Check-only software-update observability for admin users."""
+        require_admin(request)
+        return _collect_update_status()
+
+    return router

--- a/static/index.html
+++ b/static/index.html
@@ -2138,6 +2138,40 @@
         <div data-settings-panel="system" class="hidden">
 
           <div class="admin-card">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M4 7h16M4 11h16M4 15h9M13 15l7 7M13 22l7-7M13 15l7-7"/></svg>Software Update</h2>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Check your install and copy manual update commands without changing anything.</div>
+            <div id="adm-updateStatus" class="settings-col">
+              <div class="settings-row" style="align-items:flex-start;flex-wrap:wrap;gap:6px 10px;">
+                <label class="settings-label">Version</label>
+                <div id="adm-updateVersion" style="font-size:12px;word-break:break-word;flex:1;min-width:0;">Loading…</div>
+              </div>
+              <div class="settings-row" style="align-items:flex-start;flex-wrap:wrap;gap:6px 10px;">
+                <label class="settings-label">Install mode</label>
+                <div id="adm-updateMode" style="font-size:12px;word-break:break-word;flex:1;min-width:0;">Loading…</div>
+              </div>
+              <div class="settings-row" style="align-items:flex-start;flex-wrap:wrap;gap:6px 10px;">
+                <label class="settings-label">Commit</label>
+                <div id="adm-updateCommit" style="font-size:12px;word-break:break-word;flex:1;min-width:0;">Loading…</div>
+              </div>
+              <div class="settings-row" style="align-items:flex-start;flex-wrap:wrap;gap:6px 10px;">
+                <label class="settings-label">Branch</label>
+                <div id="adm-updateBranch" style="font-size:12px;word-break:break-word;flex:1;min-width:0;">Loading…</div>
+              </div>
+              <div class="settings-row" style="align-items:flex-start;flex-wrap:wrap;gap:6px 10px;">
+                <label class="settings-label">Remote</label>
+                <div id="adm-updateRemote" style="font-size:12px;word-break:break-word;flex:1;min-width:0;">Loading…</div>
+              </div>
+              <div style="display:flex;flex-wrap:wrap;gap:6px;" id="adm-updateWarnings"></div>
+              <div class="settings-row" style="justify-content:flex-end;margin-top:2px;">
+                <button type="button" class="admin-btn-add" id="adm-updateRefresh">Check</button>
+              </div>
+              <div id="adm-updateCommandsLabel" style="font-size:11px;opacity:0.55;margin-top:2px;">Manual commands</div>
+              <div id="adm-updateCommands" style="display:flex;flex-direction:column;gap:8px"></div>
+              <div id="adm-updateMsg" class="admin-empty" style="margin-top:4px;"></div>
+            </div>
+          </div>
+
+          <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>Data Backup</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">Export or import your user data (memories, presets, settings, skills, preferences) as a JSON file.</div>
             <div style="display:flex;gap:8px;flex-wrap:wrap;">

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1954,6 +1954,215 @@ function initCalDAV() {
   });
 }
 
+/* ── System tab — Software Update ── */
+let _updateStatusInited = false;
+
+function _shortSha(v) {
+  if (!v || typeof v !== 'string') return '—';
+  return v.length <= 11 ? v : `${v.slice(0, 7)}…`;
+}
+
+function _pushWarnings(target, values) {
+  if (!target) return;
+  if (!Array.isArray(values)) return;
+  values.forEach((value) => {
+    if (!value || typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (trimmed) target.push(trimmed);
+  });
+}
+
+function _setText(id, value, fallback = '—') {
+  const ref = el(id);
+  if (!ref) return;
+  ref.textContent = value || fallback;
+}
+
+function _formatUpdateMode(mode) {
+  const labels = {
+    source_docker: 'Source checkout with Docker',
+    source_native: 'Native source checkout',
+    prebuilt_docker: 'Prebuilt Docker image',
+  };
+  return labels[mode] || mode || 'Unknown';
+}
+
+function _renderUpdateCommandList(container, commands) {
+  if (!container) return;
+  container.innerHTML = '';
+  if (!Array.isArray(commands) || !commands.length) {
+    const empty = document.createElement('div');
+    empty.style.cssText = 'opacity:0.55;font-size:11px;';
+    empty.textContent = 'No manual commands available.';
+    container.appendChild(empty);
+    return;
+  }
+  commands.forEach((command) => {
+    const text = typeof command === 'string' ? command.trim() : '';
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:flex-start;gap:8px;flex-wrap:wrap;';
+    const code = document.createElement('code');
+    code.style.cssText = 'flex:1;min-width:0;word-break:break-word;font-size:11px;';
+    code.textContent = text || '—';
+    const copy = document.createElement('button');
+    copy.type = 'button';
+    copy.className = 'admin-btn-sm';
+    copy.style.flexShrink = '0';
+    copy.disabled = !text;
+    copy.textContent = 'Copy';
+    if (text) {
+      copy.addEventListener('click', async () => {
+        await uiModule.copyToClipboard(text);
+        const prev = copy.textContent;
+        copy.textContent = 'Copied';
+        setTimeout(() => { copy.textContent = prev; }, 1400);
+      });
+    }
+    row.appendChild(code);
+    row.appendChild(copy);
+    container.appendChild(row);
+  });
+}
+
+function _renderUpdateWarnings(container, gitState) {
+  if (!container) return;
+  container.innerHTML = '';
+  const warnings = [];
+  _pushWarnings(warnings, Array.isArray(gitState?.warnings) ? gitState.warnings : []);
+  if (
+    gitState && gitState.dirty === true
+    && !warnings.some((warning) => /dirty|uncommitted/i.test(warning))
+  ) {
+    warnings.push('Working tree contains uncommitted changes');
+  }
+  if (gitState && gitState.detached_head) warnings.push('Detached HEAD');
+  if (gitState && gitState.upstream && gitState.upstream.tracking_configured === false) {
+    warnings.push('No upstream tracking branch configured');
+  }
+  if (!warnings.length) {
+    const badge = document.createElement('span');
+    badge.className = 'admin-badge';
+    badge.style.background = 'color-mix(in srgb, var(--green) 20%, transparent)';
+    badge.style.color = 'var(--green)';
+    badge.textContent = gitState && gitState.dirty === false ? 'Clean' : 'No warnings';
+    container.appendChild(badge);
+    return;
+  }
+  warnings.forEach((warning) => {
+    const badge = document.createElement('span');
+    badge.className = 'admin-badge';
+    badge.textContent = warning;
+    container.appendChild(badge);
+  });
+}
+
+function _renderUpdateStatus(data) {
+  const status = data && typeof data === 'object' ? data : {};
+  const git = status.git || {};
+  const install = status.install || {};
+  const upstream = git.upstream || {};
+
+  _setText('adm-updateVersion', status.version || 'Unknown');
+  _setText('adm-updateMode', _formatUpdateMode(install.mode_guess));
+  _setText('adm-updateCommit', git.commit || 'Unknown');
+  _setText('adm-updateBranch', git.branch || 'Unknown');
+
+  const remoteBits = [];
+  if (upstream.tracking_configured && (upstream.remote || upstream.remote_branch)) {
+    const branchLabel = upstream.remote && upstream.remote_branch
+      ? `${upstream.remote}/${upstream.remote_branch}`
+      : (upstream.remote || upstream.remote_branch || 'unknown branch');
+    remoteBits.push(`Tracking ${branchLabel}`);
+  } else if (git.available === false) {
+    remoteBits.push('Git state unavailable');
+  } else {
+    remoteBits.push('No upstream tracking branch configured');
+  }
+  if (upstream.remote_url_scrubbed) remoteBits.push(upstream.remote_url_scrubbed);
+  if (git.remote && git.remote.sha) remoteBits.push(`Latest SHA ${_shortSha(git.remote.sha)}`);
+  if (typeof git.ahead === 'number' && typeof git.behind === 'number') {
+    remoteBits.push(`Ahead/behind +${git.ahead} / -${git.behind}`);
+  }
+  _setText('adm-updateRemote', remoteBits.join(' • '), 'Not available');
+
+  _renderUpdateWarnings(el('adm-updateWarnings'), git);
+  const msg = el('adm-updateMsg');
+  if (msg) {
+    const notes = [];
+    _pushWarnings(notes, Array.isArray(git.errors) ? git.errors : []);
+    if (Array.isArray(git.timeouts) && git.timeouts.length) {
+      notes.push(`Command timeout: ${git.timeouts.join(', ')}`);
+    }
+    if (notes.length) {
+      msg.className = 'admin-error';
+      msg.textContent = notes.join(' ');
+    } else {
+      msg.className = 'admin-empty';
+      msg.textContent = '';
+    }
+  }
+
+  const commands = Array.isArray(install.manual_update_commands)
+    ? install.manual_update_commands
+    : install.mode_guess && install.manual_update_commands_by_mode
+      ? install.manual_update_commands_by_mode[install.mode_guess]
+      : [];
+  _renderUpdateCommandList(el('adm-updateCommands'), Array.isArray(commands) ? commands : []);
+}
+
+async function loadUpdateStatus() {
+  const refreshBtn = el('adm-updateRefresh');
+  const msg = el('adm-updateMsg');
+  const list = el('adm-updateCommands');
+  _setText('adm-updateVersion', 'Loading…');
+  _setText('adm-updateMode', 'Loading…');
+  _setText('adm-updateCommit', 'Loading…');
+  _setText('adm-updateBranch', 'Loading…');
+  _setText('adm-updateRemote', 'Loading…');
+  const warnings = el('adm-updateWarnings');
+  if (warnings) {
+    warnings.innerHTML = '<span class="admin-badge" style="background:color-mix(in srgb, var(--fg) 14%, transparent);color:var(--fg);">Checking</span>';
+  }
+  if (list) list.innerHTML = '<div style="font-size:11px;opacity:0.6;">Loading commands…</div>';
+  if (refreshBtn) { refreshBtn.disabled = true; refreshBtn.textContent = 'Checking…'; }
+  if (msg) { msg.className = 'admin-empty'; msg.textContent = ''; }
+
+  try {
+    const res = await fetch('/api/admin/update/status', { credentials: 'same-origin' });
+    const status = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      if (msg) {
+        msg.className = 'admin-error';
+        msg.textContent = status.detail || `Failed to load (${res.status})`;
+      }
+      return;
+    }
+    _renderUpdateStatus(status);
+  } catch (e) {
+    if (msg) {
+      msg.className = 'admin-error';
+      msg.textContent = `Request failed: ${e && e.message ? e.message : 'unknown'}`;
+    }
+    _setText('adm-updateVersion', 'Unavailable');
+    _setText('adm-updateMode', 'Unavailable');
+    _setText('adm-updateCommit', 'Unavailable');
+    _setText('adm-updateBranch', 'Unavailable');
+    _setText('adm-updateRemote', 'Unavailable');
+    _renderUpdateWarnings(el('adm-updateWarnings'), { warnings: ['Failed to load update status.'] });
+    _renderUpdateCommandList(el('adm-updateCommands'), []);
+  } finally {
+    if (refreshBtn) { refreshBtn.disabled = false; refreshBtn.textContent = 'Check'; }
+  }
+}
+
+function initUpdateStatus() {
+  if (_updateStatusInited) return;
+  _updateStatusInited = true;
+  const refreshBtn = el('adm-updateRefresh');
+  if (!refreshBtn) return;
+  refreshBtn.addEventListener('click', loadUpdateStatus);
+}
+
 /* ── Data Backup (export/import) ── */
 function initBackup() {
   el('adm-exportDataBtn').addEventListener('click', async () => {
@@ -2044,7 +2253,7 @@ function initDangerZone() {
    ═══════════════════════════════════════════ */
 function initAll() {
   modalEl = el('settings-modal');
-  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
+  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initUpdateStatus, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
   for (const fn of inits) {
     try { fn(); } catch (e) { console.error('Admin init error in', fn.name || 'anonymous', e); }
   }
@@ -2057,6 +2266,7 @@ function refreshAll() {
   loadEndpoints();
   loadBuiltinTools();
   loadMcpServers();
+  loadUpdateStatus();
 }
 
 /* ═══════════════════════════════════════════

--- a/tests/test_update_status_routes.py
+++ b/tests/test_update_status_routes.py
@@ -1,0 +1,298 @@
+"""Tests for check-only update-status backend route."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from fastapi import HTTPException
+
+# `routes/update_status_routes.py` depends on `core.middleware`. Importing
+# `core.*` directly triggers package-level initialization that can touch
+# filesystem-backed SQLAlchemy setup when DB paths aren't available in the test
+# environment. Keep the tests isolated by pre-seeding lightweight module stubs
+# before import.
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if "core" not in sys.modules:
+    _core_pkg = types.ModuleType("core")
+    _core_pkg.__path__ = [os.path.join(_ROOT, "core")]
+    sys.modules["core"] = _core_pkg
+else:
+    _core_pkg = sys.modules["core"]
+    if not hasattr(_core_pkg, "__path__"):
+        _core_pkg.__path__ = [os.path.join(_ROOT, "core")]
+
+_core_db = types.ModuleType("core.database")
+for _name in (
+    "SessionLocal",
+    "Session",
+    "ChatMessage",
+    "Memory",
+    "ScheduledTask",
+    "TaskRun",
+    "Document",
+    "DocumentVersion",
+    "GalleryImage",
+    "CalendarEvent",
+    "CalendarCal",
+    "Note",
+):
+    setattr(_core_db, _name, MagicMock())
+
+if "core.database" not in sys.modules:
+    sys.modules["core.database"] = _core_db
+if not hasattr(_core_pkg, "database"):
+    setattr(_core_pkg, "database", _core_db)
+
+import routes.update_status_routes as U
+
+
+def _admin_request(current_user: str, is_admin: bool = True):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=current_user),
+        headers={},
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=SimpleNamespace(
+                    is_configured=True,
+                    is_admin=lambda u: is_admin,
+                )
+            )
+        ),
+    )
+
+
+def _route_endpoint():
+    router = U.setup_update_status_routes()
+    for route in router.routes:
+        if route.path == "/api/admin/update/status":
+            return route.endpoint
+    raise AssertionError("update-status route missing")
+
+
+def _run_response_for(commands):
+    def _fake_run_git(cwd, args, timeout=1.8):
+        command = " ".join(args)
+        result = commands.get(command)
+        if result is None:
+            return {"ok": False, "error": "missing_stub", "details": f"no stub for {command}"}
+        return result
+
+    return _fake_run_git
+
+
+def test_update_status_requires_admin():
+    """A non-admin caller cannot reach the route."""
+    endpoint = _route_endpoint()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(endpoint(request=_admin_request("alice", is_admin=False)))
+    assert exc.value.status_code == 403
+
+
+def test_update_status_no_git_shows_unavailable(monkeypatch):
+    """If git is absent, the endpoint returns a soft failure and still includes mode hints."""
+    monkeypatch.setattr(
+        U,
+        "_run_git",
+        lambda *args, **kwargs: {"ok": False, "error": "git_missing", "details": "git missing"},
+    )
+    status = U._collect_update_status("/tmp")
+    assert status["git"]["available"] is False
+    assert status["git"]["errors"]
+    assert status["install"]["mode_guess"] in {"source_native", "prebuilt_docker"}
+
+
+def test_update_status_timeout_is_reported(monkeypatch):
+    """A git timeout should be recorded and should not throw."""
+    repo_dir = os.path.join("/", "tmp", "update-status-timeout-test")
+    os.makedirs(repo_dir, exist_ok=True)
+
+    monkeypatch.setattr(
+        U,
+        "_run_git",
+        lambda *args, **kwargs: {"ok": False, "error": "timeout", "details": "timed out"},
+    )
+    status = U._collect_update_status(repo_dir)
+
+    assert status["git"]["available"] is False
+    assert status["git"]["timeouts"] == ["rev-parse --show-toplevel"]
+    assert status["git"]["errors"] == ["Repository is not a git checkout."]
+
+
+def test_update_status_clean_repo(monkeypatch, tmp_path):
+    """A clean repo returns commit/branch/upstream/remote SHA without dirty flag."""
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text("services: {}", encoding="utf-8")
+
+    stubs = {
+        "rev-parse --show-toplevel": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": str(tmp_path),
+            "stderr": "",
+        },
+        "rev-parse --short HEAD": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "cafebabe",
+            "stderr": "",
+        },
+        "rev-parse --abbrev-ref HEAD": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "main",
+            "stderr": "",
+        },
+        "status --porcelain": {"ok": True, "returncode": 0, "stdout": "", "stderr": ""},
+        "config --get branch.main.remote": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "origin",
+            "stderr": "",
+        },
+        "config --get branch.main.merge": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "refs/heads/main",
+            "stderr": "",
+        },
+        "config --get remote.origin.url": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "https://user:secret@example.com/odysseus.git",
+            "stderr": "",
+        },
+        "for-each-ref --format=%(refname:short) %(upstream:short) refs/heads": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "main origin/main",
+            "stderr": "",
+        },
+        "ls-remote --heads origin main": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "feedface1234567890\trefs/heads/main",
+            "stderr": "",
+        },
+        "rev-list --left-right --count HEAD...@{u}": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "1\t2",
+            "stderr": "",
+        },
+    }
+    monkeypatch.setattr(U, "_run_git", _run_response_for(stubs))
+    status = U._collect_update_status(str(tmp_path))
+
+    assert "repo_path" not in status
+    assert "top_level" not in status["git"]
+    assert status["git"]["available"] is True
+    assert status["git"]["commit"] == "cafebabe"
+    assert status["git"]["branch"] == "main"
+    assert status["git"]["detached_head"] is False
+    assert status["git"]["dirty"] is False
+    assert status["git"]["upstream"]["tracking_configured"] is True
+    assert status["git"]["upstream"]["remote"] == "origin"
+    assert status["git"]["upstream"]["remote_url_scrubbed"] == "https://example.com/odysseus.git"
+    assert status["git"]["remote"]["sha"] == "feedface1234567890"
+    assert status["git"]["ahead"] == 1
+    assert status["git"]["behind"] == 2
+    assert status["install"]["mode_guess"] == "source_docker"
+    assert status["install"]["manual_update_commands"] == U._MODE_COMMANDS["source_docker"]
+
+
+def test_update_status_detects_dirty_and_detached(monkeypatch, tmp_path):
+    """Detached HEAD and dirty working tree are surfaced as warnings with no upstream checks."""
+    stubs = {
+        "rev-parse --show-toplevel": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": str(tmp_path),
+            "stderr": "",
+        },
+        "rev-parse --short HEAD": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "deadbeef",
+            "stderr": "",
+        },
+        "rev-parse --abbrev-ref HEAD": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "HEAD",
+            "stderr": "",
+        },
+        "status --porcelain": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": " M dirty.txt",
+            "stderr": "",
+        },
+    }
+    monkeypatch.setattr(U, "_run_git", _run_response_for(stubs))
+    status = U._collect_update_status(str(tmp_path))
+
+    assert status["git"]["detached_head"] is True
+    assert status["git"]["branch"] == "HEAD"
+    assert status["git"]["dirty"] is True
+    assert status["git"]["upstream"]["tracking_configured"] is False
+    assert any("Detached HEAD" in warn for warn in status["git"]["warnings"])
+
+
+def test_update_status_reports_missing_upstream(monkeypatch, tmp_path):
+    """If branch config does not point to an upstream branch, callers get a warning."""
+    stubs = {
+        "rev-parse --show-toplevel": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": str(tmp_path),
+            "stderr": "",
+        },
+        "rev-parse --short HEAD": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "beefcafe",
+            "stderr": "",
+        },
+        "rev-parse --abbrev-ref HEAD": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "feature",
+            "stderr": "",
+        },
+        "status --porcelain": {"ok": True, "returncode": 0, "stdout": "", "stderr": ""},
+        "config --get branch.feature.remote": {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "",
+        },
+        "config --get branch.feature.merge": {"ok": True, "returncode": 0, "stdout": "", "stderr": ""},
+        "for-each-ref --format=%(refname:short) %(upstream:short) refs/heads": {"ok": True, "returncode": 0, "stdout": "feature ", "stderr": ""},
+    }
+    monkeypatch.setattr(U, "_run_git", _run_response_for(stubs))
+    status = U._collect_update_status(str(tmp_path))
+
+    assert status["git"]["upstream"]["tracking_configured"] is False
+    assert any("No upstream tracking branch configured." in warn for warn in status["git"]["warnings"])
+
+
+def test_scrub_remote_url_removes_credentials():
+    assert (
+        U._scrub_remote_url("https://alice:tok_xyz@example.com/odysseus.git")
+        == "https://example.com/odysseus.git"
+    )
+    assert U._scrub_remote_url("git@github.com:odysseus/odysseus.git") == "git@github.com:odysseus/odysseus.git"
+
+
+def test_remote_url_allowed_rejects_local_paths_and_unknown_schemes():
+    assert U._remote_url_allowed("https://github.com/example/odysseus.git") is True
+    assert U._remote_url_allowed("git@github.com:example/odysseus.git") is True
+    assert U._remote_url_allowed("file:///tmp/odysseus.git") is False
+    assert U._remote_url_allowed("/tmp/odysseus.git") is False


### PR DESCRIPTION
Adds a check-only Software Update status card for admins in `Settings > System`.

This intentionally keeps the first update slice observable only. It follows the maintainer feedback on #799 by avoiding:

- `git pull`;
- rebuild/restart orchestration;
- `.git` Docker mounts;
- arbitrary command execution from the browser;
- any update/apply button.

The new admin endpoint reports observable source/version state and shows manual update commands for the detected install mode. It handles dirty working trees, detached HEADs, missing upstream tracking, unavailable git metadata, bounded command timeouts, and scrubbed remote URLs.

The docs add a small update/release-channel guide for current source installs and future prebuilt-image / platform release channels.

Refs #318. Related but separate from the Windows Docker script flow in #944/#792 and prebuilt image work in #716/#893.

## Verification

- `python3 -m pytest -q tests/test_update_status_routes.py` (`8 passed`)
- `node --check static/js/admin.js`
- `python3 -m py_compile routes/update_status_routes.py tests/test_update_status_routes.py app.py`
- `python3 -m compileall -q routes app.py`
- `git diff --check origin/main..HEAD`
- Two-dot and three-dot diffs both show only the seven intended update-status files
