### PR TITLE
feat: Add workspace: confine agent tools to a folder

### DIFF
--- a/app.py
+++ b/app.py
@@ -525,6 +525,9 @@ upload_cleanup_task = None
 from routes.emoji_routes import setup_emoji_routes
 app.include_router(setup_emoji_routes())
 
+from routes.workspace_routes import setup_workspace_routes
+app.include_router(setup_workspace_routes())
+
 # Sessions
 from routes.session_routes import setup_session_routes
 session_config = {"REQUEST_TIMEOUT": REQUEST_TIMEOUT, "OPENAI_API_KEY": OPENAI_API_KEY, "SESSIONS_FILE": SESSIONS_FILE}

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 import time
 import logging
 from datetime import datetime
@@ -394,6 +395,12 @@ def setup_chat_routes(
         compare_mode = str(form_data.get("compare_mode", "")).lower() == "true"
         incognito = str(form_data.get("incognito", "")).lower() == "true"
         chat_mode = str(form_data.get("mode", "")).lower()  # 'chat' or 'agent'
+        # Workspace: confine the agent's file/shell tools to this folder. Validate
+        # it's a real directory; ignore (no confinement) otherwise.
+        workspace = (form_data.get("workspace") or "").strip()
+        if workspace:
+            _ws_real = os.path.realpath(os.path.expanduser(workspace))
+            workspace = _ws_real if os.path.isdir(_ws_real) else ""
         # Did the USER explicitly pick agent mode? (vs. us auto-escalating
         # below). Skill extraction should only learn from real agent sessions,
         # not chats we quietly promoted for a notes/calendar intent.
@@ -1007,6 +1014,7 @@ def setup_chat_routes(
                         disabled_tools=disabled_tools if disabled_tools else None,
                         owner=_user,
                         fallbacks=_fallback_candidates,
+                        workspace=workspace or None,
                     ):
                         if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
                             try:

--- a/routes/workspace_routes.py
+++ b/routes/workspace_routes.py
@@ -1,0 +1,56 @@
+"""Workspace API — browse server directories to pick a tool workspace folder."""
+import os
+from fastapi import APIRouter, Request, HTTPException, Query
+
+from src.auth_helpers import get_current_user
+from src.tool_security import owner_is_admin_or_single_user
+
+
+def setup_workspace_routes():
+    router = APIRouter(prefix="/api/workspace", tags=["workspace"])
+
+    @router.get("/browse")
+    def browse(request: Request, path: str = Query(default="")):
+        """List subdirectories of `path` (default: home) so the UI can navigate
+        the server filesystem and pick a workspace folder. Directories only.
+
+        ADMIN-ONLY: this enumerates the server filesystem, so it is gated the
+        same way the file/shell tools are (read_file/write_file/bash are in
+        NON_ADMIN_BLOCKED_TOOLS). A non-admin who can't use those tools must not
+        be able to map the host's directory tree either.
+        """
+        owner = get_current_user(request)
+        if not owner_is_admin_or_single_user(owner):
+            raise HTTPException(status_code=403, detail="Workspace browsing is admin-only")
+
+        # Resolve symlinks so the reported path is canonical and the UI navigates
+        # real directories (defends against symlink games in displayed paths).
+        target = os.path.realpath(os.path.expanduser(path.strip() or "~"))
+        if not os.path.isdir(target):
+            target = os.path.realpath(os.path.expanduser("~"))
+
+        dirs = []
+        try:
+            with os.scandir(target) as it:
+                for entry in it:
+                    try:
+                        # Don't follow symlinks when classifying — a symlinked
+                        # dir is skipped rather than letting the browser wander
+                        # off via a link. Hidden entries are omitted.
+                        if entry.is_dir(follow_symlinks=False) and not entry.name.startswith("."):
+                            # Build the child path server-side with os.path.join
+                            # so it's correct on Windows (backslashes) and Linux.
+                            dirs.append({"name": entry.name, "path": os.path.join(target, entry.name)})
+                    except OSError:
+                        continue
+        except (PermissionError, OSError):
+            dirs = []
+
+        parent = os.path.dirname(target)
+        return {
+            "path": target,
+            "parent": parent if parent and parent != target else None,
+            "dirs": sorted(dirs, key=lambda d: d["name"].lower()),
+        }
+
+    return router

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1387,6 +1387,7 @@ async def stream_agent_loop(
     owner: Optional[str] = None,
     relevant_tools: Optional[Set[str]] = None,
     fallbacks: Optional[List[tuple]] = None,
+    workspace: Optional[str] = None,
     _is_teacher_run: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Streaming agent loop generator.
@@ -1553,6 +1554,27 @@ async def stream_agent_loop(
         compact=_is_api_model,
         owner=owner,
     )
+    if workspace:
+        # PREPEND (not append) so it dominates the large base prompt — appended
+        # at the end, small models ignored it and asked the user for code. The
+        # folder IS the project; the agent must explore it, not ask.
+        _ws_note = (
+            f"## ACTIVE WORKSPACE — READ FIRST\n"
+            f"The user is working in this folder: {workspace}\n"
+            f"It IS the project. bash/python run with cwd set here and "
+            f"read_file/write_file are confined to it (paths outside are rejected).\n"
+            f"When the user says \"the code\" / \"this project\" / \"the workspace\" "
+            f"or asks to review/find/edit something WITHOUT a path, they mean THIS "
+            f"folder. Do NOT ask the user for code or a path, and do NOT read a file "
+            f"literally named \"workspace\". ALWAYS start by exploring it yourself: "
+            f"run `bash` → `git ls-files` (or `ls -R`) to see the files, then "
+            f"read_file the relevant ones by path RELATIVE to the workspace."
+        )
+        if messages and messages[0].get("role") == "system":
+            messages[0]["content"] = _ws_note + "\n\n" + (messages[0].get("content") or "")
+        else:
+            messages.insert(0, {"role": "system", "content": _ws_note})
+        logger.info("[workspace] active for this turn: %s", workspace)
     prep_timings["prompt_build"] = time.time() - _t2
 
     _t3 = time.time()
@@ -2117,6 +2139,7 @@ async def stream_agent_loop(
                         disabled_tools=disabled_tools,
                         owner=owner,
                         progress_cb=_push_progress,
+                        workspace=workspace,
                     )
                 finally:
                     # Sentinel so the drainer knows to stop.

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -293,8 +293,13 @@ def _resolve_tool_path_in_workspace(workspace: str, raw_path: str) -> str:
             f"(e.g. .ssh, .gnupg) or matches a sensitive filename"
         )
     if resolved != base:
+        # normcase so containment holds on case-insensitive filesystems
+        # (Windows, default macOS): it lowercases on Windows and is a no-op on
+        # POSIX. commonpath raises ValueError across Windows drives (C: vs D:)
+        # or mixed abs/rel — both mean "outside", so the except rejects them.
+        nbase = os.path.normcase(base)
         try:
-            if os.path.commonpath([resolved, base]) != base:
+            if os.path.commonpath([os.path.normcase(resolved), nbase]) != nbase:
                 raise ValueError
         except ValueError:
             raise ValueError(f"path '{raw_path}' is outside the workspace ({workspace})")

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -67,12 +67,13 @@ def _unified_diff(old: str, new: str, path: str) -> Optional[Dict[str, Any]]:
     }
 
 
