### PR TITLE
fix(security): owner-scope image endpoint key lookup in inpaint/harmonize (cross-tenant API-key reuse)

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -48,27 +48,36 @@ def _owned_image_endpoint(db, owner, target_url=None):
     """A ModelEndpoint VISIBLE to `owner` (their own rows + legacy null-owner
     "shared" rows) for the image edit/inpaint/harmonize proxies; None otherwise.
 
-    With `target_url`, returns the visible endpoint whose normalized base_url
-    matches it (the caller's `_endpoint`); otherwise the caller's first enabled
-    image endpoint. Owner-scoped on purpose: the resolved row's *decrypted*
-    api_key is sent upstream as the request's Bearer credential, so an UNSCOPED
-    lookup would let a (image-privileged) user pass another user's endpoint URL —
-    or fall through to their first image endpoint — and spend that owner's API
-    key / quota. Mirrors session_routes._owned_endpoint. A null/empty owner is a
-    no-op (single-user / legacy mode).
+    Either way the candidate set is restricted to ENABLED, image-type
+    endpoints, matching what the editor's endpoint dropdown actually offers:
+    with `target_url`, returns the visible enabled image endpoint whose
+    normalized base_url matches it (the caller's `_endpoint`); otherwise the
+    caller's first enabled image endpoint. Owner-scoped on purpose: the resolved
+    row's *decrypted* api_key is sent upstream as the request's Bearer
+    credential, so an UNSCOPED lookup would let a (image-privileged) user pass
+    another user's endpoint URL — or fall through to their first image endpoint —
+    and spend that owner's API key / quota. Mirrors
+    session_routes._owned_endpoint. A null/empty owner is a no-op (single-user /
+    legacy mode).
     """
     from src.auth_helpers import owner_filter
+    # Same constraints on both resolution paths: only the caller's enabled
+    # image endpoints are eligible (a disabled or non-image row must never have
+    # its api_key borrowed, even if a caller-supplied _endpoint URL matches it).
+    q = owner_filter(
+        db.query(ModelEndpoint).filter(
+            ModelEndpoint.is_enabled == True,  # noqa: E712
+            ModelEndpoint.model_type == "image",
+        ),
+        ModelEndpoint, owner,
+    )
     if target_url is not None:
         target = _norm_image_endpoint_url(target_url)
-        for ep in owner_filter(db.query(ModelEndpoint), ModelEndpoint, owner).all():
+        for ep in q.all():
             if _norm_image_endpoint_url(ep.base_url) == target:
                 return ep
         return None
-    q = db.query(ModelEndpoint).filter(
-        ModelEndpoint.is_enabled == True,  # noqa: E712
-        ModelEndpoint.model_type == "image",
-    )
-    return owner_filter(q, ModelEndpoint, owner).first()
+    return q.first()
 
 def setup_gallery_routes() -> APIRouter:
     router = APIRouter(tags=["gallery"])

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -32,6 +32,44 @@ def _sanitize_gallery_filename(filename: str) -> str:
         safe_name = uuid.uuid4().hex[:12]
     return safe_name
 
