### PR TITLE
fix: memory delete wipes every memory sharing an id prefix

### DIFF
--- a/mcp_servers/memory_server.py
+++ b/mcp_servers/memory_server.py
@@ -162,7 +162,10 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 deleted_category = m.get("category", "")
                 break
         original_len = len(memories)
-        memories = [m for m in memories if not m.get("id", "").startswith(memory_id)]
+        # Remove only the single matched id (first prefix match, same as `edit`).
+        # The old `startswith(memory_id)` filter deleted EVERY memory sharing the
+        # prefix — an ambiguous/short id silently wiped multiple entries.
+        memories = [m for m in memories if m.get("id") != full_id]
         if len(memories) == original_len:
             return [TextContent(type="text", text=f"Error: Memory '{memory_id}' not found")]
         _memory_manager.save(memories)

--- a/tests/test_memory_server_delete.py
+++ b/tests/test_memory_server_delete.py
@@ -1,0 +1,36 @@
+"""Regression: MCP memory delete must remove only the resolved id, not every prefix match."""
+import asyncio
+
+import pytest
+
+pytest.importorskip("mcp")  # memory_server imports the MCP SDK at module load
+
+import mcp_servers.memory_server as ms
+
+
+class _FakeMgr:
+    def __init__(self, mems):
+        self.mems = mems
+        self.saved = None
+
+    def load_all(self):
+        return list(self.mems)
+
+    def save(self, mems):
+        self.saved = mems
+
+
+def test_delete_removes_only_the_resolved_id(monkeypatch):
+    mems = [
+        {"id": "ab11", "text": "first", "category": "fact"},
+        {"id": "ab22", "text": "second", "category": "fact"},
+    ]
+    monkeypatch.setattr(ms, "_memory_manager", _FakeMgr(mems))
+    monkeypatch.setattr(ms, "_memory_vector", None)
+    monkeypatch.setattr(ms, "_initialized", True)
+
+    # "ab" is a prefix of both ids; only the first resolved one must be deleted.
+    asyncio.run(ms.call_tool("manage_memory", {"action": "delete", "memory_id": "ab"}))
+
+    saved_ids = [m["id"] for m in ms._memory_manager.saved]
+    assert saved_ids == ["ab22"]  # ab11 (first match) removed, sibling kept


### PR DESCRIPTION
## Summary

The MCP memory server's `delete` action looks up the target with a first-prefix match (capturing `full_id`), but then removes **every** memory whose id starts with the given string:

```python
memories = [m for m in memories if not m.get("id", "").startswith(memory_id)]
```

So a short/ambiguous `memory_id` (even a single hex char) silently deletes multiple memories, while the success message reports just the first `full_id`. The `edit` action, by contrast, stops at the first match — so the two actions disagree on multi-match behaviour.

Fix: delete only the single matched id (`full_id`), consistent with `edit`.

## Changes
- `mcp_servers/memory_server.py`: filter on `m.get("id") != full_id` instead of the prefix.