-async def _do_edit_file(content: str) -> Dict[str, Any]:
+async def _do_edit_file(content: str, workspace: Optional[str] = None) -> Dict[str, Any]:
     """Exact string-replacement edit of an on-disk file.
 
     content is JSON: {"path", "old_string", "new_string", "replace_all"?}.
     Fails if old_string is missing or non-unique (unless replace_all) so the
     model can't silently edit the wrong place. Returns a unified diff for the UI.
+    Confined to the workspace when one is set (same policy as write_file).
     """
     try:
         args = json.loads(content) if content.strip().startswith("{") else {}
@@ -84,9 +85,11 @@ async def _do_edit_file(content: str) -> Dict[str, Any]:
     replace_all = bool(args.get("replace_all", False))
     if not raw_path:
         return {"error": "edit_file: path required", "exit_code": 1}
-    # Confine to the same allowlist + sensitive-file policy as read/write_file.
+    # Confine to the workspace when set, else the same allowlist + sensitive-file
+    # policy as read/write_file.
     try:
-        path = _resolve_tool_path(raw_path)
+        path = (_resolve_tool_path_in_workspace(workspace, raw_path)
+                if workspace else _resolve_tool_path(raw_path))
     except ValueError as e:
         return {"error": f"edit_file: {e}", "exit_code": 1}
     if old == "":
@@ -339,14 +342,19 @@ _CODENAV_MAX_HITS = 200
 _CODENAV_MAX_LINE = 400
 
 
-def _resolve_search_root(raw_path: str) -> str:
+def _resolve_search_root(raw_path: str, workspace: Optional[str] = None) -> str:
     """Resolve + confine a code-nav path (grep/glob/ls).
 
-    Empty path → the agent's primary root (first allowlisted root, i.e. the
-    project data dir). A supplied path is confined by the same allowlist +
-    sensitive-file policy as read_file (_resolve_tool_path).
+    With a workspace set, the workspace folder is the root and supplied paths are
+    confined inside it (same policy as read_file). Without one, an empty path
+    defaults to the agent's primary root (project data dir) and a supplied path
+    is confined by the global allowlist + sensitive-file policy.
     """
     raw = (raw_path or "").strip()
+    if workspace:
+        if not raw:
+            return os.path.realpath(workspace)
+        return _resolve_tool_path_in_workspace(workspace, raw)
     if not raw:
         roots = _tool_path_roots()
         return roots[0] if roots else os.path.realpath(".")
