### PR TITLE
Fall back from invalid preset stores

### DIFF
--- a/src/preset_manager.py
+++ b/src/preset_manager.py
@@ -77,6 +77,9 @@ Use precise language. Show causal relationships explicitly. Quantify uncertainty
         try:
             with open(self.presets_file, 'r', encoding="utf-8") as f:
                 presets = json.load(f)
+            if not isinstance(presets, dict):
+                logger.error("Error loading presets: expected an object")
+                return self.DEFAULT_PRESETS.copy()
             custom = presets.get("custom") if isinstance(presets, dict) else None
             if isinstance(custom, dict) and "enabled" not in custom:
                 legacy_prompt = "You are a helpful, balanced assistant. Match your response style to the user's needs."

--- a/tests/test_preset_store_shape.py
+++ b/tests/test_preset_store_shape.py
@@ -1,0 +1,12 @@
+import json
+
+from src.preset_manager import PresetManager
+
+
+def test_non_object_preset_store_falls_back_to_defaults(tmp_path):
+    (tmp_path / "presets.json").write_text(json.dumps([]))
+
+    manager = PresetManager(str(tmp_path))
+
+    assert manager.presets == PresetManager.DEFAULT_PRESETS
+    assert manager.get("custom")["enabled"] is False


### PR DESCRIPTION
PresetManager could pass a valid-json list through and crash later on normal lookups.

this falls back to the built-ins when the store isnt an object.

checked: pytest -q tests/test_preset_store_shape.py tests/test_preset_fill_missing_defaults.py
