### PR TITLE
ci: add PR description check workflow

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -19,7 +19,7 @@ jobs:
     # Skip bots — they open PRs programmatically and have their own process.
     if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const body    = context.payload.pull_request.body || '';

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -1,0 +1,121 @@
+name: PR Description Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+# pull_request_target runs in the base-repo context (has secrets).
+# This workflow intentionally does NOT checkout any code — it only reads
+# context.payload and calls the GitHub API. That is the safe pattern for
+# pull_request_target: no code execution from the fork, no secret exposure.
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-description:
+    name: Check PR description
+    runs-on: ubuntu-latest
+    # Skip bots — they open PRs programmatically and have their own process.
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body    = context.payload.pull_request.body || '';
+            const prNum   = context.payload.pull_request.number;
+            const MARKER  = '<!-- pr-description-check-bot -->';
+            const owner   = context.repo.owner;
+            const repo    = context.repo.repo;
+
+            // Strip HTML comments so placeholder text does not count as content.
+            function strip(text) {
+              return (text ?? '').replace(/<!--[\s\S]*?-->/g, '').trim();
+            }
+
+            // Extract the text content of a ## Section.
+            function section(heading) {
+              const m = body.match(new RegExp(`##\\s+${heading}[\\s\\S]*?(?=\\n##\\s|$)`, 'i'));
+              return strip(m?.[0].replace(new RegExp(`##\\s+${heading}`, 'i'), '') ?? '');
+            }
+
+            const problems = [];
+
+            // 1. Summary must be filled in.
+            if (section('Summary').length < 20) {
+              problems.push('**Summary** is empty or too short — describe what changed and why.');
+            }
+
+            // 2. At least one Type of Change box must be checked.
+            const typeBlock = body.match(/##\s+Type of Change[\s\S]*?(?=\n##\s|$)/i)?.[0] ?? '';
+            if (!/- \[x\]/i.test(typeBlock)) {
+              problems.push('**Type of Change** — check at least one box.');
+            }
+
+            // 3. Duplicate-search checklist item must be checked.
+            if (!/- \[x\] I searched/i.test(body)) {
+              problems.push('**Checklist** — check the duplicate-search box to confirm you searched existing issues and PRs.');
+            }
+
+            // 4. How to Test must have at least one numbered step.
+            const howTo = section('How to Test');
+            if (!howTo || !/\d+\.\s*\S/.test(howTo)) {
+              problems.push('**How to Test** — add at least one numbered step a reviewer can follow to verify this works.');
+            }
+
+            // ── Comment ───────────────────────────────────────────────────────────
+            const commentBody = problems.length === 0
+              ? [`${MARKER}`, '✅ **PR description check passed.** All required sections are filled in.'].join('\n')
+              : [
+                  MARKER,
+                  '⚠️ **PR description — action needed**',
+                  '',
+                  'The following required sections are missing or incomplete. Please update the PR description to address them:',
+                  '',
+                  problems.map(p => `- ${p}`).join('\n'),
+                  '',
+                  '---',
+                  '_This comment updates automatically when you edit the PR description._',
+                ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNum, per_page: 100,
+            });
+            const existing = comments.find(c => (c.body ?? '').includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: commentBody });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNum, body: commentBody });
+            }
+
+            // ── Labels ────────────────────────────────────────────────────────────
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              } catch (e) {
+                if (e.status !== 422) throw e;
+              }
+            }
+
+            async function swapLabel(num, add, remove) {
+              await ensureLabel(add.name, add.color, add.description);
+              await github.rest.issues.addLabels({ owner, repo, issue_number: num, labels: [add.name] });
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: num, name: remove });
+              } catch (e) {
+                if (e.status !== 404 && e.status !== 410) throw e;
+              }
+            }
+
+            if (problems.length === 0) {
+              await swapLabel(prNum,
+                { name: 'ready for review', color: '0e8a16', description: 'Description complete — ready for maintainer review' },
+                'needs work'
+              );
+            } else {
+              await swapLabel(prNum,
+                { name: 'needs work', color: 'd93f0b', description: 'PR description incomplete — please update before review' },
+                'ready for review'
+              );
+            }


### PR DESCRIPTION
## Summary

Follow-up to #1211 (PR/issue templates). Now that the template is merged, this adds the enforcement layer: a workflow that fires on every new or updated PR, checks which required sections are missing, and posts a bot comment listing exactly what needs fixing. Labels the PR `needs work` or `ready for review` accordingly. Does not close anything — warn and label only, per the policy feedback in the #1211 thread.

This is the direct response to the concern raised there: agents and contributors who bypass the template by passing a custom `--body` will still get flagged by this check.

Fixes #1218 (consolidated governance proposal from @glenn2223).

## What it checks

Matches the four structural requirements of the template from #1211:

| Check | Passes when |
|---|---|
| Summary | Filled in with ≥ 20 characters of real content (not placeholder) |
| Type of Change | At least one box is checked |
| Checklist | Duplicate-search box is checked |
| How to Test | At least one numbered step present |

If all pass: ✅ comment + `ready for review` label.
If any fail: ⚠️ comment listing exactly which sections need attention + `needs work` label.
The bot comment updates in-place on every subsequent edit — no comment spam.

## Security note on `pull_request_target`

The maintainer flagged `pull_request_target` with write permissions as needing careful review in the original feedback. This workflow uses it, but safely:

- **No `actions/checkout`** — the fork's code is never executed. The workflow only reads `context.payload.pull_request.body` (the PR description text) and calls the GitHub API.
- **No secrets accessed** — the only credential used is `GITHUB_TOKEN`, scoped to `issues: write` and `pull-requests: write` for posting comments and managing labels.
- **No closing** — the workflow comments and labels. It never closes a PR or issue.

This is the standard safe pattern for `pull_request_target`: trigger on fork PRs, read-only access to PR content, write access only for comments and labels.

## Type of Change

- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and PRs — this consolidates #1218/#1222, not a duplicate
- [x] Targets `main`
- [x] One concern — single workflow file, no other changes
- [x] No code checkout in the workflow — pull_request_target is used safely

## How to Test

1. Open a PR against this repo with an empty or placeholder description
2. Confirm the bot posts a ⚠️ comment listing the missing sections and applies `needs work` label
3. Edit the PR description to fill in all required sections
4. Confirm the bot comment updates to ✅ and the label swaps to `ready for review`