### PR TITLE
fix(cookbook): add NVFP4 to quantization picker dropdown

### DIFF
--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -1524,7 +1524,7 @@ function _renderRecipes() {
   html += '<option value="Q4_K_M">Q4</option><option value="Q8_0">Q8</option>';
   html += '<option value="Q6_K">Q6</option><option value="Q5_K_M">Q5</option>';
   html += '<option value="Q3_K_M">Q3</option><option value="Q2_K">Q2</option>';
-  html += '<option value="AWQ-4bit">AWQ</option><option value="FP8">FP8</option><option value="FP4">FP4</option>';
+  html += '<option value="AWQ-4bit">AWQ</option><option value="FP8">FP8</option><option value="FP4">FP4</option><option value="NVFP4">NVFP4</option>';
   html += '<option value="">Native</option></select>';
   // Engine filter: show only models whose serve engine matches. "llama.cpp"
   // (GGUF) runs everywhere incl. consumer AMD/Apple; vLLM/SGLang are CUDA /


### PR DESCRIPTION
Fixes #1328

The backend already handles NVFP4 across all quant dicts (`QUANT_BPP`, `QUANT_SPEED_MULT`, `QUANT_QUALITY_PENALTY`, `QUANT_BYTES_PER_PARAM`) and 12 NVFP4 models exist in the catalog, but the Cookbook quant dropdown didn't list it as a selectable option.

Adds `<option value="NVFP4">NVFP4</option>` to the picker in `static/js/cookbook.js`.