### PR TITLE
Ignore non-object prefs JSON

### DIFF
--- a/routes/prefs_routes.py
+++ b/routes/prefs_routes.py
@@ -12,7 +12,8 @@ def _load():
     """Load the raw prefs file (internal use only)."""
     try:
         with open(PREFS_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 

--- a/tests/test_prefs_routes.py
+++ b/tests/test_prefs_routes.py
@@ -1,0 +1,20 @@
+import json
+
+import routes.prefs_routes as prefs_routes
+
+
+def test_load_ignores_non_object_prefs_file(tmp_path, monkeypatch):
+    prefs_file = tmp_path / "user_prefs.json"
+    prefs_file.write_text(json.dumps(["not", "a", "prefs", "object"]), encoding="utf-8")
+    monkeypatch.setattr(prefs_routes, "PREFS_FILE", str(prefs_file))
+
+    assert prefs_routes._load() == {}
+    assert prefs_routes._load_for_user("alice") == {}
+
+
+def test_load_keeps_object_prefs_file(tmp_path, monkeypatch):
+    prefs_file = tmp_path / "user_prefs.json"
+    prefs_file.write_text(json.dumps({"theme": "dark"}), encoding="utf-8")
+    monkeypatch.setattr(prefs_routes, "PREFS_FILE", str(prefs_file))
+
+    assert prefs_routes._load_for_user("alice") == {"theme": "dark"}


### PR DESCRIPTION
Tiny resilience fix for the prefs file.

Right now a valid-but-wrong-shaped data/user_prefs.json, like a list, can flow through _load() and make _load_for_user() blow up when it tries to treat it like an object. This keeps the existing malformed JSON fallback, and also treats non-object JSON as empty prefs.

Checked:
- venv/bin/python -m py_compile routes/prefs_routes.py tests/test_prefs_routes.py
- venv/bin/python -m pytest -q tests/test_prefs_routes.py
- git diff --check origin/main...HEAD