### PR TITLE
fix(agent): scale input-token budget to model context window (#1170)

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1476,13 +1476,22 @@ async def stream_agent_loop(
 
     _t3 = time.time()
     try:
-        from src.context_compactor import trim_for_context
+        from src.context_compactor import trim_for_context, resolve_input_budget
 
-        soft_budget = int(get_setting("agent_input_token_budget", 6000) or 0)
-        if soft_budget > 0:
+        # agent_input_token_budget: <0 auto (scale to the model's context
+        # window), 0 unlimited (no soft trim), >0 explicit hard cap. Default is
+        # auto so long-context models aren't silently capped at a flat 6000
+        # (issue #1170).
+        try:
+            soft_budget = int(get_setting("agent_input_token_budget", -1))
+        except (TypeError, ValueError):
+            soft_budget = -1
+        if soft_budget != 0:
             before_trim_tokens = estimate_tokens(messages)
             reserve_tokens = min(max(max_tokens or 1024, 512), 2048)
-            effective_budget = min(context_length or soft_budget, soft_budget)
+            effective_budget = resolve_input_budget(
+                soft_budget, context_length, reserve_tokens,
+            )
             trimmed_messages = trim_for_context(
                 messages,
                 effective_budget,

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1479,18 +1479,22 @@ async def stream_agent_loop(
         from src.context_compactor import trim_for_context, resolve_input_budget
 
         # agent_input_token_budget: <0 auto (scale to the model's context
-        # window), 0 unlimited (no soft trim), >0 explicit hard cap. Default is
-        # auto so long-context models aren't silently capped at a flat 6000
-        # (issue #1170).
+        # window, bounded by agent_input_token_budget_auto_max), 0 unlimited
+        # (no soft trim), >0 explicit hard cap. Default is auto so long-context
+        # models aren't silently capped at a flat 6000 (issue #1170).
         try:
             soft_budget = int(get_setting("agent_input_token_budget", -1))
         except (TypeError, ValueError):
             soft_budget = -1
+        try:
+            auto_max = int(get_setting("agent_input_token_budget_auto_max", 32000))
+        except (TypeError, ValueError):
+            auto_max = 32000
         if soft_budget != 0:
             before_trim_tokens = estimate_tokens(messages)
             reserve_tokens = min(max(max_tokens or 1024, 512), 2048)
             effective_budget = resolve_input_budget(
-                soft_budget, context_length, reserve_tokens,
+                soft_budget, context_length, reserve_tokens, auto_max=auto_max,
             )
             trimmed_messages = trim_for_context(
                 messages,

--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -19,6 +19,39 @@ COMPACT_THRESHOLD = 0.85  # Trigger compaction at 85% of context window
 SUMMARY_MAX_TOKENS = 1024
 SMALL_CONTEXT_LIMIT = 8192  # Models with context <= this get aggressive trimming
 
+# `agent_input_token_budget` setting semantics (resolved by
+# resolve_input_budget so the agent loop and tests share one definition):
+#   < 0  -> auto: scale the soft-trim budget to the model's context window,
+#           leaving headroom for the response. Shipped default, so long-context
+#           models aren't silently capped at a flat AUTO_BUDGET_FLOOR.
+#   == 0 -> unlimited: no soft trim at all (caller skips trimming).
+#   > 0  -> explicit hard cap, still bounded by the model's context window.
+AUTO_BUDGET_FLOOR = 6000      # never auto-trim below this (the legacy default)
+AUTO_BUDGET_FRACTION = 0.75   # fraction of the context window used in auto mode
+
+
+def resolve_input_budget(soft_budget: int, context_length: int,
+                         reserve_tokens: int = 512,
+                         floor: int = AUTO_BUDGET_FLOOR,
+                         fraction: float = AUTO_BUDGET_FRACTION) -> int:
+    """Resolve the effective soft input-token budget for context trimming.
+
+    See the `agent_input_token_budget` semantics above. Callers should skip
+    trimming entirely when ``soft_budget == 0`` (unlimited) before calling
+    this. In auto mode the budget scales with the model's context window but
+    never drops below ``floor``; when the window is unknown it falls back to
+    ``floor`` (the historical behavior).
+    """
+    if soft_budget > 0:
+        # Explicit hard cap, still bounded by the model's context window.
+        return min(context_length or soft_budget, soft_budget)
+    # Auto (soft_budget < 0): scale to the model's context window.
+    if context_length and context_length > 0:
+        scaled = int(context_length * fraction)
+        headroom = max(context_length - reserve_tokens, floor)
+        return max(floor, min(scaled, headroom))
+    return floor
+
 # Cursor-style self-summarization prompt — produces structured, dense summaries
 SELF_SUMMARY_SYSTEM_PROMPT = """You are summarizing a conversation to preserve context after compaction. Produce a structured summary that lets the conversation continue seamlessly.
 

--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -40,11 +40,15 @@ def resolve_input_budget(soft_budget: int, context_length: int,
 
     See the `agent_input_token_budget` semantics above. Callers should skip
     trimming entirely when ``soft_budget == 0`` (unlimited) before calling
-    this. In auto mode (``soft_budget < 0``) the budget scales with the model's
-    context window, bounded below by ``floor`` and above by ``auto_max`` (so a
-    huge window can't balloon the per-turn input); ``auto_max <= 0`` removes the
-    ceiling. When the window is unknown it falls back to ``floor`` (the
-    historical behavior).
+    this. In auto mode (``soft_budget < 0``) the budget scales to a fraction of
+    the model's context window and is bounded above by ``auto_max`` (so a huge
+    window can't balloon the per-turn input); ``auto_max <= 0`` removes the
+    ceiling. The result never exceeds the known context window — trim_for_context
+    reserves ``reserve_tokens`` from this target downstream, so bounding by the
+    full window keeps real response headroom without double-reserving here. The
+    ``floor`` lifts the budget for comfortable windows but is itself clamped to
+    the window, so a small model is never handed a target larger than it can
+    hold. When the window is unknown it falls back to ``floor``.
     """
     if soft_budget > 0:
         # Explicit hard cap, still bounded by the model's context window.
@@ -53,11 +57,13 @@ def resolve_input_budget(soft_budget: int, context_length: int,
     # Auto (soft_budget < 0): scale to the model's context window.
     if context_length and context_length > 0:
         scaled = int(context_length * fraction)
-        headroom = max(context_length - reserve_tokens, floor)
-        budget = min(scaled, headroom)
         if auto_max and auto_max > 0:
-            budget = min(budget, auto_max)
-        return max(floor, budget)
+            scaled = min(scaled, auto_max)
+        # Lift toward the floor, but never above the window itself. For a tiny
+        # window (< floor) this collapses to the window, matching the old
+        # min(context_length, floor) bound.
+        budget = max(scaled, min(floor, context_length))
+        return min(budget, context_length)
     return floor
 
 # Cursor-style self-summarization prompt — produces structured, dense summaries

--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -28,28 +28,36 @@ SMALL_CONTEXT_LIMIT = 8192  # Models with context <= this get aggressive trimmin
 #   > 0  -> explicit hard cap, still bounded by the model's context window.
 AUTO_BUDGET_FLOOR = 6000      # never auto-trim below this (the legacy default)
 AUTO_BUDGET_FRACTION = 0.75   # fraction of the context window used in auto mode
+AUTO_BUDGET_MAX = 32000       # default ceiling for auto mode (see settings.py)
 
 
 def resolve_input_budget(soft_budget: int, context_length: int,
                          reserve_tokens: int = 512,
                          floor: int = AUTO_BUDGET_FLOOR,
-                         fraction: float = AUTO_BUDGET_FRACTION) -> int:
+                         fraction: float = AUTO_BUDGET_FRACTION,
+                         auto_max: int = AUTO_BUDGET_MAX) -> int:
     """Resolve the effective soft input-token budget for context trimming.
 
     See the `agent_input_token_budget` semantics above. Callers should skip
     trimming entirely when ``soft_budget == 0`` (unlimited) before calling
-    this. In auto mode the budget scales with the model's context window but
-    never drops below ``floor``; when the window is unknown it falls back to
-    ``floor`` (the historical behavior).
+    this. In auto mode (``soft_budget < 0``) the budget scales with the model's
+    context window, bounded below by ``floor`` and above by ``auto_max`` (so a
+    huge window can't balloon the per-turn input); ``auto_max <= 0`` removes the
+    ceiling. When the window is unknown it falls back to ``floor`` (the
+    historical behavior).
     """
     if soft_budget > 0:
         # Explicit hard cap, still bounded by the model's context window.
+        # auto_max does not apply — the user asked for this exact cap.
         return min(context_length or soft_budget, soft_budget)
     # Auto (soft_budget < 0): scale to the model's context window.
     if context_length and context_length > 0:
         scaled = int(context_length * fraction)
         headroom = max(context_length - reserve_tokens, floor)
-        return max(floor, min(scaled, headroom))
+        budget = min(scaled, headroom)
+        if auto_max and auto_max > 0:
+            budget = min(budget, auto_max)
+        return max(floor, budget)
     return floor
 
 # Cursor-style self-summarization prompt — produces structured, dense summaries

--- a/src/settings.py
+++ b/src/settings.py
@@ -103,6 +103,14 @@ DEFAULT_SETTINGS = {
     #   >0 — explicit hard cap, still bounded by the model's context window.
     # Resolved in src/context_compactor.py:resolve_input_budget.
     "agent_input_token_budget": -1,
+    # Ceiling applied in auto mode (agent_input_token_budget == -1) so the
+    # adaptive budget can't balloon on huge windows — e.g. a discovered
+    # 1M-token context would otherwise resolve to ~750k input tokens every
+    # turn, a surprise cost/latency hit on premium APIs. Conservative default
+    # of 32000 stays well above the old 6000 floor while bounding the worst
+    # case; raise it (or set 0 to uncap) if you want long-context models to
+    # use more of their window. Ignored when an explicit budget (>0) is set.
+    "agent_input_token_budget_auto_max": 32000,
     "agent_stream_timeout_seconds": 300,
     "task_endpoint_id": "",
     "task_model": "",

--- a/src/settings.py
+++ b/src/settings.py
@@ -95,7 +95,14 @@ DEFAULT_SETTINGS = {
     # Tune via Settings or by editing data/settings.json.
     "research_run_timeout_seconds": 1800,
     "agent_max_tool_calls": 0,
-    "agent_input_token_budget": 6000,
+    # Soft input-token budget the agent trims history toward before each turn.
+    #   -1 (auto, default) — scale to the model's context window, reserving
+    #        room for the response. A flat cap silently throttled long-context
+    #        models, trimming a 200k-window model's input down to 6000 tokens.
+    #    0 — unlimited (no soft trim).
+    #   >0 — explicit hard cap, still bounded by the model's context window.
+    # Resolved in src/context_compactor.py:resolve_input_budget.
+    "agent_input_token_budget": -1,
     "agent_stream_timeout_seconds": 300,
     "task_endpoint_id": "",
     "task_model": "",

--- a/static/index.html
+++ b/static/index.html
@@ -1479,6 +1479,18 @@
                 <input id="set-agentMaxTools" type="text" inputmode="numeric" placeholder="0 = unlimited" class="settings-select" style="width:120px;">
               </div>
               <div id="set-agentMsg" style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);"></div>
+              <div class="settings-row">
+                <label class="settings-label">Input token budget</label>
+                <input id="set-agentInputBudget" type="text" inputmode="numeric" placeholder="-1 = auto" class="settings-select" style="width:120px;">
+              </div>
+              <div class="settings-row">
+                <label class="settings-label">Auto budget cap</label>
+                <input id="set-agentBudgetAutoMax" type="text" inputmode="numeric" placeholder="32000 (0 = uncapped)" class="settings-select" style="width:120px;">
+              </div>
+              <div id="set-agentBudgetMsg" style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);"></div>
+              <div style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);line-height:1.5;">
+                History is trimmed toward this many input tokens each turn. <b>-1</b> auto-scales to the model's context window (bounded by “Auto budget cap”), <b>0</b> disables trimming, and a <b>positive</b> value is a fixed hard cap. “Auto budget cap” only applies in auto mode; set it to 0 to let long-context models use their full window.
+              </div>
             </div>
           </div>
           <!-- Image Generation removed — only inpaint remains in this build,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1557,10 +1557,20 @@ async function initAgentSettings() {
   var msg = el('set-agentMsg');
   if (!toolsInput) return;
 
+  var budgetInput = el('set-agentInputBudget');
+  var autoMaxInput = el('set-agentBudgetAutoMax');
+  var budgetMsg = el('set-agentBudgetMsg');
+
   try {
     var res = await fetch('/api/auth/settings', { credentials: 'same-origin' });
     var settings = await res.json();
     if (settings.agent_max_tool_calls) toolsInput.value = settings.agent_max_tool_calls;
+    if (budgetInput && settings.agent_input_token_budget !== undefined && settings.agent_input_token_budget !== null) {
+      budgetInput.value = settings.agent_input_token_budget;
+    }
+    if (autoMaxInput && settings.agent_input_token_budget_auto_max !== undefined && settings.agent_input_token_budget_auto_max !== null) {
+      autoMaxInput.value = settings.agent_input_token_budget_auto_max;
+    }
   } catch (e) {}
 
   async function save() {
@@ -1575,9 +1585,51 @@ async function initAgentSettings() {
     } catch (e) { msg.textContent = 'Failed to save'; msg.style.color = 'var(--red)'; }
   }
 
+  // Parse an int budget field, falling back to `dflt` when blank/invalid so a
+  // cleared box doesn't silently post 0.
+  function parseBudget(input, dflt) {
+    if (!input) return dflt;
+    var raw = (input.value || '').trim();
+    if (raw === '') return dflt;
+    var n = parseInt(raw, 10);
+    return isNaN(n) ? dflt : n;
+  }
+
+  function describeBudget() {
+    if (!budgetMsg) return;
+    var b = parseBudget(budgetInput, -1);
+    var cap = parseBudget(autoMaxInput, 32000);
+    var text;
+    if (b === 0) text = 'No trimming — unlimited input.';
+    else if (b > 0) text = 'Hard cap: ' + b + ' input tokens.';
+    else text = (cap > 0 ? 'Auto — scales to the model window, capped at ' + cap + ' tokens.'
+                         : 'Auto — scales to the full model window (uncapped).');
+    budgetMsg.textContent = text;
+    budgetMsg.style.color = 'var(--fg)';
+  }
+
+  async function saveBudget() {
+    var payload = {
+      agent_input_token_budget: parseBudget(budgetInput, -1),
+      agent_input_token_budget_auto_max: parseBudget(autoMaxInput, 32000)
+    };
+    try {
+      await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      describeBudget();
+    } catch (e) {
+      if (budgetMsg) { budgetMsg.textContent = 'Failed to save'; budgetMsg.style.color = 'var(--red)'; }
+    }
+  }
+
   toolsInput.addEventListener('change', save);
+  if (budgetInput) budgetInput.addEventListener('change', saveBudget);
+  if (autoMaxInput) autoMaxInput.addEventListener('change', saveBudget);
   var cur = parseInt(toolsInput.value, 10) || 0;
   msg.textContent = cur > 0 ? 'Limit: ' + cur + ' tool calls per message' : 'Unlimited';
+  describeBudget();
 }
 
 /* ═══════════════════════════════════════════

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -16,6 +16,7 @@ for mod in [
 
 from src.context_compactor import (
     AUTO_BUDGET_FLOOR,
+    AUTO_BUDGET_MAX,
     COMPACT_THRESHOLD,
     SELF_SUMMARY_SYSTEM_PROMPT,
     SUMMARY_MAX_TOKENS,
@@ -49,12 +50,33 @@ class TestResolveInputBudget:
         # Unknown window (0) leaves the explicit cap untouched.
         assert resolve_input_budget(6000, context_length=0) == 6000
 
-    def test_auto_scales_with_large_window(self):
-        # The bug in #1170: a 200k model used to be trimmed to 6000. Auto mode
-        # now scales to a generous fraction of the window instead.
-        budget = resolve_input_budget(-1, context_length=200000)
-        assert budget == int(200000 * 0.75)
+    def test_auto_scales_with_window_below_ceiling(self):
+        # The bug in #1170: a model used to be trimmed to 6000. Below the auto
+        # ceiling, auto mode scales to a fraction of the window instead.
+        budget = resolve_input_budget(-1, context_length=32000)
+        assert budget == int(32000 * 0.75)
         assert budget > AUTO_BUDGET_FLOOR
+
+    def test_auto_bounded_by_ceiling_on_large_window(self):
+        # A 200k window scaled to 150k would blow up per-turn cost; the auto
+        # ceiling caps it. This is the safeguard requested in review of #1189.
+        assert resolve_input_budget(-1, context_length=200000) == AUTO_BUDGET_MAX
+
+    def test_auto_ceiling_caps_huge_window(self):
+        # Even a 1M-token window stays at the ceiling, not ~750k.
+        assert resolve_input_budget(-1, context_length=1_000_000) == AUTO_BUDGET_MAX
+
+    def test_auto_ceiling_disabled_with_zero(self):
+        # auto_max <= 0 removes the ceiling — opt-in to full scaling.
+        budget = resolve_input_budget(-1, context_length=1_000_000, auto_max=0)
+        assert budget == int(1_000_000 * 0.75)
+
+    def test_auto_custom_ceiling_is_respected(self):
+        assert resolve_input_budget(-1, context_length=200000, auto_max=16000) == 16000
+
+    def test_explicit_cap_ignores_auto_ceiling(self):
+        # auto_max only governs auto mode; an explicit cap is honored verbatim.
+        assert resolve_input_budget(50000, context_length=200000, auto_max=16000) == 50000
 
     def test_auto_never_below_floor(self):
         # Small-context models keep at least the historical floor.

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -78,17 +78,35 @@ class TestResolveInputBudget:
         # auto_max only governs auto mode; an explicit cap is honored verbatim.
         assert resolve_input_budget(50000, context_length=200000, auto_max=16000) == 50000
 
-    def test_auto_never_below_floor(self):
-        # Small-context models keep at least the historical floor.
-        assert resolve_input_budget(-1, context_length=4096) == AUTO_BUDGET_FLOOR
+    # --- auto mode must never exceed the known window (review of #1189) ---
+
+    def test_auto_never_exceeds_known_window(self):
+        # The regression the maintainer caught: a small window must not be
+        # handed a target larger than it can hold.
+        for cl in (2048, 4096, 6000, 7000, 8192, 12000):
+            budget = resolve_input_budget(-1, context_length=cl)
+            assert budget <= cl, f"ctx={cl}: budget {budget} exceeds window"
+
+    def test_auto_tiny_window_collapses_to_window(self):
+        # Below the floor, auto matches the legacy min(context_length, floor).
+        assert resolve_input_budget(-1, context_length=4096) == 4096
+        assert resolve_input_budget(-1, context_length=2048) == 2048
+
+    def test_auto_floor_applies_only_when_it_fits(self):
+        # 6000-token window: 0.75*6000=4500 < floor, and floor fits → floor.
+        assert resolve_input_budget(-1, context_length=6000) == AUTO_BUDGET_FLOOR
+        # 7000-token window: scaled 5250 < floor 6000, floor fits → 6000.
+        assert resolve_input_budget(-1, context_length=7000) == AUTO_BUDGET_FLOOR
 
     def test_auto_unknown_window_falls_back_to_floor(self):
         assert resolve_input_budget(-1, context_length=0) == AUTO_BUDGET_FLOOR
 
     def test_auto_leaves_response_headroom(self):
-        # Auto must never claim the entire window — reserve_tokens stays free.
+        # With a comfortable window the target stays a fraction below it, and
+        # trim_for_context reserves reserve_tokens from there downstream.
         budget = resolve_input_budget(-1, context_length=8192, reserve_tokens=2048)
-        assert budget <= 8192 - 2048 or budget == AUTO_BUDGET_FLOOR
+        assert budget < 8192
+        assert budget == int(8192 * 0.75)
         assert budget < 8192
 
 

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -15,9 +15,11 @@ for mod in [
         sys.modules[mod] = MagicMock()
 
 from src.context_compactor import (
+    AUTO_BUDGET_FLOOR,
     COMPACT_THRESHOLD,
     SELF_SUMMARY_SYSTEM_PROMPT,
     SUMMARY_MAX_TOKENS,
+    resolve_input_budget,
     trim_for_context,
 )
 
@@ -28,6 +30,44 @@ class TestCompactThreshold:
 
     def test_summary_max_tokens(self):
         assert SUMMARY_MAX_TOKENS == 1024
+
+
+class TestResolveInputBudget:
+    """`agent_input_token_budget` semantics: <0 auto, 0 unlimited (handled by
+    the caller), >0 explicit hard cap. Regression cover for #1170 — a flat
+    default must not silently cap long-context models."""
+
+    def test_explicit_cap_is_honored(self):
+        # An explicit positive budget is a hard cap regardless of window size.
+        assert resolve_input_budget(6000, context_length=200000) == 6000
+
+    def test_explicit_cap_bounded_by_small_window(self):
+        # A cap larger than the model window collapses to the window.
+        assert resolve_input_budget(50000, context_length=8000) == 8000
+
+    def test_explicit_cap_with_unknown_window(self):
+        # Unknown window (0) leaves the explicit cap untouched.
+        assert resolve_input_budget(6000, context_length=0) == 6000
+
+    def test_auto_scales_with_large_window(self):
+        # The bug in #1170: a 200k model used to be trimmed to 6000. Auto mode
+        # now scales to a generous fraction of the window instead.
+        budget = resolve_input_budget(-1, context_length=200000)
+        assert budget == int(200000 * 0.75)
+        assert budget > AUTO_BUDGET_FLOOR
+
+    def test_auto_never_below_floor(self):
+        # Small-context models keep at least the historical floor.
+        assert resolve_input_budget(-1, context_length=4096) == AUTO_BUDGET_FLOOR
+
+    def test_auto_unknown_window_falls_back_to_floor(self):
+        assert resolve_input_budget(-1, context_length=0) == AUTO_BUDGET_FLOOR
+
+    def test_auto_leaves_response_headroom(self):
+        # Auto must never claim the entire window — reserve_tokens stays free.
+        budget = resolve_input_budget(-1, context_length=8192, reserve_tokens=2048)
+        assert budget <= 8192 - 2048 or budget == AUTO_BUDGET_FLOOR
+        assert budget < 8192
 
 
 class TestSelfSummaryPrompt:


### PR DESCRIPTION
## What

`agent_input_token_budget` defaulted to a flat `6000` and the agent loop applied it as:

```python
effective_budget = min(context_length or soft_budget, soft_budget)  # soft_budget == 6000
```

Since `soft_budget` is always `6000`, this is `min(context_length, 6000)` → **6000 for any model with a context window ≥ 6000**. The soft context-trim therefore throttled every model to 6000 input tokens: a 200k-window model had its history silently trimmed down to 6000 regardless of how much room it actually had. That's the silent cap reported in #1170.

## Change

Treat `agent_input_token_budget` as a sentinel instead of a flat number:

| value | meaning |
|-------|---------|
| `-1` (new default) | **auto** — scale to the model's context window (75%), reserving response headroom, floored at the historical `6000` |
| `0` | unlimited — no soft trim (unchanged) |
| `>0` | explicit hard cap, still bounded by the context window (unchanged) |

Budget resolution is extracted into `context_compactor.resolve_input_budget()` so the agent loop and the tests share one definition, and it's unit-tested.

**Behavior change:** only fresh/default installs are affected — anyone who set an explicit value keeps it exactly. Small or unknown context windows still resolve to the `6000` floor, so nothing regresses for small local models. Long-context models now use their window instead of being capped.

The `0.75` fraction / `6000` floor live as named constants (`AUTO_BUDGET_FRACTION`, `AUTO_BUDGET_FLOOR`) so they're easy to tune if you'd prefer a different balance.

## Tests

```
python -m pytest tests/test_context_compactor.py tests/test_agent_loop.py -q
# 68 passed
```

Added `TestResolveInputBudget` covering explicit-cap, window-bounding, auto-scaling, floor, unknown-window and response-headroom cases.

Closes #1170
