### PR TITLE
fix: email pre-retrieval ignores contacts (reads non-existent email/phone keys)

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -1251,13 +1251,13 @@ def _pre_retrieve_context(body: str, sender: str) -> tuple:
                 t_lower = term.lower()
                 matches = [c for c in all_contacts
                            if t_lower in (c.get("name") or "").lower()
-                           or t_lower in (c.get("email") or "").lower()]
+                           or any(t_lower in (e or "").lower() for e in (c.get("emails") or []))]
                 for c in matches[:2]:
                     parts = [f"Name: {c.get('name','')}"]
-                    if c.get("email"):
-                        parts.append(f"Email: {c['email']}")
-                    if c.get("phone"):
-                        parts.append(f"Phone: {c['phone']}")
+                    if c.get("emails"):
+                        parts.append(f"Email: {', '.join(c['emails'])}")
+                    if c.get("phones"):
+                        parts.append(f"Phone: {', '.join(c['phones'])}")
                     context_snippets.append(f"[Contact match for \"{term}\"] " + ", ".join(parts))
         except Exception:
             pass

--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -1154,7 +1154,10 @@ def _pre_retrieve_context(body: str, sender: str) -> tuple:
         try:
             from routes.contacts_routes import _fetch_contacts
             for c in _fetch_contacts() or []:
-                if (c.get("email") or "").lower() == sender_addr:
+                # Contacts are normalized to plural `emails` lists (see
+                # contacts_routes._normalize_contact); the old `c.get("email")`
+                # singular key never exists, so known senders were never matched.
+                if sender_addr in [(e or "").lower() for e in (c.get("emails") or [])]:
                     is_known = True
                     break
         except Exception:


### PR DESCRIPTION
## Summary

`_pre_retrieve_context` (email auto-reply / context pre-retrieval) reads `c.get("email")` and `c.get("phone")` on contact dicts, but `_fetch_contacts()` returns contacts normalized by `contacts_routes._normalize_contact`, which only ever produces the plural list keys `emails` and `phones` (never singular `email`/`phone`). So:

- The known-sender check (`(c.get("email") or "").lower() == sender_addr`) always compares against `""` and never matches. A sender who IS in your contacts but isn't found in the IMAP mailbox probe is treated as unknown, and pre-retrieval is skipped entirely.
- The contact-match snippet builder filters on the empty `email` key and emits `Email:`/`Phone:` lines from keys that don't exist, so contact context is never produced.

Fix: match the sender against the contact's `emails` list, and build snippets from the `emails`/`phones` lists.

## Changes
- `routes/email_helpers.py`: use the plural `emails`/`phones` keys in the known-sender check and the contact-snippet builder.