### PR TITLE
Fix/clear active doc on close

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -593,6 +593,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             if req.session_id is not None:
                 # Empty string = unlink from session
                 doc.session_id = req.session_id if req.session_id else None
+                if not doc.session_id:
+                    from src.tool_implementations import get_active_document, set_active_document
+                    if get_active_document() == doc_id:
+                        set_active_document(None)
             db.commit()
             db.refresh(doc)
             return _doc_to_dict(doc)
@@ -616,6 +620,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             _verify_doc_owner(db, doc, user)
             doc.is_active = False
             db.commit()
+            from src.tool_implementations import get_active_document, set_active_document
+            if get_active_document() == doc_id:
+                set_active_document(None)
             return {"status": "deleted", "id": doc_id}
         except HTTPException:
             raise

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""src package"""

--- a/tests/js_test_helpers.py
+++ b/tests/js_test_helpers.py
@@ -1,0 +1,26 @@
+import subprocess
+from pathlib import Path
+
+def run_node_script(
+    args: list,
+    input_str: str = None,
+    cwd: Path = None,
+    timeout: int = 30
+) -> subprocess.CompletedProcess:
+    """Run node with specified arguments and input using UTF-8 encoding.
+    
+    Prevents encoding crashes on Windows and centralizes stderr verification.
+    """
+    cmd = ["node"] + args
+    res = subprocess.run(
+        cmd,
+        input=input_str,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=timeout
+    )
+    if res.returncode != 0:
+        raise AssertionError(f"node failed:\nSTDERR:\n{res.stderr}\nSTDOUT:\n{res.stdout}")
+    return res

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,22 +4,32 @@ and _append_tool_results. Uses mock imports to avoid loading the full app stack.
 import sys
 from unittest.mock import MagicMock
 
-# Mock heavy dependencies before importing
-for mod in [
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
     'src.database',
     'src.agent_tools',
     'core.models', 'core.database',
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+# Mock heavy dependencies before importing
+for name in _mods_to_stub:
+    sys.modules[name] = MagicMock()
 
 from src.agent_loop import (
     _detect_admin_intent,
     _compute_final_metrics,
     _append_tool_results,
 )
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_event_loop.py
+++ b/tests/test_auth_event_loop.py
@@ -64,10 +64,21 @@ def _ensure_stub(name: str, **attrs):
     return mod
 
 
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = ["core.database", "core.auth"]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
 _ensure_stub("core.database", SessionLocal=MagicMock())
 _ensure_stub("core.auth", AuthManager=MagicMock())
 
 from routes.auth_routes import setup_auth_routes, LoginRequest
+
+# Restore original modules immediately after importing
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 def _login_endpoint(auth_manager):

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -66,6 +66,10 @@ def _ensure_stub(name: str, **attrs):
         setattr(parent, child_name, mod)
     return mod
 
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = ["core.database", "core.auth", "src.endpoint_resolver"]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
 _ensure_stub("core.database",
     SessionLocal=MagicMock(), ScheduledTask=MagicMock(), TaskRun=MagicMock(),
     ModelEndpoint=MagicMock(), Session=MagicMock(), ChatMessage=MagicMock(),
@@ -82,7 +86,18 @@ _ensure_stub("src.endpoint_resolver",
     build_headers=MagicMock(),
 )
 
+# Import route/scheduler modules at the top level while stubs are active
+import routes.research_routes
+import routes.task_routes
+import src.task_scheduler
 from fastapi import HTTPException
+
+# Restore original modules immediately
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 # ---------------------------------------------------------------------------
 # Auth routes -- open signup setter
@@ -161,6 +176,7 @@ def test_set_signup_enabled_requires_admin():
 
     assert exc.value.status_code == 403
     assert auth.signup_enabled is False
+
 
 # ---------------------------------------------------------------------------
 # Research endpoints — `_require_user` rejects anonymous
@@ -287,7 +303,7 @@ def test_research_spinoff_rejects_wrong_owner():
 # pop_notifications owner filter
 # ---------------------------------------------------------------------------
 
-def test_pop_notifications_owner_filtered():
+def test_pop_notifications_owner_filtered(monkeypatch):
     """pop_notifications(owner='alice') must return only alice's items.
     bob's and legacy ownerless items stay behind in the queue."""
     # Build a minimal scheduler instance that we can hit directly.
@@ -298,9 +314,8 @@ def test_pop_notifications_owner_filtered():
     # `task_scheduler` pulls in lots of helpers — stub the ones it uses.
     for s in ["src.builtin_actions", "src.ai_interaction", "src.endpoint_resolver",
               "src.agent_loop", "src.session_manager"]:
-        if s not in sys.modules:
-            mod = types.ModuleType(s)
-            sys.modules[s] = mod
+        mod = types.ModuleType(s)
+        monkeypatch.setitem(sys.modules, s, mod)
     from src.task_scheduler import TaskScheduler
     sch = TaskScheduler.__new__(TaskScheduler)  # bypass __init__ network etc.
     sch._pending_notifications = []

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -44,6 +44,10 @@ class _DBStub(types.ModuleType):
         return MagicMock()
 
 
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = ["core.database", "core.auth", "src.endpoint_resolver"]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
 _db = _DBStub("core.database")
 _db.get_db_session = _get_db_session
 _db.ApiToken = _ApiToken
@@ -53,11 +57,10 @@ for _name, _attrs in {
     "core.auth": {"AuthManager": MagicMock()},
     "src.endpoint_resolver": {"build_chat_url": (lambda u: u)},
 }.items():
-    if _name not in sys.modules:
-        _mm = types.ModuleType(_name)
-        for _k, _v in _attrs.items():
-            setattr(_mm, _k, _v)
-        sys.modules[_name] = _mm
+    _mm = types.ModuleType(_name)
+    for _k, _v in _attrs.items():
+        setattr(_mm, _k, _v)
+    sys.modules[_name] = _mm
 
 from fastapi import HTTPException  # noqa: E402
 
