### PR TITLE
Keep group chat session cache loading

### DIFF
--- a/static/js/group.js
+++ b/static/js/group.js
@@ -8,6 +8,7 @@ import spinnerModule from './spinner.js';
 import { providerLogo } from './providers.js';
 import { PROMPT_TEMPLATES, getAllPresets } from './presets.js';
 import { sortModelObjects } from './modelSort.js';
+import Storage from './storage.js';
 
 let API_BASE = '';
 let _active = false;
@@ -546,7 +547,8 @@ export async function startGroup(models, parentSessionId) {
     _parentSessionId = pdata.id;
     // Register as group session for sidebar icon
     try {
-      const gids = JSON.parse(localStorage.getItem('odysseus-group-sessions') || '[]');
+      const storedGroupSessions = Storage.getJSON('odysseus-group-sessions', []);
+      const gids = Array.isArray(storedGroupSessions) ? storedGroupSessions : [];
       if (!gids.includes(_parentSessionId)) { gids.push(_parentSessionId); localStorage.setItem('odysseus-group-sessions', JSON.stringify(gids)); }
     } catch (e) {}
   } catch (e) {

--- a/tests/test_group_chat_storage.py
+++ b/tests/test_group_chat_storage.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+SOURCE = (
+    Path(__file__).resolve().parent.parent / "static" / "js" / "group.js"
+).read_text(encoding="utf-8")
+
+
+def test_group_session_sidebar_cache_uses_safe_json_loader():
+    assert "import Storage from './storage.js';" in SOURCE
+    assert "Storage.getJSON('odysseus-group-sessions', [])" in SOURCE
+    assert "Array.isArray(storedGroupSessions)" in SOURCE
+    assert "JSON.parse(localStorage.getItem('odysseus-group-sessions')" not in SOURCE


### PR DESCRIPTION
group chat still parsed its sidebar session cache directly. malformed json, or a valid non-array value, could silently stop the parent session from being registered.

this uses the existing safe storage loader and keeps a typed fallback.

checked: pytest -q tests/test_group_chat_storage.py
checked: node --check static/js/group.js