### PR TITLE
Keep compact font family names together

### DIFF
--- a/routes/font_routes.py
+++ b/routes/font_routes.py
@@ -5,6 +5,15 @@ from fastapi import APIRouter
 
 CUSTOM_FONTS_DIR = os.path.join("static", "fonts", "custom")
 FONT_EXTENSIONS = {".ttf", ".otf", ".woff", ".woff2"}
+FAMILY_SUFFIX_WORDS = ("Display", "Rounded", "Serif", "Sans", "Mono", "Code", "Text")
+
+
+def _split_family_token(token):
+    """Split common compact font-family suffixes without breaking brand names."""
+    for suffix in FAMILY_SUFFIX_WORDS:
+        if token.endswith(suffix) and len(token) > len(suffix):
+            return f"{token[:-len(suffix)]} {suffix}"
+    return re.sub(r'(?<=[a-z])(?=[A-Z])', ' ', token)
 
 
 def _derive_family(filename):
@@ -15,10 +24,9 @@ def _derive_family(filename):
         r'[-_ ]?(Thin|ExtraLight|UltraLight|Light|Regular|Medium|SemiBold|DemiBold|Bold|ExtraBold|UltraBold|Black|Heavy|Italic|Oblique|Variable|VF)$',
         '', name, flags=re.IGNORECASE
     )
-    # Insert spaces before uppercase runs: "JetBrainsMono" → "Jet Brains Mono"
-    name = re.sub(r'(?<=[a-z])(?=[A-Z])', ' ', name)
     # Replace dashes/underscores with spaces
     name = re.sub(r'[-_]+', ' ', name).strip()
+    name = " ".join(_split_family_token(part) for part in name.split())
     return name or filename
 
 

--- a/tests/test_font_routes.py
+++ b/tests/test_font_routes.py
@@ -1,0 +1,11 @@
+from routes.font_routes import _derive_family
+
+
+def test_derive_family_keeps_jetbrains_together():
+    assert _derive_family("JetBrainsMono-Regular.woff2") == "JetBrains Mono"
+
+
+def test_derive_family_splits_common_family_suffixes():
+    assert _derive_family("FiraCode-SemiBold.ttf") == "Fira Code"
+    assert _derive_family("NotoSans-Bold.otf") == "Noto Sans"
+    assert _derive_family("RobotoSlab-Bold.woff2") == "Roboto Slab"


### PR DESCRIPTION
Small custom-font naming fix.

The helper comment says JetBrainsMono-Regular.woff2 should become JetBrains Mono, but the current lowercase-to-uppercase split turns it into Jet Brains Mono. That makes common compact font names group under weird family labels.

This keeps known family suffixes like Mono/Sans/Code as the split point, while leaving the older fallback split in place for names like RobotoSlab.

Checked:
- venv/bin/python -m py_compile routes/font_routes.py tests/test_font_routes.py
- venv/bin/python -m pytest -q tests/test_font_routes.py
- git diff --check origin/main...HEAD