### PR TITLE
fix(security): sanitize deep-research report HTML (stored XSS via scraped content)

### DIFF
--- a/src/visual_report.py
+++ b/src/visual_report.py
@@ -45,8 +45,89 @@ def _autolink_urls(md_text: str) -> str:
     )
 
 
+# Tags/attrs kept when sanitizing the rendered report body. The body is the
+# LLM's synthesis of SCRAPED third-party pages — untrusted — and Python-Markdown
+# (with the "extra" extension) passes raw inline HTML through verbatim, so an
+# attacker-controlled source page can otherwise inject <script>/onerror into the
+# report, which is served with a permissive inline-script CSP. Allowlist: keep
+# formatting, drop everything active.
+_SAFE_TAGS = frozenset({
+    "p", "br", "hr", "div", "span", "blockquote", "pre", "code", "kbd", "samp",
+    "var", "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd",
+    "strong", "b", "em", "i", "u", "s", "strike", "del", "ins", "mark", "sub",
+    "sup", "small", "abbr", "cite", "q", "dfn", "time", "wbr",
+    "a", "img", "figure", "figcaption",
+    "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption",
+    "colgroup", "col",
+})
+# Active/embedding tags removed WITH their contents (not just unwrapped).
+_DROP_TAGS = frozenset({
+    "script", "style", "iframe", "object", "embed", "form", "input", "button",
+    "textarea", "select", "option", "svg", "math", "link", "meta", "base",
+    "noscript", "template", "frame", "frameset", "applet", "audio", "video",
+})
+_TAG_ATTRS = {
+    "a": {"href", "title", "target", "rel"},
+    "img": {"src", "alt", "title", "width", "height"},
+    "td": {"colspan", "rowspan", "align"},
+    "th": {"colspan", "rowspan", "align", "scope"},
+    "ol": {"start", "type"},
+    "time": {"datetime"},
+}
+_GLOBAL_ATTRS = frozenset({"id", "class"})
+_SAFE_URL_SCHEMES = frozenset({"http", "https", "mailto"})
+
+
+def _safe_url(url: Optional[str], *, allow_data_image: bool = False) -> bool:
+    """True if `url` is safe to keep in an href/src — blocks javascript:,
+    data:text/html, vbscript:, etc. Allows in-page/relative links and (for
+    images only) data:image/."""
+    u = (url or "").strip()
+    if not u:
+        return False
+    low = u.lower()
+    if low.startswith(("#", "/", "./", "../")):
+        return True
+    if allow_data_image and low.startswith("data:image/"):
+        return True
+    try:
+        scheme = urlparse(u).scheme.lower()
+    except ValueError:
+        return False
+    if not scheme:
+        return True  # schemeless relative path
+    return scheme in _SAFE_URL_SCHEMES
+
+
+def _sanitize_html(html_str: str) -> str:
+    """Allowlist-sanitize rendered-markdown HTML: drop active tags, strip every
+    event-handler/style/unknown attribute, and reject unsafe href/src schemes."""
+    soup = BeautifulSoup(html_str or "", "html.parser")
+    for el in list(soup.find_all(True)):
+        if el.parent is None:  # already removed as part of a dropped ancestor
+            continue
+        name = (el.name or "").lower()
+        if name in _DROP_TAGS:
+            el.decompose()
+            continue
+        if name not in _SAFE_TAGS:
+            el.unwrap()  # unknown tag: keep its text, drop the tag
+            continue
+        allowed = _TAG_ATTRS.get(name, set()) | _GLOBAL_ATTRS
+        for attr in list(el.attrs.keys()):
+            la = attr.lower()
+            if la not in allowed:
+                del el[attr]  # strips on*, style, srcset, etc.
+            elif la in ("href", "src") and not _safe_url(
+                el.get(attr), allow_data_image=(name == "img")
+            ):
+                del el[attr]
+    return str(soup)
+
+
 def _md_to_html(md_text: str) -> str:
-    """Convert markdown to HTML with common extensions."""
+    """Convert markdown to HTML with common extensions (sanitized — the body is
+    untrusted scraped/LLM content)."""
     md_text = _autolink_urls(md_text)
     result = markdown.markdown(
         md_text,
@@ -62,7 +143,7 @@ def _md_to_html(md_text: str) -> str:
         r'<a target="_blank" rel="noopener noreferrer" href="\1',
         result,
     )
-    return result
+    return _sanitize_html(result)
 
 
 def _extract_headings(md_text: str) -> List[Dict[str, str]]:

