### PR TITLE
feat(companion): update-check + SQLite export endpoints and odysseus-update CLI

### DIFF
--- a/companion/README.md
+++ b/companion/README.md
@@ -10,9 +10,52 @@ Odysseus server offers and pair to it, without duplicating any LLM logic.
 | GET | `/api/companion/models` | session or token | the **caller's own** model endpoints |
 | GET | `/api/companion/pair` | **admin cookie** | pairing page (a form; never mints) |
 | POST | `/api/companion/pair` | **admin cookie** | mint a one-time pairing token (`?format=json` for an in-app screen) |
+| GET | `/api/companion/system/update-check` | **admin** | is a newer release available? (read-only) |
+| GET | `/api/companion/system/db-export` | **admin** | download a consistent SQLite snapshot |
 
 `/models` scopes to the caller's real owner plus legacy null-owner shared rows
 (same rule as `owner_filter`) and never returns API-key material.
+
+## System endpoints (issue #1157)
+
+Two admin operations for keeping a self-hosted instance current and getting your
+data out. Both are **admin-gated** via `require_admin`: a bearer/chat token comes
+through as the sandboxed pseudo-user `api` (never an admin), so these are reachable
+from a browser logged in as admin — *not* from a paired chat token. That's
+deliberate: a DB snapshot is effectively a full data dump, and triggering updates
+is privileged.
+
+- **`GET /system/update-check`** — compares the running `APP_VERSION` against the
+  latest release at `UPDATE_CHECK_URL` (the upstream GitHub repo by default;
+  override with `ODYSSEUS_REPO` or `ODYSSEUS_UPDATE_CHECK_URL`). Read-only and
+  side-effect free — it never touches the container. A network failure degrades to
+  `{reachable: false, error: …}` rather than a 500.
+- **`GET /system/db-export`** — streams a point-in-time copy of `app.db` taken with
+  SQLite's online `.backup` API (safe while the server is running). SQLite only; a
+  non-SQLite `DATABASE_URL` returns 400. The Fernet key (`data/.app_key`) needed to
+  decrypt encrypted columns is **not** included.
+
+### Applying an update — `scripts/odysseus-update`
+
+The actual container update is a CLI (the HTTP layer never shells out to Docker, so
+the Docker socket is never exposed on the LAN):
+
+```
+odysseus-update check                       # current vs latest release
+odysseus-update apply                       # DRY-RUN: prints the plan
+odysseus-update apply --yes                 # snapshot → pull → up -d --build
+odysseus-update apply --service odysseus --no-backup
+```
+
+`apply` is a dry-run unless `--yes`. It snapshots `data/` via `odysseus-backup`
+first, then `docker compose pull` + `up -d --build` (the odysseus image is
+`build:`-based, so it's rebuilt locally and the container recreated). It does
+**not** `git pull` — update the checkout yourself first to pick up new source,
+since this workspace carries the companion overlay.
+
+The helpers live in tested units (`parse_version`, `update_available`,
+`resolve_sqlite_path`, `safe_sqlite_snapshot`) — see `companion/system.py` and
+`tests/test_companion_system.py`.
 
 ## Pairing CSRF posture
 

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -18,7 +18,7 @@ on a GET would be unsafe (Lax cookies ride top-level GET navigations), so GET
 
 import html
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from core.middleware import require_admin
@@ -232,5 +232,97 @@ def setup_companion_routes() -> APIRouter:
   device must be on the same network, and the server must bind to your LAN.</p>
 </div></body></html>"""
         return HTMLResponse(page)
+
+    @router.get("/system/update-check")
+    def system_update_check(request: Request):
+        """Admin-only: report whether a newer Odysseus release is available.
+
+        Compares the running APP_VERSION against the latest release published at
+        UPDATE_CHECK_URL (the upstream GitHub repo by default). Read-only and
+        side-effect free — it never touches the container, only the actual
+        update (via the `odysseus-update` CLI) does. A network failure degrades
+        to reachable=false with an error string rather than a 500, so a client
+        can show "couldn't check" instead of breaking."""
+        require_admin(request)
+        from datetime import datetime, timezone
+
+        from core.constants import APP_VERSION, UPDATE_CHECK_URL
+        from companion import system as _system
+
+        result = {
+            "current": APP_VERSION,
+            "latest": None,
+            "update_available": False,
+            "reachable": False,
+            "source": UPDATE_CHECK_URL,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            rel = _system.fetch_latest_release(UPDATE_CHECK_URL)
+        except Exception as e:  # network/parse/HTTP — never surface as a 500
+            result["error"] = str(e)
+            return result
+        result["reachable"] = True
+        result["latest"] = rel.get("tag")
+        result["release_name"] = rel.get("name")
+        result["release_url"] = rel.get("html_url")
+        result["published_at"] = rel.get("published_at")
+        result["update_available"] = _system.update_available(APP_VERSION, rel.get("tag"))
+        return result
+
+    @router.get("/system/db-export")
+    def system_db_export(request: Request):
+        """Admin-only: download a consistent snapshot of the SQLite database.
+
+        Streams a point-in-time copy of app.db taken with SQLite's online
+        `.backup` API, so it's safe to pull while the server is serving. Only
+        file-backed SQLite is supported (a Postgres DATABASE_URL returns 400).
+
+        Security: the snapshot contains EVERY user's data plus the encrypted
+        columns within it. It's gated to admins and should be treated as a full
+        credential dump — the Fernet key (data/.app_key) is needed to decrypt
+        those columns and is deliberately NOT included here."""
+        require_admin(request)
+        import os
+        import tempfile
+        from datetime import datetime
+
+        from fastapi.responses import FileResponse
+        from starlette.background import BackgroundTask
+
+        from core.constants import BASE_DIR
+        from core.database import DATABASE_URL
+        from companion import system as _system
+
+        db_path = _system.resolve_sqlite_path(DATABASE_URL, BASE_DIR)
+        if db_path is None:
+            raise HTTPException(400, "Database export is only supported for SQLite databases.")
+        if not db_path.is_file():
+            raise HTTPException(404, "Database file not found.")
+
+        fd, tmp_path = tempfile.mkstemp(prefix="odysseus-db-", suffix=".sqlite")
+        os.close(fd)
+        try:
+            _system.safe_sqlite_snapshot(db_path, tmp_path)
+        except Exception as e:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise HTTPException(500, f"Database snapshot failed: {e}")
+
+        def _cleanup():
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        filename = f"odysseus-db-{datetime.now().strftime('%Y%m%d-%H%M%S')}.sqlite"
+        return FileResponse(
+            tmp_path,
+            media_type="application/octet-stream",
+            filename=filename,
+            background=BackgroundTask(_cleanup),
+        )
 
     return router

--- a/companion/system.py
+++ b/companion/system.py
@@ -1,0 +1,128 @@
+"""Companion system helpers — version checks + DB snapshotting.
+
+Pure, dependency-light functions behind the `/api/companion/system/*` admin
+endpoints and the `odysseus-update` CLI. Kept out of routes.py so they can be
+unit-tested without a running app (no FastAPI, no network at import time).
+
+Two concerns:
+  * update checks — compare the running APP_VERSION against the latest release
+    published upstream (GitHub by default; overridable via env).
+  * DB extraction — resolve the live SQLite path and copy it out *consistently*
+    using SQLite's own `.backup` API, so a running server can't corrupt the
+    snapshot mid-write. Same technique as scripts/odysseus-backup.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import urllib.request
+from pathlib import Path
+
+# ── version comparison ────────────────────────────────────────────────────────
+
+_NUM = re.compile(r"\d+")
+
+
+def parse_version(value: str | None) -> tuple[int, ...]:
+    """Parse a version string into a comparable tuple of ints.
+
+    Tolerant of the shapes release tags actually take: a leading ``v`` is
+    dropped, and any pre-release/build suffix (``-rc1``, ``+build5``) is
+    ignored so ``1.2.0`` and ``v1.2.0-rc1`` reduce to ``(1, 2, 0)`` and
+    ``(1, 2, 0)`` respectively. Non-numeric junk yields an empty tuple, which
+    sorts below any real version.
+    """
+    if not value:
+        return ()
+    core = str(value).strip().lstrip("vV")
+    # Cut anything from the first pre-release/build separator onward.
+    core = re.split(r"[-+]", core, maxsplit=1)[0]
+    parts = [int(m) for m in _NUM.findall(core)]
+    # Trim trailing zeros so (1, 2) == (1, 2, 0) when compared.
+    while parts and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)
+
+
+def update_available(current: str | None, latest: str | None) -> bool:
+    """True when `latest` is a strictly newer version than `current`.
+
+    Unparseable inputs are treated conservatively: if we can't make sense of
+    `latest`, we report no update rather than nagging about a phantom one.
+    """
+    latest_t = parse_version(latest)
+    if not latest_t:
+        return False
+    return latest_t > parse_version(current)
+
+
+# ── update-feed fetch ─────────────────────────────────────────────────────────
+
+def fetch_latest_release(url: str, timeout: float = 6.0) -> dict:
+    """GET a GitHub-style "latest release" JSON and pull out the bits we show.
+
+    Returns a dict with ``tag``, ``name``, ``html_url`` and ``published_at``
+    (any may be None if absent). Raises on network/parse failure — callers wrap
+    this so a flaky network degrades to "couldn't check", never a 500.
+    """
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            # GitHub's API rejects requests without a User-Agent.
+            "User-Agent": "odysseus-companion",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (fixed https scheme)
+        data = json.loads(resp.read().decode("utf-8"))
+    return {
+        "tag": data.get("tag_name"),
+        "name": data.get("name"),
+        "html_url": data.get("html_url"),
+        "published_at": data.get("published_at"),
+    }
+
+
+# ── SQLite extraction ─────────────────────────────────────────────────────────
+
+def resolve_sqlite_path(database_url: str, base_dir: str | Path) -> Path | None:
+    """Map a SQLAlchemy DATABASE_URL to an on-disk SQLite file path.
+
+    Returns the resolved Path for file-backed SQLite URLs, or None for
+    non-SQLite engines (Postgres etc.) and in-memory databases — both of which
+    can't be handed back as a single downloadable file. Relative paths resolve
+    against `base_dir` (the repo root), matching how the app is launched.
+    """
+    if not database_url or not database_url.startswith("sqlite"):
+        return None
+    # Everything after the scheme's `sqlite:///`. A 4th slash means absolute.
+    raw = database_url.split("sqlite://", 1)[1].lstrip("/")
+    if not raw or raw == ":memory:":
+        return None
+    # Re-add the leading slash for absolute URLs (sqlite:////abs/path).
+    leading = "/" if database_url.startswith("sqlite:////") else ""
+    p = Path(leading + raw)
+    if not p.is_absolute():
+        p = Path(base_dir) / p
+    return p.resolve()
+
+
+def safe_sqlite_snapshot(src: Path, dst: Path) -> None:
+    """Copy a live SQLite DB to `dst` via the online `.backup` API.
+
+    Unlike a raw file copy, this is safe while the server is writing: SQLite
+    streams a transactionally-consistent image. Mirrors `_sqlite_safe_copy` in
+    scripts/odysseus-backup.
+    """
+    src_conn = sqlite3.connect(str(src))
+    try:
+        dst_conn = sqlite3.connect(str(dst))
+        try:
+            with dst_conn:
+                src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()

