### PR TITLE
fix(scheduler): fail closed on malformed scheduled_time instead of a 500

### DIFF
--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -122,9 +122,18 @@ def compute_next_run(schedule: str, scheduled_time: str,
     if not scheduled_time:
         return None
 
-    # Parse HH:MM
+    # Parse HH:MM — fail closed on malformed input (no colon, non-numeric,
+    # out-of-range) the same way an invalid cron expression does above, so a
+    # bad value like "9" or "9am" returns None instead of raising IndexError/
+    # ValueError out of the create route (a 500) or the scheduler loop.
     parts = scheduled_time.split(":")
-    hour, minute = int(parts[0]), int(parts[1])
+    try:
+        hour, minute = int(parts[0]), int(parts[1])
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError("hour/minute out of range")
+    except (ValueError, IndexError):
+        logger.warning(f"Invalid scheduled_time '{scheduled_time}'")
+        return None
 
     if schedule == "daily":
         candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)

--- a/tests/test_scheduler_scheduled_time_validation.py
+++ b/tests/test_scheduler_scheduled_time_validation.py
@@ -1,0 +1,26 @@
+"""Regression: compute_next_run must fail closed on a malformed scheduled_time.
+
+compute_next_run parsed scheduled_time as "HH:MM" with a bare
+`int(parts[0]), int(parts[1])` and no validation, so a value like "9", "9am",
+"25:00", "9:" or ":30" raised IndexError/ValueError. The POST /tasks create
+route calls it with the user/LLM-supplied scheduled_time *before* its try block
+(and only validates cron), so a bad value surfaced as an unhandled 500 instead
+of a clean 400 — and the same crash could fire inside the scheduler loop when
+recomputing next_run for an already-stored bad row.
+
+Now it fails closed (returns None) like an invalid cron expression does.
+"""
+from datetime import datetime
+
+from src.task_scheduler import compute_next_run
+
+
+def test_malformed_scheduled_time_returns_none():
+    now = datetime(2026, 6, 2, 12, 0)
+    for bad in ("9", "9am", "09", "9:", ":30", "abc", "25:00", "09:99", ""):
+        assert compute_next_run("daily", bad, after=now) is None, bad
+
+
+def test_valid_scheduled_time_still_computes():
+    now = datetime(2026, 6, 2, 8, 0)
+    assert compute_next_run("daily", "09:00", after=now) == datetime(2026, 6, 2, 9, 0)


### PR DESCRIPTION
## Summary

`compute_next_run` parses `scheduled_time` as `"HH:MM"` with no validation:

```python
parts = scheduled_time.split(":")
hour, minute = int(parts[0]), int(parts[1])
```

So a value like `"9"`, `"9am"`, `"25:00"`, `"9:"` or `":30"` raises `IndexError` / `ValueError`. The `POST /tasks` create route passes the user/LLM-supplied `scheduled_time` to this function **before** its try block and only validates the `cron_expression` — so a bad time surfaces as an unhandled **500** instead of the clean `400` used for every other invalid field. The same crash can also fire inside the scheduler loop when it recomputes `next_run` for an already-stored bad row (LLM-generated task, import, older schema).

## Fix

Guard the parse and **fail closed** (warn + return `None`), exactly like the invalid-cron handling a few lines above in the same function. No change to valid `HH:MM` behavior.

## Test plan

Adds `tests/test_scheduler_scheduled_time_validation.py`:

```bash
python -m pytest tests/test_scheduler_scheduled_time_validation.py -q
```

- Malformed values (`9`, `9am`, `25:00`, `9:`, `:30`, …) return `None` — **fail before** with `IndexError`/`ValueError`, **pass after**.
- Valid `09:00` still computes the next run.

Distinct from #1349 (that fixed the `once`-schedule local-vs-UTC comparison); this is the `HH:MM` parse guard, still reproducible on current `main`. No related issue — found via code review.