### PR TITLE
Pin the SearXNG image so a broken :latest can't block startup (#1414)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,12 @@ services:
     restart: unless-stopped
 
   searxng:
-    image: docker.io/searxng/searxng:latest
+    # Pinned, not :latest — odysseus waits on searxng's healthcheck
+    # (depends_on: condition: service_healthy), so a broken upstream `latest`
+    # tag blocks the whole app from starting. 2026.6.2 crashes on boot with
+    # `KeyError: 'default_doi_resolver'`, failing the healthcheck (issue #1414).
+    # Bump this deliberately after verifying a newer tag boots clean.
+    image: docker.io/searxng/searxng:2026.5.31-7159b8aed
     entrypoint:
       - /bin/sh
       - -c

--- a/tests/test_searxng_image_pinned.py
+++ b/tests/test_searxng_image_pinned.py
@@ -1,0 +1,26 @@
+"""Regression guard for issue #1414 — a broken upstream `searxng:latest` tag
+(2026.6.2 crashed on boot with KeyError: 'default_doi_resolver') failed the
+searxng healthcheck, and because `odysseus` waits on it via
+`depends_on: condition: service_healthy`, the whole app never started on fresh
+Docker installs.
+
+Pin the SearXNG image to a known-good tag so a bad upstream `latest` can't block
+startup. This guards that the pin stays in place.
+"""
+import re
+from pathlib import Path
+
+COMPOSE = Path(__file__).resolve().parent.parent / "docker-compose.yml"
+
+
+def test_searxng_image_is_pinned_not_latest():
+    text = COMPOSE.read_text(encoding="utf-8")
+    m = re.search(r"image:\s*\S*searxng/searxng:(\S+)", text)
+    assert m, "searxng image line not found in docker-compose.yml"
+    tag = m.group(1)
+    assert tag != "latest", (
+        "SearXNG must be pinned, not ':latest' — odysseus startup depends on its "
+        "healthcheck, so a broken upstream latest tag blocks the app (issue #1414)"
+    )
+    # A real version tag (date-based, e.g. 2026.5.31-7159b8aed), not a moving ref.
+    assert re.match(r"\d{4}\.\d", tag), f"expected a versioned tag, got {tag!r}"


### PR DESCRIPTION
## Problem

Fresh Docker installs fail: the `searxng` container crashes on boot with `KeyError: 'default_doi_resolver'` on the current upstream `searxng:latest` (2026.6.2), so its healthcheck never passes. Because `odysseus` waits on it via `depends_on: condition: service_healthy`, the whole app never starts (#1414).

## Fix

Pin SearXNG to the last known-good tag instead of the moving `:latest`, per your suggestion:

```yaml
image: docker.io/searxng/searxng:2026.5.31-7159b8aed
```

Added a comment explaining the pin (odysseus startup depends on searxng's healthcheck) and to bump it deliberately after verifying a newer tag boots clean. As you noted, this is separate from the mounted `config/searxng/settings.yml` template — the upstream image crashes before our settings would help, so pinning is the right immediate fix.

## Test — `tests/test_searxng_image_pinned.py`

Guards that the SearXNG image stays pinned to a real versioned tag (not `:latest`), so this regression can't silently return. Proven red→green; `docker-compose.yml` still parses as valid YAML.

```
./venv/bin/python -m pytest -q tests/test_searxng_image_pinned.py   # 1 passed
```

Two-dot diff touches only `docker-compose.yml` + the guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)