### PR TITLE
fix(search): degrade to empty results on non-JSON provider responses (#1129)

### DIFF
--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -492,12 +492,17 @@ def google_pse_search(query: str, count: int = 10, time_filter: Optional[str] = 
         if response.status_code == 429:
             raise RateLimitError("Google PSE rate limit hit")
         response.raise_for_status()
-        data = response.json()
     except httpx.RequestError as e:
         error_logger.error(f"Google PSE search failed: {e}")
         return []
     except RateLimitError as e:
         error_logger.error(str(e))
+        return []
+
+    try:
+        data = response.json()
+    except json.JSONDecodeError as e:
+        error_logger.error(f"Google PSE returned invalid JSON: {e}")
         return []
 
     results = []
@@ -544,12 +549,17 @@ def tavily_search(query: str, count: int = 10, time_filter: Optional[str] = None
         if response.status_code == 429:
             raise RateLimitError("Tavily rate limit hit")
         response.raise_for_status()
-        data = response.json()
     except httpx.RequestError as e:
         error_logger.error(f"Tavily search failed: {e}")
         return []
     except RateLimitError as e:
         error_logger.error(str(e))
+        return []
+
+    try:
+        data = response.json()
+    except json.JSONDecodeError as e:
+        error_logger.error(f"Tavily returned invalid JSON: {e}")
         return []
 
     results = []
@@ -599,12 +609,17 @@ def serper_search(query: str, count: int = 10, time_filter: Optional[str] = None
         if response.status_code == 429:
             raise RateLimitError("Serper rate limit hit")
         response.raise_for_status()
-        data = response.json()
     except httpx.RequestError as e:
         error_logger.error(f"Serper search failed: {e}")
         return []
     except RateLimitError as e:
         error_logger.error(str(e))
+        return []
+
+    try:
+        data = response.json()
+    except json.JSONDecodeError as e:
+        error_logger.error(f"Serper returned invalid JSON: {e}")
         return []
 
     results = []

--- a/tests/test_search_provider_json.py
+++ b/tests/test_search_provider_json.py
@@ -1,0 +1,59 @@
+"""Search providers must not raise on a non-JSON response body (issue #1129).
+
+`brave_search` already wraps `response.json()` in its own try/except that catches
+`json.JSONDecodeError` and returns []. The Tavily, Serper, and Google PSE
+providers parsed JSON inside the network try block, which only caught
+`httpx.RequestError`/`RateLimitError` — so a provider returning a non-JSON body
+(an HTML error page, a truncated/empty body, a gateway error) raised an
+UNCAUGHT `json.JSONDecodeError` that aborted the search in the background. These
+pin that all four providers degrade to [] on malformed JSON, matching brave.
+"""
+
+import json
+
+import pytest
+
+from services.search import providers
+
+
+class _BadJSONResponse:
+    """A 200 response whose body is not valid JSON (e.g. an HTML error page)."""
+    status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        raise json.JSONDecodeError("Expecting value", "<html>down</html>", 0)
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    # Keep everything offline + deterministic: no settings/DB, keys via env, and
+    # both httpx verbs return a body that fails to decode.
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {}, raising=False)
+    monkeypatch.setattr(providers, "_safesearch_for", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setenv("DATA_BRAVE_API_KEY", "k")
+    monkeypatch.setenv("TAVILY_API_KEY", "k")
+    monkeypatch.setenv("SERPER_API_KEY", "k")
+    monkeypatch.setenv("GOOGLE_API_KEY", "k")
+    monkeypatch.setenv("GOOGLE_PSE_CX", "cx")
+    monkeypatch.setattr(providers.httpx, "post", lambda *a, **k: _BadJSONResponse())
+    monkeypatch.setattr(providers.httpx, "get", lambda *a, **k: _BadJSONResponse())
+
+
+def test_tavily_malformed_json_returns_empty():
+    assert providers.tavily_search("hello") == []
+
+
+def test_serper_malformed_json_returns_empty():
+    assert providers.serper_search("hello") == []
+
+
+def test_google_pse_malformed_json_returns_empty():
+    assert providers.google_pse_search("hello") == []
+
+
+def test_brave_malformed_json_returns_empty():
+    # Already correct on main — guards against regressing the reference behaviour.
+    assert providers.brave_search("hello") == []


### PR DESCRIPTION
Fixes #1129

## Problem
With a non-SearXNG search provider configured, deep search silently fails in the background. Root cause: `tavily_search`, `serper_search`, and `google_pse_search` in `services/search/providers.py` call `response.json()` **inside the network `try`**, which only catches `httpx.RequestError` and `RateLimitError`. When a provider returns a non-JSON body — an HTML error/captcha page, a truncated or empty body, a gateway 5xx — `response.json()` raises an **uncaught `json.JSONDecodeError`** that propagates out and aborts the search.

`brave_search` already does this correctly: it parses JSON in its **own** `try` and returns `[]` on `json.JSONDecodeError`.

## Fix
Mirror brave's pattern in the other three providers — move `response.json()` into its own `try` that catches `json.JSONDecodeError`, log it, and return `[]`. A malformed provider response now degrades to no-results instead of throwing. Minimal, behavior-preserving for the happy path, and consistent across all four providers.

## Tests
`tests/test_search_provider_json.py` — a 200 response whose body fails to decode now yields `[]` for `tavily`, `serper`, `google_pse`, and `brave` (the last guards the reference behaviour against regression). Pure unit test: httpx is monkeypatched, no app/network/GPU.

```
$ DATABASE_URL=sqlite:///:memory: python -m pytest tests/test_search_provider_json.py
4 passed
```

Verified non-duplicate: the only other open PRs touching `providers.py` (#935 SerpApi, #530 Exa) add *new* providers and don't touch this JSON handling.