### PR TITLE
fix(ui): don't submit chat message on Enter during IME composition

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3163,7 +3163,7 @@ function initializeEventListeners() {
       setTimeout(() => uiModule.autoResize(textarea), 1);
     });
     textarea.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
         // If ghost autocomplete is active, accept the suggestion instead of submitting
         if (window._ghostAutocomplete && window._ghostAutocomplete.isActive()) {
           e.preventDefault();
@@ -3736,7 +3736,7 @@ function startOdysseusApp() {
   // Enter to send (shift+enter for newline), or new chat when empty
   if (messageInput) {
     messageInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
         e.preventDefault();
         // Flush the debounced icon update so dataset.mode reflects the current
         // text state. Without this, a fast type-and-Enter would still see the

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -3424,7 +3424,7 @@ import createResearchSynapse from './researchSynapse.js';
 
     // Also submit on Enter (without shift)
     editor.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
         e.preventDefault();
         saveBtn.click();
       }


### PR DESCRIPTION
## What

CJK / IME users confirm a candidate from the input-method popup by pressing **Enter**. The chat composer and the in-place message editor both treat `Enter` (without Shift) as "submit", but neither checked whether an IME composition was in progress. Pressing Enter to accept a candidate sent the half-composed text (e.g. a stray `ce's`) as a message instead of just confirming the candidate.

## Why it happens

These textareas intentionally hijack Enter to submit (Enter sends, Shift+Enter inserts a newline), which bypasses the browser's native form submission — and the IME guard that comes with it. So the guard has to be re-added explicitly.

## Change

Add `&& !e.isComposing` to the three Enter-to-submit handlers:

- `static/app.js` — the main composer (the button-submit path and the send / new-chat path)
- `static/js/chat.js` — the editor for an already-sent message

`isComposing` is a standard [`KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing) property supported by all current browsers. Normal Enter (when not composing) still submits; Shift+Enter still inserts a newline.

## Steps to reproduce (before this change)

1. Open a chat and switch to a CJK input method (e.g. Pinyin).
2. Type a few letters so the candidate popup appears.
3. Press Enter to pick a candidate.
4. The half-composed text is sent as a message instead of being committed to the textarea.

## Testing

- `node --check static/app.js static/js/chat.js`
- Manually verified with a Chinese IME: pressing Enter to pick a candidate no longer sends; a message is sent only after composition ends; plain Enter still sends and Shift+Enter still inserts a newline.
