### PR TITLE
fix(security): owner-scope endpoint adoption in resolve_session_auth (cross-tenant API-key reuse)

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -311,6 +311,26 @@ def fire_message_event(request, webhook_manager, session_id: str, sess, message:
     fire_event("message_sent", user)
 
 
+def _owned_endpoint_by_domain(db, domain, owner):
+    """ModelEndpoint whose base_url contains `domain` and is VISIBLE to `owner`
+    (their own rows + legacy null-owner "shared" rows); None otherwise.
+
+    Owner-scoped on purpose. ModelEndpoint is per-user (core/database.py: non-null
+    owner = private, "the model picker only shows the endpoint to that user") and
+    holds a decrypted `api_key`. resolve_session_auth copies the matched row's
+    api_key into the session headers and PERSISTS it, so an UNSCOPED match would
+    let a user create a session pointed at another user's endpoint host (with no
+    key of its own), send one message, and have that owner's api_key copied into
+    the session they own — then spend it on every call. The session's own owner is
+    the right scope (the endpoint must be one that owner can see). Mirrors
+    session_routes._owned_endpoint. A null/empty owner is a no-op (single-user /
+    legacy mode).
+    """
+    from src.auth_helpers import owner_filter
+    q = db.query(ModelEndpoint).filter(ModelEndpoint.base_url.contains(domain))
+    return owner_filter(q, ModelEndpoint, owner).first()
+
+
 def resolve_session_auth(sess, session_id: str):
     """Ensure session has auth headers — resolve from endpoint DB if missing."""
     has_auth = sess.headers and isinstance(sess.headers, dict) and any(
@@ -325,7 +345,8 @@ def resolve_session_auth(sess, session_id: str):
         try:
             domain = sess.endpoint_url.split("//")[1].split("/")[0] if "//" in sess.endpoint_url else ""
             if domain:
-                ep = db.query(ModelEndpoint).filter(ModelEndpoint.base_url.contains(domain)).first()
+                # Owner-scoped: never adopt another user's private endpoint key.
+                ep = _owned_endpoint_by_domain(db, domain, getattr(sess, "owner", None))
                 if ep and ep.api_key:
                     sess.headers = build_headers(ep.api_key, ep.base_url)
                     db.query(DBSession).filter(DBSession.id == session_id).update(

--- a/tests/test_resolve_session_auth_owner_scope.py
+++ b/tests/test_resolve_session_auth_owner_scope.py
@@ -1,0 +1,121 @@
+"""Owner-scope regression for chat_helpers.resolve_session_auth.
+
+resolve_session_auth() runs in the chat_stream path (after _verify_session_owner
+confirms the caller owns the session). When the session has no auth headers it
+matches a ModelEndpoint by the session endpoint_url's host substring and copies
+that row's *decrypted* api_key into the session headers — and PERSISTS it. The
+match must be owner-scoped (the session owner's own rows + legacy null-owner
+shared rows) so a user can't point a session they own at another user's endpoint
+host and silently adopt that owner's api_key. Mirrors the session/research/compare
+owner-scope fixes.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+if "core.database" not in sys.modules:
+    sys.modules["core.database"] = types.ModuleType("core.database")
+_cd = sys.modules["core.database"]
+_cd.Base = MagicMock()
+for _name in (
+    "Session", "ChatMessage", "Document", "GalleryImage", "SessionLocal",
+    "ModelEndpoint",
+):
+    if not hasattr(_cd, _name):
+        setattr(_cd, _name, MagicMock())
+
+from routes.chat_helpers import _owned_endpoint_by_domain  # noqa: E402
+
+
+class _Predicate:
+    def __init__(self, check):
+        self._check = check
+
+    def __call__(self, row):
+        return self._check(row)
+
+    def __or__(self, other):
+        return _Predicate(lambda row: self(row) or other(row))
+
+
+class _Column:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, value):
+        return _Predicate(lambda row: getattr(row, self.name) == value)
+
+    def contains(self, needle):
+        return _Predicate(lambda row: needle in (getattr(row, self.name) or ""))
+
+
+class _ModelEndpoint:
+    base_url = _Column("base_url")
+    owner = _Column("owner")
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *predicates):
+        self._rows = [r for r in self._rows if all(p(r) for p in predicates)]
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+class _DB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, model):
+        assert model is _ModelEndpoint
+        return _Query(self._rows)
+
+
+def _ep(base_url, owner):
+    return SimpleNamespace(base_url=base_url, owner=owner, api_key="sk-secret")
+
+
+def _resolve(rows, domain, owner):
+    # The helper references chat_helpers' module-level ModelEndpoint (bound at
+    # import via `from core.database import ModelEndpoint`), so patch it there.
+    import routes.chat_helpers as _ch
+    _ch.ModelEndpoint = _ModelEndpoint
+    return _owned_endpoint_by_domain(_DB(rows), domain, owner)
+
+
+HOST = "api.example.com"
+
+
+def test_rejects_another_owners_private_endpoint():
+    # bob's endpoint on this host; alice (session owner) must not adopt its key.
+    rows = [_ep(f"https://{HOST}/v1", "bob")]
+    assert _resolve(rows, HOST, "alice") is None
+
+
+def test_returns_session_owners_own_endpoint():
+    rows = [_ep(f"https://{HOST}/v1", "bob"), _ep(f"https://{HOST}/v1", "alice")]
+    ep = _resolve(rows, HOST, "alice")
+    assert ep is not None and ep.owner == "alice"
+
+
+def test_allows_legacy_null_owner_shared_row():
+    rows = [_ep(f"https://{HOST}/v1", None)]
+    ep = _resolve(rows, HOST, "alice")
+    assert ep is not None and ep.owner is None
+
+
+def test_no_host_match_returns_none():
+    rows = [_ep("https://other.host/v1", "alice")]
+    assert _resolve(rows, HOST, "alice") is None
+
+
+def test_null_owner_is_legacy_single_user_noop():
+    rows = [_ep(f"https://{HOST}/v1", "bob")]
+    ep = _resolve(rows, HOST, None)
+    assert ep is not None and ep.owner == "bob"


### PR DESCRIPTION
## Summary

`resolve_session_auth()` runs in the `chat_stream` path, **after** `_verify_session_owner` confirms the caller owns the session. When the session has no auth headers, it matches a `ModelEndpoint` by the session `endpoint_url`'s **host substring** and copies that row's **decrypted `api_key`** into the session headers — and **persists** it:

```python
domain = sess.endpoint_url.split("//")[1].split("/")[0] ...
ep = db.query(ModelEndpoint).filter(ModelEndpoint.base_url.contains(domain)).first()
if ep and ep.api_key:
    sess.headers = build_headers(ep.api_key, ep.base_url)   # + persisted to DB
```

The match is **not owner-scoped**. `ModelEndpoint` is per-user (`core/database.py`: non-null `owner` = private, *"the model picker only shows the endpoint to that user"*).

**Exploit:** a user creates a session they own, with `endpoint_url` pointing at another user's endpoint **host** and no api_key of its own, then sends one message. `resolve_session_auth` matches the victim's endpoint by host substring, copies the victim's `api_key` into the attacker-owned session, and persists it — so every subsequent call spends the victim's key. For public-provider hosts (e.g. `api.openai.com`) the host is non-secret, making this trivially reachable.

Same multi-tenant owner-scoping class already fixed for `companion/models`, `/api/v1/chat` (#870, #1045), session create/switch-model (#1093), `/api/research/start` (#1099) and `/api/compare/start` (#1104).

### Verified
Old (unscoped) vs new (scoped) on identical fixtures — session owner `alice`, victim `bob` on the same host:

```
OLD unscoped -> adopts: bob  | persisted into alice's session: BOB-KEY
NEW scoped   -> adopts: None
```

## Fix

Extract `_owned_endpoint_by_domain(db, domain, owner)` scoped via the shared `owner_filter` (own rows + legacy null-owner shared rows), scoping to **the session's own owner** (`getattr(sess, "owner", None)`). A null/empty owner stays a no-op (single-user / legacy mode).

## Tests

New `tests/test_resolve_session_auth_owner_scope.py`: cross-owner rejected, own-row allowed, legacy shared-row allowed, no host match, null-owner no-op.

```
$ pytest tests/test_resolve_session_auth_owner_scope.py -q
5 passed
```