### PR TITLE
fix: fire-reminder endpoint crashes with NameError on _gcu

### DIFF
--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -696,7 +696,7 @@ def setup_note_routes(task_scheduler=None):
         # the same dispatch without an HTTP roundtrip + auth cookie.
         return await dispatch_reminder(
             title=title, note_body=note_body, note_id=note_id,
-            owner=_gcu(request) or "",
+            owner=_owner(request) or "",
             queue_browser=False,
         )
 


### PR DESCRIPTION
## Summary

POST to /api/notes/fire-reminder raises a 500 because `_gcu` is referenced on line 699 but never defined. The local wrapper for `get_current_user` in this file is `_owner`.

## Testing

- `python3 -m py_compile routes/note_routes.py`
- `pytest -q tests/test_notes_update_due_date.py`