### PR TITLE
fix(ui): use raw data for 'Copy Chat' to avoid extra newlines

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -303,7 +303,9 @@ function initializeEventListeners() {
           label = (raw || '').trim() || 'Assistant';
         }
         const body = child.querySelector('.body');
-        const text = body ? (body.innerText || body.textContent || '').trim() : '';
+        // Prefer dataset.raw (original markdown) over innerText (rendered HTML as text)
+        // to avoid extra newlines and formatting artifacts.
+        const text = body ? (body.dataset.raw || body.innerText || body.textContent || '').trim() : '';
         if (text) parts.push(`${label}: ${text}`);
       } else if (child.classList?.contains('agent-thread')) {
         const lines = ['[Tool calls]'];


### PR DESCRIPTION
As requested by the maintainer in #1382, this focused PR addresses the chat copy formatting artifacts.

### Key Changes:
- **Raw Data Preference**: Updated `_serializeChatTranscript` in `static/app.js` to prefer `dataset.raw` (original markdown) over `innerText`.
- **Eliminates Extra Newlines**: Using `innerText` caused the browser to inject extra newlines when converting HTML-rendered chat messages back to plain text. Using the raw markdown source ensures a clean, predictable transcript.