### PR TITLE
fix: agent_input_token_budget wrongly treated as a secret and unsettable from chat

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -1527,7 +1527,14 @@ async def do_manage_settings(content: str, owner: Optional[str] = None) -> Dict:
             "tavily_api_key", "serper_api_key", "app_public_url",
         }
         def _is_secret(k):
-            return k in _SECRET_KEYS or any(t in k for t in ("api_key", "_key", "token", "secret", "password"))
+            # `token` must be a suffix, not a substring: otherwise the int
+            # setting `agent_input_token_budget` (which even has a "token budget"
+            # alias to set it from chat) is wrongly classified as a credential.
+            return (
+                k in _SECRET_KEYS
+                or k.endswith("token")
+                or any(t in k for t in ("api_key", "_key", "secret", "password"))
+            )
 
         # Friendly aliases → real keys, so natural phrasing resolves.
         _ALIASES_SET = {

--- a/tests/test_manage_settings_token_budget.py
+++ b/tests/test_manage_settings_token_budget.py
@@ -1,0 +1,22 @@
+"""Regression: agent_input_token_budget must be settable from chat (not flagged secret)."""
+import asyncio
+import json
+
+import src.settings as settings_mod
+from src.tool_implementations import do_manage_settings
+
+
+def test_set_token_budget_is_not_refused_as_secret(monkeypatch):
+    store = {}
+    monkeypatch.setattr(settings_mod, "load_settings", lambda: dict(store))
+    monkeypatch.setattr(settings_mod, "save_settings", lambda s: store.update(s))
+
+    result = asyncio.run(do_manage_settings(json.dumps({
+        "action": "set", "key": "agent_input_token_budget", "value": 8000,
+    })))
+
+    # The "token" substring used to flag this int setting as a credential and
+    # refuse to set it (even though there's a deliberate "token budget" alias).
+    assert "credential" not in result.get("response", "").lower(), result
+    assert result.get("exit_code") == 0, result
+    assert store.get("agent_input_token_budget") == 8000


### PR DESCRIPTION
## Summary

`do_manage_settings` refuses to set any key `_is_secret` considers a credential:

```python
def _is_secret(k):
    return k in _SECRET_KEYS or any(t in k for t in ("api_key", "_key", "token", "secret", "password"))
```

`"token"` is matched as a **substring**, so the integer setting `agent_input_token_budget` (default 6000) is classified as a secret and `manage_tasks`/`manage_settings` returns *"'agent_input_token_budget' is a credential/secret — I can't set it from chat."* — even though there's a deliberate `"token budget" → agent_input_token_budget` alias added specifically to let users set it from chat. The two directly contradict each other.

Fix: match `token` as a **suffix** (`k.endswith("token")`), which still catches real secrets like `hf_token` / `github_token` while leaving `agent_input_token_budget` settable.

## Changes
- `src/tool_implementations.py`: `_is_secret` uses `endswith("token")` instead of substring.
- `tests/test_manage_settings_token_budget.py`: setting `agent_input_token_budget` is no longer refused.