### PR TITLE
docs: add website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ───────────────────────────────────────────────
 ```
 
+[Website](https://pewdiepie-archdaemon.github.io/odysseus/)
+
 ![Odysseus](docs/odysseus.jpg)
 
 A self-hosted AI workspace -- meant to be the self-hosted version of the UI experience you get from ChatGPT and Claude. But with more jank and fun. Running on your own hardware, with your own data -- local-first, privacy-first, and no trojan.


### PR DESCRIPTION
## Summary

add website with markdown link to readme (replaces https://github.com/pewdiepie-archdaemon/odysseus/pull/1400)

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes https://github.com/pewdiepie-archdaemon/odysseus/issues/1357 (see Alternatives Considered section)

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. open https://github.com/DeanLemans/odysseus/tree/fix-readme-site-link
2. see where the link is
