### PR TITLE
fix: RAG remove_directory can't remove a ~-path added by add_directory

### DIFF
--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -120,6 +120,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         directory = arguments.get("directory", "").strip()
         if not directory:
             return [TextContent(type="text", text="Error: remove_directory needs a directory path")]
+        # Expand ~ to match add_directory, which indexes the expanded path.
+        # Without this, removing "~/docs" never matches the stored absolute path.
+        directory = os.path.expanduser(directory)
         if not _personal_docs_manager:
             return [TextContent(type="text", text="Error: Personal docs manager not available")]
         try:


### PR DESCRIPTION
## Summary

In the MCP RAG server, `add_directory` expands `~` before indexing:

```python
directory = os.path.expanduser(directory)   # add_directory
```

but `remove_directory` only `.strip()`s the path and passes it straight to the managers (which `os.path.abspath` it, and abspath does NOT expand `~`). So a directory added as `~/docs` (indexed as `/home/user/docs`) can never be removed with `~/docs` — `abspath("~/docs")` becomes `<cwd>/~/docs` and never matches the stored path, yet the tool still reports success.

Fix: expand `~` in `remove_directory` too, mirroring `add_directory`.

## Changes
- `mcp_servers/rag_server.py`: `os.path.expanduser(directory)` in the remove path.