### PR TITLE
Reject invalid preset CLI stores

### DIFF
--- a/scripts/odysseus-preset
+++ b/scripts/odysseus-preset
@@ -28,9 +28,12 @@ def _load() -> dict:
     if not _PATH.exists():
         return {}
     try:
-        return json.loads(_PATH.read_text())
+        data = json.loads(_PATH.read_text())
     except json.JSONDecodeError as e:
         fail(f"presets.json corrupt: {e}")
+    if not isinstance(data, dict):
+        fail("presets.json corrupt: expected an object")
+    return data
 
 
 def _save(data: dict) -> None:

--- a/tests/test_preset_cli_store.py
+++ b/tests/test_preset_cli_store.py
@@ -1,0 +1,28 @@
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli():
+    path = ROOT / "scripts" / "odysseus-preset"
+    loader = importlib.machinery.SourceFileLoader("odysseus_preset_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_load_rejects_non_object_preset_store(tmp_path, capsys):
+    cli = _load_cli()
+    cli._PATH = tmp_path / "presets.json"
+    cli._PATH.write_text("[]")
+
+    with pytest.raises(SystemExit):
+        cli._load()
+
+    assert "expected an object" in capsys.readouterr().err


### PR DESCRIPTION
preset cli was only catching broken json. a valid list still crashed later with a traceback.

this fails early with a useful message instead.

checked: pytest -q tests/test_preset_cli_store.py
