### PR TITLE
Expose generic attachments to agent tools

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -275,11 +275,16 @@ def extract_preset(chat_handler, preset_id) -> PresetInfo:
 async def preprocess(
     chat_handler, message, att_ids, sess,
     auto_opened_docs: Optional[list] = None,
+    expose_generic_attachment_paths: bool = False,
 ) -> PreprocessedMessage:
     """Run chat_handler.preprocess_message and wrap the result."""
     enhanced, user_content, text_ctx, yt_transcripts, att_meta = (
         await chat_handler.preprocess_message(
-            message, att_ids, sess, auto_opened_docs=auto_opened_docs
+            message,
+            att_ids,
+            sess,
+            auto_opened_docs=auto_opened_docs,
+            expose_generic_attachment_paths=expose_generic_attachment_paths,
         )
     )
     return PreprocessedMessage(
@@ -465,6 +470,7 @@ async def build_chat_context(
     preprocessed = await preprocess(
         chat_handler, message, att_ids or [], sess,
         auto_opened_docs=auto_opened_docs,
+        expose_generic_attachment_paths=agent_mode,
     )
 
     # Add user message to history

--- a/src/chat_handler.py
+++ b/src/chat_handler.py
@@ -98,6 +98,7 @@ class ChatHandler:
         att_ids: List[str],
         sess,
         auto_opened_docs: Optional[List[Dict[str, Any]]] = None,
+        expose_generic_attachment_paths: bool = False,
     ) -> tuple:
         """
         Common preprocessing for both chat endpoints.
@@ -244,6 +245,7 @@ class ChatHandler:
             auto_opened_docs=auto_opened_docs,
             owner=owner,
             resolved_uploads=files_by_id,
+            expose_generic_attachment_paths=expose_generic_attachment_paths,
         )
 
         # Strip image_url entries for text-only models (VL description is already in the text)

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -105,6 +105,50 @@ def _process_text_file(path: str) -> str:
         return result
 
 
+def _format_generic_attachment_context(
+    *,
+    upload_id: str,
+    display_name: str,
+    mime: str,
+    size: Any,
+    path: str | None = None,
+) -> str:
+    """Describe a stored attachment that cannot be inlined as text/media.
+
+    The caller has already resolved the upload through UploadHandler, including
+    owner checks and upload-directory containment. The path is useful in agent
+    mode because tools such as Python can inspect binary formats like STL.
+    """
+    try:
+        size_label = f"{int(size):,} bytes"
+    except (TypeError, ValueError):
+        size_label = "unknown size"
+    details = (
+        f"\n\n[Attached file: {display_name}]\n"
+        f"- Upload id: {upload_id}\n"
+        f"- MIME type: {mime or 'application/octet-stream'}\n"
+        f"- Size: {size_label}\n"
+    )
+    if path:
+        details += f"- Server path: {path}\n"
+        guidance = (
+            "This file is binary or not directly text-extractable. If tool access is "
+            "available and the user asks you to inspect it, use the server path above "
+            "with a file-capable tool such as Python. Do not ask the user to re-upload "
+            "the file."
+        )
+    else:
+        guidance = (
+            "This file is binary or not directly text-extractable. Switch to agent "
+            "mode if you need file-capable tools to inspect it."
+        )
+    return (
+        details
+        + "\n"
+        + guidance
+    )
+
+
 def _process_pdf(path: str) -> str:
     """Process PDF file with text extraction (pypdf). Uses VL model for image-heavy pages."""
     try:
@@ -313,6 +357,7 @@ def build_user_content(
     auto_opened_docs: list[Dict[str, Any]] | None = None,
     owner: str | None = None,
     resolved_uploads: dict[str, Dict[str, Any]] | None = None,
+    expose_generic_attachment_paths: bool = False,
 ) -> str | List[Dict[str, Any]]:
     """Build user content with attachments (text, images, audio, documents).
 
@@ -490,10 +535,17 @@ def build_user_content(
             else:
                 content.insert(0, {"type": "text", "text": extracted_text.lstrip()})
         else:
+            attached_text = _format_generic_attachment_context(
+                upload_id=upload_info.get("id") or fid,
+                display_name=display_name,
+                mime=mime,
+                size=upload_info.get("size"),
+                path=path if expose_generic_attachment_paths else None,
+            )
             if content and content[0]["type"] == "text":
-                content[0]["text"] += "\n\n[Attached non-text file]"
+                content[0]["text"] += attached_text
             else:
-                content.insert(0, {"type": "text", "text": "[Attached non-text file]"})
+                content.insert(0, {"type": "text", "text": attached_text.lstrip()})
 
     has_media = any(item.get("type") in ["image_url", "audio"] for item in content if isinstance(item, dict))
     if not has_media and content:

--- a/tests/test_generic_attachment_context.py
+++ b/tests/test_generic_attachment_context.py
@@ -1,0 +1,110 @@
+from src.document_processor import build_user_content
+
+
+class _UploadHandler:
+    def __init__(self, uploads):
+        self.uploads = uploads
+
+    def resolve_upload(self, upload_id, owner=None):
+        upload = self.uploads.get(upload_id)
+        if upload and upload.get("owner") == owner:
+            return dict(upload)
+        return None
+
+    def _inside_upload_dir(self, path):
+        return True
+
+    def is_image_file(self, filename, content_type=None):
+        return False
+
+    def is_audio_file(self, filename, content_type=None):
+        return False
+
+    def is_document_file(self, filename, content_type=None):
+        return False
+
+
+def test_generic_binary_attachment_includes_agent_usable_path(tmp_path):
+    stl_path = tmp_path / "part.stl"
+    stl_path.write_bytes(b"solid cube\nendsolid cube\n")
+    handler = _UploadHandler({
+        "abc123.stl": {
+            "id": "abc123.stl",
+            "name": "part.stl",
+            "mime": "model/stl",
+            "size": stl_path.stat().st_size,
+            "path": str(stl_path),
+            "owner": "alice",
+        }
+    })
+
+    content = build_user_content(
+        "Calculate this STL volume.",
+        ["abc123.stl"],
+        str(tmp_path),
+        handler,
+        owner="alice",
+        expose_generic_attachment_paths=True,
+    )
+
+    assert "[Attached file: part.stl]" in content
+    assert "- Upload id: abc123.stl" in content
+    assert "- MIME type: model/stl" in content
+    assert f"- Server path: {stl_path}" in content
+    assert "use the server path above" in content
+    assert "[Attached non-text file]" not in content
+
+
+def test_generic_binary_attachment_omits_path_by_default(tmp_path):
+    stl_path = tmp_path / "part.stl"
+    stl_path.write_bytes(b"solid cube\nendsolid cube\n")
+    handler = _UploadHandler({
+        "abc123.stl": {
+            "id": "abc123.stl",
+            "name": "part.stl",
+            "mime": "model/stl",
+            "size": stl_path.stat().st_size,
+            "path": str(stl_path),
+            "owner": "alice",
+        }
+    })
+
+    content = build_user_content(
+        "What is this file?",
+        ["abc123.stl"],
+        str(tmp_path),
+        handler,
+        owner="alice",
+    )
+
+    assert "[Attached file: part.stl]" in content
+    assert "- Upload id: abc123.stl" in content
+    assert "Switch to agent mode" in content
+    assert "Server path:" not in content
+    assert str(stl_path) not in content
+
+
+def test_generic_binary_attachment_does_not_leak_unresolved_upload(tmp_path):
+    stl_path = tmp_path / "bob.stl"
+    stl_path.write_bytes(b"solid bob\nendsolid bob\n")
+    handler = _UploadHandler({
+        "bob.stl": {
+            "id": "bob.stl",
+            "name": "bob.stl",
+            "mime": "model/stl",
+            "size": stl_path.stat().st_size,
+            "path": str(stl_path),
+            "owner": "bob",
+        }
+    })
+
+    content = build_user_content(
+        "Read this file.",
+        ["bob.stl"],
+        str(tmp_path),
+        handler,
+        owner="alice",
+    )
+
+    assert content == "Read this file."
+    assert str(stl_path) not in content


### PR DESCRIPTION
## Summary

The picker/drag-drop path can now accept arbitrary files, but unknown binary attachments were only surfaced to the model as `[Attached non-text file]`. An agent could see that something was attached but had no actionable reference for a request like calculating the volume of an uploaded STL file. This replaces that opaque fallback with a structured attachment descriptor for binary / non-text-extractable uploads:

- include the owner-authorized upload id, display name, MIME type, and size for generic attachments
- expose the server path only when the shared chat context is being built for agent/tool mode, so plain chat still identifies the attachment without leaking local filesystem paths to remote chat models
- keep existing handling unchanged for images, audio, PDFs, text files, and supported document formats

## Linked Issue

Fixes #1115

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [x] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I verified the agent-mode vs plain-chat behavior (path exposed only in agent/tool context) via the test suite below.

**Security / scope:** the path is only added after the upload has been resolved through `UploadHandler.resolve_upload()` and the existing upload-directory containment checks, and only for agent/tool context. If an attachment id cannot be resolved for the current owner, no descriptor or path is emitted. In plain chat mode the descriptor omits the server path and tells the user to switch to agent mode for file-capable inspection.

## How to Test

1. Run the focused suite: `venv/bin/python -m pytest -q tests/test_generic_attachment_context.py tests/test_chat_attachment_picker.py` -> passes (3 in the generic-attachment file).
2. Confirm compile: `venv/bin/python -m py_compile src/document_processor.py src/chat_handler.py routes/chat_helpers.py tests/test_generic_attachment_context.py`.
3. Manual: in agent/tool mode, drag in a binary file (e.g. an STL) and confirm the model receives a structured descriptor with a resolvable server path; in plain chat mode confirm the same attachment is identified but the server path is omitted.
