### PR TITLE
Closed duplicate - Add Docker readiness healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,23 @@ OLLAMA_HOST=0.0.0.0:11434 ollama serve
 
 ```bash
 docker compose ps
+curl -v http://127.0.0.1:7000/api/ready
 docker compose logs --tail=120 odysseus
 docker compose logs odysseus | grep -E 'ChromaDB|MemoryVectorStore|DEGRADED'
 ```
+
+If the host curl resets or returns an empty response but `docker compose ps`
+shows Odysseus as running, check whether FastAPI responds from inside the
+container:
+
+```bash
+docker compose exec odysseus python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:7000/api/ready', timeout=5).read().decode())"
+```
+
+If the in-container check passes, the app is serving and the problem is likely
+host port forwarding, a local firewall, or a conflicting port. If it fails,
+`docker compose ps` should mark Odysseus as unhealthy and the Odysseus logs are
+the next place to look.
 
 **macOS details.** `start-macos.sh` installs Homebrew deps, creates the venv,
 runs setup, and starts uvicorn on port `7860` because AirPlay often holds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,12 @@ services:
         condition: service_healthy
       chromadb:
         condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:7000/api/ready', timeout=5).read(1)\""]
+      interval: 10s
+      timeout: 6s
+      retries: 12
+      start_period: 30s
     restart: unless-stopped
 
   chromadb:

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -119,6 +119,12 @@ def test_docker_compose_binds_web_ui_to_loopback_by_default():
     assert '"${APP_PORT:-7000}:7000"' not in compose
 
 
+def test_docker_compose_healthchecks_odysseus_ready_endpoint():
+    compose = Path("docker-compose.yml").read_text(encoding="utf-8")
+    assert "http://127.0.0.1:7000/api/ready" in compose
+    assert "start_period: 30s" in compose
+
+
 def test_readme_native_quickstart_uses_loopback():
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "python -m uvicorn app:app --host 127.0.0.1 --port 7000" in readme


### PR DESCRIPTION
Closed in favor of #1248, which uses the clean branch name `docker-readiness-healthcheck`.