### PR TITLE
fix(rag): use a stable hash for document IDs so dedup survives restarts

### DIFF
--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -7,6 +7,7 @@ configurable embedding endpoint via EMBEDDING_URL env var.
 """
 
 import os
+import hashlib
 import re
 import logging
 import numpy as np
@@ -24,6 +25,10 @@ VECTOR_WEIGHT = 0.7
 KEYWORD_WEIGHT = 0.3
 
 COLLECTION_NAME = "odysseus_rag"
+
+
+def _generate_doc_id(text: str) -> str:
+    return f"doc_{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
 
 
 class VectorRAG:
@@ -99,7 +104,7 @@ class VectorRAG:
             return False
 
         try:
-            doc_id = f"doc_{hash(text) % 10**16}"
+            doc_id = _generate_doc_id(text)
             # Check if already exists
             existing = self._collection.get(ids=[doc_id])
             if existing["ids"]:
@@ -135,7 +140,7 @@ class VectorRAG:
             new_metas = []
             new_ids = []
             for t, m in valid:
-                doc_id = f"doc_{hash(t) % 10**16}"
+                doc_id = _generate_doc_id(t)
                 existing = self._collection.get(ids=[doc_id])
                 if not existing["ids"]:
                     new_texts.append(t)

--- a/tests/test_rag_vector_id_stability.py
+++ b/tests/test_rag_vector_id_stability.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import pytest
+
+def test_rag_id_stability_across_processes():
+    # Run helper in subprocesses with different PYTHONHASHSEED values to ensure cross-process stability
+    cmd = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
+    
+    env0 = os.environ.copy()
+    env0["PYTHONHASHSEED"] = "0"
+    id0 = subprocess.check_output(cmd, env=env0).decode().strip()
+    
+    env1 = os.environ.copy()
+    env1["PYTHONHASHSEED"] = "1"
+    id1 = subprocess.check_output(cmd, env=env1).decode().strip()
+    
+    env_rand = os.environ.copy()
+    env_rand["PYTHONHASHSEED"] = "random"
+    id_rand = subprocess.check_output(cmd, env=env_rand).decode().strip()
+    
+    # Assert they are all equal (deterministic across seeds and processes)
+    assert id0 == id1
+    assert id0 == id_rand
+    
+    # Assert different inputs produce different IDs
+    cmd_diff = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
+    id_diff = subprocess.check_output(cmd_diff, env=env0).decode().strip()
+    assert id0 != id_diff


### PR DESCRIPTION
## Problem

`add_document()` and `add_documents_batch()` derive the **persistent** ChromaDB document id from Python's built-in `hash()`:

```python
doc_id = f"doc_{hash(text) % 10**16}"
```

`str` hashing is randomized per process (`PYTHONHASHSEED` is on by default since 3.3), so the **same** document text produces a **different** `doc_id` on every restart.

The dedup check immediately after — `self._collection.get(ids=[doc_id])` — therefore misses across restarts, so identical documents are re-embedded and re-added as duplicates each time the app restarts. The vector store bloats and retrieval gets skewed by the duplicates.

Reproduced (two separate processes, same text):

```
process 1: doc_970826759608228
process 2: doc_1912330438375437   # different id for identical text
```

## Fix

Derive the id from a stable `hashlib.sha256` of the text via a shared `_generate_doc_id()` helper, used by **both** add paths so they agree:

```python
def _generate_doc_id(text: str) -> str:
    return f"doc_{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
```

## Test

`tests/test_rag_vector_id_stability.py` runs `_generate_doc_id` in subprocesses under `PYTHONHASHSEED=0`, `=1`, and `=random` and asserts the id is identical across all of them (and differs for different text). It fails before this change (the built-in `hash()` ids differ per seed).