### PR TITLE
Ignore non-object vault config

### DIFF
--- a/routes/vault_routes.py
+++ b/routes/vault_routes.py
@@ -61,7 +61,8 @@ def _find_bw() -> str:
 def _load_config() -> dict:
     if VAULT_FILE.exists():
         try:
-            return json.loads(VAULT_FILE.read_text(encoding="utf-8"))
+            data = json.loads(VAULT_FILE.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
         except Exception:
             pass
     return {}

--- a/tests/test_vault_password_not_in_argv.py
+++ b/tests/test_vault_password_not_in_argv.py
@@ -13,6 +13,7 @@ vault) to any local user for the lifetime of the unlock subprocess.
 """
 
 import os
+import json
 import re
 import sys
 import types
@@ -98,3 +99,11 @@ def test_unlock_handler_uses_passwordenv_not_argv():
     # And the secure shape must be present.
     assert "--passwordenv" in text
     assert re.search(r"bw_password\s*=\s*req\.master_password", text)
+
+
+def test_load_config_ignores_non_object_json(tmp_path, monkeypatch):
+    vault_file = tmp_path / "vault.json"
+    vault_file.write_text(json.dumps(["not", "a", "config", "object"]), encoding="utf-8")
+    monkeypatch.setattr(vr, "VAULT_FILE", vault_file)
+
+    assert vr._load_config() == {}


### PR DESCRIPTION
Small guard for the local vault config file.

If data/vault.json is valid JSON but not an object, the vault routes can still end up calling .get() on it. This makes _load_config fall back to an empty config unless the parsed value is actually a dict.

Checked:
- venv/bin/python -m py_compile routes/vault_routes.py tests/test_vault_password_not_in_argv.py
- venv/bin/python -m pytest -q tests/test_vault_password_not_in_argv.py
- git diff --check origin/main...HEAD