### PR TITLE
[codex] fix test suite module isolation

### DIFF
--- a/tests/test_chat_image_routing.py
+++ b/tests/test_chat_image_routing.py
@@ -1,5 +1,12 @@
 import json
+import sys
 from types import SimpleNamespace
+
+_endpoint_resolver = sys.modules.get("src.endpoint_resolver")
+if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
+    sys.modules.pop("src.endpoint_resolver", None)
+    sys.modules.pop("routes.model_routes", None)
+    sys.modules.pop("routes.chat_routes", None)
 
 from routes import chat_routes
 

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -48,6 +48,8 @@ _db = _DBStub("core.database")
 _db.get_db_session = _get_db_session
 _db.ApiToken = _ApiToken
 sys.modules["core.database"] = _db  # overwrite any minimal stub from a sibling test
+sys.modules.pop("companion.pairing", None)
+sys.modules.pop("companion.routes", None)
 
 for _name, _attrs in {
     "core.auth": {"AuthManager": MagicMock()},
@@ -69,7 +71,8 @@ from core.middleware import require_admin  # noqa: E402
 
 # --- token minting: shown once, hashed at rest -----------------------------
 
-def test_mint_token_returns_raw_once_and_stores_only_a_hash():
+def test_mint_token_returns_raw_once_and_stores_only_a_hash(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", _db)
     token_id, raw = P.mint_token("alice")
     assert raw.startswith("ody_")
     # The persisted row stores a bcrypt hash + prefix, never the plaintext.

--- a/tests/test_scheduler_restart_doublefire.py
+++ b/tests/test_scheduler_restart_doublefire.py
@@ -103,6 +103,8 @@ def _drive_scheduler(monkeypatch, pre_start_setup=None):
     # (stubbed to _never here); filter those out so the test only counts
     # real per-poll task dispatches.
     real_dispatches = [c for c in all_dispatched if c.__name__ != "_never"]
+    for coro in all_dispatched:
+        coro.close()
     return cd, ScheduledTask, TaskRun, real_dispatches
 
 

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -717,7 +717,10 @@ def test_internal_tool_owner_header_logic_requires_known_user():
 
 def test_auth_manager_migrates_legacy_admin_role(tmp_path):
     """Old setup.py wrote role='admin'; startup must turn that into is_admin."""
+    sys.modules.pop("core.atomic_io", None)
     sys.modules.pop("core.auth", None)
+    if "core" in sys.modules and not getattr(sys.modules["core"], "__file__", None):
+        sys.modules.pop("core", None)
     if "core" in sys.modules and hasattr(sys.modules["core"], "auth"):
         delattr(sys.modules["core"], "auth")
     from core.auth import AuthManager

--- a/tests/test_sqlite_foreign_keys.py
+++ b/tests/test_sqlite_foreign_keys.py
@@ -1,4 +1,16 @@
 import pytest
+import sys
+
+for name, mod in list(sys.modules.items()):
+    if name == "sqlalchemy" or name.startswith("sqlalchemy."):
+        if not getattr(mod, "__file__", None):
+            sys.modules.pop(name, None)
+sys.modules.pop("core.database", None)
+if "core" in sys.modules and not getattr(sys.modules["core"], "__file__", None):
+    sys.modules.pop("core", None)
+if "core" in sys.modules and hasattr(sys.modules["core"], "database"):
+    delattr(sys.modules["core"], "database")
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from core.database import Base, Session, ChatMessage
@@ -35,4 +47,3 @@ def test_sqlite_foreign_keys_cascade():
     assert db.query(ChatMessage).count() == 0
     
     db.close()
-

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -1,5 +1,7 @@
 """Regression tests for task-result delivery into chat sessions (issue #326)."""
 import asyncio
+import importlib
+import sys
 import types as _types
 
 import pytest
@@ -8,28 +10,30 @@ sqlalchemy = pytest.importorskip("sqlalchemy")
 if not isinstance(sqlalchemy, _types.ModuleType):
     pytest.skip("sqlalchemy is stubbed in this environment", allow_module_level=True)
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+def _real_modules():
+    for name, mod in list(sys.modules.items()):
+        if name == "sqlalchemy" or name.startswith("sqlalchemy."):
+            if not getattr(mod, "__file__", None):
+                sys.modules.pop(name, None)
+    sys.modules.pop("src.task_scheduler", None)
+    sys.modules.pop("core.database", None)
+    if "core" in sys.modules and not getattr(sys.modules["core"], "__file__", None):
+        sys.modules.pop("core", None)
+    if "core" in sys.modules and hasattr(sys.modules["core"], "database"):
+        delattr(sys.modules["core"], "database")
 
-from core.database import Base, Session as DbSession
-from src.task_scheduler import TaskScheduler
-
-# TEMPORARY ISOLATION WORKAROUND — remove once test_null_owner_gates.py is
-# refactored to use a fixture-scoped stub instead of module-level sys.modules
-# patching.  When collected after test_null_owner_gates (alphabetical order),
-# core.database is already a stub whose Base attribute is a MagicMock, so
-# Base.metadata.create_all() below does nothing and the assertions fail.
-# The test passes correctly in isolation:
-#   pytest tests/test_task_scheduler_session_delivery.py   → 1 passed
-# Full-suite baseline before this PR:  9 failed, 345 passed  (pre-upstream-pull)
-# Full-suite after this PR:            1 failed, 495 passed, 1 skipped
-if type(Base).__name__ == "MagicMock":
-    pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
+    core_db = importlib.import_module("core.database")
+    task_scheduler = importlib.import_module("src.task_scheduler")
+    return core_db, task_scheduler.TaskScheduler
 
 
 def _make_db():
+    core_db, _TaskScheduler = _real_modules()
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
     engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
+    core_db.Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)()
 
 
@@ -51,13 +55,14 @@ def test_session_delivery_survives_empty_database():
     """On a fresh/wiped database there is no session to inherit endpoint/model
     from, so _resolve_defaults returns None. The delivery must still persist a
     session instead of crashing on the NOT NULL constraint (issue #326)."""
+    core_db, TaskScheduler = _real_modules()
     db = _make_db()
     scheduler = TaskScheduler.__new__(TaskScheduler)
     scheduler._session_manager = None
 
     asyncio.run(scheduler._deliver_task_result(_make_task(), "done", db))
 
-    sessions = db.query(DbSession).all()
+    sessions = db.query(core_db.Session).all()
     assert len(sessions) == 1
     assert sessions[0].endpoint_url == ""
     assert sessions[0].model == ""

--- a/tests/test_topic_analyzer.py
+++ b/tests/test_topic_analyzer.py
@@ -1,6 +1,21 @@
 """Tests for topic keyword matching (src/topic_analyzer.py)."""
+import sys
 from types import SimpleNamespace
 import pytest
+
+for name, mod in list(sys.modules.items()):
+    if name == "sqlalchemy" or name.startswith("sqlalchemy."):
+        if not getattr(mod, "__file__", None):
+            sys.modules.pop(name, None)
+for name in ("core.database", "core.session_manager"):
+    sys.modules.pop(name, None)
+if "core" in sys.modules and not getattr(sys.modules["core"], "__file__", None):
+    sys.modules.pop("core", None)
+if "core" in sys.modules:
+    for attr in ("database", "session_manager"):
+        if hasattr(sys.modules["core"], attr):
+            delattr(sys.modules["core"], attr)
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from core.database import Base, Session as DbSession, ChatMessage as DbChatMessage

--- a/tests/test_webhook_ssrf_resilience.py
+++ b/tests/test_webhook_ssrf_resilience.py
@@ -1,8 +1,25 @@
 import sys
+import types
 # conftest.py stubs src.database with a fake module; webhook_manager imports
 # from it, so drop the stub here to load the real module under test.
-if "src.database" in sys.modules:
-    del sys.modules["src.database"]
+for name in ("src.database", "src.webhook_manager"):
+    sys.modules.pop(name, None)
+
+core_db = sys.modules.get("core.database")
+if core_db is not None:
+    module_file = getattr(core_db, "__file__", None)
+    module_all = getattr(core_db, "__all__", [])
+    if (
+        not isinstance(core_db, types.ModuleType)
+        or not isinstance(module_file, str)
+        or not isinstance(module_all, (list, tuple, set))
+        or not all(isinstance(item, str) for item in module_all)
+    ):
+        sys.modules.pop("core.database", None)
+        if "core" in sys.modules and hasattr(sys.modules["core"], "database"):
+            delattr(sys.modules["core"], "database")
+        if "core" in sys.modules and not getattr(sys.modules["core"], "__file__", None):
+            sys.modules.pop("core", None)
 
 import pytest
 from src.webhook_manager import validate_webhook_url


### PR DESCRIPTION
## Summary
- fix test module isolation so fake core/database/endpoint modules do not poison later tests
- force affected tests to load their intended real or stub modules deterministically
- close scheduler test coroutines to remove resource warnings

## Why this is needed
A clean checkout of current pewdiepie main failed the tracked pytest suite from suite-order pollution. Before this branch, the full tracked suite failed with collection/runtime errors in test_chat_image_routing, test_webhook_ssrf_resilience, companion pairing, AuthManager migration, SQLite FK cascade, topic analyzer hydration, and task scheduler delivery depending on collection order.

## Validation
- Baseline current main targeted checks: 24 passed after creating expected data/logs runtime dirs
- Baseline current main full tracked suite: failed before these fixes
- Patched branch full tracked suite: 1043 passed, 1 skipped
- python3 -m py_compile app.py core/*.py routes/*.py src/*.py services/**/*.py tests/*.py
- node --check static/js/research/panel.js && node --check static/js/modalManager.js
- docker compose --env-file .env.example config

## Notes
This is a fresh branch from pewdiepie main (537b4bc), not the stale elizaOS PR #1 branch.