### PR TITLE
fix: prevent session deletion while renamingFix session deletion when pressing Backspace during rename

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -1875,6 +1875,10 @@ function _onSessionListKeydown(e) {
   const item = e.target.closest('.list-item[data-session-id]');
   if (!item) return;
 
+  if (e.target.closest('.session-rename-input')) {
+    return;
+  }
+
   if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
     e.preventDefault();
     // Get all visible session items across all containers


### PR DESCRIPTION
## Summary
Fixes #1007
Fixes an issue where pressing Backspace while renaming a session could delete the session instead of editing the title.

## Reproduction

1. Open a session.
2. Rename the session using the Rename action.
3. Press Backspace while editing the session name.

### Before

The session is deleted.

### After

Backspace edits the session title as expected and the session is not deleted.

## Root Cause

The session list keyboard navigation handler was processing Backspace events originating from `.session-rename-input`, causing the delete-session shortcut to trigger while a rename input was focused.

## Fix

Ignore session list keyboard shortcuts when the event originates from `.session-rename-input`.
