### PR TITLE
fix: scope skill update/audit writes to the caller's owner (404 on publish)

### DIFF
--- a/routes/skills_routes.py
+++ b/routes/skills_routes.py
@@ -469,7 +469,7 @@ async def _run_skill_test_job(key, name, md, task, url, model, headers, owner, s
         conf = {"pass": 0.95, "needs_work": 0.6, "fail": 0.4}.get(v)
         if conf is not None:
             try:
-                skills_manager.update_skill(name, {"confidence": conf})
+                skills_manager.update_skill(name, {"confidence": conf}, owner=owner)
             except Exception:
                 pass
     job["status"] = "done"
@@ -638,7 +638,7 @@ def _audit_finalize_status(skills_manager, name: str, owner, verdict: str,
     c = float(confidence or 0.0)
     status = "published" if (auto_publish and necessary and verdict == "pass" and c >= min_conf) else "draft"
     try:
-        skills_manager.update_skill(name, {"status": status})
+        skills_manager.update_skill(name, {"status": status}, owner=owner)
     except Exception:
         pass
     return status
@@ -662,7 +662,7 @@ def _apply_skill_md(skills_manager, name: str, md: str, owner) -> bool:
             "teacher_model": sk.teacher_model, "owner": sk.owner or owner,
             "when_to_use": sk.when_to_use, "procedure": sk.procedure,
             "pitfalls": sk.pitfalls, "verification": sk.verification, "body_extra": sk.body_extra,
-        }))
+        }, owner=owner))
     except Exception as e:
         logger.warning(f"Audit: could not save edited skill {name}: {e}")
         return False
@@ -762,7 +762,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
     # earns a bit less; a skill that still fails is marked low.
     def _set_conf(c):
         try:
-            skills_manager.update_skill(name, {"confidence": c})
+            skills_manager.update_skill(name, {"confidence": c}, owner=owner)
         except Exception:
             pass
 
@@ -799,7 +799,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
     if generic_reason or duplicate_of or (isinstance(nec, dict) and nec.get("necessary") is False):
         reason = generic_reason or (f"Lower-priority duplicate of {duplicate_of}" if duplicate_of else str((nec or {}).get("reason") or "Unnecessary skill"))
         try:
-            skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35})
+            skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35}, owner=owner)
             skills_manager.set_audit(name, "skipped", by_teacher=False, worker_model=model)
             if duplicate_of:
                 skills_manager.set_necessity(name, False, [duplicate_of], reason)
@@ -901,7 +901,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
 
     # Still failing → demote to draft + low confidence + flag (do NOT delete).
     try:
-        skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35})
+        skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35}, owner=owner)
     except Exception:
         pass
     skills_manager.set_audit(
@@ -1474,7 +1474,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
             "pitfalls": sk.pitfalls,
             "verification": sk.verification,
             "body_extra": sk.body_extra,
-        })
+        }, owner=user)
         if not ok:
             raise HTTPException(500, "Update failed")
         # Manual markdown edits can create or substantially rewrite a draft
@@ -1496,7 +1496,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
         updates = body.dict(exclude_none=True)
         if not updates:
             return {"ok": True}
-        ok = skills_manager.update_skill(match.get("name"), updates)
+        ok = skills_manager.update_skill(match.get("name"), updates, owner=user)
         if not ok:
             raise HTTPException(404, "Skill not found")
         if not match.get("audit_verdict"):

