### PR TITLE
fix(auth): rename mixed-case owner rows

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, Request, Response, HTTPException
 from pydantic import BaseModel
+from sqlalchemy import func
 from typing import Optional
 import asyncio
 import logging
@@ -71,6 +72,28 @@ class SetOpenRegistrationRequest(BaseModel):
     enabled: bool
 
 SESSION_COOKIE = "odysseus_session"
+
+
+def _rename_owner_references(old_username: str, new_username: str) -> None:
+    from core.database import Base, SessionLocal
+
+    db = SessionLocal()
+    try:
+        for mapper in Base.registry.mappers:
+            model = mapper.class_
+            if not hasattr(model, "owner"):
+                continue
+            (
+                db.query(model)
+                .filter(func.lower(model.owner) == old_username)
+                .update({"owner": new_username}, synchronize_session=False)
+            )
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
 
 
 def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
@@ -297,24 +320,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         # owner-scoped DB rows before changing auth so the account keeps
         # access to its sessions, docs, email accounts, tasks, etc.
         try:
-            from core.database import Base, SessionLocal
-            db = SessionLocal()
-            try:
-                for mapper in Base.registry.mappers:
-                    model = mapper.class_
-                    if not hasattr(model, "owner"):
-                        continue
-                    (
-                        db.query(model)
-                        .filter(model.owner == old_username)
-                        .update({"owner": new_username}, synchronize_session=False)
-                    )
-                db.commit()
-            except Exception:
-                db.rollback()
-                raise
-            finally:
-                db.close()
+            _rename_owner_references(old_username, new_username)
         except Exception as e:
             logger.error("Failed to rename owner references %s -> %s: %s", old_username, new_username, e)
             raise HTTPException(500, "Failed to rename user data")

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -81,6 +81,17 @@ _ensure_stub("src.endpoint_resolver",
     build_chat_url=MagicMock(),
     build_headers=MagicMock(),
 )
+_ensure_stub("src.integrations",
+    load_integrations=MagicMock(return_value=[]),
+    add_integration=MagicMock(),
+    update_integration=MagicMock(),
+    delete_integration=MagicMock(),
+    get_integration=MagicMock(return_value=None),
+    mask_integration_secret=MagicMock(),
+    execute_api_call=MagicMock(),
+    INTEGRATION_PRESETS={},
+    migrate_from_settings=MagicMock(),
+)
 
 from fastapi import HTTPException
 
@@ -161,6 +172,100 @@ def test_set_signup_enabled_requires_admin():
 
     assert exc.value.status_code == 403
     assert auth.signup_enabled is False
+
+def test_rename_owner_references_matches_legacy_mixed_case_owners(monkeypatch):
+    from routes import auth_routes
+
+    class _OwnerColumn:
+        pass
+
+    class _LowerOwnerColumn:
+        def __eq__(self, expected):
+            return lambda row: (row.owner or "").lower() == expected
+
+    class _Func:
+        @staticmethod
+        def lower(column):
+            assert isinstance(column, _OwnerColumn)
+            return _LowerOwnerColumn()
+
+    class OwnedModel:
+        owner = _OwnerColumn()
+
+    class OwnerlessModel:
+        pass
+
+    rows = [
+        SimpleNamespace(owner="Admin"),
+        SimpleNamespace(owner="admin"),
+        SimpleNamespace(owner="ADMIN"),
+        SimpleNamespace(owner="bob"),
+        SimpleNamespace(owner=None),
+    ]
+
+    class _Query:
+        def __init__(self, rows):
+            self.rows = rows
+            self.predicate = lambda row: True
+
+        def filter(self, predicate):
+            self.predicate = predicate
+            return self
+
+        def update(self, values, synchronize_session=False):
+            changed = 0
+            for row in self.rows:
+                if self.predicate(row):
+                    row.owner = values["owner"]
+                    changed += 1
+            return changed
+
+    class _Db:
+        def __init__(self):
+            self.committed = False
+            self.rolled_back = False
+            self.closed = False
+
+        def query(self, model):
+            assert model is OwnedModel
+            return _Query(rows)
+
+        def commit(self):
+            self.committed = True
+
+        def rollback(self):
+            self.rolled_back = True
+
+        def close(self):
+            self.closed = True
+
+    db = _Db()
+    fake_db_mod = types.ModuleType("core.database")
+    fake_db_mod.SessionLocal = lambda: db
+    fake_db_mod.Base = SimpleNamespace(
+        registry=SimpleNamespace(
+            mappers=[
+                SimpleNamespace(class_=OwnedModel),
+                SimpleNamespace(class_=OwnerlessModel),
+            ]
+        )
+    )
+
+    monkeypatch.setattr(auth_routes, "func", _Func)
+    monkeypatch.setitem(sys.modules, "core.database", fake_db_mod)
+
+    auth_routes._rename_owner_references("admin", "missionctrl")
+
+    assert [row.owner for row in rows] == [
+        "missionctrl",
+        "missionctrl",
+        "missionctrl",
+        "bob",
+        None,
+    ]
+    assert db.committed is True
+    assert db.rolled_back is False
+    assert db.closed is True
 
 # ---------------------------------------------------------------------------
 # Research endpoints — `_require_user` rejects anonymous


### PR DESCRIPTION
## Summary
- Extract owner-reference migration into a focused helper for user renames
- Match legacy mixed-case `owner` rows with `lower(owner) == old_username` so defensive renames do not skip older data
- Add a regression test covering `Admin` / `admin` / `ADMIN` owner values while leaving other owners untouched

## Verification
- `.venv/bin/python -m py_compile routes/auth_routes.py tests/test_auth_regressions.py`
- `.venv/bin/python -m pytest tests/test_auth_regressions.py`
- `git diff --check`

Fixes pewdiepie-archdaemon/odysseus#1165
