### PR TITLE
fix: closed document stays active & leaks into new chats (#1160)

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -593,6 +593,15 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             if req.session_id is not None:
                 # Empty string = unlink from session
                 doc.session_id = req.session_id if req.session_id else None
+                if not req.session_id:
+                    # Tab closed / doc detached from its session — drop the
+                    # in-memory active-doc pointer so the last-resort injection
+                    # path doesn't re-surface this doc in a later chat (#1160).
+                    try:
+                        from src.tool_implementations import clear_active_document
+                        clear_active_document(doc_id)
+                    except Exception:
+                        pass
             db.commit()
             db.refresh(doc)
             return _doc_to_dict(doc)
@@ -615,6 +624,13 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                 raise HTTPException(404, "Document not found")
             _verify_doc_owner(db, doc, user)
             doc.is_active = False
+            # Closed/deleted — drop the in-memory active-doc pointer so it isn't
+            # re-injected into a later, unrelated chat (#1160).
+            try:
+                from src.tool_implementations import clear_active_document
+                clear_active_document(doc_id)
+            except Exception:
+                pass
             db.commit()
             return {"status": "deleted", "id": doc_id}
         except HTTPException:

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -88,6 +88,24 @@ def get_active_document():
     return _active_document_id
 
 
+def clear_active_document(doc_id: Optional[str] = None) -> bool:
+    """Clear the in-memory active-document pointer.
+
+    With ``doc_id`` given, only clears when it matches the current pointer, so a
+    different active document is left untouched. Returns True if it was cleared.
+
+    Called when a document is detached from its session or deleted (its tab is
+    closed): without this, the stale pointer makes the last-resort doc-injection
+    path re-surface a closed document in a later, unrelated chat — even one whose
+    session no longer matches — because an unlinked doc has session_id NULL (#1160).
+    """
+    global _active_document_id
+    if doc_id is None or _active_document_id == doc_id:
+        _active_document_id = None
+        return True
+    return False
+
+
 def _owned_document_query(query, Document, owner: Optional[str]):
     if owner is None:
         # A bare Python `False` is not a valid SQL expression — SQLAlchemy 1.4

--- a/tests/test_active_document_clear.py
+++ b/tests/test_active_document_clear.py
@@ -1,0 +1,39 @@
+"""Issue #1160 — a closed document must not stay 'active' and leak into new chats.
+
+Closing a document tab detaches it (session_id -> NULL) or deletes it, but the
+in-memory active-document pointer was never cleared, so the last-resort doc
+injection re-surfaced the closed doc in later, unrelated chats. The document
+routes now call clear_active_document() on detach/delete; this pins that helper.
+"""
+
+from src.tool_implementations import (
+    set_active_document,
+    get_active_document,
+    clear_active_document,
+)
+
+
+def test_clear_matching_id_resets_pointer():
+    set_active_document("doc-123")
+    assert get_active_document() == "doc-123"
+    assert clear_active_document("doc-123") is True
+    assert get_active_document() is None
+
+
+def test_clear_non_matching_id_leaves_other_active_doc():
+    set_active_document("doc-abc")
+    # Closing a DIFFERENT document must not clobber the currently active one.
+    assert clear_active_document("doc-xyz") is False
+    assert get_active_document() == "doc-abc"
+
+
+def test_clear_without_id_clears_unconditionally():
+    set_active_document("doc-abc")
+    assert clear_active_document() is True
+    assert get_active_document() is None
+
+
+def test_clear_when_already_none_is_safe():
+    set_active_document(None)
+    assert clear_active_document("doc-123") is False
+    assert get_active_document() is None

--- a/tests/test_document_close_clears_active_route.py
+++ b/tests/test_document_close_clears_active_route.py
@@ -1,31 +1,31 @@
 """Issue #1160 — route-level regression for clearing the active-document pointer.
 
-Drives the REAL ``PATCH /api/document/{id}`` (session_id="") and
-``DELETE /api/document/{id}`` handlers via TestClient, proving that closing a
-document's tab (detach or delete) clears the in-memory active-document pointer
-under the actual owner/session routing — not just the helper in isolation.
+Exercises the REAL ``PATCH /api/document/{id}`` (session_id="") and
+``DELETE /api/document/{id}`` handlers, proving that closing a document's tab
+(detach or delete) clears the in-memory active-document pointer under the actual
+owner/session routing — not just the helper in isolation.
 
-Binds a DEDICATED temporary SQLite engine and patches the route module's
-``SessionLocal`` to it (rather than setting ``DATABASE_URL`` at import time), so
-the test never touches the real dev DB, is independent of import order, and does
-not contend for the dev DB's locks (which could hang).
+Calls the route handler callables DIRECTLY (extracted from the router) instead of
+through Starlette's TestClient. The TestClient path spun up a middleware app +
+threadpool that could hang in some environments; calling the async handler with a
+minimal fake request keeps the same real coverage (handler + DB + owner routing)
+while completing reliably everywhere.
 """
 
 import tempfile
 import uuid
+from types import SimpleNamespace
 
-import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
-from fastapi import FastAPI, Request
-from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
 
 import core.database as cdb
 import routes.document_routes as droutes
 from core.database import Document
 from core.database import Session as DbSession
+from routes.document_helpers import DocumentPatch
 from src.tool_implementations import set_active_document, get_active_document
 
 _TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
@@ -36,28 +36,22 @@ _ENGINE = create_engine(
 )
 cdb.Base.metadata.create_all(_ENGINE)
 _TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+droutes.SessionLocal = _TS  # route handlers resolve SessionLocal at call time
 
 
-@pytest.fixture(autouse=True)
-def _bind_db(monkeypatch):
-    monkeypatch.setattr(droutes, "SessionLocal", _TS)
-    yield
+def _req():
+    return SimpleNamespace(state=SimpleNamespace(current_user="tester"))
 
 
-def _client():
-    app = FastAPI()
-
-    @app.middleware("http")
-    async def _inject_user(request: Request, call_next):
-        request.state.current_user = "tester"
-        return await call_next(request)
-
-    app.include_router(droutes.setup_document_routes(MagicMock(), None))
-    return TestClient(app)
+def _endpoint(method, path):
+    router = droutes.setup_document_routes(MagicMock(), None)
+    for r in router.routes:
+        if getattr(r, "path", None) == path and method in getattr(r, "methods", set()):
+            return r.endpoint
+    raise RuntimeError(f"{method} {path} not found")
 
 
 def _make_doc():
-    """Create a real session + an active document linked to it (owner 'tester')."""
     sid = "s-" + uuid.uuid4().hex[:8]
     db = _TS()
     try:
@@ -74,29 +68,26 @@ def _make_doc():
         db.close()
 
 
-def test_patch_unlink_clears_active_document():
-    client = _client()
+async def test_patch_unlink_clears_active_document():
+    patch_document = _endpoint("PATCH", "/api/document/{doc_id}")
     doc_id = _make_doc()
     set_active_document(doc_id)
-    r = client.patch(f"/api/document/{doc_id}", json={"session_id": ""})
-    assert r.status_code == 200, r.text
+    await patch_document(_req(), doc_id, DocumentPatch(session_id=""))
     assert get_active_document() is None
 
 
-def test_delete_clears_active_document():
-    client = _client()
+async def test_delete_clears_active_document():
+    delete_document = _endpoint("DELETE", "/api/document/{doc_id}")
     doc_id = _make_doc()
     set_active_document(doc_id)
-    r = client.delete(f"/api/document/{doc_id}")
-    assert r.status_code == 200, r.text
+    await delete_document(_req(), doc_id)
     assert get_active_document() is None
 
 
-def test_unlinking_a_different_doc_leaves_pointer():
-    client = _client()
+async def test_unlinking_a_different_doc_leaves_pointer():
+    patch_document = _endpoint("PATCH", "/api/document/{doc_id}")
     active_id = _make_doc()
     other_id = _make_doc()
     set_active_document(active_id)
-    r = client.patch(f"/api/document/{other_id}", json={"session_id": ""})
-    assert r.status_code == 200, r.text
+    await patch_document(_req(), other_id, DocumentPatch(session_id=""))
     assert get_active_document() == active_id

--- a/tests/test_document_close_clears_active_route.py
+++ b/tests/test_document_close_clears_active_route.py
@@ -1,34 +1,50 @@
 """Issue #1160 — route-level regression for clearing the active-document pointer.
 
-Drives the REAL `PATCH /api/document/{id}` (session_id="") and
-`DELETE /api/document/{id}` handlers through TestClient against a temporary
-SQLite DB, proving that closing a document's tab (detach or delete) clears the
-in-memory active-document pointer under the actual owner/session routing — not
-just the helper in isolation.
+Drives the REAL ``PATCH /api/document/{id}`` (session_id="") and
+``DELETE /api/document/{id}`` handlers via TestClient, proving that closing a
+document's tab (detach or delete) clears the in-memory active-document pointer
+under the actual owner/session routing — not just the helper in isolation.
+
+Binds a DEDICATED temporary SQLite engine and patches the route module's
+``SessionLocal`` to it (rather than setting ``DATABASE_URL`` at import time), so
+the test never touches the real dev DB, is independent of import order, and does
+not contend for the dev DB's locks (which could hang).
 """
 
-import os
 import tempfile
 import uuid
 
-# Point the DB at a throwaway file BEFORE importing core.database (engine is
-# created at import from DATABASE_URL).
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+
+import core.database as cdb
+import routes.document_routes as droutes
+from core.database import Document
+from core.database import Session as DbSession
+from src.tool_implementations import set_active_document, get_active_document
+
 _TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
-os.environ["DATABASE_URL"] = f"sqlite:///{_TMPDB.name}"
-
-from fastapi import FastAPI, Request  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
-from unittest.mock import MagicMock  # noqa: E402
-
-from core.database import Base, engine, SessionLocal, Document  # noqa: E402
-from core.database import Session as DbSession  # noqa: E402
-from routes.document_routes import setup_document_routes  # noqa: E402
-from src.tool_implementations import set_active_document, get_active_document  # noqa: E402
-
-Base.metadata.create_all(engine)
+_ENGINE = create_engine(
+    f"sqlite:///{_TMPDB.name}",
+    connect_args={"check_same_thread": False},
+    poolclass=NullPool,
+)
+cdb.Base.metadata.create_all(_ENGINE)
+_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
 
 
-def _app():
+@pytest.fixture(autouse=True)
+def _bind_db(monkeypatch):
+    monkeypatch.setattr(droutes, "SessionLocal", _TS)
+    yield
+
+
+def _client():
     app = FastAPI()
 
     @app.middleware("http")
@@ -36,14 +52,14 @@ def _app():
         request.state.current_user = "tester"
         return await call_next(request)
 
-    app.include_router(setup_document_routes(MagicMock(), None))
+    app.include_router(droutes.setup_document_routes(MagicMock(), None))
     return TestClient(app)
 
 
 def _make_doc():
     """Create a real session + an active document linked to it (owner 'tester')."""
     sid = "s-" + uuid.uuid4().hex[:8]
-    db = SessionLocal()
+    db = _TS()
     try:
         db.add(DbSession(id=sid, owner="tester", name="s", model="m", endpoint_url="http://x"))
         doc = Document(
@@ -59,7 +75,7 @@ def _make_doc():
 
 
 def test_patch_unlink_clears_active_document():
-    client = _app()
+    client = _client()
     doc_id = _make_doc()
     set_active_document(doc_id)
     r = client.patch(f"/api/document/{doc_id}", json={"session_id": ""})
@@ -68,7 +84,7 @@ def test_patch_unlink_clears_active_document():
 
 
 def test_delete_clears_active_document():
-    client = _app()
+    client = _client()
     doc_id = _make_doc()
     set_active_document(doc_id)
     r = client.delete(f"/api/document/{doc_id}")
@@ -77,7 +93,7 @@ def test_delete_clears_active_document():
 
 
 def test_unlinking_a_different_doc_leaves_pointer():
-    client = _app()
+    client = _client()
     active_id = _make_doc()
     other_id = _make_doc()
     set_active_document(active_id)

--- a/tests/test_document_close_clears_active_route.py
+++ b/tests/test_document_close_clears_active_route.py
@@ -1,0 +1,86 @@
+"""Issue #1160 — route-level regression for clearing the active-document pointer.
+
+Drives the REAL `PATCH /api/document/{id}` (session_id="") and
+`DELETE /api/document/{id}` handlers through TestClient against a temporary
+SQLite DB, proving that closing a document's tab (detach or delete) clears the
+in-memory active-document pointer under the actual owner/session routing — not
+just the helper in isolation.
+"""
+
+import os
+import tempfile
+import uuid
+
+# Point the DB at a throwaway file BEFORE importing core.database (engine is
+# created at import from DATABASE_URL).
+_TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+os.environ["DATABASE_URL"] = f"sqlite:///{_TMPDB.name}"
+
+from fastapi import FastAPI, Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+from core.database import Base, engine, SessionLocal, Document  # noqa: E402
+from core.database import Session as DbSession  # noqa: E402
+from routes.document_routes import setup_document_routes  # noqa: E402
+from src.tool_implementations import set_active_document, get_active_document  # noqa: E402
+
+Base.metadata.create_all(engine)
+
+
+def _app():
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _inject_user(request: Request, call_next):
+        request.state.current_user = "tester"
+        return await call_next(request)
+
+    app.include_router(setup_document_routes(MagicMock(), None))
+    return TestClient(app)
+
+
+def _make_doc():
+    """Create a real session + an active document linked to it (owner 'tester')."""
+    sid = "s-" + uuid.uuid4().hex[:8]
+    db = SessionLocal()
+    try:
+        db.add(DbSession(id=sid, owner="tester", name="s", model="m", endpoint_url="http://x"))
+        doc = Document(
+            id=str(uuid.uuid4()), session_id=sid, title="t",
+            language="markdown", current_content="hi", version_count=1,
+            is_active=True, owner="tester",
+        )
+        db.add(doc)
+        db.commit()
+        return doc.id
+    finally:
+        db.close()
+
+
+def test_patch_unlink_clears_active_document():
+    client = _app()
+    doc_id = _make_doc()
+    set_active_document(doc_id)
+    r = client.patch(f"/api/document/{doc_id}", json={"session_id": ""})
+    assert r.status_code == 200, r.text
+    assert get_active_document() is None
+
+
+def test_delete_clears_active_document():
+    client = _app()
+    doc_id = _make_doc()
+    set_active_document(doc_id)
+    r = client.delete(f"/api/document/{doc_id}")
+    assert r.status_code == 200, r.text
+    assert get_active_document() is None
+
+
+def test_unlinking_a_different_doc_leaves_pointer():
+    client = _app()
+    active_id = _make_doc()
+    other_id = _make_doc()
+    set_active_document(active_id)
+    r = client.patch(f"/api/document/{other_id}", json={"session_id": ""})
+    assert r.status_code == 200, r.text
+    assert get_active_document() == active_id


### PR DESCRIPTION
Closes #1160.

## Problem

After a user closes a document tab, the AI keeps seeing the document as active — reading it, editing it, suggesting changes — **even in a new, unrelated chat**.

Root cause is the interaction of two things:

1. `closeTab` → `_detachDocFromSession` (static/js/document.js): a document **with content** is `PATCH`ed to `session_id=""` (unlinked → `session_id` becomes `NULL`, `is_active` stays `True`); only an empty doc is `DELETE`d.
2. The chat doc-injection last-resort (routes/chat_routes.py) looks up the in-memory active-document pointer by id and injects it when `not cand.session_id or cand.session_id == session`. An unlinked doc has `session_id NULL`, so the `not cand.session_id` branch matches **any** session.

The in-memory pointer (`tool_implementations._active_document_id`, set when the agent creates/edits a doc) was **never cleared** on close/detach — so it kept re-surfacing the closed document in later chats.

## Fix

Add `clear_active_document(doc_id)` and call it when a document is **unlinked** (`PATCH session_id=""`) or **deleted**, so the stale pointer no longer resurrects a closed document. It only clears when the id matches (or no id is passed), so a *different* active document is left untouched.

## Tests

`tests/test_active_document_clear.py` (4): clears on matching id; leaves a different active doc untouched; unconditional clear with no id; safe when already cleared.

No new dependencies; no API-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)