--- a/tests/test_skills_update_owner.py
+++ b/tests/test_skills_update_owner.py
@@ -1,0 +1,144 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+from fastapi import Request
+from fastapi.datastructures import State
+
+from routes.skills_routes import SkillUpdateRequest, setup_skills_routes
+from services.memory.skill_format import slugify
+from services.memory.skills import SkillsManager
+
+
+def _write_skill_md(skills_root: Path, category: str, name: str,
+                    owner: str, description: str) -> Path:
+    """Drop a real SKILL.md on disk for the given owner."""
+    skill_dir = skills_root / slugify(category or "general", fallback="general") / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    md = textwrap.dedent(f"""\
+        ---
+        name: {name}
+        description: {description}
+        version: 1.0.0
+        category: {category}
+        tags: []
+        status: draft
+        confidence: 0.8
+        source: learned
+        owner: {owner}
+        created: 2026-01-01T00:00:00Z
+        ---
+
+        # When to use
+        test
+
+        # Procedure
+        - step 1
+        """)
+    path = skill_dir / "SKILL.md"
+    path.write_text(md, encoding="utf-8")
+    return path
+
+
+def test_update_skill_manager_requires_owner(tmp_path):
+    """Documents the contract that the PUT /api/skills/{id} route relies on:
+    update_skill() must be called WITH the owner to mutate an owned skill,
+    and without it (the bug shape) the call must fail rather than succeed.
+
+    If this test ever flips, the route may silently mutate a foreign-owned
+    skill — re-audit before changing.
+    """
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    path = _write_skill_md(
+        skills_root, category="general", name="caveman-mode",
+        owner="alice", description="original",
+    )
+    sm = SkillsManager(str(tmp_path))
+
+    # 1. Bug shape: no owner → the manager refuses (returns False).
+    assert sm.update_skill("caveman-mode", {"status": "published"}) is False
+    assert "status: draft" in path.read_text(encoding="utf-8")
+
+    # 2. Fixed shape: owner passed → succeeds.
+    assert sm.update_skill(
+        "caveman-mode", {"status": "published"}, owner="alice"
+    ) is True
+    assert "status: published" in path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_put_skill_route_publishes_owned_skill(tmp_path):
+    """End-to-end regression for the original issue:
+    `PUT /api/skills/caveman-mode` with `{"status": "published"}` returned
+    404 because the route called update_skill() without `owner=`, so the
+    manager's owner filter skipped every owned skill on disk.
+    The fix: the route now passes `owner=user`, so the publish round-trips.
+    """
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    path = _write_skill_md(
+        skills_root, category="general", name="caveman-mode",
+        owner="alice", description="published-via-route",
+    )
+    sm = SkillsManager(str(tmp_path))
+    router = setup_skills_routes(sm)
+
+    update_route_handler = next(
+        route.endpoint for route in router.routes
+        if route.path == "/api/skills/{skill_id}" and "PUT" in route.methods
+    )
+
+    class DummyApp:
+        state = State()
+    request = Request(scope={
+        "type": "http",
+        "app": DummyApp(),
+        "state": {"current_user": "alice"},
+    })
+
+    body = SkillUpdateRequest(status="published")
+    res = await update_route_handler(request, "caveman-mode", body)
+    assert res == {"ok": True}
+    assert "status: published" in path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_put_skill_route_404s_for_other_owner(tmp_path):
+    """Cross-tenant safety: a logged-in user must not be able to mutate
+    another user's same-slug skill via PUT, even after the owner-passing
+    fix. The route's own owner filter must still hide bob's file from alice.
+    """
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    bob_path = _write_skill_md(
+        skills_root, category="bobcat", name="caveman-mode",
+        owner="bob", description="bob's secret",
+    )
+    sm = SkillsManager(str(tmp_path))
+    router = setup_skills_routes(sm)
+
+    update_route_handler = next(
+        route.endpoint for route in router.routes
+        if route.path == "/api/skills/{skill_id}" and "PUT" in route.methods
+    )
+
+    class DummyApp:
+        state = State()
+    request = Request(scope={
+        "type": "http",
+        "app": DummyApp(),
+        "state": {"current_user": "alice"},
+    })
+
+    from fastapi import HTTPException
+    body = SkillUpdateRequest(status="published")
+    with pytest.raises(HTTPException) as exc:
+        await update_route_handler(request, "caveman-mode", body)
+    assert exc.value.status_code == 404
+    # Bob's file must be untouched.
+    assert "status: draft" in bob_path.read_text(encoding="utf-8")
+    assert "bob's secret" in bob_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes the `PUT /api/skills/<name>` 404 from notpalen's report and the
"audits/tests then publishing does nothing" symptom from the same thread.

## Root cause

Eight callers in `routes/skills_routes.py` invoke
`skills_manager.update_skill(name, updates)` without `owner=`.
`SkillsManager.update_skill` defaults `owner=None` and its loop skips any
skill whose `sk.owner` is non-empty (`services/memory/skills.py:385`), so
every owned skill silently fails to update.

* In the PUT/POST routes that surfaces as `404 Skill not found`
  (`PUT /api/skills/caveman-mode` in the report).
* In the audit/test pipeline it is swallowed by `try/except: pass`,
  matching the "audits/tests then publishing does nothing" symptom from
  the same thread — `set_audit` writes the sidecar fine, but the
  `update_skill({"status": "published"})` next to it silently no-ops.

Body size / character length is not involved; the 404 is raised before
the body is applied.

## Fix

Pass `owner=` on every call — the logged-in user in the routes
(`user = _owner(request)`), or the `owner` parameter the audit/test
helpers already carry. Matches the contract
`test_skills_manager_owner_isolation.py::test_update_skill_positive_scoping`
already asserts. `src/tool_implementations.py` was already correct.

## Tests

New `tests/test_skills_update_owner.py` mirrors the existing
`test_skills_delete_owner.py` shape:

* manager contract — `update_skill` without owner returns False, with
  owner returns True
* end-to-end `PUT /api/skills/{id}` publishes an owned skill
* cross-tenant safety — alice cannot mutate bob's same-slug skill,
  still 404s
python -m pytest tests/test_skills_update_owner.py
tests/test_skills_delete_owner.py
tests/test_skills_manager_owner_isolation.py
tests/test_skill_index_prompt_injection.py


11 passed.

## Not addressed here

V0idScript420's Pop!_OS / Docker `Connection reset by peer` report.
Uvicorn accepts on `0.0.0.0:7000` but no request ever lands in the
container's log, so the connection is dropped before reaching uvicorn —
that points to host networking (Docker 29 + nftables on Pop!_OS, or
another process on 7000), not app code. Worth a separate issue once
they can reproduce it from inside the container.