--- a/core/constants.py
+++ b/core/constants.py
@@ -4,6 +4,16 @@ import os
 
 APP_VERSION = "0.9.1"
 
+# Update checks — where to look for a newer release. The companion update-check
+# endpoint and the `odysseus-update` CLI compare APP_VERSION against the latest
+# release published here. Override the repo (or the full URL) via env so forks
+# and self-hosters can point at their own release feed.
+GITHUB_REPO = os.getenv("ODYSSEUS_REPO", "pewdiepie-archdaemon/odysseus")
+UPDATE_CHECK_URL = os.getenv(
+    "ODYSSEUS_UPDATE_CHECK_URL",
+    f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest",
+)
+
 # Base paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/"
 STATIC_DIR = os.path.join(BASE_DIR, "static")

--- a/scripts/odysseus-update
+++ b/scripts/odysseus-update
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""odysseus-update — check for and apply Odysseus container updates.
+
+Two subcommands:
+
+    odysseus-update check                 # is a newer release available?
+    odysseus-update apply                 # snapshot → pull → rebuild → recreate
+    odysseus-update apply --yes           # actually run it (dry-run otherwise)
+    odysseus-update apply --service odysseus --no-backup
+
+`check` compares the running APP_VERSION against the latest release published
+upstream (GitHub by default; override via ODYSSEUS_UPDATE_CHECK_URL / ODYSSEUS_REPO).
+
+`apply` updates the running stack safely. It is a DRY-RUN by default — it prints
+the exact commands it would run and exits. Pass --yes to execute. The steps:
+
+  1. snapshot data/ via `odysseus-backup snapshot` (skip with --no-backup),
+  2. `docker compose pull`  — fetch updated images,
+  3. `docker compose up -d --build` — rebuild `build:`-based services
+     (the odysseus image is built locally) and recreate containers.
+
+It deliberately does NOT `git pull`: this workspace carries a local companion
+overlay, and clobbering it automatically would be surprising. To pick up new
+*source*, update the checkout yourself first, then run `apply`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "_lib"))
+from cli import quiet_logs, emit, fail, common_parser, run, REPO_ROOT  # noqa: E402
+
+quiet_logs()
+
+
+def _detect_compose() -> list[str] | None:
+    """Return the working compose base command, preferring Compose v2.
+
+    Tries `docker compose` (v2 plugin) then `docker-compose` (v1 standalone);
+    returns the first that responds, or None if neither is installed.
+    """
+    for cand in (["docker", "compose"], ["docker-compose"]):
+        try:
+            subprocess.run(cand + ["version"], capture_output=True, check=True)
+            return cand
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue
+    return None
+
+
+def cmd_check(args):
+    """Compare the running version against the latest published release."""
+    from core.constants import APP_VERSION, UPDATE_CHECK_URL
+    from companion import system as _system
+
+    out = {
+        "current": APP_VERSION,
+        "latest": None,
+        "update_available": False,
+        "reachable": False,
+        "source": UPDATE_CHECK_URL,
+    }
+    try:
+        rel = _system.fetch_latest_release(UPDATE_CHECK_URL, timeout=args.timeout)
+    except Exception as e:
+        out["error"] = str(e)
+        emit(out, args)
+        return
+    out["reachable"] = True
+    out["latest"] = rel.get("tag")
+    out["release_name"] = rel.get("name")
+    out["release_url"] = rel.get("html_url")
+    out["published_at"] = rel.get("published_at")
+    out["update_available"] = _system.update_available(APP_VERSION, rel.get("tag"))
+    emit(out, args)
+
+
+def cmd_apply(args):
+    """Snapshot, then pull + rebuild + recreate the compose stack."""
+    compose_file = REPO_ROOT / "docker-compose.yml"
+    if not compose_file.is_file():
+        fail(f"no docker-compose.yml at {compose_file}")
+    base = _detect_compose()
+    if base is None and args.yes:
+        fail("docker compose not found (need Compose v2 `docker compose` or v1 `docker-compose`)")
+    # For a dry-run preview we still want to show the plan even where Docker
+    # isn't installed (e.g. previewing from a dev box). Fall back to the v2 name.
+    compose = base or ["docker", "compose"]
+
+    svc = [args.service] if args.service else []
+    steps: list[tuple[list[str], str]] = []
+    if not args.no_backup:
+        steps.append((
+            [sys.executable, str(REPO_ROOT / "scripts" / "odysseus-backup"), "snapshot"],
+            "snapshot data/ before updating",
+        ))
+    steps.append((compose + ["pull"] + svc, "pull updated images"))
+    steps.append((compose + ["up", "-d", "--build"] + svc, "rebuild + recreate containers"))
+
+    plan = [{"cmd": cmd, "why": why} for cmd, why in steps]
+    if not args.yes:
+        out = {"dry_run": True, "note": "pass --yes to execute", "plan": plan}
+        if base is None:
+            out["warning"] = "docker compose not detected; showing default plan"
+        emit(out, args)
+        return
+
+    ran = []
+    for cmd, why in steps:
+        sys.stderr.write(f"→ {why}: {' '.join(cmd)}\n")
+        result = subprocess.run(cmd, cwd=str(REPO_ROOT))
+        if result.returncode != 0:
+            fail(f"step failed ({why}): {' '.join(cmd)} → exit {result.returncode}")
+        ran.append(cmd)
+    emit({"ok": True, "ran": ran}, args)
+
+
+def _build_parser():
+    p = common_parser("odysseus-update", "Check for and apply Odysseus container updates.")
+    common = p._common_parents[0]
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pc = sub.add_parser("check", parents=[common], help="report whether a newer release is available")
+    pc.add_argument("--timeout", type=float, default=6.0, help="network timeout in seconds (default 6)")
+    pc.set_defaults(func=cmd_check)
+
+    pa = sub.add_parser("apply", parents=[common], help="snapshot, pull, rebuild and recreate the stack")
+    pa.add_argument("--yes", action="store_true", help="execute (otherwise dry-run prints the plan)")
+    pa.add_argument("--no-backup", action="store_true", help="skip the pre-update data/ snapshot")
+    pa.add_argument("--service", help="limit to one compose service (default: whole stack)")
+    pa.set_defaults(func=cmd_apply)
+
+    return p
+
+
+if __name__ == "__main__":
+    sys.exit(run(_build_parser()))

