### PR TITLE
fix(calendar): readable title text on solid event colours (#1141)

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -12,7 +12,7 @@ import {
   WEEKDAYS, MONTHS, MON_SHORT,
   CAL_PALETTE, CAL_COLORS, _CAL_CUSTOM_GRADIENT, _TYPE_PALETTE,
   _trashIcon, _moreIcon, _bellIcon,
-  _isCalBgImage, _calBgImageUrl, _calBgCss,
+  _isCalBgImage, _calBgImageUrl, _calBgCss, _calTextColor,
   _ds, _addDays, _shiftDT, _tzOffset, _localDateOf,
 } from './calendar/utils.js';
 
@@ -975,7 +975,9 @@ async function _renderMonth() {
       const startColInt = Math.round(startCol);
       const endColInt = Math.round(endCol);
       const span = endColInt - startColInt + 1;
-      h += `<div class="cal-multiday" style="--col:${startColInt};--span:${span};--slot:${barSlot};background:${_calColor(md)}" draggable="true" data-uid="${_e(md.uid)}" title="${_e(md.summary)}">${_e(md.summary)}</div>`;
+      const _mdBg = _calColor(md);
+      const _mdTxt = _calTextColor(_mdBg);
+      h += `<div class="cal-multiday" style="--col:${startColInt};--span:${span};--slot:${barSlot};background:${_mdBg}${_mdTxt ? `;color:${_mdTxt}` : ''}" draggable="true" data-uid="${_e(md.uid)}" title="${_e(md.summary)}">${_e(md.summary)}</div>`;
       barSlot++;
     }
     h += '</div>';
@@ -1141,7 +1143,9 @@ async function _renderWeek() {
     // All-day strip
     colsHtml += `<div class="cal-wk-allday">`;
     for (const ev of allDayEvents) {
-      colsHtml += `<div class="cal-wk-allday-event" data-uid="${_e(ev.uid)}" style="background:${_calColor(ev)};" title="${_e(ev.summary)}">${_e(ev.summary)}</div>`;
+      const _adBg = _calColor(ev);
+      const _adTxt = _calTextColor(_adBg);
+      colsHtml += `<div class="cal-wk-allday-event" data-uid="${_e(ev.uid)}" style="background:${_adBg};${_adTxt ? `color:${_adTxt};` : ''}" title="${_e(ev.summary)}">${_e(ev.summary)}</div>`;
     }
     colsHtml += `</div>`;
     // Hour-grid body

--- a/static/js/calendar/utils.js
+++ b/static/js/calendar/utils.js
@@ -74,6 +74,34 @@ export function _calBgCss(c, fallback) {
   return c || fallback || 'var(--accent)';
 }
 
+// Pick a readable text colour (near-black / near-white) for a label painted
+// directly on a solid event-colour background — multi-day bars and the week
+// all-day strip do this. The event palette (CAL_COLORS) is deliberately pale,
+// so a fixed `#fff`/`var(--fg)` left titles unreadable on light tints.
+// Returns '' for non-hex colours (CSS vars, `bg:` image sentinels, named
+// colours) so the stylesheet's default colour applies unchanged.
+export function _calTextColor(color) {
+  if (typeof color !== 'string') return '';
+  let hex = color.trim();
+  if (hex[0] !== '#') return '';                 // var(--accent), bg:…, named
+  hex = hex.slice(1);
+  if (hex.length === 3) hex = hex.split('').map((c) => c + c).join('');
+  if (hex.length === 8) hex = hex.slice(0, 6);   // ignore alpha channel
+  if (hex.length !== 6 || /[^0-9a-f]/i.test(hex)) return '';
+  const lin = (v) => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  const L = 0.2126 * lin(parseInt(hex.slice(0, 2), 16))
+          + 0.7152 * lin(parseInt(hex.slice(2, 4), 16))
+          + 0.0722 * lin(parseInt(hex.slice(4, 6), 16));
+  // 0.179 is the W3C cross-over luminance where black and white text yield
+  // equal contrast against the background. Using pure black/white (rather than
+  // a near-black) guarantees >= 4.58:1 — clearing WCAG AA — for every colour,
+  // including mid-tones where a softened text colour would dip below 4.5:1.
+  return L > 0.179 ? '#000' : '#fff';
+}
+
 // ── date helpers ──
 
 // `YYYY-MM-DD` string from a Date.

--- a/tests/test_calendar_contrast.py
+++ b/tests/test_calendar_contrast.py
@@ -1,0 +1,106 @@
+"""Pin the calendar's text-contrast helper (#1141). Multi-day bars and the
+week all-day strip paint the title directly on the solid event colour; the
+event palette is deliberately pale, so a fixed `#fff`/`var(--fg)` left titles
+unreadable. `_calTextColor` must pick a text colour that clears WCAG AA
+(>= 4.5:1) against any solid event colour.
+
+Driven through `node --input-type=module` so we exercise the real JS, mirroring
+tests/test_compare_js.py. Skips if `node` isn't installed.
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HAS_NODE = shutil.which("node") is not None
+
+
+@pytest.fixture(scope="module")
+def node_available():
+    if not _HAS_NODE:
+        pytest.skip("node binary not on PATH")
+
+
+def _run_node(script: str) -> dict:
+    res = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO,
+        capture_output=True,
+        timeout=15,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise AssertionError(f"node failed:\n{res.stderr}")
+    out_lines = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    if not out_lines:
+        raise AssertionError("node produced no stdout")
+    return json.loads(out_lines[-1])
+
+
+# The full set of solid colours an event title can be painted on: the pale
+# CAL_COLORS swatches plus the CAL_PALETTE hex entries.
+_EVENT_COLORS = [
+    "#f0b5ba", "#e8ccb2", "#f2dfbd", "#cce0bc", "#b0d7f7",
+    "#e2bcee", "#abdbe0", "#f0b5cc",                          # CAL_COLORS (pale)
+    "#5b8abf", "#bf6b5b", "#5bbf7a", "#bf9a5b", "#9a5bbf",
+    "#5bbfb8", "#bf8a5b", "#7070c0", "#bf5b8a",               # CAL_PALETTE
+]
+
+
+def test_text_color_clears_wcag_aa_on_every_event_color(node_available):
+    """The chosen text colour must reach >= 4.5:1 contrast on each swatch."""
+    colors_json = json.dumps(_EVENT_COLORS)
+    script = textwrap.dedent(f"""
+        const {{ _calTextColor }} = await import('./static/js/calendar/utils.js');
+        const lin = (v) => {{ v /= 255; return v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055, 2.4); }};
+        const lum = (hex) => {{
+          let h = hex.slice(1);
+          if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+          return 0.2126*lin(parseInt(h.slice(0,2),16)) + 0.7152*lin(parseInt(h.slice(2,4),16)) + 0.0722*lin(parseInt(h.slice(4,6),16));
+        }};
+        const ratio = (a, b) => {{ const la = lum(a), lb = lum(b); const hi = Math.max(la, lb), lo = Math.min(la, lb); return (hi + 0.05) / (lo + 0.05); }};
+        const out = {{}};
+        for (const c of {colors_json}) {{
+          const txt = _calTextColor(c);
+          out[c] = {{ txt, ratio: ratio(txt, c) }};
+        }}
+        console.log(JSON.stringify(out));
+    """)
+    out = _run_node(script)
+    for color, r in out.items():
+        assert r["txt"] in ("#000", "#fff"), f"{color} -> {r['txt']}"
+        assert r["ratio"] >= 4.5, f"{color}: contrast {r['ratio']:.2f} < 4.5 (text {r['txt']})"
+
+
+def test_pale_swatches_get_dark_text(node_available):
+    """Sanity check on the reported case: pale tints must take dark text."""
+    script = textwrap.dedent("""
+        const { _calTextColor } = await import('./static/js/calendar/utils.js');
+        console.log(JSON.stringify(['#f2dfbd', '#abdbe0', '#f0b5cc'].map(_calTextColor)));
+    """)
+    assert _run_node(script) == ["#000", "#000", "#000"]
+
+
+def test_non_hex_colors_defer_to_css(node_available):
+    """CSS vars, bg-image sentinels and junk return '' so the stylesheet wins."""
+    script = textwrap.dedent("""
+        const { _calTextColor } = await import('./static/js/calendar/utils.js');
+        const cases = ['var(--accent)', 'bg:http://x/y.png', '', 'tomato', null, undefined];
+        console.log(JSON.stringify(cases.map(_calTextColor)));
+    """)
+    assert _run_node(script) == ["", "", "", "", "", ""]
+
+
+def test_shorthand_and_alpha_hex_supported(node_available):
+    """3-digit shorthand and 8-digit (alpha) hex still resolve to a colour."""
+    script = textwrap.dedent("""
+        const { _calTextColor } = await import('./static/js/calendar/utils.js');
+        console.log(JSON.stringify({ white3: _calTextColor('#fff'), black3: _calTextColor('#000'), alpha: _calTextColor('#0b0b0bff') }));
+    """)
+    out = _run_node(script)
+    assert out == {"white3": "#000", "black3": "#fff", "alpha": "#fff"}


### PR DESCRIPTION
## What

Multi-day event bars and the week **all-day strip** render the event title directly on top of the solid event colour, with a fixed text colour:

- `.cal-multiday` → `color: #fff`
- `.cal-wk-allday-event` → `color: var(--fg)`

But the event palette (`CAL_COLORS` in `static/js/calendar/utils.js`) is *deliberately* pale — `#f2dfbd` (yellow), `#abdbe0` (teal), `#f0b5cc` (pink), etc. White text on those pale bars is unreadable (contrast ~1.1:1), and `var(--fg)` fails the same way in dark themes. That's the unreadable-title report in #1141.

## Change

Add `_calTextColor(color)`: derive a black/white title colour from the background's WCAG **relative luminance**, switching at the W3C `0.179` cross-over. Using pure black/white guarantees **≥ 4.58:1** contrast (clears WCAG AA) for *every* event colour, including mid-tones where a softened near-black would dip below 4.5:1.

- Pure hex (incl. `#rgb` shorthand and `#rrggbbaa`) → resolves to `#000` / `#fff`.
- Non-hex (`var(--accent)`, `bg:` image sentinels, named colours, junk) → returns `''`, so the stylesheet default is left exactly as-is.

Applied at the two solid-bar render sites in `calendar.js`; nothing else changes. The soft-tinted month/agenda items (`color-mix(... 18%, var(--bg))`) were already readable and are untouched.

## Tests

`tests/test_calendar_contrast.py` drives the real helper through `node --input-type=module` (mirroring `tests/test_compare_js.py`; skips if node is absent) and asserts the chosen text colour clears **≥ 4.5:1** against every `CAL_COLORS` + `CAL_PALETTE` swatch, plus shorthand/alpha parsing and the non-hex passthrough.

```
python -m pytest tests/test_calendar_contrast.py -q
# 4 passed
```

Closes #1141
