### PR TITLE
fix: odysseus-ui.service serves on 8000 instead of the documented 7000

### DIFF
--- a/odysseus-ui.service
+++ b/odysseus-ui.service
@@ -9,7 +9,7 @@ Type=simple
 # CHANGE THESE to match your user and install path:
 User=YOURUSER
 WorkingDirectory=/home/YOURUSER/odysseus-ui
-ExecStart=/home/YOURUSER/odysseus-ui/venv/bin/uvicorn app:app --port 8000 --host 0.0.0.0
+ExecStart=/home/YOURUSER/odysseus-ui/venv/bin/uvicorn app:app --port 7000 --host 0.0.0.0
 Restart=always
 RestartSec=3
 EnvironmentFile=-/home/YOURUSER/odysseus-ui/.env


### PR DESCRIPTION
## Summary

The sample systemd unit starts the app on port **8000**:

```
ExecStart=.../venv/bin/uvicorn app:app --port 8000 --host 0.0.0.0
```

Every other entrypoint and the docs use **7000**: `Dockerfile` (`EXPOSE 7000`, `CMD ... --port 7000`), `docker-compose.yml` (`${APP_PORT:-7000}:7000`), `setup.py` (prints `--port 7000` then "open http://localhost:7000"), and the README. So a user who installs via `install-service.sh` and follows the README hits `http://<host>:7000` and gets connection refused, while 8000 also collides with the documented local model/provider API range.

Fix: serve on 7000 in the unit file.

## Changes
- `odysseus-ui.service`: `--port 8000` → `--port 7000`.