### PR TITLE
Keep Cookbook download-failure toasts visible long enough to read (#1355)

### DIFF
--- a/static/js/cookbookDownload.js
+++ b/static/js/cookbookDownload.js
@@ -555,18 +555,20 @@ export async function _runModelDownload(panel, model, backend, hostOverride) {
       body: JSON.stringify(payload),
     });
     if (!res.ok) {
-      uiModule.showToast('Download failed: HTTP ' + res.status);
+      // Errors carry actionable text (e.g. "tmux is required …"); keep them up
+      // long enough to read, matching the serve path's duration (issue #1355).
+      uiModule.showToast('Download failed: HTTP ' + res.status, 9000);
       return;
     }
     const data = await res.json();
     if (!data.ok) {
-      uiModule.showToast('Download failed: ' + (data.error || ''));
+      uiModule.showToast('Download failed: ' + (data.error || ''), 9000);
       return;
     }
     _addTask(data.session_id, shortName, 'download', payload);
     uiModule.showToast(`Downloading ${shortName}...`);
   } catch (e) {
-    uiModule.showToast('Download failed: ' + e.message);
+    uiModule.showToast('Download failed: ' + e.message, 9000);
   }
 }
 

--- a/tests/test_cookbook_download_toast_duration.py
+++ b/tests/test_cookbook_download_toast_duration.py
@@ -1,0 +1,27 @@
+"""Regression guard for issue #1355 — the Cookbook *download* error toast used
+the default ~1.2s duration, so an actionable message like "tmux is required …"
+vanished before it could be read. The serve path already used multi-second
+durations; the download-failure toasts now match.
+
+cookbookDownload.js pulls in browser globals so it can't run under node; this
+guards the durations at the source level.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "static/js/cookbookDownload.js"
+_MIN_MS = 5000
+
+
+def test_download_failure_toasts_stay_visible():
+    # Each download-failure toast is a single line; assert each carries an
+    # explicit duration >= _MIN_MS so the actionable error stays readable.
+    lines = [
+        ln for ln in SRC.read_text(encoding="utf-8").splitlines()
+        if "showToast(" in ln and "Download failed:" in ln
+    ]
+    assert lines, "expected at least one 'Download failed' showToast call"
+    for ln in lines:
+        m = re.search(r",\s*(\d{3,})\s*\)\s*;?\s*$", ln)
+        assert m, f"download-failure toast has no explicit duration: {ln.strip()}"
+        assert int(m.group(1)) >= _MIN_MS, f"duration too short to read: {ln.strip()}"


### PR DESCRIPTION
## Problem

On the Cookbook **download** path, error toasts use the default ~1.2s duration, so an actionable message like *"Download failed: tmux is required for Cookbook background downloads/serves … install it with your OS package manager"* vanishes before it can be read (#1355).

## Fix

The serve path already passes multi-second durations to `showToast`. Give the three "Download failed" toasts in `static/js/cookbookDownload.js` a **9s** duration to match (the value the issue suggests).

## Test — `tests/test_cookbook_download_toast_duration.py`

`cookbookDownload.js` pulls in browser globals so it can't run under node; the test guards each "Download failed" toast call carrying an explicit duration ≥ 5s at the source level. Proven red→green, and `node --check` passes.

```
./venv/bin/python -m pytest -q tests/test_cookbook_download_toast_duration.py   # 1 passed
node --check static/js/cookbookDownload.js                                       # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)