### PR TITLE
fix: pass owner to update_skill on skills PUT and audit paths (#1227)

### DIFF
--- a/routes/skills_routes.py
+++ b/routes/skills_routes.py
@@ -469,7 +469,7 @@ async def _run_skill_test_job(key, name, md, task, url, model, headers, owner, s
         conf = {"pass": 0.95, "needs_work": 0.6, "fail": 0.4}.get(v)
         if conf is not None:
             try:
-                skills_manager.update_skill(name, {"confidence": conf})
+                skills_manager.update_skill(name, {"confidence": conf}, owner=owner)
             except Exception:
                 pass
     job["status"] = "done"
@@ -638,7 +638,7 @@ def _audit_finalize_status(skills_manager, name: str, owner, verdict: str,
     c = float(confidence or 0.0)
     status = "published" if (auto_publish and necessary and verdict == "pass" and c >= min_conf) else "draft"
     try:
-        skills_manager.update_skill(name, {"status": status})
+        skills_manager.update_skill(name, {"status": status}, owner=owner)
     except Exception:
         pass
     return status
@@ -659,10 +659,10 @@ def _apply_skill_md(skills_manager, name: str, md: str, owner) -> bool:
             "category": sk.category, "tags": sk.tags, "platforms": sk.platforms,
             "requires_toolsets": sk.requires_toolsets, "fallback_for_toolsets": sk.fallback_for_toolsets,
             "status": sk.status, "confidence": sk.confidence, "source": sk.source,
-            "teacher_model": sk.teacher_model, "owner": sk.owner or owner,
+            "teacher_model": sk.teacher_model,
             "when_to_use": sk.when_to_use, "procedure": sk.procedure,
             "pitfalls": sk.pitfalls, "verification": sk.verification, "body_extra": sk.body_extra,
-        }))
+        }, owner=owner))
     except Exception as e:
         logger.warning(f"Audit: could not save edited skill {name}: {e}")
         return False
@@ -762,7 +762,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
     # earns a bit less; a skill that still fails is marked low.
     def _set_conf(c):
         try:
-            skills_manager.update_skill(name, {"confidence": c})
+            skills_manager.update_skill(name, {"confidence": c}, owner=owner)
         except Exception:
             pass
 
@@ -799,7 +799,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
     if generic_reason or duplicate_of or (isinstance(nec, dict) and nec.get("necessary") is False):
         reason = generic_reason or (f"Lower-priority duplicate of {duplicate_of}" if duplicate_of else str((nec or {}).get("reason") or "Unnecessary skill"))
         try:
-            skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35})
+            skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35}, owner=owner)
             skills_manager.set_audit(name, "skipped", by_teacher=False, worker_model=model)
             if duplicate_of:
                 skills_manager.set_necessity(name, False, [duplicate_of], reason)
@@ -901,7 +901,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
 
     # Still failing → demote to draft + low confidence + flag (do NOT delete).
     try:
-        skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35})
+        skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35}, owner=owner)
     except Exception:
         pass
     skills_manager.set_audit(
@@ -1468,13 +1468,12 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
             "confidence": sk.confidence,
             "source": sk.source,
             "teacher_model": sk.teacher_model,
-            "owner": sk.owner,
             "when_to_use": sk.when_to_use,
             "procedure": sk.procedure,
             "pitfalls": sk.pitfalls,
             "verification": sk.verification,
             "body_extra": sk.body_extra,
-        })
+        }, owner=user)
         if not ok:
             raise HTTPException(500, "Update failed")
         # Manual markdown edits can create or substantially rewrite a draft
@@ -1496,7 +1495,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
         updates = body.dict(exclude_none=True)
         if not updates:
             return {"ok": True}
-        ok = skills_manager.update_skill(match.get("name"), updates)
+        ok = skills_manager.update_skill(match.get("name"), updates, owner=user)
         if not ok:
             raise HTTPException(404, "Skill not found")
         if not match.get("audit_verdict"):

--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -1076,11 +1076,12 @@ async function _deleteSkill(name, card = null) {
 
 async function _setSkillStatus(name, status) {
   try {
-    await fetch(`${API}/api/skills/${encodeURIComponent(name)}`, {
+    const res = await fetch(`${API}/api/skills/${encodeURIComponent(name)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status }),
     });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
     await loadSkills();
     uiModule.showToast(status === 'published' ? 'Skill approved' : 'Skill moved to draft');
   } catch (e) { uiModule.showError('Update failed: ' + e.message); }
@@ -1787,7 +1788,7 @@ async function _showSkillSource(name) {
       </div>
       <div class="modal-body" style="display:flex;flex-direction:column;gap:8px">
         <textarea id="skill-md-textarea" spellcheck="false" style="flex:1;min-height:50vh;width:100%;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;padding:10px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);box-sizing:border-box"></textarea>
-        <p class="memory-desc" style="margin:0">Edit the frontmatter and body directly. Save replaces the file via PUT /api/skills/{name}.</p>
+        <p class="memory-desc" style="margin:0">Edit the frontmatter and body directly. Save replaces the file via POST /api/skills/{name}/markdown.</p>
       </div>
     </div>
   `;

--- a/tests/test_skills_manager_owner_isolation.py
+++ b/tests/test_skills_manager_owner_isolation.py
@@ -262,3 +262,42 @@ def test_update_skill_positive_scoping(tmp_path):
     assert "bob original" in after_bob and "alice updated" not in after_bob, (
         "Bob's file was mutated by Alice's update_skill call — cross-tenant leak."
     )
+
+
+def test_publish_skill_requires_owner_scoping(tmp_path):
+    """Regression for issue #1227: PUT publish returned 404 because the route
+    called update_skill without owner=user on owner-stamped skills."""
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    skill_dir = skills_root / "general" / "caveman-mode"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(textwrap.dedent("""\
+        ---
+        name: caveman-mode
+        description: test
+        version: 1.0.0
+        category: general
+        tags: []
+        status: draft
+        confidence: 0.8
+        source: user
+        owner: alice
+        created: 2026-01-01T00:00:00Z
+        ---
+
+        # When to use
+        test
+
+        # Procedure
+        - step 1
+        """), encoding="utf-8")
+
+    sm = SkillsManager(str(tmp_path))
+
+    assert sm.update_skill("caveman-mode", {"status": "published"}) is False
+    assert "status: draft" in path.read_text(encoding="utf-8")
+
+    assert sm.update_skill("caveman-mode", {"status": "published"}, owner="alice") is True
+    assert "status: published" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Fixes `PUT /api/skills/{id}` returning 404 when publishing, editing, or saving markdown for skills owned by a logged-in user.
- Root cause: the route resolved the skill with `load(owner=user)` but called `SkillsManager.update_skill()` without `owner=user` — the same scoping gap already fixed for DELETE.
- Also passes `owner` through audit/test background paths so auto-publish after audit works for owned skills.
- UI: publish now checks `res.ok` and shows an error instead of a false success toast.

Fixes #1227

## Test plan
- [x] `pytest tests/test_skills_manager_owner_isolation.py` (includes new `test_publish_skill_requires_owner_scoping`)
