### PR TITLE
fix: RAG add_directory indexes but never tracks the directory

### DIFF
--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -112,6 +112,15 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         try:
             result = _rag_manager.index_personal_documents(directory)
             indexed = result.get("indexed_count", 0) if isinstance(result, dict) else 0
+            # Record the directory so `list` and `remove_directory` can see it.
+            # Indexing was just done above, so pass index=False to avoid a second
+            # (ownerless) pass. Without this the directory was indexed but never
+            # tracked in indexed_directories, so it was invisible/unremovable.
+            if _personal_docs_manager and hasattr(_personal_docs_manager, "add_directory"):
+                try:
+                    _personal_docs_manager.add_directory(directory, index=False)
+                except Exception:
+                    pass
             return [TextContent(type="text", text=f"Directory '{directory}' added to RAG index ({indexed} chunks indexed)")]
         except Exception as e:
             return [TextContent(type="text", text=f"Error: Failed to index directory: {e}")]


### PR DESCRIPTION
## Summary

The MCP RAG server's `add_directory` indexes a folder via `_rag_manager.index_personal_documents(directory)` but never registers it with `PersonalDocsManager`. Tracking (the `indexed_directories` list that backs `list` and `remove_directory`) only happens inside `PersonalDocsManager.add_directory`, which this path doesn't call.

Result: a directory added through the tool is indexed but invisible to `manage_rag list`, and `remove_directory` can't find it to remove it.

Fix: after indexing, also call `_personal_docs_manager.add_directory(directory, index=False)` to record it (the `index=False` avoids a second indexing pass).

## Changes
- `mcp_servers/rag_server.py`: track the directory in `add_directory`.