### PR TITLE
fix(chat): surface file path/name/size for non-text attachments (#1115)

### DIFF
--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -490,10 +490,28 @@ def build_user_content(
             else:
                 content.insert(0, {"type": "text", "text": extracted_text.lstrip()})
         else:
+            try:
+                _size_bytes = os.path.getsize(path)
+                if _size_bytes < 1024:
+                    _size_h = f"{_size_bytes} B"
+                elif _size_bytes < 1024 * 1024:
+                    _size_h = f"{_size_bytes / 1024:.1f} KB"
+                else:
+                    _size_h = f"{_size_bytes / (1024 * 1024):.1f} MB"
+            except OSError:
+                _size_h = "unknown size"
+            note = (
+                f"\n\n[Attached non-text file: {display_name} "
+                f"({_size_h}, {mime})]\n"
+                f"[Saved to: {path}]\n"
+                f"[upload_id: {fid}]\n"
+                f"Use bash or python tools (cat, python -c, file, xxd, "
+                f"numpy-stl, trimesh, etc.) to inspect or process this file."
+            )
             if content and content[0]["type"] == "text":
-                content[0]["text"] += "\n\n[Attached non-text file]"
+                content[0]["text"] += note
             else:
-                content.insert(0, {"type": "text", "text": "[Attached non-text file]"})
+                content.insert(0, {"type": "text", "text": note.lstrip()})
 
     has_media = any(item.get("type") in ["image_url", "audio"] for item in content if isinstance(item, dict))
     if not has_media and content:

--- a/tests/test_attachment_nontext_fallback.py
+++ b/tests/test_attachment_nontext_fallback.py
@@ -1,0 +1,178 @@
+"""Pin the fix for issue #1115: non-text, non-image, non-audio
+attachments (e.g. .stl, .obj, .step, .blend, archives) used to surface
+to the model as the bare string ``"[Attached non-text file]"`` with no
+name, path, size, or hint. The agent had no anchor to call bash/python
+against, so a user who dragged a .stl into the chat would hear the
+agent say "I don't see a file" even though ``save_upload`` had stored
+it on disk.
+
+These tests pin the new behaviour: every non-text attachment leaks
+its name, absolute path, size, and MIME into the user-content text,
+and the text tells the model it can use shell / Python tools against
+the saved file.
+"""
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _make_resolved(path: Path, name: str = "model.stl", mime: str = "application/octet-stream") -> dict:
+    return {
+        "id": path.name,
+        "path": str(path),
+        "name": name,
+        "original_name": name,
+        "mime": mime,
+        "size": path.stat().st_size,
+        "owner": "alice",
+    }
+
+
+def _make_handler(tmp_path: Path):
+    from src.upload_handler import UploadHandler
+    base = tmp_path / "base"
+    upload = tmp_path / "uploads"
+    base.mkdir()
+    upload.mkdir()
+    return UploadHandler(base_dir=str(base), upload_dir=str(upload)), upload
+
+
+def test_stl_attachment_surfaces_path_and_name(tmp_path):
+    from src.document_processor import build_user_content
+
+    handler, upload_dir = _make_handler(tmp_path)
+    stl = upload_dir / "abc123def456.stl"
+    stl.write_bytes(b"solid empty\nendsolid empty\n")
+
+    info = _make_resolved(stl, name="model.stl")
+    content = build_user_content(
+        "What's the volume of this STL?",
+        [info["id"]],
+        str(upload_dir),
+        handler,
+        owner="alice",
+        resolved_uploads={info["id"]: info},
+    )
+
+    assert "model.stl" in content
+    assert str(stl) in content
+    assert "non-text file" in content
+    assert "bash" in content.lower() or "python" in content.lower()
+
+
+def test_stl_attachment_surfaces_size_and_mime(tmp_path):
+    from src.document_processor import build_user_content
+
+    handler, upload_dir = _make_handler(tmp_path)
+    stl = upload_dir / "x.stl"
+    stl.write_bytes(b"solid x\nendsolid x\n")
+    info = _make_resolved(stl, name="tiny.stl", mime="application/sla")
+    content = build_user_content(
+        "inspect this",
+        [info["id"]],
+        str(upload_dir),
+        handler,
+        owner="alice",
+        resolved_uploads={info["id"]: info},
+    )
+
+    assert "tiny.stl" in content
+    assert "application/sla" in content
+
+
+def test_multiple_nontext_attachments_all_surfaced(tmp_path):
+    from src.document_processor import build_user_content
+
+    handler, upload_dir = _make_handler(tmp_path)
+    a = upload_dir / "a.stl"
+    b = upload_dir / "b.obj"
+    a.write_bytes(b"solid a\nendsolid a\n")
+    b.write_bytes(b"# obj a\n")
+    info_a = _make_resolved(a, name="mesh_a.stl")
+    info_b = _make_resolved(b, name="mesh_b.obj", mime="model/obj")
+
+    content = build_user_content(
+        "compare these",
+        [info_a["id"], info_b["id"]],
+        str(upload_dir),
+        handler,
+        owner="alice",
+        resolved_uploads={info_a["id"]: info_a, info_b["id"]: info_b},
+    )
+
+    assert "mesh_a.stl" in content
+    assert "mesh_b.obj" in content
+    assert str(a) in content
+    assert str(b) in content
+
+
+def test_nontext_attachment_with_missing_path_silently_skipped(tmp_path):
+    from src.document_processor import build_user_content
+
+    handler, upload_dir = _make_handler(tmp_path)
+    info = {
+        "id": "ghost.stl",
+        "path": str(upload_dir / "ghost.stl"),
+        "name": "ghost.stl",
+        "original_name": "ghost.stl",
+        "mime": "application/octet-stream",
+        "size": 0,
+        "owner": "alice",
+    }
+    content = build_user_content(
+        "where is the file?",
+        [info["id"]],
+        str(upload_dir),
+        handler,
+        owner="alice",
+        resolved_uploads={info["id"]: info},
+    )
+
+    assert content == "where is the file?"
+    assert "non-text file" not in content
+
+
+def test_existing_image_audio_document_paths_unchanged(tmp_path):
+    """Regression guard: the fix must not affect image or text-document
+    paths. A small PNG and a small .txt file should still inline as
+    before (image_url / extracted text), not as the new "non-text file"
+    banner."""
+    from src.document_processor import build_user_content
+
+    handler, upload_dir = _make_handler(tmp_path)
+    png = upload_dir / "i.png"
+    png.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+    txt = upload_dir / "r.txt"
+    txt.write_text("hello world\n", encoding="utf-8")
+
+    info_png = _make_resolved(png, name="i.png", mime="image/png")
+    info_txt = _make_resolved(txt, name="r.txt", mime="text/plain")
+    content = build_user_content(
+        "see attachments",
+        [info_png["id"], info_txt["id"]],
+        str(upload_dir),
+        handler,
+        owner="alice",
+        resolved_uploads={info_png["id"]: info_png, info_txt["id"]: info_txt},
+    )
+
+    if isinstance(content, list):
+        has_image = any(
+            isinstance(item, dict) and item.get("type") == "image_url"
+            for item in content
+        )
+        assert has_image, "PNG attachment must still produce an image_url entry"
+        text = "".join(
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        )
+    else:
+        text = content
+    assert "hello world" in text
+    assert "non-text file" not in text


### PR DESCRIPTION
Closes #1115.

## Problem
Drag-dropping a `.stl`, `.obj`, `.step`, archive, or any other file that isn't an image, audio, or inlined document used to fall into the `[Attached non-text file]` branch in `build_user_content` with no name, path, or hint. The agent had no anchor to call bash/Python against, so a user who uploaded a `.stl` would hear the model say "I don't see a file" even though `save_upload` had stored it on disk.

## Fix
The fallback now leaks the file's display name, MIME, size, and absolute path into the user content, and tells the model it can use shell or Python tools to inspect the file:

```
[Attached non-text file: model.stl (1.2 KB, application/octet-stream)]
[Saved to: /.../uploads/2026/06/02/abc.stl]
[upload_id: abc.stl]
Use bash or python tools (cat, python -c, file, xxd, numpy-stl, trimesh, etc.) to inspect or process this file.
```

One branch in `src/document_processor.py:492-514`; the image / audio / text-document paths are unchanged.

## Tests
`tests/test_attachment_nontext_fallback.py` (5, all passing):
- STL/OBJ attachments surface name + path
- Size and MIME are included
- Multiple non-text attachments all surface
- Missing-path attachments are still silently skipped (pre-existing behaviour preserved)
- Image and text attachment paths are unchanged (regression guard)

Re-ran the existing cross-owner test `tests/test_security_regressions.py::test_build_user_content_skips_cross_owner_attachments` and the chat-preprocess cross-owner test — both still green.

## Validation
- `python -m pytest tests/test_attachment_nontext_fallback.py -v` → **5 passed**
- `python -m pytest tests/test_upload_handler_atomicity.py tests/test_chat_attachment_picker.py tests/test_attachment_nontext_fallback.py tests/test_security_regressions.py::test_build_user_content_skips_cross_owner_attachments tests/test_security_regressions.py::test_chat_preprocess_does_not_surface_cross_owner_attachment` → **16 passed**