### PR TITLE
fix: use cached blob URL in attachment chip to prevent memory leak

### DIFF
--- a/static/js/fileHandler.js
+++ b/static/js/fileHandler.js
@@ -112,7 +112,7 @@ function _createChip(f, idx) {
     chip.classList.add('thumb-image');  // lets CSS overlay the remove-X on the corner (mobile)
     const img = document.createElement('img');
     img.className = 'thumb-img';
-    img.src = URL.createObjectURL(f);
+    img.src = _getPreviewUrl(f);
     img.alt = f.name || 'image';
     chip.appendChild(img);
   } else {


### PR DESCRIPTION
## Summary
- `_createChip` in fileHandler.js calls `URL.createObjectURL(f)` directly instead of the existing `_getPreviewUrl(f)` helper
- This bypasses the `_previewUrls` WeakMap cache, so blob URLs are never revoked via `_revokePreviewUrl`
- Each re-render of the attachment strip leaks all previous blob URLs, keeping file data in memory

One-line fix: replace `URL.createObjectURL(f)` with `_getPreviewUrl(f)` (which caches and enables proper revocation).