### PR TITLE
fix: confirm chat deletion actions

### DIFF
--- a/static/js/documentLibrary.js
+++ b/static/js/documentLibrary.js
@@ -2059,6 +2059,7 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
           { label: 'Copy', action: () => _copyChatById(s.id) },
           { label: 'Archive', action: async () => { await fetch(API_BASE + '/api/session/' + s.id + '/archive', { method: 'POST', headers: {'Content-Type':'application/json'} }); _renderLibChats(); } },
           { label: 'Delete', action: async () => {
+            if (!await window.styledConfirm('Delete this chat?', { confirmText: 'Delete', danger: true })) return;
             await fetch(API_BASE + '/api/session/' + s.id, { method: 'DELETE' });
             card.style.maxHeight = `${Math.max(card.getBoundingClientRect().height, card.scrollHeight)}px`;
             card.classList.add('memory-tidy-removing');
@@ -2412,7 +2413,11 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
           { label: 'Open', action: () => { if (window.sessionModule) window.sessionModule.selectSession(s.id); } },
           { label: 'Copy', action: () => _copyChatById(s.id) },
           { label: 'Restore', action: async () => { await fetch(API_BASE + '/api/session/' + s.id + '/unarchive', { method: 'POST' }); _renderLibArchive(); } },
-          { label: 'Delete', action: async () => { await fetch(API_BASE + '/api/session/' + s.id, { method: 'DELETE' }); _renderLibArchive(); }, danger: true },
+          { label: 'Delete', action: async () => {
+            if (!await window.styledConfirm('Delete this chat permanently?', { confirmText: 'Delete', danger: true })) return;
+            await fetch(API_BASE + '/api/session/' + s.id, { method: 'DELETE' });
+            _renderLibArchive();
+          }, danger: true },
         ], { onSelect: () => {
           _arcSelectMode = true;
           _arcSelected.add('chats:' + s.id);

--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -616,6 +616,10 @@ function createSessionItem(s) {
       return;
     }
     dropdown.style.display = 'none';
+    if (!await uiModule.styledConfirm('Delete this session?', { confirmText: 'Delete', danger: true })) {
+      _forceSidebarOpen();
+      return;
+    }
     // Optimistic: remove from UI immediately
     const sessionEl = document.querySelector(`.list-item[data-session-id="${s.id}"]`);
     if (sessionEl) sessionEl.remove();
@@ -1871,7 +1875,7 @@ export function setCurrentSessionId(id) {
 }
 
 // Session list keyboard navigation: arrows to move, Delete to delete
-function _onSessionListKeydown(e) {
+async function _onSessionListKeydown(e) {
   const item = e.target.closest('.list-item[data-session-id]');
   if (!item) return;
 
@@ -1899,6 +1903,8 @@ function _onSessionListKeydown(e) {
       uiModule.showToast('Unfavorite before deleting');
       return;
     }
+    const ok = await uiModule.styledConfirm('Delete this session?', { confirmText: 'Delete', danger: true });
+    if (!ok) return;
     _sessionListFocused = true;
     (async () => {
       await fetch(`${API_BASE}/api/session/${s.id}`, { method: 'DELETE' });


### PR DESCRIPTION
## Summary
- add a confirmation before deleting the current chat from the sidebar/session list
- add the same confirmation to library chat action menus, including archived chats
- keep scope narrow: this does not change the Backspace/rename logic from #1011

## Test Plan
- `node --check static/js/sessions.js`
- `node --check static/js/documentLibrary.js`

Refs #1006