### PR TITLE
Ignore invalid personal docs state

### DIFF
--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -199,7 +199,10 @@ class PersonalDocsManager:
         try:
             if os.path.exists(self.directories_file):
                 with open(self.directories_file, 'r', encoding="utf-8") as f:
-                    self.indexed_directories = json.load(f)
+                    directories = json.load(f)
+                if not isinstance(directories, list):
+                    raise ValueError("indexed directories must be a list")
+                self.indexed_directories = [d for d in directories if isinstance(d, str)]
                 logger.info(f"Loaded {len(self.indexed_directories)} indexed directories")
             else:
                 self.indexed_directories = []
@@ -221,7 +224,10 @@ class PersonalDocsManager:
         try:
             if os.path.exists(self._excluded_file):
                 with open(self._excluded_file, 'r', encoding="utf-8") as f:
-                    self.excluded_files = set(json.load(f))
+                    excluded = json.load(f)
+                if not isinstance(excluded, list):
+                    raise ValueError("excluded files must be a list")
+                self.excluded_files = {p for p in excluded if isinstance(p, str)}
             else:
                 self.excluded_files = set()
         except Exception as e:

--- a/tests/test_personal_docs_state_store.py
+++ b/tests/test_personal_docs_state_store.py
@@ -1,0 +1,23 @@
+import json
+
+from src.personal_docs import PersonalDocsManager
+
+
+def test_manager_ignores_invalid_persisted_state_shapes(tmp_path):
+    (tmp_path / "indexed_directories.json").write_text(json.dumps({"bad": "shape"}))
+    (tmp_path / "excluded_files.json").write_text(json.dumps({"bad": "shape"}))
+
+    manager = PersonalDocsManager(str(tmp_path))
+
+    assert manager.indexed_directories == []
+    assert manager.excluded_files == set()
+
+
+def test_manager_filters_invalid_persisted_state_rows(tmp_path):
+    (tmp_path / "indexed_directories.json").write_text(json.dumps(["/tmp/docs", 123]))
+    (tmp_path / "excluded_files.json").write_text(json.dumps(["/tmp/docs/a.txt", None]))
+
+    manager = PersonalDocsManager(str(tmp_path))
+
+    assert manager.indexed_directories == ["/tmp/docs"]
+    assert manager.excluded_files == {"/tmp/docs/a.txt"}


### PR DESCRIPTION
personal docs state files could be valid json with the wrong shape and break later updates.

this drops bad shapes and filters bad rows while keeping valid paths.

checked: pytest -q tests/test_personal_docs_state_store.py tests/test_personal_docs_exclusions.py
