### PR TITLE
fix(security): owner-scope endpoint_id lookup in session create/switch-model (cross-tenant API-key reuse)

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -11,7 +11,7 @@ from core.session_manager import SessionManager
 from core.models import ChatMessage
 from src.request_models import SessionResponse
 from core.database import Session as DbSession, SessionLocal, Document, GalleryImage
-from src.auth_helpers import get_current_user, effective_user
+from src.auth_helpers import get_current_user, effective_user, owner_filter
 
 
 def _sanitize_export_filename(name: str) -> str:
@@ -53,6 +53,27 @@ def _verify_session_owner(request: Request, session_id: str, session_manager=Non
         if ghost is not None and getattr(ghost, "owner", None) == user:
             return
     raise HTTPException(404, f"Session {session_id} not found")
+
+
+def _owned_endpoint(db, endpoint_id, owner):
+    """The ModelEndpoint with `endpoint_id` VISIBLE to `owner` — their own row or
+    a legacy null-owner ("shared") row — else None.
+
+    ModelEndpoint is per-user (non-null owner = private to that user — see
+    core/database.py: "the model picker only shows the endpoint to that user")
+    and holds a decrypted `api_key`. Session create / switch-model copy that key
+    and base_url into the session's auth headers, so an UNSCOPED lookup by the
+    caller-supplied endpoint_id would let a user bind their session to ANOTHER
+    user's PRIVATE endpoint — spending that owner's api_key/quota and reaching
+    whatever internal base_url they configured. Owner-scoped via owner_filter,
+    matching routes/model_routes.py, companion/routes.py and webhook_routes.py.
+    A null/empty owner is a no-op (single-user / legacy mode).
+    """
+    from core.database import ModelEndpoint
+    q = db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id)
+    q = owner_filter(q, ModelEndpoint, owner)
+    return q.first()
+
 
 logger = logging.getLogger(__name__)
 
@@ -255,10 +276,12 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         resolved_key = api_key.strip() if api_key else ""
         resolved_base = endpoint_url
         if not resolved_key and endpoint_id and endpoint_id.strip():
-            from core.database import ModelEndpoint
             _db = SessionLocal()
             try:
-                ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id.strip()).first()
+                # Owner-scoped: never resolve another user's private endpoint
+                # (and its decrypted api_key / internal base_url). See
+                # _owned_endpoint.
+                ep = _owned_endpoint(_db, endpoint_id.strip(), user)
                 if ep and ep.api_key:
                     resolved_key = ep.api_key
                     resolved_base = ep.base_url
@@ -291,6 +314,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         endpoint_id: str = Form(None),
     ):
         _verify_session_owner(request, sid)
+        owner = effective_user(request)
         try:
             session = session_manager.get_session(sid)
         except KeyError:
@@ -314,10 +338,13 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         # Switch model/endpoint mid-session
         if model is not None and endpoint_url is not None:
             if endpoint_id:
-                from core.database import ModelEndpoint
                 _db = SessionLocal()
                 try:
-                    ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id).first()
+                    # Owner-scoped: a scoped miss (another user's endpoint, or a
+                    # deleted one) reads as "no longer exists" so existence isn't
+                    # revealed and the private api_key is never copied. See
+                    # _owned_endpoint.
+                    ep = _owned_endpoint(_db, endpoint_id, owner)
                     if not ep:
                         raise HTTPException(400, "Model endpoint no longer exists")
                 finally:
@@ -328,7 +355,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             if endpoint_id:
                 _db = SessionLocal()
                 try:
-                    ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id).first()
+                    ep = _owned_endpoint(_db, endpoint_id, owner)
                     if ep and ep.api_key:
                         from src.endpoint_resolver import build_headers
                         session.headers = build_headers(ep.api_key, ep.base_url)

--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -252,6 +252,7 @@ class _Column:
 
 
 class _ModelEndpoint:
+    id = _Column("id")
     is_enabled = _Column("is_enabled")
     owner = _Column("owner")
 
@@ -319,3 +320,52 @@ def test_sync_chat_fallback_null_owner_is_legacy_single_user_noop():
     rows = [_ep("first", "bob"), _ep("second", "alice")]
     ep = _select(rows, None)
     assert ep is not None and ep.name == "first"
