### PR TITLE
fix: add aria-labels to icon-only buttons

### DIFF
--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -828,7 +828,7 @@ export function openEmailLibrary(opts = {}) {
             <div class="email-search-row" style="display:flex;gap:6px;align-items:flex-start;">
             <div class="email-search-wrap" style="position:relative;flex:1;min-width:140px;">
               <input type="text" id="email-lib-search" placeholder="Search emails\u2026" class="memory-search-input" style="width:100%;padding-right:96px;" />
-              <button class="memory-toolbar-btn email-undone-toggle email-undone-toggle-inline" id="email-undone-btn" title="Show only emails not marked as done (undone)" aria-label="Show only unread emails">
+              <button class="memory-toolbar-btn email-undone-toggle email-undone-toggle-inline" id="email-undone-btn" title="Show only emails not marked as done (undone)" aria-label="Show only emails not marked as done">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
               </button>
               <button class="memory-toolbar-btn email-reminder-toggle-inline hidden" id="email-reminder-btn" title="Show Odysseus reminder emails" aria-label="Show reminder emails">
@@ -2320,11 +2320,13 @@ async function _toggleCardPreview(card, em) {
         attsToggle.addEventListener('click', (ev) => {
           ev.stopPropagation();
           attsWrap.classList.toggle('collapsed');
+          attsToggle.setAttribute('aria-expanded', attsWrap.classList.contains('collapsed') ? 'false' : 'true');
         });
         attsToggle.addEventListener('keydown', (ev) => {
           if (ev.key === 'Enter' || ev.key === ' ') {
             ev.preventDefault();
             attsWrap.classList.toggle('collapsed');
+            attsToggle.setAttribute('aria-expanded', attsWrap.classList.contains('collapsed') ? 'false' : 'true');
           }
         });
       }
@@ -3080,8 +3082,10 @@ function _showCachedSummary(reader, summary, btn) {
   const _flip = () => {
     panel.classList.toggle('collapsed');
     _setSummaryCollapsedPref(panel.classList.contains('collapsed'));
+    if (toggle) toggle.setAttribute('aria-expanded', panel.classList.contains('collapsed') ? 'false' : 'true');
   };
   if (toggle) {
+    toggle.setAttribute('aria-expanded', panel.classList.contains('collapsed') ? 'false' : 'true');
     toggle.addEventListener('click', (ev) => { ev.stopPropagation(); _flip(); });
     toggle.addEventListener('keydown', (ev) => {
       if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); _flip(); }
@@ -4342,9 +4346,11 @@ async function _generateSummary(reader, data, btn) {
   body.insertBefore(panel, body.firstChild);
   const _genToggle = panel.querySelector('.email-summary-toggle');
   if (_genToggle) {
+    _genToggle.setAttribute('aria-expanded', panel.classList.contains('collapsed') ? 'false' : 'true');
     const _genFlip = () => {
       panel.classList.toggle('collapsed');
       _setSummaryCollapsedPref(panel.classList.contains('collapsed'));
+      _genToggle.setAttribute('aria-expanded', panel.classList.contains('collapsed') ? 'false' : 'true');
     };
     _genToggle.addEventListener('click', (ev) => { ev.stopPropagation(); _genFlip(); });
     _genToggle.addEventListener('keydown', (ev) => {

--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -777,11 +777,11 @@ export function openEmailLibrary(opts = {}) {
             <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
           </svg>
           Email
-          <span id="email-lib-unread-badge" class="email-lib-unread-badge" role="button" tabindex="0" title="Show unread emails" style="display:none"></span>
+          <span id="email-lib-unread-badge" class="email-lib-unread-badge" role="button" tabindex="0" title="Show unread emails" aria-label="Show unread emails" style="display:none"></span>
           <span id="email-lib-stats" class="memory-count" style="font-size:0.6em;opacity:0.6;font-weight:normal;margin-left:8px;position:relative;top:-2px"></span>
         </h4>
         <div class="email-lib-header-actions" style="display:flex;align-items:center;gap:8px;">
-          <button class="close-btn" id="email-lib-close">\u2716</button>
+          <button class="close-btn" id="email-lib-close" aria-label="Close">\u2716</button>
         </div>
       </div>
       <div class="modal-body" style="display:flex;flex-direction:column;gap:10px;overflow:hidden;">
@@ -817,10 +817,10 @@ export function openEmailLibrary(opts = {}) {
                 </optgroup>
               </select>
               <button class="memory-toolbar-btn email-filter-select-btn" id="email-lib-select-btn">Select</button>
-              <button class="memory-toolbar-btn email-filter-refresh-btn" id="email-lib-refresh-btn" title="Refresh">
+              <button class="memory-toolbar-btn email-filter-refresh-btn" id="email-lib-refresh-btn" title="Refresh" aria-label="Refresh">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;"><path d="M1 4v6h6"/><path d="M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
               </button>
-              <button class="memory-toolbar-btn email-reminders-clear-btn hidden" id="email-reminders-clear-btn" title="Permanently delete Odysseus reminder emails">
+              <button class="memory-toolbar-btn email-reminders-clear-btn hidden" id="email-reminders-clear-btn" title="Permanently delete Odysseus reminder emails" aria-label="Permanently delete reminder emails">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/></svg>
                 Clear
               </button>
@@ -828,13 +828,13 @@ export function openEmailLibrary(opts = {}) {
             <div class="email-search-row" style="display:flex;gap:6px;align-items:flex-start;">
             <div class="email-search-wrap" style="position:relative;flex:1;min-width:140px;">
               <input type="text" id="email-lib-search" placeholder="Search emails\u2026" class="memory-search-input" style="width:100%;padding-right:96px;" />
-              <button class="memory-toolbar-btn email-undone-toggle email-undone-toggle-inline" id="email-undone-btn" title="Show only emails not marked as done (undone)">
+              <button class="memory-toolbar-btn email-undone-toggle email-undone-toggle-inline" id="email-undone-btn" title="Show only emails not marked as done (undone)" aria-label="Show only unread emails">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
               </button>
-              <button class="memory-toolbar-btn email-reminder-toggle-inline hidden" id="email-reminder-btn" title="Show Odysseus reminder emails">
+              <button class="memory-toolbar-btn email-reminder-toggle-inline hidden" id="email-reminder-btn" title="Show Odysseus reminder emails" aria-label="Show reminder emails">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/></svg>
               </button>
-              <button class="memory-toolbar-btn email-attach-toggle email-attach-toggle-inline" id="email-attach-btn" title="Show only emails with attachments">
+              <button class="memory-toolbar-btn email-attach-toggle email-attach-toggle-inline" id="email-attach-btn" title="Show only emails with attachments" aria-label="Show emails with attachments">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 17.93 8.8l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
               </button>
             </div>
@@ -845,7 +845,7 @@ export function openEmailLibrary(opts = {}) {
             <span id="email-lib-selected-count" style="position:relative;top:1px;">0 Selected</span>
             <button class="memory-toolbar-btn" id="email-lib-bulk-actions" style="position:relative;top:-2px;"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:3px;"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>Actions <span style="opacity:0.55;font-size:9px;">▼</span></button>
             <button class="memory-toolbar-btn" id="email-lib-bulk-delete" style="position:relative;top:-2px;"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:3px;"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>Delete</button>
-            <button class="memory-toolbar-btn" id="email-lib-bulk-cancel" title="Cancel (Esc)" style="margin-left:4px;padding:3px 6px;position:relative;top:-2px;"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+            <button class="memory-toolbar-btn" id="email-lib-bulk-cancel" title="Cancel (Esc)" aria-label="Cancel" style="margin-left:4px;padding:3px 6px;position:relative;top:-2px;"><svg aria-hidden="true" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
           </div>
           <div id="email-lib-grid" class="doclib-grid"></div>
           <button class="email-lib-fab" id="email-lib-fab" type="button" aria-label="New email">
@@ -1762,7 +1762,8 @@ async function _loadScheduled(grid, sp) {
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'memory-item-btn';
     cancelBtn.title = 'Cancel scheduled send';
-    cancelBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
+    cancelBtn.setAttribute('aria-label', 'Cancel scheduled send');
+    cancelBtn.innerHTML = '<svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>';
     cancelBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const { styledConfirm } = await import('./ui.js');
@@ -1998,8 +1999,8 @@ function _createCard(em) {
   const navArrows = document.createElement('span');
   navArrows.className = 'email-card-nav-arrows';
   navArrows.innerHTML = `
-    <button type="button" class="email-card-nav-btn" data-nav-dir="-1" title="Previous email"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></button>
-    <button type="button" class="email-card-nav-btn" data-nav-dir="1" title="Next email"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></button>
+    <button type="button" class="email-card-nav-btn" data-nav-dir="-1" title="Previous email" aria-label="Previous email"><svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></button>
+    <button type="button" class="email-card-nav-btn" data-nav-dir="1" title="Next email" aria-label="Next email"><svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg></button>
   `;
   navArrows.addEventListener('click', async (ev) => {
     const btn = ev.target.closest('.email-card-nav-btn');
@@ -2025,7 +2026,8 @@ function _createCard(em) {
   headerMenuBtn.type = 'button';
   headerMenuBtn.className = 'email-card-header-menu';
   headerMenuBtn.title = 'Actions';
-  headerMenuBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>';
+  headerMenuBtn.setAttribute('aria-label', 'Actions');
+  headerMenuBtn.innerHTML = '<svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>';
   headerMenuBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     _showCardMenu(em, headerMenuBtn);
@@ -2056,6 +2058,7 @@ function _createCard(em) {
     const menuBtn = document.createElement('button');
     menuBtn.className = 'memory-item-btn';
     menuBtn.title = 'Actions';
+    menuBtn.setAttribute('aria-label', 'Actions');
     menuBtn.style.position = 'relative';
     menuBtn.style.top = '-1px';
     menuBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>';
@@ -3063,7 +3066,7 @@ function _showCachedSummary(reader, summary, btn) {
   panel.className = 'email-summary-panel';
   if (_summaryCollapsedPref()) panel.classList.add('collapsed');
   panel.innerHTML =
-    '<div class="email-summary-header email-summary-toggle" role="button" tabindex="0">'
+    '<div class="email-summary-header email-summary-toggle" role="button" tabindex="0" aria-label="Toggle summary" aria-expanded="false">'
     +   '<svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0L14.59 8.41L23 12L14.59 15.59L12 24L9.41 15.59L1 12L9.41 8.41Z"/></svg>'
     +   '<span>Summary</span>'
     +   '<svg class="email-summary-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-left:auto;transition:transform .15s ease;"><polyline points="6 9 12 15 18 9"/></svg>'
@@ -3139,7 +3142,7 @@ async function _toggleFromSenderPanel(reader, data, btn) {
     <div class="from-sender-header">
       <span class="from-sender-chips"></span>
       <span class="from-sender-header-empty" hidden>All senders</span>
-      <button type="button" class="from-sender-toggle" data-toggle="attachments" title="Show only emails with attachments" aria-pressed="false">
+      <button type="button" class="from-sender-toggle" data-toggle="attachments" title="Show only emails with attachments" aria-label="Show only emails with attachments" aria-pressed="false">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 17.93 8.8l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
       </button>
       <button type="button" class="from-sender-close" title="Close" aria-label="Close sender panel">&times;</button>
@@ -3689,7 +3692,7 @@ function _buildAttsHtmlFor(uid, data) {
   }).join('');
   return (
     '<div class="email-reader-atts-wrap collapsed">'
-    +   '<div class="email-reader-atts-header email-summary-toggle" role="button" tabindex="0">'
+    +   '<div class="email-reader-atts-header email-summary-toggle" role="button" tabindex="0" aria-label="Toggle attachments" aria-expanded="false">'
     +     '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 17.93 8.8l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>'
     +     `<span>Attachments (${data.attachments.length})</span>`
     +     '<svg class="email-summary-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-left:auto;transition:transform .15s ease;"><polyline points="6 9 12 15 18 9"/></svg>'
@@ -3808,8 +3811,8 @@ async function _openEmailAsTab(em, folder) {
         <h4 style="display:flex;align-items:center;gap:6px;min-width:0;flex:1;">
           <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-left:8px;">${_esc(em.subject || '(no subject)')}</span>
         </h4>
-        <button class="minimize-btn" type="button" title="Minimize">_</button>
-        <button class="close-btn" type="button" title="Close">&#x2716;</button>
+        <button class="minimize-btn" type="button" title="Minimize" aria-label="Minimize">_</button>
+        <button class="close-btn" type="button" title="Close" aria-label="Close">&#x2716;</button>
       </div>
       <div class="modal-body email-reader-tab-body" style="display:flex;flex-direction:column;overflow:hidden;flex:1;min-height:0;padding:0;">
         <div class="email-card-reader email-card-expanded" style="flex:1;min-height:0;display:flex;flex-direction:column;">
@@ -4041,7 +4044,7 @@ async function _openEmailWindow(em, folder) {
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
           <span class="email-window-subject" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${_esc(em.subject || '(no subject)')}</span>
         </h4>
-        <button class="close-btn" type="button" title="Close">&#x2716;</button>
+        <button class="close-btn" type="button" title="Close" aria-label="Close">&#x2716;</button>
       </div>
       <div class="modal-body email-window-body" style="overflow:auto;padding:14px 16px;flex:1;min-height:0;">
         <div class="email-window-loading" style="display:flex;justify-content:center;padding:24px;"></div>
@@ -4329,7 +4332,7 @@ async function _generateSummary(reader, data, btn) {
   const panel = document.createElement('div');
   panel.className = 'email-summary-panel';
   panel.innerHTML =
-    '<div class="email-summary-header email-summary-toggle" role="button" tabindex="0">'
+    '<div class="email-summary-header email-summary-toggle" role="button" tabindex="0" aria-label="Toggle summary" aria-expanded="false">'
     +   '<svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0L14.59 8.41L23 12L14.59 15.59L12 24L9.41 15.59L1 12L9.41 8.41Z"/></svg>'
     +   '<span>Summary</span>'
     +   '<svg class="email-summary-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-left:auto;transition:transform .15s ease;"><polyline points="6 9 12 15 18 9"/></svg>'

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -2394,7 +2394,7 @@ async function _cmdTourCompare(args, ctx) {
         '<div class="tour-nav">' +
           '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target);
@@ -2680,7 +2680,7 @@ async function _cmdTourCookbook(args, ctx) {
         '<div class="tour-nav">' +
           '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target, placement);
@@ -2917,7 +2917,7 @@ async function _cmdTourTheme(args, ctx) {
           '<div class="tour-nav">' +
             '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3161,7 +3161,7 @@ async function _cmdTourSettings(args, ctx) {
           '<div class="tour-nav">' +
             '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3393,7 +3393,7 @@ async function _cmdTourGallery(args, ctx) {
           '<div class="tour-nav">' +
             '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3606,7 +3606,7 @@ async function _cmdTourNotes(args, ctx) {
           '<div class="tour-nav">' +
             '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3806,7 +3806,7 @@ async function _cmdTourBrain(args, ctx) {
           '<div class="tour-nav">' +
             '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -4243,7 +4243,7 @@ async function _cmdTourResearch(args, ctx) {
         '<div class="tour-nav">' +
           '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target, placement);
@@ -4459,7 +4459,7 @@ async function _cmdTourLibrary(args, ctx) {
         '<div class="tour-nav">' +
           '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="' + (isLast ? 'Finish' : 'Next') + '">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target, placement);

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -270,6 +270,7 @@ function slashReply(text) {
       btn.type = 'button';
       btn.className = 'copy-code';
       btn.setAttribute('data-code', pre.textContent);
+      btn.setAttribute('aria-label', 'Copy code');
       btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
       pre.appendChild(btn);
     }
@@ -398,7 +399,8 @@ function typewriterBlocksReply(blocks, options = {}) {
         useBtn.type = 'button';
         useBtn.className = 'use-code';
         useBtn.title = 'Use in Chat';
-        useBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12l7 7 7-7"/></svg>';
+        useBtn.setAttribute('aria-label', 'Use in Chat');
+        useBtn.innerHTML = '<svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12l7 7 7-7"/></svg>';
         const copyText = block.copyText || block.text || '';
         const useNow = (e) => {
           e.preventDefault();
@@ -426,6 +428,7 @@ function typewriterBlocksReply(blocks, options = {}) {
         btn.className = 'copy-code';
         btn.setAttribute('data-code', copyText);
         btn.title = 'Copy';
+        btn.setAttribute('aria-label', 'Copy code');
         btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
         const copyNow = (e) => {
           e.preventDefault();
@@ -2045,9 +2048,9 @@ async function _cmdDemo(args, ctx) {
       tooltip.innerHTML = `<div class="tour-text">${text}</div>
         ${breathing ? '<div style="font-size:0.72rem;opacity:0.35;margin-bottom:6px">Click the highlighted element to continue</div>' : ''}
         <div class="tour-nav" style="${breathing ? 'justify-content:center' : ''}">
-          ${breathing ? '' : `<button class="tour-btn-arrow${isFirst ? ' disabled' : ''}" data-act="back">\u2190</button>`}
+          ${breathing ? '' : `<button class="tour-btn-arrow${isFirst ? ' disabled' : ''}" data-act="back" aria-label="Back">\u2190</button>`}
           <button class="tour-btn-skip" data-act="skip">${stepOpts.finishLabel ? 'finish tour' : 'skip tour'}</button>
-          ${breathing ? '' : `<button class="tour-btn-arrow${pulseNext ? ' tour-btn-arrow-pulse' : ''}" data-act="next">\u2192</button>`}
+          ${breathing ? '' : `<button class="tour-btn-arrow${pulseNext ? ' tour-btn-arrow-pulse' : ''}" data-act="next" aria-label="Next">\u2192</button>`}
         </div>`;
 
       // Position based on the fully-rendered tooltip so it doesn't jump as
@@ -2389,9 +2392,9 @@ async function _cmdTourCompare(args, ctx) {
       tooltip.innerHTML =
         '<div class="tour-text">' + text + '</div>' + hint +
         '<div class="tour-nav">' +
-          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target);
@@ -2675,9 +2678,9 @@ async function _cmdTourCookbook(args, ctx) {
       tooltip.innerHTML =
         '<div class="tour-text">' + text + '</div>' +
         '<div class="tour-nav">' +
-          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target, placement);
@@ -2912,9 +2915,9 @@ async function _cmdTourTheme(args, ctx) {
         tooltip.innerHTML =
           '<div class="tour-text">' + text + '</div>' +
           '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3156,9 +3159,9 @@ async function _cmdTourSettings(args, ctx) {
         tooltip.innerHTML =
           '<div class="tour-text">' + text + '</div>' +
           '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3388,9 +3391,9 @@ async function _cmdTourGallery(args, ctx) {
         tooltip.innerHTML =
           '<div class="tour-text">' + text + '</div>' +
           '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3601,9 +3604,9 @@ async function _cmdTourNotes(args, ctx) {
         tooltip.innerHTML =
           '<div class="tour-text">' + text + '</div>' +
           '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3801,9 +3804,9 @@ async function _cmdTourBrain(args, ctx) {
         tooltip.innerHTML =
           '<div class="tour-text">' + text + '</div>' +
           '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           _positionTooltip(target, placement);
@@ -3990,9 +3993,9 @@ async function _runTaskTour(steps, doneText, opts) {
         tooltip.innerHTML =
           '<div class="tour-text">' + step.text + '</div>' +
           '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (i === 0 ? ' disabled' : '') + '" data-act="back">←</button>' +
+            '<button class="tour-btn-arrow' + (i === 0 ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
             '<button class="tour-btn-skip" data-act="skip">' + (i === steps.length - 1 ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (i === steps.length - 1 ? '✓' : '→') + '</button>' +
+            '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (i === steps.length - 1 ? '✓' : '→') + '</button>' +
           '</div>';
         requestAnimationFrame(() => {
           positionTooltip(target);
@@ -4238,9 +4241,9 @@ async function _cmdTourResearch(args, ctx) {
       tooltip.innerHTML =
         '<div class="tour-text">' + text + '</div>' +
         '<div class="tour-nav">' +
-          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target, placement);
@@ -4454,9 +4457,9 @@ async function _cmdTourLibrary(args, ctx) {
       tooltip.innerHTML =
         '<div class="tour-text">' + text + '</div>' +
         '<div class="tour-nav">' +
-          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back" aria-label="Back">←</button>' +
           '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next" aria-label="Next">' + (isLast ? '✓' : '→') + '</button>' +
         '</div>';
       requestAnimationFrame(() => {
         _positionTooltip(target, placement);
@@ -4899,6 +4902,7 @@ async function _cmdShortcuts(args, ctx) {
   btn.type = 'button';
   btn.className = 'copy-code';
   btn.setAttribute('data-code', pre.textContent);
+  btn.setAttribute('aria-label', 'Copy code');
   btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
   pre.appendChild(btn);
   body.appendChild(pre);

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -649,7 +649,7 @@ export function initThemeUI() {
           <span style="background:${c.red}"></span>
         </div>
         <span class="theme-swatch-name">${name}</span>
-        <button type="button" class="theme-delete-btn" data-delete="${name}" title="Delete theme"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+        <button type="button" class="theme-delete-btn" data-delete="${name}" title="Delete theme" aria-label="Delete theme"><svg aria-hidden="true" focusable="false" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
       </div>
     `).join('');
   } else if (userCard) {


### PR DESCRIPTION
Several SVG-only and symbol-only buttons were missing accessible names across the email library, slash commands tour, and theme editor. Screen readers would either skip these entirely or announce raw SVG markup / Unicode symbols (✖, `_`, ←, →, ✓).

Part of ROADMAP — *Accessibility pass: keyboard navigation, focus states, contrast, reduced motion.*

## Changes

- **`emailLibrary.js`** — `aria-label` added to: unread badge, close, refresh, filter buttons (undone/reminder/attachments), bulk cancel, prev/next nav arrows, actions menus, scheduled-send cancel, minimize, from-sender attachment toggle. `aria-hidden="true"` on decorative SVGs inside labelled buttons. Summary/attachments toggle divs get `aria-label` + `aria-expanded` wired to the existing JS collapse toggle — state updates on every click/keydown.
- **`slashCommands.js`** — Tour back/next arrows labelled `aria-label="Back"` / `"Next"` across all steps. Final step uses `"Finish"`. `copy-code` and `use-in-chat` buttons labelled.
- **`theme.js`** — Swatch delete button labelled.

No logic or visual changes. Every modified line keeps its original element and only gains aria attribute(s).

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] Searched open issues and PRs — not a duplicate
- [x] Targets `main`
- [x] Scoped to 3 files only, no unrelated changes

## How to Test

1. Open email library → DevTools → Accessibility tree → inspect any filter button (Refresh, Undone, Attachments) — should show computed accessible name
2. Expand/collapse a Summary or Attachments panel → `aria-expanded` toggles between `true` and `false`
3. Step through onboarding tour to final step → next button announced as "Finish", not "Next"
4. `node --check static/js/emailLibrary.js static/js/slashCommands.js static/js/theme.js` → exits clean