### PR TITLE
fix: prevent iOS Safari focus-zoom on form fields (touch only)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -35357,3 +35357,53 @@ body.theme-frosted .modal {
   font-family: 'Fira Code', ui-monospace, monospace;
   color: var(--accent, var(--red));
 }
+
+/* ══ iOS focus-zoom fix — touch devices only; desktop sizes untouched ══
+   16px is the threshold below which iOS Safari auto-zooms on focus.
+   Selects and date/time inputs are excluded on purpose — they open native
+   pickers and never zoom. */
+@media (hover: none) and (pointer: coarse) {
+
+  /* 1 ── Catch-all: every text-entry control NOT pinned with its own
+     !important. !important here beats any non-important rule regardless of
+     specificity, so this clears the long tail (settings, admin, memory,
+     notes, calendar, email, gallery, tasks, model picker, etc.). */
+  input[type="text"],
+  input[type="search"],
+  input[type="email"],
+  input[type="url"],
+  input[type="tel"],
+  input[type="password"],
+  input[type="number"],
+  input:not([type]),
+  textarea {
+    font-size: 16px !important;
+  }
+
+  /* 2 ── Fields that pin their own !important at specificity our catch-all
+     can't beat. Each is matched at equal-or-higher specificity and, being
+     later in the file, wins the tie. */
+  #message { font-size: 16px !important; }                                  /* chat composer (was 13px !important) */
+  .cookbook-dl-repo,
+  .hwfit-search { font-size: 16px !important; }                             /* cookbook repo path + hardware search */
+  .ge-topbar input { font-size: 16px !important; }                          /* image-editor topbar input */
+  .ge-transform-field > input.ge-transform-popup-input {                    /* image-editor transform values */
+    font-size: 16px !important;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  /* Only the sub-16px tiers need bumping; large lands ABOVE 16 so it
+     stays zoom-safe AND visibly larger than medium (otherwise L collapses
+     onto M on touch). All three editor layers move together so the
+     highlight/line-number overlay stays metrically aligned with the textarea. */
+  .doc-font-m .doc-editor-textarea, .doc-font-m .doc-editor-highlight, .doc-font-m .doc-line-numbers {
+    font-size: 16px !important;   /* was 13px */
+  }
+  .doc-font-l .doc-editor-textarea, .doc-font-l .doc-editor-highlight, .doc-font-l .doc-line-numbers {
+    font-size: 18px !important;   /* was 15px — keep L > M */
+  }
+  /* Email compose rich-body. Medium (15px) zooms, so bump it; large (17px)
+     is already ≥16px and never zoomed — leave it so we don't shrink it. */
+  .doc-email-richbody.doc-font-m { font-size: 16px !important; }
+}


### PR DESCRIPTION
## Summary

On iOS Safari, focusing any input whose `font-size` is below 16px triggers an automatic page zoom that doesn't reset on blur, leaving the layout zoomed and forcing a manual pinch-out. This makes the chat composer, Settings fields, the document editor, and most other text inputs awkward to use on iPhone. This PR raises text-entry controls to 16px — the documented zoom threshold — but only under `@media (hover: none) and (pointer: coarse)`, so desktop sizing is completely untouched.

The fix is scoped carefully:
- A catch-all covers the long tail of text inputs/textareas; fields that pin their own `!important` (chat composer, cookbook/hardware search, image-editor inputs) are re-pinned at matching specificity so they actually take effect.
- Date/time inputs and `<select>` are deliberately excluded — they open native pickers and never zoom.
- Document-editor font tiers keep their hierarchy: Large lands at 18px (above the 16px threshold) rather than collapsing onto Medium's 16px, and the email rich-body Large (17px) is left as-is since it was already zoom-safe. All three editor layers (textarea, highlight overlay, line numbers) move together so the syntax overlay stays metrically aligned with the textarea.

## Linked Issue

Fixes #1317

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. On an iPhone (or the iOS Simulator running Safari), open Odysseus and tap into the chat composer at the bottom. Before: the page zooms in on focus and stays zoomed. After: no zoom.
2. Repeat on a Settings text field and the document editor — confirm none trigger zoom-on-focus.
3. In the document editor, toggle font size Medium <-> Large on the phone and confirm Large is still visibly larger than Medium (didn't collapse), and that the syntax highlight overlay stays aligned with the typed text.
4. On desktop, confirm input/editor font sizes are visually unchanged.

CSS-only change; no Python/JS affected. Verified the edit is scoped to the single appended block and that brace balance is preserved.

## Videos (UI changes only)
Before:
https://github.com/user-attachments/assets/e30bfbac-601e-469a-aa12-eb13d189f620

After:
https://github.com/user-attachments/assets/2a8668d7-4434-4488-8999-f3c84810c5e4