### PR TITLE
Add delete confirmation when deleting a chat

### DIFF
--- a/static/js/documentLibrary.js
+++ b/static/js/documentLibrary.js
@@ -2059,6 +2059,7 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
           { label: 'Copy', action: () => _copyChatById(s.id) },
           { label: 'Archive', action: async () => { await fetch(API_BASE + '/api/session/' + s.id + '/archive', { method: 'POST', headers: {'Content-Type':'application/json'} }); _renderLibChats(); } },
           { label: 'Delete', action: async () => {
+            if(!await uiModule.styledConfirm('Are you sure you want to delete this conversation? This action cannot be undone.', {confirmText: 'Yes', cancelText: 'No', danger: true})) return;
             await fetch(API_BASE + '/api/session/' + s.id, { method: 'DELETE' });
             card.style.maxHeight = `${Math.max(card.getBoundingClientRect().height, card.scrollHeight)}px`;
             card.classList.add('memory-tidy-removing');
@@ -2412,7 +2413,7 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
           { label: 'Open', action: () => { if (window.sessionModule) window.sessionModule.selectSession(s.id); } },
           { label: 'Copy', action: () => _copyChatById(s.id) },
           { label: 'Restore', action: async () => { await fetch(API_BASE + '/api/session/' + s.id + '/unarchive', { method: 'POST' }); _renderLibArchive(); } },
-          { label: 'Delete', action: async () => { await fetch(API_BASE + '/api/session/' + s.id, { method: 'DELETE' }); _renderLibArchive(); }, danger: true },
+          { label: 'Delete', action: async () => { if(!await uiModule.styledConfirm('Are you sure you want to delete this conversation? This action cannot be undone.', {confirmText: 'Yes', cancelText: 'No', danger: true})) return; await fetch(API_BASE + '/api/session/' + s.id, { method: 'DELETE' }); _renderLibArchive(); }, danger: true },
         ], { onSelect: () => {
           _arcSelectMode = true;
           _arcSelected.add('chats:' + s.id);

--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -615,6 +615,8 @@ function createSessionItem(s) {
       dropdown.style.display = 'none';
       return;
     }
+    if(!await uiModule.styledConfirm('Are you sure you want to delete this conversation? This action cannot be undone.', {confirmText: 'Yes', cancelText: 'No', danger: true})) return;
+    
     dropdown.style.display = 'none';
     // Optimistic: remove from UI immediately
     const sessionEl = document.querySelector(`.list-item[data-session-id="${s.id}"]`);


### PR DESCRIPTION
## What
Deleting a conversation was immediate and irreversible across several surfaces. This adds a confirmation dialog to every **single-chat delete** path that was missing one, using the app's existing `styledConfirm` (danger variant).

Paths now gated:
- **Sidebar** session dropdown → Delete (`static/js/sessions.js`)
- **Documents/Chats library** card ⋯ dropdown → Delete (`static/js/documentLibrary.js`)
- **Archive tab** card ⋯ dropdown → Delete (`static/js/documentLibrary.js`)

Bulk deletes, the chat-card preview delete button, and folder / "delete all unsorted" already confirmed — left unchanged. The automatic incognito-session cleanup (not a user action) is intentionally untouched.

## Why
Addresses #1006 — *"Add delete confirmation when deleting a chat"*. Matches the confirmation UX already used elsewhere in the app.

## Testing
- Manual: trigger Delete from the sidebar dropdown, the Chats library ⋯ menu, and the Archive ⋯ menu — each now prompts; "No" keeps the chat, "Yes" deletes as before.
- `node --check static/js/sessions.js static/js/documentLibrary.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
