### PR TITLE
Odysseus hardening

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,6 +73,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+API_TOKEN_ALLOWED_PATHS = {
+    "/api/v1/chat",
+}
+
 # ========= APP =========
 app = FastAPI(
     title="AI Chat Application",
@@ -289,6 +293,11 @@ if AUTH_ENABLED:
             # --- Bearer token auth (API tokens for external integrations) ---
             auth_header = request.headers.get("authorization", "")
             if auth_header.startswith("Bearer ody_"):
+                # API tokens are integration credentials, not browser sessions.
+                # Keep them on explicit token routes so a leaked chat token
+                # cannot walk into unrelated admin/user endpoints.
+                if path not in API_TOKEN_ALLOWED_PATHS:
+                    return JSONResponse(status_code=403, content={"error": "API tokens are only accepted on scoped API routes"})
                 raw_token = auth_header[7:]
                 # Sanity check: tokens are "ody_" + 43 chars of base64
                 if len(raw_token) < 12 or len(raw_token) > 100:

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -528,13 +528,20 @@ def setup_calendar_routes() -> APIRouter:
         owner = _require_user(request)
         from routes.prefs_routes import _load_for_user
         cfg = (_load_for_user(owner) or {}).get("caldav", {}) or {}
+        caldav_password = cfg.get("password") or ""
+        if caldav_password:
+            try:
+                from src.secret_storage import decrypt
+                caldav_password = decrypt(caldav_password)
+            except Exception:
+                pass
         # Surface url+username but never hand the password back to the
         # client — saved-state UI shouldn't leak the credential.
         return {
             "url": cfg.get("url", "") or "",
             "username": cfg.get("username", "") or "",
             "password": "",
-            "has_password": bool(cfg.get("password")),
+            "has_password": bool(caldav_password),
             "local": not bool(cfg.get("url")),
         }
 
@@ -553,12 +560,20 @@ def setup_calendar_routes() -> APIRouter:
             prefs.pop("caldav", None)
             _save_for_user(owner, prefs)
             return {"ok": True, "cleared": True}
-        cfg["url"] = body.get("url", "").strip()
+        from src.caldav_sync import validate_caldav_url
+        try:
+            cfg["url"] = validate_caldav_url(body.get("url", ""))
+        except ValueError as e:
+            raise HTTPException(400, str(e))
         cfg["username"] = (body.get("username") or "").strip()
         # Preserve the stored password when the client sends an empty
         # one (edit form re-submitted without re-typing the password).
         if body.get("password"):
-            cfg["password"] = body["password"]
+            from src.secret_storage import encrypt
+            cfg["password"] = encrypt(body["password"])
+        elif cfg.get("password"):
+            from src.secret_storage import encrypt
+            cfg["password"] = encrypt(cfg["password"])
         prefs["caldav"] = cfg
         _save_for_user(owner, prefs)
         return {"ok": True}
@@ -585,9 +600,21 @@ def setup_calendar_routes() -> APIRouter:
             cfg = (_load_for_user(owner) or {}).get("caldav", {}) or {}
             url = url or (cfg.get("url") or "")
             user = user or (cfg.get("username") or "")
-            pw = pw or (cfg.get("password") or "")
+            if not pw:
+                pw = cfg.get("password") or ""
+                if pw:
+                    try:
+                        from src.secret_storage import decrypt
+                        pw = decrypt(pw)
+                    except Exception:
+                        pass
         if not (url and user and pw):
             return {"ok": False, "error": "Missing URL, username, or password"}
+        from src.caldav_sync import validate_caldav_url
+        try:
+            url = validate_caldav_url(url)
+        except ValueError as e:
+            return {"ok": False, "error": str(e)}
         import httpx
         propfind_body = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
@@ -595,7 +622,7 @@ def setup_calendar_routes() -> APIRouter:
             '</d:prop></d:propfind>'
         )
         try:
-            async with httpx.AsyncClient(timeout=8.0, follow_redirects=True) as cx:
+            async with httpx.AsyncClient(timeout=8.0, follow_redirects=False, trust_env=False) as cx:
                 r = await cx.request(
                     "PROPFIND", url,
                     auth=(user, pw),
@@ -612,6 +639,8 @@ def setup_calendar_routes() -> APIRouter:
                 return {"ok": False, "error": "Forbidden — user can't access that URL"}
             if r.status_code == 404:
                 return {"ok": False, "error": "Not found — check the URL path"}
+            if 300 <= r.status_code < 400:
+                return {"ok": False, "error": "Redirects are not followed for CalDAV safety; use the final URL"}
             return {"ok": False, "error": f"HTTP {r.status_code}"}
         except httpx.ConnectError as e:
             return {"ok": False, "error": f"Connection refused: {e}"[:200]}
@@ -1100,7 +1129,7 @@ def setup_calendar_routes() -> APIRouter:
         "tomorrow", "next Tuesday", "in 30 minutes" resolve correctly.
         Uses the "utility" endpoint (small / fast model) to keep latency low.
         """
-        _require_user(request)
+        owner = _require_user(request)
         from src.endpoint_resolver import resolve_endpoint
         from src.llm_core import llm_call_async
         from src.text_helpers import strip_think
@@ -1113,9 +1142,9 @@ def setup_calendar_routes() -> APIRouter:
             raise HTTPException(400, "text is required")
         tz_hint = (body.get("tz") or "").strip()
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=owner)
         if not url:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=owner)
         if not url or not model:
             return {"ok": False, "error": "No LLM endpoint configured"}
 

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -148,8 +148,9 @@ async def auto_name_session(session_manager, sess):
         if not first_msg:
             return
 
+        owner = getattr(sess, "owner", None)
         t_url, t_model, t_headers = resolve_task_endpoint(
-            sess.endpoint_url, sess.model, sess.headers,
+            sess.endpoint_url, sess.model, sess.headers, owner=owner,
         )
         if not t_model:
             logger.debug("[auto-name] No model provided, skipping")
@@ -311,7 +312,24 @@ def fire_message_event(request, webhook_manager, session_id: str, sess, message:
     fire_event("message_sent", user)
 
 
-def resolve_session_auth(sess, session_id: str):
+def _session_url_matches_endpoint(session_url: str, endpoint_base: str) -> bool:
+    if not session_url or not endpoint_base:
+        return False
+    try:
+        from src.endpoint_resolver import build_chat_url, normalize_base
+
+        sess_url = session_url.rstrip("/")
+        base = normalize_base(endpoint_base).rstrip("/")
+        return sess_url in {
+            base,
+            base + "/chat/completions",
+            build_chat_url(base).rstrip("/"),
+        }
+    except Exception:
+        return False
+
+
+def resolve_session_auth(sess, session_id: str, owner: Optional[str] = None):
     """Ensure session has auth headers — resolve from endpoint DB if missing."""
     has_auth = sess.headers and isinstance(sess.headers, dict) and any(
         k.lower() in ('authorization', 'x-api-key') for k in sess.headers
@@ -320,19 +338,33 @@ def resolve_session_auth(sess, session_id: str):
         return
 
     try:
-        from src.endpoint_resolver import build_headers
+        from src.endpoint_resolver import build_headers, normalize_base
         db = SessionLocal()
         try:
-            domain = sess.endpoint_url.split("//")[1].split("/")[0] if "//" in sess.endpoint_url else ""
-            if domain:
-                ep = db.query(ModelEndpoint).filter(ModelEndpoint.base_url.contains(domain)).first()
-                if ep and ep.api_key:
-                    sess.headers = build_headers(ep.api_key, ep.base_url)
-                    db.query(DBSession).filter(DBSession.id == session_id).update(
-                        {"headers": json.dumps(sess.headers)}
-                    )
-                    db.commit()
-                    logger.info(f"Resolved and persisted auth headers for session {session_id} from endpoint {ep.name}")
+            target_url = getattr(sess, "endpoint_url", "") or ""
+            if not target_url:
+                return
+            q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+            if owner:
+                # Missing headers usually means "recover from the saved endpoint".
+                # Scope that lookup to the session owner, otherwise two users
+                # with similar endpoint URLs can borrow each other's API key.
+                from src.auth_helpers import owner_filter
+                q = owner_filter(q, ModelEndpoint, owner)
+            for ep in q.all():
+                if not _session_url_matches_endpoint(target_url, ep.base_url or ""):
+                    continue
+                if not ep.api_key:
+                    return
+                base = normalize_base(ep.base_url or "")
+                sess.headers = build_headers(ep.api_key, base)
+                update_q = db.query(DBSession).filter(DBSession.id == session_id)
+                if owner:
+                    update_q = update_q.filter(DBSession.owner == owner)
+                update_q.update({"headers": sess.headers})
+                db.commit()
+                logger.info(f"Resolved and persisted auth headers for session {session_id} from endpoint {ep.name}")
+                return
         finally:
             db.close()
     except Exception as e:
@@ -806,7 +838,7 @@ def run_post_response_tasks(
         from services.memory.memory_extractor import extract_and_store
         from src.task_endpoint import resolve_task_endpoint
         t_url, t_model, t_headers = resolve_task_endpoint(
-            sess.endpoint_url, sess.model, sess.headers,
+            sess.endpoint_url, sess.model, sess.headers, owner=owner,
         )
         asyncio.create_task(extract_and_store(
             sess, memory_manager, memory_vector,
@@ -843,7 +875,7 @@ def run_post_response_tasks(
             from services.memory.skill_extractor import maybe_extract_skill
             from src.task_endpoint import resolve_task_endpoint
             s_url, s_model, s_headers = resolve_task_endpoint(
-                sess.endpoint_url, sess.model, sess.headers,
+                sess.endpoint_url, sess.model, sess.headers, owner=owner,
             )
             logger.debug("[skill-extract] dispatching extractor (model=%s)", s_model)
             asyncio.create_task(maybe_extract_skill(

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -72,13 +72,17 @@ def _session_url_matches_endpoint(session_url: str, endpoint_base: str) -> bool:
     return sess in variants or sess.startswith(base + "/")
 
 
-def _clear_orphaned_session_endpoint(sess) -> bool:
+def _clear_orphaned_session_endpoint(sess, owner: str | None = None) -> bool:
     """Clear a session model if its endpoint was deleted from ModelEndpoint."""
     if not getattr(sess, "endpoint_url", ""):
         return False
     db = SessionLocal()
     try:
-        endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+        q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            from src.auth_helpers import owner_filter
+            q = owner_filter(q, ModelEndpoint, owner)
+        endpoints = q.all()
         for ep in endpoints:
             if _session_url_matches_endpoint(sess.endpoint_url or "", ep.base_url or ""):
                 return False
@@ -118,7 +122,7 @@ def _endpoint_cache_contains_model(endpoint, model: str) -> bool:
     return wanted in {str(item).strip() for item in models}
 
 
-def _is_image_generation_session(sess) -> bool:
+def _is_image_generation_session(sess, owner: str | None = None) -> bool:
     """Whether this chat session should bypass text chat and generate images.
 
     Model-name prefixes are explicit image models. Endpoint type is only used
@@ -137,7 +141,11 @@ def _is_image_generation_session(sess) -> bool:
 
     db = SessionLocal()
     try:
-        endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+        q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            from src.auth_helpers import owner_filter
+            q = owner_filter(q, ModelEndpoint, owner)
+        endpoints = q.all()
         for endpoint in endpoints:
             if (getattr(endpoint, "model_type", None) or "llm") != "image":
                 continue
@@ -152,7 +160,7 @@ def _is_image_generation_session(sess) -> bool:
     return False
 
 
-def _recover_empty_session_model(sess, session_id: str) -> bool:
+def _recover_empty_session_model(sess, session_id: str, owner: str | None = None) -> bool:
     """Re-populate sess.model from the matching endpoint's cached models.
 
     Covers the window between endpoint setup and the first chat send: the
@@ -172,7 +180,11 @@ def _recover_empty_session_model(sess, session_id: str) -> bool:
         # cached model is the most defensible default.
         ep = None
         if getattr(sess, "endpoint_url", ""):
-            endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+            q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+            if owner:
+                from src.auth_helpers import owner_filter
+                q = owner_filter(q, ModelEndpoint, owner)
+            endpoints = q.all()
             for cand in endpoints:
                 if _session_url_matches_endpoint(sess.endpoint_url or "", cand.base_url or ""):
                     ep = cand
@@ -251,13 +263,14 @@ def setup_chat_routes(
             sess = session_manager.get_session(session)
         except KeyError:
             raise HTTPException(404, f"Session '{session}' not found")
-        if _clear_orphaned_session_endpoint(sess):
+        owner = get_current_user(request)
+        if _clear_orphaned_session_endpoint(sess, owner=owner):
             raise HTTPException(400, "Selected model endpoint was removed. Pick another model in Settings.")
 
         # Empty model + live endpoint = setup race (Issue #587). Repair from
         # the endpoint's cached model list before privilege checks, which
         # otherwise see "" and behave inconsistently with the allowlist.
-        _recover_empty_session_model(sess, session)
+        _recover_empty_session_model(sess, session, owner=owner)
         if not getattr(sess, "model", "").strip():
             raise HTTPException(
                 400,
@@ -401,7 +414,8 @@ def setup_chat_routes(
             # but BEFORE loading. Prevents cross-user session hijack.
             _verify_session_owner(request, session)
             sess = session_manager.get_session(session)
-            if _clear_orphaned_session_endpoint(sess):
+            owner = get_current_user(request)
+            if _clear_orphaned_session_endpoint(sess, owner=owner):
                 raise HTTPException(400, "Selected model endpoint was removed. Pick another model in Settings.")
             # Issue #587: picker shows a model from the endpoint cache but
             # s.model never made it onto the DB row (first-send race after
@@ -409,7 +423,7 @@ def setup_chat_routes(
             # the first cached model off the matching endpoint so the
             # upstream isn't called with model="" (which surfaces as a
             # generic 401/503).
-            _recover_empty_session_model(sess, session)
+            _recover_empty_session_model(sess, session, owner=owner)
             if not getattr(sess, "model", "").strip():
                 raise HTTPException(
                     400,
@@ -431,7 +445,7 @@ def setup_chat_routes(
         _enforce_chat_privileges(request, sess)
 
         # Ensure session has auth headers
-        resolve_session_auth(sess, session)
+        resolve_session_auth(sess, session, owner=get_current_user(request))
 
         # Check for research_pending BEFORE mode persist overwrites it
         do_research = str(use_research).lower() == "true"
@@ -767,7 +781,7 @@ def setup_chat_routes(
             # output. Resolved once per request.
             try:
                 from src.endpoint_resolver import resolve_chat_fallback_candidates
-                _fallback_candidates = resolve_chat_fallback_candidates()
+                _fallback_candidates = resolve_chat_fallback_candidates(owner=_user)
             except Exception:
                 _fallback_candidates = []
 
@@ -780,7 +794,7 @@ def setup_chat_routes(
                 _model_info["character_name"] = ctx.preset.character_name
             yield f'data: {json.dumps(_model_info)}\n\n'
 
-            if _is_image_generation_session(sess):
+            if _is_image_generation_session(sess, owner=_user):
                 from src.settings import get_setting
                 if not get_setting("image_gen_enabled", True):
                     yield f'data: {json.dumps({"delta": "Image generation is disabled by the administrator."})}\n\n'
@@ -791,7 +805,7 @@ def setup_chat_routes(
                 _user_msg = message or ""
                 yield f'data: {json.dumps({"type": "tool_start", "tool": "generate_image", "command": _user_msg[:100]})}\n\n'
                 yield ": heartbeat\n\n"
-                _img_result = await do_generate_image(f"{_user_msg}\n{sess.model}", session)
+                _img_result = await do_generate_image(f"{_user_msg}\n{sess.model}", session, owner=_user)
                 _img_output = _img_result.get("results", _img_result.get("error", ""))
                 _img_tool_data = {"type": "tool_output", "tool": "generate_image", "command": _user_msg[:100], "output": _img_output, "exit_code": 0 if "error" not in _img_result else 1}
                 for _k in ("image_url", "image_id", "image_prompt", "image_model", "image_size", "image_quality"):

--- a/routes/contacts_routes.py
+++ b/routes/contacts_routes.py
@@ -41,10 +41,19 @@ def _save_settings(settings):
 def _get_carddav_config():
     import os
     settings = _load_settings()
+    password = settings.get("carddav_password", os.environ.get("CARDDAV_PASSWORD", ""))
+    # Stored CardDAV passwords are encrypted at rest (see update_config). Legacy
+    # plaintext values and env-supplied passwords decrypt to themselves.
+    if password:
+        try:
+            from src.secret_storage import decrypt
+            password = decrypt(password)
+        except Exception:
+            pass
     return {
         "url": settings.get("carddav_url", os.environ.get("CARDDAV_URL", "")),
         "username": settings.get("carddav_username", os.environ.get("CARDDAV_USERNAME", "")),
-        "password": settings.get("carddav_password", os.environ.get("CARDDAV_PASSWORD", "")),
+        "password": password,
     }
 
 
@@ -740,7 +749,19 @@ def setup_contacts_routes():
         settings = _load_settings()
         for key in ("carddav_url", "carddav_username", "carddav_password"):
             if key in data:
-                settings[key] = data[key]
+                value = data[key]
+                # Encrypt the password at rest (legacy plaintext stays readable
+                # via the decrypt fallback in _get_carddav_config). Skip the
+                # masked sentinel so re-saving the form doesn't clobber the key.
+                if key == "carddav_password" and value and value != "***":
+                    try:
+                        from src.secret_storage import encrypt
+                        value = encrypt(value)
+                    except Exception:
+                        pass
+                if key == "carddav_password" and value == "***":
+                    continue
+                settings[key] = value
         _save_settings(settings)
         # Force re-fetch
         _contact_cache["fetched_at"] = None

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1706,13 +1706,20 @@ def setup_cookbook_routes() -> APIRouter:
             return {"ok": False, "error": str(e)}
 
     @router.get("/api/cookbook/hf-latest")
-    async def hf_latest(vram_gb: float = 0, limit: int = 10, pipeline: str = "text-generation", owner: str = Depends(require_user)):
+    async def hf_latest(
+        request: Request,
+        vram_gb: float = 0,
+        limit: int = 10,
+        pipeline: str = "text-generation",
+        _owner: str = Depends(require_user),
+    ):
         """Fetch latest HuggingFace models, filtered by what fits in available VRAM.
 
         vram_gb: total available VRAM in GB. 0 = no filter (return everything).
         limit:   how many models to return (default 10).
         pipeline: HF pipeline_tag filter (text-generation, text-to-image, etc.).
         """
+        require_admin(request)
         import re
         import httpx
 

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -823,10 +823,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         from src.llm_core import llm_call_async
 
         user = get_current_user(request)
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=user)
         if not url or not model:
             # Fall back to default endpoint
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=user)
         if not url or not model:
             raise HTTPException(500, "No endpoint configured for AI tidy")
 
@@ -1130,7 +1130,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         settings = _load_vl_settings()
         vl_model = settings.get("vision_model", "")
         try:
-            url, model_id, headers = _resolve_vl_model(vl_model)
+            url, model_id, headers = _resolve_vl_model(vl_model, owner=user)
         except Exception as e:
             raise HTTPException(503, f"No vision model available: {e}")
 

--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -297,7 +297,8 @@ def _init_scheduled_db():
             send_at TEXT NOT NULL,
             created_at TEXT NOT NULL,
             status TEXT NOT NULL DEFAULT 'pending',
-            error TEXT
+            error TEXT,
+            owner TEXT DEFAULT ''
         )
     """)
     # Email summary cache (keyed by Message-ID)
