### PR TITLE
fix(ui): give cookbook and memory modals a definite height so inner body can scroll

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -9722,6 +9722,7 @@ details a:hover {
 .memory-modal-content {
   width: min(560px, 90vw);
   max-height: 78vh;
+  height: 78vh;
   font-size: 12px;
   overflow: hidden;   /* clip both axes; the inner .memory-modal-body owns scrolling.
                          (overflow-x alone promotes overflow-y to `auto` → a stray vertical scrollbar) */
@@ -17637,6 +17638,7 @@ body.gallery-selecting .gallery-dl-btn,
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  height: 85vh;
 }
 #cookbook-modal .modal-header {
   flex: 0 0 auto;


### PR DESCRIPTION
Fixes #1204. Follow-up to #1180.

**CONTEXT:** The Cookbook and Memory modals use a flex layout where the header is lex: 0 0 auto and the scrollable body is lex: 1; overflow-y: auto. But the flex container (modal-content) only had max-height set — no height. Without a definite height on the parent, a flex child with lex: 1 has nothing concrete to size against, so it just expands to fit all its content and overflow-y: auto never activates. The modal grows until it hits max-height and then clips with overflow: hidden — content is invisible with no scrollbar.

**CHANGE:** Two 1-line additions to static/style.css:
- #cookbook-modal .modal-content → height: 85vh (matches its existing max-height: 85vh from the base rule)
- .memory-modal-content → height: 78vh (matches its existing max-height: 78vh)

**WHY:** height gives the flex container a definite size. max-height alone does not — it only caps growth, it does not establish a size for flex children to work against. With height set, cookbook-body/memory-modal-body's lex: 1; overflow-y: auto behaves as intended: the body fills the remaining space below the header and scrolls its own overflow. The modal window itself stays at a fixed height in the viewport rather than trying to grow to fit all content.

**IMPACT:** Users can scroll through all Cookbook serve options, the Launch button, and all Memory/settings content without needing to zoom out. Settings modal was already fine (it uses overflow-y: auto directly on modal-content, not a nested flex scroller).

## Files changed

| File | Change |
|---|---|
| static/style.css | +1 line each in #cookbook-modal .modal-content and .memory-modal-content |