### PR TITLE
fix: rank search recency by UTC, not local time (#1116)

### DIFF
--- a/src/search/ranking.py
+++ b/src/search/ranking.py
@@ -2,11 +2,48 @@
 
 import re
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+_AGE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S")
+
+
+def _utcnow_naive() -> datetime:
+    """Naive UTC 'now'. Matches the naive, UTC-style published dates parsed below,
+    and is safe on Python 3.14 where ``datetime.utcnow()`` is removed (#1116)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def recency_score(age_str: Optional[str], now: Optional[datetime] = None) -> float:
+    """Score how recent a result is: 1.0 for <=7 days old, 0.0 for >=30 days.
+
+    The age is measured against UTC, not local time. The previous code used
+    ``datetime.now()`` (local) against UTC-style published dates, so the age was
+    skewed by the host's UTC offset; it was also a latent crash once neighbouring
+    code moves to timezone-aware datetimes (#1116). ``now`` is injectable for tests.
+    """
+    if not age_str:
+        return 0.0
+    dt = None
+    for fmt in _AGE_FORMATS:
+        try:
+            dt = datetime.strptime(age_str, fmt)
+            break
+        except Exception:
+            dt = None
+    if not dt:
+        return 0.0
+    now = now or _utcnow_naive()
+    days_old = (now - dt).days
+    if days_old <= 7:
+        return 1.0
+    if days_old >= 30:
+        return 0.0
+    return (30 - days_old) / 23
+
 
 _NEWS_HINTS = {"news", "nyheter", "headlines", "breaking", "latest", "today", "idag"}
 _SPORTS_HINTS = {
@@ -67,24 +104,6 @@ def rank_search_results(query: str, results: List[dict]) -> List[dict]:
         if netloc.endswith(".org"):
             return 0.7
         return 0.4
-
-    def recency_score(age_str: Optional[str]) -> float:
-        if not age_str:
-            return 0.0
-        for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
-            try:
-                dt = datetime.strptime(age_str, fmt)
-                break
-            except Exception:
-                dt = None
-        if not dt:
-            return 0.0
-        days_old = (datetime.now() - dt).days
-        if days_old <= 7:
-            return 1.0
-        if days_old >= 30:
-            return 0.0
-        return (30 - days_old) / 23
 
     def news_quality_adjustment(title: str, snippet: str, url: str) -> float:
         if not is_news_query:

--- a/tests/test_search_ranking_recency.py
+++ b/tests/test_search_ranking_recency.py
@@ -1,0 +1,39 @@
+"""Issue #1116 (latent ranking bug) — recency scoring uses UTC, not local time.
+
+`recency_score` measured age with `datetime.now()` (local) against UTC-style
+published dates, skewing the age by the host's UTC offset and risking a TypeError
+once neighbouring code becomes timezone-aware. It now uses naive UTC and is a
+module-level, time-injectable function.
+"""
+
+from datetime import datetime, timezone
+
+from src.search.ranking import recency_score, _utcnow_naive
+
+
+def test_fresh_result_scores_one():
+    assert recency_score("2026-01-01", now=datetime(2026, 1, 5)) == 1.0  # 4 days old
+
+
+def test_old_result_scores_zero():
+    assert recency_score("2026-01-01", now=datetime(2026, 3, 1)) == 0.0  # >30 days
+
+
+def test_mid_range_decays_linearly():
+    score = recency_score("2026-01-01", now=datetime(2026, 1, 20))  # 19 days old
+    assert score == (30 - 19) / 23
+
+
+def test_empty_or_unparseable_scores_zero():
+    assert recency_score("", now=datetime(2026, 1, 1)) == 0.0
+    assert recency_score(None, now=datetime(2026, 1, 1)) == 0.0
+    assert recency_score("not-a-date", now=datetime(2026, 1, 1)) == 0.0
+
+
+def test_default_now_is_naive_utc():
+    # Naive (no tzinfo) so it subtracts cleanly from the naive parsed dates,
+    # and UTC-based (3.14-safe, no datetime.utcnow()).
+    now = _utcnow_naive()
+    assert now.tzinfo is None
+    reference = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert abs((now - reference).total_seconds()) < 5


### PR DESCRIPTION
Addresses the latent recency bug called out in #1116 (and removes one `datetime.utcnow()`-class hazard from the search path).

## Problem

`src/search/ranking.py` scores result recency with:

```python
dt = datetime.strptime(age_str, fmt)     # naive, parsed from a UTC-style date
days_old = (datetime.now() - dt).days    # datetime.now() is LOCAL
```

Two issues:

1. **Correctness:** `datetime.now()` is local time, but `dt` comes from a UTC-style published date. The age is skewed by the host's UTC offset — enough to flip the <=7 / <30 / >=30 day buckets near a boundary, mis-ranking fresh vs stale results depending on the server's timezone.
2. **Latent crash (#1116):** once neighbouring code moves to timezone-aware datetimes, subtracting a naive `dt` from an aware `now` raises `TypeError`.

## Fix

- Measure age against **naive UTC** so it's consistent with the parsed timestamps.
- Lift the scoring out of the `rank_search_results` closure into a module-level, **time-injectable** `recency_score(age_str, now=None)` so it's unit-testable deterministically.
- `_utcnow_naive()` uses `datetime.now(timezone.utc).replace(tzinfo=None)` — identical semantics to the old naive UTC, and safe on Python 3.14 where `datetime.utcnow()` is removed.

This is a focused slice of #1116; the broader 130-callsite `datetime.utcnow()` migration is left for a separate change.

## Tests

`tests/test_search_ranking_recency.py` (5): fresh→1.0, old→0.0, linear mid-range, empty/unparseable→0.0, and default-now is naive UTC. The existing `tests/test_search_ranking.py` still passes.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)