### PR TITLE
fix: owner-less document query passes bare False to SQLAlchemy filter()

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -90,7 +90,11 @@ def get_active_document():
 
 def _owned_document_query(query, Document, owner: Optional[str]):
     if owner is None:
-        return query.filter(False)
+        # A bare Python `False` is not a valid SQL expression — SQLAlchemy 1.4
+        # deprecates it and 2.0 raises ArgumentError. Use the SQL `false()`
+        # literal to return zero rows for an unscoped (owner-less) query.
+        from sqlalchemy import false
+        return query.filter(false())
     return query.filter(Document.owner == owner)
 
 

--- a/tests/test_owned_document_query.py
+++ b/tests/test_owned_document_query.py
@@ -1,0 +1,31 @@
+"""Tests for _owned_document_query owner scoping (src/tool_implementations.py)."""
+from src.tool_implementations import _owned_document_query
+
+
+class _FakeQuery:
+    def __init__(self):
+        self.filter_args = []
+
+    def filter(self, *args):
+        self.filter_args.append(args)
+        return self
+
+
+class _Doc:
+    owner = "owner-column-sentinel"
+
+
+def test_owner_none_does_not_pass_python_false():
+    q = _FakeQuery()
+    _owned_document_query(q, _Doc, None)
+    arg = q.filter_args[-1][0]
+    # The old code passed the bare Python bool False, which SQLAlchemy 2.x
+    # rejects; the fix passes a SQL false() literal instead.
+    assert arg is not False
+    assert arg is not None
+
+
+def test_owner_set_filters_by_owner():
+    q = _FakeQuery()
+    _owned_document_query(q, _Doc, "alice")
+    assert q.filter_args, "should apply an owner filter"


### PR DESCRIPTION
## Summary

`_owned_document_query` scopes document queries to the owner; for an owner-less (e.g. unauthenticated / no-auth) request it intends to return zero rows via `query.filter(False)`. But a bare Python `False` is not a SQL expression: SQLAlchemy 1.4 deprecates it and 2.0 raises `ArgumentError: SQL expression element expected, got False`. So every document tool call with `owner=None` (`do_manage_documents`, `do_edit_document`, ...) raises instead of returning an empty result.

Fix: use the SQL `false()` literal.

## Changes
- `src/tool_implementations.py`: `query.filter(false())` for the owner-less branch.
- `tests/test_owned_document_query.py`: owner-less branch no longer passes a bare `False`; owner-scoped branch still filters.