### PR TITLE
fix: manage_tasks create crashes on an explicit null prompt

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -892,7 +892,9 @@ async def do_manage_tasks(content: str, owner: Optional[str] = None) -> Dict:
                 )
 
             task_id = str(_uuid.uuid4())
-            name = args.get("name") or args.get("prompt", args.get("action_name", "Task"))[:50]
+            # Guard each fallback with `or`: args.get("prompt", default) returns
+            # None when the key is present but null, and None[:50] raises.
+            name = args.get("name") or (args.get("prompt") or args.get("action_name") or "Task")[:50]
 
             task = ScheduledTask(
                 id=task_id,


### PR DESCRIPTION
## Summary

In `do_manage_tasks` create, the task name is derived as:

```python
name = args.get("name") or args.get("prompt", args.get("action_name", "Task"))[:50]
```

`dict.get("prompt", default)` only uses the default when the key is **absent**. If the model sends `"prompt": null` (key present, value None) with no `name`, `args.get("prompt", ...)` returns `None`, and `None[:50]` raises `TypeError: 'NoneType' object is not subscriptable`.

Fix: guard each fallback with `or` so a present-but-null prompt falls through to `action_name`/`"Task"`.

## Changes
- `src/tool_implementations.py`: `name = args.get("name") or (args.get("prompt") or args.get("action_name") or "Task")[:50]`.