### PR TITLE
Ignore non-object embedding endpoint config

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -86,7 +86,8 @@ def _load_custom_endpoint() -> dict:
     """Load the saved custom embedding endpoint, if any."""
     try:
         if os.path.exists(_ENDPOINT_FILE):
-            return json.loads(Path(_ENDPOINT_FILE).read_text(encoding="utf-8"))
+            data = json.loads(Path(_ENDPOINT_FILE).read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
     except Exception:
         pass
     return {}

--- a/tests/test_embedding_endpoint_config.py
+++ b/tests/test_embedding_endpoint_config.py
@@ -1,0 +1,25 @@
+import json
+
+import routes.embedding_routes as embedding_routes
+
+
+def test_load_custom_endpoint_ignores_non_object_json(tmp_path, monkeypatch):
+    endpoint_file = tmp_path / "embedding_endpoint.json"
+    endpoint_file.write_text(json.dumps(["not", "an", "endpoint", "object"]), encoding="utf-8")
+    monkeypatch.setattr(embedding_routes, "_ENDPOINT_FILE", str(endpoint_file))
+
+    assert embedding_routes._load_custom_endpoint() == {}
+
+
+def test_load_custom_endpoint_keeps_object_json(tmp_path, monkeypatch):
+    endpoint_file = tmp_path / "embedding_endpoint.json"
+    endpoint_file.write_text(
+        json.dumps({"url": "http://127.0.0.1:11434", "model": "nomic-embed-text"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(embedding_routes, "_ENDPOINT_FILE", str(endpoint_file))
+
+    assert embedding_routes._load_custom_endpoint() == {
+        "url": "http://127.0.0.1:11434",
+        "model": "nomic-embed-text",
+    }


### PR DESCRIPTION
Small guard around the saved embedding endpoint config.

/api/embeddings/endpoint expects _load_custom_endpoint() to return a dict, but a valid JSON file with the wrong shape would still get through and break the .get() calls. This keeps bad/corrupt endpoint config from taking the route down.

Checked:
- venv/bin/python -m py_compile routes/embedding_routes.py tests/test_embedding_endpoint_config.py
- venv/bin/python -m pytest -q tests/test_embedding_endpoint_config.py
- git diff --check origin/main...HEAD