### PR TITLE
fix: extract_statistics drops large numbers and trailing % signs

### DIFF
--- a/services/search/content.py
+++ b/services/search/content.py
@@ -390,8 +390,11 @@ def extract_quotes(text: str) -> List[str]:
 
 def extract_statistics(text: str) -> List[str]:
     """Find numbers, percentages, dates and simple measurements."""
+    # Match a comma-grouped number (1,000,000) OR a plain digit run (50000) —
+    # the old `\d{1,3}(?:,\d{3})*` matched only the first 3 digits of a
+    # comma-less number, and the trailing `\b` dropped a closing `%`.
     pattern = re.compile(
-        r"\b\d{1,3}(?:,\d{3})*(?:\.\d+)?\s*(%|percent|‰|per cent|[a-zA-Z]+)?\b",
+        r"\b(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\s*(%|percent|‰|per cent|[a-zA-Z]+)?",
         re.IGNORECASE,
     )
     return [m.group(0).strip() for m in pattern.finditer(text)]

--- a/src/search/content.py
+++ b/src/search/content.py
@@ -395,8 +395,11 @@ def extract_quotes(text: str) -> List[str]:
 
 def extract_statistics(text: str) -> List[str]:
     """Find numbers, percentages, dates and simple measurements."""
+    # Match a comma-grouped number (1,000,000) OR a plain digit run (50000) —
+    # the old `\d{1,3}(?:,\d{3})*` matched only the first 3 digits of a
+    # comma-less number, and the trailing `\b` dropped a closing `%`.
     pattern = re.compile(
-        r"\b\d{1,3}(?:,\d{3})*(?:\.\d+)?\s*(%|percent|‰|per cent|[a-zA-Z]+)?\b",
+        r"\b(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?\s*(%|percent|‰|per cent|[a-zA-Z]+)?",
         re.IGNORECASE,
     )
     return [m.group(0).strip() for m in pattern.finditer(text)]

--- a/tests/test_extract_statistics.py
+++ b/tests/test_extract_statistics.py
@@ -1,0 +1,25 @@
+"""Tests for extract_statistics (src/search/content.py)."""
+import pytest
+
+pytest.importorskip("bs4")  # content.py imports BeautifulSoup at module load
+
+from src.search.content import extract_statistics
+
+
+def test_captures_comma_less_large_number():
+    # Regression: `\d{1,3}(?:,\d{3})*` matched only the first 3 digits of a
+    # comma-less number, so "50000" was never captured whole.
+    assert any(s.startswith("50000") for s in extract_statistics("about 50000 users"))
+
+
+def test_keeps_percent_sign():
+    # Regression: a trailing `\b` after the optional unit dropped the "%".
+    assert "12%" in extract_statistics("conversion rose to 12% this quarter")
+
+
+def test_comma_grouped_number():
+    assert any(s.startswith("1,000,000") for s in extract_statistics("revenue of 1,000,000 dollars"))
+
+
+def test_four_digit_year_captured():
+    assert any("2024" in s for s in extract_statistics("released in 2024"))


### PR DESCRIPTION
## Summary

`extract_statistics` (deep-research content extraction) misses much of what it's supposed to capture:

- `\d{1,3}(?:,\d{3})*` only matches the first three digits of a **comma-less** number, so `50000` is split (or dropped) and a 4-digit year like `2024` never matches at all.
- The trailing `\b` after the optional unit fails right after a `%`, so `12%` is captured as `12` — the percent sign is dropped.

Example — `"revenue was 50000 in 2024, up 12%"` returns just `["12"]` today.

Fix: match either a comma-grouped number (`1,000,000`) or a plain digit run (`50000`), with an optional decimal, and drop the trailing `\b` so a closing `%` is kept. Now returns `["50000 in", "2024", "12%"]`.

## Changes
- `src/search/content.py` and `services/search/content.py`: number/percent regex.
- `tests/test_extract_statistics.py`: comma-less numbers, comma-grouped, 4-digit years, and `%` retention.

(Note: touches the same file as #1113, a different function — adjacent hunks, trivial to rebase.)