@@ -795,7 +803,7 @@ async def _direct_fallback(
                 max_hits = _CODENAV_MAX_HITS
             max_hits = max(1, min(max_hits, _CODENAV_MAX_HITS))
             try:
-                root = _resolve_search_root(str(args.get("path", "")))
+                root = _resolve_search_root(str(args.get("path", "")), workspace)
             except ValueError as e:
                 return {"error": f"grep: {e}", "exit_code": 1}
 
@@ -879,7 +887,7 @@ async def _direct_fallback(
             if not pattern:
                 return {"error": "glob: pattern is required", "exit_code": 1}
             try:
-                root = _resolve_search_root(str(args.get("path", "")))
+                root = _resolve_search_root(str(args.get("path", "")), workspace)
             except ValueError as e:
                 return {"error": f"glob: {e}", "exit_code": 1}
 
@@ -926,7 +934,7 @@ async def _direct_fallback(
             else:
                 raw_path = _s.split("\n", 1)[0].strip()
             try:
-                root = _resolve_search_root(raw_path)
+                root = _resolve_search_root(raw_path, workspace)
             except ValueError as e:
                 return {"error": f"ls: {e}", "exit_code": 1}
 
@@ -1178,7 +1186,7 @@ async def execute_tool_block(
         _is_bg, _bg_cmd = _split_bg_marker(content)
         if _is_bg and _bg_cmd:
             from src import bg_jobs
-            rec = bg_jobs.launch(_bg_cmd, session_id=session_id, cwd=workspace or None)
+            rec = bg_jobs.launch(_bg_cmd, session_id=session_id, cwd=workspace or _AGENT_WORKDIR)
             short = _bg_cmd.strip().split(chr(10))[0][:80]
             desc = f"bash (background): {short}"
             result = {
@@ -1308,7 +1316,7 @@ async def execute_tool_block(
         desc = "edit_image"
         result = await do_edit_image(content, owner=owner)
     elif tool == "edit_file":
-        result = await _do_edit_file(content)
+        result = await _do_edit_file(content, workspace=workspace)
         desc = result.get("output") or result.get("error") or "edit_file"
     elif tool == "trigger_research":
         desc = "trigger_research"

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -268,6 +268,35 @@ def _resolve_tool_path(raw_path: str) -> str:
         f"path '{raw_path}' is outside the allowed roots"
     )
 
+
+def _resolve_tool_path_in_workspace(workspace: str, raw_path: str) -> str:
+    """Confine a model-supplied path to the active workspace.
+
+    Layered on top of upstream's path policy: the workspace is the allowed
+    root (relative paths resolve under it; paths that escape it are rejected),
+    and the sensitive-file deny list (.ssh, .gnupg, id_rsa, …) still applies
+    inside it. When no workspace is set, callers use _resolve_tool_path (the
+    default data/tmp allowlist) instead.
+    """
+    if raw_path is None or not str(raw_path).strip():
+        raise ValueError("path is required")
+    base = os.path.realpath(workspace)
+    expanded = os.path.expanduser(str(raw_path).strip())
+    candidate = expanded if os.path.isabs(expanded) else os.path.join(base, expanded)
+    resolved = os.path.realpath(candidate)
+    if _is_sensitive_path(resolved):
+        raise ValueError(
+            f"path '{raw_path}' is inside a sensitive directory "
+            f"(e.g. .ssh, .gnupg) or matches a sensitive filename"
+        )
+    if resolved != base:
+        try:
+            if os.path.commonpath([resolved, base]) != base:
+                raise ValueError
+        except ValueError:
+            raise ValueError(f"path '{raw_path}' is outside the workspace ({workspace})")
+    return resolved
+
 # Bash + python tools used to share a single 60s timeout. That's
 # enough for one-shot commands but starves real workloads (pip
 # install, ffmpeg conversions, etc.) — and worse, the agent saw the
@@ -534,11 +563,12 @@ async def _call_mcp_tool(
     tool: str,
     content: str,
     progress_cb: Optional[Callable[[Dict], Awaitable[None]]] = None,
+    workspace: Optional[str] = None,
 ) -> Dict:
     """Route a legacy tool call through the MCP manager, with direct fallbacks."""
     mcp = get_mcp_manager()
     if not mcp:
-        return await _direct_fallback(tool, content, progress_cb=progress_cb) or {"error": f"MCP manager not available for tool '{tool}'", "exit_code": 1}
+        return await _direct_fallback(tool, content, progress_cb=progress_cb, workspace=workspace) or {"error": f"MCP manager not available for tool '{tool}'", "exit_code": 1}
 
     server_id, tool_name = _MCP_TOOL_MAP[tool]
     qualified = f"mcp__{server_id}__{tool_name}"
@@ -547,7 +577,7 @@ async def _call_mcp_tool(
 
     # If MCP server not connected, try direct fallback
     if isinstance(result, dict) and result.get("exit_code") == 1 and "not connected" in result.get("error", ""):
-        fallback = await _direct_fallback(tool, content, progress_cb=progress_cb)
+        fallback = await _direct_fallback(tool, content, progress_cb=progress_cb, workspace=workspace)
         if fallback:
             return fallback
 
@@ -574,6 +604,7 @@ async def _direct_fallback(
     tool: str,
     content: str,
     progress_cb: Optional[Callable[[Dict], Awaitable[None]]] = None,
+    workspace: Optional[str] = None,
 ) -> Optional[Dict]:
     """In-process execution path for the eight tools that used to live as
     stdio MCP servers under mcp_servers/. Those servers were deleted in
@@ -609,7 +640,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
-                cwd=_AGENT_WORKDIR,
+                cwd=workspace or _AGENT_WORKDIR,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -636,7 +667,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
-                cwd=_AGENT_WORKDIR,
+                cwd=workspace or _AGENT_WORKDIR,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -666,7 +697,8 @@ async def _direct_fallback(
                 except (_json.JSONDecodeError, TypeError, ValueError):
                     pass
             try:
-                path = _resolve_tool_path(raw_path)
+                path = (_resolve_tool_path_in_workspace(workspace, raw_path)
+                        if workspace else _resolve_tool_path(raw_path))
             except ValueError as e:
                 return {"error": f"read_file: {e}", "exit_code": 1}
             try:
@@ -709,7 +741,8 @@ async def _direct_fallback(
             raw_path = lines[0].strip()
             body = lines[1] if len(lines) > 1 else ""
             try:
-                path = _resolve_tool_path(raw_path)
+                path = (_resolve_tool_path_in_workspace(workspace, raw_path)
+                        if workspace else _resolve_tool_path(raw_path))
             except ValueError as e:
                 return {"error": f"write_file: {e}", "exit_code": 1}
             try:
@@ -1057,6 +1090,7 @@ async def execute_tool_block(
     disabled_tools: Optional[set] = None,
     owner: Optional[str] = None,
     progress_cb: Optional[Callable[[Dict], Awaitable[None]]] = None,
+    workspace: Optional[str] = None,
 ) -> Tuple[str, Dict]:
     """Execute a single tool block. Returns (description, result_dict).
 
@@ -1144,7 +1178,7 @@ async def execute_tool_block(
         _is_bg, _bg_cmd = _split_bg_marker(content)
         if _is_bg and _bg_cmd:
             from src import bg_jobs
-            rec = bg_jobs.launch(_bg_cmd, session_id=session_id)
+            rec = bg_jobs.launch(_bg_cmd, session_id=session_id, cwd=workspace or None)
             short = _bg_cmd.strip().split(chr(10))[0][:80]
             desc = f"bash (background): {short}"
             result = {
@@ -1166,12 +1200,13 @@ async def execute_tool_block(
     if tool in _MCP_TOOL_MAP:
         first_line = content.split(chr(10))[0][:80]
         desc = f"{tool}: {first_line}"
-        result = await _call_mcp_tool(tool, content, progress_cb=progress_cb)
+        result = await _call_mcp_tool(tool, content, progress_cb=progress_cb, workspace=workspace)
     elif tool in ("grep", "glob", "ls"):
         # Code-navigation tools — no MCP server; run the direct implementation.
+        # Confined to the workspace when one is set (same policy as read_file).
         first_line = content.split(chr(10))[0][:80]
         desc = f"{tool}: {first_line}"
-        result = await _direct_fallback(tool, content, progress_cb=progress_cb) \
+        result = await _direct_fallback(tool, content, progress_cb=progress_cb, workspace=workspace) \
             or {"error": f"{tool}: execution failed", "exit_code": 1}
     elif tool == "create_document":
         title = content.split("\n")[0].strip()[:60]

--- a/static/app.js
+++ b/static/app.js
@@ -4,6 +4,7 @@
 // ============================================
 import Storage from './js/storage.js';
 import uiModule from './js/ui.js';
+import workspaceModule from './js/workspace.js';
 import fileHandlerModule from './js/fileHandler.js';
 import modelsModule from './js/models.js';
 import ragModule from './js/rag.js';
@@ -1687,6 +1688,7 @@ function initializeEventListeners() {
   }
   setupToggle('web-toggle-btn', 'web-toggle', 'web');
   setupToggle('bash-toggle-btn', 'bash-toggle', 'bash');
+  try { workspaceModule.initWorkspace(); } catch (_) {}
 
   // Document editor toggle (special: uses module panel, not a checkbox)
   const overflowDocBtn = el('overflow-doc-btn');

--- a/static/index.html
+++ b/static/index.html
@@ -2281,7 +2281,7 @@
 <script type="module" src="/static/js/chatRenderer.js"></script>
 <script type="module" src="/static/js/codeRunner.js"></script>
 <script type="module" src="/static/js/chatStream.js"></script>
-<script type="module" src="/static/js/chat.js?v=20260604r"></script>
+<script type="module" src="/static/js/chat.js?v=20260604s"></script>
 <script type="module" src="/static/js/cookbook.js"></script>
 <script type="module" src="/static/js/search-chat.js"></script>
 <script type="module" src="/static/js/compare/index.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -2281,7 +2281,7 @@
 <script type="module" src="/static/js/chatRenderer.js"></script>
 <script type="module" src="/static/js/codeRunner.js"></script>
 <script type="module" src="/static/js/chatStream.js"></script>
-<script type="module" src="/static/js/chat.js?v=20260604q"></script>
+<script type="module" src="/static/js/chat.js?v=20260604r"></script>
 <script type="module" src="/static/js/cookbook.js"></script>
 <script type="module" src="/static/js/search-chat.js"></script>
 <script type="module" src="/static/js/compare/index.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -1031,6 +1031,13 @@
                 <span>RAG</span>
                 <span class="overflow-active-dot"></span>
               </button>
+              <button type="button" class="overflow-menu-item" id="overflow-workspace-btn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                </svg>
+                <span>Workspace</span>
+                <span class="overflow-active-dot"></span>
+              </button>
               <!-- Inline "deep research mode" toggle removed (superseded by the
                    Deep Research sidebar / trigger_research). The hidden
                    #research-toggle checkbox is kept inert so existing JS refs
@@ -1061,6 +1068,12 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
             </svg>
+          </button>
+          <!-- Workspace indicator (hidden until a folder is set) -->
+          <button type="button" class="input-icon-btn tool-indicator" title="Workspace — click to clear" id="workspace-indicator-btn" aria-label="Clear workspace" style="display:none;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+            <span style="font-size:11px;margin-left:2px;max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" id="workspace-indicator-name"></span>
+            <svg class="tool-indicator-x" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
           </button>
           <!-- RAG toolbar indicator (hidden until active) -->
           <button type="button" class="input-icon-btn tool-indicator" title="RAG active — click to deactivate" id="rag-indicator-btn" style="display:none;">

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -781,6 +781,10 @@ import createResearchSynapse from './researchSynapse.js';
       if (incognitoChk && incognitoChk.checked) {
         fd.append('incognito', 'true');
       }
+      const _ws = (Storage.KEYS && Storage.get(Storage.KEYS.WORKSPACE, '')) || '';
+      if (_ws) {
+        fd.append('workspace', _ws);
+      }
       if (presetsModule.getSelectedPreset()) {
         fd.append('preset_id', presetsModule.getSelectedPreset());
       }

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -17,6 +17,7 @@ import chatRenderer from './chatRenderer.js';
 import spinnerModule from './spinner.js';
 import themeModule from './theme.js';
 import documentModule from './document.js';
+import workspaceModule from './workspace.js';
 import settingsModule from './settings.js';
 import cookbookModule from './cookbook.js';
 import { EVAL_PROMPTS } from './compare/index.js';
@@ -1138,6 +1139,35 @@ async function _cmdToggleDoc(args, ctx) {
       slashReply('Document editor: opened');
     }
   } else { slashReply('Document module not available'); }
+  return true;
+}
+
+// Workspace: confine the agent's file/shell tools to a folder. Not a boolean —
+// show / set <path> / clear / pick (open the directory browser).
+async function _cmdWorkspace(args, ctx) {
+  const sub = (args[0] || '').toLowerCase();
+  const rest = args.slice(1).join(' ').trim();
+  const cur = workspaceModule.getWorkspace();
+  if (!sub || sub === 'show' || sub === 'status' || sub === 'info') {
+    slashReply(cur ? `Workspace: <code>${uiModule.esc(cur)}</code>` : 'No workspace set. <code>/workspace pick</code> or <code>/workspace set /path</code>.');
+    return true;
+  }
+  if (sub === 'set' || sub === 'cd' || sub === 'use') {
+    if (!rest) { slashReply('Usage: <code>/workspace set /absolute/path</code>'); return true; }
+    workspaceModule.setWorkspace(rest);
+    slashReply(`Workspace set: <code>${uiModule.esc(rest)}</code>`);
+    return true;
+  }
+  if (sub === 'clear' || sub === 'off' || sub === 'none' || sub === 'unset') {
+    workspaceModule.clearWorkspace();
+    slashReply('Workspace cleared.');
+    return true;
+  }
+  if (sub === 'pick' || sub === 'browse' || sub === 'open') {
+    workspaceModule.openWorkspaceBrowser();
+    return true;
+  }
+  slashReply('Usage: <code>/workspace</code> · <code>set /path</code> · <code>clear</code> · <code>pick</code>');
   return true;
 }
 
@@ -5454,6 +5484,14 @@ const COMMANDS = {
       'sidebar':   { handler: _cmdToggleSidebar,   alias: ['sb'], help: 'Cycle sidebar (full/mini/off)', usage: '/toggle sidebar [1|2|3]' },
       '_show':     { handler: _cmdToggleShow,      alias: [],     help: 'Show all toggle states',  usage: '/toggle' }
     }
+  },
+  workspace: {
+    alias: ['ws'],
+    category: 'Agent',
+    help: 'Set the folder the agent works in',
+    handler: _cmdWorkspace,
+    noUserBubble: true,
+    usage: '/workspace [set <path> | clear | pick]',
   },
   memory: {
     alias: ['m'],

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -23,7 +23,8 @@ export const KEYS = {
   MCP_ACTIVE: 'odysseus-mcp-active',
   SECTION_ORDER: 'sidebar-section-order',
   ADMIN_LAST_TAB: 'admin-last-tab',
-  DENSITY: 'odysseus-density'
+  DENSITY: 'odysseus-density',
+  WORKSPACE: 'odysseus-workspace'
 };
 
 /**

--- a/static/js/workspace.js
+++ b/static/js/workspace.js
@@ -63,7 +63,11 @@ function _render(data) {
   _curPath = data.path;
   const body = _modal.querySelector('#workspace-body');
   const pathEl = _modal.querySelector('#workspace-cur-path');
-  if (pathEl) pathEl.textContent = data.path;
+  if (pathEl) {
+    // Reflect the resolved (realpath) location back into the editable field.
+    pathEl.value = data.path;
+    pathEl.title = data.path;
+  }
   let rows = '';
   if (data.parent) {
     rows += `<div class="workspace-row workspace-up" data-path="${encodeURIComponent(data.parent)}">↑ ..</div>`;
@@ -94,21 +98,31 @@ function _getModal() {
   _modal.className = 'modal';
   _modal.style.display = 'none';
   _modal.innerHTML = `
-    <div class="modal-content workspace-modal-content">
+    <div class="modal-content">
       <div class="modal-header">
         <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Select workspace</h4>
         <button class="close-btn" id="workspace-close" aria-label="Close">✖</button>
       </div>
-      <div class="workspace-cur" id="workspace-cur-path"></div>
+      <input type="text" class="styled-prompt-input workspace-cur" id="workspace-cur-path"
+             spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"
+             placeholder="Type or paste a folder path, then press Enter" />
       <div class="modal-body workspace-body" id="workspace-body"></div>
       <div class="modal-footer workspace-footer">
-        <button type="button" class="workspace-btn" id="workspace-cancel">Cancel</button>
-        <button type="button" class="workspace-btn workspace-btn-primary" id="workspace-use">Use this folder</button>
+        <button type="button" class="confirm-btn confirm-btn-secondary" id="workspace-cancel">Cancel</button>
+        <button type="button" class="confirm-btn confirm-btn-primary" id="workspace-use">Use this folder</button>
       </div>
     </div>`;
   document.body.appendChild(_modal);
   _modal.querySelector('#workspace-close').addEventListener('click', closeWorkspaceBrowser);
   _modal.querySelector('#workspace-cancel').addEventListener('click', closeWorkspaceBrowser);
+  // Editable path bar: Enter navigates to a typed/pasted folder.
+  _modal.querySelector('#workspace-cur-path').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const v = e.target.value.trim();
+      if (v) _navigate(v);
+    }
+  });
   _modal.querySelector('#workspace-use').addEventListener('click', () => {
     setWorkspace(_curPath);
     if (uiModule && uiModule.showToast) uiModule.showToast(`Workspace set: ${_basename(_curPath)}`);

--- a/static/js/workspace.js
+++ b/static/js/workspace.js
@@ -1,0 +1,146 @@
+// static/js/workspace.js
+//
+// Workspace picker: browse server directories in a draggable modal, choose a
+// folder, and show it as a removable pill in the chat input bar. While set, the
+// chat request sends `workspace` so the agent's file/shell tools are confined
+// to that folder (see routes/chat_routes.py + src/tool_execution.py).
+
+import Storage, { KEYS } from './storage.js';
+import uiModule from './ui.js';
+import { makeWindowDraggable } from './windowDrag.js';
+
+const API_BASE = window.location.origin;
+// Same folder glyph as the overflow menu item + pill (not an emoji).
+const _FOLDER_SVG = '<svg class="workspace-row-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>';
+let _modal = null;
+let _curPath = '';
+
+export function getWorkspace() {
+  return Storage.get(KEYS.WORKSPACE, '') || '';
+}
+
+function _basename(p) {
+  if (!p) return '';
+  // Handle both POSIX (/) and Windows (\) separators.
+  const parts = p.replace(/[\\/]+$/, '').split(/[\\/]/);
+  return parts[parts.length - 1] || p;
+}
+
+export function syncWorkspaceIndicator(path) {
+  const pill = document.getElementById('workspace-indicator-btn');
+  const name = document.getElementById('workspace-indicator-name');
+  const overflow = document.getElementById('overflow-workspace-btn');
+  if (pill) {
+    pill.style.display = path ? '' : 'none';
+    pill.classList.toggle('active', !!path);
+    if (path) pill.title = `Workspace: ${path} — click to clear`;
+  }
+  if (name) name.textContent = path ? _basename(path) : '';
+  if (overflow) overflow.classList.toggle('active', !!path);
+  // Recompute the "+" overflow dot (app.js owns updatePlusDot via this event).
+  try { document.dispatchEvent(new CustomEvent('overflow-state-change')); } catch (_) {}
+}
+
+export function setWorkspace(path) {
+  if (path) Storage.set(KEYS.WORKSPACE, path);
+  else Storage.remove(KEYS.WORKSPACE);
+  syncWorkspaceIndicator(path || '');
+}
+
+export function clearWorkspace() {
+  setWorkspace('');
+  if (uiModule && uiModule.showToast) uiModule.showToast('Workspace cleared');
+}
+
+async function _load(path) {
+  const url = `${API_BASE}/api/workspace/browse${path ? `?path=${encodeURIComponent(path)}` : ''}`;
+  const res = await fetch(url, { credentials: 'same-origin' });
+  if (!res.ok) throw new Error(`browse failed: ${res.status}`);
+  return res.json();
+}
+
+function _render(data) {
+  _curPath = data.path;
+  const body = _modal.querySelector('#workspace-body');
+  const pathEl = _modal.querySelector('#workspace-cur-path');
+  if (pathEl) pathEl.textContent = data.path;
+  let rows = '';
+  if (data.parent) {
+    rows += `<div class="workspace-row workspace-up" data-path="${encodeURIComponent(data.parent)}">↑ ..</div>`;
+  }
+  for (const d of data.dirs) {
+    // Backend supplies the full child path (os.path.join → cross-platform).
+    rows += `<div class="workspace-row" data-path="${encodeURIComponent(d.path)}">${_FOLDER_SVG}<span>${uiModule.esc(d.name)}</span></div>`;
+  }
+  if (!data.dirs.length && !data.parent) rows = '<div class="workspace-empty">No subfolders</div>';
+  body.innerHTML = rows || '<div class="workspace-empty">No subfolders</div>';
+  body.querySelectorAll('.workspace-row').forEach((row) => {
+    row.addEventListener('click', () => _navigate(decodeURIComponent(row.dataset.path)));
+  });
+}
+
+async function _navigate(path) {
+  try {
+    _render(await _load(path));
+  } catch (e) {
+    if (uiModule && uiModule.showError) uiModule.showError('Could not open folder');
+  }
+}
+
+function _getModal() {
+  if (_modal) return _modal;
+  _modal = document.createElement('div');
+  _modal.id = 'workspace-modal';
+  _modal.className = 'modal';
+  _modal.style.display = 'none';
+  _modal.innerHTML = `
+    <div class="modal-content workspace-modal-content">
+      <div class="modal-header">
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Select workspace</h4>
+        <button class="close-btn" id="workspace-close" aria-label="Close">✖</button>
+      </div>
+      <div class="workspace-cur" id="workspace-cur-path"></div>
+      <div class="modal-body workspace-body" id="workspace-body"></div>
+      <div class="modal-footer workspace-footer">
+        <button type="button" class="workspace-btn" id="workspace-cancel">Cancel</button>
+        <button type="button" class="workspace-btn workspace-btn-primary" id="workspace-use">Use this folder</button>
+      </div>
+    </div>`;
+  document.body.appendChild(_modal);
+  _modal.querySelector('#workspace-close').addEventListener('click', closeWorkspaceBrowser);
+  _modal.querySelector('#workspace-cancel').addEventListener('click', closeWorkspaceBrowser);
+  _modal.querySelector('#workspace-use').addEventListener('click', () => {
+    setWorkspace(_curPath);
+    if (uiModule && uiModule.showToast) uiModule.showToast(`Workspace set: ${_basename(_curPath)}`);
+    closeWorkspaceBrowser();
+  });
+  const content = _modal.querySelector('.modal-content');
+  const header = _modal.querySelector('.modal-header');
+  if (content && header) makeWindowDraggable(_modal, { content, header });
+  return _modal;
+}
+
+export async function openWorkspaceBrowser() {
+  const modal = _getModal();
+  modal.style.display = 'flex';
+  try {
+    _render(await _load(getWorkspace() || ''));
+  } catch (e) {
+    if (uiModule && uiModule.showError) uiModule.showError('Could not browse folders');
+  }
+}
+
+export function closeWorkspaceBrowser() {
+  if (_modal) _modal.style.display = 'none';
+}
+
+export function initWorkspace() {
+  // Restore persisted workspace into the pill on load.
+  syncWorkspaceIndicator(getWorkspace());
+  const overflow = document.getElementById('overflow-workspace-btn');
+  if (overflow) overflow.addEventListener('click', openWorkspaceBrowser);
+  const pill = document.getElementById('workspace-indicator-btn');
+  if (pill) pill.addEventListener('click', clearWorkspace);
+}
+
+export default { initWorkspace, openWorkspaceBrowser, getWorkspace, setWorkspace, clearWorkspace, syncWorkspaceIndicator };

--- a/static/style.css
+++ b/static/style.css
@@ -35878,27 +35878,22 @@ body.theme-frosted .modal {
   color: color-mix(in srgb, var(--fg) 45%, transparent);
 }
 /* ── Workspace picker ───────────────────────────────────────────── */
-.workspace-modal-content {
-  width: 520px;
-  max-width: 92vw;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-}
+/* Layout (width/flex column/max-height) inherited from base .modal-content. */
+/* Editable path/address bar: reuses .styled-prompt-input for border/bg/radius/
+   focus ring (set in the element's class list). Overrides only the deltas:
+   mono font, and full-bleed via flex stretch with no horizontal margin (the
+   modal-content's 10px padding is the gutter) instead of the base width:100%,
+   which overflowed against the overflow:auto scrollbar. */
 .workspace-cur {
-  padding: 8px 18px;
+  align-self: stretch;
+  width: auto;
+  min-width: 0;
+  margin: 4px 0 8px;
   font-family: var(--mono, monospace);
   font-size: 12px;
-  opacity: 0.7;
-  border-bottom: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
-  overflow-x: auto;
-  white-space: nowrap;
 }
-.workspace-body {
-  flex: 1 1 auto;
-  overflow-y: auto;
-  padding: 6px 0;
-}
+/* flex/overflow inherited from base .modal-body; only the padding differs. */
+.workspace-body { padding: 6px 0; }
 .workspace-row {
   padding: 7px 18px;
   cursor: pointer;
@@ -35914,7 +35909,7 @@ body.theme-frosted .modal {
 }
 .workspace-row-icon { flex-shrink: 0; opacity: 0.75; }
 .workspace-row:hover {
-  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  background: color-mix(in srgb, var(--border) 20%, transparent);
 }
 .workspace-up { opacity: 0.7; }
 .workspace-empty { padding: 14px 18px; opacity: 0.5; font-size: 13px; }
@@ -35923,22 +35918,5 @@ body.theme-frosted .modal {
   justify-content: flex-end;
   gap: 8px;
   padding: 10px 18px;
-  border-top: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
+  border-top: 1px solid var(--border);
 }
-.workspace-btn {
-  font: inherit;
-  font-size: 13px;
-  padding: 6px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  color: var(--fg);
-  background: color-mix(in srgb, var(--fg) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--fg) 22%, transparent);
-}
-.workspace-btn:hover { background: color-mix(in srgb, var(--fg) 15%, transparent); }
-.workspace-btn-primary {
-  background: var(--accent, var(--red));
-  border-color: var(--accent, var(--red));
-  color: var(--bg);
-}
-.workspace-btn-primary:hover { opacity: 0.9; }

--- a/static/style.css
+++ b/static/style.css
@@ -35877,3 +35877,68 @@ body.theme-frosted .modal {
   line-height: 1.4;
   color: color-mix(in srgb, var(--fg) 45%, transparent);
 }
+/* ── Workspace picker ───────────────────────────────────────────── */
+.workspace-modal-content {
+  width: 520px;
+  max-width: 92vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+.workspace-cur {
+  padding: 8px 18px;
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+  opacity: 0.7;
+  border-bottom: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.workspace-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+.workspace-row {
+  padding: 7px 18px;
+  cursor: pointer;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.workspace-row > span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.workspace-row-icon { flex-shrink: 0; opacity: 0.75; }
+.workspace-row:hover {
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+.workspace-up { opacity: 0.7; }
+.workspace-empty { padding: 14px 18px; opacity: 0.5; font-size: 13px; }
+.workspace-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 18px;
+  border-top: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
+}
+.workspace-btn {
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fg) 22%, transparent);
+}
+.workspace-btn:hover { background: color-mix(in srgb, var(--fg) 15%, transparent); }
+.workspace-btn-primary {
+  background: var(--accent, var(--red));
+  border-color: var(--accent, var(--red));
+  color: var(--bg);
+}
+.workspace-btn-primary:hover { opacity: 0.9; }

--- a/tests/test_workspace_confine.py
+++ b/tests/test_workspace_confine.py
@@ -16,12 +16,13 @@ def test_workspace_resolver_confines():
     assert _resolve_tool_path_in_workspace(ws, "a.txt") == real
     # absolute path inside the workspace is allowed
     assert _resolve_tool_path_in_workspace(ws, os.path.join(ws, "a.txt")) == real
-    # absolute path outside is rejected
+    # absolute path outside is rejected (sibling temp dir, portable across OSes)
+    outside = tempfile.mkdtemp()
     with pytest.raises(ValueError):
-        _resolve_tool_path_in_workspace(ws, "/etc/hosts")
+        _resolve_tool_path_in_workspace(ws, os.path.join(outside, "x.txt"))
     # parent-escape is rejected
     with pytest.raises(ValueError):
-        _resolve_tool_path_in_workspace(ws, "../../etc/passwd")
+        _resolve_tool_path_in_workspace(ws, os.path.join("..", "..", "escape.txt"))
 
 
 def test_workspace_resolver_blocks_sensitive():
@@ -42,12 +43,17 @@ async def test_read_write_confined_in_workspace():
     # Read it back.
     res = await _direct_fallback("read_file", "note.txt", workspace=ws)
     assert res["exit_code"] == 0 and res["output"] == "hello"
-    # Reading outside the workspace is rejected.
-    res = await _direct_fallback("read_file", "/etc/hosts", workspace=ws)
+    # Reading outside the workspace is rejected (sibling temp dir, portable).
+    outside = tempfile.mkdtemp()
+    outside_file = os.path.join(outside, "secret.txt")
+    open(outside_file, "w").write("nope")
+    res = await _direct_fallback("read_file", outside_file, workspace=ws)
     assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
     # Writing outside is rejected (file must not be created).
-    res = await _direct_fallback("write_file", "/etc/_ws_escape.txt\nx", workspace=ws)
+    escape = os.path.join(outside, "_ws_escape.txt")
+    res = await _direct_fallback("write_file", f"{escape}\nx", workspace=ws)
     assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
+    assert not os.path.exists(escape)
 
 
 def test_browse_is_admin_gated(monkeypatch):
@@ -72,9 +78,11 @@ def test_browse_is_admin_gated(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_bash_runs_with_workspace_cwd():
+async def test_subprocess_runs_with_workspace_cwd():
+    """bash/python subprocesses run with cwd set to the workspace. Use the
+    python tool for an OS-agnostic cwd probe (Windows cmd has no `pwd`)."""
     ws = tempfile.mkdtemp()
-    res = await _direct_fallback("bash", "pwd", workspace=ws)
+    res = await _direct_fallback("python", "import os; print(os.getcwd())", workspace=ws)
     assert res["exit_code"] == 0
     assert os.path.realpath(res["output"].strip()) == os.path.realpath(ws)
 
@@ -92,9 +100,12 @@ async def test_edit_file_confined_in_workspace():
         {"path": "f.txt", "old_string": "foo", "new_string": "baz"}), workspace=ws)
     assert res["exit_code"] == 0
     assert open(os.path.join(ws, "f.txt")).read() == "baz bar"
-    # Editing outside the workspace is rejected.
+    # Editing outside the workspace is rejected (sibling temp dir, portable).
+    outside = tempfile.mkdtemp()
+    outside_file = os.path.join(outside, "f.txt")
+    open(outside_file, "w").write("a")
     res = await _do_edit_file(json.dumps(
-        {"path": "/etc/hosts", "old_string": "a", "new_string": "b"}), workspace=ws)
+        {"path": outside_file, "old_string": "a", "new_string": "b"}), workspace=ws)
     assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
 
 
@@ -106,11 +117,12 @@ async def test_grep_and_ls_confined_in_workspace():
     # grep with no path searches the workspace root and finds the match.
     res = await _direct_fallback("grep", json.dumps({"pattern": "hello"}), workspace=ws)
     assert res["exit_code"] == 0 and "doc.txt" in res["output"]
-    # grep pointed outside the workspace is rejected.
-    res = await _direct_fallback("grep", json.dumps({"pattern": "x", "path": "/etc"}), workspace=ws)
+    # grep pointed outside the workspace is rejected (sibling temp dir, portable).
+    outside = tempfile.mkdtemp()
+    res = await _direct_fallback("grep", json.dumps({"pattern": "x", "path": outside}), workspace=ws)
     assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
     # ls of the workspace lists its files; ls outside is rejected.
     res = await _direct_fallback("ls", "", workspace=ws)
     assert res["exit_code"] == 0 and "doc.txt" in res["output"]
-    res = await _direct_fallback("ls", "/etc", workspace=ws)
+    res = await _direct_fallback("ls", outside, workspace=ws)
     assert res["exit_code"] == 1 and "outside the workspace" in res["error"]

--- a/tests/test_workspace_confine.py
+++ b/tests/test_workspace_confine.py
@@ -77,3 +77,40 @@ async def test_bash_runs_with_workspace_cwd():
     res = await _direct_fallback("bash", "pwd", workspace=ws)
     assert res["exit_code"] == 0
     assert os.path.realpath(res["output"].strip()) == os.path.realpath(ws)
+
+
+# --- Tools that landed after this PR, now wired into the workspace -----------
+
+@pytest.mark.asyncio
+async def test_edit_file_confined_in_workspace():
+    import json
+    from src.tool_execution import _do_edit_file
+    ws = tempfile.mkdtemp()
+    open(os.path.join(ws, "f.txt"), "w").write("foo bar")
+    # Edit inside the workspace succeeds.
+    res = await _do_edit_file(json.dumps(
+        {"path": "f.txt", "old_string": "foo", "new_string": "baz"}), workspace=ws)
+    assert res["exit_code"] == 0
+    assert open(os.path.join(ws, "f.txt")).read() == "baz bar"
+    # Editing outside the workspace is rejected.
+    res = await _do_edit_file(json.dumps(
+        {"path": "/etc/hosts", "old_string": "a", "new_string": "b"}), workspace=ws)
+    assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_grep_and_ls_confined_in_workspace():
+    import json
+    ws = tempfile.mkdtemp()
+    open(os.path.join(ws, "doc.txt"), "w").write("hello workspace\n")
+    # grep with no path searches the workspace root and finds the match.
+    res = await _direct_fallback("grep", json.dumps({"pattern": "hello"}), workspace=ws)
+    assert res["exit_code"] == 0 and "doc.txt" in res["output"]
+    # grep pointed outside the workspace is rejected.
+    res = await _direct_fallback("grep", json.dumps({"pattern": "x", "path": "/etc"}), workspace=ws)
+    assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
+    # ls of the workspace lists its files; ls outside is rejected.
+    res = await _direct_fallback("ls", "", workspace=ws)
+    assert res["exit_code"] == 0 and "doc.txt" in res["output"]
+    res = await _direct_fallback("ls", "/etc", workspace=ws)
+    assert res["exit_code"] == 1 and "outside the workspace" in res["error"]

--- a/tests/test_workspace_confine.py
+++ b/tests/test_workspace_confine.py
@@ -1,0 +1,79 @@
+"""Workspace confinement: file tools are hard-bounded to the workspace folder
+(layered on upstream's sensitive-path policy); bash runs with cwd there."""
+import os
+import tempfile
+
+import pytest
+
+from src.tool_execution import _resolve_tool_path_in_workspace, _direct_fallback
+
+
+def test_workspace_resolver_confines():
+    ws = tempfile.mkdtemp()
+    open(os.path.join(ws, "a.txt"), "w").write("x")
+    real = os.path.realpath(os.path.join(ws, "a.txt"))
+    # relative path resolves under the workspace
+    assert _resolve_tool_path_in_workspace(ws, "a.txt") == real
+    # absolute path inside the workspace is allowed
+    assert _resolve_tool_path_in_workspace(ws, os.path.join(ws, "a.txt")) == real
+    # absolute path outside is rejected
+    with pytest.raises(ValueError):
+        _resolve_tool_path_in_workspace(ws, "/etc/hosts")
+    # parent-escape is rejected
+    with pytest.raises(ValueError):
+        _resolve_tool_path_in_workspace(ws, "../../etc/passwd")
+
+
+def test_workspace_resolver_blocks_sensitive():
+    """Upstream's sensitive-file deny list still applies inside the workspace."""
+    ws = tempfile.mkdtemp()
+    os.makedirs(os.path.join(ws, ".ssh"), exist_ok=True)
+    with pytest.raises(ValueError):
+        _resolve_tool_path_in_workspace(ws, ".ssh/authorized_keys")
+
+
+@pytest.mark.asyncio
+async def test_read_write_confined_in_workspace():
+    ws = tempfile.mkdtemp()
+    # Write inside the workspace (relative path) succeeds.
+    res = await _direct_fallback("write_file", "note.txt\nhello", workspace=ws)
+    assert res["exit_code"] == 0
+    assert os.path.isfile(os.path.join(ws, "note.txt"))
+    # Read it back.
+    res = await _direct_fallback("read_file", "note.txt", workspace=ws)
+    assert res["exit_code"] == 0 and res["output"] == "hello"
+    # Reading outside the workspace is rejected.
+    res = await _direct_fallback("read_file", "/etc/hosts", workspace=ws)
+    assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
+    # Writing outside is rejected (file must not be created).
+    res = await _direct_fallback("write_file", "/etc/_ws_escape.txt\nx", workspace=ws)
+    assert res["exit_code"] == 1 and "outside the workspace" in res["error"]
+
+
+def test_browse_is_admin_gated(monkeypatch):
+    """The directory-browser endpoint must refuse non-admin callers."""
+    from fastapi import HTTPException
+    import routes.workspace_routes as wr
+
+    router = wr.setup_workspace_routes()
+    browse = next(r.endpoint for r in router.routes if r.path == "/api/workspace/browse")
+
+    monkeypatch.setattr(wr, "get_current_user", lambda req: "bob")
+    monkeypatch.setattr(wr, "owner_is_admin_or_single_user", lambda owner: False)
+    with pytest.raises(HTTPException) as ei:
+        browse(request=object(), path="/")
+    assert ei.value.status_code == 403
+
+    # Admin / single-user is allowed.
+    monkeypatch.setattr(wr, "owner_is_admin_or_single_user", lambda owner: True)
+    out = browse(request=object(), path=os.path.expanduser("~"))
+    assert "dirs" in out and "path" in out
+    assert all("name" in d and "path" in d for d in out["dirs"])
+
+
+@pytest.mark.asyncio
+async def test_bash_runs_with_workspace_cwd():
+    ws = tempfile.mkdtemp()
+    res = await _direct_fallback("bash", "pwd", workspace=ws)
+    assert res["exit_code"] == 0
+    assert os.path.realpath(res["output"].strip()) == os.path.realpath(ws)


### PR DESCRIPTION
## Summary

Pick a server folder as the agent's workspace so its file/shell tools work there and don't touch files outside it.

**UX**
- "+" overflow menu → **Workspace** opens a draggable directory-browser modal (navigate folders, "Use this folder").
- The current-folder strip is an **editable address bar**: type or paste a full path and press Enter to jump there (also reaches other Windows drives and hidden dirs the up-only browser can't).
- A removable **pill** in the input bar shows the folder; click it / its `x` to clear. Persisted in localStorage, sent as `workspace` on `/api/chat_stream`.

**Backend**
- `routes/workspace_routes.py` — `GET /api/workspace/browse` lists subdirectories. **Admin-only** (file/shell tools are already admin-gated, so FS enumeration must be too): 401 unauth, 403 non-admin. Child paths built with `os.path.join` (Windows/Linux).
- `src/tool_execution.py` — `read_file`/`write_file`/`edit_file`/`grep`/`glob`/`ls` paths are **hard-rejected** when they resolve outside the workspace (`_resolve_tool_path_in_workspace`: `realpath` + `commonpath`, `normcase` so containment holds on case-insensitive filesystems, fails closed on Windows cross-drive and on `../`/symlink escape). The sensitive-file deny list (`.ssh`, `id_rsa`, …) still applies inside the workspace. `bash`/`python` (incl. background jobs) run with `cwd` = workspace. Threaded route → `stream_agent_loop` → `execute_tool_block`.
- `src/agent_loop.py` — when a workspace is set, a short note is prepended to the system prompt so the agent treats the folder as the project root (explore it, use relative paths) instead of asking for code.

**Style:** the modal reuses shared classes — base `.modal-content`/`.modal-body`, the `.confirm-btn` button family, and `.styled-prompt-input` for the path field — rather than bespoke widgets.

**Honest boundary:** file/search tools are a hard boundary; bash/python `cwd` is a default, not a sandbox (raw shell can still `cd /` or use absolute paths).

Pairs well with plan mode (#638): scope the agent to a repo (this PR), have it propose a plan, approve, then execute confined to that folder. Both add one optional param to `stream_agent_loop`/`execute_tool_block` at distinct sites.

## Linked Issue

Part of #2023

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. "+" overflow menu → **Workspace** → browse, or type/paste a path and press Enter → pick a folder → confirm the pill appears in the input bar.
2. In agent mode, ask the agent to read/write/edit/grep/ls a file inside the folder (works) and one outside it (hard-rejected).
3. Ask it to run a command via bash/python → cwd is the workspace folder.
4. Click the pill's `x` → workspace clears; confinement off.
5. Unauthenticated `GET /api/workspace/browse` → 401; non-admin → 403.

Checks run:
- `pytest tests/test_workspace_confine.py` — 7 pass (outside/relative/parent-escape rejection; read/write/edit_file/grep/ls confined; sensitive-file deny; subprocess `cwd`; admin-gating). Tests are OS-portable (sibling temp dirs, `os.getcwd()` — no `/etc`/`pwd` assumptions).
- `py_compile` + `node --check` on changed files — pass.
- Verified live in Chrome on macOS: browse, paste-path navigation, confinement, pill clear.

## Screenshots

<img width="249" height="205" alt="Screenshot 2026-06-02 at 14 30 00" src="https://github.com/user-attachments/assets/36bb90aa-8d3c-49ac-a72e-fe5ce495911e" />
<img width="529" height="256" alt="Screenshot 2026-06-02 at 14 35 36" src="https://github.com/user-attachments/assets/7086cc15-096d-48ef-b109-ed1a091a8234" />
<img width="840" height="873" alt="Screenshot 2026-06-02 at 14 25 26" src="https://github.com/user-attachments/assets/357b6814-ad9b-4412-9964-7f305a74253d" />
<img width="842" height="883" alt="Screenshot 2026-06-02 at 14 26 35" src="https://github.com/user-attachments/assets/913697fb-e559-4c54-b4d5-30d51246d6d4" />

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app — see the **Screenshots** section above.
- [x] **Style match**: reuses existing CSS variables (`--fg`, `--bg`, `--border`, `--panel`, `--red`/`--accent`, …) and existing button/input/card/border classes (`.confirm-btn`, `.styled-prompt-input`, base `.modal-content`/`.modal-body`) — no new color values, font sizes, or spacing units.
  - [x] **No Unicode emoji in UI or code** — inline monochrome SVG / plain text only.
  - [x] Monospaced font (`Fira Code`) untouched; dark theme via the existing theme system, nothing hard-coded.
- [x] **No new component patterns** — extends existing widgets instead of adding parallel ones.
- [x] **I am not an LLM agent submitting a bulk PR.** An issue was opened first describing the feature (see Linked Issue above), per CONTRIBUTING.
