### PR TITLE
fix: minor memory service cleanups (directory creation, tokenization, timestamps)

### DIFF
--- a/services/memory/memory.py
+++ b/services/memory/memory.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def tokenize(text: str) -> List[str]:
     """Simple tokenizer that splits on whitespace and removes punctuation."""
-    return [word.strip('.,!?";') for word in text.split()]
+    return [cleaned for word in text.split() if (cleaned := word.strip('.,!?";'))]
 
 def get_text_similarity(text1: str, text2: str) -> float:
     """Calculate Jaccard similarity between two texts."""
@@ -66,7 +66,7 @@ class MemoryManager:
                             if text:
                                 memories.append({
                                     "text": text,
-                                    "timestamp": int(datetime.now().timestamp()),
+                                    "timestamp": int(time.time()),
                                     "session_id": session_id
                                 })
                     # If we see a heading that suggests memories
@@ -101,6 +101,7 @@ class MemoryManager:
     def ensure_file_exists(self):
         """Create memory file if it doesn't exist."""
         if not os.path.exists(self.memory_file):
+            os.makedirs(os.path.dirname(self.memory_file), exist_ok=True)
             with open(self.memory_file, 'w', encoding='utf-8') as f:
                 json.dump([], f, ensure_ascii=False, indent=2)
     


### PR DESCRIPTION
## Summary

This PR addresses a few minor bugs and consistency issues in `services/memory/memory.py`. It prevents `FileNotFoundError` initialisation crashes by ensuring the data directory is created before writing the fallback JSON file. It also updates the tokenizer to strip out empty strings (which previously skewed Jaccard similarity scores when isolated punctuation was parsed) and standardizes timestamp generation by using `int(time.time())` across the module.

## Linked Issue

Fixes # <!-- Add issue number here if applicable -->

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Stop the application, delete the `data` directory (or specifically `data/memory.json` and its parent if isolated), and restart the application. Verify the memory service initializes gracefully and creates the directory/file without raising a `FileNotFoundError`.
2. Inspect or debug the `tokenize(text)` method output by passing a string with isolated punctuation (e.g., `"hello . world"`). Verify the resulting list does not contain empty string elements (`""`).
3. Trigger a scenario where a memory is automatically extracted from chat history. Check the resulting `memory.json` file to ensure the `timestamp` field is correctly written as a valid integer Unix timestamp.