### PR TITLE
fix(compare): keep blind helper sessions anonymous

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -106,6 +106,17 @@ def _persist_session_headers(session_id: str, headers: dict | None) -> None:
         db.close()
 
 
+def _is_blind_compare_session_name(name: str) -> bool:
+    if not isinstance(name, str):
+        return False
+    return re.match(r"^\[CMP\] Model [A-Z0-9]+$", name.strip()) is not None
+
+
+def _public_session_model(name: str, model: str) -> str:
+    """Hide model IDs for active blind compare helper sessions."""
+    return "" if _is_blind_compare_session_name(name) else model
+
+
 def _pick_endpoint_for_sort(owner=None):
     """Pick model endpoint for auto-sort LLM call — uses utility endpoint setting, falls back to default."""
     from src.endpoint_resolver import resolve_endpoint
@@ -215,7 +226,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         finally:
             db.close()
 
-        sessions = [{"id": s.id, "name": s.name, "model": s.model,
+        sessions = [{"id": s.id, "name": s.name, "model": _public_session_model(s.name, s.model),
                      "endpoint_url": s.endpoint_url, "rag": s.rag,
                      "archived": s.archived, "folder": folder_map.get(s.id),
                      "total_tokens": token_map.get(s.id, 0),

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -10,7 +10,7 @@
  */
 
 // ── Submodule imports ──
-import state from './state.js';
+import state, { compareSessionName } from './state.js';
 import { EVAL_PROMPTS, WAVE_FRAMES,
   ICON_DICE, ICON_EXPAND, ICON_COLLAPSE, ICON_CLOSE,
   ICON_REROLL, ICON_COPY, ICON_PLAY, ICON_CODE,
@@ -210,7 +210,7 @@ async function _buildCompareUI() {
     for (let i = 0; i < n; i++) {
       const m = state._selectedModels[i];
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + modelShorts[i]);
+      fd.append('name', compareSessionName(modelShorts[i], i, state._blindMode, state._parallel));
       fd.append('endpoint_url', m.endpoint || '');
       fd.append('model', m.model || '');
       if (m.endpointId) {

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -1,5 +1,5 @@
 // compare/panes.js — pane lifecycle, actions, layout
-import state from './state.js';
+import state, { compareSessionName } from './state.js';
 import { _persistSelections } from './models.js';
 import { buildVoteBar } from './vote.js';
 import {
@@ -382,7 +382,7 @@ async function _createAndAppendPane(m) {
 
   // Create session
   const fd = new FormData();
-  fd.append('name', '[CMP] ' + m.name);
+  fd.append('name', compareSessionName(m.name, i, state._blindMode, state._parallel));
   fd.append('endpoint_url', m.url || '');
   fd.append('model', m.id || '');
   if (m.endpointId) {
@@ -584,7 +584,7 @@ function _showModelSwapDropdown(paneIdx, titleBtn) {
         fetch(`${state.API_BASE}/api/session/${oldSid}`, { method: 'DELETE' }).catch(() => {});
       }
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + m.name);
+      fd.append('name', compareSessionName(m.name, paneIdx, state._blindMode, state._parallel));
       fd.append('endpoint_url', m.url || '');
       fd.append('model', m.id || '');
       if (m.endpointId) {

--- a/static/js/compare/state.js
+++ b/static/js/compare/state.js
@@ -35,6 +35,16 @@ const state = {
                                    // stream.js reads this and stamps ✓/✗ per pane
 };
 
+/**
+ * Return the compare-session title persisted in the sidebar/session list.
+ * In blind mode we keep the same neutral Model A / Model 1 labels used in the
+ * pane UI so the sidebar cannot leak the real model before a vote.
+ */
+export function compareSessionName(displayName, slotIndex, blindMode, parallelMode = true) {
+  const slotLabel = parallelMode ? String.fromCharCode(65 + slotIndex) : String(slotIndex + 1);
+  return blindMode ? `[CMP] Model ${slotLabel}` : `[CMP] ${displayName}`;
+}
+
 /** Reset transient state to defaults — useful for clean restarts. */
 export function reset() {
   state._openingSelector = false;

--- a/tests/test_compare_js.py
+++ b/tests/test_compare_js.py
@@ -179,3 +179,22 @@ def test_storage_keys_are_namespaced(node_available):
     out = _run_node(script)
     assert out["votes"].startswith("odysseus-")
     assert out["pool"].startswith("odysseus-")
+
+
+def test_compare_session_name_uses_blind_slot_labels(node_available):
+    """Blind compare helper sessions must use neutral labels so the sidebar/API
+    cannot reveal real model names before a vote."""
+    script = textwrap.dedent("""
+        const { compareSessionName } = await import('./static/js/compare/state.js');
+        console.log(JSON.stringify({
+          blind_parallel: compareSessionName('gpt-4o', 0, true, true),
+          blind_sequential: compareSessionName('llama-3.1-70b', 1, true, false),
+          visible_name: compareSessionName('claude-sonnet-4', 2, false, true),
+        }));
+    """)
+    out = _run_node(script)
+    assert out == {
+        "blind_parallel": "[CMP] Model A",
+        "blind_sequential": "[CMP] Model 2",
+        "visible_name": "[CMP] claude-sonnet-4",
+    }

--- a/tests/test_session_ghost_delete.py
+++ b/tests/test_session_ghost_delete.py
@@ -114,6 +114,16 @@ def test_unauthenticated_still_403(monkeypatch):
     assert exc.value.status_code == 403
 
 
+def test_public_session_model_redacts_blind_compare_helper_sessions():
+    assert SR._public_session_model("[CMP] Model A", "gpt-4o") == ""
+    assert SR._public_session_model("[CMP] Model 2", "llama-3.1-70b") == ""
+
+
+def test_public_session_model_keeps_non_blind_or_saved_session_names():
+    assert SR._public_session_model("[CMP] gpt-4o", "gpt-4o") == "gpt-4o"
+    assert SR._public_session_model("Regular chat", "claude-sonnet-4") == "claude-sonnet-4"
+
+
 # --- manager layer: delete_session clears memory-only ghosts ---------------
 
 def test_manager_deletes_memory_only_ghost(monkeypatch):


### PR DESCRIPTION
## Summary
- keep blind compare helper sessions anonymous by naming them `[CMP] Model A` / `[CMP] Model 2` instead of persisting real model names before a vote
- redact the `model` field from `GET /api/sessions` for those active blind helper sessions
- add regression coverage for the compare naming helper and the session-list redaction rule

## Scope
This PR fixes the current frontend compare flow (`static/js/compare/*.js`) plus the session sidebar/API leak in `routes/session_routes.py`.

It intentionally does **not** change the legacy `POST /api/compare/start` path in `routes/compare_routes.py`, because there is already an adjacent open PR in that file (#1104). I kept this PR to the non-overlapping blind-session naming/session-list slice.

## Why
Refs #1285.

Blind compare already hides pane titles, but the sidebar and `/api/sessions` were still exposing real model identities via `[CMP] <model>` session names and the returned `model` field. This patch keeps those helper sessions anonymous until the user chooses to save/reveal results later.

## Test Plan
- `python -m pytest tests/test_compare_js.py tests/test_session_ghost_delete.py -q`
- `python -m py_compile routes/session_routes.py`
- `node --check static/js/compare/state.js`
- `node --check static/js/compare/index.js`
- `node --check static/js/compare/panes.js`

## Duplicate preflight
Checked open PRs for overlap before opening:
- issue number / linkage: `#1285`
- exact issue title fragment: `Blind Compare leaks model identities`
- distinctive strings: `/api/sessions`, `[CMP] Model`, `session sidebar`, `blind compare`
- affected files/areas: `static/js/compare/index.js`, `static/js/compare/panes.js`, `routes/session_routes.py`

No open PR matched this frontend/session-list slice. The only nearby open PR I found was #1104, which touches `routes/compare_routes.py` for endpoint owner scoping, so I explicitly avoided that file here.
