### PR TITLE
fix(email): guard _decode_header against unknown MIME charset

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -751,7 +751,13 @@ def _decode_header(raw):
     decoded = []
     for data, charset in parts:
         if isinstance(data, bytes):
-            decoded.append(data.decode(charset or "utf-8", errors="replace"))
+            try:
+                decoded.append(data.decode(charset or "utf-8", errors="replace"))
+            except (LookupError, ValueError):
+                # Unknown/invalid MIME charset (e.g. a malformed or spam header
+                # like =?x-unknown-charset?B?...?=). errors="replace" only covers
+                # byte-decode errors, not codec lookup, so fall back to utf-8.
+                decoded.append(data.decode("utf-8", errors="replace"))
         else:
             decoded.append(data)
     return " ".join(decoded)

--- a/tests/test_email_decode_header.py
+++ b/tests/test_email_decode_header.py
@@ -1,0 +1,51 @@
+"""Regression tests for routes.email_helpers._decode_header.
+
+A single email whose Subject/From/To/Cc header declares an unknown or invalid
+MIME charset (e.g. `=?x-unknown-charset?B?...?=`, common in spam/malformed mail)
+used to raise an uncaught LookupError, because `bytes.decode(..., errors="replace")`
+only handles byte-decode errors — not codec *lookup* failures. That crash
+propagated into the inbox list endpoint, message fetch, and the background mail
+pollers (routes/email_routes.py, routes/email_pollers.py, src/builtin_actions.py),
+so one bad message could take down the whole inbox render / poller loop.
+
+These pin the fallback so a bogus charset degrades gracefully to utf-8.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+_tmp_data = Path(tempfile.mkdtemp(prefix="odysseus_decode_hdr_"))
+os.environ.setdefault("DATA_DIR", str(_tmp_data))
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{_tmp_data / 'app.db'}")
+
+from routes.email_helpers import _decode_header
+
+
+def test_unknown_charset_does_not_raise():
+    # The regression: an unknown codec name must not raise LookupError.
+    assert _decode_header("=?x-unknown-charset?B?aGVsbG8=?=") == "hello"
+
+
+def test_invalid_charset_falls_back_to_utf8():
+    # A made-up charset on non-ASCII bytes should still produce a string.
+    raw = "=?totally-bogus?Q?caf=C3=A9?="
+    out = _decode_header(raw)
+    assert isinstance(out, str)
+    assert "caf" in out
+
+
+def test_valid_utf8_unchanged():
+    assert _decode_header("=?utf-8?B?SGVsbG8gV29ybGQ=?=") == "Hello World"
+
+
+def test_valid_iso8859_1_unchanged():
+    assert _decode_header("=?iso-8859-1?Q?caf=E9?=") == "café"
+
+
+def test_plain_ascii_passthrough():
+    assert _decode_header("Just a subject") == "Just a subject"
+
+
+def test_empty_and_none():
+    assert _decode_header("") == ""
+    assert _decode_header(None) == ""


### PR DESCRIPTION
## Summary

A header that declares an unknown or invalid MIME charset (e.g. a malformed or spam `Subject` like `=?x-unknown-charset?B?...?=`) makes `_decode_header` raise an uncaught `LookupError`.

`bytes.decode(charset, errors="replace")` only handles *byte-decode* errors — it does **not** catch a codec *lookup* failure, so the `errors="replace"` safety net never engages for a bogus charset name.

## Why it matters

`_decode_header` decodes `Subject`/`From`/`To`/`Cc` (and attachment filenames) for:
- the inbox list endpoint and single-message fetch (`routes/email_routes.py`, `routes/email_helpers.py`)
- the background mail pollers (`routes/email_pollers.py`)
- agent email actions (`src/builtin_actions.py`)

So a single malformed/spam message can crash the whole inbox render or the poller loop with `LookupError: unknown encoding: ...`.

## Fix

Wrap the per-part decode in `try/except (LookupError, ValueError)` and fall back to `utf-8` with `errors="replace"`. Valid charsets (`utf-8`, `iso-8859-1`, …) are byte-for-byte unchanged. Pure parsing change — no network/auth/self-host impact.

## Test plan

Adds `tests/test_email_decode_header.py` (follows the existing `DATA_DIR`/`DATABASE_URL` + direct-import convention used by the other email tests):

```bash
python -m pytest tests/test_email_decode_header.py -v
```

- `test_unknown_charset_does_not_raise` **fails before** this change (`LookupError`) and **passes after**.
- Existing email tests still green:

```bash
python -m pytest tests/test_email_smtp_security.py tests/test_email_owner_scope.py \
  tests/test_email_library_bulk_actions.py tests/test_email_imap_timeout.py
```

```bash
python -m py_compile routes/email_helpers.py
```

No related issue — found via code review.