### PR TITLE
fix: research query misclassifies 'whatsapp'/'however' as questions

### DIFF
--- a/services/search/query.py
+++ b/services/search/query.py
@@ -15,7 +15,10 @@ def _detect_question_type(query: str) -> Optional[str]:
     """Return the leading question word if present (who, what, when, where, why, how)."""
     q = query.strip().lower()
     for word in ("who", "what", "when", "where", "why", "how"):
-        if q.startswith(word):
+        # Require a whole-word match: a bare prefix mis-flags ordinary queries
+        # like "whatsapp pricing" (-> what) or "however ..." (-> how), which
+        # then get spurious boost terms OR-appended in enhance_query.
+        if q == word or q.startswith(word + " "):
             return word
     return None
 

--- a/src/search/query.py
+++ b/src/search/query.py
@@ -15,7 +15,10 @@ def _detect_question_type(query: str) -> Optional[str]:
     """Return the leading question word if present (who, what, when, where, why, how)."""
     q = query.strip().lower()
     for word in ("who", "what", "when", "where", "why", "how"):
-        if q.startswith(word):
+        # Require a whole-word match: a bare prefix mis-flags ordinary queries
+        # like "whatsapp pricing" (-> what) or "however ..." (-> how), which
+        # then get spurious boost terms OR-appended in enhance_query.
+        if q == word or q.startswith(word + " "):
             return word
     return None
 

--- a/tests/test_question_type_detection.py
+++ b/tests/test_question_type_detection.py
@@ -1,0 +1,18 @@
+"""Tests for question-word detection in research query enhancement."""
+
+from src.search.query import _detect_question_type
+
+
+def test_whole_word_questions_detected():
+    assert _detect_question_type("what is topological data analysis") == "what"
+    assert _detect_question_type("how do transformers work") == "how"
+    assert _detect_question_type("why") == "why"
+
+
+def test_prefix_lookalikes_not_misclassified():
+    # Regression: a bare prefix used to flag these as questions and append
+    # spurious boost terms in enhance_query.
+    assert _detect_question_type("whatsapp pricing") is None
+    assert _detect_question_type("however we proceed") is None
+    assert _detect_question_type("whole foods stock") is None
+    assert _detect_question_type("howard stern show") is None


### PR DESCRIPTION
## Summary

`_detect_question_type` (used by `enhance_query` for deep research) flags a query as a who/what/when/where/why/how question via `q.startswith(word)`. That's a bare prefix match, so ordinary queries are misclassified and get spurious boost terms OR-appended into the enhanced search query:

- `whatsapp pricing` -> `what`
- `however we proceed` -> `how`
- `whole foods stock` -> `who`
- `howard stern show` -> `how`

Each then gets a `(...) OR (method|person|...)` clause that pollutes the search.

Fix: require a whole-word match (`q == word or q.startswith(word + " ")`). Applied to both the `src/search` and `services/search` copies.

## Changes
- `src/search/query.py`, `services/search/query.py`: whole-word question detection.
- `tests/test_question_type_detection.py`: real questions detected; prefix lookalikes rejected.