@@ -435,6 +436,35 @@ def _init_scheduled_db():
             conn.execute("ALTER TABLE scheduled_emails ADD COLUMN account_id TEXT")
         if "odysseus_kind" not in cols:
             conn.execute("ALTER TABLE scheduled_emails ADD COLUMN odysseus_kind TEXT")
+        if "owner" not in cols:
+            conn.execute("ALTER TABLE scheduled_emails ADD COLUMN owner TEXT DEFAULT ''")
+        conn.execute("CREATE INDEX IF NOT EXISTS ix_scheduled_emails_owner_status ON scheduled_emails(owner, status)")
+        # Backfill owner on legacy rows from the owning email account so the
+        # owner-scoped list/cancel routes surface pre-migration scheduled
+        # sends to the right user (the poller already resolves these by
+        # account at send time; this aligns the UI with that).
+        legacy_accounts = conn.execute(
+            "SELECT DISTINCT account_id FROM scheduled_emails "
+            "WHERE (owner IS NULL OR owner = '') AND account_id IS NOT NULL AND account_id != ''"
+        ).fetchall()
+        if legacy_accounts:
+            try:
+                from core.database import SessionLocal as _SL, EmailAccount as _EA
+                _db = _SL()
+                try:
+                    for (acct_id,) in legacy_accounts:
+                        row = _db.query(_EA.owner).filter(_EA.id == acct_id).first()
+                        acct_owner = (row[0] or "") if row else ""
+                        if acct_owner:
+                            conn.execute(
+                                "UPDATE scheduled_emails SET owner = ? "
+                                "WHERE account_id = ? AND (owner IS NULL OR owner = '')",
+                                (acct_owner, acct_id),
+                            )
+                finally:
+                    _db.close()
+            except Exception:
+                pass
     except Exception:
         pass
     # Lazy migration: add turns_json to email_boundaries for server-side
@@ -815,10 +845,10 @@ def _detect_spam_folder(conn):
         return None
 
 
-def _imap_move(uid, dest, src="INBOX"):
+def _imap_move(uid, dest, src="INBOX", account_id: str | None = None, owner: str = ""):
     """Move a single IMAP UID from src folder to dest. Returns True on success."""
     try:
-        c = _imap_connect()
+        c = _imap_connect(account_id, owner=owner)
         c.select(_q(src))
         status, _ = c.copy(uid, _q(dest))
         if status != "OK":
@@ -1021,7 +1051,9 @@ def _fetch_sender_thread_context(sender_addr: str,
                                  exclude_folder: str = "INBOX",
                                  limit: int = 3,
                                  max_chars_per_email: int = 1500,
-                                 max_attachment_chars: int = 4000) -> str:
+                                 max_attachment_chars: int = 4000,
+                                 account_id: str | None = None,
+                                 owner: str = "") -> str:
     """Pull the last N emails from `sender_addr` (across common folders),
     extract their body snippets + attachment text, and return one formatted
     block ready to be glued into an LLM system prompt as "REFERENCED MATERIAL".
@@ -1043,7 +1075,7 @@ def _fetch_sender_thread_context(sender_addr: str,
         seen_uids.add((exclude_folder or "INBOX", str(exclude_uid)))
 
     try:
-        conn = _imap_connect()
+        conn = _imap_connect(account_id, owner=owner)
     except Exception as e:
         logger.warning(f"sender-thread-context: imap connect failed: {e}")
         return ""
@@ -1126,7 +1158,12 @@ def _fetch_sender_thread_context(sender_addr: str,
     return "\n\n=====\n\n".join(blocks)
 
 
-def _pre_retrieve_context(body: str, sender: str) -> tuple:
+def _pre_retrieve_context(
+    body: str,
+    sender: str,
+    account_id: str | None = None,
+    owner: str = "",
+) -> tuple:
     """Extract key terms from an incoming email and search past emails + contacts.
 
     Returns (context_snippets, terms_list). Best-effort; never raises.
@@ -1150,18 +1187,35 @@ def _pre_retrieve_context(body: str, sender: str) -> tuple:
         # ── Known-sender check: only retrieve context for senders we already
         # have a relationship with. New / cold senders get an empty context.
         sender_addr = email.utils.parseaddr(sender or "")[1].lower()
-        is_known = False
+        # The CardDAV address book is global admin data backed by a single
+        # Radicale instance, so only fold it into reply context for an admin /
+        # single-user owner. Non-admin owners still get their own (owner-scoped)
+        # IMAP history below, just not the shared contacts.
         try:
-            from routes.contacts_routes import _fetch_contacts
-            for c in _fetch_contacts() or []:
-                if (c.get("email") or "").lower() == sender_addr:
-                    is_known = True
-                    break
+            from src.tool_security import owner_is_admin_or_single_user
+            contacts_allowed = owner_is_admin_or_single_user(owner or None)
         except Exception:
-            pass
+            contacts_allowed = not bool(owner)
+        is_known = False
+        if contacts_allowed:
+            try:
+                from routes.contacts_routes import _fetch_contacts
+                for c in _fetch_contacts() or []:
+                    contact_emails = []
+                    raw_emails = c.get("emails")
+                    if isinstance(raw_emails, list):
+                        contact_emails.extend(str(e or "") for e in raw_emails)
+                    legacy_email = c.get("email")
+                    if legacy_email:
+                        contact_emails.append(str(legacy_email))
+                    if any((addr or "").strip().lower() == sender_addr for addr in contact_emails):
+                        is_known = True
+                        break
+            except Exception:
+                pass
         if not is_known and sender_addr:
             try:
-                with _imap() as _ck:
+                with _imap(account_id, owner=owner) as _ck:
                     _ck.select("INBOX", readonly=True)
                     st_known, dk = _ck.search(None, f'(FROM "{sender_addr}")')
                     if st_known == "OK" and dk and dk[0]:
@@ -1199,7 +1253,7 @@ def _pre_retrieve_context(body: str, sender: str) -> tuple:
             return context_snippets, terms_list
 
         try:
-            ctx_conn = _imap_connect()
+            ctx_conn = _imap_connect(account_id, owner=owner)
             for folder in ["INBOX", "Sent", "Archive", "Drafts"]:
                 try:
                     st_sel, _sd = ctx_conn.select(_q(folder), readonly=True)
@@ -1243,7 +1297,7 @@ def _pre_retrieve_context(body: str, sender: str) -> tuple:
 
         try:
             from routes.contacts_routes import _fetch_contacts
-            all_contacts = _fetch_contacts()
+            all_contacts = _fetch_contacts() if contacts_allowed else []
             for term in terms_list:
                 t_lower = term.lower()
                 matches = [c for c in all_contacts

--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -45,6 +45,21 @@ from routes.email_helpers import (
 logger = logging.getLogger(__name__)
 
 
+def _owner_for_email_account(account_id: str | None) -> str:
+    if not account_id:
+        return ""
+    try:
+        from core.database import SessionLocal as _SL, EmailAccount as _EA
+        db = _SL()
+        try:
+            row = db.query(_EA.owner).filter(_EA.id == account_id).first()
+            return (row[0] or "") if row else ""
+        finally:
+            db.close()
+    except Exception:
+        return ""
+
+
 # ── Routes ──
 
 async def _emit_progress(progress_cb, message: str):
@@ -143,25 +158,17 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
     if not auto_sum and not auto_reply and not auto_tag and not auto_spam and not auto_cal:
         return "Nothing to do"
 
-    # Owner of the account being processed. All calendar reads/writes below are
-    # scoped to this user: the multi-account fan-out runs every user's mailbox,
-    # so an unscoped pass would disclose and mutate other tenants' calendars.
-    _acct_owner = None
-    try:
-        from core.database import SessionLocal as _SLo, EmailAccount as _EAo
-        _dbo = _SLo()
-        try:
-            if account_id:
-                _arow = _dbo.query(_EAo).filter(_EAo.id == account_id).first()
-                _acct_owner = _arow.owner if _arow else None
-        finally:
-            _dbo.close()
-    except Exception:
-        _acct_owner = None
+    # Owner of the account being processed. All calendar + mailbox reads/writes
+    # below are scoped to this user: the multi-account fan-out runs every user's
+    # mailbox, so an unscoped pass would disclose/mutate other tenants' data.
+    # One resolution feeds both the mailbox path (account_owner) and upstream's
+    # calendar path (_acct_owner, which expects None rather than "").
+    account_owner = _owner_for_email_account(account_id)
+    _acct_owner = account_owner or None
 
     try:
         await _emit_progress(progress_cb, "Connecting to mail…")
-        conn = _imap_connect(account_id)
+        conn = _imap_connect(account_id, owner=account_owner)
         from datetime import timedelta as _td
         since = (datetime.utcnow() - _td(days=max(1, days_back))).strftime("%d-%b-%Y")
         # uid_list carries real IMAP UIDs, matching the email UI/read routes.
@@ -212,7 +219,13 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
         _c = _sql3.connect(SCHEDULED_DB)
         _sum_existing = {r[0] for r in _c.execute("SELECT message_id FROM email_summaries").fetchall()}
         _reply_existing = {r[0] for r in _c.execute("SELECT message_id FROM email_ai_replies").fetchall()}
-        _tag_existing = {r[0] for r in _c.execute("SELECT message_id FROM email_tags").fetchall()} if (auto_tag or auto_spam) else set()
+        if auto_tag or auto_spam:
+            if account_owner:
+                _tag_existing = {r[0] for r in _c.execute("SELECT message_id FROM email_tags WHERE owner=?", (account_owner,)).fetchall()}
+            else:
+                _tag_existing = {r[0] for r in _c.execute("SELECT message_id FROM email_tags WHERE owner='' OR owner IS NULL").fetchall()}
+        else:
+            _tag_existing = set()
         _cal_existing = {r[0] for r in _c.execute("SELECT message_id FROM email_calendar_extractions").fetchall()} if auto_cal else set()
         # Urgency is handled by the built-in `check_email_urgency` task. Keep
         # this legacy poller path disabled so users don't get two independent
@@ -225,7 +238,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
         # this per-iteration was making big inbox scans crawl. Used by the
         # urgency self-loop check below.
         try:
-            _self_self_addr = (_get_email_config(account_id).get("from_address") or "").strip().lower()
+            _self_self_addr = (_get_email_config(account_id, owner=account_owner).get("from_address") or "").strip().lower()
         except Exception:
             _self_self_addr = ""
 
@@ -233,9 +246,9 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
         if auto_spam and not spam_folder:
             logger.warning("Auto-spam enabled but no Junk/Spam folder detected — will classify but not move")
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=account_owner)
         if not url:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=account_owner)
         if not url or not model:
             conn.logout()
             return "No model configured"
@@ -395,8 +408,8 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                     await _emit_progress(progress_cb, f"Drafting reply {processed + 1}/{_max_process} · checked {examined}/{len(uid_list)}")
                     # Background reply drafting should not make the whole app
                     # feel busy. Keep it lightweight: no extra IMAP context
-                    # mining here; manual AI Reply can still do that when the
-                    # user explicitly asks for a draft on one email.
+                    # mining here; manual AI Reply can still do that (owner-scoped)
+                    # when the user explicitly asks for a draft on one email.
                     context_snippets, _terms = [], []
                     sys_prompt = _EMAIL_REPLY_SYS_PROMPT_BASE
                     if att_text:
@@ -711,7 +724,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                             # Send alert email immediately if critical or high
                             if urgency in ("critical", "high"):
                                 try:
-                                    cfg = _get_email_config(account_id)
+                                    cfg = _get_email_config(account_id, owner=account_owner)
                                     to_addr = cfg["from_address"]  # self-email
 
                                     # Deep-link to open the original email in Odysseus (if public URL is configured).
@@ -846,17 +859,17 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
 
                                 moved_to = ""
                                 if is_spam and auto_spam and spam_folder:
-                                    if _imap_move(uid, spam_folder):
+                                    if _imap_move(uid, spam_folder, account_id=account_id, owner=account_owner):
                                         moved_to = spam_folder
                                         logger.info(f"Auto-spam moved uid={uid.decode()} to {spam_folder}: {spam_reason}")
 
                                 _c = _sql3.connect(SCHEDULED_DB)
                                 _c.execute("""
                                     INSERT OR REPLACE INTO email_tags
-                                    (message_id, uid, folder, subject, sender, tags, spam_verdict,
+                                    (message_id, owner, uid, folder, subject, sender, tags, spam_verdict,
                                      spam_reason, moved_to, model_used, created_at)
-                                    VALUES (?, ?, 'INBOX', ?, ?, ?, ?, ?, ?, ?, ?)
-                                """, (message_id, uid.decode(), subject, sender,
+                                    VALUES (?, ?, ?, 'INBOX', ?, ?, ?, ?, ?, ?, ?, ?)
+                                """, (message_id, account_owner or "", uid.decode(), subject, sender,
                                       json.dumps(tags), 1 if is_spam else 0,
                                       spam_reason, moved_to, model, datetime.utcnow().isoformat()))
                                 _c.commit()
@@ -936,8 +949,9 @@ def _scheduled_poll_once() -> dict:
         conn = sqlite3.connect(SCHEDULED_DB)
         cols = [row[1] for row in conn.execute("PRAGMA table_info(scheduled_emails)").fetchall()]
         kind_expr = "odysseus_kind" if "odysseus_kind" in cols else "'scheduled' AS odysseus_kind"
+        owner_expr = "owner" if "owner" in cols else "'' AS owner"
         rows = conn.execute(f"""
-            SELECT id, to_addr, cc, bcc, subject, body, in_reply_to, references_hdr, attachments, account_id, {kind_expr}
+            SELECT id, to_addr, cc, bcc, subject, body, in_reply_to, references_hdr, attachments, account_id, {kind_expr}, {owner_expr}
             FROM scheduled_emails
             WHERE status = 'pending' AND send_at <= ?
         """, (now_iso,)).fetchall()
@@ -949,7 +963,8 @@ def _scheduled_poll_once() -> dict:
                 attachments = json.loads(r[8] or "[]")
                 row_account_id = r[9] if len(r) > 9 else None
                 odysseus_kind = r[10] if len(r) > 10 else "scheduled"
-                cfg = _get_email_config(row_account_id)
+                row_owner = (r[11] if len(r) > 11 else "") or _owner_for_email_account(row_account_id)
+                cfg = _get_email_config(row_account_id, owner=row_owner)
                 has_atts = bool(attachments)
                 if has_atts:
                     outer = MIMEMultipart("mixed")
@@ -986,7 +1001,7 @@ def _scheduled_poll_once() -> dict:
 
                 # Append to local Sent folder
                 try:
-                    with _imap() as imap:
+                    with _imap(row_account_id, owner=row_owner) as imap:
                         sent_folder = _detect_sent_folder(imap)
                         imap.append(sent_folder, "\\Seen", None, outer.as_bytes())
                 except Exception as e:

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -90,6 +90,16 @@ def _email_tag_owner_aliases(account_id: str | None, owner: str = "") -> list[st
     return out or [""]
 
 
+def _email_tag_owner_clause(account_id: str | None, owner: str = "") -> tuple[str, list[str]]:
+    aliases = _email_tag_owner_aliases(account_id, owner)
+    placeholders = ",".join("?" * len(aliases))
+    # In configured multi-user mode, do not treat legacy owner='' rows as
+    # visible to everyone. Single-user/unconfigured mode keeps legacy rows.
+    if owner:
+        return f"owner IN ({placeholders})", aliases
+    return f"(owner IN ({placeholders}) OR owner IS NULL)", aliases
+
+
 def _record_email_received_events(owner: str, account_id: str | None, folder: str, emails: list[dict]):
     """Baseline inbox messages, then fire `email_received` for new arrivals."""
     if not owner or (folder or "INBOX").upper() != "INBOX" or not emails:
@@ -645,8 +655,7 @@ def setup_email_routes():
                 try:
                     import sqlite3 as _sql3t
                     _ct = _sql3t.connect(SCHEDULED_DB)
-                    _owner_aliases = _email_tag_owner_aliases(account_id, owner)
-                    _owner_ph = ",".join("?" * len(_owner_aliases))
+                    _owner_clause, _owner_params = _email_tag_owner_clause(account_id, owner)
                     # SECURITY: owner-scope the lookup (review C2/H8). Without
                     # this, user A's `tag:urgent` filter would surface UIDs
                     # written by user B and IMAP would return whatever
@@ -658,8 +667,8 @@ def setup_email_routes():
                         rows_t = _ct.execute(
                             "SELECT message_id, uid FROM email_tags "
                             "WHERE folder=? AND spam_verdict=1 "
-                            f"AND (owner IN ({_owner_ph}) OR owner IS NULL)",
-                            (folder, *_owner_aliases),
+                            f"AND {_owner_clause}",
+                            (folder, *_owner_params),
                         ).fetchall()
                         for mid, uid in rows_t:
                             if mid:
@@ -670,8 +679,8 @@ def setup_email_routes():
                         rows_t = _ct.execute(
                             "SELECT message_id, uid, tags FROM email_tags "
                             "WHERE folder=? AND tags IS NOT NULL AND tags != '' "
-                            f"AND (owner IN ({_owner_ph}) OR owner IS NULL)",
-                            (folder, *_owner_aliases),
+                            f"AND {_owner_clause}",
+                            (folder, *_owner_params),
                         ).fetchall()
                         for r in rows_t:
                             try:
@@ -743,12 +752,11 @@ def setup_email_routes():
                 _uid_strs = [u.decode() for u in uid_list]
                 if _uid_strs:
                     placeholders = ",".join("?" * len(_uid_strs))
-                    _owner_aliases = _email_tag_owner_aliases(account_id, owner)
-                    _owner_ph = ",".join("?" * len(_owner_aliases))
+                    _owner_clause, _owner_params = _email_tag_owner_clause(account_id, owner)
                     rows = _c.execute(
                         f"SELECT uid, tags, spam_verdict FROM email_tags "
-                        f"WHERE folder=? AND (owner IN ({_owner_ph}) OR owner IS NULL) AND uid IN ({placeholders})",
-                        [folder, *_owner_aliases, *_uid_strs],
+                        f"WHERE folder=? AND {_owner_clause} AND uid IN ({placeholders})",
+                        [folder, *_owner_params, *_uid_strs],
                     ).fetchall()
                     for r in rows:
                         try:
@@ -805,14 +813,13 @@ def setup_email_routes():
                     if header_ids:
                         import sqlite3 as _sql3m
                         _cm = _sql3m.connect(SCHEDULED_DB)
-                        _owner_aliases_m = _email_tag_owner_aliases(account_id, owner)
-                        _owner_ph_m = ",".join("?" * len(_owner_aliases_m))
+                        _owner_clause_m, _owner_params_m = _email_tag_owner_clause(account_id, owner)
                         _mid_ph = ",".join("?" * len(header_ids))
                         rows_m = _cm.execute(
                             f"SELECT message_id, tags, spam_verdict FROM email_tags "
-                            f"WHERE folder=? AND (owner IN ({_owner_ph_m}) OR owner IS NULL) "
+                            f"WHERE folder=? AND {_owner_clause_m} "
                             f"AND message_id IN ({_mid_ph})",
-                            [folder, *_owner_aliases_m, *header_ids],
+                            [folder, *_owner_params_m, *header_ids],
                         ).fetchall()
                         _cm.close()
                         for mid, tags_raw, spam_raw in rows_m:
@@ -971,10 +978,11 @@ def setup_email_routes():
     async def unflag_spam(uid: str, owner: str = Depends(require_owner)):
         """User override — mark email as not spam."""
         try:
+            owner_clause, owner_params = _email_tag_owner_clause(None, owner)
             _c = _sql3.connect(SCHEDULED_DB)
             _c.execute(
-                "UPDATE email_tags SET spam_verdict=0, spam_reason='' WHERE uid=?",
-                (uid,),
+                f"UPDATE email_tags SET spam_verdict=0, spam_reason='' WHERE uid=? AND {owner_clause}",
+                [uid, *owner_params],
             )
             _c.commit()
             _c.close()
@@ -997,8 +1005,10 @@ def setup_email_routes():
         ql = (q or "").strip().lower()
         try:
             conn = _sql3.connect(SCHEDULED_DB)
+            owner_clause, owner_params = _email_tag_owner_clause(None, owner)
             rows = conn.execute(
-                "SELECT sender FROM email_tags WHERE sender IS NOT NULL AND sender != ''"
+                f"SELECT sender FROM email_tags WHERE sender IS NOT NULL AND sender != '' AND {owner_clause}",
+                owner_params,
             ).fetchall()
             conn.close()
             seen = {}
@@ -1969,8 +1979,8 @@ def setup_email_routes():
             conn = sqlite3.connect(SCHEDULED_DB)
             conn.execute("""
                 INSERT INTO scheduled_emails
-                (id, to_addr, cc, bcc, subject, body, in_reply_to, references_hdr, attachments, send_at, created_at, status, account_id, odysseus_kind)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                (id, to_addr, cc, bcc, subject, body, in_reply_to, references_hdr, attachments, send_at, created_at, status, account_id, odysseus_kind, owner)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
             """, (
                 sid,
                 req.get("to", ""),
@@ -1985,6 +1995,7 @@ def setup_email_routes():
                 datetime.utcnow().isoformat(),
                 req.get("account_id") or None,
                 req.get("odysseus_kind") or "scheduled",
+                owner or "",
             ))
             conn.commit()
             conn.close()
@@ -2003,9 +2014,9 @@ def setup_email_routes():
             rows = conn.execute("""
                 SELECT id, to_addr, cc, subject, send_at, created_at, status, error
                 FROM scheduled_emails
-                WHERE status IN ('pending', 'failed')
+                WHERE status IN ('pending', 'failed') AND owner = ?
                 ORDER BY send_at ASC
-            """).fetchall()
+            """, (owner or "",)).fetchall()
             conn.close()
             return {"scheduled": [
                 {
@@ -2023,7 +2034,10 @@ def setup_email_routes():
         import sqlite3
         try:
             conn = sqlite3.connect(SCHEDULED_DB)
-            conn.execute("DELETE FROM scheduled_emails WHERE id = ? AND status = 'pending'", (sid,))
+            conn.execute(
+                "DELETE FROM scheduled_emails WHERE id = ? AND status = 'pending' AND owner = ?",
+                (sid, owner or ""),
+            )
             conn.commit()
             conn.close()
             return {"success": True}
@@ -2035,7 +2049,7 @@ def setup_email_routes():
     async def resolve_contact(name: str = Query(..., description="Name to search for"), owner: str = Depends(require_owner)):
         """Search Sent folder for a contact by name. Returns matching email addresses."""
         try:
-            with _imap() as conn:
+            with _imap(owner=owner) as conn:
                 matches = {}
                 for folder in ["Sent", "INBOX", "Drafts"]:
                     try:
@@ -2590,7 +2604,7 @@ def setup_email_routes():
                     # `api_key` field.
                     from core.database import SessionLocal as _SL, Session as _CS
                     _db = _SL()
-                    sess = _db.query(_CS).filter(_CS.id == session_id).first()
+                    sess = _db.query(_CS).filter(_CS.id == session_id, _CS.owner == owner).first()
                     if sess and sess.endpoint_url:
                         url = sess.endpoint_url
                         # Some sessions stored headers double-encoded (a JSON
@@ -2649,9 +2663,10 @@ def setup_email_routes():
             # Manual AI Reply should feel immediate. The heavier context mining
             # can involve multiple IMAP folder searches and attachment parsing;
             # reserve that for callers that explicitly opt out of fast mode.
+            # Owner-scoped so pre-retrieval never crosses tenants.
             context_snippets, _terms = ([], [])
             if not fast_reply:
-                context_snippets, _terms = _pre_retrieve_context(original_body, to)
+                context_snippets, _terms = _pre_retrieve_context(original_body, to, owner=owner)
 
             # NEW: also pull the last few emails from the original sender +
             # their attachments. The "to" field on this endpoint is the
@@ -2667,6 +2682,7 @@ def setup_email_routes():
                         exclude_uid=source_uid,
                         exclude_folder=source_folder,
                         limit=3,
+                        owner=owner,
                     )
                 except Exception as _e:
                     logger.warning(f"sender-thread-context failed: {_e}")
@@ -2728,7 +2744,7 @@ def setup_email_routes():
             # Configured fallback chains last.
             for cand in resolve_utility_fallback_candidates(owner=owner) or []:
                 _add(*cand)
-            for cand in resolve_chat_fallback_candidates() or []:
+            for cand in resolve_chat_fallback_candidates(owner=owner) or []:
                 _add(*cand)
             try:
                 reply = await llm_call_async_with_fallback(
@@ -2819,9 +2835,12 @@ def setup_email_routes():
         import uuid as _uuid
         db = SessionLocal()
         try:
-            row = db.query(EmailAccount).filter(EmailAccount.is_default == True).first()  # noqa: E712
+            q = db.query(EmailAccount).filter(EmailAccount.is_default == True)  # noqa: E712
+            if owner:
+                q = q.filter(EmailAccount.owner == owner)
+            row = q.first()
             if row is None:
-                row = EmailAccount(id=_uuid.uuid4().hex, name="Default", is_default=True, enabled=True)
+                row = EmailAccount(id=_uuid.uuid4().hex, owner=owner, name="Default", is_default=True, enabled=True)
                 db.add(row)
             field_map = {
                 "smtp_host": "smtp_host", "smtp_port": "smtp_port", "smtp_user": "smtp_user",
@@ -2843,6 +2862,10 @@ def setup_email_routes():
                 row.imap_password = _enc(data["imap_password"])
             if data.get("smtp_password"):
                 row.smtp_password = _enc(data["smtp_password"])
+            clear_q = db.query(EmailAccount).filter(EmailAccount.id != row.id)
+            if owner:
+                clear_q = clear_q.filter(EmailAccount.owner == owner)
+            clear_q.update({EmailAccount.is_default: False})
             db.commit()
         finally:
             db.close()

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -1700,7 +1700,7 @@ def setup_gallery_routes() -> APIRouter:
                 return {"error": "Vision is disabled — enable it in Settings → Vision"}
             configured = vl_settings.get("vision_model", "")
             try:
-                chat_url, model_name, headers = _resolve_vl_model(configured)
+                chat_url, model_name, headers = _resolve_vl_model(configured, owner=user)
             except ValueError:
                 return {"error": "No vision model configured — set one in Settings → Vision"}
             if not chat_url:

--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -520,7 +520,7 @@ def setup_history_routes(session_manager) -> APIRouter:
             )
 
             # Use utility model if available
-            util_url, util_model, util_headers = resolve_endpoint("utility")
+            util_url, util_model, util_headers = resolve_endpoint("utility", owner=user)
             compact_url = util_url or session.endpoint_url
             compact_model = util_model or session.model
             compact_headers = util_headers if util_url else session.headers

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -179,9 +179,9 @@ async def dispatch_reminder(
         try:
             from src.endpoint_resolver import resolve_endpoint
             from src.llm_core import llm_call_async
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=owner)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=owner)
             if url and model:
                 raw = await llm_call_async(
                     url=url, model=model,

--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel, Field
 from src.endpoint_resolver import resolve_endpoint
-from src.auth_helpers import _auth_disabled, get_current_user
+from src.auth_helpers import _auth_disabled, get_current_user, owner_filter
 
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9-]{1,128}$")
 
@@ -44,6 +44,7 @@ def _resolve_research_endpoint(sess) -> tuple:
         fallback_url=sess.endpoint_url,
         fallback_model=sess.model,
         fallback_headers=sess.headers,
+        owner=getattr(sess, "owner", None),
     )
     return url, model, headers
 
@@ -351,7 +352,8 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                 ep = db.query(ModelEndpoint).filter(
                     ModelEndpoint.id == body.endpoint_id,
                     ModelEndpoint.is_enabled == True,
-                ).first()
+                )
+                ep = owner_filter(ep, ModelEndpoint, user).first()
                 if not ep:
                     raise HTTPException(404, "Endpoint not found or disabled")
                 base = normalize_base(ep.base_url)
@@ -369,26 +371,27 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
             finally:
                 db.close()
         else:
-            ep_url, ep_model, ep_headers = resolve_endpoint("research")
+            ep_url, ep_model, ep_headers = resolve_endpoint("research", owner=user)
             if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("utility")
+                ep_url, ep_model, ep_headers = resolve_endpoint("utility", owner=user)
             # When neither research nor utility is configured, use the user's
             # configured DEFAULT model (default_endpoint_id/default_model) rather
             # than arbitrarily grabbing the first enabled endpoint's first model
             # (which surfaced gpt-3.5). "Default" should mean the default model.
             if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("default")
+                ep_url, ep_model, ep_headers = resolve_endpoint("default", owner=user)
             if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("chat")
+                ep_url, ep_model, ep_headers = resolve_endpoint("chat", owner=user)
             if not ep_url:
                 from src.database import SessionLocal
                 from src.database import ModelEndpoint
                 from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
                 db = SessionLocal()
                 try:
-                    ep = db.query(ModelEndpoint).filter(
+                    q = db.query(ModelEndpoint).filter(
                         ModelEndpoint.is_enabled == True,
-                    ).first()
+                    )
+                    ep = owner_filter(q, ModelEndpoint, user).first()
                     if ep:
                         base = normalize_base(ep.base_url)
                         ep_url = build_chat_url(base)
@@ -548,11 +551,11 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                 ep_headers = dict(r_headers)
 
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("chat"))
+            _merge(*resolve_endpoint("chat", owner=user))
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("research"))
+            _merge(*resolve_endpoint("research", owner=user))
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("utility"))
+            _merge(*resolve_endpoint("utility", owner=user))
         if not ep_url or not ep_model:
             # Last resort: any enabled endpoint
             from src.database import SessionLocal
@@ -560,7 +563,8 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
             from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
             db = SessionLocal()
             try:
-                ep = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()
+                q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+                ep = owner_filter(q, ModelEndpoint, user).first()
                 if ep:
                     base = normalize_base(ep.base_url)
                     fallback_url = build_chat_url(base)

--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -58,23 +58,71 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["sessions"])
 
-def _pick_endpoint_for_sort():
+
+def _current_user_is_admin(request: Request, user: str | None) -> bool:
+    if not user:
+        return False
+    auth_mgr = getattr(request.app.state, "auth_manager", None)
+    is_admin = getattr(auth_mgr, "is_admin", None)
+    if not callable(is_admin):
+        return False
+    try:
+        return bool(is_admin(user))
+    except Exception:
+        return False
+
+
+def _reject_raw_endpoint_url_for_non_admin(
+    request: Request,
+    user: str | None,
+    endpoint_id: str | None,
+    endpoint_url: str | None,
+) -> None:
+    """Require registered endpoints for signed-in non-admin session changes."""
+    if endpoint_id and endpoint_id.strip():
+        return
+    if not endpoint_url:
+        return
+    # Raw URLs make the server dial whatever host the request supplies. For
+    # non-admin users, require a saved endpoint row so normal owner scoping and
+    # endpoint validation have already happened.
+    if user and not _current_user_is_admin(request, user):
+        raise HTTPException(403, "Choose a registered model endpoint")
+
+
+def _persist_session_headers(session_id: str, headers: dict | None) -> None:
+    """Persist endpoint auth headers for DB-backed session metadata."""
+    db = SessionLocal()
+    try:
+        db_session = db.query(DbSession).filter(DbSession.id == session_id).first()
+        if db_session:
+            db_session.headers = headers or {}
+            db_session.updated_at = datetime.utcnow()
+            db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def _pick_endpoint_for_sort(owner=None):
     """Pick model endpoint for auto-sort LLM call — uses utility endpoint setting, falls back to default."""
     from src.endpoint_resolver import resolve_endpoint
     # Try utility endpoint first (what the user configured for background tasks)
-    url, model, headers = resolve_endpoint("utility")
+    url, model, headers = resolve_endpoint("utility", owner=owner)
     if url and model:
         return url, model, headers
     # Fall back to task endpoint
     try:
         from src.task_endpoint import resolve_task_endpoint
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=owner)
         if url and model:
             return url, model, headers
     except Exception:
         pass
     # Fall back to default
-    url, model, headers = resolve_endpoint("default")
+    url, model, headers = resolve_endpoint("default", owner=owner)
     if url and model:
         return url, model, headers
     return None, None, None
@@ -197,11 +245,41 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         endpoint_id: str = Form(""),
     ):
         skip_val = str(skip_validation).lower() == "true"
+        user = get_current_user(request)
+        endpoint_api_key = ""
+        endpoint_base_url = ""
+        _reject_raw_endpoint_url_for_non_admin(request, user, endpoint_id, endpoint_url)
+        if endpoint_id and endpoint_id.strip():
+            from core.database import ModelEndpoint
+            from src.auth_helpers import owner_filter
+            from src.endpoint_resolver import build_chat_url, normalize_base
+            _db = SessionLocal()
+            try:
+                q = _db.query(ModelEndpoint).filter(
+                    ModelEndpoint.id == endpoint_id.strip(),
+                    ModelEndpoint.is_enabled == True,
+                )
+                if user:
+                    q = owner_filter(q, ModelEndpoint, user)
+                endpoint_row = q.first()
+                if not endpoint_row:
+                    raise HTTPException(400, "Model endpoint no longer exists")
+                endpoint_base_url = endpoint_row.base_url or ""
+                endpoint_api_key = endpoint_row.api_key or ""
+                endpoint_url = build_chat_url(normalize_base(endpoint_base_url))
+            finally:
+                _db.close()
 
         if not endpoint_url and not skip_val:
             raise HTTPException(400, "endpoint_url is required (choose from /api/models)")
 
         model_to_use = model
+        request_api_key = api_key.strip() if api_key else ""
+        effective_api_key = request_api_key or endpoint_api_key
+        validation_headers = None
+        if effective_api_key:
+            from src.endpoint_resolver import build_headers
+            validation_headers = build_headers(effective_api_key, endpoint_base_url or endpoint_url)
 
         if skip_val:
             # skip_validation = trust the caller and do NOT probe /v1/models.
@@ -212,7 +290,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         elif not model_to_use:
             from src.llm_core import list_model_ids
             ids = list_model_ids(endpoint_url, timeout=REQUEST_TIMEOUT,
-                                 headers={"Authorization": f"Bearer {api_key}"} if api_key.strip() else None)
+                                 headers=validation_headers)
             if not ids:
                 raise HTTPException(400, "Cannot reach /v1/models")
             # Default to the first CHAT model — endpoints often list embedding/
@@ -227,7 +305,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             import os as _os
             req_base = _os.path.basename(model_to_use.rstrip("/"))
             avail = list_model_ids(endpoint_url, timeout=REQUEST_TIMEOUT,
-                                   headers={"Authorization": f"Bearer {api_key}"} if api_key.strip() else None)
+                                   headers=validation_headers)
             if not avail:
                 raise HTTPException(400, "Cannot reach /v1/models")
             if model_to_use not in avail:
@@ -252,22 +330,15 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             owner=user,
         )
         # Set auth headers for custom API-key endpoints
-        resolved_key = api_key.strip() if api_key else ""
+        resolved_key = request_api_key
         resolved_base = endpoint_url
-        if not resolved_key and endpoint_id and endpoint_id.strip():
-            from core.database import ModelEndpoint
-            _db = SessionLocal()
-            try:
-                ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id.strip()).first()
-                if ep and ep.api_key:
-                    resolved_key = ep.api_key
-                    resolved_base = ep.base_url
-            finally:
-                _db.close()
+        if not resolved_key and endpoint_api_key:
+            resolved_key = endpoint_api_key
+            resolved_base = endpoint_base_url
         if resolved_key:
             from src.endpoint_resolver import build_headers
             session.headers = build_headers(resolved_key, resolved_base)