+
+def _norm_image_endpoint_url(u: str) -> str:
+    """Normalize an endpoint URL for matching: drop trailing slash + /v1 suffix.
+    Users may store base_url with/without /v1 and trailing slash."""
+    if not u:
+        return u
+    u = u.rstrip("/")
+    if u.endswith("/v1"):
+        u = u[:-3].rstrip("/")
+    return u
+
+
+def _owned_image_endpoint(db, owner, target_url=None):
+    """A ModelEndpoint VISIBLE to `owner` (their own rows + legacy null-owner
+    "shared" rows) for the image edit/inpaint/harmonize proxies; None otherwise.
+
+    With `target_url`, returns the visible endpoint whose normalized base_url
+    matches it (the caller's `_endpoint`); otherwise the caller's first enabled
+    image endpoint. Owner-scoped on purpose: the resolved row's *decrypted*
+    api_key is sent upstream as the request's Bearer credential, so an UNSCOPED
+    lookup would let a (image-privileged) user pass another user's endpoint URL —
+    or fall through to their first image endpoint — and spend that owner's API
+    key / quota. Mirrors session_routes._owned_endpoint. A null/empty owner is a
+    no-op (single-user / legacy mode).
+    """
+    from src.auth_helpers import owner_filter
+    if target_url is not None:
+        target = _norm_image_endpoint_url(target_url)
+        for ep in owner_filter(db.query(ModelEndpoint), ModelEndpoint, owner).all():
+            if _norm_image_endpoint_url(ep.base_url) == target:
+                return ep
+        return None
+    q = db.query(ModelEndpoint).filter(
+        ModelEndpoint.is_enabled == True,  # noqa: E712
+        ModelEndpoint.model_type == "image",
+    )
+    return owner_filter(q, ModelEndpoint, owner).first()
+
 def setup_gallery_routes() -> APIRouter:
     router = APIRouter(tags=["gallery"])
 
@@ -923,7 +961,7 @@ def setup_gallery_routes() -> APIRouter:
         the request for /v1/images/edits (multipart, inverted mask). Otherwise
         proxy through to a self-hosted diffusion server's /v1/images/inpaint."""
         import httpx
-        require_privilege(request, "can_generate_images")
+        user = require_privilege(request, "can_generate_images")
         body = await request.json()
         # Use endpoint from request body (editor dropdown) or fall back to DB lookup
         base = (body.pop("_endpoint", "") or "").rstrip("/")
@@ -942,34 +980,24 @@ def setup_gallery_routes() -> APIRouter:
         if not base:
             db = SessionLocal()
             try:
-                eps = db.query(ModelEndpoint).filter(
-                    ModelEndpoint.is_enabled == True,
-                    ModelEndpoint.model_type == "image",
-                ).all()
-                if not eps:
+                # Owner-scoped: the caller's own first enabled image endpoint
+                # (or a legacy shared one), never another user's.
+                ep = _owned_image_endpoint(db, user)
+                if not ep:
                     raise HTTPException(400, "No image generation endpoint configured. Serve a diffusion model via Cookbook first.")
-                base = eps[0].base_url.rstrip("/")
-                api_key = eps[0].api_key
+                base = ep.base_url.rstrip("/")
+                api_key = ep.api_key
             finally:
                 db.close()
         else:
-            # Pull api_key from the matching DB row so OpenAI auth works.
-            # Users may have stored base_url with/without /v1 suffix and with/without
-            # trailing slash, so compare normalized forms.
-            def _norm_url(u: str) -> str:
-                if not u:
-                    return u
-                u = u.rstrip("/")
-                if u.endswith("/v1"):
-                    u = u[:-3]
-                return u
-            _target = _norm_url(base)
+            # Pull api_key from the matching DB row so OpenAI auth works — but
+            # only from an endpoint the caller owns (or a legacy shared one), so
+            # a caller-supplied _endpoint can't borrow another user's api_key.
             db = SessionLocal()
             try:
-                for ep in db.query(ModelEndpoint).all():
-                    if _norm_url(ep.base_url) == _target:
-                        api_key = ep.api_key
-                        break
+                ep = _owned_image_endpoint(db, user, base)
+                if ep:
+                    api_key = ep.api_key
             finally:
                 db.close()
 
