### PR TITLE
Sidebar: ignore session-list keydown when typing in a field

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -1872,6 +1872,11 @@ export function setCurrentSessionId(id) {
 
 // Session list keyboard navigation: arrows to move, Delete to delete
 function _onSessionListKeydown(e) {
+  // Bail out when the user is typing inside a field (e.g. inline rename input)
+  // — otherwise Backspace bubbles up and deletes the whole chat. See #1007.
+  const t = e.target;
+  if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+
   const item = e.target.closest('.list-item[data-session-id]');
   if (!item) return;
 


### PR DESCRIPTION
The list keyboard handler (_onSessionListKeydown) treats Backspace and Delete as "delete the focused session". When the user double-clicks a chat to rename it, an <input class="session-rename-input"> is mounted inside the .list-item row. Backspace on the input bubbles up to the list container, the handler walks closest('.list-item[data-session-id]') from e.target, finds the parent row and DELETEs the session via the API — so a single typo correction nukes the whole conversation.

Bail out at the top of the handler when e.target is an INPUT, TEXTAREA, or contentEditable element. Arrow / Enter / Delete navigation still works for rows themselves (the row is the focused element then, not the input). Mirrors the guard pattern already used in ui.js, notes.js, tasks.js, calendar.js, emailLibrary.js and galleryEditor.js.

Closes #1007.