### PR TITLE
Add tests for open-signup endpoint

### DIFF
--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -84,6 +84,83 @@ _ensure_stub("src.endpoint_resolver",
 
 from fastapi import HTTPException
 
+# ---------------------------------------------------------------------------
+# Auth routes -- open signup setter
+# ---------------------------------------------------------------------------
+
+def _auth_route_endpoint(path: str, method: str):
+    from routes.auth_routes import setup_auth_routes
+
+    auth_manager = MagicMock()
+    router = setup_auth_routes(auth_manager)
+    for route in router.routes:
+        if getattr(route, "path", "") == path and method in getattr(route, "methods", set()):
+            return auth_manager, route.endpoint
+    raise AssertionError(f"{method} {path} route not registered")
+
+
+def _fake_auth_request(token="session-token"):
+    from routes.auth_routes import SESSION_COOKIE
+
+    req = SimpleNamespace()
+    req.cookies = {SESSION_COOKIE: token}
+    req.client = SimpleNamespace(host="127.0.0.1")
+    return req
+
+
+def test_set_signup_enabled_true_is_idempotent():
+    from routes.auth_routes import SetOpenRegistrationRequest
+
+    auth, target = _auth_route_endpoint("/api/auth/open-signup", "PUT")
+    auth.get_username_for_token.return_value = "admin"
+    auth.is_admin.return_value = True
+
+    request = _fake_auth_request()
+    auth.signup_enabled = False
+
+    out = asyncio.run(target(body=SetOpenRegistrationRequest(enabled=True),request=request))
+
+    assert out == {"ok": True, "signup_enabled": True}
+    assert auth.signup_enabled is True
+
+    out = asyncio.run(target(body=SetOpenRegistrationRequest(enabled=True), request=request))
+
+    assert out == {"ok": True, "signup_enabled": True}
+    assert auth.signup_enabled is True
+
+def test_set_signup_enabled_false_is_idempotent():
+    from routes.auth_routes import SetOpenRegistrationRequest
+
+    auth, target = _auth_route_endpoint("/api/auth/open-signup", "PUT")
+    auth.get_username_for_token.return_value = "admin"
+    auth.is_admin.return_value = True
+
+    request = _fake_auth_request()
+    auth.signup_enabled = True
+
+    out = asyncio.run(target(body=SetOpenRegistrationRequest(enabled=False), request=request))
+
+    assert out == {"ok": True, "signup_enabled": False}
+    assert auth.signup_enabled is False
+
+    out = asyncio.run(target(body=SetOpenRegistrationRequest(enabled=False), request=request))
+
+    assert out == {"ok": True, "signup_enabled": False}
+    assert auth.signup_enabled is False
+
+def test_set_signup_enabled_requires_admin():
+    from routes.auth_routes import SetOpenRegistrationRequest
+
+    auth, target = _auth_route_endpoint("/api/auth/open-signup", "PUT")
+    auth.get_username_for_token.return_value = "bob"
+    auth.is_admin.return_value = False
+    auth.signup_enabled = False
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(target(body=SetOpenRegistrationRequest(enabled=True), request=_fake_auth_request()))
+
+    assert exc.value.status_code == 403
+    assert auth.signup_enabled is False
 
 # ---------------------------------------------------------------------------
 # Research endpoints — `_require_user` rejects anonymous


### PR DESCRIPTION
This PR adds unit tests for the PUT /api/auth/open-signup endpoint introduced in #767.

The new tests verify:

- Idempotent behavior when setting enabled=True
- Idempotent behavior when setting enabled=False
- Admin-only access control (non-admin users receive 403)