### PR TITLE
fix: email list ignores unresponded_only unless unread_only is also set

### DIFF
--- a/mcp_servers/email_server.py
+++ b/mcp_servers/email_server.py
@@ -417,6 +417,11 @@ def _list_emails(folder="INBOX", max_results=20, unresponded_only=False,
         status, data = conn.uid("SEARCH", None, "(UNSEEN UNANSWERED)")
     elif unread_only:
         status, data = conn.uid("SEARCH", None, "(UNSEEN)")
+    elif unresponded_only:
+        # Was missing — unresponded_only=True (without unread_only) fell through
+        # to "ALL" and returned answered mail too, despite the documented
+        # "emails without replies" behaviour.
+        status, data = conn.uid("SEARCH", None, "(UNANSWERED)")
     else:
         # Include read too — IMAP search "ALL" returns the entire folder
         status, data = conn.uid("SEARCH", None, "ALL")


### PR DESCRIPTION
## Summary

`_list_emails` (MCP email server) builds its IMAP search like this:

```python
if unread_only and unresponded_only:  SEARCH "(UNSEEN UNANSWERED)"
elif unread_only:                     SEARCH "(UNSEEN)"
else:                                 SEARCH "ALL"
```

There's no branch for `unresponded_only` on its own, so calling `list_emails(unresponded_only=True)` (without `unread_only`) falls through to `ALL` and returns answered mail too — contradicting the documented behaviour ("emails without replies" / attention scans).

Fix: add an `elif unresponded_only:` branch that searches `(UNANSWERED)`.

## Changes
- `mcp_servers/email_server.py`: handle `unresponded_only` independently of `unread_only`.