### PR TITLE
fix: persist and display multimodal messages (image/audio attachments)

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -29,6 +29,21 @@ def _message_timestamp_iso(value: Optional[datetime]) -> Optional[str]:
     return value.isoformat().replace("+00:00", "Z")
 
 
+def _parse_msg_content(raw):
+    """Parse message content from DB — deserialises JSON arrays back to lists
+    (multimodal content with image/audio attachments)."""
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, str) and raw.startswith('[{') and '"type"' in raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list) and all(isinstance(p, dict) for p in parsed):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return raw
+
+
 class SessionManager:
     """
     Manages chat sessions with database persistence.
@@ -119,7 +134,7 @@ class SessionManager:
                 meta.setdefault('timestamp', _message_timestamp_iso(db_msg.timestamp))
                 history.append(ChatMessage(
                     role=db_msg.role,
-                    content=db_msg.content,
+                    content=_parse_msg_content(db_msg.content),
                     metadata=meta,
                 ))
         else:
@@ -134,7 +149,7 @@ class SessionManager:
                 meta.setdefault('timestamp', _message_timestamp_iso(db_msg.timestamp))
                 history.append(ChatMessage(
                     role=db_msg.role,
-                    content=db_msg.content,
+                    content=_parse_msg_content(db_msg.content),
                     metadata=meta,
                 ))
 
@@ -192,11 +207,17 @@ class SessionManager:
             if message.metadata is None:
                 message.metadata = {}
             message.metadata.setdefault('timestamp', _message_timestamp_iso(msg_time))
+            # Multimodal content (image/audio attachments) is a list — serialize
+            # to JSON so the Text column can store it.  On reload, _db_to_session
+            # detects the JSON-array prefix and parses it back.
+            _content = message.content
+            if isinstance(_content, list):
+                _content = json.dumps(_content)
             db_message = DbChatMessage(
                 id=msg_id,
                 session_id=session_id,
                 role=message.role,
-                content=message.content,
+                content=_content,
                 meta_data=json.dumps(message.metadata) if message.metadata else None,
                 timestamp=msg_time,
             )

--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -1610,7 +1610,15 @@ export async function selectSession(id, { keepSidebar = false } = {}) {
     } else if (msgHistory.length) {
       for (const msg of msgHistory) {
         const meta = msg.metadata ? { ...msg.metadata, _fromHistory: true } : null;
-        let displayContent = typeof msg.content === 'string' ? msg.content : (msg.content ? String(msg.content) : '');
+        let displayContent;
+        if (typeof msg.content === 'string') {
+          displayContent = msg.content;
+        } else if (Array.isArray(msg.content)) {
+          // Multimodal (image/audio attachments): extract text parts, skip binary
+          displayContent = msg.content.filter(p => p.type === 'text').map(p => p.text).join('\n').trim();
+        } else {
+          displayContent = '';
+        }
         // Clean up doc selection context for display
         if (msg.role === 'user') {
           // Hide "Continue where you left off" bubbles


### PR DESCRIPTION
## What
Fixes `[object Object],[object Object]` appearing in chat history on reload when messages contain image or audio attachments.

## Why
Two bugs working together:

1. **DB persist failure** — Multimodal content (`[{type: 'text', ...}, {type: 'image_url', ...}]`) is a Python list, but the `DBChatMessage.content` column is `Text`. SQLAlchemy silently rejects the insert, the message is never stored, and the rollback leaves no trace.

2. **Frontend display** — On reload, `sessions.js` line 1613 used `String(msg.content)` to coerce content. For list values this produces `[object Object],[object Object]` instead of readable text.

## Changes

**`core/session_manager.py`** (+27/-3):
- `_persist_message()`: serialize list content to JSON before writing to DB
- `_db_to_session()`: deserialize JSON arrays back to lists via new `_parse_msg_content()` helper
- `_parse_msg_content()` detects stored multimodal JSON (starts with `[{`, contains `"type"`) and parses it back; plain strings pass through unchanged

**`static/js/sessions.js`** (+10/-1):
- Extract text parts from multimodal content arrays (`filter(p => p.type === 'text').map(p => p.text)`) instead of `String()` coercion

## Testing
- Attached an image in chat with a vision model → message displays correctly
- Reloaded page → message text shows (no more `[object Object]`)
- Plain text messages → unchanged behavior

## Scope
- No changes to the LLM call path — multimodal content still reaches providers as a list
- No DB migration needed — the column already stores strings, we just serialize/deserialize
- Backward compatible — old plain-text messages are unaffected (no `[{` prefix)