### PR TITLE
fix(upload): align per-minute rate limit with frontend MAX_FILES

### DIFF
--- a/src/upload_handler.py
+++ b/src/upload_handler.py
@@ -50,7 +50,7 @@ class UploadHandler:
         self.max_upload_size = 10 * 1024 * 1024  # 10MB
         self.max_concurrent_uploads = 3
         self.cleanup_days = 30
-        self.upload_rate_limit = 5  # Max 5 uploads per minute per IP
+        self.upload_rate_limit = 10  # Match frontend MAX_FILES (fileHandler.js)
         self.upload_rate_window = 60  # 60 seconds
         
         # Track upload rates


### PR DESCRIPTION
Fixes #1346 (partially — complements #1362)

`save_upload()` enforces `upload_rate_limit = 5` per file in the sliding window, but `fileHandler.js` sets `MAX_FILES = 10`. A batch of 6+ files silently drops the excess — `save_upload` throws 429 on file 6, the route's generic `except` catches it, and the chat is sent with missing attachments.

Raises `upload_rate_limit` from 5 to 10 to match the frontend limit. The per-file size cap (10 MB) and concurrent upload guard (3) still throttle abuse.