### PR TITLE
feat: make context-budget hard_max configurable via agent_input_token_hard_max (#1272)

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1501,6 +1501,7 @@ async def stream_agent_loop(
                 soft_budget,
                 context_length,
                 is_setting_overridden("agent_input_token_budget"),
+                hard_max=int(get_setting("agent_input_token_hard_max", 200000) or 200000),
             )
             trimmed_messages = trim_for_context(
                 messages,

--- a/src/settings.py
+++ b/src/settings.py
@@ -96,6 +96,12 @@ DEFAULT_SETTINGS = {
     "research_run_timeout_seconds": 1800,
     "agent_max_tool_calls": 0,
     "agent_input_token_budget": 6000,
+    # Hard ceiling for the auto-derived input budget on long-context models
+    # (#1272). The adaptive path scales to ~85% of the model's context window
+    # but caps here so a 1M-context model doesn't send a pathologically large
+    # prompt every turn. Only applies on the auto path (no explicit
+    # agent_input_token_budget); matches the old DEFAULT_HARD_MAX constant.
+    "agent_input_token_hard_max": 200000,
     "agent_stream_timeout_seconds": 300,
     # Extra directory roots that read_file / write_file may access, in
     # addition to the built-in project data/ and system temp dirs. Each

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -1531,6 +1531,9 @@ async def do_manage_settings(content: str, owner: Optional[str] = None) -> Dict:
             "agent tool calls": "agent_max_tool_calls", "max tool calls": "agent_max_tool_calls",
             "agent timeout": "agent_stream_timeout_seconds", "stream timeout": "agent_stream_timeout_seconds",
             "token budget": "agent_input_token_budget",
+            "hard max": "agent_input_token_hard_max",
+            "token budget cap": "agent_input_token_hard_max",
+            "input budget cap": "agent_input_token_hard_max",
         }
         def _resolve(k):
             k2 = (k or "").strip().lower()

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -33,6 +33,27 @@ def test_unknown_window_falls_back_to_configured():
     assert compute_input_token_budget(0, 0, explicit=False) == 6000  # default
 
 
+def test_hard_max_default_setting_matches_constant():
+    # #1272 — the ceiling is now a named setting; its default must match the
+    # historical module constant so behaviour is unchanged out of the box.
+    from src.settings import DEFAULT_SETTINGS
+    assert DEFAULT_SETTINGS["agent_input_token_hard_max"] == DEFAULT_HARD_MAX == 200000
+
+
+def test_configurable_hard_max_raises_ceiling():
+    # An admin lifting the cap lets a 1M-context model use more of its window.
+    assert compute_input_token_budget(6000, 1_000_000, explicit=False, hard_max=500_000) == 500_000
+
+
+def test_configurable_hard_max_lowers_ceiling():
+    assert compute_input_token_budget(6000, 1_000_000, explicit=False, hard_max=50_000) == 50_000
+
+
+def test_hard_max_ignored_when_explicit_budget_set():
+    # The explicit branch ignores hard_max entirely (#1272 no-op note).
+    assert compute_input_token_budget(6000, 1_000_000, explicit=True, hard_max=50_000) == 6000
+
+
 def test_is_setting_overridden_reads_raw_saved_file(tmp_path, monkeypatch):
     import src.settings as settings
 


### PR DESCRIPTION
Closes #1272 (carry-over from the #1170/#1230 review).

## Problem

#1230 shipped the adaptive input-budget derivation, but left the ceiling as a module-level constant `DEFAULT_HARD_MAX = 200_000` in `src/context_budget.py`. So an admin who wants a 1M-context model (kimi-k2:1t, minimax-m3) to actually use more of its window has no setting to raise it — their only options are editing source or setting `agent_input_token_budget` explicitly, which then drops them off the adaptive auto-path entirely.

## Fix (matches the issue's proposed surface)

- Register **`agent_input_token_hard_max`** in `DEFAULT_SETTINGS` (default `200000`, matching the existing constant → behaviour unchanged out of the box).
- Read it at the `agent_loop` call site and pass it through `compute_input_token_budget`'s existing `hard_max` kwarg. No-op when `agent_input_token_budget` is set explicitly (that branch already ignores `hard_max`).
- `manage_settings` friendly aliases: `"hard max"`, `"token budget cap"`, `"input budget cap"` → `agent_input_token_hard_max`.

~31 lines total.

## Tests

`tests/test_context_budget.py` (+4): the default setting equals the constant (200000); a higher `hard_max` raises the ceiling; a lower one lowers it; `hard_max` is ignored when an explicit budget is set. `./venv/bin/python -m pytest -q tests/test_context_budget.py` → **10 passed**.

No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)