### PR TITLE
fix: manage_memory edit/delete hits the first memory on a blank id

### DIFF
--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -995,6 +995,10 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
             return {"error": "Edit needs line 2: memory_id, line 3: new text"}
         memory_id = lines[1].strip()
         new_text = lines[2].strip()
+        if not memory_id:
+            # Without this, "".startswith("") matches the first memory and the
+            # wrong entry gets silently edited.
+            return {"error": "memory_id cannot be empty"}
         if not new_text:
             return {"error": "New text cannot be empty"}
 
@@ -1028,6 +1032,10 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
         if len(lines) < 2:
             return {"error": "Delete needs line 2: memory_id"}
         memory_id = lines[1].strip()
+        if not memory_id:
+            # "".startswith("") matches the first memory — refuse to delete the
+            # wrong entry on a blank id.
+            return {"error": "memory_id cannot be empty"}
 
         memories = _memory_manager.load_all()
         original_len = len(memories)

--- a/tests/test_manage_memory_blank_id.py
+++ b/tests/test_manage_memory_blank_id.py
@@ -1,0 +1,42 @@
+"""Regression: manage_memory edit/delete must reject a blank memory_id.
+
+`m.get("id","").startswith("")` is always True, so a blank id used to match
+(and edit/delete) the FIRST stored memory.
+"""
+import asyncio
+
+from src.ai_interaction import do_manage_memory, set_memory_manager
+
+
+class _FakeMgr:
+    def __init__(self, mems):
+        self.mems = mems
+        self.saved = None
+
+    def load_all(self):
+        return self.mems
+
+    def save(self, mems):
+        self.saved = mems
+
+
+def test_edit_with_blank_memory_id_is_rejected():
+    mems = [
+        {"id": "aaa111", "text": "first", "owner": None},
+        {"id": "bbb222", "text": "second", "owner": None},
+    ]
+    mgr = _FakeMgr(mems)
+    set_memory_manager(mgr)
+    result = asyncio.run(do_manage_memory("edit\n\nreplacement text"))
+    assert "error" in result and "memory_id" in result["error"], result
+    assert mems[0]["text"] == "first"   # first memory untouched
+    assert mgr.saved is None            # nothing persisted
+
+
+def test_delete_with_blank_memory_id_is_rejected():
+    mems = [{"id": "aaa111", "text": "first", "owner": None}]
+    mgr = _FakeMgr(mems)
+    set_memory_manager(mgr)
+    result = asyncio.run(do_manage_memory("delete\n\nignored"))
+    assert "error" in result and "memory_id" in result["error"], result
+    assert len(mems) == 1               # nothing deleted


### PR DESCRIPTION
## Summary

In `do_manage_memory`, the edit and delete branches match a memory with:

```python
if m.get("id", "").startswith(memory_id):
```

`memory_id` (from line 2 of the tool content) is never checked for emptiness — only `new_text` is. When the id line is blank, `memory_id == ""`, and `"<any id>".startswith("")` is always `True`, so the loop matches the **first** memory in the store and silently edits or deletes the wrong entry.

This is easy for a model to trigger, e.g. `manage_memory("edit\n\nreplacement text")` (forgot the id) edits the first memory; `manage_memory("delete\n\n...")` deletes it.

Fix: reject a blank `memory_id` in both branches.

## Changes
- `src/ai_interaction.py`: return an error when `memory_id` is empty (edit and delete).
- `tests/test_manage_memory_blank_id.py`: blank id is rejected; the first memory is left untouched.