### PR TITLE
fix(documents): add deactivate endpoint to clear active document on tab close

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -1659,4 +1659,20 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         finally:
             db.close()
 
+    # ---- POST /api/document/deactivate ----
+    @router.post("/api/document/deactivate")
+    async def deactivate_document(request: Request) -> Dict[str, Any]:
+        """Clear the server-side active document state so the agent stops
+        injecting a closed document's content into subsequent chat turns.
+
+        The frontend should call this when the user closes a document tab.
+        Without it, the in-process ``_active_document_id`` global persists
+        indefinitely (it is only cleared on *delete*), causing the agent to
+        reference documents the user explicitly closed.
+        """
+        from src.tool_implementations import set_active_document, get_active_document
+        prev = get_active_document()
+        set_active_document(None)
+        return {"ok": True, "previous_id": prev}
+
     return router


### PR DESCRIPTION
## Problem

After closing a document tab in the UI the agent continues to see the
document in subsequent chat turns — even in new, unrelated conversations.
The AI reads, edits, or suggests changes to a document the user
explicitly closed.

Reported in #1160.

## Root cause

`_active_document_id` is a process-global in `src/tool_implementations.py`.
It is set when the agent creates, edits, or reads a document, but only
cleared when the document is **deleted** (`manage_documents` action
`delete`). There is no backend path for the frontend to signal that a
tab was closed.

On every chat request, `chat_routes.py` falls back to
`get_active_document()` when neither `active_doc_id` nor a session-bound
document is found. The stale global matches, the document is loaded from
the DB, and its full content is injected into the system prompt.

## Fix

Add `POST /api/document/deactivate` that calls `set_active_document(None)`.
The frontend can invoke this when the user closes a document tab.

16 lines added to `routes/document_routes.py`. No existing behavior
changed.

## Verification

- `py_compile` passes on the modified file
- Manual trace of the chat_routes fallback chain: after deactivate,
  `get_active_document()` returns `None`, the in-memory fallback is
  skipped, and no document content is injected

## Out of scope

- Frontend wiring (this PR adds the backend endpoint; frontend will
  call it on tab-close in a separate change)
- Per-session or per-user scoping of `_active_document_id` (the global
  is already process-wide; a full refactor is a larger change)