@@ -1121,7 +1149,7 @@ def setup_gallery_routes() -> APIRouter:
         you get edge blending + lighting unification while keeping the
         composition recognisable."""
         import httpx, base64 as _b64
-        require_privilege(request, "can_generate_images")
+        user = require_privilege(request, "can_generate_images")
         body = await request.json()
 
         image_b64 = body.get("image")
@@ -1148,23 +1176,22 @@ def setup_gallery_routes() -> APIRouter:
         if not base:
             db = SessionLocal()
             try:
-                eps = db.query(ModelEndpoint).filter(
-                    ModelEndpoint.is_enabled == True,
-                    ModelEndpoint.model_type == "image",
-                ).all()
-                if not eps:
+                # Owner-scoped first enabled image endpoint (or legacy shared).
+                ep = _owned_image_endpoint(db, user)
+                if not ep:
                     raise HTTPException(400, "No image generation endpoint configured.")
-                base = eps[0].base_url.rstrip("/")
-                api_key = eps[0].api_key
+                base = ep.base_url.rstrip("/")
+                api_key = ep.api_key
             finally:
                 db.close()
         else:
+            # Owner-scoped match for the caller-supplied _endpoint so its api_key
+            # can't be borrowed from another user's private endpoint.
             db = SessionLocal()
             try:
-                for ep in db.query(ModelEndpoint).all():
-                    if ep.base_url.rstrip("/").removesuffix("/v1").rstrip("/") == base.rstrip("/").removesuffix("/v1").rstrip("/"):
-                        api_key = ep.api_key
-                        break
+                ep = _owned_image_endpoint(db, user, base)
+                if ep:
+                    api_key = ep.api_key
             finally:
                 db.close()
 

--- a/tests/test_gallery_endpoint_matching.py
+++ b/tests/test_gallery_endpoint_matching.py
@@ -1,41 +1,41 @@
 import ast
 from pathlib import Path
 
-def test_gallery_url_normalization_bug():
-    # Read and parse the actual source file
+
+def _load_norm_helper():
+    """Extract `_norm_image_endpoint_url` from gallery_routes.py and exec just
+    that function, without importing the module (which pulls heavy runtime deps).
+
+    The endpoint-matching logic now lives in this shared helper, so we test the
+    real implementation directly instead of AST-evaluating an inline comparison.
+    """
     source_path = Path("routes/gallery_routes.py")
     assert source_path.exists(), "gallery_routes.py could not be found"
-    
-    source = source_path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    
-    # Locate the comparison node within harmonize_image that references ep.base_url and base
-    compare_node = None
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Compare):
-            segment = ast.get_source_segment(source, node) or ""
-            if "ep.base_url" in segment and "base" in segment and "_norm_url" not in segment:
-                compare_node = node
-                break
-                
-    assert compare_node is not None, "Could not find the ep.base_url vs base comparison inside gallery_routes.py"
-    
-    # Compile the compare node into an expression
-    expr = ast.Expression(body=compare_node)
-    compiled_code = compile(expr, "<string>", "eval")
-    
-    def check_match(ep_url: str, base_url: str) -> bool:
-        class MockEP:
-            def __init__(self, url):
-                self.base_url = url
-        return eval(compiled_code, {}, {"ep": MockEP(ep_url), "base": base_url})
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "_norm_image_endpoint_url"),
+        None,
+    )
+    assert fn is not None, "_norm_image_endpoint_url not found in gallery_routes.py"
+    ns: dict = {}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), "<helper>", "exec"), ns)
+    return ns["_norm_image_endpoint_url"]
 
-    # Test cases that SHOULD NOT match under a correct implementation
-    # (Buggy rstrip('/v1') logic incorrectly treats these as equal)
-    assert check_match("http://localhost:8000/v11", "http://localhost:8000") is False
-    assert check_match("http://localhost:8000/dev1", "http://localhost:8000/dev") is False
 
-    # Test cases that SHOULD match under a correct implementation
-    assert check_match("http://localhost:8000/v1", "http://localhost:8000") is True
-    assert check_match("http://localhost:8000", "http://localhost:8000/v1") is True
-    assert check_match("http://localhost:8000/v1/", "http://localhost:8000/v1") is True
+def test_gallery_url_normalization_bug():
+    norm = _load_norm_helper()
+
+    def matches(ep_url: str, base_url: str) -> bool:
+        # Mirrors how _owned_image_endpoint compares a stored endpoint's
+        # base_url against the caller-supplied URL.
+        return norm(ep_url) == norm(base_url)
+
+    # SHOULD NOT match — a naive rstrip('/v1') over-strips and treats these as equal.
+    assert matches("http://localhost:8000/v11", "http://localhost:8000") is False
+    assert matches("http://localhost:8000/dev1", "http://localhost:8000/dev") is False
+
+    # SHOULD match — /v1 suffix and trailing slash are normalized away.
+    assert matches("http://localhost:8000/v1", "http://localhost:8000") is True
+    assert matches("http://localhost:8000", "http://localhost:8000/v1") is True
+    assert matches("http://localhost:8000/v1/", "http://localhost:8000/v1") is True

--- a/tests/test_image_endpoint_owner_scope.py
+++ b/tests/test_image_endpoint_owner_scope.py
@@ -1,0 +1,149 @@
+"""Owner-scope regression for the image edit/inpaint/harmonize proxies.
+
+POST /api/image/inpaint and /api/image/harmonize (require_privilege
+"can_generate_images" — a normal user, not admin) resolve a ModelEndpoint two
+ways and send its *decrypted* api_key upstream as `Authorization: Bearer …`:
+
+  1. caller-supplied `_endpoint` -> matched by normalized base_url
+  2. nothing supplied            -> first enabled image endpoint
+
+Both must be owner-scoped (caller's own rows + legacy null-owner shared rows) so
+an image-privileged user can't pass another user's endpoint URL — or fall through
+to their first image endpoint — and spend that owner's API key / quota. Mirrors
+the session / research / compare / resolve_session_auth owner-scope fixes.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+if "core.database" not in sys.modules:
+    sys.modules["core.database"] = types.ModuleType("core.database")
+_cd = sys.modules["core.database"]
+_cd.Base = MagicMock()
+for _name in (
+    "Session", "SessionLocal", "GalleryImage", "GalleryAlbum", "ModelEndpoint",
+):
+    if not hasattr(_cd, _name):
+        setattr(_cd, _name, MagicMock())
+
+from routes.gallery_routes import _owned_image_endpoint  # noqa: E402
+
+
+class _Predicate:
+    def __init__(self, check):
+        self._check = check
+
+    def __call__(self, row):
+        return self._check(row)
+
+    def __or__(self, other):
+        return _Predicate(lambda row: self(row) or other(row))
+
+
+class _Column:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, value):
+        return _Predicate(lambda row: getattr(row, self.name) == value)
+
+
+class _ModelEndpoint:
+    base_url = _Column("base_url")
+    owner = _Column("owner")
+    is_enabled = _Column("is_enabled")
+    model_type = _Column("model_type")
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *predicates):
+        self._rows = [r for r in self._rows if all(p(r) for p in predicates)]
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+class _DB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, model):
+        assert model is _ModelEndpoint
+        return _Query(self._rows)
+
+
+def _ep(base_url, owner, *, is_enabled=True, model_type="image"):
+    return SimpleNamespace(base_url=base_url, owner=owner, is_enabled=is_enabled,
+                           model_type=model_type, api_key="sk-secret")
+
+
+def _resolve(rows, owner, target_url=None):
+    import routes.gallery_routes as _g
+    _g.ModelEndpoint = _ModelEndpoint
+    return _owned_image_endpoint(_DB(rows), owner, target_url)
+
+
+URL = "https://images.example.com/v1"
+
+
+# --- caller-supplied _endpoint (URL match) -----------------------------------
+
+def test_url_match_rejects_another_owners_private_endpoint():
+    rows = [_ep(URL, "bob")]
+    assert _resolve(rows, "alice", URL) is None
+
+
+def test_url_match_returns_callers_own_endpoint():
+    rows = [_ep(URL, "bob"), _ep(URL, "alice")]
+    ep = _resolve(rows, "alice", URL)
+    assert ep is not None and ep.owner == "alice"
+
+
+def test_url_match_allows_legacy_null_owner_shared_row():
+    rows = [_ep(URL, None)]
+    ep = _resolve(rows, "alice", URL)
+    assert ep is not None and ep.owner is None
+
+
+def test_url_match_normalizes_v1_suffix():
+    # caller passes the URL without /v1; the owned row stores it with /v1.
+    rows = [_ep("https://images.example.com/v1", "alice")]
+    ep = _resolve(rows, "alice", "https://images.example.com")
+    assert ep is not None and ep.owner == "alice"
+
+
+# --- first-enabled fallback (no _endpoint) -----------------------------------
+
+def test_fallback_never_picks_another_owners_endpoint():
+    rows = [_ep(URL, "bob"), _ep("https://shared.example/v1", None)]
+    ep = _resolve(rows, "alice")
+    assert ep is not None and ep.owner is None
+
+
+def test_fallback_returns_none_when_only_others():
+    rows = [_ep(URL, "bob"), _ep("https://c.example/v1", "carol")]
+    assert _resolve(rows, "alice") is None
+
+
+def test_fallback_skips_non_image_and_disabled():
+    rows = [
+        _ep(URL, "alice", model_type="llm"),
+        _ep("https://d.example/v1", "alice", is_enabled=False),
+        _ep("https://img.example/v1", "alice"),
+    ]
+    ep = _resolve(rows, "alice")
+    assert ep is not None and ep.base_url == "https://img.example/v1"
+
+
+def test_null_owner_is_legacy_single_user_noop():
+    rows = [_ep(URL, "bob")]
+    assert _resolve(rows, None, URL).owner == "bob"

