### PR TITLE
fix: claim_ownerless script never claims ownerless documents

### DIFF
--- a/scripts/claim_ownerless.py
+++ b/scripts/claim_ownerless.py
@@ -58,10 +58,12 @@ def main():
         count = db.query(Session).filter(Session.owner == None).update({"owner": owner})
         print(f"  sessions: claimed {count}")
 
-        # Documents
-        count = db.query(Document).filter(Document.session_id.in_(
-            db.query(Session.id).filter(Session.owner == owner)
-        )).update({"session_id": Document.session_id}, synchronize_session=False)
+        # Documents (have their own owner column; claim the ownerless ones,
+        # mirroring the sessions/gallery/comparisons blocks). The old query set
+        # session_id to itself — a no-op — and never set owner, so ownerless
+        # documents stayed ownerless and invisible in the user's Library.
+        count = db.query(Document).filter(Document.owner == None).update({"owner": owner})
+        print(f"  documents: claimed {count}")
 
         # Gallery
         if GalleryImage:


### PR DESCRIPTION
## Summary

`scripts/claim_ownerless.py` reassigns ownerless data to an admin user. Sessions, gallery images, and comparisons are claimed correctly (`owner == None → owner`), but the Documents block is broken:

```python
count = db.query(Document).filter(Document.session_id.in_(
    db.query(Session.id).filter(Session.owner == owner)
)).update({"session_id": Document.session_id}, synchronize_session=False)
```

It sets `session_id` to itself — a no-op — and never touches `owner`, even though `Document` has its own `owner` column. So ownerless documents stay ownerless (and invisible in the user's Library), and no count is printed (it's immediately overwritten by the gallery query).

Fix: claim ownerless documents the same way as the other tables.

## Changes
- `scripts/claim_ownerless.py`: `Document.owner == None → owner`, and print the count.