--- a/tests/test_visual_report_sanitize.py
+++ b/tests/test_visual_report_sanitize.py
@@ -1,0 +1,76 @@
+"""Stored-XSS regression for deep-research report rendering.
+
+The report body is the LLM's synthesis of SCRAPED third-party pages (untrusted)
+and is interpolated unescaped into a page served with an inline-script CSP.
+Python-Markdown's "extra" extension passes raw inline HTML through verbatim, so
+without sanitization an attacker-controlled source page could land
+<script>/onerror into a victim's report (executes same-origin with their
+session cookie). `_md_to_html` must allowlist-sanitize its output.
+"""
+
+from src.visual_report import _md_to_html, _sanitize_html, _safe_url
+
+
+def test_script_tag_is_removed_with_contents():
+    out = _md_to_html("<script>alert('xss')</script>")
+    assert "<script" not in out.lower()
+    assert "alert('xss')" not in out  # decomposed, not just unwrapped
+
+
+def test_inline_event_handler_attribute_stripped():
+    out = _md_to_html('<img src="x" onerror="alert(1)">')
+    assert "onerror" not in out.lower()
+    assert "<img" in out.lower()  # the image itself is kept
+
+
+def test_javascript_url_scheme_stripped():
+    out = _md_to_html('<a href="javascript:alert(1)">click</a>')
+    assert "javascript:" not in out.lower()
+    assert "click" in out  # link text preserved
+
+
+def test_svg_script_payload_removed():
+    out = _md_to_html("<svg><script>alert(1)</script></svg>")
+    assert "alert(1)" not in out
+    assert "<svg" not in out.lower()
+
+
+def test_onclick_on_generic_element_stripped_but_text_kept():
+    out = _md_to_html('<div onclick="evil()">hello</div>')
+    assert "onclick" not in out.lower()
+    assert "evil()" not in out
+    assert "hello" in out
+
+
+def test_inline_style_attribute_stripped():
+    out = _md_to_html('<p style="x:expression(alert(1))">hi</p>')
+    assert "style=" not in out.lower()
+    assert "hi" in out
+
+
+# --- must NOT break legitimate formatting ----------------------------------
+
+def test_safe_markdown_formatting_preserved():
+    out = _md_to_html("**bold** and `code` and [link](https://example.com)")
+    assert "<strong>bold</strong>" in out
+    assert "<code>code</code>" in out
+    assert 'href="https://example.com"' in out
+    assert 'target="_blank"' in out  # external-link rewrite still applied
+
+
+def test_relative_and_fragment_links_kept():
+    assert _safe_url("#section") is True
+    assert _safe_url("/local/path") is True
+    assert _safe_url("https://example.com") is True
+    assert _safe_url("mailto:a@b.com") is True
+    assert _safe_url("javascript:alert(1)") is False
+    assert _safe_url("data:text/html,<script>") is False
+    assert _safe_url("data:image/png;base64,AAAA", allow_data_image=True) is True
+    assert _safe_url("data:image/png;base64,AAAA", allow_data_image=False) is False
+
+
+def test_data_image_kept_on_img_but_html_data_uri_dropped():
+    keep = _sanitize_html('<img src="data:image/png;base64,AAAA">')
+    assert "data:image/png" in keep
+    drop = _sanitize_html('<a href="data:text/html,<b>x">y</a>')
+    assert "data:text/html" not in drop


### PR DESCRIPTION
## Summary

The deep-research visual report body is rendered by `_md_to_html` (`src/visual_report.py`):

```python
result = markdown.markdown(md_text, extensions=["extra", "codehilite", ...])  # raw HTML passes through
...
return result   # interpolated UNESCAPED as {report_html} into the report page
```

`{report_html}` is injected **unescaped** into a page served with a permissive **`script-src 'self' 'unsafe-inline'`** CSP (the report's own toolbar needs inline script — see `core/middleware.py` `is_report` branch). Python-Markdown's `extra` extension passes raw inline HTML through verbatim.

The report markdown is the LLM's synthesis of the **third-party pages the research agent scrapes**. So an attacker who controls a page the agent visits — plus light prompt-injection to get it quoted verbatim — can land `<script>` / `<img onerror>` that **executes same-origin with the viewing user's session cookie**. The report is opened as a top-level same-origin document (`window.open('/api/research/report/{id}')`), reachable by any research-capable user; if the viewer is an admin it can mint an `ody_` token, read `/api/documents`/`/api/memory`, etc. **Stored XSS** (persisted in the research JSON, fires on later view).

## Fix

Allowlist-sanitize the rendered body at the single chokepoint (`_md_to_html`) using the **already-imported `BeautifulSoup`** — no new dependency, no CSP/middleware change:

- **Drop** active/embedding tags with their contents: `script`, `style`, `iframe`, `object`, `embed`, `svg`, `math`, `form`, `link`, `meta`, `base`, …
- **Strip** every event-handler / `style` / unknown attribute (keeps only a per-tag allowlist + `id`/`class`).
- **Reject** unsafe `href`/`src` schemes (`javascript:`, `data:text/html`, `vbscript:`) while allowing `http(s)`/`mailto`, in-page/relative links, and `data:image/` **only on `<img>`**.

The report page's own toolbar `<script>` is a separate template literal — unaffected. Legitimate markdown (headings, lists, code, tables, external links with `target="_blank"`) is preserved.

## Tests

New `tests/test_visual_report_sanitize.py`: `<script>`, `onerror`, `onclick`, inline `style`, `<svg><script>`, and `javascript:`/`data:text/html` URLs are removed; safe formatting and relative/fragment/`data:image` links survive. Existing `tests/test_visual_report.py` still passes.

```
$ pytest tests/test_visual_report.py tests/test_visual_report_sanitize.py -q
10 passed
```


## Linked Issue

Fixes #2257

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. (Verified via the deterministic regression tests below / red→green; manual repro included for a reviewer.)

## How to Test

1. `pytest tests/test_visual_report.py tests/test_visual_report_sanitize.py -q` → 10 passed.
2. Produce a research report whose markdown contains `<script>alert(1)</script>` and `<img src=x onerror=alert(1)>`, then open `/api/research/report/{id}`. **Before:** the script executes same-origin. **After:** active tags/handlers are stripped; headings/lists/code/links still render.

_No UI/visual changes — backend route(s) + tests only._
