### PR TITLE
Add expandable Deep Research synapse view

### DIFF
--- a/static/js/research/panel.js
+++ b/static/js/research/panel.js
@@ -961,8 +961,12 @@ function _buildJobCard(job) {
       entry = { synapse, status: 'running' };
       _jobSynapses.set(job.id, entry);
     } else {
-      // Move the existing element into the freshly-rendered host
-      host.appendChild(entry.synapse.element);
+      // Move the existing element into the freshly-rendered host unless the
+      // user has it expanded in the overlay. In expanded mode the component
+      // restores itself to its placeholder when closed.
+      if (!entry.synapse.isExpanded || !entry.synapse.isExpanded()) {
+        host.appendChild(entry.synapse.element);
+      }
     }
     // Push the current progress state
     if (job.progress) {

--- a/static/js/researchSynapse.js
+++ b/static/js/researchSynapse.js
@@ -27,6 +27,16 @@ export default function createResearchSynapse(container, opts = {}) {
   const wrap = document.createElement('div');
   wrap.className = 'research-synapse' + (opts.compact ? ' research-synapse-compact' : '');
   wrap.innerHTML = `
+    <div class="rs-toolbar">
+      <button type="button" class="rs-expand-btn" title="Expand visualization" aria-label="Expand research visualization">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polyline points="15 3 21 3 21 9"></polyline>
+          <polyline points="9 21 3 21 3 15"></polyline>
+          <line x1="21" y1="3" x2="14" y2="10"></line>
+          <line x1="3" y1="21" x2="10" y2="14"></line>
+        </svg>
+      </button>
+    </div>
     <div class="rs-stage">
       <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="xMidYMid meet">
         <g class="rs-edges"></g>
@@ -53,6 +63,7 @@ export default function createResearchSynapse(container, opts = {}) {
   const roundE  = wrap.querySelector('.rs-round b');
   const srcE    = wrap.querySelector('.rs-sources b');
   const timerE  = wrap.querySelector('.rs-timer');
+  const expandBtn = wrap.querySelector('.rs-expand-btn');
 
   // ── root (query) ───────────────────────────────────────────────
   const root = document.createElementNS(SVG_NS, 'circle');
@@ -72,6 +83,11 @@ export default function createResearchSynapse(container, opts = {}) {
   let sourceCount = 0;
   let lastRound = 0;
   let completed = false;
+  let expanded = false;
+  let overlay = null;
+  let placeholder = null;
+  let originalParent = null;
+  let originalNextSibling = null;
 
   // ── timer ──────────────────────────────────────────────────────
   const startedAt = opts.startedAt || Date.now();
@@ -164,9 +180,91 @@ export default function createResearchSynapse(container, opts = {}) {
     nodesG.appendChild(leaf);
   }
 
+  function _closeExpanded() {
+    if (!expanded) return;
+    expanded = false;
+    wrap.classList.remove('research-synapse-expanded');
+    if (expandBtn) {
+      expandBtn.title = 'Expand visualization';
+      expandBtn.setAttribute('aria-label', 'Expand research visualization');
+      expandBtn.setAttribute('aria-expanded', 'false');
+    }
+    if (placeholder && placeholder.parentNode) {
+      placeholder.parentNode.insertBefore(wrap, placeholder);
+      placeholder.remove();
+    } else if (originalParent) {
+      originalParent.insertBefore(wrap, originalNextSibling);
+    }
+    if (overlay && overlay.parentNode) overlay.remove();
+    overlay = null;
+    placeholder = null;
+    originalParent = null;
+    originalNextSibling = null;
+    document.removeEventListener('keydown', _onExpandedKeydown);
+  }
+
+  function _onExpandedKeydown(e) {
+    if (e.key === 'Escape') _closeExpanded();
+  }
+
+  function _openExpanded() {
+    if (expanded) return;
+    originalParent = wrap.parentNode;
+    originalNextSibling = wrap.nextSibling;
+    placeholder = document.createElement('div');
+    placeholder.className = 'research-synapse-placeholder';
+    if (originalParent) originalParent.insertBefore(placeholder, wrap);
+
+    overlay = document.createElement('div');
+    overlay.className = 'research-synapse-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-label', 'Expanded research visualization');
+    overlay.innerHTML = `
+      <div class="research-synapse-shell">
+        <div class="research-synapse-shell-header">
+          <span class="research-synapse-shell-title">Deep Research Map</span>
+          <button type="button" class="research-synapse-close" title="Close" aria-label="Close expanded research visualization">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+        <div class="research-synapse-shell-body"></div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+    overlay.querySelector('.research-synapse-shell-body').appendChild(wrap);
+    overlay.querySelector('.research-synapse-close')?.addEventListener('click', _closeExpanded);
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) _closeExpanded();
+    });
+    expanded = true;
+    wrap.classList.add('research-synapse-expanded');
+    if (expandBtn) {
+      expandBtn.title = 'Collapse visualization';
+      expandBtn.setAttribute('aria-label', 'Collapse research visualization');
+      expandBtn.setAttribute('aria-expanded', 'true');
+    }
+    document.addEventListener('keydown', _onExpandedKeydown);
+  }
+
+  if (expandBtn) {
+    expandBtn.setAttribute('aria-expanded', 'false');
+    expandBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (expanded) _closeExpanded();
+      else _openExpanded();
+    });
+  }
+
   // ── public API ─────────────────────────────────────────────────
   return {
     element: wrap,
+    isExpanded() {
+      return expanded;
+    },
 
     /** Reflect a phase change in the status text + side effects. */
     setPhase(phase, extra = {}) {
@@ -218,6 +316,7 @@ export default function createResearchSynapse(container, opts = {}) {
     },
 
     destroy() {
+      _closeExpanded();
       if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
       if (wrap.parentNode) wrap.parentNode.removeChild(wrap);
     },

--- a/static/style.css
+++ b/static/style.css
@@ -22493,6 +22493,38 @@ input.settings-select::placeholder { color: color-mix(in srgb, var(--fg) 35%, tr
     radial-gradient(ellipse at center, color-mix(in srgb, var(--accent, var(--red)) 10%, transparent) 0%, transparent 70%),
     color-mix(in srgb, var(--panel) 50%, var(--bg));
   overflow: hidden;
+  position: relative;
+}
+.research-synapse .rs-toolbar {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  display: flex;
+  gap: 4px;
+}
+.research-synapse .rs-expand-btn {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: 6px;
+  color: var(--fg-dim, var(--fg));
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  cursor: pointer;
+  opacity: 0.72;
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s, background 0.15s;
+}
+.research-synapse .rs-expand-btn:hover,
+.research-synapse .rs-expand-btn:focus-visible {
+  opacity: 1;
+  color: var(--fg);
+  border-color: var(--accent, var(--red));
+  background: color-mix(in srgb, var(--accent, var(--red)) 10%, var(--bg));
+  outline: none;
 }
 .research-synapse .rs-stage {
   height: 200px;
@@ -22604,6 +22636,122 @@ input.settings-select::placeholder { color: color-mix(in srgb, var(--fg) 35%, tr
 }
 .research-synapse.rs-complete .rs-meta .rs-status { color: var(--color-success, #4caf50); }
 .research-synapse.rs-error .rs-meta .rs-status { color: var(--red); }
+.research-synapse-placeholder {
+  min-height: 38px;
+  border: 1px dashed color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 8px;
+  margin: 6px 0 4px;
+}
+.research-synapse-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10020;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12px, 3vw, 32px);
+  background: color-mix(in srgb, var(--bg) 72%, black 28%);
+}
+.research-synapse-shell {
+  width: min(1120px, 96vw);
+  height: min(760px, 88vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+}
+.research-synapse-shell-header {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px 8px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.research-synapse-shell-title {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg);
+  font: 600 12px/1.2 ui-monospace, "JetBrains Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.research-synapse-close {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg-dim, var(--fg));
+  background: transparent;
+  cursor: pointer;
+}
+.research-synapse-close:hover,
+.research-synapse-close:focus-visible {
+  color: var(--fg);
+  border-color: var(--red);
+  outline: none;
+}
+.research-synapse-shell-body {
+  flex: 1;
+  min-height: 0;
+  padding: 12px;
+}
+.research-synapse.research-synapse-expanded {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+}
+.research-synapse.research-synapse-expanded .rs-toolbar {
+  top: 10px;
+  right: 10px;
+}
+.research-synapse.research-synapse-expanded .rs-stage {
+  flex: 1;
+  height: auto;
+  min-height: 0;
+}
+.research-synapse.research-synapse-expanded .rs-meta {
+  padding: 10px 12px 12px;
+  font-size: 12px;
+}
+.research-synapse.research-synapse-expanded .rs-label {
+  font-size: 12px;
+}
+.research-synapse.research-synapse-expanded .rs-label-sub {
+  font-size: 10px;
+}
+@media (max-width: 700px) {
+  .research-synapse-overlay {
+    padding: 8px;
+  }
+  .research-synapse-shell {
+    width: 100vw;
+    height: 92vh;
+  }
+  .research-synapse-shell-body {
+    padding: 8px;
+  }
+  .research-synapse.research-synapse-expanded .rs-meta {
+    font-size: 11px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .research-synapse .rs-edge.rs-edge-firing,
+  .research-synapse .rs-node-new,
+  .research-synapse .rs-pulse {
+    animation: none;
+  }
+}
 
 /* ── Raw findings items (inside sources-style box) ── */
 .finding-item {

--- a/tests/test_research_synapse_expand.py
+++ b/tests/test_research_synapse_expand.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_research_synapse_has_expand_control_and_dialog():
+    js = _read("static/js/researchSynapse.js")
+
+    assert "class=\"rs-expand-btn\"" in js
+    assert "aria-label=\"Expand research visualization\"" in js
+    assert "research-synapse-overlay" in js
+    assert "role', 'dialog'" in js
+    assert "Deep Research Map" in js
+    assert "research-synapse-close" in js
+
+
+def test_research_synapse_restores_original_position_on_close():
+    js = _read("static/js/researchSynapse.js")
+
+    assert "originalParent = wrap.parentNode" in js
+    assert "originalNextSibling = wrap.nextSibling" in js
+    assert "research-synapse-placeholder" in js
+    assert "placeholder.parentNode.insertBefore(wrap, placeholder)" in js
+    assert "document.removeEventListener('keydown', _onExpandedKeydown)" in js
+    assert "if (e.key === 'Escape') _closeExpanded()" in js
+
+
+def test_research_synapse_public_api_reports_expanded_state():
+    js = _read("static/js/researchSynapse.js")
+
+    assert "isExpanded()" in js
+    assert "return expanded;" in js
+    assert "destroy() {" in js
+    assert "_closeExpanded();" in js
+
+
+def test_research_panel_does_not_remount_expanded_synapse():
+    panel_js = _read("static/js/research/panel.js")
+
+    assert "entry.synapse.isExpanded" in panel_js
+    assert "!entry.synapse.isExpanded()" in panel_js
+    assert "host.appendChild(entry.synapse.element)" in panel_js
+
+
+def test_research_synapse_expand_styles_exist():
+    css = _read("static/style.css")
+
+    assert ".research-synapse .rs-toolbar" in css
+    assert ".research-synapse .rs-expand-btn" in css
+    assert ".research-synapse-overlay" in css
+    assert ".research-synapse-shell" in css
+    assert ".research-synapse.research-synapse-expanded .rs-stage" in css
+    assert "@media (max-width: 700px)" in css
+    assert "@media (prefers-reduced-motion: reduce)" in css


### PR DESCRIPTION
## Summary

Adds an expand control to the live Deep Research synapse visualization. The synapse graph is useful during Deep Research, but in its inline/compact size it gets hard to inspect once several rounds and source leaves are present. This opens the existing live graph in a larger overlay on demand, without changing the default compact chat/research-card layout:

- opens the existing live graph in a larger overlay while preserving its current nodes, timer, phase, and source count
- supports Escape / backdrop / close-button dismissal and restores the graph to its original inline location
- keeps running research-panel re-renders from remounting an expanded graph
- adds responsive / reduced-motion styles and regression coverage

## Linked Issue

Fixes #2339

(Originally filed against #1145, which the maintainer closed as not actionable for lack of detail. #2339 restates the request with the full enhancement template.)

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [x] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I ran the app and verified the expand/restore behavior end-to-end (see screenshots and How to Test).

## How to Test

1. Run a Deep Research query so the live synapse graph renders inline in the research panel.
2. Click the new expand control: the graph opens in a larger overlay, preserving its current nodes, timer, phase, and source count while research continues.
3. Dismiss via Escape, backdrop click, and the close button: the graph restores to its original inline location each time, and ongoing panel re-renders do not remount the expanded graph.
4. Automated checks: `node --check static/js/researchSynapse.js && node --check static/js/research/panel.js` and `venv/bin/python -m pytest -q tests/test_research_synapse_expand.py` -> 5 passed.

## Visual / UI changes

- [x] Screenshot of the change in the running app, attached below.
- [x] Style match: reuses existing overlay/backdrop patterns, CSS variables, and the monochrome icon style; no new color values, font sizes, or spacing units; no Unicode emoji.
- [x] No new component patterns: extends the existing synapse graph rather than writing a parallel one.
- [x] I am not a bulk LLM-agent submission; this targets the specific request in #2339.

### Screenshots

Inline view:

![Inline Deep Research synapse](https://raw.githubusercontent.com/ghreprimand/odysseus/pr-assets/1145-research-synapse-expand/pr-assets/1145/research-synapse-inline.png)

Expanded view:

![Expanded Deep Research synapse](https://raw.githubusercontent.com/ghreprimand/odysseus/pr-assets/1145-research-synapse-expand/pr-assets/1145/research-synapse-expanded.png)

