### PR TITLE
companion: mint pairing tokens with the companion scope (not just chat)

### DIFF
--- a/companion/pairing.py
+++ b/companion/pairing.py
@@ -15,7 +15,12 @@ import uuid
 import bcrypt
 
 PAIRING_VERSION = 1
-COMPANION_SCOPE = "chat"
+# Scopes granted to a paired mobile client. "chat" lets it stream chat; the
+# companion data routes (notes/tasks/memory) gate on a narrower "companion"
+# scope, so the pairing token must carry both — otherwise a paired phone would
+# 403 on those endpoints even though it owns the data. Comma-separated; the
+# auth middleware splits this into a scope list.
+COMPANION_SCOPE = "chat,companion"
 
 
 def default_port() -> int:
@@ -74,7 +79,7 @@ def find_admin_user() -> str | None:
 
 
 def mint_token(owner: str, name: str = "companion") -> tuple[str, str]:
-    """Create a chat-scoped API token row and return (token_id, raw_token).
+    """Create a companion-scoped (chat + companion) API token row and return (token_id, raw_token).
 
     The raw token is returned ONCE -- only its bcrypt hash + an 8-char prefix
     are persisted. Mirrors routes/api_token_routes.py so cookie- and

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -164,7 +164,7 @@ def setup_companion_routes() -> APIRouter:
 </style></head>
 <body><div class="card">
   <h2>Pair a device</h2>
-  <p>Generate a one-time pairing code (a chat-scoped API token) for a LAN client.</p>
+  <p>Generate a one-time pairing code (a chat + companion scoped API token) for a LAN client.</p>
   <form method="POST" action="/api/companion/pair">
     <button type="submit">Generate pairing code</button>
   </form>

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -77,7 +77,10 @@ def test_mint_token_returns_raw_once_and_stores_only_a_hash():
     assert _CAPTURED["token_hash"].startswith("$2")  # bcrypt
     assert _CAPTURED["token_prefix"] == raw[:8]
     assert _CAPTURED["owner"] == "alice"
-    assert _CAPTURED["scopes"] == "chat"
+    # chat lets the phone stream; companion unlocks the notes/tasks/memory
+    # data routes that gate on the narrower "companion" scope.
+    assert _CAPTURED["scopes"] == "chat,companion"
+    assert "companion" in _CAPTURED["scopes"].split(",")
     assert _CAPTURED["is_active"] is True
 
 


### PR DESCRIPTION
## Problem

The companion data routes (notes / tasks / memory) — see #881 — gate on a narrower `companion` token scope. But the pairing flow mints a **`chat`-only** token:

```python
# companion/pairing.py
COMPANION_SCOPE = "chat"
```

So a paired mobile client authenticates fine for chat streaming but would get **403** on the notes/tasks/memory endpoints — even though it owns that data. The token's scope is narrower than the surface the companion client is built to use.

## Fix

Mint the pairing token with **both** scopes (`chat,companion`). The auth middleware already splits the scopes string on commas into a list (`app.py`), and `has_companion_scope` checks for `"companion"` membership, so the existing chat path is unaffected and the data routes now accept a paired token.

- `COMPANION_SCOPE = "chat,companion"`
- Updated the `/pair` page copy and `mint_token` docstring (were stale "chat-scoped").
- Updated `test_mint_token_*` to assert both scopes.

Forward-compatible with `main` (nothing on main reads the `companion` scope yet, so the extra scope is harmless) and unlocks the data routes once #881 lands.

## Test
```
pytest tests/test_companion_pairing.py tests/test_companion_readonly.py -q
25 passed
```