### PR TITLE
Send num_ctx to Ollama so prompts are not truncated at 2048

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -238,6 +238,7 @@ def _build_ollama_payload(
     max_tokens: int,
     stream: bool = False,
     tools: Optional[List[Dict]] = None,
+    num_ctx: Optional[int] = None,
 ) -> Dict:
     payload: Dict = {
         "model": model,
@@ -249,11 +250,32 @@ def _build_ollama_payload(
         options["temperature"] = temperature
     if max_tokens and max_tokens > 0:
         options["num_predict"] = max_tokens
+    # Ollama defaults num_ctx to 2048 when unspecified, silently truncating
+    # the *input* window regardless of what the model actually supports. Only
+    # emit the option when we have a value larger than that default so we
+    # don't accidentally clamp a model whose server-side default is higher.
+    if num_ctx and num_ctx > 2048:
+        options["num_ctx"] = int(num_ctx)
     if options:
         payload["options"] = options
     if tools:
         payload["tools"] = tools
     return payload
+
+
+def _resolve_ollama_num_ctx(url: str, model: str) -> Optional[int]:
+    """Look up the serving context length for an Ollama-backed model.
+
+    Returns ``None`` on any failure so the caller falls back to Ollama's
+    default behaviour. Wrapped in a broad try/except because a context-length
+    probe failure must never break the chat path.
+    """
+    try:
+        from src.model_context import get_context_length
+        return get_context_length(url, model)
+    except Exception as e:
+        logger.debug(f"Skipping num_ctx for {model}: {e}")
+        return None
 
 
 def _parse_ollama_response(data: dict) -> str:
@@ -675,7 +697,10 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        payload = _build_ollama_payload(
+            model, messages_copy, temperature, max_tokens, stream=False,
+            num_ctx=_resolve_ollama_num_ctx(url, model),
+        )
     else:
         target_url = url
         payload = {
@@ -790,7 +815,10 @@ async def llm_call_async(
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        payload = _build_ollama_payload(
+            model, messages_copy, temperature, max_tokens, stream=False,
+            num_ctx=_resolve_ollama_num_ctx(url, model),
+        )
     else:
         target_url = url
         h = _provider_headers(provider, headers)
@@ -888,7 +916,10 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
+        payload = _build_ollama_payload(
+            model, messages_copy, temperature, max_tokens, stream=True, tools=tools,
+            num_ctx=_resolve_ollama_num_ctx(url, model),
+        )
     else:
         target_url = url
         payload = {

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -25,6 +25,9 @@ def test_llm_call_posts_native_ollama_payload(monkeypatch):
         )
 
     monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+    # Pin the context probe so this test stays focused on payload shape;
+    # dedicated tests below cover num_ctx wiring end-to-end.
+    monkeypatch.setattr(llm_core, "_resolve_ollama_num_ctx", lambda url, model: None)
 
     result = llm_core.llm_call(
         "https://ollama.com/api",
@@ -113,3 +116,78 @@ def test_ollama_payload_tolerates_malformed_arguments():
     payload = llm_core._build_ollama_payload("m", msgs, temperature=0.0, max_tokens=0)
     # Falls back to an empty object rather than raising.
     assert payload["messages"][0]["tool_calls"][0]["function"]["arguments"] == {}
+
+
+# ---------------------------------------------------------------------------
+# num_ctx: Ollama silently defaults the input window to 2048 tokens when the
+# request omits options.num_ctx, truncating long prompts regardless of the
+# model's advertised context length. _build_ollama_payload must forward a
+# caller-supplied num_ctx so the compactor's budget is actually honoured.
+# ---------------------------------------------------------------------------
+
+def test_ollama_payload_emits_num_ctx_when_supplied():
+    msgs = [{"role": "user", "content": "hi"}]
+    payload = llm_core._build_ollama_payload(
+        "kimi-k2", msgs, temperature=0.0, max_tokens=0, num_ctx=128_000,
+    )
+    assert payload["options"]["num_ctx"] == 128_000
+
+
+def test_ollama_payload_skips_num_ctx_at_or_below_default():
+    """Don't clamp a model whose server-side default already exceeds 2048."""
+    msgs = [{"role": "user", "content": "hi"}]
+    for ctx in (None, 0, 2048, 1024):
+        payload = llm_core._build_ollama_payload(
+            "m", msgs, temperature=0.0, max_tokens=0, num_ctx=ctx,
+        )
+        assert "num_ctx" not in payload.get("options", {})
+
+
+def test_ollama_payload_num_ctx_coexists_with_num_predict():
+    msgs = [{"role": "user", "content": "hi"}]
+    payload = llm_core._build_ollama_payload(
+        "m", msgs, temperature=0.2, max_tokens=512, num_ctx=32_768,
+    )
+    assert payload["options"] == {
+        "temperature": 0.2,
+        "num_predict": 512,
+        "num_ctx": 32_768,
+    }
+
+
+def test_llm_call_forwards_num_ctx_for_ollama(monkeypatch):
+    seen = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        seen["json"] = json
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"message": {"content": "OK"}, "done": True},
+        )
+
+    monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+    monkeypatch.setattr(llm_core, "_resolve_ollama_num_ctx", lambda url, model: 65_536)
+
+    llm_core.llm_call(
+        "https://ollama.com/api",
+        "minimax-m3",
+        [{"role": "user", "content": "hello"}],
+        temperature=0.0,
+        max_tokens=0,
+        headers={"Authorization": "Bearer k"},
+    )
+    assert seen["json"]["options"]["num_ctx"] == 65_536
+
+
+def test_resolve_ollama_num_ctx_swallows_lookup_errors(monkeypatch):
+    """A failed context probe must never break the chat path — returning None
+    lets the payload helper fall back to Ollama's default behaviour."""
+    import src.model_context as model_context
+
+    def boom(*_a, **_k):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(model_context, "get_context_length", boom)
+    assert llm_core._resolve_ollama_num_ctx("http://x/api", "m") is None


### PR DESCRIPTION
_build_ollama_payload set options.num_predict (output cap) and options.temperature but never options.num_ctx (input window). Ollama's documented behaviour is to default num_ctx to 2048 tokens when the request omits it, regardless of the model's advertised context length. Result: long prompts going from Odysseus -> any Ollama backend (local, Ollama Cloud, OpenRouter-via-Ollama) are silently truncated at 2048 input tokens. The compactor in src/context_compactor.py sizes its budget against the actual model window via get_context_length(...), sees the prompt fits, and does not compact — so the trim happens server-side, mid-paragraph, on the way in. Symptom: the model only "sees" the tail of a long paste; system prompts get clipped first.

Fix is in two pieces, both in src/llm_core.py:

- _build_ollama_payload gains an optional num_ctx kwarg and emits options.num_ctx only when the supplied value is > 2048. The 2048 floor matters: we do not want to push a smaller value than Ollama was going to use anyway, and we do not want to clamp a server whose operator has raised the default via OLLAMA_NUM_CTX.

- A new _resolve_ollama_num_ctx(url, model) wraps the existing get_context_length helper from src/model_context.py (which already understands /api/show, the llama.cpp /slots endpoint, and the KNOWN_CONTEXT_WINDOWS table). It is wrapped in a broad try/except so a probe failure -> returns None -> payload helper falls back to Ollama's default; the chat path must never break because the context probe failed.

The three chat call sites (llm_call, llm_call_async, stream_llm) thread the resolved value in. The /api/health diagnostic test in routes/model_routes.py is intentionally left alone: it sends a 5-token "Say OK" prompt and exists to check reachability and auth, not context behaviour.

Tests in tests/test_llm_core_ollama.py cover the new payload key, the > 2048 floor (None/0/2048/1024 all skip), coexistence with num_predict, end-to-end wiring through llm_call, and the swallow-on-probe-failure contract. The existing
test_llm_call_posts_native_ollama_payload now pins _resolve_ollama_num_ctx to None so it stays focused on payload shape.

Closes #909.