+
+
+# ---------------------------------------------------------------------------
+# session_routes._owned_endpoint  (POST /session, PATCH /session/{sid})
+# ---------------------------------------------------------------------------
+# The SAME multi-tenant leak on the session model-picker: create_session and
+# rename_session resolve a CALLER-SUPPLIED endpoint_id to a ModelEndpoint and
+# copy its *decrypted* api_key + base_url into the session's auth headers. The
+# lookup was a bare `.filter(ModelEndpoint.id == endpoint_id).first()`, so a
+# user (or a paired chat-scoped mobile token) could bind their session to
+# ANOTHER user's PRIVATE endpoint and silently spend that owner's api_key /
+# reach their internal base_url. The lookup must be owner-scoped (own rows +
+# legacy null-owner shared rows), exactly like the webhook fallback above and
+# routes/model_routes.py / companion/routes.py.
+
+def _ep_id(eid, owner, *, api_key="sk-secret"):
+    return SimpleNamespace(id=eid, owner=owner, api_key=api_key)
+
+
+def _select_owned(rows, endpoint_id, owner):
+    sess_mod = __import__("routes.session_routes", fromlist=["_owned_endpoint"])
+    sys.modules["core.database"].ModelEndpoint = _ModelEndpoint
+    return sess_mod._owned_endpoint(_DB(rows), endpoint_id, owner)
+
+
+def test_owned_endpoint_rejects_another_owners_private_endpoint():
+    # bob's private endpoint exists, but alice asking for it by id gets nothing.
+    rows = [_ep_id("ep-bob", "bob"), _ep_id("ep-alice", "alice")]
+    assert _select_owned(rows, "ep-bob", "alice") is None
+
+
+def test_owned_endpoint_returns_callers_own_endpoint():
+    rows = [_ep_id("ep-bob", "bob"), _ep_id("ep-alice", "alice")]
+    ep = _select_owned(rows, "ep-alice", "alice")
+    assert ep is not None and ep.id == "ep-alice"
+
+
+def test_owned_endpoint_allows_legacy_null_owner_shared_row():
+    rows = [_ep_id("ep-shared", None)]
+    ep = _select_owned(rows, "ep-shared", "alice")
+    assert ep is not None and ep.id == "ep-shared"
+
+
+def test_owned_endpoint_null_owner_is_legacy_single_user_noop():
+    # Single-user / unresolved owner: owner_filter is a no-op, so an exact id
+    # match still resolves (preserves pre-multi-user behaviour).
+    rows = [_ep_id("ep-x", "bob")]
+    ep = _select_owned(rows, "ep-x", None)
+    assert ep is not None and ep.id == "ep-x"


### PR DESCRIPTION
## Summary

`POST /api/session` and `PATCH /api/session/{sid}` (switch model mid-session) resolve a **caller-supplied `endpoint_id`** to a `ModelEndpoint` and copy that row's **decrypted `api_key`** and `base_url` into the session's auth headers — which are then used for every LLM call on that session. Both lookups are unscoped:

```python
ep = db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id).first()
```

`ModelEndpoint` is a **per-user private resource** (`core/database.py`: non-null `owner` = private, *"the model picker only shows the endpoint to that user"*). With no owner check, any authenticated user — or a paired chat-scoped mobile bearer token — can bind their own session to **another user's private endpoint** by passing its id, then:

- silently spend that owner's **API key / quota**, and
- reach whatever **internal `base_url`** they configured (SSRF to internal services).

The session-ownership gate (`_verify_session_owner`) does **not** protect this: the attacker legitimately owns the session — the missing authorization is on the **endpoint**, not the session.

This is the same multi-tenant owner-scoping class already fixed for `companion/models`, `/api/v1/chat`'s session gate, and the `/api/v1/chat` fallback (`_first_enabled_endpoint`, #1045). These two sinks on the session model-picker were missed.

### Exploit sketch (multi-user deploy)
1. Alice creates a session: `POST /api/session` with `endpoint_id=<Bob's endpoint id>`.
2. Server copies **Bob's** decrypted `api_key` + `base_url` into Alice's session headers.
3. Every message Alice sends bills Bob's provider key and hits Bob's configured (possibly internal) URL.

## Fix

Extract `_owned_endpoint(db, endpoint_id, owner)` that scopes the lookup through the shared `owner_filter` helper (caller's own rows **+** legacy null-owner shared rows), matching `routes/model_routes.py`, `companion/routes.py`, and `routes/webhook_routes.py`. Used in both sinks.

- A scoped miss → `None`: create silently skips the key; switch-model returns the existing `"Model endpoint no longer exists"` 400 — endpoint existence isn't revealed.
- Null/empty owner → `owner_filter` no-op, preserving single-user / legacy behaviour.

## Tests

`tests/test_null_owner_gates.py` — pins the scoped lookup: cross-owner rejected, own-row allowed, legacy shared-row allowed, null-owner no-op.

```
$ pytest tests/test_null_owner_gates.py -q
22 passed
```