### PR TITLE
Add update status and release artifact workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,177 @@
+name: Release artifacts
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  linux:
+    name: Linux bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+
+      - name: Build Linux artifact
+        run: |
+          set -euo pipefail
+          version="$(python -c 'from core.constants import APP_VERSION; print(APP_VERSION)')"
+          short_sha="${GITHUB_SHA::7}"
+          python -m PyInstaller --noconfirm --clean --onedir --name odysseus \
+            --add-data "static:static" \
+            --add-data "scripts:scripts" \
+            --add-data "mcp_servers:mcp_servers" \
+            --add-data "services/hwfit/data:services/hwfit/data" \
+            --add-data "config:config" \
+            scripts/release_launcher.py
+          mkdir -p artifacts
+          tar -czf "artifacts/odysseus-linux-${version}-${short_sha}.tar.gz" -C dist odysseus
+          (cd artifacts && sha256sum *.tar.gz > SHA256SUMS)
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: odysseus-linux-${{ github.sha }}
+          path: artifacts/
+
+  macos:
+    name: macOS DMG
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+
+      - name: Build macOS artifact
+        run: |
+          set -euo pipefail
+          version="$(python -c 'from core.constants import APP_VERSION; print(APP_VERSION)')"
+          short_sha="${GITHUB_SHA::7}"
+          python -m PyInstaller --noconfirm --clean --onedir --windowed --name Odysseus \
+            --add-data "static:static" \
+            --add-data "scripts:scripts" \
+            --add-data "mcp_servers:mcp_servers" \
+            --add-data "services/hwfit/data:services/hwfit/data" \
+            --add-data "config:config" \
+            scripts/release_launcher.py
+          mkdir -p artifacts
+          hdiutil create \
+            -volname Odysseus \
+            -srcfolder dist/Odysseus.app \
+            -ov \
+            -format UDZO \
+            "artifacts/odysseus-macos-${version}-${short_sha}.dmg"
+          (cd artifacts && shasum -a 256 *.dmg > SHA256SUMS)
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: odysseus-macos-${{ github.sha }}
+          path: artifacts/
+
+  windows:
+    name: Windows EXE bundle
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pyinstaller
+
+      - name: Build Windows artifact
+        shell: pwsh
+        run: |
+          $version = python -c "from core.constants import APP_VERSION; print(APP_VERSION)"
+          $shortSha = $env:GITHUB_SHA.Substring(0, 7)
+          python -m PyInstaller --noconfirm --clean --onedir --name Odysseus `
+            --add-data "static;static" `
+            --add-data "scripts;scripts" `
+            --add-data "mcp_servers;mcp_servers" `
+            --add-data "services/hwfit/data;services/hwfit/data" `
+            --add-data "config;config" `
+            scripts/release_launcher.py
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          $zip = "artifacts\odysseus-windows-$version-$shortSha.zip"
+          Compress-Archive -Path "dist\Odysseus" -DestinationPath $zip -Force
+          Get-FileHash $zip -Algorithm SHA256 |
+            ForEach-Object { "$($_.Hash.ToLower())  $(Split-Path $_.Path -Leaf)" } |
+            Set-Content -Encoding utf8 "artifacts\SHA256SUMS"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: odysseus-windows-${{ github.sha }}
+          path: artifacts/
+
+  publish:
+    name: Publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs:
+      - linux
+      - macos
+      - windows
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: odysseus-*
+          path: release-artifacts
+
+      - name: Prepare release files
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find release-artifacts -type f ! -name SHA256SUMS -exec cp {} release/ \;
+          (cd release && sha256sum * > SHA256SUMS)
+          cat > RELEASE_NOTES.md <<'EOF'
+          These are unsigned release artifacts built from the tagged commit.
+
+          Included:
+          - Windows: zipped onedir bundle containing Odysseus.exe
+          - macOS: DMG built on the macOS runner
+          - Linux: tar.gz onedir bundle
+
+          SHA256SUMS is included for integrity checks.
+          EOF
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" release/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Odysseus ${GITHUB_REF_NAME}" \
+            --notes-file RELEASE_NOTES.md

