### PR TITLE
Report provider-specific search API keys correctly

### DIFF
--- a/services/search/core.py
+++ b/services/search/core.py
@@ -30,6 +30,7 @@ from .providers import (
     tavily_search,
     serper_search,
     _get_search_settings,
+    _get_provider_key,
     _get_result_count,
 )
 from .content import (
@@ -54,7 +55,7 @@ def get_search_config() -> Dict[str, Any]:
     settings = _get_search_settings()
     provider = settings.get("search_provider", "searxng")
     config["active_provider"] = provider
-    config["has_api_key"] = bool((settings.get("search_api_key") or "").strip())
+    config["has_api_key"] = bool(_get_provider_key(provider))
     config["result_count"] = _get_result_count()
     if provider == "searxng":
         from .providers import _get_search_instance

--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -64,7 +64,17 @@ def _get_provider_key(provider: str) -> str:
         if val:
             return val
     # Legacy fallback: old shared search_api_key field
-    return (settings.get("search_api_key") or "").strip()
+    legacy = (settings.get("search_api_key") or "").strip()
+    if legacy:
+        return legacy
+    env_map = {
+        "brave": "DATA_BRAVE_API_KEY",
+        "google_pse": "GOOGLE_API_KEY",
+        "tavily": "TAVILY_API_KEY",
+        "serper": "SERPER_API_KEY",
+    }
+    env_name = env_map.get(provider, "")
+    return (os.environ.get(env_name) or "").strip() if env_name else ""
 
 
 def _get_result_count() -> int:

--- a/tests/test_search_config_provider_key.py
+++ b/tests/test_search_config_provider_key.py
@@ -1,0 +1,34 @@
+from services.search import core, providers
+
+
+def _config(monkeypatch, settings):
+    monkeypatch.setattr(core, "_get_search_settings", lambda: settings)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: settings)
+    return core.get_search_config()
+
+
+def test_search_config_detects_active_provider_specific_key(monkeypatch):
+    config = _config(monkeypatch, {
+        "search_provider": "tavily",
+        "tavily_api_key": "tavily-key",
+    })
+
+    assert config["has_api_key"] is True
+
+
+def test_search_config_ignores_key_for_different_provider(monkeypatch):
+    config = _config(monkeypatch, {
+        "search_provider": "brave",
+        "tavily_api_key": "tavily-key",
+    })
+
+    assert config["has_api_key"] is False
+
+
+def test_search_config_keeps_legacy_shared_key_fallback(monkeypatch):
+    config = _config(monkeypatch, {
+        "search_provider": "serper",
+        "search_api_key": "legacy-key",
+    })
+
+    assert config["has_api_key"] is True

--- a/tests/test_search_config_provider_key.py
+++ b/tests/test_search_config_provider_key.py
@@ -1,7 +1,16 @@
 from services.search import core, providers
 
+PROVIDER_ENV_KEYS = (
+    "DATA_BRAVE_API_KEY",
+    "GOOGLE_API_KEY",
+    "TAVILY_API_KEY",
+    "SERPER_API_KEY",
+)
+
 
 def _config(monkeypatch, settings):
+    for env_name in PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(env_name, raising=False)
     monkeypatch.setattr(core, "_get_search_settings", lambda: settings)
     monkeypatch.setattr(providers, "_get_search_settings", lambda: settings)
     return core.get_search_config()
@@ -32,3 +41,15 @@ def test_search_config_keeps_legacy_shared_key_fallback(monkeypatch):
     })
 
     assert config["has_api_key"] is True
+
+
+def test_search_config_detects_provider_env_key(monkeypatch):
+    settings = {"search_provider": "tavily"}
+    for env_name in PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setenv("TAVILY_API_KEY", "env-key")
+    monkeypatch.setattr(core, "_get_search_settings", lambda: settings)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: settings)
+
+    assert core.get_search_config()["has_api_key"] is True
+    assert providers._get_provider_key("tavily") == "env-key"


### PR DESCRIPTION
Search settings store API keys per provider now, but `/api/search/config` still checked only the old shared `search_api_key` field. With a Tavily, Brave, Serper, or Google PSE key saved in its normal field, the config endpoint could report `has_api_key: false`.

This uses the existing provider-key lookup for the active provider and teaches that lookup about the runtime env vars the search calls already support. That keeps the legacy shared-key fallback while making both config status and provider availability match the key the search code actually uses.

Checked:
- `venv/bin/python -m pytest -q tests/test_search_config_provider_key.py tests/test_service_search_provider_guards.py tests/test_search_module_consolidation.py`
- `venv/bin/python -m py_compile services/search/core.py services/search/providers.py tests/test_search_config_provider_key.py`
- `git diff --check`
