### PR TITLE
fix: once-schedule task comparison uses local time against UTC date

### DIFF
--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -115,7 +115,7 @@ def compute_next_run(schedule: str, scheduled_time: str,
             return None
 
     if schedule == "once":
-        if scheduled_date and scheduled_date > (now.replace(tzinfo=None) if tz is not None else now):
+        if scheduled_date and scheduled_date > (_to_utc_naive(now) if tz is not None else now):
             return scheduled_date
         return None
 


### PR DESCRIPTION
## Summary
- `compute_next_run` for `once` schedules compares `scheduled_date` (naive UTC) against `now.replace(tzinfo=None)` (naive local time) when a timezone is configured
- For users east of UTC, tasks expire prematurely; for users west, tasks linger past their due time
- Fix: use `_to_utc_naive(now)` (already defined in the function) so both sides are naive UTC

One-line change: `now.replace(tzinfo=None)` → `_to_utc_naive(now)`