### PR TITLE
fix(security): owner-scope the email contacts autocomplete (cross-tenant correspondent leak)

### DIFF
--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -996,9 +996,18 @@ def setup_email_routes():
         won't appear yet."""
         ql = (q or "").strip().lower()
         try:
+            # SECURITY: scope to the caller's own tag rows (+ legacy null-owner),
+            # exactly like every other email_tags read in this file. Without this
+            # owner filter the query returned senders harvested from EVERY user's
+            # classified inbox, leaking one user's email correspondents to any
+            # authenticated user on a multi-user deploy.
+            _owner_aliases = _email_tag_owner_aliases(None, owner)
+            _owner_ph = ",".join("?" * len(_owner_aliases))
             conn = _sql3.connect(SCHEDULED_DB)
             rows = conn.execute(
-                "SELECT sender FROM email_tags WHERE sender IS NOT NULL AND sender != ''"
+                "SELECT sender FROM email_tags WHERE sender IS NOT NULL AND sender != '' "
+                f"AND (owner IN ({_owner_ph}) OR owner IS NULL)",
+                (*_owner_aliases,),
             ).fetchall()
             conn.close()
             seen = {}

--- a/tests/test_email_contacts_owner_scope.py
+++ b/tests/test_email_contacts_owner_scope.py
@@ -1,0 +1,66 @@
+"""Cross-tenant disclosure regression: GET /api/email/contacts must owner-scope.
+
+The from-sender autocomplete reads distinct `sender` values from the
+owner-partitioned `email_tags` table. The query lacked an owner filter, so any
+authenticated user received the email correspondents harvested from EVERY user's
+classified inbox. It must scope to the caller's own rows (+ legacy null-owner),
+exactly like every other email_tags read in routes/email_routes.py.
+"""
+
+import asyncio
+import sqlite3
+
+
+def _make_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE email_tags (message_id TEXT, owner TEXT, sender TEXT)")
+    conn.executemany(
+        "INSERT INTO email_tags (message_id, owner, sender) VALUES (?,?,?)",
+        [
+            ("m1", "alice", "Alice Contact <alice-contact@example.com>"),
+            ("m2", "bob", "Bob Secret <bob-contact@example.com>"),
+            ("m3", None, "Legacy Shared <legacy@example.com>"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _contacts_endpoint():
+    from routes.email_routes import setup_email_routes
+    router = setup_email_routes()
+    for r in router.routes:
+        if getattr(r, "path", "").endswith("/contacts") and "GET" in (getattr(r, "methods", set()) or set()):
+            return r.endpoint
+    raise AssertionError("/contacts route not found")
+
+
+def test_contacts_is_owner_scoped(tmp_path, monkeypatch):
+    db = tmp_path / "scheduled.db"
+    _make_db(str(db))
+    import routes.email_routes as er
+    monkeypatch.setattr(er, "SCHEDULED_DB", str(db))
+    # Avoid the real account-config DB lookup; alias resolves to the username.
+    monkeypatch.setattr(er, "_email_tag_owner_aliases", lambda account_id, owner: [owner or ""])
+
+    handler = _contacts_endpoint()
+    result = asyncio.run(handler(q="", limit=20, owner="alice"))
+    addrs = {c["address"] for c in result["contacts"]}
+
+    assert "alice-contact@example.com" in addrs       # caller's own row
+    assert "legacy@example.com" in addrs              # legacy null-owner shared row
+    assert "bob-contact@example.com" not in addrs     # cross-owner MUST be hidden
+
+
+def test_contacts_other_owner_only_returns_nothing_cross_tenant(tmp_path, monkeypatch):
+    db = tmp_path / "scheduled.db"
+    _make_db(str(db))
+    import routes.email_routes as er
+    monkeypatch.setattr(er, "SCHEDULED_DB", str(db))
+    monkeypatch.setattr(er, "_email_tag_owner_aliases", lambda account_id, owner: [owner or ""])
+
+    handler = _contacts_endpoint()
+    # carol owns no tag rows → sees only the legacy shared row, never alice/bob.
+    result = asyncio.run(handler(q="", limit=20, owner="carol"))
+    addrs = {c["address"] for c in result["contacts"]}
+    assert addrs == {"legacy@example.com"}


### PR DESCRIPTION
## Summary

`GET /api/email/contacts` (gated by `require_owner` — **any authenticated non-admin user**) powers the from-sender autocomplete by reading distinct senders from the `email_tags` table:

```python
rows = conn.execute(
    "SELECT sender FROM email_tags WHERE sender IS NOT NULL AND sender != ''"
).fetchall()
```

**The query has no owner filter.** `email_tags` is owner-partitioned (`PRIMARY KEY (message_id, owner)`), and **every other read of it in `routes/email_routes.py` scopes** `(owner IN (<caller aliases>) OR owner IS NULL)`. This endpoint resolves `owner = Depends(require_owner)` but then never uses it.

So on a multi-user deployment, **any user** calling `/api/email/contacts` receives the sender names + email addresses harvested from **every other user's classified inbox** — i.e. who they correspond with — surfaced right in the compose sidebar autocomplete. Cross-tenant disclosure of private contact graphs.

(Reported as part of #639's "something I found" but unconfirmed there; this is the concrete, verified instance.)

## Fix

Scope the read to the caller's own rows plus legacy null-owner rows via the existing `_email_tag_owner_aliases(None, owner)` helper, mirroring the sibling tag reads in the same file:

```python
_owner_aliases = _email_tag_owner_aliases(None, owner)
_owner_ph = ",".join("?" * len(_owner_aliases))
rows = conn.execute(
    "SELECT sender FROM email_tags WHERE sender IS NOT NULL AND sender != '' "
    f"AND (owner IN ({_owner_ph}) OR owner IS NULL)",
    (*_owner_aliases,),
).fetchall()
```

## Tests

New `tests/test_email_contacts_owner_scope.py` (seeds alice/bob/legacy-null rows in a temp `email_tags` DB, calls the real route handler): a caller sees their own + legacy-shared senders and **never** another owner's; a caller with no rows sees only the legacy-shared one.

```
$ pytest tests/test_email_contacts_owner_scope.py -q
2 passed
```