### PR TITLE
fix(ui): keep emojis visible after finalize

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -300,7 +300,10 @@ function _emojiImg(emoji) {
   // with the surrounding text color (currentColor), so emoji render as a single
   // theme-tinted line glyph — never colorful (project rule). If the proxy can't
   // supply the glyph it returns a transparent SVG, so the mask shows nothing.
-  return `<span class="emoji" role="img" aria-label="${emoji}" style="--em:url('/api/emoji/${code}.svg')"></span>`;
+  // Include the unicode emoji as a fallback text node. CSS renders it as a
+  // monochrome silhouette (via text-shadow) so emoji remain visible even when
+  // the proxy returns a blank SVG (offline / CDN blocked / unknown codepoints).
+  return `<span class="emoji" role="img" aria-label="${emoji}" style="--em:url('/api/emoji/${code}.svg')">${emoji}</span>`;
 }
 function _svgifyText(text) {
   if (!_emojiSeg) return text;

--- a/static/style.css
+++ b/static/style.css
@@ -34811,6 +34811,13 @@ body.theme-frosted .modal {
   background-color: currentColor;
   -webkit-mask: var(--em) center / contain no-repeat;
           mask: var(--em) center / contain no-repeat;
+  /* Fallback: if the SVG proxy returns a blank mask (offline/CDN blocked),
+     keep the unicode emoji visible as a monochrome silhouette. */
+  overflow: visible;
+  line-height: 1;
+  font-size: 1em;
+  color: transparent;
+  text-shadow: 0 0 0 currentColor;
 }
 
 /* Nudge the X icon in the "Clear all" button down 2px. */


### PR DESCRIPTION
## Summary
Ensure emojis stay visible after the final render even when the OpenMoji SVG mask is unavailable.

## Root cause
Final message rendering converts Unicode emojis to monochrome OpenMoji SVG masks via `/api/emoji/<code>.svg`.
When the proxy returns a blank SVG (offline/CDN blocked/unknown codepoint), the CSS mask becomes empty and the emoji disappears.

## Fix
- Keep the Unicode emoji as a fallback text node inside `.emoji`.
- Render the fallback as a monochrome silhouette (via `text-shadow`) so it matches the “no colorful emoji” rule.

## Test plan
- Send a message with emojis (e.g. 😀👍🔥) and wait for completion: emojis should remain visible.
- Repeat offline / with CDN blocked: emojis should still be visible.

Fixes #1024