-            session_manager.save_sessions()
+            _persist_session_headers(sid, session.headers)
         # Fire webhook (sync-safe)
         if webhook_manager:
             webhook_manager.fire_and_forget("session.created", {
@@ -313,27 +384,38 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 db.close()
         # Switch model/endpoint mid-session
         if model is not None and endpoint_url is not None:
+            user = get_current_user(request)
+            _reject_raw_endpoint_url_for_non_admin(request, user, endpoint_id, endpoint_url)
+            endpoint_api_key = ""
+            endpoint_base_url = ""
             if endpoint_id:
                 from core.database import ModelEndpoint
+                from src.auth_helpers import owner_filter
+                from src.endpoint_resolver import build_chat_url, normalize_base
                 _db = SessionLocal()
                 try:
-                    ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id).first()
+                    q = _db.query(ModelEndpoint).filter(
+                        ModelEndpoint.id == endpoint_id,
+                        ModelEndpoint.is_enabled == True,
+                    )
+                    if user:
+                        q = owner_filter(q, ModelEndpoint, user)
+                    ep = q.first()
                     if not ep:
                         raise HTTPException(400, "Model endpoint no longer exists")
+                    endpoint_base_url = ep.base_url or ""
+                    endpoint_api_key = ep.api_key or ""
+                    endpoint_url = build_chat_url(normalize_base(endpoint_base_url))
                 finally:
                     _db.close()
             session.model = model
             session.endpoint_url = endpoint_url
             # Update auth headers from the endpoint's stored API key
-            if endpoint_id:
-                _db = SessionLocal()
-                try:
-                    ep = _db.query(ModelEndpoint).filter(ModelEndpoint.id == endpoint_id).first()
-                    if ep and ep.api_key:
-                        from src.endpoint_resolver import build_headers
-                        session.headers = build_headers(ep.api_key, ep.base_url)
-                finally:
-                    _db.close()
+            if endpoint_api_key:
+                from src.endpoint_resolver import build_headers
+                session.headers = build_headers(endpoint_api_key, endpoint_base_url)
+            else:
+                session.headers = {}
             # Persist to DB
             db = SessionLocal()
             try:
@@ -341,6 +423,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
                 if db_session:
                     db_session.model = model
                     db_session.endpoint_url = endpoint_url
+                    db_session.headers = session.headers or {}
                     db_session.updated_at = datetime.utcnow()
                     db.commit()
             finally:
@@ -754,7 +837,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         from src.endpoint_resolver import resolve_endpoint
         from src.llm_core import llm_call_async
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=get_current_user(request))
         if not url or not model:
             url, model, headers = session.endpoint_url, session.model, session.headers
         if not url or not model:
@@ -954,9 +1037,9 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
 
         # Pick an endpoint — prefer admin-configured task endpoint
         from src.task_endpoint import resolve_task_endpoint
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=user)
         if not url:
-            url, model, headers = _pick_endpoint_for_sort()
+            url, model, headers = _pick_endpoint_for_sort(owner=user)
         if not url:
             raise HTTPException(503, "No available model endpoint for auto-sort")
 

--- a/routes/skills_routes.py
+++ b/routes/skills_routes.py
@@ -463,13 +463,13 @@ async def _run_skill_test_job(key, name, md, task, url, model, headers, owner, s
     if skills_manager is not None:
         v = (job["verdict"] or {}).get("verdict") or "unknown"
         try:
-            skills_manager.set_audit(name, v, by_teacher=False, worker_model=model)
+            skills_manager.set_audit(name, v, by_teacher=False, worker_model=model, owner=owner)
         except Exception:
             pass
         conf = {"pass": 0.95, "needs_work": 0.6, "fail": 0.4}.get(v)
         if conf is not None:
             try:
-                skills_manager.update_skill(name, {"confidence": conf})
+                skills_manager.update_skill(name, {"confidence": conf}, owner=owner)
             except Exception:
                 pass
     job["status"] = "done"
@@ -563,6 +563,7 @@ def _skill_duplicate_blocker(skills_manager, name: str, owner) -> Optional[str]:
                 False,
                 [keeper_name],
                 f"Lower-priority duplicate of {keeper_name}",
+                owner=owner,
             )
         except Exception:
             pass
@@ -629,7 +630,7 @@ def _audit_finalize_status(skills_manager, name: str, owner, verdict: str,
     if generic_reason:
         necessary = False
         try:
-            skills_manager.set_necessity(name, False, [], generic_reason)
+            skills_manager.set_necessity(name, False, [], generic_reason, owner=owner)
         except Exception:
             pass
     duplicate_of = _skill_duplicate_blocker(skills_manager, name, owner) if verdict == "pass" else None
@@ -638,7 +639,7 @@ def _audit_finalize_status(skills_manager, name: str, owner, verdict: str,
     c = float(confidence or 0.0)
     status = "published" if (auto_publish and necessary and verdict == "pass" and c >= min_conf) else "draft"
     try:
-        skills_manager.update_skill(name, {"status": status})
+        skills_manager.update_skill(name, {"status": status}, owner=owner)
     except Exception:
         pass
     return status
@@ -662,7 +663,7 @@ def _apply_skill_md(skills_manager, name: str, md: str, owner) -> bool:
             "teacher_model": sk.teacher_model, "owner": sk.owner or owner,
             "when_to_use": sk.when_to_use, "procedure": sk.procedure,
             "pitfalls": sk.pitfalls, "verification": sk.verification, "body_extra": sk.body_extra,
-        }))
+        }, owner=owner))
     except Exception as e:
         logger.warning(f"Audit: could not save edited skill {name}: {e}")
         return False
@@ -762,7 +763,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
     # earns a bit less; a skill that still fails is marked low.
     def _set_conf(c):
         try:
-            skills_manager.update_skill(name, {"confidence": c})
+            skills_manager.update_skill(name, {"confidence": c}, owner=owner)
         except Exception:
             pass
 
@@ -788,7 +789,8 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
         nec = await _eval_skill_necessity(md, others, url, model, headers)
         if nec is not None:
             skills_manager.set_necessity(name, nec.get("necessary", True),
-                                         nec.get("redundant_with"), nec.get("reason"))
+                                         nec.get("redundant_with"), nec.get("reason"),
+                                         owner=owner)
             if not nec.get("necessary", True):
                 log(f"{name}: possibly unnecessary — {nec.get('reason', '')[:80]}")
     except Exception as e:
@@ -799,12 +801,12 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
     if generic_reason or duplicate_of or (isinstance(nec, dict) and nec.get("necessary") is False):
         reason = generic_reason or (f"Lower-priority duplicate of {duplicate_of}" if duplicate_of else str((nec or {}).get("reason") or "Unnecessary skill"))
         try:
-            skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35})
-            skills_manager.set_audit(name, "skipped", by_teacher=False, worker_model=model)
+            skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35}, owner=owner)
+            skills_manager.set_audit(name, "skipped", by_teacher=False, worker_model=model, owner=owner)
             if duplicate_of:
-                skills_manager.set_necessity(name, False, [duplicate_of], reason)
+                skills_manager.set_necessity(name, False, [duplicate_of], reason, owner=owner)
             else:
-                skills_manager.set_necessity(name, False, [], reason)
+                skills_manager.set_necessity(name, False, [], reason, owner=owner)
         except Exception:
             pass
         log(f"{name}: draft — skipped functional test ({reason[:100]})")
@@ -848,13 +850,13 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
             if fixed and fixed.strip() != md.strip():
                 _apply_skill_md(skills_manager, name, fixed, owner)
         _set_conf(0.95)
-        skills_manager.set_audit(name, "pass", by_teacher=False, worker_model=model)
+        skills_manager.set_audit(name, "pass", by_teacher=False, worker_model=model, owner=owner)
         refreshed = next((s for s in skills_manager.load(owner=owner) if s.get("name") == name), None)
         status = _audit_finalize_status(skills_manager, name, owner, "pass", 0.95, (refreshed or {}).get("necessity"), verdict)
         log(f"{name}: {status} — confidence 95%")
         return {"skill": name, "result": "pass", "verdict": verdict, "confidence": 0.95, "status": status}
     if v in ("unknown", "inconclusive"):
-        skills_manager.set_audit(name, "inconclusive", by_teacher=False, worker_model=model)
+        skills_manager.set_audit(name, "inconclusive", by_teacher=False, worker_model=model, owner=owner)
         status = _audit_finalize_status(skills_manager, name, owner, "inconclusive", skill.get("confidence") or 0.0, skill.get("necessity"))
         log(f"{name}: {status} — inconclusive")
         return {"skill": name, "result": "inconclusive", "verdict": verdict, "status": status}
@@ -869,7 +871,7 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
         log(f"{name}: retry (self) = {v}")
         if v == "pass":
             _set_conf(0.85)
-            skills_manager.set_audit(name, "pass", by_teacher=False, worker_model=model)
+            skills_manager.set_audit(name, "pass", by_teacher=False, worker_model=model, owner=owner)
             refreshed = next((s for s in skills_manager.load(owner=owner) if s.get("name") == name), None)
             status = _audit_finalize_status(skills_manager, name, owner, "pass", 0.85, (refreshed or {}).get("necessity"), verdict)
             log(f"{name}: {status} — confidence 85% after self-edit")
@@ -893,7 +895,9 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
         log(f"{name}: retry on student after teacher rewrite = {v}")
         if v == "pass":
             _set_conf(0.8)
-            skills_manager.set_audit(name, "pass", by_teacher=True, worker_model=model, teacher_model=t_model)
+            skills_manager.set_audit(
+                name, "pass", by_teacher=True, worker_model=model, teacher_model=t_model, owner=owner
+            )
             refreshed = next((s for s in skills_manager.load(owner=owner) if s.get("name") == name), None)
             status = _audit_finalize_status(skills_manager, name, owner, "pass", 0.8, (refreshed or {}).get("necessity"), verdict)
             log(f"{name}: {status} — confidence 80% after teacher rewrite")
@@ -901,13 +905,14 @@ async def _audit_one_skill(skills_manager, skill, url, model, headers,
 
     # Still failing → demote to draft + low confidence + flag (do NOT delete).
     try:
-        skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35})
+        skills_manager.update_skill(name, {"status": "draft", "confidence": 0.35}, owner=owner)
     except Exception:
         pass
     skills_manager.set_audit(
         name, v or "fail", by_teacher=teacher_ran,
         worker_model=model,
         teacher_model=(teacher[1] if teacher_ran and teacher else ""),
+        owner=owner,
     )
     log(f"{name}: flagged — confidence lowered, kept as draft for manual review")
     return {"skill": name, "result": "flagged", "verdict": verdict, "confidence": 0.35}
@@ -976,7 +981,7 @@ async def _run_audit_all_job(key, skills_manager, names, url, model, headers, te
         job.pop("task", None)
 
 
-def _resolve_audit_models():
+def _resolve_audit_models(owner=None):
     """Resolve (url, model, headers, teacher) for an audit run from Settings.
 
     Worker = Utility model (falling back to Default, normalized to a served
@@ -985,7 +990,7 @@ def _resolve_audit_models():
     ValueError if no worker model.
     """
     from src.endpoint_resolver import resolve_endpoint
-    url, model, headers = resolve_endpoint("utility")
+    url, model, headers = resolve_endpoint("utility", owner=owner)
     if not url or not model:
         raise ValueError("No model configured — set a Default or Utility model in Settings.")
     try:
@@ -1029,7 +1034,7 @@ async def run_scheduled_skill_audit(skills_manager: SkillsManager,
         return {"status": "running", "skipped": True}
 
     try:
-        url, model, headers, teacher = _resolve_audit_models()
+        url, model, headers, teacher = _resolve_audit_models(owner=owner)
     except ValueError as e:
         logger.info(f"Scheduled skill audit skipped — {e}")
         return {"status": "skipped", "reason": str(e)}
@@ -1280,7 +1285,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
 
         # Prefer the configured DEFAULT (→ Utility) model — not the current chat
         # session's model. Fall back to the caller's session model only if unset.
-        url, model, headers = resolve_endpoint("default")
+        url, model, headers = resolve_endpoint("default", owner=user)
         if not url or not model:
             url = url or ((body.get("endpoint_url") or "").strip() or None)
             model = model or ((body.get("model") or "").strip() or None)
@@ -1360,7 +1365,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
 
         # Worker model (Default, normalized) + optional teacher — shared resolver.
         try:
-            url, model, headers, teacher = _resolve_audit_models()
+            url, model, headers, teacher = _resolve_audit_models(owner=user)
         except ValueError as e:
             raise HTTPException(400, str(e))
 
@@ -1474,7 +1479,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
             "pitfalls": sk.pitfalls,
             "verification": sk.verification,
             "body_extra": sk.body_extra,
-        })
+        }, owner=user)
         if not ok:
             raise HTTPException(500, "Update failed")
         # Manual markdown edits can create or substantially rewrite a draft
@@ -1496,7 +1501,7 @@ def setup_skills_routes(skills_manager: SkillsManager) -> APIRouter:
         updates = body.dict(exclude_none=True)
         if not updates:
             return {"ok": True}
-        ok = skills_manager.update_skill(match.get("name"), updates)
+        ok = skills_manager.update_skill(match.get("name"), updates, owner=user)
         if not ok:
             raise HTTPException(404, "Skill not found")
         if not match.get("audit_verdict"):

--- a/routes/task_routes.py
+++ b/routes/task_routes.py
@@ -10,8 +10,8 @@ from typing import Optional, Dict, Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from core.database import SessionLocal, ScheduledTask, TaskRun
-from src.auth_helpers import get_current_user
+from core.database import SessionLocal, ScheduledTask, TaskRun, ModelEndpoint
+from src.auth_helpers import get_current_user, owner_filter
 from src.task_scheduler import compute_next_run, HOUSEKEEPING_DEFAULTS
 from routes.prefs_routes import _load_for_user, _save_for_user
 
@@ -156,8 +156,8 @@ def _resolve_run_endpoint(db, task: ScheduledTask, run: TaskRun) -> str:
         return ""
 
     try:
-        from core.database import ModelEndpoint
-        eps = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+        q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        eps = owner_filter(q, ModelEndpoint, getattr(task, "owner", None) or "").all()
         for ep in eps:
             cached = []
             if ep.cached_models:
@@ -178,22 +178,42 @@ def setup_task_routes(task_scheduler) -> APIRouter:
     def _owner(request: Request):
         return get_current_user(request)
 
-    async def _generate_task_name(prompt: str) -> str:
+    def _resolve_task_model_choice(db, owner: str | None, endpoint_url: str | None, model: str | None) -> tuple[str | None, str | None]:
+        """Validate a task's pinned endpoint against the owner's registered endpoints."""
+        clean_url = (endpoint_url or "").strip()
+        clean_model = (model or "").strip()
+        if not clean_url:
+            return None, clean_model or None
+
+        from src.endpoint_resolver import normalize_base, build_chat_url
+        target_base = normalize_base(clean_url)
+        q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        q = owner_filter(q, ModelEndpoint, owner or "")
+        for ep in q.all():
+            base = normalize_base(ep.base_url or "")
+            if target_base != base:
+                continue
+            if clean_model and ep.cached_models:
+                try:
+                    cached = json.loads(ep.cached_models) or []
+                except Exception:
+                    cached = []
+                if cached and clean_model not in cached:
+                    raise HTTPException(400, "Model is not available on the selected endpoint")
+            return build_chat_url(base), clean_model or None
+
+        raise HTTPException(400, "Model endpoint is not available to this user")
+
+    async def _generate_task_name(prompt: str, owner: str | None = None) -> str:
         """Use LLM to generate a short task name from the prompt."""
         try:
             from src.llm_core import llm_call_async
-            from core.database import Session as DbSession
-            db = SessionLocal()
-            try:
-                recent = db.query(DbSession).filter(
-                    DbSession.endpoint_url.isnot(None),
-                    DbSession.model.isnot(None),
-                ).order_by(DbSession.created_at.desc()).first()
-                if not recent:
-                    return prompt[:50].strip()
-                url, model = recent.endpoint_url, recent.model
-            finally:
-                db.close()
+            from src.endpoint_resolver import resolve_endpoint
+            url, model, headers = resolve_endpoint("utility", owner=owner)
+            if not url:
+                url, model, headers = resolve_endpoint("default", owner=owner)
+            if not (url and model):
+                return prompt[:50].strip()
 
             result = await llm_call_async(
                 url=url, model=model,
@@ -202,6 +222,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
                     {"role": "user", "content": prompt[:500]},
                 ],
                 max_tokens=20,
+                headers=headers,
                 timeout=15,
             )
             title = result.strip().strip('"\'').strip()
@@ -352,7 +373,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
                 from src.builtin_actions import BUILTIN_ACTION_INFO
                 name = BUILTIN_ACTION_INFO.get(req.action, req.action or "Action Task")
             elif req.prompt:
-                name = await _generate_task_name(req.prompt)
+                name = await _generate_task_name(req.prompt, user)
             else:
                 name = "Untitled Task"
 
@@ -379,6 +400,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
         task_id = str(uuid.uuid4())
         db = SessionLocal()
         try:
