### PR TITLE
fix: fire-reminder endpoint crashes with NameError on _gcu

### DIFF
--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -696,7 +696,7 @@ def setup_note_routes(task_scheduler=None):
         # the same dispatch without an HTTP roundtrip + auth cookie.
         return await dispatch_reminder(
             title=title, note_body=note_body, note_id=note_id,
-            owner=_gcu(request) or "",
+            owner=get_current_user(request) or "",
             queue_browser=False,
         )
 

--- a/tests/test_note_fire_reminder_nameError.py
+++ b/tests/test_note_fire_reminder_nameError.py
@@ -1,0 +1,101 @@
+"""Regression: fire-reminder endpoint crashed with NameError on _gcu.
+
+The route called _gcu(request) but _gcu was never defined or imported.
+get_current_user (already imported at module level) is the correct call.
+"""
+import sys
+import types
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+
+def _install_stubs(monkeypatch):
+    """Stub heavy deps so note_routes can be imported without a real DB."""
+    for mod in ("core.auth", "sqlalchemy.orm.attributes"):
+        if mod not in sys.modules:
+            monkeypatch.setitem(sys.modules, mod, MagicMock())
+
+    fake_db_mod = types.ModuleType("core.database")
+    fake_db_mod.SessionLocal = MagicMock()
+    fake_db_mod.Note = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", fake_db_mod)
+
+    fake_auth = types.ModuleType("src.auth_helpers")
+    fake_auth.get_current_user = lambda req: getattr(req, "_test_user", None)
+    fake_auth.require_user = lambda req: None
+    monkeypatch.setitem(sys.modules, "src.auth_helpers", fake_auth)
+
+    fake_settings = types.ModuleType("src.settings")
+    fake_settings.load_settings = MagicMock(return_value={})
+    monkeypatch.setitem(sys.modules, "src.settings", fake_settings)
+
+    fake_dispatch = AsyncMock(return_value={"synthesis": "ok", "email_sent": False})
+    return fake_dispatch
+
+
+def test_fire_reminder_uses_get_current_user_not_gcu(monkeypatch):
+    """fire_reminder must not raise NameError; owner must come from get_current_user."""
+    import importlib
+
+    fake_dispatch = _install_stubs(monkeypatch)
+
+    import routes.note_routes as note_mod
+    importlib.reload(note_mod)
+
+    monkeypatch.setattr(note_mod, "dispatch_reminder", fake_dispatch)
+
+    router = note_mod.setup_note_routes(task_scheduler=None)
+
+    # Find the fire-reminder endpoint
+    handler = None
+    for route in router.routes:
+        if hasattr(route, "path") and route.path.endswith("/fire-reminder"):
+            handler = route.endpoint
+            break
+
+    assert handler is not None, "fire-reminder route not found in router"
+
+    req = MagicMock()
+    req._test_user = "alice"
+    req.json = AsyncMock(return_value={"note_id": "n1", "title": "Test", "body": "hello"})
+
+    result = asyncio.run(handler(req))
+
+    fake_dispatch.assert_awaited_once()
+    kw = fake_dispatch.call_args.kwargs
+    assert kw["owner"] == "alice"
+    assert kw["note_id"] == "n1"
+
+
+def test_fire_reminder_owner_empty_when_anonymous(monkeypatch):
+    """Anonymous callers (get_current_user → None) yield owner=''."""
+    import importlib
+
+    fake_dispatch = _install_stubs(monkeypatch)
+
+    # Override get_current_user to return None (anonymous)
+    anon_auth = types.ModuleType("src.auth_helpers")
+    anon_auth.get_current_user = lambda req: None
+    anon_auth.require_user = lambda req: None
+    monkeypatch.setitem(sys.modules, "src.auth_helpers", anon_auth)
+
+    import routes.note_routes as note_mod
+    importlib.reload(note_mod)
+    monkeypatch.setattr(note_mod, "dispatch_reminder", fake_dispatch)
+
+    router = note_mod.setup_note_routes(task_scheduler=None)
+
+    handler = None
+    for route in router.routes:
+        if hasattr(route, "path") and route.path.endswith("/fire-reminder"):
+            handler = route.endpoint
+            break
+
+    req = MagicMock()
+    req.json = AsyncMock(return_value={"note_id": "n2", "title": "X", "body": ""})
+
+    asyncio.run(handler(req))
+
+    kw = fake_dispatch.call_args.kwargs
+    assert kw["owner"] == ""


### PR DESCRIPTION
## Summary

- `routes/note_routes.py:699` called `_gcu(request)` but `_gcu` was never defined or imported anywhere in the file.
- The correct call is `get_current_user(request)`, which is already imported at module level (`from src.auth_helpers import get_current_user`).
- Every other auth-gated route in the same file uses `_owner(request)` (which wraps `get_current_user`) — the `fire-reminder` handler was the only outlier.

## Root cause

A leftover alias name (`_gcu`) from an earlier refactor was never wired up, making every call to `POST /api/notes/fire-reminder` raise `NameError: name '_gcu' is not defined`.

## Test plan

- [x] `test_fire_reminder_uses_get_current_user_not_gcu` — handler resolves owner to the authenticated user; no `NameError`
- [x] `test_fire_reminder_owner_empty_when_anonymous` — anonymous callers (`get_current_user → None`) produce `owner=""` instead of crashing

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)