--- a/app.py
+++ b/app.py
@@ -535,6 +535,10 @@ app.include_router(setup_session_routes(session_manager, session_config, webhook
 from routes.admin_wipe_routes import setup_admin_wipe_routes
 app.include_router(setup_admin_wipe_routes(session_manager))
 
+# Check-only software update status (Settings → System)
+from routes.update_routes import setup_update_routes
+app.include_router(setup_update_routes())
+
 # Memory
 from routes.memory_routes import setup_memory_routes
 app.include_router(setup_memory_routes(memory_manager, session_manager, memory_vector=memory_vector))

--- a/routes/update_routes.py
+++ b/routes/update_routes.py
@@ -1,0 +1,229 @@
+"""Check-only software update status routes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+from fastapi import APIRouter, Request
+
+from core.constants import APP_VERSION, BASE_DIR
+from core.middleware import require_admin
+
+
+GIT_TIMEOUT_SECONDS = 2.5
+
+_MODE_COMMANDS = {
+    "source_docker": [
+        "git pull --ff-only",
+        "docker compose up -d --build",
+    ],
+    "source_native": [
+        "git pull --ff-only",
+        "python -m pip install -r requirements.txt",
+        "python setup.py",
+    ],
+}
+
+
+def _scrub_remote_url(remote_url: str | None) -> str | None:
+    if not remote_url:
+        return None
+    remote_url = remote_url.strip()
+    if "://" not in remote_url:
+        return remote_url
+    parsed = urlparse(remote_url)
+    if not (parsed.username or parsed.password):
+        return remote_url
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _remote_url_allowed(remote_url: str | None) -> bool:
+    if not remote_url:
+        return False
+    value = remote_url.strip()
+    if not value:
+        return False
+    if "://" in value:
+        return urlparse(value).scheme.lower() in {"https", "http", "ssh", "git"}
+    return "@" in value and ":" in value and not value.startswith(("/", "."))
+
+
+def _run_git(repo_dir: str, args: list[str], timeout: float = GIT_TIMEOUT_SECONDS) -> dict[str, Any]:
+    try:
+        env = os.environ.copy()
+        env["GIT_TERMINAL_PROMPT"] = "0"
+        env.setdefault("GIT_SSH_COMMAND", "ssh -oBatchMode=yes")
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+            env=env,
+        )
+        return {
+            "ok": True,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except FileNotFoundError as exc:
+        return {"ok": False, "error": "git_missing", "details": str(exc)}
+    except subprocess.TimeoutExpired as exc:
+        return {"ok": False, "error": "timeout", "details": str(exc)}
+    except Exception as exc:  # pragma: no cover - defensive guard.
+        return {"ok": False, "error": "unexpected", "details": str(exc)}
+
+
+def _git_output(repo_dir: str, args: list[str], state: dict[str, Any], timeout_tag: str) -> str | None:
+    result = _run_git(repo_dir, args)
+    if not result.get("ok"):
+        if result.get("error") == "timeout":
+            state["git"]["timeouts"].append(timeout_tag)
+        else:
+            state["git"]["errors"].append(f"git {' '.join(args)} failed")
+        return None
+    if result.get("returncode") != 0:
+        return None
+    return (result.get("stdout") or "").strip()
+
+
+def _parse_ahead_behind(raw: str | None) -> tuple[int | None, int | None]:
+    if not raw:
+        return None, None
+    parts = raw.split()
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        return None, None
+    return int(parts[0]), int(parts[1])
+
+
+def _detect_install_mode(repo_dir: str, git_available: bool) -> str:
+    if git_available and os.path.exists(os.path.join(repo_dir, "docker-compose.yml")):
+        return "source_docker"
+    return "source_native"
+
+
+def collect_update_status(repo_dir: str | None = None) -> dict[str, Any]:
+    repo_dir = os.path.abspath(repo_dir or BASE_DIR)
+    state: dict[str, Any] = {
+        "version": APP_VERSION,
+        "git": {
+            "available": False,
+            "commit": None,
+            "short_commit": None,
+            "branch": None,
+            "detached_head": False,
+            "dirty": None,
+            "remote": None,
+            "remote_branch": None,
+            "remote_url": None,
+            "remote_commit": None,
+            "ahead": None,
+            "behind": None,
+            "warnings": [],
+            "errors": [],
+            "timeouts": [],
+        },
+        "update": {
+            "checkable": False,
+            "available": False,
+            "reason": None,
+        },
+        "install": {
+            "mode": None,
+            "manual_commands": [],
+            "apply_supported": False,
+        },
+    }
+
+    toplevel = _git_output(repo_dir, ["rev-parse", "--show-toplevel"], state, "rev-parse")
+    if not toplevel:
+        state["git"]["errors"].append("Repository metadata is unavailable.")
+        state["install"]["mode"] = _detect_install_mode(repo_dir, False)
+        state["install"]["manual_commands"] = _MODE_COMMANDS[state["install"]["mode"]]
+        state["update"]["reason"] = "not_a_git_checkout"
+        return state
+
+    repo_dir = os.path.abspath(toplevel)
+    state["git"]["available"] = True
+
+    commit = _git_output(repo_dir, ["rev-parse", "HEAD"], state, "rev-parse HEAD")
+    if commit:
+        state["git"]["commit"] = commit
+        state["git"]["short_commit"] = commit[:12]
+
+    branch = _git_output(repo_dir, ["rev-parse", "--abbrev-ref", "HEAD"], state, "rev-parse branch")
+    if branch:
+        state["git"]["branch"] = branch
+        state["git"]["detached_head"] = branch == "HEAD"
+
+    status = _git_output(repo_dir, ["status", "--porcelain"], state, "status")
+    if status is not None:
+        state["git"]["dirty"] = bool(status.strip())
+
+    if state["git"]["detached_head"]:
+        state["git"]["warnings"].append("Detached HEAD; branch update checks are not available.")
+    elif branch:
+        remote = _git_output(repo_dir, ["config", "--get", f"branch.{branch}.remote"], state, "branch remote")
+        merge_ref = _git_output(repo_dir, ["config", "--get", f"branch.{branch}.merge"], state, "branch merge")
+        remote_branch = None
+        if merge_ref and merge_ref.startswith("refs/heads/"):
+            remote_branch = merge_ref.replace("refs/heads/", "", 1)
+        if remote and remote_branch:
+            state["git"]["remote"] = remote
+            state["git"]["remote_branch"] = remote_branch
+            remote_url = _git_output(repo_dir, ["config", "--get", f"remote.{remote}.url"], state, "remote url")
+            state["git"]["remote_url"] = _scrub_remote_url(remote_url)
+            if remote_url and _remote_url_allowed(remote_url):
+                remote_head = _git_output(
+                    repo_dir,
+                    ["ls-remote", "--heads", remote, remote_branch],
+                    state,
+                    "ls-remote",
+                )
+                if remote_head:
+                    state["git"]["remote_commit"] = remote_head.split()[0]
+                    state["update"]["checkable"] = True
+                    state["update"]["available"] = state["git"]["remote_commit"] != state["git"]["commit"]
+                    if state["update"]["available"]:
+                        state["update"]["reason"] = "remote_head_changed"
+                ahead_behind = _git_output(
+                    repo_dir,
+                    ["rev-list", "--left-right", "--count", "HEAD...@{u}"],
+                    state,
+                    "rev-list",
+                )
+                ahead, behind = _parse_ahead_behind(ahead_behind)
+                state["git"]["ahead"] = ahead
+                state["git"]["behind"] = behind
+            elif remote_url:
+                state["git"]["warnings"].append("Remote URL is not supported for update checks.")
+        else:
+            state["git"]["warnings"].append("No upstream tracking branch configured.")
+
+    if state["git"]["dirty"]:
+        state["git"]["warnings"].append("Working tree has uncommitted changes.")
+
+    state["install"]["mode"] = _detect_install_mode(repo_dir, True)
+    state["install"]["manual_commands"] = _MODE_COMMANDS[state["install"]["mode"]]
+    if state["update"]["checkable"] and not state["update"]["reason"]:
+        state["update"]["reason"] = "up_to_date"
+    return state
+
+
+def setup_update_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+    @router.get("/update/status")
+    def get_update_status(request: Request) -> dict[str, Any]:
+        require_admin(request)
+        return collect_update_status()
+
+    return router

--- a/scripts/release_launcher.py
+++ b/scripts/release_launcher.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Release bundle entrypoint.
+
+The normal source install starts Odysseus with `uvicorn app:app`. PyInstaller
+needs an executable entrypoint, so release artifacts package this small launcher
+instead of `app.py` directly.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import urllib.request
+import webbrowser
+
+import uvicorn
+
+
+def _open_when_ready(url: str) -> None:
+    for _ in range(90):
+        try:
+            with urllib.request.urlopen(url, timeout=1.5):  # noqa: S310 - local URL built below
+                webbrowser.open(url)
+                return
+        except Exception:
+            time.sleep(1)
+
+
+def main() -> None:
+    host = os.getenv("ODYSSEUS_HOST", "127.0.0.1")
+    port = int(os.getenv("ODYSSEUS_PORT", "7860"))
+    url = f"http://{host}:{port}"
+    if os.getenv("ODYSSEUS_OPEN_BROWSER", "1").lower() not in {"0", "false", "no", "off"}:
+        threading.Thread(target=_open_when_ready, args=(url,), daemon=True).start()
+    uvicorn.run("app:app", host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/static/index.html
+++ b/static/index.html
@@ -2138,6 +2138,16 @@
         <div data-settings-panel="system" class="hidden">
 
           <div class="admin-card">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><polyline points="21 3 21 9 15 9"/></svg>Software Update</h2>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Check whether this checkout is behind its configured Git remote. This only checks status; it does not run update commands.</div>
+            <div class="settings-row" style="align-items:center;">
+              <button class="admin-btn-add" id="adm-updateCheckBtn">Check for Updates</button>
+              <span id="adm-updateSummary" style="font-size:11px;margin-left:8px;"></span>
+            </div>
+            <div id="adm-updateDetails" class="admin-toggle-sub" style="margin-top:8px;"></div>
+          </div>
+
+          <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>Data Backup</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">Export or import your user data (memories, presets, settings, skills, preferences) as a JSON file.</div>
             <div style="display:flex;gap:8px;flex-wrap:wrap;">

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2004,6 +2004,70 @@ function initBackup() {
   });
 }
 
+/* ── Software Update ── */
+function _renderUpdateDetails(data) {
+  const git = data.git || {};
+  const install = data.install || {};
+  const update = data.update || {};
+  const bits = [];
+  if (git.branch) bits.push(`Branch: ${esc(git.branch)}`);
+  if (git.short_commit) bits.push(`Current: ${esc(git.short_commit)}`);
+  if (git.remote && git.remote_branch) bits.push(`Remote: ${esc(git.remote)}/${esc(git.remote_branch)}`);
+  if (git.remote_commit) bits.push(`Remote commit: ${esc(String(git.remote_commit).slice(0, 12))}`);
+  if (typeof git.behind === 'number' || typeof git.ahead === 'number') {
+    bits.push(`Ahead/behind: ${Number(git.ahead || 0)}/${Number(git.behind || 0)}`);
+  }
+  if (git.dirty) bits.push('Uncommitted changes present');
+  if (update.reason && update.reason !== 'up_to_date') bits.push(`Reason: ${esc(update.reason)}`);
+
+  const warnings = Array.isArray(git.warnings) ? git.warnings : [];
+  const errors = Array.isArray(git.errors) ? git.errors : [];
+  const commands = Array.isArray(install.manual_commands) ? install.manual_commands : [];
+  const commandHtml = commands.length
+    ? `<div style="margin-top:6px;opacity:0.8">Manual update path:</div><pre style="white-space:pre-wrap;margin:4px 0 0;font-size:11px;">${esc(commands.join('\n'))}</pre>`
+    : '';
+  const warnHtml = warnings.length || errors.length
+    ? `<div style="margin-top:6px;color:var(--red);">${esc([...warnings, ...errors].join(' '))}</div>`
+    : '';
+  return `${bits.map(x => `<div>${x}</div>`).join('')}${commandHtml}${warnHtml}`;
+}
+
+function initUpdateStatus() {
+  const btn = el('adm-updateCheckBtn');
+  const summary = el('adm-updateSummary');
+  const details = el('adm-updateDetails');
+  if (!btn || !summary || !details) return;
+  btn.addEventListener('click', async () => {
+    const prev = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Checking...';
+    summary.textContent = '';
+    summary.className = '';
+    details.innerHTML = '';
+    try {
+      const res = await fetch('/api/admin/update/status', { credentials: 'same-origin' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.detail || 'Update check failed');
+      if (data.update && data.update.available) {
+        summary.textContent = 'Update available';
+        summary.className = 'admin-success';
+      } else if (data.update && data.update.checkable) {
+        summary.textContent = 'Up to date';
+        summary.className = 'admin-success';
+      } else {
+        summary.textContent = 'Could not check remote';
+        summary.className = 'admin-error';
+      }
+      details.innerHTML = _renderUpdateDetails(data);
+    } catch (e) {
+      summary.textContent = e.message || 'Update check failed';
+      summary.className = 'admin-error';
+    }
+    btn.disabled = false;
+    btn.textContent = prev;
+  });
+}
+
 /* ── Danger Zone ── */
 function initDangerZone() {
   // Per-category Danger Zone wipes. Each button declares its target
@@ -2044,7 +2108,7 @@ function initDangerZone() {
    ═══════════════════════════════════════════ */
 function initAll() {
   modalEl = el('settings-modal');
-  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
+  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initUpdateStatus, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
   for (const fn of inits) {
     try { fn(); } catch (e) { console.error('Admin init error in', fn.name || 'anonymous', e); }
   }

--- a/tests/test_release_artifacts_workflow.py
+++ b/tests/test_release_artifacts_workflow.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_artifacts_workflow_builds_three_platforms():
+    workflow = (ROOT / ".github/workflows/release-artifacts.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "tags:" in workflow
+    assert "ubuntu-latest" in workflow
+    assert "macos-latest" in workflow
+    assert "windows-latest" in workflow
+    assert "PyInstaller" in workflow
+    assert "scripts/release_launcher.py" in workflow
+    assert "hdiutil create" in workflow
+    assert "Compress-Archive" in workflow
+    assert "tar -czf" in workflow
+    assert "SHA256SUMS" in workflow
+    assert "gh release create" in workflow

--- a/tests/test_update_routes.py
+++ b/tests/test_update_routes.py
@@ -1,0 +1,115 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import routes.update_routes as update_routes
+
+
+def _admin_request(is_admin=True):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user="alice"),
+        headers={},
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=SimpleNamespace(
+                    is_configured=True,
+                    is_admin=lambda _user: is_admin,
+                )
+            )
+        ),
+    )
+
+
+def _route_endpoint():
+    router = update_routes.setup_update_routes()
+    for route in router.routes:
+        if route.path == "/api/admin/update/status":
+            return route.endpoint
+    raise AssertionError("update status route missing")
+
+
+def _fake_git(commands):
+    def run(_repo_dir, args, timeout=2.5):
+        result = commands.get(" ".join(args))
+        if result is None:
+            return {"ok": False, "error": "missing_stub", "details": " ".join(args)}
+        return result
+
+    return run
+
+
+def _ok(stdout=""):
+    return {"ok": True, "returncode": 0, "stdout": stdout, "stderr": ""}
+
+
+def test_update_status_requires_admin():
+    endpoint = _route_endpoint()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(endpoint(request=_admin_request(is_admin=False)))
+    assert exc.value.status_code == 403
+
+
+def test_collect_update_status_reports_remote_change(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    local = "a" * 40
+    remote = "b" * 40
+    monkeypatch.setattr(
+        update_routes,
+        "_run_git",
+        _fake_git(
+            {
+                "rev-parse --show-toplevel": _ok(str(tmp_path)),
+                "rev-parse HEAD": _ok(local),
+                "rev-parse --abbrev-ref HEAD": _ok("main"),
+                "status --porcelain": _ok(""),
+                "config --get branch.main.remote": _ok("origin"),
+                "config --get branch.main.merge": _ok("refs/heads/main"),
+                "config --get remote.origin.url": _ok("https://user:secret@example.com/repo.git"),
+                "ls-remote --heads origin main": _ok(f"{remote}\trefs/heads/main"),
+                "rev-list --left-right --count HEAD...@{u}": _ok("0\t1"),
+            }
+        ),
+    )
+
+    status = update_routes.collect_update_status(str(tmp_path))
+
+    assert status["version"]
+    assert status["git"]["available"] is True
+    assert status["git"]["short_commit"] == local[:12]
+    assert status["git"]["remote_commit"] == remote
+    assert status["git"]["remote_url"] == "https://example.com/repo.git"
+    assert status["git"]["ahead"] == 0
+    assert status["git"]["behind"] == 1
+    assert status["update"]["checkable"] is True
+    assert status["update"]["available"] is True
+    assert status["install"]["mode"] == "source_docker"
+    assert "docker compose up -d --build" in status["install"]["manual_commands"]
+
+
+def test_collect_update_status_handles_missing_git(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        update_routes,
+        "_run_git",
+        lambda *_args, **_kwargs: {"ok": False, "error": "git_missing", "details": "git missing"},
+    )
+
+    status = update_routes.collect_update_status(str(tmp_path))
+
+    assert status["git"]["available"] is False
+    assert status["update"]["checkable"] is False
+    assert status["update"]["available"] is False
+    assert status["update"]["reason"] == "not_a_git_checkout"
+    assert status["install"]["mode"] == "source_native"
+
+
+def test_remote_url_policy_and_scrubbing():
+    assert update_routes._remote_url_allowed("https://github.com/a/b.git") is True
+    assert update_routes._remote_url_allowed("git@github.com:a/b.git") is True
+    assert update_routes._remote_url_allowed("file:///tmp/repo.git") is False
+    assert update_routes._remote_url_allowed("/tmp/repo.git") is False
+    assert (
+        update_routes._scrub_remote_url("https://alice:token@example.com/a/b.git")
+        == "https://example.com/a/b.git"
+    )


### PR DESCRIPTION
Part of #318 and #261.

This is a smaller first slice of the updater/release work. It does not try to land the full desktop updater surface.

Problem:
- main does not have a supported update-status surface or release artifact workflow
- existing updater/desktop PRs are broad and hard to review together

What changed:
- adds an admin-only, check-only `/api/admin/update/status` endpoint
- adds a Settings > System software update card that reports local/remote Git state and manual update commands
- adds a small release launcher entrypoint for packaged artifacts
- adds a tag/manual GitHub Actions workflow for unsigned Linux, macOS, and Windows artifacts plus SHA256 sums

Kept out of scope:
- no automatic update execution
- no `git pull` / apply endpoint
- no signing or notarization claims
- no tray, autostart, global hotkeys, or desktop shell features

Why this is low-risk:
- the endpoint is admin-only and check-only
- it reports Git status but does not run update commands
- automatic update execution, signing, and desktop shell behavior stay out of scope

Checks passed:
- `./venv/bin/python -m pytest -q tests/test_release_artifacts_workflow.py tests/test_update_routes.py`
- `./venv/bin/python -m py_compile app.py routes/update_routes.py scripts/release_launcher.py tests/test_release_artifacts_workflow.py tests/test_update_routes.py`
- `node --check static/js/admin.js`
- `git diff --check origin/main...HEAD`

### App / visual check

Ran the app locally on this branch:

`AUTH_ENABLED=false LOCALHOST_BYPASS=true APP_PORT=7010 ODYSSEUS_INPROCESS_POLLERS=0 ODYSSEUS_INPROCESS_TASKS=0 ./venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port 7010`

Viewed Settings > System in Safari using the local admin test session. The update card rendered with the existing Settings/admin-card styling, and the check-only request returned source-install status for the current branch.

![Settings update visual check](https://github.com/redpersongpt/odysseus/releases/download/pr-screenshots-2026-06-03-visual-policy/pr-1368-update-card.png)