+            endpoint_url, model = _resolve_task_model_choice(db, user, req.endpoint_url, req.model)
             notifications_enabled = (
                 False if req.task_type == "action" and req.notifications_enabled is None
                 else bool(req.notifications_enabled) if req.notifications_enabled is not None
@@ -403,8 +425,8 @@ def setup_task_routes(task_scheduler) -> APIRouter:
                 next_run=next_run,
                 status="active" if (req.trigger_type in ("event", "webhook") or next_run) else "completed",
                 output_target=req.output_target,
-                model=req.model or None,
-                endpoint_url=req.endpoint_url or None,
+                model=model,
+                endpoint_url=endpoint_url,
                 then_task_id=req.then_task_id or None,
                 webhook_token=webhook_token,
                 notifications_enabled=notifications_enabled,
@@ -538,10 +560,13 @@ def setup_task_routes(task_scheduler) -> APIRouter:
                 task.action = req.action
             if req.output_target is not None:
                 task.output_target = req.output_target
-            if req.model is not None:
-                task.model = req.model or None
-            if req.endpoint_url is not None:
-                task.endpoint_url = req.endpoint_url or None
+            if req.model is not None or req.endpoint_url is not None:
+                task.endpoint_url, task.model = _resolve_task_model_choice(
+                    db,
+                    user,
+                    req.endpoint_url if req.endpoint_url is not None else task.endpoint_url,
+                    req.model if req.model is not None else task.model,
+                )
             if req.trigger_type is not None:
                 # Generate webhook token when switching to webhook trigger
                 if req.trigger_type == "webhook" and not task.webhook_token:
@@ -919,6 +944,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
         from datetime import datetime as _dt
 
         body = await request.json()
+        user = _owner(request)
         desc = (body.get("description") or "").strip()
         if not desc:
             return {"success": False, "message": "Nothing to parse"}
@@ -948,9 +974,9 @@ def setup_task_routes(task_scheduler) -> APIRouter:
             "use cron '0 H * * 1-5'. Keep the prompt actionable and self-contained."
         )
         try:
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=user)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=user)
             if not (url and model):
                 return {"success": False, "message": "No model endpoint configured"}
             raw = await llm_call_async(

--- a/routes/upload_routes.py
+++ b/routes/upload_routes.py
@@ -205,7 +205,7 @@ def setup_upload_routes(upload_handler):
                 logger.warning(f"Vision cache read failed for {file_id}: {e}")
         from src.document_processor import analyze_image_with_vl
         try:
-            text = analyze_image_with_vl(path) or ""
+            text = analyze_image_with_vl(path, owner=current_user) or ""
         except Exception as e:
             logger.error(f"Vision analysis failed for {file_id}: {e}")
             raise HTTPException(500, f"Vision analysis failed: {e}")

--- a/routes/vault_routes.py
+++ b/routes/vault_routes.py
@@ -183,13 +183,12 @@ def setup_vault_routes():
     async def unlock(req: VaultUnlockRequest, request: Request):
         """Unlock the vault and save the session key."""
         require_admin(request)
-        # Pass the master password via the environment (--passwordenv), NOT as
-        # an argv element — argv is visible to every local user through `ps` /
-        # /proc/<pid>/cmdline. (The sibling /login handler already keeps the
-        # password off argv by feeding it on stdin.)
+        # Pass the master password on stdin, not argv. argv is visible through
+        # `ps` / /proc/<pid>/cmdline; stdin also avoids leaving the secret in
+        # the child process environment.
         stdout, stderr, rc = await _run_bw(
-            ["unlock", "--passwordenv", "BW_PASSWORD", "--raw"],
-            bw_password=req.master_password,
+            ["unlock", "--raw"],
+            input_text=req.master_password + "\n",
         )
         if rc != 0:
             return {"ok": False, "error": f"Unlock failed: {stderr[:300]}"}

--- a/services/memory/skills.py
+++ b/services/memory/skills.py
@@ -6,8 +6,8 @@ YAML frontmatter and a structured markdown body (When to Use / Procedure /
 Pitfalls / Verification). See `skill_format.py` for the format.
 
 Usage counters (`uses`, `last_used`) live in a sidecar
-`data/skills/_usage.json` keyed by skill name so the SKILL.md content
-doesn't churn on every retrieval.
+`data/skills/_usage.json` keyed by owner plus skill name so the SKILL.md
+content doesn't churn on every retrieval.
 
 Ownership: skills declare `owner: <username>` in frontmatter. Single-user
 deployments can leave that blank.
@@ -105,14 +105,29 @@ class SkillsManager:
                 json.dump(usage, f, indent=2)
             os.replace(tmp, self.usage_file)
 
+    @staticmethod
+    def _usage_key(name: str, owner: Optional[str] = None) -> str:
+        # Skill names are not globally unique once multiple owners are present.
+        # Keep the usage sidecar keyed the same way the skill file is scoped.
+        return f"{owner}::{name}" if owner else name
+
+    def _usage_entry(self, usage: Dict[str, Dict], name: str, owner: Optional[str] = None) -> Dict:
+        key = self._usage_key(name, owner)
+        entry = usage.get(key)
+        if isinstance(entry, dict):
+            return entry
+        return {}
+
     def set_audit(self, name: str, verdict: str, by_teacher: bool = False,
-                  worker_model: str = "", teacher_model: str = "") -> None:
+                  worker_model: str = "", teacher_model: str = "",
+                  owner: Optional[str] = None) -> None:
         """Record the last test/audit result for a skill in the usage sidecar
         (so it surfaces in load() without touching SKILL.md). Drives the
         'verified' check + teacher mark on the card."""
         import time as _t
         usage = self._load_usage()
-        e = usage.setdefault(name, {"uses": 0, "last_used": None})
+        key = self._usage_key(name, owner)
+        e = usage.setdefault(key, {"uses": 0, "last_used": None})
         e["audit_verdict"] = verdict
         e["audit_by_teacher"] = bool(by_teacher)
         if worker_model:
@@ -123,11 +138,13 @@ class SkillsManager:
         self._save_usage(usage)
 
     def set_necessity(self, name: str, necessary: bool,
-                      redundant_with=None, reason: str = "") -> None:
+                      redundant_with=None, reason: str = "",
+                      owner: Optional[str] = None) -> None:
         """Record the advisory 'is this skill necessary?' judgment in the usage
         sidecar. Surfaced on the card as a flag; never acts on the skill."""
         usage = self._load_usage()
