### PR TITLE
Stop email composer divider bleeding across modals

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -14577,6 +14577,7 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
     z-index: 260 !important;
     margin-top: 0 !important;
     transform: none !important;
+    border-left: none !important;
   }
 }
 

--- a/tests/test_email_split_border_css.py
+++ b/tests/test_email_split_border_css.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+CSS = (Path(__file__).parents[1] / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _rule(selector: str) -> str:
+    return CSS.split(selector, 1)[1].split("}", 1)[0]
+
+
+def test_email_split_document_pane_drops_duplicate_border():
+    rule = _rule("body.email-doc-split-active.doc-view .doc-editor-pane {")
+    assert "border-left: none !important;" in rule
+
+
+def test_email_split_panel_keeps_visible_seam():
+    rule = _rule(".modal.email-snap-left .modal-content {")
+    assert "border-right: 1px solid var(--border);" in rule


### PR DESCRIPTION
Fixes #1066.

The split composer was hiding the draggable divider, but the document pane still kept its own left border. Since that pane sits above the rest of the UI, the border showed through Settings and the Tools menu.

The email panel already draws the split line on its right edge, so this drops the duplicate border only while the desktop email split layout is active.

Checked:
- `venv/bin/python -m pytest -q tests/test_email_split_border_css.py`
- `git diff --check`
