### PR TITLE
fix: 2FA bypassed when enabled but TOTP secret is missing (fail-open)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -376,7 +376,10 @@ class AuthManager:
             return True  # 2FA not enabled, always pass
         secret = user.get("totp_secret")
         if not secret:
-            return True
+            # 2FA is enabled but no secret is stored (corrupt/partially-written
+            # auth.json). Fail closed — returning True here bypassed the second
+            # factor entirely.
+            return False
         # Check backup codes first
         backup = user.get("totp_backup_codes", [])
         if code in backup:

--- a/tests/test_totp_failclosed.py
+++ b/tests/test_totp_failclosed.py
@@ -1,0 +1,21 @@
+"""Regression: 2FA must fail closed when enabled but the secret is missing."""
+import json
+
+from core.auth import AuthManager
+
+
+def test_totp_fails_closed_when_enabled_but_secret_missing(tmp_path):
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps({"users": {
+        "alice": {"password_hash": "x", "totp_enabled": True},  # no totp_secret
+    }}))
+    mgr = AuthManager(str(auth_path))
+    # Previously returned True, bypassing the second factor entirely.
+    assert mgr.totp_verify("alice", "123456") is False
+
+
+def test_totp_passes_when_2fa_disabled(tmp_path):
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps({"users": {"bob": {"password_hash": "x"}}}))
+    mgr = AuthManager(str(auth_path))
+    assert mgr.totp_verify("bob", "000000") is True


### PR DESCRIPTION
## Summary

`AuthManager.totp_verify` returns `True` when a user has `totp_enabled: True` but no `totp_secret`:

```python
secret = user.get("totp_secret")
if not secret:
    return True
```

That fails **open** — if the secret is missing (a corrupt or partially-written `auth.json`, or a manual edit), the second factor is silently skipped and any code passes. A 2FA check should fail **closed**.

Fix: return `False` when 2FA is enabled but no secret is stored.

## Changes
- `core/auth.py`: fail closed on a missing TOTP secret.
- `tests/test_totp_failclosed.py`: missing-secret rejects; 2FA-disabled still passes.