### PR TITLE
fix(webhook): block IPv6 SSRF bypasses (unspecified + IPv4-mapped)

### DIFF
--- a/src/webhook_manager.py
+++ b/src/webhook_manager.py
@@ -38,6 +38,20 @@ _PRIVATE_NETWORKS = [
 
 
 def _ip_is_private(addr: ipaddress._BaseAddress) -> bool:
+    # If the address is IPv4-mapped IPv6, extract and evaluate the embedded IPv4
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    ):
+        return True
+
     return any(addr in net for net in _PRIVATE_NETWORKS)
 
 

--- a/tests/test_webhook_ssrf_resilience.py
+++ b/tests/test_webhook_ssrf_resilience.py
@@ -1,0 +1,28 @@
+import sys
+# conftest.py stubs src.database with a fake module; webhook_manager imports
+# from it, so drop the stub here to load the real module under test.
+if "src.database" in sys.modules:
+    del sys.modules["src.database"]
+
+import pytest
+from src.webhook_manager import validate_webhook_url
+
+
+def test_webhook_url_ssrf_mitigation():
+    # SSRF bypasses that must be rejected, including IPv6 unspecified and
+    # IPv4-mapped IPv6 (loopback + cloud metadata).
+    private_urls = [
+        "http://[::]/",
+        "http://[::ffff:127.0.0.1]/",
+        "http://[::ffff:169.254.169.254]/",
+        "http://127.0.0.1/",
+        "http://0.0.0.0/",
+    ]
+    for url in private_urls:
+        with pytest.raises(ValueError) as exc:
+            validate_webhook_url(url)
+        assert "private/internal addresses" in str(exc.value)
+
+    # A clearly public IP literal must still be accepted.
+    public_url = "http://93.184.216.34/"
+    assert validate_webhook_url(public_url) == public_url


### PR DESCRIPTION
## Problem

The webhook URL guard's `_ip_is_private()` only checks a hardcoded `_PRIVATE_NETWORKS` list, which misses several internally-routable addresses. So `validate_webhook_url()` currently **allows** these:

```python
validate_webhook_url("http://[::]/")                       # IPv6 unspecified -> localhost
validate_webhook_url("http://[::ffff:127.0.0.1]/")         # IPv4-mapped IPv6 loopback = 127.0.0.1
validate_webhook_url("http://[::ffff:169.254.169.254]/")   # IPv4-mapped cloud metadata endpoint
```

The last one is the dangerous case: a webhook pointed at the IPv4-mapped `169.254.169.254` can reach the cloud instance metadata service and pull credentials — SSRF → credential theft. The first two reach the local host.

Root cause: the manual network list doesn't account for the IPv6 unspecified address (`::`) or IPv4-mapped IPv6 (`::ffff:a.b.c.d`), which Python's `ipaddress` classifies correctly but the hardcoded list never sees.

## Fix

Harden `_ip_is_private()`:
1. If the address is IPv4-mapped IPv6 (`addr.ipv4_mapped is not None`), unwrap to the embedded IPv4 and evaluate that.
2. Reject using the stdlib address properties — `is_private`, `is_loopback`, `is_link_local`, `is_reserved`, `is_multicast`, `is_unspecified` — in addition to the existing `_PRIVATE_NETWORKS` list (kept as defense-in-depth).

Public addresses still pass.

## Test

`tests/test_webhook_ssrf_resilience.py` asserts `validate_webhook_url` raises `ValueError` for `http://[::]/`, `http://[::ffff:127.0.0.1]/`, `http://[::ffff:169.254.169.254]/`, `http://127.0.0.1/`, and `http://0.0.0.0/`, and still accepts a public IP literal (`http://93.184.216.34/`). The IPv6 cases fail before this change. Existing webhook tests still pass.