### PR TITLE
Ignore invalid integration rows

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -197,6 +197,10 @@ def load_integrations() -> List[Dict[str, Any]]:
         if not isinstance(integrations, list):
             log.error("Invalid integrations file shape: expected a list")
             return []
+        valid_integrations = [item for item in integrations if isinstance(item, dict)]
+        if len(valid_integrations) != len(integrations):
+            log.error("Invalid integrations file rows: ignored non-object entries")
+        integrations = valid_integrations
         if _has_plaintext_api_key(integrations):
             save_integrations(_decrypt_integration_secrets(integrations))
         return _decrypt_integration_secrets(integrations)

--- a/tests/test_integrations_store_shape.py
+++ b/tests/test_integrations_store_shape.py
@@ -1,0 +1,11 @@
+import json
+
+from src import integrations
+
+
+def test_load_integrations_skips_non_object_rows(tmp_path, monkeypatch):
+    data_file = tmp_path / "integrations.json"
+    data_file.write_text(json.dumps([{"id": "good", "name": "Good"}, "bad", None]))
+    monkeypatch.setattr(integrations, "DATA_FILE", str(data_file))
+
+    assert integrations.load_integrations() == [{"id": "good", "name": "Good"}]


### PR DESCRIPTION
one non-object row in integrations.json could hide every integration.

this keeps the valid entries and ignores only the bad rows.

checked: pytest -q tests/test_integrations_store_shape.py
