### PR TITLE
fix: uploaded files with no extension become permanently unresolvable

### DIFF
--- a/src/upload_handler.py
+++ b/src/upload_handler.py
@@ -31,7 +31,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-UPLOAD_ID_RE = re.compile(r"^[0-9a-fA-F]{32}\.[A-Za-z0-9]+$")
+# The extension is optional: save_upload builds the id as `{uuid.hex}{ext}`,
+# and a file with no extension (Dockerfile, README, ...) yields a bare 32-hex
+# id. Requiring `.ext` made those ids fail validation, so the stored file
+# could never be resolved or downloaded again.
+UPLOAD_ID_RE = re.compile(r"^[0-9a-fA-F]{32}(?:\.[A-Za-z0-9]+)?$")
 
 
 def is_valid_upload_id(upload_id: str) -> bool:

--- a/tests/test_upload_id_validation.py
+++ b/tests/test_upload_id_validation.py
@@ -1,0 +1,21 @@
+"""Tests for upload id validation (src/upload_handler.py)."""
+import uuid
+
+from src.upload_handler import is_valid_upload_id
+
+
+def test_extensionless_id_is_valid():
+    # save_upload builds `{uuid.hex}{ext}`; a file with no extension yields a
+    # bare 32-hex id, which used to fail validation and become unresolvable.
+    assert is_valid_upload_id(uuid.uuid4().hex) is True
+
+
+def test_id_with_extension_still_valid():
+    assert is_valid_upload_id(uuid.uuid4().hex + ".png") is True
+
+
+def test_invalid_ids_rejected():
+    assert is_valid_upload_id("not-an-id") is False
+    assert is_valid_upload_id(uuid.uuid4().hex + ".") is False
+    assert is_valid_upload_id("") is False
+    assert is_valid_upload_id(uuid.uuid4().hex + ".tar.gz") is False


### PR DESCRIPTION
## Summary

`save_upload` builds the upload id as `{uuid.uuid4().hex}{ext}` where `ext` comes from `os.path.splitext`. For a file with no extension (e.g. `Dockerfile`, `README`, `LICENSE`), `ext == ""`, so the id is a bare 32-hex string. But `UPLOAD_ID_RE` requires a `.ext`:

```python
UPLOAD_ID_RE = re.compile(r"^[0-9a-fA-F]{32}\.[A-Za-z0-9]+$")
```

So `is_valid_upload_id(file_id)` returns False for that id. The file is written and its metadata saved, but every later lookup (`resolve_upload`, `get_upload_info`, `validate_upload_id`, ...) early-returns None — the upload can never be resolved, downloaded, or attached again.

Fix: make the extension optional in the pattern.

## Changes
- `src/upload_handler.py`: `UPLOAD_ID_RE` accepts an optional extension.
- `tests/test_upload_id_validation.py`: extensionless ids accepted; with-extension still valid; malformed ids rejected.