### PR TITLE
fix(agent): coerce non-object tool-call arguments instead of crashing the stream

### DIFF
--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -1074,6 +1074,14 @@ def function_call_to_tool_block(name: str, arguments: str) -> Optional[ToolBlock
         logger.error(f"Failed to parse function call arguments for {name}: {arguments}")
         return None
 
+    # Some models emit valid JSON that isn't an object (e.g. a bare array
+    # ["ls -la"], string, or number) as the function arguments. Every branch
+    # below assumes a dict and calls args.get(...), so a non-dict would raise
+    # AttributeError and abort the whole agent stream. Coerce to {} instead.
+    if not isinstance(args, dict):
+        logger.warning(f"Non-object function call arguments for {name}: {args!r}; treating as empty")
+        args = {}
+
     tool_type = _TOOL_NAME_MAP.get(name, name)
 
     # Allow MCP tools through (namespaced as mcp__serverid__toolname)

--- a/tests/test_function_call_non_object_args.py
+++ b/tests/test_function_call_non_object_args.py
@@ -1,0 +1,37 @@
+import sys
+from unittest.mock import MagicMock
+
+# Clean up any mocks from previous tests to ensure we load real modules
+for mod in ['src.agent_tools', 'src.tool_parsing', 'src.tool_schemas', 'src.tool_execution']:
+    sys.modules.pop(mod, None)
+
+# Mock heavy database/model dependencies before importing
+for mod in [
+    'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
+    'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
+    'src.database', 'core.models', 'core.database', 'core.auth'
+]:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+import pytest
+import src.agent_tools  # noqa: F401
+from src.tool_schemas import function_call_to_tool_block
+
+
+@pytest.mark.parametrize("arguments", [
+    '["ls -la"]',   # JSON array
+    '"ls -la"',     # bare JSON string
+    '42',            # JSON number
+    'true',          # JSON bool
+    'null',          # JSON null
+])
+def test_non_object_arguments_do_not_crash(arguments):
+    """A native function call whose arguments are valid JSON but not an object
+    must not raise (it used to throw AttributeError: 'list' object has no
+    attribute 'get', aborting the entire agent stream)."""
+    block = function_call_to_tool_block("bash", arguments)
+    # Coerced to empty args -> empty bash command, but importantly NO crash.
+    assert block is not None
+    assert block.tool_type == "bash"
+    assert block.content == ""


### PR DESCRIPTION
## Summary

A native function/tool call whose `arguments` field is **valid JSON but not an object** — a bare array like `["ls -la"]`, or a string / number / bool / null — was parsed fine by `function_call_to_tool_block`, after which every branch calls `args.get(...)`. That raised `AttributeError: 'list' object has no attribute 'get'` (etc.).

The call site (`_resolve_tool_blocks` → `stream_agent_loop`) has no surrounding try/except, so the error propagates out of the async SSE generator and **aborts the user's entire turn**. Weaker / local models routinely emit malformed tool args like a bare array, which is exactly why the surrounding code already parses defensively.

## Fix

Right after the `json.loads` guard, coerce a non-`dict` parsed value to `{}` (mirrors the existing empty-arguments behavior), so the tool runs with empty args instead of killing the stream:

```python
if not isinstance(args, dict):
    logger.warning(f"Non-object function call arguments for {name}: {args!r}; treating as empty")
    args = {}
```

Single concern, ~8 lines, no impact on auth/network/self-host. The existing unparseable-JSON path (returns `None`) and valid-object path are unchanged.

## Test plan

Adds `tests/test_function_call_non_object_args.py` (parametrized over `["ls -la"]`, `"ls -la"`, `42`, `true`, `null`):

```bash
python -m pytest tests/test_function_call_non_object_args.py tests/test_unknown_tool_calls.py -q
```

- New cases **fail before** this change (`AttributeError`) and **pass after**.
- The 5 existing `tests/test_unknown_tool_calls.py` cases still pass (invalid-JSON and valid-object paths unchanged). 10 passed total.

```bash
python -m py_compile src/tool_schemas.py
```

No related issue — found via code review.