### PR TITLE
fix: auto-naming for 24h time format

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -121,7 +121,7 @@ def needs_auto_name(name: str) -> bool:
     if name.startswith("Chat:") or name == "Chat":
         return True
     # Default frontend name: "modelname HH:MM:SS AM/PM"
-    if re.match(r'^.+ \d{1,2}:\d{2}:\d{2}\s*(AM|PM)$', name):
+    if re.match(r"^.+ \d{1,2}:\d{2}:\d{2}(\s*(AM|PM))?$", name, re.IGNORECASE):
         return True
     return False
 

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -1,0 +1,29 @@
+import pytest
+from routes.chat_helpers import needs_auto_name
+
+
+@pytest.mark.parametrize("name,expected", [
+    # 24h format (the bug this PR fixes)
+    ("deepseek-v4-flash 14:05:33", True),
+    ("qwq 17:46:02", True),
+    ("gemma3 23:59:59", True),
+    ("claude-sonnet 4 0:00:00", True),
+
+    # 12h format (was already working)
+    ("deepseek-v4-flash 2:05:33 PM", True),
+    ("qwq 06:46:02 AM", True),
+    ("claude-sonnet-4 8:05:17 am", True),
+
+    # empty / default
+    ("", True),
+    ("  ", False),
+    ("Chat: something", True),
+
+    # custom titles – should NOT trigger auto-naming
+    ("custom title", False),
+    ("CW Decoder for STM32", False),
+    ("my chat about python", False),
+    ("Fix the login bug", False),
+])
+def test_needs_auto_name(name, expected):
+    assert needs_auto_name(name) == expected, f"needs_auto_name({name!r}) should be {expected}"


### PR DESCRIPTION
## Что починили

**Баг:** Автонейминг чатов (`auto_name_session`) не срабатывал на системах с 24-часовым форматом времени.

### Причина

Фронтенд генерирует имя сессии как `модель ЧЧ:ММ:СС` (24h), но регулярка в `needs_auto_name()` требовала `AM/PM` в конце:

```python
# Было — только 12-часовой формат
r"^.+ \d{1,2}:\d{2}:\d{2}\s*(AM|PM)$"
```

### Фикс

Сделали `AM/PM` опциональным, добавили `re.IGNORECASE`:

```python
# Стало — 12h и 24h
r"^.+ \d{1,2}:\d{2}:\d{2}(\s*(AM|PM))?$"
```

## Как проверить

1. Создать новый чат
2. Отправить любое сообщение
3. После ответа название должно смениться на осмысленный заголовок (3–6 слов)

Fixes: автонейминг теперь работает на любых системах, независимо от locale и формата времени.