### PR TITLE
settings polish.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1308,7 +1308,7 @@
         </button>
         <button class="close-btn" aria-label="Close settings">✖</button>
       </div>
-      <div class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;">Toggle on/off visibility of tools and modules across the interface.</div>
+      <div id="settings-tab-blurb" class="admin-toggle-sub" style="padding:0 12px 8px;opacity:0.6;font-size:11px;"></div>
       <div class="settings-layout">
         <div class="settings-sidebar">
           <!-- Section 1: AI plumbing (Add Models → AI Defaults → Search) -->
@@ -1900,12 +1900,12 @@
 
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>Writing Style</h2>
-            <div class="admin-toggle-sub" style="margin-bottom:8px">AI-extracted from your sent emails. Used when AI drafts replies.</div>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Learns your tone from recent sent mail (max 15, min 3). Used when AI drafts replies.</div>
             <div class="settings-col">
               <textarea id="set-email-style" rows="4" class="settings-select" style="font-family:inherit;resize:vertical" placeholder="e.g. I write emails in this style. I don't use exclamation marks. I sign emails with: ..."></textarea>
               <div class="settings-row" style="margin-top:4px">
                 <span id="set-email-style-msg" style="font-size:11px;"></span>
-                <button class="admin-btn-add" id="set-email-style-extract" style="margin-left:auto;">Extract from Sent (15 emails)</button>
+                <button class="admin-btn-add" id="set-email-style-extract" style="margin-left:auto;">Extract from Sent</button>
                 <button class="admin-btn-add" id="set-email-style-save">Save</button>
               </div>
             </div>
@@ -1986,7 +1986,7 @@
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>Add User</h2>
             <div class="admin-add-form">
-              <input id="adm-newUsername" type="text" placeholder="Username (email)">
+              <input id="adm-newUsername" type="text" placeholder="Username">
               <input id="adm-newPassword" type="password" placeholder="Password (min 8)">
               <div class="admin-switch-inline" title="Grant full admin access"><label class="admin-switch"><input type="checkbox" id="adm-newIsAdmin"><span class="admin-slider"></span></label> Admin</div>
             </div>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -17,6 +17,29 @@ function esc(s) { return uiModule.esc(s); }
 /* ── Tab switching ── */
 const ADMIN_TABS = new Set(['services', 'integrations', 'tools', 'users', 'system']);
 
+const SETTINGS_TAB_BLURBS = {
+  services: 'Connect local and cloud model endpoints for chat and images.',
+  ai: 'Default chat model, utility model, and related AI behavior.',
+  search: 'Search API used for web search and deep research.',
+  integrations: 'All external service connections in one place.',
+  email: 'Email writing style and links to account setup in Integrations.',
+  reminders: 'How fired note reminders are delivered (browser, email, ntfy).',
+  appearance: 'Toggle visibility of tools and modules across the interface.',
+  shortcuts: 'Click a shortcut to rebind; press Escape to cancel.',
+  account: 'Profile, password, and two-factor authentication.',
+  tools: 'Enable or disable tools available to the AI agent.',
+  users: 'User accounts, open signup, and per-user privileges.',
+  system: 'Backup, import, tokens, webhooks, and server maintenance.',
+};
+
+function syncSettingsTabBlurb(tab) {
+  const blurb = el('settings-tab-blurb');
+  if (!blurb) return;
+  const text = SETTINGS_TAB_BLURBS[tab] || '';
+  blurb.textContent = text;
+  blurb.style.display = text ? '' : 'none';
+}
+
 function initTabs() {
   modalEl.querySelectorAll('[data-settings-tab]').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -28,6 +51,7 @@ function initTabs() {
       }
       modalEl.querySelectorAll('[data-settings-tab]').forEach(b => b.classList.toggle('active', b.dataset.settingsTab === tab));
       modalEl.querySelectorAll('[data-settings-panel]').forEach(p => p.classList.toggle('hidden', p.dataset.settingsPanel !== tab));
+      syncSettingsTabBlurb(tab);
       // Mark when the Appearance tab is open so the modal can go
       // semi-transparent — lets the user see the rest of the UI react as
       // they flip toggles instead of having to close + reopen the modal.
@@ -4358,6 +4382,7 @@ export function open(tab) {
   }
   // Auto-init admin data if showing an admin tab
   const activeTab = tab || (modalEl.querySelector('[data-settings-tab].active') || {}).dataset?.settingsTab || 'services';
+  syncSettingsTabBlurb(activeTab);
   document.body.classList.toggle('settings-appearance-open', activeTab === 'appearance');
   syncAppearanceOpacity(activeTab === 'appearance');
   if (activeTab === 'ai') refreshAiModelEndpoints();


### PR DESCRIPTION
## What this PR does

- Replaces the old hard-coded Settings helper text with a dynamic blurb that updates per active tab.
- Polishes copy in Settings:
  - Writing Style helper text
  - "Extract from Sent" button label
  - Add User placeholder (`Username`)

## Context

Follow-up split from [#796](https://github.com/pewdiepie-archdaemon/odysseus/pull/796) to keep this PR limited to harmless copy/UX polish only.

## Not included

- No `Appearance -> Visibility` rename
- No tour/tab selector rename

## Screenshots
Updated screenshots on current `main`-rebased UI:
- Settings with dynamic blurb on multiple tabs (fixes the static one that was there before.)
<img width="1197" height="271" alt="image" src="https://github.com/user-attachments/assets/b49debda-f112-4231-93d6-455907f3d27f" />

- Writing Style copy update to (done to make it clearer.)
<img width="849" height="438" alt="image" src="https://github.com/user-attachments/assets/5d4eb815-99c5-472d-9256-743b403fb1a0" />

- Add User placeholder update (removed "email" as it was not enforced. If this should be enforced, maybe add it back later.)
<img width="446" height="315" alt="image" src="https://github.com/user-attachments/assets/e3ab3329-c8d2-4955-9937-312749516849" />

## Test plan
- `node --check static/js/settings.js`
- Manual: Settings tab blurbs update per tab; Writing Style / Add User copy verified
- Full `pytest`: ran locally (797 passed, 9 failed in unrelated modules: research, scheduler, auth migration, topic analyzer). No backend files changed in this PR.

# Note
on images, I'm not sure if I should take close up images to show the single feature or show them within the broader context.