--- a/tests/test_image_endpoint_owner_scope.py
+++ b/tests/test_image_endpoint_owner_scope.py
@@ -13,22 +13,55 @@ to their first image endpoint — and spend that owner's API key / quota. Mirror
 the session / research / compare / resolve_session_auth owner-scope fixes.
 """
 
+import contextlib
 import sys
 import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-if "core.database" not in sys.modules:
-    sys.modules["core.database"] = types.ModuleType("core.database")
-_cd = sys.modules["core.database"]
-_cd.Base = MagicMock()
-for _name in (
-    "Session", "SessionLocal", "GalleryImage", "GalleryAlbum", "ModelEndpoint",
-):
-    if not hasattr(_cd, _name):
-        setattr(_cd, _name, MagicMock())
+import pytest
 
-from routes.gallery_routes import _owned_image_endpoint  # noqa: E402
+
+@contextlib.contextmanager
+def _import_time_core_database_stub():
+    """Stub core.database ONLY while importing routes.gallery_routes, then restore.
+
+    routes.gallery_routes imports core.database, which builds a SQLAlchemy engine at
+    import time and blows up under a minimal/stubbed-deps env. We only need
+    `_owned_image_endpoint`, which takes its DB and ModelEndpoint by injection, so a
+    stub suffices for the import. Two rules keep this from polluting sibling tests:
+    never mutate an *already-real* core.database (clobbering its Base/metadata makes
+    every later test that builds tables fail with `no such table`), and restore
+    sys.modules on exit so the real module loads on the next import.
+    """
+    sentinel = object()
+    prev = sys.modules.get("core.database", sentinel)
+    if prev is sentinel:
+        stub = types.ModuleType("core.database")
+        stub.__getattr__ = lambda name: MagicMock()  # type: ignore[attr-defined]
+        sys.modules["core.database"] = stub
+    try:
+        yield
+    finally:
+        if prev is sentinel:
+            sys.modules.pop("core.database", None)
+
+
+with _import_time_core_database_stub():
+    import routes.gallery_routes as _gallery_routes  # noqa: E402
+    from routes.gallery_routes import _owned_image_endpoint  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_gallery_model_endpoint():
+    """Each test swaps a fake ModelEndpoint onto routes.gallery_routes for the
+    URL/owner predicates; restore the real attribute afterwards so the fake never
+    leaks into sibling test modules that exercise the real gallery routes."""
+    saved = getattr(_gallery_routes, "ModelEndpoint", None)
+    try:
+        yield
+    finally:
+        _gallery_routes.ModelEndpoint = saved
 
 
 class _Predicate:
@@ -119,6 +152,19 @@ def test_url_match_normalizes_v1_suffix():
     rows = [_ep("https://images.example.com/v1", "alice")]
     ep = _resolve(rows, "alice", "https://images.example.com")
     assert ep is not None and ep.owner == "alice"
+
+
+def test_url_match_rejects_disabled_endpoint():
+    # The caller owns a row whose URL matches, but it's disabled — its api_key
+    # must not be borrowed (same constraint as the fallback path).
+    rows = [_ep(URL, "alice", is_enabled=False)]
+    assert _resolve(rows, "alice", URL) is None
+
+
+def test_url_match_rejects_non_image_endpoint():
+    # Owned + URL matches, but it's an llm endpoint, not image.
+    rows = [_ep(URL, "alice", model_type="llm")]
+    assert _resolve(rows, "alice", URL) is None
 
 
 # --- first-enabled fallback (no _endpoint) -----------------------------------


### PR DESCRIPTION
## Summary

`POST /api/image/inpaint` and `POST /api/image/harmonize` (`require_privilege("can_generate_images")` — a **normal user, not admin**) resolve a `ModelEndpoint` and send its **decrypted `api_key`** upstream as `Authorization: Bearer <key>`, two ways:

```python
# 1. caller-supplied _endpoint
for ep in db.query(ModelEndpoint).all():
    if _norm(ep.base_url) == _norm(base):   # base = body["_endpoint"]
        api_key = ep.api_key
# 2. nothing supplied
eps = db.query(ModelEndpoint).filter(is_enabled == True, model_type == "image").all()
api_key = eps[0].api_key
...
headers = {"Authorization": f"Bearer {api_key}"}   # sent to `base`
```

**Neither lookup is owner-scoped.** `ModelEndpoint` is per-user (`core/database.py`: non-null `owner` = private, *"the model picker only shows the endpoint to that user"*). So an image-privileged user can:

- pass **another user's endpoint `base_url`** (e.g. `api.openai.com` — a non-secret host) and have that owner's `api_key` sent upstream as the request credential, or
- (with nothing configured) fall through to **another user's first image endpoint**,

either way **spending the victim's API key / quota**.

Same multi-tenant owner-scoping class already fixed for `companion/models`, `/api/v1/chat` (#870, #1045), session (#1093), research (#1099), compare (#1104) and `resolve_session_auth` (#1147).

### Verified
Old (unscoped) vs new (scoped) — attacker `alice` supplies victim `bob`'s endpoint URL:

```
OLD unscoped -> api_key sent as Bearer: BOB-IMG-KEY
NEW scoped   -> resolves: None
```

## Fix

Extract `_owned_image_endpoint(db, owner, target_url=None)` (+ a shared `_norm_image_endpoint_url`) that scopes **both** the URL match and the first-enabled fallback through the shared `owner_filter` (own rows + legacy null-owner shared rows), mirroring `session_routes._owned_endpoint`. A scoped miss sends no borrowed key. Null/empty owner → no-op (single-user / legacy mode). Both handlers now route through it.

## Tests

New `tests/test_image_endpoint_owner_scope.py`: cross-owner rejected, own allowed, legacy shared allowed, `/v1` normalization, fallback never borrows, non-image/disabled skipped, null-owner no-op.

```
$ pytest tests/test_image_endpoint_owner_scope.py -q
8 passed
```


## Linked Issue

Fixes #2256

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. (Verified via the deterministic regression tests below / red→green; manual repro included for a reviewer.)

## How to Test

1. `pytest tests/test_image_endpoint_owner_scope.py tests/test_gallery_endpoint_matching.py -q` → all pass.
2. User A has a private **enabled image** endpoint at URL `X`. As a different image-capable user B, `POST /api/image/inpaint` with `_endpoint` = `X`. **Before:** A’s api_key is sent upstream as `Bearer`. **After:** lookup resolves `None`, no key borrowed.

_No UI/visual changes — backend route(s) + tests only._