-        e = usage.setdefault(name, {"uses": 0, "last_used": None})
+        key = self._usage_key(name, owner)
+        e = usage.setdefault(key, {"uses": 0, "last_used": None})
         e["necessity"] = {
             "necessary": bool(necessary),
             "redundant_with": list(redundant_with or []),
@@ -207,7 +224,7 @@ class SkillsManager:
             if not sk:
                 continue
             d = sk.to_dict()
-            u = usage.get(sk.name) or {}
+            u = self._usage_entry(usage, sk.name, sk.owner)
             d["uses"] = int(u.get("uses", 0))
             d["last_used"] = u.get("last_used")
             d["audit_verdict"] = u.get("audit_verdict")
@@ -308,6 +325,7 @@ class SkillsManager:
         # never auto-skipped — a human asked for it. The every-X AI audit
         # handles the fuzzier near-duplicates this cheap check won't catch.
         _all = self.load_all()
+        _dedup_pool = _all if owner is None else [s for s in _all if s.get("owner") == owner]
         if source != "user":
             cand = _tokenize(" ".join([
                 nm, (description or title or ""),
@@ -315,7 +333,7 @@ class SkillsManager:
                 " ".join(procedure if procedure is not None else (steps or [])),
             ]))
             if cand:
-                for s in _all:
+                for s in _dedup_pool:
                     ex = _tokenize(" ".join([
                         s.get("name", ""), s.get("description", ""),
                         s.get("when_to_use", ""),
@@ -326,7 +344,7 @@ class SkillsManager:
                         # existing skill's usage and return it so the caller
                         # knows it already exists.
                         try:
-                            self.record_use(s["name"])
+                            self.record_use(s["name"], owner=s.get("owner"))
                         except Exception:
                             pass
                         return {**s, "_deduped": True, "_duplicate_of": s.get("name")}
@@ -428,8 +446,9 @@ class SkillsManager:
                 os.rename(old_dir, new_dir)
                 # Also rename usage key
                 usage = self._load_usage()
-                if skill_id in usage:
-                    usage[sk.name] = usage.pop(skill_id)
+                old_usage_key = self._usage_key(skill_id, sk.owner)
+                if old_usage_key in usage:
+                    usage[self._usage_key(sk.name, sk.owner)] = usage.pop(old_usage_key)
                     self._save_usage(usage)
             self._write_skill(sk)
             return True
@@ -455,15 +474,17 @@ class SkillsManager:
                 logger.warning(f"Failed to remove skill dir {skill_dir}: {e}")
                 return False
             usage = self._load_usage()
-            if skill_id in usage:
-                del usage[skill_id]
+            usage_key = self._usage_key(skill_id, sk.owner)
+            if usage_key in usage:
+                del usage[usage_key]
                 self._save_usage(usage)
             return True
         return False
 
-    def record_use(self, skill_id: str) -> None:
+    def record_use(self, skill_id: str, owner: Optional[str] = None) -> None:
         usage = self._load_usage()
-        entry = usage.setdefault(skill_id, {"uses": 0, "last_used": None})
+        key = self._usage_key(skill_id, owner)
+        entry = usage.setdefault(key, {"uses": 0, "last_used": None})
         entry["uses"] = int(entry.get("uses", 0)) + 1
         entry["last_used"] = int(time.time())
         self._save_usage(usage)

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -862,7 +862,7 @@ def _build_system_prompt(
                 # matter how often it's been matched and applied.
                 for _sk in relevant_skills:
                     try:
-                        sm.record_use(_sk.get('name', ''))
+                        sm.record_use(_sk.get('name', ''), owner=owner)
                     except Exception:
                         pass
                 lines.append("## Relevant skills for this request")
@@ -961,6 +961,10 @@ _ADMIN_TOOLS = {
     "manage_endpoints", "manage_mcp", "manage_webhooks", "manage_tokens",
     "manage_documents", "manage_settings", "create_session", "list_sessions",
     "send_to_session", "pipeline", "ask_teacher", "list_models",
+    "download_model", "serve_model", "serve_preset", "list_serve_presets",
+    "list_cookbook_servers", "list_served_models", "list_downloads",
+    "list_cached_models", "stop_served_model", "cancel_download",
+    "adopt_served_model",
 }
 
 def _build_base_prompt(
@@ -1436,13 +1440,27 @@ async def stream_agent_loop(
     _endpoint_supports: Optional[bool] = None
     try:
         from core.database import SessionLocal as _SL, ModelEndpoint as _ME
+        from src.endpoint_resolver import build_chat_url as _build_chat_url, normalize_base as _normalize_base
         _db = _SL()
         try:
-            _ep = _db.query(_ME).filter(_ME.base_url == endpoint_url).first()
-            if not _ep and endpoint_url:
-                _u = endpoint_url.rstrip("/")
-                _ep = _db.query(_ME).filter(_ME.base_url == _u).first() or \
-                      _db.query(_ME).filter(_ME.base_url == _u + "/").first()
+            _ep = None
+            _target_chat = (endpoint_url or "").rstrip("/")
+            _q = _db.query(_ME).filter(_ME.is_enabled == True)
+            if owner:
+                from src.auth_helpers import owner_filter as _owner_filter
+                _q = _owner_filter(_q, _ME, owner)
+            for _candidate in _q.all():
+                _base = _normalize_base(_candidate.base_url or "")
+                if (endpoint_url or "").rstrip("/") in {
+                    (_candidate.base_url or "").rstrip("/"),
+                    _base.rstrip("/"),
+                    _build_chat_url(_base).rstrip("/"),
+                }:
+                    _ep = _candidate
+                    break
+                if _target_chat and _target_chat == _build_chat_url(_base).rstrip("/"):
+                    _ep = _candidate
+                    break
             if _ep is not None:
                 _endpoint_supports = _ep.supports_tools
         finally:

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -58,7 +58,7 @@ def set_rag_manager(rag_mgr, personal_docs_mgr=None):
 from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url, build_headers, build_models_url
 
 
-def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
+def _resolve_model(spec: str, owner: Optional[str] = None) -> Tuple[str, str, Dict]:
     """Resolve a model specifier to (endpoint_url, model_id, headers).
 
     Accepts:
@@ -84,6 +84,9 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
     db = SessionLocal()
     try:
         query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            from src.auth_helpers import owner_filter
+            query = owner_filter(query, ModelEndpoint, owner)
         if target_endpoint_name:
             query = query.filter(ModelEndpoint.name.ilike(f"%{target_endpoint_name}%"))
         endpoints = query.all()
@@ -141,7 +144,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_chat_with_model(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Send a message to a specific model and return its response.
 
     Content format:
@@ -160,7 +163,7 @@ async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> 
         return {"error": "No message provided (line 2+ is the message)"}
 
     try:
-        url, model, headers = _resolve_model(model_spec)
+        url, model, headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -190,7 +193,7 @@ _TEACHER_SYSTEM_PROMPT = (
 )
 
 
-async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_ask_teacher(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Ask a more capable model for help.
 
     Content format:
@@ -213,7 +216,7 @@ async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict
             return {"error": "No teacher model configured. Specify a model name or set teacher_model in settings."}
 
     try:
-        url, model, headers = _resolve_model(model_spec)
+        url, model, headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -235,7 +238,7 @@ async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict
         return {"error": f"Teacher call failed ({model_spec}): {e}"}
 
 
-async def do_second_opinion(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_second_opinion(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Get a second opinion from another model, then have the original model
     evaluate the feedback and produce a unified version.
 
@@ -259,7 +262,7 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
     focus = lines[1].strip() if len(lines) > 1 else ""
 
     try:
-        reviewer_url, reviewer_model, reviewer_headers = _resolve_model(model_spec)
+        reviewer_url, reviewer_model, reviewer_headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -400,7 +403,7 @@ async def do_create_session(content: str, session_id: Optional[str] = None, owne
         return {"error": "Session name cannot be empty"}
 
     try:
-        url, model, headers = _resolve_model(model_spec)
+        url, model, headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -517,7 +520,7 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
         return {"error": str(e)}
 
 
-async def do_send_to_session(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_send_to_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Send a message to an existing session and get a response.
 
     Content format:
@@ -539,6 +542,8 @@ async def do_send_to_session(content: str, session_id: Optional[str] = None) -> 
 
     sess = _session_manager.get_session(target_sid)
     if not sess:
+        return {"error": f"Session '{target_sid}' not found"}
+    if owner and getattr(sess, "owner", None) != owner:
         return {"error": f"Session '{target_sid}' not found"}
 
     if not message:
@@ -580,7 +585,7 @@ async def stream_ai_tool(tool: str, content: str, session_id: Optional[str] = No
     yield {"_final": True, "desc": desc, "result": result}
 
 
-async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_pipeline(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Execute a multi-step pipeline where each model's output feeds the next.
 
     Content format (JSON):
@@ -634,7 +639,7 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
         if not model_spec or not instruction:
             return {"error": f"Step {i + 1}: both 'model' and 'instruction' are required"}
         try:
-            url, model, headers = _resolve_model(model_spec)
+            url, model, headers = _resolve_model(model_spec, owner=owner)
             resolved.append((url, model, headers, instruction))
         except ValueError as e:
             return {"error": f"Step {i + 1}: {e}"}
@@ -1087,7 +1092,7 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
 # List models tool
 # ---------------------------------------------------------------------------
 
-async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_list_models(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """List all available models across configured endpoints.
 
     Content = optional filter keyword.
@@ -1100,7 +1105,11 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
 
     db = SessionLocal()
     try:
-        endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+        query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            from src.auth_helpers import owner_filter
+            query = owner_filter(query, ModelEndpoint, owner)
+        endpoints = query.all()
         if not endpoints:
             return {"results": "No enabled model endpoints configured."}
 
@@ -1244,7 +1253,7 @@ async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
 # UI control tool (returns events for frontend to apply)
 # ---------------------------------------------------------------------------
 
-async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_ui_control(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Control frontend UI: toggle settings, switch model, change theme.
 
     Content format:
@@ -1319,7 +1328,7 @@ async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
 
         # Resolve the model to validate it exists
         try:
-            url, model_id, headers = _resolve_model(model_spec)
+            url, model_id, headers = _resolve_model(model_spec, owner=owner)
         except ValueError as e:
             return {"error": str(e)}
 
@@ -1574,7 +1583,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     if not model_spec:
         for candidate in ("gpt-image-1.5", "gpt-image-1", "dall-e-3"):
             try:
-                _resolve_model(candidate)
+                _resolve_model(candidate, owner=owner)
                 model_spec = candidate
                 break
             except ValueError:
@@ -1586,10 +1595,14 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                 import httpx as _req
                 _idb = SessionLocal()
                 try:
-                    _img_eps = _idb.query(ModelEndpoint).filter(
+                    _img_q = _idb.query(ModelEndpoint).filter(
                         ModelEndpoint.is_enabled == True,
                         ModelEndpoint.model_type == "image",
-                    ).all()
+                    )
+                    if owner:
+                        from src.auth_helpers import owner_filter
+                        _img_q = owner_filter(_img_q, ModelEndpoint, owner)
+                    _img_eps = _img_q.all()
                     for _iep in _img_eps:
                         _ibase = _iep.base_url.rstrip("/")
                         if not _ibase.endswith("/v1"):
@@ -1612,7 +1625,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
 
     # Resolve the model to find the right endpoint
     try:
-        url, model_id, headers = _resolve_model(model_spec)
+        url, model_id, headers = _resolve_model(model_spec, owner=owner)
     except ValueError:
         return {"error": f"No endpoint found with image model '{model_spec}'. "
                 "Configure an OpenAI-compatible endpoint with image generation support."}
@@ -1754,7 +1767,7 @@ async def dispatch_ai_tool(
     if tool == "chat_with_model":
         model_spec = content.split("\n")[0].strip()[:60]
         desc = f"chat_with_model: {model_spec}"
-        result = await do_chat_with_model(content, session_id)
+        result = await do_chat_with_model(content, session_id, owner=owner)
 
     elif tool == "create_session":
         name = content.split("\n")[0].strip()[:60]
@@ -1769,11 +1782,11 @@ async def dispatch_ai_tool(
     elif tool == "send_to_session":
         sid = content.split("\n")[0].strip()[:20]
         desc = f"send_to_session: {sid}"
-        result = await do_send_to_session(content, session_id)
+        result = await do_send_to_session(content, session_id, owner=owner)
 
     elif tool == "pipeline":
         desc = "pipeline: running steps"
-        result = await do_pipeline(content, session_id)
+        result = await do_pipeline(content, session_id, owner=owner)
 
     elif tool == "manage_session":
         action = content.split("\n")[0].strip()[:40]
@@ -1788,17 +1801,17 @@ async def dispatch_ai_tool(
     elif tool == "list_models":
         keyword = content.strip()[:40]
         desc = f"list_models{': ' + keyword if keyword else ''}"
-        result = await do_list_models(content, session_id)
+        result = await do_list_models(content, session_id, owner=owner)
 
     elif tool == "ui_control":
         action = content.split("\n")[0].strip()[:60]
         desc = f"ui_control: {action}"
-        result = await do_ui_control(content, session_id)
+        result = await do_ui_control(content, session_id, owner=owner)
 
     elif tool == "ask_teacher":
         problem = content.split("\n", 1)[-1].strip()[:60]
         desc = f"ask_teacher: {problem}"
-        result = await do_ask_teacher(content, session_id)
+        result = await do_ask_teacher(content, session_id, owner=owner)
 
     else:
         desc = f"unknown ai tool: {tool}"

--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -590,9 +590,9 @@ async def action_classify_events(owner: str, **kwargs) -> Tuple[str, bool]:
             if not events:
                 return "No upcoming events to classify", True
 
-            llm_url, llm_model, llm_headers = resolve_endpoint("utility")
+            llm_url, llm_model, llm_headers = resolve_endpoint("utility", owner=owner)
             if not llm_url:
-                llm_url, llm_model, llm_headers = resolve_endpoint("default")
+                llm_url, llm_model, llm_headers = resolve_endpoint("default", owner=owner)
             llm_available = bool(llm_url and llm_model)
 
             # Pull user memories so the LLM has personal context (relationships,
@@ -815,9 +815,9 @@ async def action_mark_email_boundaries(owner: str, **kwargs) -> Tuple[str, bool]
         if not mails:
             raise TaskNoop("no emails to analyze")
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=owner)
         if not url or not model:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=owner)
         if not url or not model:
             return "No LLM endpoint available", False
 
@@ -1053,9 +1053,9 @@ async def action_learn_sender_signatures(owner: str, **kwargs) -> Tuple[str, boo
         if not eligible:
             return "All sender sigs already cached (or no eligible senders)", True
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=owner)
         if not url or not model:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=owner)
         if not url or not model:
             return "No LLM endpoint available", False
 
@@ -1313,7 +1313,7 @@ async def action_test_skills(owner: str, **kwargs) -> Tuple[str, bool]:
         if not names:
             raise TaskNoop("no skills to test")
 
-        url, model, headers = resolve_endpoint("default")
+        url, model, headers = resolve_endpoint("default", owner=owner)
         if not url or not model:
             return "No Default/Utility model configured — set one in Settings.", False
 
@@ -1374,7 +1374,7 @@ async def action_test_skills(owner: str, **kwargs) -> Tuple[str, bool]:
                 # user-set value (e.g. 1.0 → 0.95) is destructive.
                 if v in ("pass", "needs_work", "fail", "inconclusive"):
                     try:
-                        sm.set_audit(name, v, by_teacher=False, worker_model=model)
+                        sm.set_audit(name, v, by_teacher=False, worker_model=model, owner=owner)
                     except Exception as _e:
                         logger.warning(f"test_skills set_audit({name}) failed: {_e}")
                 if v == "unknown":
@@ -1666,12 +1666,12 @@ async def action_check_email_urgency(owner: str, **kwargs) -> Tuple[str, bool]:
 
         # ── 1. Resolve LLM candidates (utility primary + utility fallbacks; fall
         # through to default chat as a last resort).
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=owner)
         if not url or not model:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=owner)
         if not url or not model:
             return "No LLM endpoint available", False
-        candidates = [(url, model, headers)] + resolve_utility_fallback_candidates()
+        candidates = [(url, model, headers)] + resolve_utility_fallback_candidates(owner=owner)
 
         # ── 2. Enumerate enabled accounts. Match this task's owner AND fall
         # back to the legacy "unowned account whose imap_user / from_address

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -24,9 +24,12 @@ Design notes:
 
 import asyncio
 import hashlib
+import ipaddress
 import logging
+import os
 import uuid
 from datetime import date, datetime, timedelta, timezone
+from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,52 @@ logger = logging.getLogger(__name__)
 # events still come through via RRULE expansion on the frontend.
 _LOOKBACK_DAYS = 90
 _LOOKAHEAD_DAYS = 365
+_BLOCKED_HOSTS = {
+    "localhost",
+    "localhost.",
+    "ip6-localhost",
+    "metadata.google.internal",
+}
+
+
+def _private_caldav_allowed() -> bool:
+    return os.environ.get("ODYSSEUS_ALLOW_PRIVATE_CALDAV", "0").lower() in {"1", "true", "yes"}
+
+
+def _validate_caldav_ip(host: str) -> None:
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return
+    if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+        raise ValueError("CalDAV URL host is not allowed")
+    if ip.is_private and not _private_caldav_allowed():
+        raise ValueError("Private CalDAV IPs require ODYSSEUS_ALLOW_PRIVATE_CALDAV=1")
+
+
+def validate_caldav_url(raw_url: str) -> str:
+    """Validate and normalize a user-provided CalDAV URL before server-side use."""
+    url = (raw_url or "").strip()
+    if not url:
+        raise ValueError("CalDAV URL is required")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("CalDAV URL must start with http:// or https://")
+    if not parsed.hostname:
+        raise ValueError("CalDAV URL must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("Put CalDAV credentials in the username/password fields, not the URL")
+    if parsed.fragment:
+        raise ValueError("CalDAV URL fragments are not allowed")
+    try:
+        parsed.port
+    except ValueError:
+        raise ValueError("CalDAV URL has an invalid port")
+    host = (parsed.hostname or "").lower()
+    if host in _BLOCKED_HOSTS or host.endswith(".localhost"):
+        raise ValueError("CalDAV URL host is not allowed")
+    _validate_caldav_ip(host)
+    return urlunparse(parsed._replace(fragment="")).rstrip("/")
 
 
 def _stable_cal_id(remote_url: str) -> str:
@@ -250,13 +299,21 @@ async def sync_caldav(owner: str) -> dict:
     url = (cfg.get("url") or "").strip()
     user = (cfg.get("username") or "").strip()
     pw = cfg.get("password") or ""
+    try:
+        from src.secret_storage import decrypt
+        pw = decrypt(pw)
+    except Exception:
+        pass
     if not (url and user and pw):
         return {
             "calendars": 0, "events": 0, "deleted": 0,
             "errors": ["CalDAV is not configured"],
         }
     try:
+        url = validate_caldav_url(url)
         return await asyncio.to_thread(_sync_blocking, owner, url, user, pw)
+    except ValueError as e:
+        return {"calendars": 0, "events": 0, "deleted": 0, "errors": [str(e)]}
     except Exception as e:
         logger.exception("CalDAV sync raised")
         return {"calendars": 0, "events": 0, "deleted": 0, "errors": [str(e)[:200]]}

--- a/src/chat_handler.py
+++ b/src/chat_handler.py
@@ -219,7 +219,7 @@ class ChatHandler:
                             except Exception:
                                 vl_desc = None
                         if not vl_desc:
-                            vl_result = analyze_image_with_vl_result(file_info["path"])
+                            vl_result = analyze_image_with_vl_result(file_info["path"], owner=owner)
                             vl_desc = vl_result.get("text", "")
                             vl_model = vl_result.get("model", "")
                             if vl_desc and not vl_desc.startswith("["):

--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -285,7 +285,7 @@ async def maybe_compact(
     )
 
     # Use utility model if configured, otherwise fall back to session model
-    util_url, util_model, util_headers = resolve_endpoint("utility")
+    util_url, util_model, util_headers = resolve_endpoint("utility", owner=getattr(session, "owner", None))
     compact_url = util_url or endpoint_url
     compact_model = util_model or model
     compact_headers = util_headers if util_url else headers

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -215,7 +215,7 @@ def _load_vl_settings() -> dict:
         return {}
 
 
-def _resolve_vl_model(configured: str) -> tuple:
+def _resolve_vl_model(configured: str, owner: str | None = None) -> tuple:
     """Resolve the vision model to (url, model_id, headers).
 
     Uses admin-configured model if set, otherwise tries auto-detection
@@ -224,7 +224,7 @@ def _resolve_vl_model(configured: str) -> tuple:
     from src.ai_interaction import _resolve_model
 
     if configured:
-        return _resolve_model(configured)
+        return _resolve_model(configured, owner=owner)
 
     # Auto-detect: try known vision-capable models in priority order
     candidates = [
@@ -235,14 +235,14 @@ def _resolve_vl_model(configured: str) -> tuple:
     ]
     for candidate in candidates:
         try:
-            return _resolve_model(candidate)
+            return _resolve_model(candidate, owner=owner)
         except (ValueError, Exception):
             continue
 
     raise ValueError("No vision model available")
 
 
-def analyze_image_with_vl_result(image_path: str) -> dict:
+def analyze_image_with_vl_result(image_path: str, owner: str | None = None) -> dict:
     """Analyze an image and return both text and the model that produced it."""
     logger.info(f"Analyzing image with VL model: {image_path}")
     try:
@@ -252,7 +252,7 @@ def analyze_image_with_vl_result(image_path: str) -> dict:
         vl_model = settings.get("vision_model", "")
 
         try:
-            url, model_id, headers = _resolve_vl_model(vl_model)
+            url, model_id, headers = _resolve_vl_model(vl_model, owner=owner)
         except ValueError:
             return {"text": "[No vision model configured — set one in Settings → Vision]", "model": vl_model or ""}
 
@@ -277,7 +277,7 @@ def analyze_image_with_vl_result(image_path: str) -> dict:
         # — same shape as task/chat but its own list (`vision_model_fallbacks`).
         try:
             from src.endpoint_resolver import resolve_vision_fallback_candidates
-            _vl_candidates = [(url, model_id, headers)] + resolve_vision_fallback_candidates()
+            _vl_candidates = [(url, model_id, headers)] + resolve_vision_fallback_candidates(owner=owner)
         except Exception:
             _vl_candidates = [(url, model_id, headers)]
 
@@ -299,9 +299,9 @@ def analyze_image_with_vl_result(image_path: str) -> dict:
         return {"text": "[VL model unavailable - image not analyzed]", "model": ""}
 
 
-def analyze_image_with_vl(image_path: str) -> str:
+def analyze_image_with_vl(image_path: str, owner: str | None = None) -> str:
     """Analyze an image using the admin-configured Vision-Language model."""
-    return analyze_image_with_vl_result(image_path).get("text", "")
+    return analyze_image_with_vl_result(image_path, owner=owner).get("text", "")
 
 
 def build_user_content(

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -234,7 +234,7 @@ def resolve_endpoint(
     ep_id = _stg(f"{setting_prefix}_endpoint_id")
     model = _stg(f"{setting_prefix}_model")
 
-    # If the specific endpoint is not configured, but the caller provided a 
+    # If the specific endpoint is not configured, but the caller provided a
     # valid fallback (e.g. the active session model), use that immediately.
     # This prevents background tasks from jumping to the global default_model
     # when the user is mid-conversation with a different model.
@@ -295,7 +295,7 @@ def resolve_endpoint(
 
 
 def resolve_endpoint_by_id(
-    ep_id: str, model: Optional[str] = None
+    ep_id: str, model: Optional[str] = None, owner: Optional[str] = None
 ) -> Optional[Tuple[str, str, Dict]]:
     """Resolve a specific endpoint id (+ optional model) to (chat_url, model, headers).
 
@@ -306,10 +306,14 @@ def resolve_endpoint_by_id(
         return None
     db = SessionLocal()
     try:
-        ep = db.query(ModelEndpoint).filter(
+        q = db.query(ModelEndpoint).filter(
             ModelEndpoint.id == ep_id,
             ModelEndpoint.is_enabled == True,
-        ).first()
+        )
+        if owner:
+            from src.auth_helpers import owner_filter
+            q = owner_filter(q, ModelEndpoint, owner)
+        ep = q.first()
         if not ep:
             return None
         base = normalize_base(ep.base_url)
@@ -332,14 +336,14 @@ def resolve_endpoint_by_id(
         db.close()
 
 
-def resolve_chat_fallback_candidates() -> list:
+def resolve_chat_fallback_candidates(owner: Optional[str] = None) -> list:
     """Build the configured default-chat fallback chain as a list of
     (chat_url, model, headers) tuples, skipping any that can't resolve.
 
     The primary model is NOT included — callers prepend their session's
     current (url, model, headers) so per-session model overrides are honored.
     """
-    return _resolve_fallback_candidates("default_model_fallbacks")
+    return _resolve_fallback_candidates("default_model_fallbacks", owner=owner)
 
 
 def resolve_utility_fallback_candidates(owner: Optional[str] = None) -> list:
@@ -355,9 +359,9 @@ def resolve_utility_fallback_candidates(owner: Optional[str] = None) -> list:
     return _resolve_fallback_candidates("utility_model_fallbacks", owner=owner)
 
 
-def resolve_vision_fallback_candidates() -> list:
+def resolve_vision_fallback_candidates(owner: Optional[str] = None) -> list:
     """Configured fallback chain for the Vision model (`vision_model_fallbacks`)."""
-    return _resolve_fallback_candidates("vision_model_fallbacks")
+    return _resolve_fallback_candidates("vision_model_fallbacks", owner=owner)
 
 
 def _resolve_fallback_candidates(setting_key: str, owner: Optional[str] = None) -> list:
@@ -371,7 +375,7 @@ def _resolve_fallback_candidates(setting_key: str, owner: Optional[str] = None) 
     for entry in chain:
         if not isinstance(entry, dict):
             continue
-        resolved = resolve_endpoint_by_id(entry.get("endpoint_id", ""), entry.get("model", ""))
+        resolved = resolve_endpoint_by_id(entry.get("endpoint_id", ""), entry.get("model", ""), owner=owner)
         if resolved:
             out.append(resolved)
     return out

--- a/src/session_actions.py
+++ b/src/session_actions.py
@@ -126,7 +126,7 @@ async def run_auto_sort(owner: str, skip_llm: bool = False) -> str:
         if skip_llm:
             return f"Cleaned {deleted_empty + deleted_throwaway} sessions (folder sort skipped)."
 
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=owner)
         if not url:
             return f"Cleaned {deleted_empty + deleted_throwaway} sessions. No model endpoint available for sorting."
 

--- a/src/task_endpoint.py
+++ b/src/task_endpoint.py
@@ -3,11 +3,11 @@
 from src.endpoint_resolver import resolve_endpoint
 
 
-def resolve_task_endpoint(fallback_url=None, fallback_model=None, fallback_headers=None):
+def resolve_task_endpoint(fallback_url=None, fallback_model=None, fallback_headers=None, owner=None):
     """Return (endpoint_url, model, headers) for background tasks.
 
     Reads task_endpoint_id / task_model from admin settings.
     Falls back to the provided values when the setting is empty or the
     endpoint cannot be resolved.
     """
-    return resolve_endpoint("task", fallback_url, fallback_model, fallback_headers)
+    return resolve_endpoint("task", fallback_url, fallback_model, fallback_headers, owner=owner)

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -1259,6 +1259,8 @@ class TaskScheduler:
         if (not endpoint_url or not model) and crew:
             endpoint_url = endpoint_url or crew.endpoint_url
             model = model or crew.model
+        if endpoint_url:
+            endpoint_url, model = self._registered_task_endpoint(db, task.owner, endpoint_url, model)
         if not endpoint_url or not model:
             endpoint_url, model = self._resolve_defaults(db, task.owner)
         if not endpoint_url or not model:
@@ -1403,6 +1405,8 @@ class TaskScheduler:
         if (not endpoint_url or not model_name) and crew:
             endpoint_url = endpoint_url or crew.endpoint_url
             model_name = model_name or crew.model
+        if endpoint_url:
+            endpoint_url, model_name = self._registered_task_endpoint(db, task.owner, endpoint_url, model_name)
         if not endpoint_url or not model_name:
             try:
                 resolved_url, resolved_model = self._resolve_defaults(db, task.owner)
@@ -1537,9 +1541,11 @@ class TaskScheduler:
         try:
             from core.database import SessionLocal, ModelEndpoint
             from src.endpoint_resolver import normalize_base, build_headers
+            from src.auth_helpers import owner_filter
             db2 = SessionLocal()
             try:
-                eps = db2.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+                q = db2.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+                eps = owner_filter(q, ModelEndpoint, task.owner or "").all()
                 for ep in eps:
                     if normalize_base(ep.base_url) in endpoint_url or endpoint_url in normalize_base(ep.base_url):
                         headers = build_headers(ep.api_key, normalize_base(ep.base_url))
@@ -1560,7 +1566,7 @@ class TaskScheduler:
         # chat uses but with the utility list (`utility_model_fallbacks`).
         try:
             from src.endpoint_resolver import resolve_utility_fallback_candidates
-            _task_fallbacks = resolve_utility_fallback_candidates()
+            _task_fallbacks = resolve_utility_fallback_candidates(owner=task.owner)
         except Exception:
             _task_fallbacks = []
         async for event_str in stream_agent_loop(
@@ -1603,7 +1609,7 @@ class TaskScheduler:
                 else:
                     grace_context += "No tool results were captured."
                 grace_context += "\n\nSummarize what you accomplished and what's still pending. Be concise."
-                _grace_candidates = [(endpoint_url, model, headers)] + resolve_utility_fallback_candidates()
+                _grace_candidates = [(endpoint_url, model, headers)] + resolve_utility_fallback_candidates(owner=task.owner)
                 full_text = await llm_call_async_with_fallback(
                     _grace_candidates,
                     messages=[
@@ -1631,6 +1637,9 @@ class TaskScheduler:
         # Resolve endpoint/model: research settings > task settings > session defaults
         endpoint_url = task.endpoint_url
         model = task.model
+        headers = {}
+        if endpoint_url:
+            endpoint_url, model = self._registered_task_endpoint(db, task.owner, endpoint_url, model)
 
         if not endpoint_url or not model:
             try:
@@ -1640,9 +1649,11 @@ class TaskScheduler:
                     endpoint_url or None,
                     model or None,
                     None,
+                    owner=task.owner,
                 )
                 endpoint_url = ep_url or endpoint_url
                 model = ep_model or model
+                headers = ep_headers or {}
             except Exception:
                 pass
 
@@ -1654,12 +1665,13 @@ class TaskScheduler:
         self._last_run_model = model
 
         # Resolve headers
-        headers = {}
         try:
             from core.database import ModelEndpoint
             from src.endpoint_resolver import normalize_base, build_headers
+            from src.auth_helpers import owner_filter
             db2 = db
-            eps = db2.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+            q = db2.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+            eps = owner_filter(q, ModelEndpoint, task.owner or "").all()
             for ep in eps:
                 if normalize_base(ep.base_url) in endpoint_url or endpoint_url in normalize_base(ep.base_url):
                     headers = build_headers(ep.api_key, normalize_base(ep.base_url))
@@ -1770,7 +1782,15 @@ class TaskScheduler:
         return True  # too deep, treat as cycle
 
     def _resolve_defaults(self, db, owner):
-        """Find the first available endpoint + model from an existing session."""
+        """Find the owner's configured task endpoint, then fall back to recent sessions."""
+        try:
+            from src.endpoint_resolver import resolve_endpoint
+            endpoint_url, model, _headers = resolve_endpoint("task", owner=owner)
+            if endpoint_url and model:
+                return endpoint_url, model
+        except Exception:
+            pass
+
         from core.database import Session as DbSession
         try:
             recent = db.query(DbSession).filter(
@@ -1783,6 +1803,43 @@ class TaskScheduler:
         except Exception:
             pass
         return None, None
+
+    def _registered_task_endpoint(self, db, owner, endpoint_url, model):
+        """Return a pinned task endpoint only if it is registered for this owner."""
+        endpoint_url = (endpoint_url or "").strip()
+        model = (model or "").strip()
+        if not endpoint_url:
+            return None, model or None
+
+        try:
+            from core.database import ModelEndpoint
+            from src.auth_helpers import owner_filter
+            from src.endpoint_resolver import normalize_base, build_chat_url
+            target_base = normalize_base(endpoint_url)
+            q = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+            # Scheduled tasks can outlive endpoint edits and user changes.
+            # Treat a stale or foreign endpoint as unavailable instead of
+            # letting a background task reuse another user's credentials.
+            eps = owner_filter(q, ModelEndpoint, owner or "").all()
+            for ep in eps:
+                base = normalize_base(ep.base_url or "")
+                if target_base != base:
+                    continue
+                cached = []
+                if ep.cached_models:
+                    try:
+                        cached = json.loads(ep.cached_models) or []
+                    except Exception:
+                        cached = []
+                if model and cached and model not in cached:
+                    continue
+                if not model and cached:
+                    model = str(cached[0])
+                return build_chat_url(base), model or None
+        except Exception:
+            logger.debug("Could not validate scheduled-task endpoint", exc_info=True)
+        logger.warning("Ignoring unavailable scheduled-task endpoint for owner=%r: %s", owner, endpoint_url)
+        return None, model or None
 
     async def _deliver_via_mcp(self, tool_name: str, task, result: str):
         """Send the task result via an MCP tool (e.g. Gmail send).

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -311,11 +311,19 @@ _ADMIN_TOOLS = {
     "manage_webhooks",
     "manage_tokens",
     "manage_settings",
+    # These look like convenience helpers, but they describe or mutate local
+    # model-serving state. Treat the whole serving surface as admin-only.
     "download_model",
     "serve_model",
     "serve_preset",
+    "list_serve_presets",
+    "list_cookbook_servers",
+    "list_served_models",
+    "list_downloads",
+    "list_cached_models",
     "stop_served_model",
     "cancel_download",
+    "adopt_served_model",
 }
 
 

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -88,10 +88,19 @@ def get_active_document():
     return _active_document_id
 
 
+def _ownerless_document_clause(Document):
+    none_clause = Document.owner == None  # noqa: E711 - SQLAlchemy null comparison
+    empty_clause = Document.owner == ""
+    try:
+        return none_clause | empty_clause
+    except TypeError:
+        return ("or", none_clause, empty_clause)
+
+
 def _owned_document_query(query, Document, owner: Optional[str]):
-    if owner is None:
-        return query.filter(False)
-    return query.filter(Document.owner == owner)
+    if owner:
+        return query.filter(Document.owner == owner)
+    return query.filter(_ownerless_document_clause(Document))
 
 
 def _get_owned_document(db, Document, doc_id: str, owner: Optional[str], active_only: bool = False):
@@ -1030,10 +1039,14 @@ async def do_manage_tasks(content: str, owner: Optional[str] = None) -> Dict:
 async def do_manage_endpoints(content: str, owner: Optional[str] = None) -> Dict:
     """Manage model endpoints: list, add, delete, enable, disable."""
     from core.database import SessionLocal, ModelEndpoint
+    from src.tool_security import owner_is_admin_or_single_user
     try:
         args = _parse_tool_args(content)
     except ValueError:
         return {"error": "Invalid JSON arguments", "exit_code": 1}
+
+    if not owner_is_admin_or_single_user(owner):
+        return {"error": "manage_endpoints requires an admin user", "exit_code": 1}
 
     action = args.get("action", "list")
     db = SessionLocal()
@@ -1049,12 +1062,14 @@ async def do_manage_endpoints(content: str, owner: Optional[str] = None) -> Dict
             name = args.get("name", "")
             base_url = args.get("base_url", "")
             api_key = args.get("api_key", "")
+            shared = str(args.get("shared", "")).strip().lower() in {"1", "true", "yes", "on"}
             if not base_url:
                 return {"error": "base_url is required", "exit_code": 1}
             eid = str(_uuid.uuid4())[:8]
             from datetime import datetime
             ep = ModelEndpoint(id=eid, name=name or base_url, base_url=base_url,
                                api_key=api_key, is_enabled=True,
+                               owner=None if shared else owner,
                                created_at=datetime.utcnow(), updated_at=datetime.utcnow())
             db.add(ep)
             db.commit()
@@ -3803,11 +3818,13 @@ async def do_resolve_contact(content: str, owner: Optional[str] = None) -> Dict:
 
     # 1. CardDAV (Radicale) — structured contacts. Call in-process: a
     # server-side httpx GET to /api/contacts/search carries no session
-    # cookie and would 401 under require_user.
+    # cookie and would 401 under require_user. The address book is global
+    # admin data, so only consult it for an admin / single-user owner.
+    from src.tool_security import owner_is_admin_or_single_user
     try:
         import asyncio
         from routes import contacts_routes as cc
-        all_contacts = await asyncio.to_thread(cc._fetch_contacts)
+        all_contacts = await asyncio.to_thread(cc._fetch_contacts) if owner_is_admin_or_single_user(owner) else []
         q = name.lower()
         for c in (all_contacts or []):
             hay_name = (c.get("name") or "").lower()
@@ -3853,6 +3870,11 @@ async def do_manage_contact(content: str, owner: Optional[str] = None) -> Dict:
     except ValueError:
         return {"error": "Invalid JSON arguments", "exit_code": 1}
     action = (args.get("action") or "").strip().lower()
+    # The CardDAV address book is global admin data backed by one Radicale
+    # instance; managing it is admin-only, matching the /api/contacts/* routes.
+    from src.tool_security import owner_is_admin_or_single_user
+    if not owner_is_admin_or_single_user(owner):
+        return {"error": "manage_contact requires an admin user", "exit_code": 1}
     try:
         from routes import contacts_routes as cc
     except Exception as e:
@@ -4060,7 +4082,9 @@ async def do_vault_unlock(content: str, owner: Optional[str] = None) -> Dict:
     if not master_password:
         return {"error": "master_password is required", "exit_code": 1}
 
-    stdout, stderr, rc = await _run_bw(["unlock", master_password, "--raw"])
+    # Do not pass the master password as an argv element. Local process lists
+    # can expose argv to other users; stdin keeps the secret out of `ps`.
+    stdout, stderr, rc = await _run_bw(["unlock", "--raw"], input_text=master_password + "\n")
     if rc != 0:
         return {"error": f"Unlock failed: {stderr[:300]}", "exit_code": 1}
 

--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -38,9 +38,17 @@ NON_ADMIN_BLOCKED_TOOLS = {
     "vault_search",
     "vault_get",
     "vault_unlock",
+    # Cookbook/model serving tools expose local runtime state and can start,
+    # stop, or adopt model servers. Keep even read-looking inventory calls out
+    # of non-admin sessions.
     "download_model",
     "serve_model",
     "serve_preset",
+    "list_serve_presets",
+    "list_cookbook_servers",
+    "list_served_models",
+    "list_downloads",
+    "list_cached_models",
     "stop_served_model",
     "cancel_download",
     "adopt_served_model",

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -72,7 +72,10 @@ def _pairing_db_stub(monkeypatch):
 
 for _name, _attrs in {
     "core.auth": {"AuthManager": MagicMock()},
-    "src.endpoint_resolver": {"build_chat_url": (lambda u: u)},
+    "src.endpoint_resolver": {
+        "build_chat_url": (lambda u: u),
+        "resolve_url": (lambda u: u),
+    },
 }.items():
     if _name not in sys.modules:
         _mm = types.ModuleType(_name)

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -47,7 +47,28 @@ class _DBStub(types.ModuleType):
 _db = _DBStub("core.database")
 _db.get_db_session = _get_db_session
 _db.ApiToken = _ApiToken
-sys.modules["core.database"] = _db  # overwrite any minimal stub from a sibling test
+
+
+def _install_db_stub(monkeypatch=None):
+    # Overwrite any minimal stub from a sibling test. Update the parent package
+    # too because importlib may otherwise reuse core.database from the package
+    # attribute even after sys.modules["core.database"] is replaced.
+    if monkeypatch is None:
+        sys.modules["core.database"] = _db
+        if "core" in sys.modules:
+            setattr(sys.modules["core"], "database", _db)
+        return
+    monkeypatch.setitem(sys.modules, "core.database", _db)
+    if "core" in sys.modules:
+        monkeypatch.setattr(sys.modules["core"], "database", _db, raising=False)
+
+
+_install_db_stub()
+
+
+@pytest.fixture(autouse=True)
+def _pairing_db_stub(monkeypatch):
+    _install_db_stub(monkeypatch)
 
 for _name, _attrs in {
     "core.auth": {"AuthManager": MagicMock()},

--- a/tests/test_document_tool_owner_scope.py
+++ b/tests/test_document_tool_owner_scope.py
@@ -73,11 +73,18 @@ def _install_database_stub(monkeypatch, module_name, query):
     return db
 
 
-def test_owned_document_query_rejects_missing_owner():
+def test_owned_document_query_without_owner_filters_to_ownerless():
     query = _Query()
 
     assert tools._owned_document_query(query, _Document, None) is query
-    assert False in query.filters
+    assert ("or", ("owner", "eq", None), ("owner", "eq", "")) in query.filters
+
+
+def test_owned_document_query_empty_owner_filters_to_ownerless():
+    query = _Query()
+
+    assert tools._owned_document_query(query, _Document, "") is query
+    assert ("or", ("owner", "eq", None), ("owner", "eq", "")) in query.filters
 
 
 def test_owned_document_query_filters_to_owner():

--- a/tests/test_endpoint_probing.py
+++ b/tests/test_endpoint_probing.py
@@ -31,16 +31,27 @@ _endpoint_resolver = sys.modules.get("src.endpoint_resolver")
 if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
     sys.modules.pop("src.endpoint_resolver", None)
     sys.modules.pop("routes.model_routes", None)
+    _src_pkg = sys.modules.get("src")
+    if isinstance(_src_pkg, types.ModuleType) and hasattr(_src_pkg, "endpoint_resolver"):
+        delattr(_src_pkg, "endpoint_resolver")
 
-if "core.database" not in sys.modules:
+_core_db = sys.modules.get("core.database")
+if _core_db is None or not isinstance(_core_db, types.ModuleType):
     _core_db = types.ModuleType("core.database")
-    for _name in [
-        "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
-        "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
-        "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun", "McpServer",
-    ]:
-        setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
+for _name in [
+    "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
+    "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
+    "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun", "McpServer",
+]:
+    if not hasattr(_core_db, _name):
+        setattr(_core_db, _name, MagicMock())
+if not hasattr(_core_db, "DATABASE_URL"):
+    _core_db.DATABASE_URL = "sqlite:///:memory:"
+if not hasattr(_core_db, "engine"):
+    _core_db.engine = MagicMock()
+if "core" in sys.modules:
+    setattr(sys.modules["core"], "database", _core_db)
 
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
@@ -52,6 +63,14 @@ from routes.model_routes import (
     _rewrite_loopback_for_docker,
     _PROVIDER_CURATED,
 )
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_endpoint_resolver(monkeypatch):
+    monkeypatch.setitem(sys.modules, "src.endpoint_resolver", endpoint_resolver)
+    _src_pkg = sys.modules.get("src")
+    if isinstance(_src_pkg, types.ModuleType):
+        monkeypatch.setattr(_src_pkg, "endpoint_resolver", endpoint_resolver, raising=False)
 
 
 def _patch_resolve(monkeypatch):

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -12,17 +12,28 @@ if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__"
     # the real URL normalization helpers so Anthropic /v1 handling is covered.
     sys.modules.pop("src.endpoint_resolver", None)
     sys.modules.pop("routes.model_routes", None)
+    _src_pkg = sys.modules.get("src")
+    if isinstance(_src_pkg, types.ModuleType) and hasattr(_src_pkg, "endpoint_resolver"):
+        delattr(_src_pkg, "endpoint_resolver")
 
-if "core.database" not in sys.modules:
+_core_db = sys.modules.get("core.database")
+if _core_db is None or not isinstance(_core_db, types.ModuleType):
     _core_db = types.ModuleType("core.database")
-    for _name in [
-        "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
-        "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
-        "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun",
-        "McpServer",
-    ]:
-        setattr(_core_db, _name, MagicMock())
     sys.modules["core.database"] = _core_db
+for _name in [
+    "SessionLocal", "ModelEndpoint", "Session", "ChatMessage", "Document",
+    "DocumentVersion", "GalleryImage", "GalleryAlbum", "Note",
+    "CalendarCal", "CalendarEvent", "ScheduledTask", "TaskRun",
+    "McpServer",
+]:
+    if not hasattr(_core_db, _name):
+        setattr(_core_db, _name, MagicMock())
+if not hasattr(_core_db, "DATABASE_URL"):
+    _core_db.DATABASE_URL = "sqlite:///:memory:"
+if not hasattr(_core_db, "engine"):
+    _core_db.engine = MagicMock()
+if "core" in sys.modules:
+    setattr(sys.modules["core"], "database", _core_db)
 
 import routes.model_routes as model_routes
 import src.endpoint_resolver as endpoint_resolver
@@ -41,6 +52,14 @@ from routes.model_routes import (
     _PROVIDER_CURATED,
 )
 from src.llm_core import ANTHROPIC_MODELS
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_endpoint_resolver(monkeypatch):
+    monkeypatch.setitem(sys.modules, "src.endpoint_resolver", endpoint_resolver)
+    _src_pkg = sys.modules.get("src")
+    if isinstance(_src_pkg, types.ModuleType):
+        monkeypatch.setattr(_src_pkg, "endpoint_resolver", endpoint_resolver, raising=False)
 
 
 # ── speech endpoint settings ──

--- a/tests/test_research_query_fallback.py
+++ b/tests/test_research_query_fallback.py
@@ -5,16 +5,20 @@ bare affirmation ("yes", "ok", "go ahead"), that follow-up must not become the
 research topic — we fall back to the original substantive ask. A short but
 meaningful answer ("UK", "C++", "Rust") is a real topic and must be preserved.
 """
+from types import SimpleNamespace
+
 import pytest
 
-from core.models import ChatMessage, Session
 from src.research_handler import ResearchHandler
 
 
 def _session(history):
-    return Session(
-        id="s1", name="t", endpoint_url="http://local.test", model="m",
-        history=[ChatMessage(role, content) for role, content in history],
+    return SimpleNamespace(
+        id="s1",
+        name="t",
+        endpoint_url="http://local.test",
+        model="m",
+        history=[SimpleNamespace(role=role, content=content) for role, content in history],
     )
 
 

--- a/tests/test_scheduler_restart_doublefire.py
+++ b/tests/test_scheduler_restart_doublefire.py
@@ -13,8 +13,20 @@ polls.
 import sys, types, asyncio
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
-from sqlalchemy import create_engine, Column, String, DateTime, Integer, Boolean, Text
-from sqlalchemy.orm import sessionmaker, declarative_base
+
+import pytest
+
+
+_SQLALCHEMY_MODULES = (
+    "sqlalchemy",
+    "sqlalchemy.orm",
+    "sqlalchemy.types",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.declarative",
+    "sqlalchemy.sql",
+    "sqlalchemy.sql.expression",
+    "sqlalchemy.sql.sqltypes",
+)
 
 
 def _stub_heavy():
@@ -25,7 +37,28 @@ def _stub_heavy():
         sys.modules.setdefault(name, types.ModuleType(name))
 
 
-def _setup_isolated_db():
+def _drop_module(name: str):
+    module = sys.modules.pop(name, None)
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, types.ModuleType) and hasattr(parent, attr):
+        delattr(parent, attr)
+
+
+def _drop_stale_mock(name: str):
+    module = sys.modules.get(name)
+    if module is not None and not isinstance(module, types.ModuleType):
+        _drop_module(name)
+
+
+def _setup_isolated_db(monkeypatch):
+    for mod in _SQLALCHEMY_MODULES:
+        _drop_stale_mock(mod)
+    pytest.importorskip("sqlalchemy")
+    from sqlalchemy import create_engine, Column, String, DateTime, Integer, Text
+    from sqlalchemy.orm import sessionmaker, declarative_base
+
+    _drop_module("core.database")
     import core.database as cd
     B = declarative_base()
 
@@ -52,17 +85,20 @@ def _setup_isolated_db():
 
     eng = create_engine("sqlite:///:memory:")
     B.metadata.create_all(eng)
-    cd.engine = eng
-    cd.SessionLocal = sessionmaker(bind=eng, autocommit=False, autoflush=False)
-    cd.ScheduledTask = ScheduledTask
-    cd.TaskRun = TaskRun
+    monkeypatch.setattr(cd, "engine", eng, raising=False)
+    monkeypatch.setattr(cd, "SessionLocal", sessionmaker(bind=eng, autocommit=False, autoflush=False), raising=False)
+    monkeypatch.setattr(cd, "ScheduledTask", ScheduledTask, raising=False)
+    monkeypatch.setattr(cd, "TaskRun", TaskRun, raising=False)
+    monkeypatch.setitem(sys.modules, "core.database", cd)
+    if "core" in sys.modules:
+        monkeypatch.setattr(sys.modules["core"], "database", cd, raising=False)
     return cd, ScheduledTask, TaskRun
 
 
 def _drive_scheduler(monkeypatch, pre_start_setup=None):
     """Build a TaskScheduler bypassing __init__ and run start() + two polls."""
     _stub_heavy()
-    cd, ScheduledTask, TaskRun = _setup_isolated_db()
+    cd, ScheduledTask, TaskRun = _setup_isolated_db(monkeypatch)
 
     from src.task_scheduler import TaskScheduler
     sch = TaskScheduler.__new__(TaskScheduler)

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -14,7 +14,9 @@ These are pure-function tests — no FastAPI app boot, no DB.
 import sys
 import types
 import json
+import re
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -122,7 +124,7 @@ def test_docker_compose_binds_web_ui_to_loopback_by_default():
 def test_readme_native_quickstart_uses_loopback():
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "python -m uvicorn app:app --host 127.0.0.1 --port 7000" in readme
-    assert "Use `--host 0.0.0.0` only when you intentionally want" in readme
+    assert re.search(r"Use `--host 0\.0\.0\.0` only when\s+you intentionally want", readme)
 
 
 def test_ollama_cookbook_runner_does_not_force_public_bind():
@@ -295,6 +297,7 @@ def _stub_core_database_for_route_imports(monkeypatch):
     core_pkg = types.ModuleType("core")
     core_pkg.__path__ = []
     models = types.ModuleType("core.models")
+    models.Session = MagicMock()
     models.ChatMessage = MagicMock()
 
     db = types.ModuleType("core.database")
@@ -943,6 +946,60 @@ def test_mcp_oauth_page_escapes_reflected_values():
         assert f"{var} = html.escape({var}" in body, var
 
 
+# ── session endpoint SSRF guard ─────────────────────────────────────────────
+
+def _fake_request_for_user(user, *, admin=False):
+    auth_manager = SimpleNamespace(is_admin=lambda username: bool(admin))
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=auth_manager)),
+    )
+
+
+def test_non_admin_session_create_rejects_raw_endpoint_url_without_endpoint_id():
+    from fastapi import HTTPException
+    from routes.session_routes import _reject_raw_endpoint_url_for_non_admin
+
+    request = _fake_request_for_user("alice", admin=False)
+    with pytest.raises(HTTPException) as exc:
+        _reject_raw_endpoint_url_for_non_admin(
+            request,
+            "alice",
+            "",
+            "http://169.254.169.254/latest/meta-data",
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_non_admin_session_create_allows_registered_endpoint_id():
+    from routes.session_routes import _reject_raw_endpoint_url_for_non_admin
+
+    request = _fake_request_for_user("alice", admin=False)
+    _reject_raw_endpoint_url_for_non_admin(
+        request,
+        "alice",
+        "owned-endpoint-id",
+        "http://127.0.0.1:8765/v1/chat/completions",
+    )
+
+
+def test_admin_and_single_user_mode_can_still_use_raw_endpoint_urls():
+    from routes.session_routes import _reject_raw_endpoint_url_for_non_admin
+
+    _reject_raw_endpoint_url_for_non_admin(
+        _fake_request_for_user("admin", admin=True),
+        "admin",
+        "",
+        "http://127.0.0.1:8765/v1/chat/completions",
+    )
+    _reject_raw_endpoint_url_for_non_admin(
+        _fake_request_for_user(None, admin=False),
+        None,
+        "",
+        "http://127.0.0.1:8765/v1/chat/completions",
+    )
+
 
 # -- export/gallery filename hardening ----------------------------------------
 
@@ -965,6 +1022,7 @@ def _install_route_import_stubs(monkeypatch):
     session_manager_mod.SessionManager = type("SessionManager", (), {})
 
     models_mod = types.ModuleType("core.models")
+    models_mod.Session = type("Session", (), {})
     models_mod.ChatMessage = type("ChatMessage", (), {})
 
     monkeypatch.setitem(sys.modules, "core", core_mod)
@@ -1022,6 +1080,7 @@ def test_gallery_replace_filename_sanitizer_falls_back_when_empty(monkeypatch):
 
     assert mod._sanitize_gallery_filename("../") == "abcdef123456"
 
+
 def test_chat_active_document_lookup_is_owner_scoped():
     """The explicit `active_doc_id` path in /api/chat_stream must scope the
     document lookup to the caller. Resolving by id alone let any user inject
@@ -1041,3 +1100,16 @@ def test_chat_active_document_lookup_is_owner_scoped():
     assert "filter( DBDocument.id == active_doc_id, ).first()" not in flat
     assert "filter(DBDocument.id == active_doc_id).first()" not in flat
     assert "filter(DBDocument.id == _mem_id).first()" not in flat
+
+
+def test_chat_endpoint_recovery_helpers_are_owner_scoped():
+    """Endpoint recovery must not let another owner's private endpoint decide
+    whether this user's chat endpoint is still valid or which model to recover."""
+    src = Path(__file__).resolve().parents[1] / "routes" / "chat_routes.py"
+    text = src.read_text()
+
+    assert "def _clear_orphaned_session_endpoint(sess, owner:" in text
+    assert "def _recover_empty_session_model(sess, session_id: str, owner:" in text
+    assert "q = owner_filter(q, ModelEndpoint, owner)" in text
+    assert "_clear_orphaned_session_endpoint(sess, owner=owner)" in text
+    assert "_recover_empty_session_model(sess, session, owner=owner)" in text

--- a/tests/test_session_owner_attribution.py
+++ b/tests/test_session_owner_attribution.py
@@ -25,15 +25,19 @@ _STUBS = {
     "core.database": {"Session": MagicMock(), "SessionLocal": MagicMock(),
                       "Document": MagicMock(), "GalleryImage": MagicMock()},
     "core.session_manager": {"SessionManager": MagicMock()},
-    "core.models": {"ChatMessage": MagicMock()},
+    "core.models": {"Session": MagicMock(), "ChatMessage": MagicMock()},
     "src.request_models": {"SessionResponse": MagicMock()},
 }
 for _name, _attrs in _STUBS.items():
     if _name not in sys.modules:
         _m = types.ModuleType(_name)
-        for _k, _v in _attrs.items():
-            setattr(_m, _k, _v)
         sys.modules[_name] = _m
+    _m = sys.modules[_name]
+    for _k, _v in _attrs.items():
+        setattr(_m, _k, _v)
+    _parent, _, _attr = _name.rpartition(".")
+    if _parent in sys.modules:
+        setattr(sys.modules[_parent], _attr, _m)
 
 from fastapi import HTTPException  # noqa: E402
 

--- a/tests/test_skills_manager_owner_isolation.py
+++ b/tests/test_skills_manager_owner_isolation.py
@@ -24,7 +24,6 @@ silently mutates a file owned by a different user AND overwrites the
 import os
 import sys
 import textwrap
-import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -33,27 +32,12 @@ import pytest
 
 # ── module-load stubbing (matches other tests in this repo) ──────────
 # Stub heavy deps so importing the skills manager doesn't pull DB / FastAPI.
-for _mod in [
-    "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext",
-    "sqlalchemy.ext.declarative", "src.database",
-    "core.atomic_io",  # we'll patch atomic_write_text below
-]:
+for _mod in ("sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext", "sqlalchemy.ext.declarative"):
     if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
-
-
-# Provide a no-op atomic_write_text for SkillsManager._write_skill.
-def _fake_atomic_write_text(path, content, **kw):
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    Path(path).write_text(content, encoding="utf-8")
-
-_fake_core = types.ModuleType("core.atomic_io")
-_fake_core.atomic_write_text = _fake_atomic_write_text
-_fake_core.atomic_write_json = lambda p, d, **kw: Path(p).write_text(
-    "{}", encoding="utf-8"
-)
-sys.modules["core.atomic_io"] = _fake_core
-
+        try:
+            __import__(_mod)
+        except ImportError:
+            sys.modules[_mod] = MagicMock()
 
 from services.memory.skills import SkillsManager  # noqa: E402
 from services.memory.skill_format import Skill, slugify  # noqa: E402
@@ -195,13 +179,12 @@ def test_update_skill_scalar_keys_exclude_owner():
     )
 
 
-def test_read_skill_md_scopes_to_owner(tmp_path):
+def test_read_skill_md_and_references_are_owner_scoped(tmp_path):
     """Two users own distinct skills with the same slug. read_skill_md()
     called with owner='alice' must return Alice's content, not Bob's.
     Called without an owner it must match only ownerless skills."""
     skills_root = tmp_path / "skills"
     skills_root.mkdir(parents=True, exist_ok=True)
-
     alice_path = _write_skill_md(
         skills_root, category="alice-cat", name="login-flow",
         owner="alice", description="alice secret",
@@ -210,27 +193,28 @@ def test_read_skill_md_scopes_to_owner(tmp_path):
         skills_root, category="bob-cat", name="login-flow",
         owner="bob", description="bob secret",
     )
+    refs = bob_path.parent / "references"
+    refs.mkdir()
+    (refs / "notes.txt").write_text("bob private notes", encoding="utf-8")
 
     sm = SkillsManager(str(tmp_path))
 
     alice_md = sm.read_skill_md("login-flow", owner="alice")
     assert alice_md is not None, "read_skill_md returned None for alice's skill"
-    assert "alice secret" in alice_md, (
-        f"read_skill_md(owner='alice') returned the wrong file: {alice_md[:200]}"
-    )
+    assert "alice secret" in alice_md
 
     bob_md = sm.read_skill_md("login-flow", owner="bob")
     assert bob_md is not None, "read_skill_md returned None for bob's skill"
-    assert "bob secret" in bob_md, (
-        f"read_skill_md(owner='bob') returned the wrong file: {bob_md[:200]}"
-    )
+    assert "bob secret" in bob_md
 
     no_owner_md = sm.read_skill_md("login-flow")
     assert no_owner_md is None, (
         "read_skill_md without owner matched an owned skill — "
-        "default should only match ownerless skills. Got: "
-        f"{no_owner_md[:200] if no_owner_md else 'None'}"
+        "default should only match ownerless skills."
     )
+    assert sm.read_skill_md("login-flow", owner="charlie") is None
+    assert sm.read_skill_reference("login-flow", "references/notes.txt", owner="bob") == "bob private notes"
+    assert sm.read_skill_reference("login-flow", "references/notes.txt", owner="alice") is None
 
 
 def test_update_skill_positive_scoping(tmp_path):
@@ -262,3 +246,61 @@ def test_update_skill_positive_scoping(tmp_path):
     assert "bob original" in after_bob and "alice updated" not in after_bob, (
         "Bob's file was mutated by Alice's update_skill call — cross-tenant leak."
     )
+
+
+def test_add_skill_dedup_does_not_cross_owners(tmp_path):
+    sm = SkillsManager(str(tmp_path))
+    first = sm.add_skill(
+        name="shared-flow",
+        description="same description",
+        category="general",
+        when_to_use="same trigger",
+        procedure=["same procedure"],
+        owner="alice",
+        source="learned",
+    )
+    second = sm.add_skill(
+        name="shared-flow",
+        description="same description",
+        category="general",
+        when_to_use="same trigger",
+        procedure=["same procedure"],
+        owner="bob",
+        source="learned",
+    )
+
+    assert not first.get("_deduped")
+    assert not second.get("_deduped")
+    assert second.get("owner") == "bob"
+
+
+def test_usage_sidecar_is_owner_scoped(tmp_path):
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    _write_skill_md(
+        skills_root, category="alice-cat", name="shared-flow",
+        owner="alice", description="alice secret",
+    )
+    _write_skill_md(
+        skills_root, category="bob-cat", name="shared-flow",
+        owner="bob", description="bob secret",
+    )
+
+    sm = SkillsManager(str(tmp_path))
+    sm.record_use("shared-flow", owner="alice")
+    sm.set_audit("shared-flow", "pass", by_teacher=False, owner="bob")
+    sm.set_necessity("shared-flow", False, ["other-flow"], "redundant", owner="bob")
+
+    alice = sm.load(owner="alice")[0]
+    bob = sm.load(owner="bob")[0]
+
+    assert alice["uses"] == 1
+    assert alice["audit_verdict"] is None
+    assert alice["necessity"] is None
+    assert bob["uses"] == 0
+    assert bob["audit_verdict"] == "pass"
+    assert bob["necessity"] == {
+        "necessary": False,
+        "redundant_with": ["other-flow"],
+        "reason": "redundant",
+    }

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -1,8 +1,40 @@
 """Regression tests for task-result delivery into chat sessions (issue #326)."""
 import asyncio
+import sys
 import types as _types
 
 import pytest
+
+_SQLALCHEMY_MODULES = (
+    "sqlalchemy",
+    "sqlalchemy.orm",
+    "sqlalchemy.types",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.declarative",
+    "sqlalchemy.sql",
+    "sqlalchemy.sql.expression",
+    "sqlalchemy.sql.sqltypes",
+)
+
+
+def _drop_module(name: str):
+    module = sys.modules.pop(name, None)
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    sentinel = object()
+    parent_attr = getattr(parent, attr, sentinel) if isinstance(parent, _types.ModuleType) else sentinel
+    if parent_attr is not sentinel and (module is None or parent_attr is module):
+        delattr(parent, attr)
+
+
+def _drop_stale_mock(name: str):
+    module = sys.modules.get(name)
+    if module is not None and not isinstance(module, _types.ModuleType):
+        _drop_module(name)
+
+
+for _mod in _SQLALCHEMY_MODULES:
+    _drop_stale_mock(_mod)
 
 sqlalchemy = pytest.importorskip("sqlalchemy")
 if not isinstance(sqlalchemy, _types.ModuleType):
@@ -11,23 +43,24 @@ if not isinstance(sqlalchemy, _types.ModuleType):
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from core.database import Base, Session as DbSession
-from src.task_scheduler import TaskScheduler
+if not isinstance(sys.modules.get("sqlalchemy.orm"), _types.ModuleType):
+    pytest.skip("sqlalchemy.orm is stubbed in this environment", allow_module_level=True)
 
-# TEMPORARY ISOLATION WORKAROUND — remove once test_null_owner_gates.py is
-# refactored to use a fixture-scoped stub instead of module-level sys.modules
-# patching.  When collected after test_null_owner_gates (alphabetical order),
-# core.database is already a stub whose Base attribute is a MagicMock, so
-# Base.metadata.create_all() below does nothing and the assertions fail.
-# The test passes correctly in isolation:
-#   pytest tests/test_task_scheduler_session_delivery.py   → 1 passed
-# Full-suite baseline before this PR:  9 failed, 345 passed  (pre-upstream-pull)
-# Full-suite after this PR:            1 failed, 495 passed, 1 skipped
-if type(Base).__name__ == "MagicMock":
-    pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
+def _load_real_scheduler():
+    for _mod in _SQLALCHEMY_MODULES:
+        _drop_stale_mock(_mod)
+    for _mod in ("src.task_scheduler", "src.endpoint_resolver", "src.database", "core.database"):
+        _drop_module(_mod)
+
+    from core.database import Base, Session as DbSession
+    from src.task_scheduler import TaskScheduler
+
+    if type(Base).__name__ == "MagicMock" or type(TaskScheduler).__name__ == "MagicMock":
+        pytest.skip("core.database/task_scheduler is stubbed — run this file in isolation")
+    return Base, DbSession, TaskScheduler
 
 
-def _make_db():
+def _make_db(Base):
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)()
@@ -51,9 +84,11 @@ def test_session_delivery_survives_empty_database():
     """On a fresh/wiped database there is no session to inherit endpoint/model
     from, so _resolve_defaults returns None. The delivery must still persist a
     session instead of crashing on the NOT NULL constraint (issue #326)."""
-    db = _make_db()
+    Base, DbSession, TaskScheduler = _load_real_scheduler()
+    db = _make_db(Base)
     scheduler = TaskScheduler.__new__(TaskScheduler)
     scheduler._session_manager = None
+    scheduler._resolve_defaults = lambda _db, _owner: (None, None)
 
     asyncio.run(scheduler._deliver_task_result(_make_task(), "done", db))
 

--- a/tests/test_vault_password_not_in_argv.py
+++ b/tests/test_vault_password_not_in_argv.py
@@ -4,8 +4,8 @@
 ``asyncio.create_subprocess_exec(bw_path, *args)`` — every element of ``args``
 becomes a process argument, which is world-readable through ``ps`` /
 ``/proc/<pid>/cmdline``. The master password therefore must be handed to ``bw``
-via the environment (``--passwordenv BW_PASSWORD``), exactly like the existing
-``BW_SESSION`` env passing, and never as a positional argv element.
+out-of-band (stdin or ``--passwordenv BW_PASSWORD``), and never as a positional
+argv element.
 
 The /unlock route previously did ``_run_bw(["unlock", req.master_password,
 "--raw"])`` — leaking the Bitwarden master password (which decrypts the whole
@@ -32,12 +32,35 @@ if "core.database" not in sys.modules:
     sys.modules["core.database"] = _db
 if "core.middleware" not in sys.modules:
     _mw = types.ModuleType("core.middleware")
-    _mw.require_admin = MagicMock()
+    _mw.INTERNAL_TOOL_TOKEN = "test-internal-token"
+    _mw.INTERNAL_TOOL_HEADER = "X-Odysseus-Internal-Token"
+
+    def _require_admin(request):
+        from fastapi import HTTPException
+
+        headers = getattr(request, "headers", {}) or {}
+        state = getattr(request, "state", None)
+        token = headers.get(_mw.INTERNAL_TOOL_HEADER) if hasattr(headers, "get") else None
+        if token == _mw.INTERNAL_TOOL_TOKEN or getattr(state, "current_user", None) == "internal-tool":
+            return None
+        if os.getenv("AUTH_ENABLED", "true").lower() == "false":
+            return None
+        auth_mgr = getattr(getattr(request, "app", None), "state", None)
+        auth_mgr = getattr(auth_mgr, "auth_manager", None)
+        if not auth_mgr or not getattr(auth_mgr, "is_configured", True):
+            raise HTTPException(403, "Admin only")
+        user = getattr(state, "current_user", None)
+        if not user or not auth_mgr.is_admin(user):
+            raise HTTPException(403, "Admin only")
+        return None
+
+    _mw.require_admin = _require_admin
+    _mw.SecurityHeadersMiddleware = MagicMock()
     sys.modules["core.middleware"] = _mw
 if "core.platform_compat" not in sys.modules:
     _pc = types.ModuleType("core.platform_compat")
     _pc.IS_WINDOWS = False
-    _pc.safe_chmod = MagicMock()
+    _pc.safe_chmod = lambda path, mode: os.chmod(path, mode)
     _pc.which_tool = MagicMock(return_value="bw")
     sys.modules["core.platform_compat"] = _pc
 
@@ -86,15 +109,15 @@ async def test_run_bw_without_password_does_not_set_env(monkeypatch):
     assert "BW_PASSWORD" not in captured["env"]
 
 
-def test_unlock_handler_uses_passwordenv_not_argv():
+def test_unlock_handler_feeds_password_on_stdin_not_argv():
     """Source-level guard: the /unlock route must feed the master password via
-    --passwordenv / bw_password=, never as a bare positional argv element."""
+    stdin, never as a bare positional argv element."""
     src = vr.__file__
     with open(src, encoding="utf-8") as fh:
         text = fh.read()
     # The old, vulnerable call shape must be gone.
     assert 'req.master_password, "--raw"' not in text
     assert "[\"unlock\", req.master_password" not in text
-    # And the secure shape must be present.
-    assert "--passwordenv" in text
-    assert re.search(r"bw_password\s*=\s*req\.master_password", text)
+    # And the safer stdin shape must be present.
+    assert "[\"unlock\", \"--raw\"]" in text
+    assert re.search(r'input_text\s*=\s*req\.master_password\s*\+\s*"\\n"', text)


### PR DESCRIPTION

  Description
  This PR tightens multi-user isolation and credential handling across Odysseus. The main goal is to
  make sure user-owned sessions, endpoints, scheduled tasks, skills, email data, contacts, and tool
  calls do not accidentally cross tenant boundaries.

  It also keeps the branch reconciled with the latest upstream main, including the recent owner-scoped
  skill-route and email contact matching fixes.

  What Changed

  - Enforced owner-scoped endpoint resolution across chat, sessions, research, tasks, notes, gallery,
    documents, uploads, skills, and background LLM calls.

  - Blocked non-admin users from creating/updating sessions with arbitrary raw endpoint URLs unless
    they select a registered endpoint.

  - Scoped session endpoint recovery and fallback selection so one user cannot recover another user’s
    private endpoint/API key.

  - Hardened scheduled tasks so pinned endpoints are validated against the task owner before execution.
  - Scoped skill reads, references, audit state, necessity state, usage counters, updates, and
    deduplication by owner.

  - Made endpoint/tool management and shared CardDAV contact management admin-only where the underlying
    data is global.

  - Scoped email pre-retrieval, auto-summary, spam/tag records, scheduled sends, IMAP movement, and
    reply fallback resolution by owner/account.

  - Preserved upstream’s fix for matching CardDAV contacts via normalized plural emails.
  - Encrypted stored CalDAV passwords, validated CalDAV URLs, disabled redirects/proxy environment use
    for CalDAV checks, and avoided returning stored passwords.

  - Moved Bitwarden unlock password handling off process argv and into stdin.
  - Tightened admin-only access for model-serving/cookbook tools.
  - Added comments in the affected code paths explaining the security-sensitive behavior.
  - Fixed test isolation around endpoint helper tests so they can run in larger combined pytest batches
    without stale module stubs leaking across files.