### PR TITLE
fix: clear composer when starting a new chat

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -669,6 +669,9 @@ function initializeEventListeners() {
     if (modeToggle && modeToggle.checked) { modeToggle.checked = false; modeToggle.dispatchEvent(new Event('change')); }
     // Clear character/persona
     if (presetsModule && presetsModule.deactivateCharacter) presetsModule.deactivateCharacter();
+    // Clear the composer so stale draft text doesn't carry over to the new chat.
+    const _msgInput = el('message');
+    if (_msgInput) { _msgInput.value = ''; if (uiModule && uiModule.autoResize) uiModule.autoResize(_msgInput); }
   }
 
   /** Sync Research indicator button + overflow + tool sidebar active state. */
@@ -3059,6 +3062,8 @@ function initializeEventListeners() {
       if (chatModule && chatModule.showWelcomeScreen) {
         chatModule.showWelcomeScreen();
       }
+      const _msgInputNoModel = el('message');
+      if (_msgInputNoModel) { _msgInputNoModel.value = ''; if (uiModule && uiModule.autoResize) uiModule.autoResize(_msgInputNoModel); }
       document.querySelectorAll('.session-item.active').forEach(s => s.classList.remove('active'));
     });
   }


### PR DESCRIPTION
## Summary
  
  Typing something in the chat input and then clicking "New Chat" in the sidebar left the draft text visible in the next
  session. `_startFreshChat()` correctly reset the chat history, panels, and character state — but never touched the
  textarea. The no-model fallback path inside the `rail-new-session` click handler had the same gap. Added
  `msgInput.value = ''` + `autoResize()` to both paths so the composer is always empty when a new chat starts.

  ## Linked Issue

  Closes #1343

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)
  
  ## Checklist
  
  - [x] I searched open issues and open PRs — this is not a duplicate.
  - [x] This PR targets `main` 
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

  ## How to Test
  
  1. Type something in the chat input field (do not press Enter).
  2. Click "New Chat" in the left sidebar.
  3. The input field should be empty immediately after.
  4. Repeat using the mobile "New Chat" button — same result expected.
  5. Confirm that starting a chat normally still works.