### PR TITLE
fix(documents): clear active context on close

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -20,6 +20,7 @@ from src.model_context import estimate_tokens
 from src.chat_helpers import coerce_message_and_session
 from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url
 from src.prompt_security import untrusted_context_message
+from src.tool_implementations import resolve_active_document_for_chat
 from core.exceptions import SessionNotFoundError
 from src.auth_helpers import get_current_user
 from routes.session_routes import _verify_session_owner
@@ -486,51 +487,25 @@ def setup_chat_routes(
         active_doc = None
         _doc_db = SessionLocal()
         try:
-            from src.tool_implementations import get_closed_documents, set_active_document
-            _closed_doc_ids = get_closed_documents()
-            if active_doc_closed and not active_doc_id:
-                set_active_document(None)
-            if active_doc_id:
-                logger.info(f"[doc-inject] active_doc_id from frontend: {active_doc_id}")
-                # Scope to the caller's documents. The session and in-memory
-                # fallbacks below are already owner/session-bound; this
-                # explicit-id path looked up by id alone, so a user could
-                # inject another user's document by passing its id.
-                _doc_q = _doc_db.query(DBDocument).filter(DBDocument.id == active_doc_id)
-                active_doc = _owner_session_filter(_doc_q, ctx.user).first()
-                if active_doc:
-                    set_active_document(active_doc.id)
-                    logger.info(f"[doc-inject] found by ID: title={active_doc.title!r}, lang={active_doc.language!r}, is_active={active_doc.is_active}, content_len={len(active_doc.current_content or '')}")
-                else:
-                    logger.warning(f"[doc-inject] NOT FOUND by ID {active_doc_id}")
-            if not active_doc and not active_doc_closed:
-                _session_doc_q = _doc_db.query(DBDocument).filter(
-                    DBDocument.session_id == session,
-                    DBDocument.is_active == True
+            active_doc = resolve_active_document_for_chat(
+                _doc_db,
+                DBDocument,
+                _owner_session_filter,
+                session_id=session,
+                owner=ctx.user,
+                active_doc_id=active_doc_id,
+                active_doc_closed=active_doc_closed,
+            )
+            if active_doc:
+                logger.info(
+                    "[doc-inject] resolved active doc: title=%r, lang=%r, "
+                    "is_active=%s, session_id=%r, content_len=%s",
+                    active_doc.title,
+                    active_doc.language,
+                    active_doc.is_active,
+                    active_doc.session_id,
+                    len(active_doc.current_content or ""),
                 )
-                if _closed_doc_ids:
-                    _session_doc_q = _session_doc_q.filter(~DBDocument.id.in_(_closed_doc_ids))
-                active_doc = _owner_session_filter(_session_doc_q, ctx.user).order_by(DBDocument.updated_at.desc()).first()
-                if active_doc:
-                    logger.info(f"[doc-inject] found by session fallback: title={active_doc.title!r}")
-            # Last resort: the document the agent itself just created/edited
-            # (tracked in-memory by the tool layer). This rescues docs that
-            # got orphaned from their session (session_id NULL) — otherwise
-            # neither lookup above can associate them with this conversation,
-            # so the agent never sees what it just wrote. Guarded so we never
-            # leak a doc that belongs to a DIFFERENT session.
-            if not active_doc and not active_doc_closed:
-                try:
-                    from src.tool_implementations import get_active_document
-                    _mem_id = get_active_document()
-                    if _mem_id and _mem_id not in _closed_doc_ids:
-                        _mem_q = _doc_db.query(DBDocument).filter(DBDocument.id == _mem_id)
-                        cand = _owner_session_filter(_mem_q, ctx.user).first()
-                        if cand and (not cand.session_id or cand.session_id == session):
-                            active_doc = cand
-                            logger.info(f"[doc-inject] found by in-memory active id: title={active_doc.title!r} (session_id={cand.session_id!r})")
-                except Exception as _e:
-                    logger.debug(f"[doc-inject] in-memory fallback failed: {_e}")
             if not active_doc:
                 logger.info(f"[doc-inject] no active doc for session {session}")
             if active_doc:

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -385,7 +385,9 @@ def setup_chat_routes(
             auto_escalated = True
             logger.info("chat→agent auto-escalation: message matched tool-intent pattern")
         active_doc_id = form_data.get("active_doc_id", "").strip()
-        logger.info(f"[doc-inject] chat_mode={chat_mode}, active_doc_id={active_doc_id!r}")
+        active_doc_state = form_data.get("active_doc_state", "").strip().lower()
+        active_doc_closed = active_doc_state == "closed"
+        logger.info(f"[doc-inject] chat_mode={chat_mode}, active_doc_id={active_doc_id!r}, active_doc_state={active_doc_state!r}")
 
         try:
             # Attachment-only sends: skip the message-required check when the
@@ -484,6 +486,10 @@ def setup_chat_routes(
         active_doc = None
         _doc_db = SessionLocal()
         try:
+            from src.tool_implementations import get_closed_documents, set_active_document
+            _closed_doc_ids = get_closed_documents()
+            if active_doc_closed and not active_doc_id:
+                set_active_document(None)
             if active_doc_id:
                 logger.info(f"[doc-inject] active_doc_id from frontend: {active_doc_id}")
                 # Scope to the caller's documents. The session and in-memory
@@ -493,14 +499,17 @@ def setup_chat_routes(
                 _doc_q = _doc_db.query(DBDocument).filter(DBDocument.id == active_doc_id)
                 active_doc = _owner_session_filter(_doc_q, ctx.user).first()
                 if active_doc:
+                    set_active_document(active_doc.id)
                     logger.info(f"[doc-inject] found by ID: title={active_doc.title!r}, lang={active_doc.language!r}, is_active={active_doc.is_active}, content_len={len(active_doc.current_content or '')}")
                 else:
                     logger.warning(f"[doc-inject] NOT FOUND by ID {active_doc_id}")
-            if not active_doc:
+            if not active_doc and not active_doc_closed:
                 _session_doc_q = _doc_db.query(DBDocument).filter(
                     DBDocument.session_id == session,
                     DBDocument.is_active == True
                 )
+                if _closed_doc_ids:
+                    _session_doc_q = _session_doc_q.filter(~DBDocument.id.in_(_closed_doc_ids))
                 active_doc = _owner_session_filter(_session_doc_q, ctx.user).order_by(DBDocument.updated_at.desc()).first()
                 if active_doc:
                     logger.info(f"[doc-inject] found by session fallback: title={active_doc.title!r}")
@@ -510,11 +519,11 @@ def setup_chat_routes(
             # neither lookup above can associate them with this conversation,
             # so the agent never sees what it just wrote. Guarded so we never
             # leak a doc that belongs to a DIFFERENT session.
-            if not active_doc:
+            if not active_doc and not active_doc_closed:
                 try:
                     from src.tool_implementations import get_active_document
                     _mem_id = get_active_document()
-                    if _mem_id:
+                    if _mem_id and _mem_id not in _closed_doc_ids:
                         _mem_q = _doc_db.query(DBDocument).filter(DBDocument.id == _mem_id)
                         cand = _owner_session_filter(_mem_q, ctx.user).first()
                         if cand and (not cand.session_id or cand.session_id == session):

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -11,11 +11,11 @@ from sqlalchemy import func
 from core.database import SessionLocal, Document, DocumentVersion
 from core.database import Session as DbSession
 from src.auth_helpers import get_current_user
-
-logger = logging.getLogger(__name__)
-
-
-
+from src.tool_implementations import (
+    clear_active_document,
+    _looks_like_email_document,
+    _sniff_doc_language,
+)
 from routes.document_helpers import (
     DocumentCreate, DocumentUpdate, DocumentPatch,
     _doc_to_dict, _version_to_dict,
@@ -23,6 +23,8 @@ from routes.document_helpers import (
     _slug, _resolve_user_upload_path, _assert_pdf_marker_upload_owned, _derive_title,
     _PDF_RENDER_SCALE,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
@@ -75,10 +77,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             # to markdown for prose.
             language = req.language
             if not language:
-                from src.tool_implementations import _looks_like_email_document, _sniff_doc_language
                 language = _sniff_doc_language(req.content)
-            else:
-                from src.tool_implementations import _looks_like_email_document
             if _looks_like_email_document(req.content, req.title):
                 language = "email"
 
@@ -595,7 +594,6 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                 doc.session_id = req.session_id if req.session_id else None
                 if not doc.session_id:
                     try:
-                        from src.tool_implementations import clear_active_document
                         clear_active_document(doc_id)
                     except Exception:
                         logger.debug("active document clear failed during unlink", exc_info=True)
@@ -620,7 +618,6 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             if not doc:
                 raise HTTPException(404, "Document not found")
             _verify_doc_owner(db, doc, user)
-            from src.tool_implementations import clear_active_document
             cleared = clear_active_document(doc_id)
             return {"status": "closed", "id": doc_id, "cleared": cleared}
         finally:
@@ -639,7 +636,6 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             doc.is_active = False
             db.commit()
             try:
-                from src.tool_implementations import clear_active_document
                 clear_active_document(doc_id)
             except Exception:
                 logger.debug("active document clear failed during delete", exc_info=True)

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -593,6 +593,12 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             if req.session_id is not None:
                 # Empty string = unlink from session
                 doc.session_id = req.session_id if req.session_id else None
+                if not doc.session_id:
+                    try:
+                        from src.tool_implementations import clear_active_document
+                        clear_active_document(doc_id)
+                    except Exception:
+                        logger.debug("active document clear failed during unlink", exc_info=True)
             db.commit()
             db.refresh(doc)
             return _doc_to_dict(doc)
@@ -601,6 +607,22 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         except Exception as e:
             db.rollback()
             raise HTTPException(500, str(e))
+        finally:
+            db.close()
+
+    # ---- POST /api/document/{doc_id}/close — clear editor-active context ----
+    @router.post("/api/document/{doc_id}/close")
+    async def close_document(request: Request, doc_id: str) -> Dict[str, Any]:
+        user = get_current_user(request)
+        db = SessionLocal()
+        try:
+            doc = db.query(Document).filter(Document.id == doc_id).first()
+            if not doc:
+                raise HTTPException(404, "Document not found")
+            _verify_doc_owner(db, doc, user)
+            from src.tool_implementations import clear_active_document
+            cleared = clear_active_document(doc_id)
+            return {"status": "closed", "id": doc_id, "cleared": cleared}
         finally:
             db.close()
 
@@ -616,6 +638,11 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             _verify_doc_owner(db, doc, user)
             doc.is_active = False
             db.commit()
+            try:
+                from src.tool_implementations import clear_active_document
+                clear_active_document(doc_id)
+            except Exception:
+                logger.debug("active document clear failed during delete", exc_info=True)
             return {"status": "deleted", "id": doc_id}
         except HTTPException:
             raise

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 MAX_OUTPUT_CHARS = 10_000
@@ -69,7 +70,10 @@ def _parse_tool_args(content):
 # ---------------------------------------------------------------------------
 
 _active_document_id: Optional[str] = None
-_closed_document_ids: set[str] = set()
+# Keep only recent UI-close markers. The frontend sends active_doc_state on
+# every chat turn, so this cache is a compatibility guard, not durable state.
+_CLOSED_DOCUMENT_IDS_LIMIT = 256
+_closed_document_ids: OrderedDict[str, None] = OrderedDict()
 _active_model: Optional[str] = None
 
 
@@ -78,7 +82,14 @@ def set_active_document(doc_id: Optional[str]):
     global _active_document_id
     _active_document_id = doc_id
     if doc_id:
-        _closed_document_ids.discard(doc_id)
+        _closed_document_ids.pop(doc_id, None)
+
+
+def _mark_document_closed(doc_id: str) -> None:
+    _closed_document_ids[doc_id] = None
+    _closed_document_ids.move_to_end(doc_id)
+    while len(_closed_document_ids) > _CLOSED_DOCUMENT_IDS_LIMIT:
+        _closed_document_ids.popitem(last=False)
 
 
 def clear_active_document(doc_id: Optional[str] = None) -> bool:
@@ -90,7 +101,7 @@ def clear_active_document(doc_id: Optional[str] = None) -> bool:
     """
     global _active_document_id
     if doc_id:
-        _closed_document_ids.add(doc_id)
+        _mark_document_closed(doc_id)
     if doc_id is None or _active_document_id == doc_id:
         _active_document_id = None
         return True
@@ -98,7 +109,55 @@ def clear_active_document(doc_id: Optional[str] = None) -> bool:
 
 
 def get_closed_documents() -> set[str]:
-    return set(_closed_document_ids)
+    return set(_closed_document_ids.keys())
+
+
+def resolve_active_document_for_chat(
+    db,
+    Document,
+    owner_filter,
+    *,
+    session_id: str,
+    owner: Optional[str],
+    active_doc_id: str = "",
+    active_doc_closed: bool = False,
+):
+    """Resolve the editor document that should be visible to an agent turn."""
+    active_doc = None
+    active_doc_id = (active_doc_id or "").strip()
+    closed_doc_ids = get_closed_documents()
+
+    if active_doc_id:
+        # Scope frontend-supplied IDs to the caller's documents. Resolving by
+        # id alone would let another user's document be injected into context.
+        q = db.query(Document).filter(Document.id == active_doc_id)
+        active_doc = owner_filter(q, owner).first()
+        if active_doc:
+            set_active_document(active_doc.id)
+
+    if not active_doc and not active_doc_closed:
+        # Fallback to the latest active document linked to this chat session,
+        # while honoring UI-close markers from recent close/unlink events.
+        q = db.query(Document).filter(
+            Document.session_id == session_id,
+            Document.is_active == True,
+        )
+        if closed_doc_ids:
+            q = q.filter(~Document.id.in_(closed_doc_ids))
+        active_doc = owner_filter(q, owner).order_by(Document.updated_at.desc()).first()
+
+    # Last resort: the document the agent itself just created/edited (tracked
+    # in-memory by the tool layer). This rescues docs that got orphaned from
+    # their session (session_id NULL), while preserving the session/owner guard.
+    if not active_doc and not active_doc_closed:
+        mem_id = get_active_document()
+        if mem_id and mem_id not in closed_doc_ids:
+            q = db.query(Document).filter(Document.id == mem_id)
+            cand = owner_filter(q, owner).first()
+            if cand and (not cand.session_id or cand.session_id == session_id):
+                active_doc = cand
+
+    return active_doc
 
 
 def set_active_model(model: Optional[str]):

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -69,6 +69,7 @@ def _parse_tool_args(content):
 # ---------------------------------------------------------------------------
 
 _active_document_id: Optional[str] = None
+_closed_document_ids: set[str] = set()
 _active_model: Optional[str] = None
 
 
@@ -76,6 +77,28 @@ def set_active_document(doc_id: Optional[str]):
     """Set the active document ID for document tool execution."""
     global _active_document_id
     _active_document_id = doc_id
+    if doc_id:
+        _closed_document_ids.discard(doc_id)
+
+
+def clear_active_document(doc_id: Optional[str] = None) -> bool:
+    """Clear the active document pointer.
+
+    When ``doc_id`` is supplied, only clear if that document is currently
+    active. This lets UI close/delete routes invalidate stale agent context
+    without racing a different document that was opened meanwhile.
+    """
+    global _active_document_id
+    if doc_id:
+        _closed_document_ids.add(doc_id)
+    if doc_id is None or _active_document_id == doc_id:
+        _active_document_id = None
+        return True
+    return False
+
+
+def get_closed_documents() -> set[str]:
+    return set(_closed_document_ids)
 
 
 def set_active_model(model: Optional[str]):
@@ -1457,8 +1480,7 @@ async def do_manage_documents(content: str, owner: Optional[str] = None) -> Dict
             title = doc.title
             doc.is_active = False
             db.commit()
-            if _active_document_id == doc.id:
-                set_active_document(None)
+            clear_active_document(doc.id)
             return {"response": f"Deleted document '{title}'", "exit_code": 0}
 
         elif action == "tidy":

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -739,6 +739,9 @@ import createResearchSynapse from './researchSynapse.js';
       if (documentModule && documentModule.isPanelOpen() && documentModule.getCurrentDocId()) {
         try { await documentModule.saveDocument({ silent: true }); } catch (_e) { /* best-effort */ }
         fd.append('active_doc_id', documentModule.getCurrentDocId());
+        fd.append('active_doc_state', 'open');
+      } else {
+        fd.append('active_doc_state', 'closed');
       }
       // Web toggle: pre-search in Chat mode, tool permission in Agent mode
       const toggleState = Storage.loadToggleState();

--- a/static/js/document.js
+++ b/static/js/document.js
@@ -129,6 +129,14 @@ import * as Modals from './modalManager.js';
     }
   }
 
+  function _clearServerActiveDocument(docId) {
+    if (!docId) return Promise.resolve(false);
+    return fetch(`${API_BASE}/api/document/${encodeURIComponent(docId)}/close`, {
+      method: 'POST',
+      credentials: 'same-origin',
+    }).catch(() => {});
+  }
+
   /** Switch chat to agent mode if not already */
   function _ensureAgentMode() {
     const ab = document.getElementById('mode-agent-btn');
@@ -3492,6 +3500,7 @@ import * as Modals from './modalManager.js';
   function _detachDocFromSession(docId, { toast = false } = {}) {
     const doc = docs.get(docId);
     const hasContent = doc && doc.content && doc.content.trim().length > 0;
+    _clearServerActiveDocument(docId);
     if (hasContent) {
       fetch(`${API_BASE}/api/document/${docId}`, {
         method: 'PATCH',
@@ -5558,12 +5567,14 @@ import * as Modals from './modalManager.js';
   export function closePanel(direction) {
     if (!isOpen) {
       if (direction !== 'down' && Modals.isRegistered('doc-panel')) {
+        _clearServerActiveDocument(_minimizedDocId);
         _minimizedDocId = null;
         _markDocVisibleState(_lastSessionId, 'closed');
         Modals.unregister('doc-panel');
       }
       return;
     }
+    const closingDocId = activeDocId;
     isOpen = false;
     // On touch, closing the doc should leave the keyboard DOWN. The tap blurs
     // the textarea (keyboard starts down), but a stray refocus during teardown
@@ -5580,6 +5591,7 @@ import * as Modals from './modalManager.js';
     }
     // Save current state
     saveCurrentToMap();
+    if (direction !== 'down') _clearServerActiveDocument(closingDocId);
 
     // A "down" close means minimize, not close. Register the chip and flip
     // the dock state to minimized so a chip appears at the bottom. Any

--- a/tests/test_document_deeplink.py
+++ b/tests/test_document_deeplink.py
@@ -31,24 +31,3 @@ def test_failed_document_load_surfaces_user_error():
     js = (_REPO / "static" / "js" / "document.js").read_text(encoding="utf-8")
     assert "uiModule.showError" in js
     assert "Document not found" in js
-
-
-def test_document_close_clears_agent_active_context():
-    """Closing a tab/panel must notify the backend so the next agent turn
-    cannot rediscover the closed document as active context."""
-    js = (_REPO / "static" / "js" / "document.js").read_text(encoding="utf-8")
-    chat_js = (_REPO / "static" / "js" / "chat.js").read_text(encoding="utf-8")
-    routes = (_REPO / "routes" / "document_routes.py").read_text(encoding="utf-8")
-    chat = (_REPO / "routes" / "chat_routes.py").read_text(encoding="utf-8")
-
-    assert "/api/document/${encodeURIComponent(docId)}/close" in js
-    assert "_clearServerActiveDocument(docId)" in js
-    assert "_clearServerActiveDocument(closingDocId)" in js
-    assert "fd.append('active_doc_state', 'open')" in chat_js
-    assert "fd.append('active_doc_state', 'closed')" in chat_js
-    assert '@router.post("/api/document/{doc_id}/close")' in routes
-    assert "clear_active_document(doc_id)" in routes
-    assert 'active_doc_state = form_data.get("active_doc_state", "").strip().lower()' in chat
-    assert "active_doc_closed = active_doc_state == \"closed\"" in chat
-    assert "get_closed_documents()" in chat
-    assert "_session_doc_q.filter(~DBDocument.id.in_(_closed_doc_ids))" in chat

--- a/tests/test_document_deeplink.py
+++ b/tests/test_document_deeplink.py
@@ -31,3 +31,24 @@ def test_failed_document_load_surfaces_user_error():
     js = (_REPO / "static" / "js" / "document.js").read_text(encoding="utf-8")
     assert "uiModule.showError" in js
     assert "Document not found" in js
+
+
+def test_document_close_clears_agent_active_context():
+    """Closing a tab/panel must notify the backend so the next agent turn
+    cannot rediscover the closed document as active context."""
+    js = (_REPO / "static" / "js" / "document.js").read_text(encoding="utf-8")
+    chat_js = (_REPO / "static" / "js" / "chat.js").read_text(encoding="utf-8")
+    routes = (_REPO / "routes" / "document_routes.py").read_text(encoding="utf-8")
+    chat = (_REPO / "routes" / "chat_routes.py").read_text(encoding="utf-8")
+
+    assert "/api/document/${encodeURIComponent(docId)}/close" in js
+    assert "_clearServerActiveDocument(docId)" in js
+    assert "_clearServerActiveDocument(closingDocId)" in js
+    assert "fd.append('active_doc_state', 'open')" in chat_js
+    assert "fd.append('active_doc_state', 'closed')" in chat_js
+    assert '@router.post("/api/document/{doc_id}/close")' in routes
+    assert "clear_active_document(doc_id)" in routes
+    assert 'active_doc_state = form_data.get("active_doc_state", "").strip().lower()' in chat
+    assert "active_doc_closed = active_doc_state == \"closed\"" in chat
+    assert "get_closed_documents()" in chat
+    assert "_session_doc_q.filter(~DBDocument.id.in_(_closed_doc_ids))" in chat

--- a/tests/test_document_tool_owner_scope.py
+++ b/tests/test_document_tool_owner_scope.py
@@ -5,13 +5,21 @@ import types
 from src import tool_implementations as tools
 
 
-def test_clear_active_document_only_clears_matching_doc():
+def test_closing_doc_b_does_not_clear_active_doc_a():
     tools._closed_document_ids.clear()
     tools.set_active_document("doc-a")
     try:
         assert tools.clear_active_document("doc-b") is False
         assert tools.get_active_document() == "doc-a"
+    finally:
+        tools.set_active_document(None)
+        tools._closed_document_ids.clear()
 
+
+def test_setting_closed_doc_reopens_it_for_context():
+    tools._closed_document_ids.clear()
+    tools.set_active_document("doc-a")
+    try:
         assert tools.clear_active_document("doc-a") is True
         assert tools.get_active_document() is None
         assert "doc-a" in tools.get_closed_documents()
@@ -21,6 +29,180 @@ def test_clear_active_document_only_clears_matching_doc():
     finally:
         tools.set_active_document(None)
         tools._closed_document_ids.clear()
+
+
+def test_closed_document_ids_are_bounded():
+    tools._closed_document_ids.clear()
+    try:
+        for i in range(tools._CLOSED_DOCUMENT_IDS_LIMIT + 5):
+            tools.clear_active_document(f"doc-{i}")
+
+        closed = tools.get_closed_documents()
+        assert len(closed) == tools._CLOSED_DOCUMENT_IDS_LIMIT
+        assert "doc-0" not in closed
+        assert f"doc-{tools._CLOSED_DOCUMENT_IDS_LIMIT + 4}" in closed
+    finally:
+        tools.set_active_document(None)
+        tools._closed_document_ids.clear()
+
+
+class _ChatExpr:
+    def __init__(self, op, field=None, value=None, inner=None):
+        self.op = op
+        self.field = field
+        self.value = value
+        self.inner = inner
+
+    def __invert__(self):
+        return _ChatExpr("not", inner=self)
+
+
+class _ChatColumn:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, value):
+        return _ChatExpr("eq", self.name, value)
+
+    def in_(self, values):
+        return _ChatExpr("in", self.name, set(values))
+
+    def desc(self):
+        return ("desc", self.name)
+
+
+class _ChatDocumentModel:
+    id = _ChatColumn("id")
+    owner = _ChatColumn("owner")
+    session_id = _ChatColumn("session_id")
+    is_active = _ChatColumn("is_active")
+    updated_at = _ChatColumn("updated_at")
+
+
+class _ChatDoc:
+    def __init__(self, doc_id, *, owner="alice", session_id="session-a", is_active=True, updated_at=0):
+        self.id = doc_id
+        self.owner = owner
+        self.session_id = session_id
+        self.is_active = is_active
+        self.updated_at = updated_at
+
+
+def _chat_matches(doc, expr):
+    if expr.op == "eq":
+        return getattr(doc, expr.field) == expr.value
+    if expr.op == "in":
+        return getattr(doc, expr.field) in expr.value
+    if expr.op == "not":
+        return not _chat_matches(doc, expr.inner)
+    raise AssertionError(f"unknown op {expr.op}")
+
+
+class _ChatQuery:
+    def __init__(self, docs):
+        self.docs = docs
+        self.filters = []
+        self.sort_desc = None
+
+    def filter(self, *clauses):
+        self.filters.extend(c for c in clauses if isinstance(c, _ChatExpr))
+        return self
+
+    def order_by(self, *args):
+        for arg in args:
+            if isinstance(arg, tuple) and arg[0] == "desc":
+                self.sort_desc = arg[1]
+        return self
+
+    def first(self):
+        docs = [d for d in self.docs if all(_chat_matches(d, f) for f in self.filters)]
+        if self.sort_desc:
+            docs.sort(key=lambda d: getattr(d, self.sort_desc), reverse=True)
+        return docs[0] if docs else None
+
+
+class _ChatDb:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def query(self, *args):
+        return _ChatQuery(self.docs)
+
+
+def _chat_owner_filter(query, owner):
+    return query.filter(_ChatDocumentModel.owner == owner)
+
+
+def _reset_active_doc_state():
+    tools.set_active_document(None)
+    tools._closed_document_ids.clear()
+
+
+def test_closed_doc_is_not_injected_by_session_fallback():
+    _reset_active_doc_state()
+    try:
+        doc_a = _ChatDoc("doc-a", updated_at=10)
+        tools.set_active_document("doc-a")
+        tools.clear_active_document("doc-a")
+
+        resolved = tools.resolve_active_document_for_chat(
+            _ChatDb([doc_a]),
+            _ChatDocumentModel,
+            _chat_owner_filter,
+            session_id="session-a",
+            owner="alice",
+            active_doc_closed=False,
+        )
+
+        assert resolved is None
+    finally:
+        _reset_active_doc_state()
+
+
+def test_explicit_active_doc_reopens_closed_doc():
+    _reset_active_doc_state()
+    try:
+        doc_a = _ChatDoc("doc-a", updated_at=10)
+        tools.clear_active_document("doc-a")
+        assert "doc-a" in tools.get_closed_documents()
+
+        resolved = tools.resolve_active_document_for_chat(
+            _ChatDb([doc_a]),
+            _ChatDocumentModel,
+            _chat_owner_filter,
+            session_id="session-a",
+            owner="alice",
+            active_doc_id="doc-a",
+            active_doc_closed=False,
+        )
+
+        assert resolved is doc_a
+        assert tools.get_active_document() == "doc-a"
+        assert "doc-a" not in tools.get_closed_documents()
+    finally:
+        _reset_active_doc_state()
+
+
+def test_normal_closed_turn_does_not_clear_other_active_doc():
+    _reset_active_doc_state()
+    try:
+        doc_a = _ChatDoc("doc-a", owner="alice", session_id="session-a")
+        tools.set_active_document("doc-a")
+
+        resolved = tools.resolve_active_document_for_chat(
+            _ChatDb([doc_a]),
+            _ChatDocumentModel,
+            _chat_owner_filter,
+            session_id="session-b",
+            owner="bob",
+            active_doc_closed=True,
+        )
+
+        assert resolved is None
+        assert tools.get_active_document() == "doc-a"
+        assert not tools.get_closed_documents()
+    finally:
+        _reset_active_doc_state()
 
 
 class _Column:

--- a/tests/test_document_tool_owner_scope.py
+++ b/tests/test_document_tool_owner_scope.py
@@ -5,6 +5,24 @@ import types
 from src import tool_implementations as tools
 
 
+def test_clear_active_document_only_clears_matching_doc():
+    tools._closed_document_ids.clear()
+    tools.set_active_document("doc-a")
+    try:
+        assert tools.clear_active_document("doc-b") is False
+        assert tools.get_active_document() == "doc-a"
+
+        assert tools.clear_active_document("doc-a") is True
+        assert tools.get_active_document() is None
+        assert "doc-a" in tools.get_closed_documents()
+
+        tools.set_active_document("doc-a")
+        assert "doc-a" not in tools.get_closed_documents()
+    finally:
+        tools.set_active_document(None)
+        tools._closed_document_ids.clear()
+
+
 class _Column:
     def __init__(self, name):
         self.name = name


### PR DESCRIPTION
Closed document tabs should not be rediscovered by session or tool-layer fallbacks on later agent turns.