### PR TITLE
Fix slow attachment thumbnail loading in chat

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1837,7 +1837,7 @@ import createResearchSynapse from './researchSynapse.js';
                         _iw.style.cursor = 'pointer';
                         _iw.onclick = () => window.open(API_BASE + '/api/upload/' + _att.id, '_blank');
                         const _im = document.createElement('img');
-                        _im.src = API_BASE + '/api/upload/' + _att.id;
+                        _im.src = API_BASE + '/api/upload/' + _att.id + '?thumb=1';
                         _im.alt = _att.name || 'Image';
                         _im.style.cssText = 'max-width:300px;max-height:200px;border-radius:6px;display:block;';
                         _iw.appendChild(_im);

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -105,7 +105,7 @@ function buildAttachCards(attachments) {
         // Small cached thumbnail — the preview is tiny, no need to pull the
         // full-resolution photo. Click still opens the full image.
         img.alt = att.name || 'Image';
-        img.loading = 'lazy';
+        img.decoding = 'async';
         img.style.cssText = 'max-width:300px;max-height:200px;border-radius:6px;display:' + (att.previewUrl ? 'block' : 'none') + ';';
         let _revealed = false;
         let _revealTimer = null;


### PR DESCRIPTION
## Problem
Chat image thumbnails take 3-5s to appear when reopening a session, despite the cached thumbnails being tiny (~10-20KB). Clicking the spinner placeholder opens the full image instantly.

## Root Cause
Two issues:

1. **`loading='lazy'` in `overflow-y: auto` containers** — `buildAttachCards()` in `chatRenderer.js` sets `loading='lazy'` on thumbnail `<img>` elements. The browser's lazy-load uses viewport-level `IntersectionObserver`, which doesn't account for scroll containers. Images visible inside `#chat-history` but outside the main viewport rectangle get deferred for seconds.

2. **SSE fallback path loads full-resolution image** — The `attachments` event handler in `chat.js` fetches `/api/upload/{id}` (full photo) instead of `/api/upload/{id}?thumb=1` (cached 320×320 JPEG).

## Fix
- Replace `loading='lazy'` with `decoding='async'` in `chatRenderer.js` — eager loading (appropriate for small cached thumbnails) with non-blocking decode off the main thread
- Add `?thumb=1` to the SSE fallback path in `chat.js`

## Files Changed
| File | Change |
|---|---|
| `static/js/chatRenderer.js` | `loading='lazy'` → `decoding='async'` |
| `static/js/chat.js` | SSE fallback: added `?thumb=1` to image src |

**2 files, +2/-2 lines**