### PR TITLE
Clear the composer draft when entering the New Chat / welcome state (#1343)

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -1217,6 +1217,17 @@ export function showWelcomeScreen() {
   const cc = document.getElementById('chat-container');
   if (ws) ws.classList.remove('hidden');
   if (cc) cc.classList.add('welcome-active');
+  // Entering the New Chat / welcome state: discard any stale draft left in the
+  // composer from the previous session so the input starts empty (issue #1343).
+  // Switching between existing sessions loads them directly and does NOT call
+  // this, so genuine drafts are not erased. Reset the autosized height and fire
+  // an `input` event so the send button + autosize listeners update.
+  const _msg = document.getElementById('message');
+  if (_msg) {
+    _msg.value = '';
+    _msg.style.height = '';
+    _msg.dispatchEvent(new Event('input', { bubbles: true }));
+  }
   // Re-trigger the L→R clip-wipe reveal on the welcome name each time the
   // welcome screen is shown (new session, deleted last session, etc.) — without
   // this, the CSS animation only fires on initial DOM insertion.

--- a/tests/test_new_chat_clears_input.py
+++ b/tests/test_new_chat_clears_input.py
@@ -1,0 +1,34 @@
+"""Regression guard for issue #1343 — clicking "New chat" left the previous
+session's draft text in the composer.
+
+The direct model-picker path (sessions.js:createDirectChat) already cleared the
+input, but the brand/welcome New-Chat navigation path did not. The shared entry
+point for that state is chatRenderer.js:showWelcomeScreen(), which now clears the
+`#message` composer. Switching between existing sessions loads them directly and
+does not call showWelcomeScreen, so real drafts aren't erased.
+
+chatRenderer.js pulls in browser globals, so it can't be imported under node;
+this guards the fix at the source level so it can't be silently dropped.
+"""
+import re
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parent.parent / "static/js/compare").parent / "chatRenderer.js"
+
+
+def _show_welcome_body() -> str:
+    text = SRC.read_text(encoding="utf-8")
+    start = text.index("export function showWelcomeScreen()")
+    # Body runs until the next top-level `export function` / `function ` decl.
+    rest = text[start + len("export function showWelcomeScreen()"):]
+    m = re.search(r"\nexport function |\nfunction ", rest)
+    return rest[: m.start()] if m else rest
+
+
+def test_new_chat_welcome_clears_the_composer():
+    body = _show_welcome_body()
+    # Clears the draft value...
+    assert re.search(r"getElementById\(['\"]message['\"]\)", body)
+    assert re.search(r"\.value\s*=\s*['\"]['\"]", body), "must reset #message value"
+    # ...and notifies listeners (send button icon / autosize) of the change.
+    assert "new Event('input'" in body or 'new Event("input"' in body


### PR DESCRIPTION
## Problem

Clicking **New chat** left the previous session's unsent draft in the composer (#1343).

## Root cause (as you diagnosed)

The direct model-picker path (`sessions.js:createDirectChat`) already clears the input, but the **brand/welcome New-Chat navigation path** does not. That path lands in the welcome state via `chatRenderer.js:showWelcomeScreen()`, which focused `#message` but never cleared it.

## Fix

Clear `#message` in `showWelcomeScreen()` — the shared entry point for the New Chat / welcome state — resetting its autosized height and dispatching an `input` event so the send-button icon and autosize listeners update.

Scoped exactly as you suggested: switching between **existing** sessions loads them directly and does **not** call `showWelcomeScreen`, so genuine drafts are not erased — only entering the empty New-Chat/welcome state clears the draft.

## Test — `tests/test_new_chat_clears_input.py`

`chatRenderer.js` pulls in browser globals so it can't run under node; the test guards the fix at the source level (the `showWelcomeScreen` body clears `#message` and fires an `input` event). Proven red→green, and `node --check static/js/chatRenderer.js` passes.

```
./venv/bin/python -m pytest -q tests/test_new_chat_clears_input.py   # 1 passed
node --check static/js/chatRenderer.js                               # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)