### PR TITLE
Allow any file type in chat attachments

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -981,7 +981,7 @@
     <input type="checkbox" id="research-toggle" style="display:none;">
     <input type="checkbox" id="rag-toggle" style="display:none;">
     <input type="checkbox" id="incognito-toggle" style="display:none;">
-    <input type="file" id="file-input" class="hidden" multiple accept="image/*,application/pdf,video/*,.txt,.py,.html,.htm,.md,.json,.csv,.log,audio/*" />
+    <input type="file" id="file-input" class="hidden" multiple />
 
     <!-- Unified chat input bar -->
     <div class="chat-input-bar">

--- a/tests/test_chat_attachment_picker.py
+++ b/tests/test_chat_attachment_picker.py
@@ -1,0 +1,33 @@
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _InputParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.inputs = {}
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "input":
+            return
+        attr_map = dict(attrs)
+        input_id = attr_map.get("id")
+        if input_id:
+            self.inputs[input_id] = attr_map
+
+
+def _inputs():
+    parser = _InputParser()
+    parser.feed((ROOT / "static" / "index.html").read_text(encoding="utf-8"))
+    return parser.inputs
+
+
+def test_chat_attachment_picker_allows_any_file_type():
+    file_input = _inputs()["file-input"]
+
+    assert file_input["type"] == "file"
+    assert "multiple" in file_input
+    assert "accept" not in file_input


### PR DESCRIPTION
Fixes #1071.

The chat attachment picker was using a long `accept` list, which makes desktop file dialogs show a weird Custom Files filter and also blocks common source files that the backend can still handle.

This removes the chat picker filter so the dialog behaves like the drag/drop path: pick the file, then let upload/processing decide what can actually be used. The specialized import pickers still keep their own filters.

Checked:
- venv/bin/python -m py_compile tests/test_chat_attachment_picker.py
- venv/bin/python -m pytest -q tests/test_chat_attachment_picker.py
- git diff origin/main...HEAD --check
