### PR TITLE
fix(cookbook): increase download error toast duration to 9s

### DIFF
--- a/static/js/cookbookDownload.js
+++ b/static/js/cookbookDownload.js
@@ -560,7 +560,7 @@ export async function _runModelDownload(panel, model, backend, hostOverride) {
     }
     const data = await res.json();
     if (!data.ok) {
-      uiModule.showToast('Download failed: ' + (data.error || ''));
+      uiModule.showToast('Download failed: ' + (data.error || ''), 9000);
       return;
     }
     _addTask(data.session_id, shortName, 'download', payload);


### PR DESCRIPTION
## Summary
The download error toast in Cookbook used the default 1200ms duration, so messages like "tmux is required" vanished before users could read them. The serve path already used 9000ms explicitly. This aligns the download error path to 9000ms for consistency.
## Linked Issue
Fixes #1355
## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
## How to Test
1. Open Cookbook on a system without `tmux` installed (or temporarily rename the tmux binary)
2. Click Download on any model
3. Observe the error toast "tmux is required..." stays visible for ~9 seconds instead of flashing briefly