### PR TITLE
Surface upload failures instead of silently dropping the files (follow-up to #1346)

### DIFF
--- a/static/js/fileHandler.js
+++ b/static/js/fileHandler.js
@@ -172,6 +172,17 @@ export async function uploadPending() {
       method: 'POST',
       body: fd
     });
+    if (!res.ok) {
+      // Surface the failure instead of swallowing it. Previously a non-OK
+      // response (e.g. 429 rate limit, 413 too large) was ignored: the files
+      // silently vanished and the chat sent with no attachments, so the model
+      // "didn't even see them" (issue #1346). Show the server's reason and keep
+      // pendingFiles so the strip re-renders for a retry (see finally below).
+      let detail = '';
+      try { const e = await res.json(); detail = e.detail || e.error || ''; } catch (_) {}
+      _showToast('Upload failed' + (detail ? ': ' + detail : ` (HTTP ${res.status})`));
+      return [];
+    }
     const data = await res.json();
     uploaded = (data.files || []);
     pendingFiles = [];          // clear only on success

--- a/tests/test_upload_error_surfaced.py
+++ b/tests/test_upload_error_surfaced.py
@@ -1,0 +1,31 @@
+"""Regression guard for the frontend error-surfacing follow-up to #1346.
+
+`uploadPending()` in static/js/fileHandler.js used to read `data.files` from the
+`/api/upload` response without checking `res.ok`, so a non-OK response (429 rate
+limit, 413 too large, …) was swallowed: the files silently vanished and the chat
+sent with no attachments, with no feedback to the user. It now checks `res.ok`
+and shows a toast on failure, keeping the pending files for a retry.
+
+fileHandler.js pulls in browser globals so it can't run under node; guard the
+fix at the source level.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "static/js/fileHandler.js"
+
+
+def _upload_pending_body() -> str:
+    text = SRC.read_text(encoding="utf-8")
+    start = text.index("export async function uploadPending()")
+    rest = text[start:]
+    m = re.search(r"\n(export |function )", rest[1:])
+    return rest[: m.start() + 1] if m else rest
+
+
+def test_upload_pending_checks_response_and_surfaces_error():
+    body = _upload_pending_body()
+    # Must guard on the HTTP status before trusting the body...
+    assert re.search(r"if\s*\(\s*!res\.ok\s*\)", body), "uploadPending must check res.ok"
+    # ...and tell the user the upload failed (not swallow it).
+    assert "Upload failed" in body


### PR DESCRIPTION
## Context

Follow-up you suggested on #1346 ("frontend error surfacing"). With the rate-limit/concurrency fixes merged, a failed `/api/upload` is now rarer — but when it does happen (429 rate limit, 413 too large, network error) it's still **swallowed**.

## Problem

`uploadPending()` (`static/js/fileHandler.js`) read `data.files` from the response without checking `res.ok`. On a non-OK response `data.files` is `undefined`, so it returned no ids **and** cleared the pending files — the attachments silently vanished and the chat sent with nothing attached, with no feedback. That's part of why the model "didn't even see them." (The code even had a `// restored on error so the user can retry` comment that the logic never honored.)

## Fix

Check `res.ok`. On failure:
- show the server's reason via a toast (`Upload failed: <detail>` / `(HTTP <status>)`);
- **keep** `pendingFiles` so the `finally` re-renders the attach strip for a retry.

Success path is unchanged.

## Test — `tests/test_upload_error_surfaced.py`

`fileHandler.js` pulls in browser globals so it can't run under node; the test guards at the source level that `uploadPending` checks `res.ok` and surfaces an "Upload failed" message. Proven red→green; `node --check` passes.

```
./venv/bin/python -m pytest -q tests/test_upload_error_surfaced.py   # 1 passed
node --check static/js/fileHandler.js                                 # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)