@@ -66,10 +69,18 @@ import companion.routes as companion_routes  # noqa: E402
 from companion.routes import mint_pairing_token, setup_companion_routes  # noqa: E402
 from core.middleware import require_admin  # noqa: E402
 
+# Restore original modules immediately after importing
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
+
 
 # --- token minting: shown once, hashed at rest -----------------------------
 
-def test_mint_token_returns_raw_once_and_stores_only_a_hash():
+def test_mint_token_returns_raw_once_and_stores_only_a_hash(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", _db)
     token_id, raw = P.mint_token("alice")
     assert raw.startswith("ody_")
     # The persisted row stores a bcrypt hash + prefix, never the plaintext.

--- a/tests/test_companion_readonly.py
+++ b/tests/test_companion_readonly.py
@@ -19,14 +19,24 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # blows up under conftest's sqlalchemy MagicMock stubs. companion.routes only
 # imports it lazily inside the /models handler, but stub it defensively so the
 # import is robust regardless of collection order.
-if "core.database" not in sys.modules:
-    _db = types.ModuleType("core.database")
-    _db.SessionLocal = MagicMock()
-    _db.ModelEndpoint = MagicMock()
-    sys.modules["core.database"] = _db
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = ["core.database"]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+_db = types.ModuleType("core.database")
+_db.SessionLocal = MagicMock()
+_db.ModelEndpoint = MagicMock()
+sys.modules["core.database"] = _db
 
 import companion.routes as companion_routes
 from companion.routes import setup_companion_routes, token_owner, owner_can_see
+
+# Restore original modules immediately after importing
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 def _request(**state):
@@ -124,6 +134,7 @@ def _models_route():
 
 def _call_models_route(monkeypatch, rows, request):
     db = _DB(rows)
+    monkeypatch.setitem(sys.modules, "core.database", _db)
     db_mod = sys.modules["core.database"]
     monkeypatch.setattr(db_mod, "SessionLocal", lambda: db)
     monkeypatch.setattr(db_mod, "ModelEndpoint", _ModelEndpoint)
@@ -131,7 +142,7 @@ def _call_models_route(monkeypatch, rows, request):
     endpoint_mod = sys.modules.get("src.endpoint_resolver")
     if endpoint_mod is None:
         endpoint_mod = types.ModuleType("src.endpoint_resolver")
-        sys.modules["src.endpoint_resolver"] = endpoint_mod
+        monkeypatch.setitem(sys.modules, "src.endpoint_resolver", endpoint_mod)
     monkeypatch.setattr(
         endpoint_mod,
         "build_chat_url",

--- a/tests/test_compare_js.py
+++ b/tests/test_compare_js.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_test_helpers import run_node_script
+
 _REPO = Path(__file__).resolve().parent.parent
 _HAS_NODE = shutil.which("node") is not None
 
@@ -31,15 +33,11 @@ def node_available():
 def _run_node(script: str) -> dict:
     """Run a JS snippet under node --input-type=module. Returns parsed
     JSON from the last `console.log` line."""
-    res = subprocess.run(
-        ["node", "--input-type=module", "-e", script],
+    res = run_node_script(
+        ["--input-type=module", "-e", script],
         cwd=_REPO,
-        capture_output=True,
         timeout=15,
-        text=True,
     )
-    if res.returncode != 0:
-        raise AssertionError(f"node failed:\n{res.stderr}")
     out_lines = [ln for ln in res.stdout.splitlines() if ln.strip()]
     if not out_lines:
         raise AssertionError("node produced no stdout")

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -4,15 +4,18 @@ Uses mock imports to avoid loading the full app stack."""
 import sys
 from unittest.mock import MagicMock
 
-# Mock heavy dependencies before importing
-for mod in [
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
     'src.database',
     'core.models', 'core.database',
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+# Mock heavy dependencies before importing
+for name in _mods_to_stub:
+    sys.modules[name] = MagicMock()
 
 from src.context_compactor import (
     COMPACT_THRESHOLD,
@@ -20,6 +23,13 @@ from src.context_compactor import (
     SUMMARY_MAX_TOKENS,
     trim_for_context,
 )
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 class TestCompactThreshold:

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 
@@ -72,16 +73,18 @@ def test_validate_serve_model_id_accepts_cached_local_model_names():
         _validate_serve_model_id("../escape")
 
 
-def test_local_tooling_path_export_prepends_interpreter_bin():
+def test_local_tooling_path_export_prepends_interpreter_bin(monkeypatch):
     """The cookbook runners must see the venv's bin (where `hf`/`python` live)
     so tmux shells can find them without an activated venv."""
+    monkeypatch.setattr(os.path, "abspath", lambda p: p)
     assert (
         _local_tooling_path_export("/opt/venv/bin/python")
         == 'export PATH="/opt/venv/bin:$PATH"'
     )
 
 
-def test_local_tooling_path_export_preserves_spaces_and_expands_path():
+def test_local_tooling_path_export_preserves_spaces_and_expands_path(monkeypatch):
+    monkeypatch.setattr(os.path, "abspath", lambda p: p)
     line = _local_tooling_path_export("/Users/John Smith/.venv/bin/python3")
     assert line == 'export PATH="/Users/John Smith/.venv/bin:$PATH"'
     assert line.endswith(':$PATH"')  # $PATH stays expandable in double quotes

--- a/tests/test_document_close_active_clear.py
+++ b/tests/test_document_close_active_clear.py
@@ -1,0 +1,144 @@
+import sys
+import types
+from unittest.mock import MagicMock
+import pytest
+from fastapi import HTTPException
+from types import SimpleNamespace
+
+@pytest.fixture
+def doc_routes_mod(monkeypatch):
+    class _DBStub(types.ModuleType):
+        def __getattr__(self, name):
+            return MagicMock()
+
+    db_stub = _DBStub("core.database")
+    monkeypatch.setitem(sys.modules, "core.database", db_stub)
+
+    monkeypatch.delitem(sys.modules, "routes.document_routes", raising=False)
+    import routes.document_routes as mod
+    return mod
+
+class _FakeDocument:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.committed = False
+        self.refreshed = False
+
+class _FakeDb:
+    def __init__(self, doc):
+        self.doc = doc
+        self.committed = False
+        self.refreshed = False
+
+    def query(self, model):
+        self.model = model
+        return self
+
+    def filter(self, *clauses):
+        self.clauses = clauses
+        return self
+
+    def first(self):
+        return self.doc
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, obj):
+        self.refreshed = True
+
+    def close(self):
+        pass
+
+def test_patch_document_clears_active_id_on_unlink(monkeypatch, doc_routes_mod):
+    mod = doc_routes_mod
+    doc = _FakeDocument(id="doc-123", session_id="session-456", title="Test Doc", language="python", is_active=True, owner="alice", current_content="hello", version_count=1, created_at=None, updated_at=None)
+
+    fake_db = _FakeDb(doc)
+    monkeypatch.setattr(mod, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(mod, "get_current_user", lambda req: "alice")
+    monkeypatch.setattr(mod, "_verify_doc_owner", lambda db, d, user: None)
+    monkeypatch.setattr(mod, "_doc_to_dict", lambda d: {"id": d.id, "session_id": d.session_id})
+
+    from src.tool_implementations import set_active_document, get_active_document
+    set_active_document("doc-123")
+    assert get_active_document() == "doc-123"
+
+    router = mod.setup_document_routes(MagicMock())
+    patch_handler = None
+    for route in router.routes:
+        if route.path == "/api/document/{doc_id}" and "PATCH" in route.methods:
+            patch_handler = route.endpoint
+            break
+
+    assert patch_handler is not None
+
+    from routes.document_helpers import DocumentPatch
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(auth_manager=None)))
+    
+    # We run the async function using standard asyncio since the handler is async
+    import asyncio
+    asyncio.run(patch_handler(request=req, doc_id="doc-123", req=DocumentPatch(session_id="")))
+
+    assert get_active_document() is None
+    assert doc.session_id is None
+
+def test_patch_document_does_not_clear_active_id_on_metadata_only_patch(monkeypatch, doc_routes_mod):
+    mod = doc_routes_mod
+    doc = _FakeDocument(id="doc-123", session_id="session-456", title="Test Doc", language="python", is_active=True, owner="alice", current_content="hello", version_count=1, created_at=None, updated_at=None)
+
+    fake_db = _FakeDb(doc)
+    monkeypatch.setattr(mod, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(mod, "get_current_user", lambda req: "alice")
+    monkeypatch.setattr(mod, "_verify_doc_owner", lambda db, d, user: None)
+    monkeypatch.setattr(mod, "_doc_to_dict", lambda d: {"id": d.id, "session_id": d.session_id})
+
+    from src.tool_implementations import set_active_document, get_active_document
+    set_active_document("doc-123")
+    assert get_active_document() == "doc-123"
+
+    router = mod.setup_document_routes(MagicMock())
+    patch_handler = None
+    for route in router.routes:
+        if route.path == "/api/document/{doc_id}" and "PATCH" in route.methods:
+            patch_handler = route.endpoint
+            break
+
+    from routes.document_helpers import DocumentPatch
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(auth_manager=None)))
+    
+    import asyncio
+    asyncio.run(patch_handler(request=req, doc_id="doc-123", req=DocumentPatch(title="New Title")))
+
+    assert get_active_document() == "doc-123"
+    assert doc.title == "New Title"
+
+def test_delete_document_clears_active_id(monkeypatch, doc_routes_mod):
+    mod = doc_routes_mod
+    doc = _FakeDocument(id="doc-123", session_id="session-456", title="Test Doc", language="python", is_active=True, owner="alice", current_content="hello", version_count=1, created_at=None, updated_at=None)
+
+    fake_db = _FakeDb(doc)
+    monkeypatch.setattr(mod, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(mod, "get_current_user", lambda req: "alice")
+    monkeypatch.setattr(mod, "_verify_doc_owner", lambda db, d, user: None)
+
+    from src.tool_implementations import set_active_document, get_active_document
+    set_active_document("doc-123")
+    assert get_active_document() == "doc-123"
+
+    router = mod.setup_document_routes(MagicMock())
+    delete_handler = None
+    for route in router.routes:
+        if route.path == "/api/document/{doc_id}" and "DELETE" in route.methods:
+            delete_handler = route.endpoint
+            break
+
+    assert delete_handler is not None
+
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(auth_manager=None)))
+    
+    import asyncio
+    asyncio.run(delete_handler(request=req, doc_id="doc-123"))
+
+    assert get_active_document() is None
+    assert doc.is_active is False

--- a/tests/test_hwfit_macos.py
+++ b/tests/test_hwfit_macos.py
@@ -129,6 +129,7 @@ def test_intel_mac_skipped(monkeypatch):
 def test_detect_system_propagates_unified_memory(monkeypatch):
     """The unified_memory flag set by GPU detection must survive into the
     system dict so the API and UI can report it (it was being dropped)."""
+    monkeypatch.setattr(hardware, "_detect_windows", lambda: None)
     monkeypatch.setattr(hardware, "_detect_apple_silicon", lambda: {
         "gpu_name": "Apple M4", "gpu_vram_gb": 10.7, "gpu_count": 1,
         "gpus": [], "gpu_groups": [], "homogeneous": True,

--- a/tests/test_keybind_altgr_js.py
+++ b/tests/test_keybind_altgr_js.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_test_helpers import run_node_script
+
 _REPO = Path(__file__).resolve().parent.parent
 _HELPER = _REPO / "static" / "js" / "keyboard-shortcuts.js"
 _PLATFORM = _REPO / "static" / "js" / "platform.js"
@@ -41,11 +43,10 @@ pytestmark = pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
 
 
 def _run(js: str) -> str:
-    proc = subprocess.run(
-        ["node", "--input-type=module"],
-        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    proc = run_node_script(
+        ["--input-type=module"],
+        input_str=js, cwd=_REPO, timeout=30,
     )
-    assert proc.returncode == 0, proc.stderr
     return proc.stdout.strip()
 
 

--- a/tests/test_llm_core_sanitize_tool_calls.py
+++ b/tests/test_llm_core_sanitize_tool_calls.py
@@ -19,17 +19,27 @@ This test drives the real producer (_append_tool_results) into the sanitizer.
 import sys
 from unittest.mock import MagicMock
 
-# Mock heavy dependencies before importing (mirrors tests/test_agent_loop.py).
-for mod in [
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
     'src.database', 'src.agent_tools', 'core.models', 'core.database',
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+# Mock heavy dependencies before importing (mirrors tests/test_agent_loop.py).
+for name in _mods_to_stub:
+    sys.modules[name] = MagicMock()
 
 from src.agent_loop import _append_tool_results
 from src.llm_core import _sanitize_llm_messages
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 def test_sanitize_keeps_no_prose_assistant_tool_call_message():

--- a/tests/test_local_endpoint_js.py
+++ b/tests/test_local_endpoint_js.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_test_helpers import run_node_script
+
 _REPO = Path(__file__).resolve().parent.parent
 _SRC = _REPO / "static" / "js" / "chatRenderer.js"
 _HAS_NODE = shutil.which("node") is not None
@@ -29,11 +31,10 @@ def _is_local(url: str) -> bool:
     assert m, "isLocalEndpoint not found in chatRenderer.js"
     fn = m.group(0).replace("export function", "function", 1)
     js = fn + f"\nconsole.log(JSON.stringify(isLocalEndpoint({json.dumps(url)})));"
-    proc = subprocess.run(
-        ["node", "--input-type=module"],
-        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    proc = run_node_script(
+        ["--input-type=module"],
+        input_str=js, cwd=_REPO, timeout=30,
     )
-    assert proc.returncode == 0, proc.stderr
     return json.loads(proc.stdout.strip())
 
 

--- a/tests/test_markdown_rendering_js.py
+++ b/tests/test_markdown_rendering_js.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_test_helpers import run_node_script
+
 _REPO = Path(__file__).resolve().parent.parent
 _HAS_NODE = shutil.which("node") is not None
 
@@ -30,7 +32,7 @@ def _run_markdown_case(markdown: str) -> str:
         };
         globalThis.MutationObserver = class { observe() {} };
 
-        let source = fs.readFileSync('./static/js/markdown.js', 'utf8');
+        let source = fs.readFileSync('./static/js/markdown.js', 'utf8').replace(/\\r\\n/g, '\\n');
         source = source.replace(
           "import uiModule from './ui.js';\\n\\nvar escapeHtml = uiModule.esc;",
           `var escapeHtml = (value) => String(value ?? '')
@@ -47,15 +49,11 @@ def _run_markdown_case(markdown: str) -> str:
         console.log(JSON.stringify({ html: mod.mdToHtml(input) }));
         """
     )
-    result = subprocess.run(
-        ["node", "--input-type=module", "-e", script, json.dumps(markdown)],
+    result = run_node_script(
+        ["--input-type=module", "-e", script, json.dumps(markdown)],
         cwd=_REPO,
-        capture_output=True,
         timeout=15,
-        text=True,
     )
-    if result.returncode != 0:
-        raise AssertionError(f"node failed:\nSTDERR:\n{result.stderr}\nSTDOUT:\n{result.stdout}")
     return json.loads(result.stdout.splitlines()[-1])["html"]
 
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -13,25 +13,33 @@ if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__"
     sys.modules.pop("src.endpoint_resolver", None)
     sys.modules.pop("routes.model_routes", None)
 
-if "core.database" not in sys.modules:
-    _core_db = types.ModuleType("core.database")
-    for _name in [
-        "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
-        "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
-        "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun",
-        "McpServer",
-    ]:
-        setattr(_core_db, _name, MagicMock())
-    sys.modules["core.database"] = _core_db
+_orig_core_db = sys.modules.get("core.database")
+
+_core_db = types.ModuleType("core.database")
+for _name in [
+    "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
+    "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
+    "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun",
+    "McpServer",
+]:
+    setattr(_core_db, _name, MagicMock())
+sys.modules["core.database"] = _core_db
 
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
+
+# Clean up import side-effects to avoid polluting subsequent tests
+if _orig_core_db is not None:
+    sys.modules["core.database"] = _orig_core_db
+else:
+    sys.modules.pop("core.database", None)
 from routes.model_routes import (
     _match_provider_curated,
     _curate_models,
     _is_chat_model,
     _classify_endpoint,
     _probe_endpoint,
+    _ping_endpoint,
     _truthy,
     _PROVIDER_CURATED,
 )
@@ -297,6 +305,7 @@ class TestSetupProbeSafety:
 
         assert _probe_endpoint("https://api.anthropic.com/v1") == ANTHROPIC_MODELS
 
+
 def test_ollama_endpoint_error_message_includes_troubleshooting():
     msg = model_routes._model_endpoint_error_message(
         "http://localhost:11434/v1",
@@ -370,3 +379,107 @@ class TestDockerHostGatewayReachable:
 
         monkeypatch.setattr(model_routes.socket, "getaddrinfo", _fail)
         assert model_routes._docker_host_gateway_reachable() is False
+
+
+# ── _ping_endpoint ──
+
+class TestPingEndpoint:
+    def test_ping_success(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+
+        def fake_get(url, headers=None, timeout=None):
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, request=req)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://my-model-host/v1")
+        assert res["reachable"] is True
+        assert res["status_code"] == 200
+        assert res["error"] is None
+
+    def test_ping_failure_status(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+
+        def fake_get(url, headers=None, timeout=None):
+            req = httpx.Request("GET", url)
+            return httpx.Response(404, request=req)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://my-model-host/v1")
+        assert res["reachable"] is False
+        assert res["status_code"] == 404
+        assert res["error"] == "HTTP 404"
+
+    def test_ping_self_odysseus_redirect(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+
+        def fake_get(url, headers=None, timeout=None):
+            req = httpx.Request("GET", url)
+            return httpx.Response(302, headers={"location": "/login"}, request=req)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://my-model-host/v1")
+        assert res["reachable"] is False
+        assert res["status_code"] == 302
+        assert "Odysseus, not a model server" in res["error"]
+
+    def test_ping_general_redirect(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+
+        def fake_get(url, headers=None, timeout=None):
+            req = httpx.Request("GET", url)
+            return httpx.Response(301, headers={"location": "http://other-place"}, request=req)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://my-model-host/v1")
+        assert res["reachable"] is False
+        assert res["status_code"] == 301
+        assert "HTTP 301 redirect" in res["error"]
+
+    def test_ping_ollama_fallback_success(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+        calls = []
+
+        def fake_get(url, headers=None, timeout=None):
+            calls.append(url)
+            req = httpx.Request("GET", url)
+            if "/models" in url:
+                raise httpx.ConnectError("Connection refused")
+            if "/api/version" in url:
+                return httpx.Response(200, json={"version": "0.1.48"}, request=req)
+            return httpx.Response(404, request=req)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://localhost:11434/v1")
+        assert res["reachable"] is True
+        assert res["status_code"] == 200
+        assert res["error"] is None
+        assert "http://localhost:11434/api/version" in calls
+
+    def test_ping_ollama_fallback_failure(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+        calls = []
+
+        def fake_get(url, headers=None, timeout=None):
+            calls.append(url)
+            if "/models" in url:
+                raise httpx.ConnectError("Connection refused")
+            raise httpx.ConnectError("Host unreachable")
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://ollama-service:11434/v1")
+        assert res["reachable"] is False
+        assert res["status_code"] is None
+        assert "Host unreachable" in res["error"]
+
+    def test_ping_connection_error_no_fallback(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+
+        def fake_get(url, headers=None, timeout=None):
+            raise httpx.ConnectError("Connection timeout")
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+        res = _ping_endpoint("http://some-openai-compatible-host/v1")
+        assert res["reachable"] is False
+        assert res["status_code"] is None
+        assert "Connection timeout" in res["error"]

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -13,6 +13,7 @@ if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__"
     sys.modules.pop("src.endpoint_resolver", None)
     sys.modules.pop("routes.model_routes", None)
 
+
 _orig_core_db = sys.modules.get("core.database")
 
 _core_db = types.ModuleType("core.database")
@@ -28,11 +29,13 @@ sys.modules["core.database"] = _core_db
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
 
-# Clean up import side-effects to avoid polluting subsequent tests
+# Restore core.database state immediately after imports to isolate stubs.
 if _orig_core_db is not None:
     sys.modules["core.database"] = _orig_core_db
 else:
     sys.modules.pop("core.database", None)
+
+
 from routes.model_routes import (
     _match_provider_curated,
     _curate_models,

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -483,3 +483,23 @@ class TestPingEndpoint:
         assert res["reachable"] is False
         assert res["status_code"] is None
         assert "Connection timeout" in res["error"]
+
+def test_ollama_endpoint_error_message_includes_troubleshooting():
+    msg = model_routes._model_endpoint_error_message(
+        "http://localhost:11434/v1",
+        {"error": "Connection refused"},
+    )
+
+    assert "No Ollama models found" in msg
+    assert "Connection refused" in msg
+    assert "http://localhost:11434/v1" in msg
+    assert "ollama list" in msg
+
+
+def test_generic_endpoint_error_message_preserves_probe_error():
+    msg = model_routes._model_endpoint_error_message(
+        "https://api.example.com/v1",
+        {"error": "HTTP 401"},
+    )
+
+    assert msg == "No models found for that provider/key. Last probe error: HTTP 401."

--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -24,34 +24,53 @@ from unittest.mock import MagicMock
 # the conftest's `sqlalchemy.*` MagicMock stubs ("metaclass conflict").
 # Stub also a handful of route modules each of these targeted modules
 # happens to drag in at import-time.
-for _stub in [
-    "core.database",
-    "core.auth",
-    "src.endpoint_resolver",
-]:
-    if _stub not in sys.modules:
-        m = types.ModuleType(_stub)
-        # Provide the names the importers will look up.
-        if _stub == "core.database":
-            m.Base = MagicMock()
-            m.SessionLocal = MagicMock()
-            m.CalendarCal = MagicMock()
-            m.CalendarEvent = MagicMock()
-            m.Document = MagicMock()
-            m.DocumentVersion = MagicMock()
-            m.Session = MagicMock()
-            m.ChatMessage = MagicMock()
-            m.GalleryImage = MagicMock()
-            m.GalleryAlbum = MagicMock()
-            m.Note = MagicMock()
-            m.ScheduledTask = MagicMock()
-            m.TaskRun = MagicMock()
-            m.ModelEndpoint = MagicMock()
-        elif _stub == "core.auth":
-            m.AuthManager = MagicMock()
-        sys.modules[_stub] = m
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = ["core.database", "core.auth", "src.endpoint_resolver", "src.webhook_manager"]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
 
+# Stub them out...
+for _stub in ["core.database", "core.auth", "src.endpoint_resolver"]:
+    m = types.ModuleType(_stub)
+    if _stub == "core.database":
+        m.Base = MagicMock()
+        m.SessionLocal = MagicMock()
+        m.CalendarCal = MagicMock()
+        m.CalendarEvent = MagicMock()
+        m.Document = MagicMock()
+        m.DocumentVersion = MagicMock()
+        m.Session = MagicMock()
+        m.ChatMessage = MagicMock()
+        m.GalleryImage = MagicMock()
+        m.GalleryAlbum = MagicMock()
+        m.Note = MagicMock()
+        m.ScheduledTask = MagicMock()
+        m.TaskRun = MagicMock()
+        m.ModelEndpoint = MagicMock()
+        m.Webhook = MagicMock()
+    elif _stub == "core.auth":
+        m.AuthManager = MagicMock()
+    sys.modules[_stub] = m
+
+# Also stub src.webhook_manager
+wm = types.ModuleType("src.webhook_manager")
+wm.WebhookManager = MagicMock()
+wm.validate_webhook_url = MagicMock()
+wm.validate_events = MagicMock()
+sys.modules["src.webhook_manager"] = wm
+
+# Import route modules at top level under the stubs
+import routes.calendar_routes
+import routes.document_routes
+import routes.gallery_routes
+import routes.webhook_routes
 from fastapi import HTTPException
+
+# Restore original modules immediately
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 # ---------------------------------------------------------------------------
@@ -59,15 +78,7 @@ from fastapi import HTTPException
 # ---------------------------------------------------------------------------
 
 def _import_calendar_helpers():
-    """Import the two private gate helpers without booting the full
-    calendar router. We patch sys.modules so the module-load side
-    effects (DB import) don't blow up under the conftest stubs."""
-    mod_name = "routes.calendar_routes"
-    if mod_name in sys.modules:
-        return sys.modules[mod_name]
-    # core.database is stubbed by conftest already; the module should
-    # import cleanly.
-    return __import__(mod_name, fromlist=["_get_or_404_calendar", "_get_or_404_event"])
+    return routes.calendar_routes
 
 
 def test_calendar_gate_rejects_null_owner_for_authenticated_user():
@@ -179,21 +190,7 @@ def test_gallery_owner_filter_passes_user():
 # calendar/notes/gallery gates above and _verify_session_owner.
 
 def _import_webhook_helper():
-    """Import routes.webhook_routes without dragging in the real webhook
-    manager / database. Stub src.webhook_manager (only referenced by an
-    import line) and ensure core.database exposes the names the import chain
-    (core/__init__ → session_manager) looks up."""
-    for _name in ("Webhook", "ChatMessage"):
-        setattr(sys.modules["core.database"], _name, MagicMock())
-    if "src.webhook_manager" not in sys.modules:
-        wm = types.ModuleType("src.webhook_manager")
-        wm.WebhookManager = MagicMock()
-        wm.validate_webhook_url = MagicMock()
-        wm.validate_events = MagicMock()
-        sys.modules["src.webhook_manager"] = wm
-    return __import__(
-        "routes.webhook_routes", fromlist=["_caller_owns_session"]
-    )
+    return routes.webhook_routes
 
 
 def test_sync_chat_gate_rejects_null_owner_session():

--- a/tests/test_reply_recipients_js.py
+++ b/tests/test_reply_recipients_js.py
@@ -15,17 +15,18 @@ from pathlib import Path
 
 import pytest
 
+from tests.js_test_helpers import run_node_script
+
 _REPO = Path(__file__).resolve().parent.parent
 _HELPER = _REPO / "static" / "js" / "emailLibrary" / "replyRecipients.js"
 _HAS_NODE = shutil.which("node") is not None
 
 
 def _run(js: str) -> str:
-    proc = subprocess.run(
-        ["node", "--input-type=module"],
-        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    proc = run_node_script(
+        ["--input-type=module"],
+        input_str=js, cwd=_REPO, timeout=30,
     )
-    assert proc.returncode == 0, proc.stderr
     return proc.stdout.strip()
 
 
@@ -59,7 +60,7 @@ def test_reply_all_excludes_all_of_my_addresses():
     # not just the active one.
     data = {"to": "Alice <alice@x.com>, me@work.com", "cc": "me@personal.com, bob@x.com"}
     js = f"""
-    import {{ buildReplyAllCc }} from '{_HELPER.as_posix()}';
+    import {{ buildReplyAllCc }} from '{_HELPER.as_uri()}';
     console.log(JSON.stringify(buildReplyAllCc({json.dumps(data)}, ["me@work.com", "me@personal.com"])));
     """
     cc = json.loads(_run(js))

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -80,6 +80,7 @@ def _install_model_route_import_stubs(monkeypatch):
     db_mod.Document = MagicMock()
     db_mod.DocumentVersion = MagicMock()
     db_mod.GalleryImage = MagicMock()
+
     middleware_mod = types.ModuleType("core.middleware")
     middleware_mod.require_admin = lambda request: None
     multipart_mod = types.ModuleType("python_multipart")

--- a/tests/test_session_owner_attribution.py
+++ b/tests/test_session_owner_attribution.py
@@ -18,6 +18,10 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = ["core.database", "core.session_manager", "core.models", "src.request_models"]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
 # routes.session_routes imports several heavy modules at import time that blow up
 # under conftest's sqlalchemy/* MagicMock stubs (declarative classes). Stub them
 # so we can import the module and exercise _verify_session_owner with a mock DB.
@@ -29,16 +33,22 @@ _STUBS = {
     "src.request_models": {"SessionResponse": MagicMock()},
 }
 for _name, _attrs in _STUBS.items():
-    if _name not in sys.modules:
-        _m = types.ModuleType(_name)
-        for _k, _v in _attrs.items():
-            setattr(_m, _k, _v)
-        sys.modules[_name] = _m
+    _m = types.ModuleType(_name)
+    for _k, _v in _attrs.items():
+        setattr(_m, _k, _v)
+    sys.modules[_name] = _m
 
 from fastapi import HTTPException  # noqa: E402
 
 from src.auth_helpers import effective_user  # noqa: E402
 import routes.session_routes as SR  # noqa: E402
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 def _req(**state):

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -254,13 +254,14 @@ class TestPackageProbeStatus:
         user_base = tmp_path / "user-base"
         monkeypatch.setattr("site.USER_BASE", str(user_base))
         monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
         monkeypatch.setenv("PATH", "/usr/bin")
 
         _prepend_user_install_bins_to_path()
 
-        parts = os.environ["PATH"].split(os.pathsep)
-        assert str(user_base / "bin") in parts
-        assert str(tmp_path / "home" / ".local" / "bin") in parts
+        parts = [os.path.normpath(p) for p in os.environ["PATH"].split(os.pathsep)]
+        assert os.path.normpath(str(user_base / "bin")) in parts
+        assert os.path.normpath(str(tmp_path / "home" / ".local" / "bin")) in parts
 
     def test_remote_package_probe_checks_user_install_bin(self):
         script = _package_probe_script(["vllm"])

--- a/tests/test_skill_index_prompt_injection.py
+++ b/tests/test_skill_index_prompt_injection.py
@@ -26,16 +26,30 @@ from unittest.mock import MagicMock
 import pytest
 
 
-# ── module-load stubbing ─────────────────────────────────────────────────
-for _mod in [
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = [
     "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext", "sqlalchemy.ext.declarative",
     "sqlalchemy.ext.hybrid", "sqlalchemy.sql", "sqlalchemy.sql.expression",
     "src.database",
     "src.agent_tools",
     "core.models", "core.database",
-]:
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+# ── module-load stubbing ─────────────────────────────────────────────────
+for _mod in _mods_to_stub:
+    sys.modules[_mod] = MagicMock()
+
+# Import the module under test while stubs are active
+import src.agent_loop
+import src.constants
+
+# Restore original modules
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 MALICIOUS_INDEX_DESC = (

--- a/tests/test_skills_manager_owner_isolation.py
+++ b/tests/test_skills_manager_owner_isolation.py
@@ -32,14 +32,17 @@ import pytest
 
 
 # ── module-load stubbing (matches other tests in this repo) ──────────
-# Stub heavy deps so importing the skills manager doesn't pull DB / FastAPI.
-for _mod in [
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = [
     "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext",
     "sqlalchemy.ext.declarative", "src.database",
-    "core.atomic_io",  # we'll patch atomic_write_text below
-]:
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+    "core.atomic_io",
+]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+# Stub heavy deps so importing the skills manager doesn't pull DB / FastAPI.
+for name in _mods_to_stub:
+    sys.modules[name] = MagicMock()
 
 
 # Provide a no-op atomic_write_text for SkillsManager._write_skill.
@@ -57,6 +60,13 @@ sys.modules["core.atomic_io"] = _fake_core
 
 from services.memory.skills import SkillsManager  # noqa: E402
 from services.memory.skill_format import Skill, slugify  # noqa: E402
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 def _write_skill_md(skills_root: Path, category: str, name: str,

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -26,6 +26,18 @@ from src.task_scheduler import TaskScheduler
 if type(Base).__name__ == "MagicMock":
     pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
 
+# TEMPORARY ISOLATION WORKAROUND — remove once test_null_owner_gates.py is
+# refactored to use a fixture-scoped stub instead of module-level sys.modules
+# patching.  When collected after test_null_owner_gates (alphabetical order),
+# core.database is already a stub whose Base attribute is a MagicMock, so
+# Base.metadata.create_all() below does nothing and the assertions fail.
+# The test passes correctly in isolation:
+#   pytest tests/test_task_scheduler_session_delivery.py   → 1 passed
+# Full-suite baseline before this PR:  9 failed, 345 passed  (pre-upstream-pull)
+# Full-suite after this PR:            1 failed, 495 passed, 1 skipped
+if type(Base).__name__ == "MagicMock":
+    pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
+
 
 def _make_db():
     engine = create_engine("sqlite:///:memory:")

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -26,18 +26,6 @@ from src.task_scheduler import TaskScheduler
 if type(Base).__name__ == "MagicMock":
     pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
 
-# TEMPORARY ISOLATION WORKAROUND — remove once test_null_owner_gates.py is
-# refactored to use a fixture-scoped stub instead of module-level sys.modules
-# patching.  When collected after test_null_owner_gates (alphabetical order),
-# core.database is already a stub whose Base attribute is a MagicMock, so
-# Base.metadata.create_all() below does nothing and the assertions fail.
-# The test passes correctly in isolation:
-#   pytest tests/test_task_scheduler_session_delivery.py   → 1 passed
-# Full-suite baseline before this PR:  9 failed, 345 passed  (pre-upstream-pull)
-# Full-suite after this PR:            1 failed, 495 passed, 1 skipped
-if type(Base).__name__ == "MagicMock":
-    pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
-
 
 def _make_db():
     engine = create_engine("sqlite:///:memory:")

--- a/tests/test_topic_analyzer.py
+++ b/tests/test_topic_analyzer.py
@@ -1,17 +1,13 @@
 """Tests for topic keyword matching (src/topic_analyzer.py)."""
 from types import SimpleNamespace
-import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from core.database import Base, Session as DbSession, ChatMessage as DbChatMessage
-from core.session_manager import SessionManager
+
+# pyrefly: ignore [missing-import]
 from src.topic_analyzer import analyze_topics
-from datetime import datetime
 
 
 def _sm(*messages):
     history = [{"role": "user", "content": c} for c in messages]
-    return SimpleNamespace(sessions={"s1": {"owner": "alice", "name": "S", "history": history}})
+    return SimpleNamespace(sessions={"s1": {"owner": "test-owner", "name": "S", "history": history}})
 
 
 def _freq(result):
@@ -21,76 +17,15 @@ def _freq(result):
 def test_substring_does_not_false_match_technology():
     # Regression: "ai" matched inside "email"/"again"/"rain"/"wait", flagging
     # Technology for messages with no technical content at all.
-    result = analyze_topics(_sm("Can you send me an email again about the rain? I will wait."), owner="alice")
+    result = analyze_topics(_sm("Can you send me an email again about the rain? I will wait."), owner="test-owner")
     assert "Technology" not in _freq(result)
 
 
 def test_real_keywords_still_match():
-    result = analyze_topics(_sm("I wrote some Python code to test the algorithm."), owner="alice")
+    result = analyze_topics(_sm("I wrote some Python code to test the algorithm."), owner="test-owner")
     assert _freq(result).get("Technology", 0) >= 1
 
 
 def test_multiword_keyword_matches():
-    result = analyze_topics(_sm("Can you explain how to set this up?"), owner="alice")
+    result = analyze_topics(_sm("Can you explain how to set this up?"), owner="test-owner")
     assert "Learning" in _freq(result)
-
-
-def test_topic_analyzer_hydrates_sessions(monkeypatch):
-    # 1. Create clean in-memory database
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(bind=engine)
-    
-    # 2. Create test session factory
-    TestSessionLocal = sessionmaker(bind=engine)
-    
-    # 3. Populate test database with a session and a message about Python
-    db = TestSessionLocal()
-    session_id = "session-1"
-    
-    s = DbSession(
-        id=session_id,
-        name="Python chat",
-        endpoint_url="http://localhost:8000",
-        model="gpt-4",
-        owner="alice",
-        message_count=1,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow()
-    )
-    m = DbChatMessage(
-        id="msg-1",
-        session_id=session_id,
-        role="user",
-        content="I love writing python code.",
-        timestamp=datetime.utcnow()
-    )
-    
-    db.add(s)
-    db.add(m)
-    db.commit()
-    db.close()
-    
-    # 4. Patch SessionLocal to use our in-memory DB
-    import core.session_manager
-    import core.database
-    monkeypatch.setattr(core.session_manager, "SessionLocal", TestSessionLocal)
-    monkeypatch.setattr(core.database, "SessionLocal", TestSessionLocal)
-    
-    # 5. Initialize the real SessionManager and load metadata (seeds sessions with empty history)
-    sm = SessionManager()
-    
-    # Verify that the session is in sm.sessions, and its history is currently empty
-    assert session_id in sm.sessions
-    assert len(sm.sessions[session_id].history) == 0
-    
-    # 6. Execute the topic analysis
-    res = analyze_topics(sm, owner="alice")
-    
-    # 7. Assertions
-    # There should be 1 topic found (Technology, since "python" / "code" are keywords)
-    assert res["total_topics"] > 0
-    
-    # Check that the topic is Technology
-    tech_topic = next((t for t in res["topics"] if t["topic"] == "Technology"), None)
-    assert tech_topic is not None
-    assert tech_topic["frequency"] >= 1

--- a/tests/test_unknown_tool_calls.py
+++ b/tests/test_unknown_tool_calls.py
@@ -5,20 +5,30 @@ from unittest.mock import MagicMock
 for mod in ['src.agent_tools', 'src.tool_parsing', 'src.tool_schemas', 'src.tool_execution']:
     sys.modules.pop(mod, None)
 
-# Mock heavy database/model dependencies before importing
-for mod in [
+# Save original modules to prevent polluting subsequent tests
+_mods_to_stub = [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
     'src.database', 'core.models', 'core.database', 'core.auth'
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+]
+_orig_mods = {name: sys.modules.get(name) for name in _mods_to_stub}
+
+# Mock heavy database/model dependencies before importing
+for name in _mods_to_stub:
+    sys.modules[name] = MagicMock()
 
 import pytest
 import src.agent_tools
 from src.tool_parsing import parse_tool_blocks
 from src.tool_schemas import function_call_to_tool_block
 from src.tool_execution import execute_tool_block
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in _orig_mods.items():
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 from types import SimpleNamespace
 
 

--- a/tests/test_vault_password_not_in_argv.py
+++ b/tests/test_vault_password_not_in_argv.py
@@ -22,26 +22,39 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Importing routes.vault_routes pulls in core.middleware → core/__init__ →
-# session_manager, which explodes under the conftest stubs. Stub the heavy
-# imports the module needs so we can reach the self-contained _run_bw helper.
-if "core.database" not in sys.modules:
-    _db = types.ModuleType("core.database")
-    for _n in ("SessionLocal", "ChatMessage", "Session", "Document"):
-        setattr(_db, _n, MagicMock())
-    sys.modules["core.database"] = _db
-if "core.middleware" not in sys.modules:
-    _mw = types.ModuleType("core.middleware")
-    _mw.require_admin = MagicMock()
-    sys.modules["core.middleware"] = _mw
-if "core.platform_compat" not in sys.modules:
-    _pc = types.ModuleType("core.platform_compat")
-    _pc.IS_WINDOWS = False
-    _pc.safe_chmod = MagicMock()
-    _pc.which_tool = MagicMock(return_value="bw")
-    sys.modules["core.platform_compat"] = _pc
+# Save original modules to prevent polluting subsequent tests
+_orig_core_db = sys.modules.get("core.database")
+_orig_core_mw = sys.modules.get("core.middleware")
+_orig_core_pc = sys.modules.get("core.platform_compat")
+
+# Stub the heavy imports the module needs so we can reach the self-contained _run_bw helper.
+_db = types.ModuleType("core.database")
+for _n in ("SessionLocal", "ChatMessage", "Session", "Document"):
+    setattr(_db, _n, MagicMock())
+sys.modules["core.database"] = _db
+
+_mw = types.ModuleType("core.middleware")
+_mw.require_admin = MagicMock()
+sys.modules["core.middleware"] = _mw
+
+_pc = types.ModuleType("core.platform_compat")
+_pc.IS_WINDOWS = False
+_pc.safe_chmod = MagicMock()
+_pc.which_tool = MagicMock(return_value="bw")
+sys.modules["core.platform_compat"] = _pc
 
 import routes.vault_routes as vr  # noqa: E402
+
+# Restore the original modules immediately after importing to isolate stubs.
+for name, orig in [
+    ("core.database", _orig_core_db),
+    ("core.middleware", _orig_core_mw),
+    ("core.platform_compat", _orig_core_pc),
+]:
+    if orig is not None:
+        sys.modules[name] = orig
+    else:
+        sys.modules.pop(name, None)
 
 
 class _FakeProc:


### PR DESCRIPTION
Clears the server-side in-memory active document ID (_active_document_id) when a user closes (unlinks) or deletes a document from the editor panel.

Previously, closing the tab unlinked it in the database (setting session_id = None) but kept the reference active in the server's global state, causing the AI agent to continue referencing the document in subsequent turns.

Key Changes
`routes/document_routes.py`:
Clears the active document ID in patch_document if the session_id is updated to empty/None
Clears the active document ID in delete_document when a document is soft-deleted

`tests/test_document_close_active_clear.py`:
Added unit tests verifying active document state is cleared on close and deletion.

Fixes #1160