--- a/tests/test_companion_system.py
+++ b/tests/test_companion_system.py
@@ -1,0 +1,95 @@
+"""Unit tests for companion.system — the pure helpers behind the
+/api/companion/system/* endpoints and the odysseus-update CLI.
+
+These exercise version comparison, SQLite path resolution, and the online
+`.backup` snapshot directly, with no network and no running app, so the update
+and DB-extraction logic can't silently regress.
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from companion import system as s
+
+
+# ── version comparison ────────────────────────────────────────────────────────
+
+def test_parse_version_strips_prefix_and_suffix():
+    assert s.parse_version("v1.2.3") == (1, 2, 3)
+    assert s.parse_version("1.2.3-rc1") == (1, 2, 3)
+    assert s.parse_version("1.2.3+build.5") == (1, 2, 3)
+    assert s.parse_version("  V0.9.1  ") == (0, 9, 1)
+
+
+def test_parse_version_trailing_zeros_normalized():
+    # 1.2 and 1.2.0 must compare equal.
+    assert s.parse_version("1.2.0") == s.parse_version("1.2")
+
+
+def test_parse_version_garbage_is_empty():
+    assert s.parse_version("garbage") == ()
+    assert s.parse_version("") == ()
+    assert s.parse_version(None) == ()
+
+
+def test_update_available_basic():
+    assert s.update_available("0.9.1", "0.9.2") is True
+    assert s.update_available("0.9.1", "0.10.0") is True
+    assert s.update_available("0.9.1", "1.0.0") is True
+
+
+def test_update_available_not_when_equal_or_older():
+    assert s.update_available("0.9.1", "0.9.1") is False
+    assert s.update_available("0.9.1", "v0.9.1") is False
+    assert s.update_available("1.0.0", "0.9.9") is False
+
+
+def test_update_available_unparseable_latest_is_conservative():
+    # If we can't read `latest`, never claim an update exists.
+    assert s.update_available("0.9.1", None) is False
+    assert s.update_available("0.9.1", "garbage") is False
+
+
+# ── SQLite path resolution ────────────────────────────────────────────────────
+
+def test_resolve_sqlite_relative_path_against_base():
+    p = s.resolve_sqlite_path("sqlite:///./data/app.db", "/repo")
+    assert p == Path("/repo/data/app.db")
+
+
+def test_resolve_sqlite_absolute_path():
+    p = s.resolve_sqlite_path("sqlite:////srv/app.db", "/repo")
+    # .resolve() may canonicalize symlinks; compare the tail to stay portable.
+    assert p is not None and p.name == "app.db" and p.is_absolute()
+
+
+def test_resolve_sqlite_rejects_non_sqlite_and_memory():
+    assert s.resolve_sqlite_path("postgresql://u:p@h/db", "/repo") is None
+    assert s.resolve_sqlite_path("sqlite://", "/repo") is None
+    assert s.resolve_sqlite_path("", "/repo") is None
+
+
+# ── safe snapshot ─────────────────────────────────────────────────────────────
+
+def test_safe_sqlite_snapshot_copies_data():
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "app.db"
+        conn = sqlite3.connect(str(src))
+        conn.execute("CREATE TABLE t (x TEXT)")
+        conn.execute("INSERT INTO t VALUES ('hello')")
+        conn.commit()
+        conn.close()
+
+        dst = Path(d) / "snap.sqlite"
+        s.safe_sqlite_snapshot(src, dst)
+
+        assert dst.is_file()
+        out = sqlite3.connect(str(dst))
+        rows = out.execute("SELECT x FROM t").fetchall()
+        out.close()
+        assert rows == [("hello",)]

--- a/tests/test_companion_system_routes.py
+++ b/tests/test_companion_system_routes.py
@@ -1,0 +1,228 @@
+"""Route-layer tests for the companion system endpoints.
+
+Helper-level tests (test_companion_system.py) cover the pure logic; these pin
+the *HTTP surface* — the admin gate and response behavior — because
+/system/db-export is a full-data-export endpoint where authorization and what
+ends up in the response body are the security-critical parts.
+
+The harness mounts the real `setup_companion_routes()` router on a bare FastAPI
+app and reproduces exactly what AuthMiddleware stamps on request.state for each
+caller type, plus an `app.state.auth_manager` stub whose `is_admin` only blesses
+the admin user. `require_admin` (core/middleware.py) reads those, so the gate is
+exercised for real — no monkeypatching of the gate itself.
+"""
+
+import importlib
+import os
+import sqlite3
+import sys
+import tempfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def db_module():
+    """Force the genuine `core.database` into sys.modules for the test.
+
+    Sibling companion test modules (test_companion_pairing/readonly) replace
+    `sys.modules['core.database']` with a MagicMock stub at import time so they
+    can run under conftest's sqlalchemy stubs. The db-export route reads
+    `core.database.DATABASE_URL` at call time, so these tests need the real
+    module present and patchable. We swap it in for the duration of the test and
+    restore the sibling's stub afterward, keeping the fix order-independent.
+    """
+    saved = sys.modules.get("core.database")
+    sys.modules.pop("core.database", None)
+    mod = importlib.import_module("core.database")
+    try:
+        yield mod
+    finally:
+        if saved is not None:
+            sys.modules["core.database"] = saved
+
+
+class _AuthMgr:
+    """Minimal stand-in for the real AuthManager: configured, and only the
+    'admin' username is an admin."""
+    is_configured = True
+
+    def is_admin(self, username):
+        return username == "admin"
+
+
+def _make_client(monkeypatch):
+    """Build a TestClient over the real companion router. The `X-Test-Auth`
+    header selects the caller type and the middleware stamps request.state the
+    same way app.py's AuthMiddleware would for that caller."""
+    # require_admin short-circuits to allow-all when AUTH_ENABLED=false; keep the
+    # gate live for these tests regardless of the ambient environment.
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+
+    from companion.routes import setup_companion_routes
+
+    app = FastAPI()
+    app.state.auth_manager = _AuthMgr()
+    app.state.invalidate_token_cache = lambda: None
+
+    @app.middleware("http")
+    async def _fake_auth(request, call_next):
+        mode = request.headers.get("x-test-auth", "anon")
+        if mode == "admin":
+            request.state.current_user = "admin"
+            request.state.api_token = False
+        elif mode == "user":  # logged-in non-admin cookie session
+            request.state.current_user = "alice"
+            request.state.api_token = False
+        elif mode == "token":  # bearer/API token → sandboxed 'api' pseudo-user
+            request.state.current_user = "api"
+            request.state.api_token = True
+            request.state.api_token_owner = "alice"
+            request.state.api_token_scopes = ["companion", "chat"]
+        else:  # unauthenticated
+            request.state.current_user = None
+            request.state.api_token = False
+        return await call_next(request)
+
+    app.include_router(setup_companion_routes())
+    return TestClient(app)
+
+
+# ── admin gate ────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", ["/api/companion/system/update-check",
+                                  "/api/companion/system/db-export"])
+def test_non_admin_session_is_forbidden(monkeypatch, path):
+    client = _make_client(monkeypatch)
+    assert client.get(path, headers={"X-Test-Auth": "user"}).status_code == 403
+
+
+@pytest.mark.parametrize("path", ["/api/companion/system/update-check",
+                                  "/api/companion/system/db-export"])
+def test_bearer_token_is_forbidden(monkeypatch, path):
+    """A paired companion/chat token resolves to the 'api' pseudo-user, which is
+    never an admin — it must not reach either system route."""
+    client = _make_client(monkeypatch)
+    assert client.get(path, headers={"X-Test-Auth": "token"}).status_code == 403
+
+
+@pytest.mark.parametrize("path", ["/api/companion/system/update-check",
+                                  "/api/companion/system/db-export"])
+def test_anonymous_is_forbidden(monkeypatch, path):
+    client = _make_client(monkeypatch)
+    assert client.get(path, headers={"X-Test-Auth": "anon"}).status_code == 403
+
+
+# ── update-check behavior ─────────────────────────────────────────────────────
+
+def test_update_check_admin_success(monkeypatch):
+    monkeypatch.setattr(
+        "companion.system.fetch_latest_release",
+        lambda url, timeout=6.0: {
+            "tag": "v9.9.9", "name": "big release",
+            "html_url": "https://example/releases/9.9.9",
+            "published_at": "2030-01-01T00:00:00Z",
+        },
+    )
+    client = _make_client(monkeypatch)
+    r = client.get("/api/companion/system/update-check", headers={"X-Test-Auth": "admin"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["reachable"] is True
+    assert body["latest"] == "v9.9.9"
+    assert body["update_available"] is True
+    assert body["release_url"] == "https://example/releases/9.9.9"
+
+
+def test_update_check_network_failure_degrades_not_500(monkeypatch):
+    def _boom(url, timeout=6.0):
+        raise OSError("name resolution failed")
+
+    monkeypatch.setattr("companion.system.fetch_latest_release", _boom)
+    client = _make_client(monkeypatch)
+    r = client.get("/api/companion/system/update-check", headers={"X-Test-Auth": "admin"})
+    assert r.status_code == 200  # not a 500
+    body = r.json()
+    assert body["reachable"] is False
+    assert body["latest"] is None
+    assert body["update_available"] is False
+    assert "error" in body
+
+
+# ── db-export behavior ────────────────────────────────────────────────────────
+
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+def _seed_data_dir(tmp_path):
+    """A realistic data/ layout: a SQLite DB plus a Fernet key file that must
+    NEVER ride along in the export."""
+    data = tmp_path / "data"
+    data.mkdir()
+    db = data / "app.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE api_tokens (id TEXT, token_hash TEXT)")
+    conn.execute("INSERT INTO api_tokens VALUES ('t1', 'secret-hash')")
+    conn.commit()
+    conn.close()
+    (data / ".app_key").write_bytes(b"FERNET-KEY-SENTINEL-do-not-leak")
+    return db
+
+
+def test_db_export_admin_returns_sqlite_and_cleans_tmp(monkeypatch, tmp_path, db_module):
+    db = _seed_data_dir(tmp_path)
+    monkeypatch.setattr(db_module, "DATABASE_URL", f"sqlite:////{db}")
+
+    # Capture the temp snapshot path the route creates so we can assert the
+    # background task deleted it after the response.
+    created = []
+    real_mkstemp = tempfile.mkstemp
+
+    def _spy_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        created.append(path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", _spy_mkstemp)
+
+    client = _make_client(monkeypatch)
+    r = client.get("/api/companion/system/db-export", headers={"X-Test-Auth": "admin"})
+
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/octet-stream"
+    assert "attachment;" in r.headers["content-disposition"]
+    assert ".sqlite" in r.headers["content-disposition"]
+    # Body is a bare SQLite database, and the seeded row survived the snapshot.
+    assert r.content.startswith(_SQLITE_MAGIC)
+    assert b"secret-hash" in r.content
+
+    # TestClient runs the response's background task; the temp file is gone.
+    assert created, "route did not create a temp snapshot"
+    assert not os.path.exists(created[0])
+
+
+def test_db_export_body_is_only_the_snapshot_no_key_or_archive(monkeypatch, tmp_path, db_module):
+    db = _seed_data_dir(tmp_path)
+    monkeypatch.setattr(db_module, "DATABASE_URL", f"sqlite:////{db}")
+
+    client = _make_client(monkeypatch)
+    r = client.get("/api/companion/system/db-export", headers={"X-Test-Auth": "admin"})
+
+    assert r.status_code == 200
+    body = r.content
+    # A single SQLite file — not a tar/gzip/zip bundle of the data directory.
+    assert body.startswith(_SQLITE_MAGIC)
+    assert b"ustar" not in body          # tar
+    assert not body.startswith(b"\x1f\x8b")  # gzip
+    assert not body.startswith(b"PK\x03\x04")  # zip
+    # The Fernet key file's contents must not appear anywhere in the export.
+    assert b"FERNET-KEY-SENTINEL-do-not-leak" not in body
+
+
+def test_db_export_non_sqlite_returns_400(monkeypatch, db_module):
+    monkeypatch.setattr(db_module, "DATABASE_URL", "postgresql://u:p@host/db")
+    client = _make_client(monkeypatch)
+    r = client.get("/api/companion/system/db-export", headers={"X-Test-Auth": "admin"})
+    assert r.status_code == 400


### PR DESCRIPTION
Closes #1157.

Two admin-only capabilities for keeping a self-hosted instance current and getting its data out, added as an additive overlay on the companion bridge (no changes to core LLM logic).

## Update checking
`GET /api/companion/system/update-check` (admin) — compares the running `APP_VERSION` against the latest release at `UPDATE_CHECK_URL` (this repo by default; override via `ODYSSEUS_REPO` / `ODYSSEUS_UPDATE_CHECK_URL`). Read-only and side-effect free — it never touches the container. A network failure degrades to `{reachable:false, error}` rather than a 500.

## Database extraction
`GET /api/companion/system/db-export` (admin) — streams a consistent point-in-time copy of `app.db` taken with SQLite's online `.backup` API (safe while the server is running). SQLite only (a non-SQLite `DATABASE_URL` returns 400). The Fernet key (`data/.app_key`) needed to decrypt encrypted columns is deliberately **not** included.

## Applying an update
`scripts/odysseus-update`:

```
odysseus-update check        # current vs latest release
odysseus-update apply        # DRY-RUN: prints the plan
odysseus-update apply --yes  # snapshot -> docker compose pull -> up -d --build
```

`apply` snapshots `data/` via `odysseus-backup` first, then pulls images and rebuilds/recreates (the `odysseus` service is `build:`-based). Dry-run unless `--yes`.

## Security
- The **HTTP layer never shells out to Docker** — the privileged container lifecycle lives only in the local admin CLI, so the Docker socket is never exposed on the LAN.
- Both endpoints are gated via `require_admin`. Bearer/API tokens resolve to the sandboxed `api` pseudo-user (never admin), so a DB dump or update trigger can't ride a chat-scoped token.
- `apply` does not `git pull` (won't clobber a local checkout); update the source yourself first.

## Tests
Pure helpers (version compare, SQLite path resolution, safe snapshot, release fetch) live in `companion/system.py` and are covered by `tests/test_companion_system.py`. Existing companion tests still pass.