### PR TITLE
Ignore invalid background job store rows

### DIFF
--- a/src/bg_jobs.py
+++ b/src/bg_jobs.py
@@ -55,7 +55,10 @@ _RETENTION_S = 3600  # 1 hour after follow-up
 def _load() -> Dict[str, Dict[str, Any]]:
     try:
         if _STORE.exists():
-            return json.loads(_STORE.read_text(encoding="utf-8")) or {}
+            data = json.loads(_STORE.read_text(encoding="utf-8")) or {}
+            if not isinstance(data, dict):
+                return {}
+            return {str(job_id): rec for job_id, rec in data.items() if isinstance(rec, dict)}
     except Exception:
         pass
     return {}

--- a/tests/test_bg_jobs_store.py
+++ b/tests/test_bg_jobs_store.py
@@ -1,0 +1,28 @@
+import json
+
+from src import bg_jobs
+
+
+def test_load_ignores_non_object_store(tmp_path, monkeypatch):
+    store = tmp_path / "bg_jobs.json"
+    store.write_text(json.dumps(["not", "a", "job", "store"]), encoding="utf-8")
+    monkeypatch.setattr(bg_jobs, "_STORE", store)
+
+    assert bg_jobs._load() == {}
+
+
+def test_load_keeps_only_object_job_records(tmp_path, monkeypatch):
+    store = tmp_path / "bg_jobs.json"
+    store.write_text(
+        json.dumps(
+            {
+                "good": {"id": "good", "status": "done"},
+                "bad-list": ["not", "a", "job"],
+                "bad-null": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bg_jobs, "_STORE", store)
+
+    assert bg_jobs._load() == {"good": {"id": "good", "status": "done"}}


### PR DESCRIPTION
Small defensive fix for the background job store.

The monitor expects data/bg_jobs.json to be an object of job objects. If the file is valid JSON but has the wrong shape, or one row is not an object, refresh/pending followups can trip over it later. This keeps only object-shaped job records and treats anything else as empty/no-op state.

Checked:
- venv/bin/python -m py_compile src/bg_jobs.py tests/test_bg_jobs_store.py
- venv/bin/python -m pytest -q tests/test_bg_jobs_store.py
- git diff --check origin/main...HEAD