### PR TITLE
Make README.md header fancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # Odysseus
+<div align="center">
+  <img align="middle" width="1000" src="docs/header-line.svg" />
+  <img align="middle" width="800" src="docs/header.svg" />
+  <img align="middle" width="1000" src="docs/header-line.svg" />
+</div>
+<br>
+
+<!--
 ───────────────────────────────────────────────
  ⊹ ࣪ ˖ ૮( ˶ᵔ ᵕ ᵔ˶ )っ  Odysseus vers. 1.0
 ───────────────────────────────────────────────
+-->
 
 ![Odysseus](docs/odysseus.jpg)
 

--- a/docs/header-line.svg
+++ b/docs/header-line.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="5" viewBox="0 0 500 6">
+    <style>
+        .text > * {
+            paint-order: stroke fill markers;
+        }
+        .text > line {
+            outline: 1px solid #000;
+            border-radius: 1px;
+            stroke-linejoin: round;
+        }
+    </style>
+    <g class="text">
+        <line x1="2" y1="3" x2="498" y2="3" stroke="#fff" stroke-linecap="round" stroke-width="2"/>
+    </g>
+</svg>

--- a/docs/header.svg
+++ b/docs/header.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="30" viewBox="0 0 380 25">
+    <style>
+        .text {
+            fill: #ffffff;
+            font-size: 16px;
+            stroke: #000000;
+            stroke-width: 2px;
+            font-family: 'Courier New', Courier, monospace
+        }
+        .text > * {
+            paint-order: stroke fill markers;
+        }
+        .text > line {
+            stroke: #ffffff;
+        }
+    </style>
+    <g class="text">
+        <text x="190" y="20" text-anchor="middle">⊹ ࣪ ˖ ૮( ˶ᵔ ᵕ ᵔ˶ )っ  Odysseus vers. 1.0</text>
+    </g>
+</svg>


### PR DESCRIPTION
made it a bit more fancy. GitHub is extremely restrictive about css styling (not allowed at all outside of svg). Now it looks good on web too, as long as the browser supports deprecated HTML attributes for `div`s and `img`s. I put the original text in a comment, so it's still fancily readable when viewing this in source.

The only problem right now is with light mode users, since the top and bottom line are outlined with black (to make them visible), but this makes them appear as if they were above and below each line, since the img elemnt cuts of the corners from each side. But at this point I don't care anymore, I hardly believe you can make it any better than it is right now. Even `srcset` isn't allowed, so good luck if anyone wants to make this better without making it a single svg that can't have nicely resizable text.