### PR TITLE
Add configurable workspace cwd for agent tools

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -17,6 +17,7 @@ from src.settings import (
     save_features as _save_features,
     DEFAULT_SETTINGS,
 )
+from src.workspace import WorkspaceError, resolve_workspace_dir
 from src.integrations import (
     load_integrations,
     add_integration,
@@ -421,6 +422,11 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
         current = _load_settings()
         for key in DEFAULT_SETTINGS:
             if key in body:
+                if key == "workspace_dir" and str(body[key] or "").strip():
+                    try:
+                        resolve_workspace_dir(str(body[key]))
+                    except WorkspaceError as exc:
+                        raise HTTPException(400, str(exc)) from exc
                 current[key] = body[key]
         _save_settings(current)
         return current

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -38,7 +38,7 @@ from core.platform_compat import (
     detached_popen_kwargs,
     find_bash,
 )
-from src.workspace import WorkspaceError, resolve_workspace_dir
+from src.workspace import WorkspaceError, resolve_workspace_dir, workspace_subprocess_env
 
 
 def _require_admin(request: Request):
@@ -383,11 +383,13 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT, cwd: str | None
     proc = None
     try:
         workdir = resolve_workspace_dir(cwd)
+        env = workspace_subprocess_env(workdir)
         proc = await _create_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=workdir,
+            env=env,
         )
         stdout_b, stderr_b = await asyncio.wait_for(
             proc.communicate(), timeout=timeout
@@ -423,6 +425,7 @@ async def _generate_pty(cmd: str, timeout: int, request: Request, cwd: str | Non
         yield f"data: {json.dumps({'stream': 'stderr', 'data': str(e)})}\n\n"
         yield f"data: {json.dumps({'exit_code': -1})}\n\n"
         return
+    env = workspace_subprocess_env(workdir)
 
     loop = asyncio.get_running_loop()
     master_fd, slave_fd = pty.openpty()
@@ -437,6 +440,7 @@ async def _generate_pty(cmd: str, timeout: int, request: Request, cwd: str | Non
         stdout=slave_fd,
         stderr=slave_fd,
         cwd=workdir,
+        env=env,
         preexec_fn=os.setsid,
     )
     os.close(slave_fd)  # parent doesn't need the slave side
@@ -564,6 +568,7 @@ async def _generate_tmux(cmd: str, request: Request, cwd: str | None = None):
         yield f"data: {json.dumps({'stream': 'stderr', 'data': str(e)})}\n\n"
         yield f"data: {json.dumps({'exit_code': -1})}\n\n"
         return
+    env = workspace_subprocess_env(workdir)
 
     TMUX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     session_id = f"cookbook-{uuid.uuid4().hex[:8]}"
@@ -574,6 +579,9 @@ async def _generate_tmux(cmd: str, request: Request, cwd: str | None = None):
     script_path = TMUX_LOG_DIR / f"{session_id}.sh"
     script_path.write_text(
         f"#!/bin/bash\n"
+        f"export ODYSSEUS_WORKSPACE_DIR={shlex.quote(env.get('ODYSSEUS_WORKSPACE_DIR', workdir))}\n"
+        f"export ODYSSEUS_APP_DIR={shlex.quote(env.get('ODYSSEUS_APP_DIR', ''))}\n"
+        f"export PATH={shlex.quote(env.get('PATH', ''))}\n"
         f"ODYSSEUS_USER_SHELL=\"${{SHELL:-}}\"\n"
         f"if [ -n \"$ODYSSEUS_USER_SHELL\" ] && [ -x \"$ODYSSEUS_USER_SHELL\" ]; then\n"
         f"  ODYSSEUS_USER_PATH=\"$(\"$ODYSSEUS_USER_SHELL\" -ic 'printf \"__ODYSSEUS_PATH__%s\\n\" \"$PATH\"' 2>/dev/null | sed -n 's/^__ODYSSEUS_PATH__//p' | tail -n 1 || true)\"\n"
@@ -596,6 +604,7 @@ async def _generate_tmux(cmd: str, request: Request, cwd: str | None = None):
         tmux_cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=env,
     )
     await proc.wait()
     if proc.returncode != 0:
@@ -687,6 +696,7 @@ async def _generate_win_detached(cmd: str, request: Request, cwd: str | None = N
         yield f"data: {json.dumps({'stream': 'stderr', 'data': str(e)})}\n\n"
         yield f"data: {json.dumps({'exit_code': -1})}\n\n"
         return
+    env = workspace_subprocess_env(workdir)
 
     TMUX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     session_id = f"cookbook-{uuid.uuid4().hex[:8]}"
@@ -720,6 +730,7 @@ async def _generate_win_detached(cmd: str, request: Request, cwd: str | None = N
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
             cwd=workdir,
+            env=env,
             **detached_popen_kwargs(),
         )
     except Exception as e:
@@ -824,11 +835,13 @@ def setup_shell_routes() -> APIRouter:
             reader_tasks = []
             try:
                 workdir = resolve_workspace_dir(req.cwd)
+                env = workspace_subprocess_env(workdir)
                 proc = await _create_shell(
                     cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=workdir,
+                    env=env,
                 )
 
                 q: asyncio.Queue = asyncio.Queue()

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -38,6 +38,7 @@ from core.platform_compat import (
     detached_popen_kwargs,
     find_bash,
 )
+from src.workspace import WorkspaceError, resolve_workspace_dir
 
 
 def _require_admin(request: Request):
@@ -357,6 +358,7 @@ PTY_UNSUPPORTED_ERROR = "pty_unsupported"
 
 class ShellExecRequest(BaseModel):
     command: str
+    cwd: str | None = None
     timeout: int | None = None  # optional override; 0 = no timeout (run until client disconnects)
     use_pty: bool = False       # use pseudo-TTY (for progress bars)
     use_tmux: bool = False      # run in tmux session (survives browser disconnect)
@@ -376,15 +378,16 @@ async def _create_shell(command: str, **kwargs):
     return await asyncio.create_subprocess_shell(command, **kwargs)
 
 
-async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, Any]:
+async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT, cwd: str | None = None) -> Dict[str, Any]:
     """Run a shell command and return stdout/stderr/exit_code."""
     proc = None
     try:
+        workdir = resolve_workspace_dir(cwd)
         proc = await _create_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(Path.home()),
+            cwd=workdir,
         )
         stdout_b, stderr_b = await asyncio.wait_for(
             proc.communicate(), timeout=timeout
@@ -404,7 +407,7 @@ async def _exec_shell(command: str, timeout: int = EXEC_TIMEOUT) -> Dict[str, An
         return {"stdout": "", "stderr": str(e), "exit_code": -1}
 
 
-async def _generate_pty(cmd: str, timeout: int, request: Request):
+async def _generate_pty(cmd: str, timeout: int, request: Request, cwd: str | None = None):
     """Run command in a pseudo-TTY so tqdm/progress bars work natively."""
     if not PTY_SUPPORTED:
         msg = "PTY streaming is not supported on this platform"
@@ -412,6 +415,13 @@ async def _generate_pty(cmd: str, timeout: int, request: Request):
             msg += f": {_PTY_IMPORT_ERROR}"
         yield f"data: {json.dumps({'stream': 'stderr', 'data': msg, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
         yield f"data: {json.dumps({'exit_code': -1, 'error': PTY_UNSUPPORTED_ERROR})}\n\n"
+        return
+
+    try:
+        workdir = resolve_workspace_dir(cwd)
+    except WorkspaceError as e:
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': str(e)})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
         return
 
     loop = asyncio.get_running_loop()
@@ -426,7 +436,7 @@ async def _generate_pty(cmd: str, timeout: int, request: Request):
         stdin=slave_fd,
         stdout=slave_fd,
         stderr=slave_fd,
-        cwd=str(Path.home()),
+        cwd=workdir,
         preexec_fn=os.setsid,
     )
     os.close(slave_fd)  # parent doesn't need the slave side
@@ -544,10 +554,17 @@ def _pty_read(fd: int) -> bytes | None:
     return None  # timeout, no data yet
 
 
-async def _generate_tmux(cmd: str, request: Request):
+async def _generate_tmux(cmd: str, request: Request, cwd: str | None = None):
     """Run command in a tmux session. Streams output via a log file.
     The tmux session survives browser disconnect — user can reconnect or
     `tmux attach -t <name>` to see it live."""
+    try:
+        workdir = resolve_workspace_dir(cwd)
+    except WorkspaceError as e:
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': str(e)})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        return
+
     TMUX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     session_id = f"cookbook-{uuid.uuid4().hex[:8]}"
     log_path = TMUX_LOG_DIR / f"{session_id}.log"
@@ -562,6 +579,7 @@ async def _generate_tmux(cmd: str, request: Request):
         f"  ODYSSEUS_USER_PATH=\"$(\"$ODYSSEUS_USER_SHELL\" -ic 'printf \"__ODYSSEUS_PATH__%s\\n\" \"$PATH\"' 2>/dev/null | sed -n 's/^__ODYSSEUS_PATH__//p' | tail -n 1 || true)\"\n"
         f"  if [ -n \"$ODYSSEUS_USER_PATH\" ]; then export PATH=\"$ODYSSEUS_USER_PATH:$PATH\"; fi\n"
         f"fi\n"
+        f"cd {shlex.quote(workdir)} || exit 1\n"
         f"{cmd} 2>&1 | tee '{log_path}'\n"
         f"EC=${{PIPESTATUS[0]}}\n"
         f"echo ':::EXIT_CODE:::'$EC >> '{log_path}'\n"
@@ -654,7 +672,7 @@ async def _generate_tmux(cmd: str, request: Request):
         pass
 
 
-async def _generate_win_detached(cmd: str, request: Request):
+async def _generate_win_detached(cmd: str, request: Request, cwd: str | None = None):
     """Windows stand-in for the tmux path (issues #84/#162).
 
     tmux doesn't exist on Windows, so we run the command in a *detached* child
@@ -663,6 +681,13 @@ async def _generate_win_detached(cmd: str, request: Request):
     (Git Bash) for command-syntax parity; falls back to cmd.exe. There's no
     `tmux attach` equivalent, but the "keeps running if you disconnect" contract
     holds, which is the point of the feature for long Cookbook downloads."""
+    try:
+        workdir = resolve_workspace_dir(cwd)
+    except WorkspaceError as e:
+        yield f"data: {json.dumps({'stream': 'stderr', 'data': str(e)})}\n\n"
+        yield f"data: {json.dumps({'exit_code': -1})}\n\n"
+        return
+
     TMUX_LOG_DIR.mkdir(parents=True, exist_ok=True)
     session_id = f"cookbook-{uuid.uuid4().hex[:8]}"
     log_path = TMUX_LOG_DIR / f"{session_id}.log"
@@ -694,6 +719,7 @@ async def _generate_win_detached(cmd: str, request: Request):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            cwd=workdir,
             **detached_popen_kwargs(),
         )
     except Exception as e:
@@ -752,8 +778,8 @@ def setup_shell_routes() -> APIRouter:
         if not cmd:
             return {"stdout": "", "stderr": "No command provided", "exit_code": 1}
 
-        logger.info("User shell exec requested: length=%d", len(cmd))
-        result = await _exec_shell(cmd, timeout=EXEC_TIMEOUT)
+        logger.info("User shell exec requested: cwd_override=%s length=%d", bool(req.cwd), len(cmd))
+        result = await _exec_shell(cmd, timeout=EXEC_TIMEOUT, cwd=req.cwd)
         return result
 
     @router.post("/api/shell/stream")
@@ -771,22 +797,23 @@ def setup_shell_routes() -> APIRouter:
         use_pty = req.use_pty
         use_tmux = req.use_tmux
         logger.info(
-            "User shell stream requested: timeout=%s pty=%s tmux=%s length=%d",
+            "User shell stream requested: timeout=%s pty=%s tmux=%s cwd_override=%s length=%d",
             "none" if timeout == 0 else f"{timeout}s",
             use_pty,
             use_tmux,
+            bool(req.cwd),
             len(cmd),
         )
 
         if use_tmux:
             # tmux is POSIX-only; Windows uses a detached-process + logfile tail
             # that preserves the "survives disconnect" behaviour.
-            gen = _generate_win_detached(cmd, request) if IS_WINDOWS else _generate_tmux(cmd, request)
+            gen = _generate_win_detached(cmd, request, cwd=req.cwd) if IS_WINDOWS else _generate_tmux(cmd, request, cwd=req.cwd)
             return StreamingResponse(gen, media_type="text/event-stream")
 
         if use_pty and not IS_WINDOWS:
             return StreamingResponse(
-                _generate_pty(cmd, timeout, request),
+                _generate_pty(cmd, timeout, request, cwd=req.cwd),
                 media_type="text/event-stream",
             )
         # Windows has no PTY; fall through to pipe streaming below (output still
@@ -796,11 +823,12 @@ def setup_shell_routes() -> APIRouter:
             proc = None
             reader_tasks = []
             try:
+                workdir = resolve_workspace_dir(req.cwd)
                 proc = await _create_shell(
                     cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
-                    cwd=str(Path.home()),
+                    cwd=workdir,
                 )
 
                 q: asyncio.Queue = asyncio.Queue()

--- a/src/bg_jobs.py
+++ b/src/bg_jobs.py
@@ -74,7 +74,8 @@ def _pid_alive(pid: Optional[int]) -> bool:
 
 
 def launch(command: str, session_id: str, cwd: Optional[str] = None,
-           max_runtime_s: int = DEFAULT_MAX_RUNTIME_S) -> Dict[str, Any]:
+           max_runtime_s: int = DEFAULT_MAX_RUNTIME_S,
+           env: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """Launch `command` detached. Returns the job record (status='running').
 
     Output + the final exit code are written to files so status survives a
@@ -131,6 +132,7 @@ def launch(command: str, session_id: str, cwd: Optional[str] = None,
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
         cwd=cwd or None,
+        env=env,
         **detached_popen_kwargs(),  # detach from the request lifecycle (setsid / DETACHED_PROCESS)
     )
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -94,6 +94,7 @@ DEFAULT_SETTINGS = {
     # unbounded model/API bill. Other values are bounded to [60, 86400].
     # Tune via Settings or by editing data/settings.json.
     "research_run_timeout_seconds": 1800,
+    "workspace_dir": "",
     "agent_max_tool_calls": 0,
     "agent_input_token_budget": 6000,
     # Ceiling on the *auto-derived* input budget that #1230 introduced. Has

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -17,6 +17,7 @@ import time
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_user
+from src.workspace import WorkspaceError, resolve_workspace_dir, resolve_workspace_path
 
 MAX_OUTPUT_CHARS = 10_000
 MAX_READ_CHARS = 20_000
@@ -84,6 +85,13 @@ def _tool_path_roots() -> list[str]:
     from src.constants import DATA_DIR
     roots.append(DATA_DIR)
 
+    # Configured workspace directory — relative read_file/write_file paths are
+    # resolved there, while sensitive-subpath checks below still apply.
+    try:
+        roots.append(resolve_workspace_dir())
+    except WorkspaceError:
+        pass
+
     # /tmp (and its macOS realpath /private/tmp).
     roots.append("/tmp")
     try:
@@ -136,8 +144,10 @@ def _resolve_tool_path(raw_path: str) -> str:
     """
     if raw_path is None or not str(raw_path).strip():
         raise ValueError("path is required")
-    expanded = os.path.expanduser(str(raw_path).strip())
-    resolved = os.path.realpath(expanded)
+    try:
+        resolved = os.path.realpath(resolve_workspace_path(str(raw_path).strip()))
+    except WorkspaceError as e:
+        raise ValueError(str(e)) from e
 
     if _is_sensitive_path(resolved):
         raise ValueError(
@@ -465,11 +475,13 @@ async def _direct_fallback(
 
     try:
         if tool == "bash":
+            workdir = resolve_workspace_dir()
             proc = await asyncio.create_subprocess_shell(
                 content,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
+                cwd=workdir,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -486,6 +498,7 @@ async def _direct_fallback(
             return {"output": output or "(no output)", "exit_code": rc or 0}
 
         if tool == "python":
+            workdir = resolve_workspace_dir()
             # Run user code in a subprocess so an infinite loop or crash
             # can't take the whole server down. -I = isolated mode (skip
             # user site, no PYTHONPATH inheritance) for hygiene.
@@ -496,6 +509,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
+                cwd=workdir,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -772,7 +786,11 @@ async def execute_tool_block(
         _is_bg, _bg_cmd = _split_bg_marker(content)
         if _is_bg and _bg_cmd:
             from src import bg_jobs
-            rec = bg_jobs.launch(_bg_cmd, session_id=session_id)
+            try:
+                workdir = resolve_workspace_dir()
+            except WorkspaceError as e:
+                return "bash (background): workspace", {"error": str(e), "exit_code": 1}
+            rec = bg_jobs.launch(_bg_cmd, session_id=session_id, cwd=workdir)
             short = _bg_cmd.strip().split(chr(10))[0][:80]
             desc = f"bash (background): {short}"
             result = {

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -17,7 +17,12 @@ import time
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_user
-from src.workspace import WorkspaceError, resolve_workspace_dir, resolve_workspace_path
+from src.workspace import (
+    WorkspaceError,
+    resolve_workspace_dir,
+    resolve_workspace_path,
+    workspace_subprocess_env,
+)
 
 MAX_OUTPUT_CHARS = 10_000
 MAX_READ_CHARS = 20_000
@@ -476,11 +481,12 @@ async def _direct_fallback(
     try:
         if tool == "bash":
             workdir = resolve_workspace_dir()
+            env = workspace_subprocess_env(workdir, _subproc_env)
             proc = await asyncio.create_subprocess_shell(
                 content,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env=_subproc_env,
+                env=env,
                 cwd=workdir,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
@@ -499,6 +505,7 @@ async def _direct_fallback(
 
         if tool == "python":
             workdir = resolve_workspace_dir()
+            env = workspace_subprocess_env(workdir, _subproc_env)
             # Run user code in a subprocess so an infinite loop or crash
             # can't take the whole server down. -I = isolated mode (skip
             # user site, no PYTHONPATH inheritance) for hygiene.
@@ -508,7 +515,7 @@ async def _direct_fallback(
                 (sys.executable or "python"), "-I", "-c", content,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env=_subproc_env,
+                env=env,
                 cwd=workdir,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
@@ -790,7 +797,8 @@ async def execute_tool_block(
                 workdir = resolve_workspace_dir()
             except WorkspaceError as e:
                 return "bash (background): workspace", {"error": str(e), "exit_code": 1}
-            rec = bg_jobs.launch(_bg_cmd, session_id=session_id, cwd=workdir)
+            env = workspace_subprocess_env(workdir, _subproc_env)
+            rec = bg_jobs.launch(_bg_cmd, session_id=session_id, cwd=workdir, env=env)
             short = _bg_cmd.strip().split(chr(10))[0][:80]
             desc = f"bash (background): {short}"
             result = {

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -1571,6 +1571,8 @@ async def do_manage_settings(content: str, owner: Optional[str] = None) -> Dict:
             "hard max": "agent_input_token_hard_max",
             "token budget cap": "agent_input_token_hard_max",
             "input budget cap": "agent_input_token_hard_max",
+            "workspace": "workspace_dir", "workspace dir": "workspace_dir",
+            "workspace directory": "workspace_dir", "working directory": "workspace_dir",
         }
         def _resolve(k):
             k2 = (k or "").strip().lower()

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -9,6 +9,8 @@ from typing import Optional
 from src.settings import get_setting
 
 ENV_WORKSPACE_DIR = "ODYSSEUS_WORKSPACE_DIR"
+ENV_APP_DIR = "ODYSSEUS_APP_DIR"
+APP_DIR = Path(__file__).resolve().parent.parent
 
 
 class WorkspaceError(ValueError):
@@ -53,3 +55,28 @@ def resolve_workspace_path(path: str) -> str:
     if expanded.is_absolute():
         return str(expanded)
     return str((Path(resolve_workspace_dir()) / expanded).resolve())
+
+
+def workspace_subprocess_env(
+    workdir: str,
+    base_env: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """Build the environment for subprocesses launched from a workspace.
+
+    User-facing shell/tool commands run from the configured workspace instead
+    of the app root. Keep Odysseus' own CLIs discoverable from there by adding
+    the repo scripts directory to PATH and exposing the app root explicitly.
+    """
+    env = dict(base_env or os.environ)
+    scripts_dir = str(APP_DIR / "scripts")
+    local_bin_dir = str(APP_DIR / ".local" / "bin")
+    existing_path = env.get("PATH", "")
+    path_parts = [p for p in existing_path.split(os.pathsep) if p]
+    merged: list[str] = []
+    for path in (scripts_dir, local_bin_dir, *path_parts):
+        if path and path not in merged:
+            merged.append(path)
+    env["PATH"] = os.pathsep.join(merged)
+    env[ENV_WORKSPACE_DIR] = workdir
+    env[ENV_APP_DIR] = str(APP_DIR)
+    return env

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -1,0 +1,55 @@
+"""Workspace directory resolution for shell and file tools."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from src.settings import get_setting
+
+ENV_WORKSPACE_DIR = "ODYSSEUS_WORKSPACE_DIR"
+
+
+class WorkspaceError(ValueError):
+    """Raised when a configured workspace path cannot be used."""
+
+
+def resolve_workspace_dir(cwd: Optional[str] = None) -> str:
+    """Resolve the effective workspace directory.
+
+    Precedence:
+      1. explicit API/request cwd
+      2. persisted workspace_dir setting
+      3. ODYSSEUS_WORKSPACE_DIR environment variable
+      4. the process user's home directory
+    """
+    raw = (cwd or "").strip()
+    if not raw:
+        raw = str(get_setting("workspace_dir", "") or "").strip()
+    if not raw:
+        raw = (os.environ.get(ENV_WORKSPACE_DIR) or "").strip()
+    if not raw:
+        return str(Path.home())
+
+    path = Path(raw).expanduser()
+    try:
+        resolved = path.resolve()
+    except OSError as exc:
+        raise WorkspaceError(f"Workspace directory is not accessible: {path}") from exc
+    if not resolved.exists():
+        raise WorkspaceError(f"Workspace directory does not exist: {resolved}")
+    if not resolved.is_dir():
+        raise WorkspaceError(f"Workspace path is not a directory: {resolved}")
+    return str(resolved)
+
+
+def resolve_workspace_path(path: str) -> str:
+    """Resolve a tool path, anchoring relative paths inside the workspace."""
+    raw = (path or "").strip()
+    if not raw:
+        return ""
+    expanded = Path(raw).expanduser()
+    if expanded.is_absolute():
+        return str(expanded)
+    return str((Path(resolve_workspace_dir()) / expanded).resolve())

--- a/static/index.html
+++ b/static/index.html
@@ -1062,6 +1062,26 @@
               <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
             </svg>
           </button>
+          <div class="workspace-control-wrap" id="workspace-control-wrap" style="display:none;">
+            <button type="button" class="input-icon-btn workspace-cwd-btn" id="workspace-cwd-btn" title="Workspace" aria-label="Workspace directory" aria-expanded="false">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/><path d="M3 10h18"/>
+              </svg>
+              <span id="workspace-cwd-label">CWD</span>
+            </button>
+            <div class="workspace-cwd-menu hidden" id="workspace-cwd-menu" role="dialog" aria-label="Workspace directory">
+              <label class="workspace-cwd-field">
+                <span>Workspace</span>
+                <input id="workspace-cwd-input" type="text" autocomplete="off" placeholder="/app/data/workspace">
+              </label>
+              <div class="workspace-cwd-actions">
+                <button type="button" id="workspace-cwd-test">pwd</button>
+                <button type="button" id="workspace-cwd-reset">Home</button>
+                <button type="button" id="workspace-cwd-save">Save</button>
+              </div>
+              <div id="workspace-cwd-status" class="workspace-cwd-status"></div>
+            </div>
+          </div>
           <!-- RAG toolbar indicator (hidden until active) -->
           <button type="button" class="input-icon-btn tool-indicator" title="RAG active — click to deactivate" id="rag-indicator-btn" style="display:none;">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -2266,6 +2286,7 @@
 <script type="module" src="/static/js/codeRunner.js"></script>
 <script type="module" src="/static/js/chatStream.js"></script>
 <script type="module" src="/static/js/chat.js?v=20260520m"></script>
+<script type="module" src="/static/js/workspace.js?v=20260602"></script>
 <script type="module" src="/static/js/cookbook.js"></script>
 <script type="module" src="/static/js/search-chat.js"></script>
 <script type="module" src="/static/js/compare/index.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -1478,7 +1478,12 @@
                 <label class="settings-label">Tool call limit</label>
                 <input id="set-agentMaxTools" type="text" inputmode="numeric" placeholder="0 = unlimited" class="settings-select" style="width:120px;">
               </div>
+              <div class="settings-row">
+                <label class="settings-label">Workspace</label>
+                <input id="set-agentWorkspaceDir" type="text" placeholder="/workspace/project" class="settings-select" style="width:220px;">
+              </div>
               <div id="set-agentMsg" style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);"></div>
+              <div id="set-agentWorkspaceMsg" style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);"></div>
             </div>
           </div>
           <!-- Image Generation removed — only inpaint remains in this build,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1581,14 +1581,22 @@ async function initAgentSettings() {
   async function saveWorkspace() {
     var path = (workspaceInput.value || '').trim();
     try {
-      await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
+      var res = await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ workspace_dir: path })
       });
+      if (!res.ok) {
+        var detail = 'Failed to save';
+        try {
+          var data = await res.json();
+          detail = data.detail || data.error || detail;
+        } catch (_) {}
+        throw new Error(detail);
+      }
       workspaceMsg.textContent = path ? 'Saved' : 'Using home directory';
       workspaceMsg.style.color = 'var(--fg)';
       setTimeout(function() { workspaceMsg.textContent = ''; }, 2000);
-    } catch (e) { workspaceMsg.textContent = 'Failed to save'; workspaceMsg.style.color = 'var(--red)'; }
+    } catch (e) { workspaceMsg.textContent = e.message || 'Failed to save'; workspaceMsg.style.color = 'var(--red)'; }
   }
 
   if (toolsInput) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1554,16 +1554,19 @@ async function initResearchSearchSettings() {
 /* ── Agent Settings (AI tab) ── */
 async function initAgentSettings() {
   var toolsInput = el('set-agentMaxTools');
+  var workspaceInput = el('set-agentWorkspaceDir');
   var msg = el('set-agentMsg');
-  if (!toolsInput) return;
+  var workspaceMsg = el('set-agentWorkspaceMsg');
+  if (!toolsInput && !workspaceInput) return;
 
   try {
     var res = await fetch('/api/auth/settings', { credentials: 'same-origin' });
     var settings = await res.json();
-    if (settings.agent_max_tool_calls) toolsInput.value = settings.agent_max_tool_calls;
+    if (toolsInput && settings.agent_max_tool_calls) toolsInput.value = settings.agent_max_tool_calls;
+    if (workspaceInput) workspaceInput.value = settings.workspace_dir || '';
   } catch (e) {}
 
-  async function save() {
+  async function saveTools() {
     var val = parseInt(toolsInput.value, 10) || 0;
     try {
       await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
@@ -1575,9 +1578,25 @@ async function initAgentSettings() {
     } catch (e) { msg.textContent = 'Failed to save'; msg.style.color = 'var(--red)'; }
   }
 
-  toolsInput.addEventListener('change', save);
-  var cur = parseInt(toolsInput.value, 10) || 0;
-  msg.textContent = cur > 0 ? 'Limit: ' + cur + ' tool calls per message' : 'Unlimited';
+  async function saveWorkspace() {
+    var path = (workspaceInput.value || '').trim();
+    try {
+      await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspace_dir: path })
+      });
+      workspaceMsg.textContent = path ? 'Saved' : 'Using home directory';
+      workspaceMsg.style.color = 'var(--fg)';
+      setTimeout(function() { workspaceMsg.textContent = ''; }, 2000);
+    } catch (e) { workspaceMsg.textContent = 'Failed to save'; workspaceMsg.style.color = 'var(--red)'; }
+  }
+
+  if (toolsInput) {
+    toolsInput.addEventListener('change', saveTools);
+    var cur = parseInt(toolsInput.value, 10) || 0;
+    msg.textContent = cur > 0 ? 'Limit: ' + cur + ' tool calls per message' : 'Unlimited';
+  }
+  if (workspaceInput) workspaceInput.addEventListener('change', saveWorkspace);
 }
 
 /* ═══════════════════════════════════════════

--- a/static/js/workspace.js
+++ b/static/js/workspace.js
@@ -1,0 +1,164 @@
+import uiModule from './ui.js';
+
+const API_BASE = window.location.origin;
+
+function shortPath(path) {
+  const value = (path || '').trim();
+  if (!value) return 'Home';
+  const parts = value.split('/').filter(Boolean);
+  if (!parts.length) return value;
+  const tail = parts.slice(-2).join('/');
+  return value.startsWith('/') ? '/' + tail : tail;
+}
+
+function setStatus(el, text, ok = true) {
+  if (!el) return;
+  el.textContent = text || '';
+  el.classList.toggle('error', !ok);
+}
+
+function positionMenu(btn, menu) {
+  const rect = btn.getBoundingClientRect();
+  const width = Math.min(360, window.innerWidth - 24);
+  menu.style.width = width + 'px';
+  let left = rect.left;
+  if (left + width > window.innerWidth - 12) left = window.innerWidth - width - 12;
+  menu.style.left = Math.max(12, left) + 'px';
+  menu.style.bottom = Math.max(12, window.innerHeight - rect.top + 8) + 'px';
+}
+
+async function loadSettings() {
+  const res = await fetch(`${API_BASE}/api/auth/settings`, { credentials: 'same-origin' });
+  if (!res.ok) throw new Error(`settings ${res.status}`);
+  return res.json();
+}
+
+async function saveWorkspace(path) {
+  const res = await fetch(`${API_BASE}/api/auth/settings`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ workspace_dir: path }),
+  });
+  if (!res.ok) {
+    let message = `save ${res.status}`;
+    try {
+      const data = await res.json();
+      message = data.detail || data.error || message;
+    } catch (_) {}
+    throw new Error(message);
+  }
+  return res.json();
+}
+
+async function testPwd() {
+  const res = await fetch(`${API_BASE}/api/shell/exec`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command: 'pwd' }),
+  });
+  if (!res.ok) throw new Error(`shell ${res.status}`);
+  return res.json();
+}
+
+async function initWorkspaceControl() {
+  const wrap = document.getElementById('workspace-control-wrap');
+  const btn = document.getElementById('workspace-cwd-btn');
+  const label = document.getElementById('workspace-cwd-label');
+  const menu = document.getElementById('workspace-cwd-menu');
+  const input = document.getElementById('workspace-cwd-input');
+  const saveBtn = document.getElementById('workspace-cwd-save');
+  const resetBtn = document.getElementById('workspace-cwd-reset');
+  const testBtn = document.getElementById('workspace-cwd-test');
+  const status = document.getElementById('workspace-cwd-status');
+  if (!wrap || !btn || !label || !menu || !input || !saveBtn || !resetBtn || !testBtn) return;
+
+  let workspaceDir = '';
+  try {
+    const auth = await fetch(`${API_BASE}/api/auth/status`, { credentials: 'same-origin' }).then(r => r.json());
+    if (auth && auth.configured && !auth.is_admin) return;
+    const settings = await loadSettings();
+    workspaceDir = settings.workspace_dir || '';
+  } catch (_) {
+    return;
+  }
+
+  function render() {
+    input.value = workspaceDir;
+    label.textContent = shortPath(workspaceDir);
+    btn.title = workspaceDir ? `CWD: ${workspaceDir}` : 'CWD: home directory';
+  }
+
+  function close() {
+    menu.classList.add('hidden');
+    btn.classList.remove('active');
+    btn.setAttribute('aria-expanded', 'false');
+  }
+
+  function open() {
+    positionMenu(btn, menu);
+    menu.classList.remove('hidden');
+    btn.classList.add('active');
+    btn.setAttribute('aria-expanded', 'true');
+    input.focus();
+    input.select();
+  }
+
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (menu.classList.contains('hidden')) open();
+    else close();
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    const next = (input.value || '').trim();
+    setStatus(status, 'Saving...');
+    try {
+      await saveWorkspace(next);
+      workspaceDir = next;
+      render();
+      setStatus(status, next ? 'Saved' : 'Using home directory');
+      uiModule.showToast('Workspace saved');
+    } catch (e) {
+      setStatus(status, e.message || 'Save failed', false);
+    }
+  });
+
+  resetBtn.addEventListener('click', async () => {
+    input.value = '';
+    saveBtn.click();
+  });
+
+  testBtn.addEventListener('click', async () => {
+    setStatus(status, 'Running pwd...');
+    try {
+      const data = await testPwd();
+      const out = (data.stdout || '').trim();
+      setStatus(status, data.exit_code === 0 ? out : (data.stderr || 'pwd failed'), data.exit_code === 0);
+    } catch (e) {
+      setStatus(status, 'pwd failed', false);
+    }
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') saveBtn.click();
+    if (e.key === 'Escape') close();
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!wrap.contains(e.target) && !menu.contains(e.target)) close();
+  });
+  window.addEventListener('resize', () => {
+    if (!menu.classList.contains('hidden')) positionMenu(btn, menu);
+  });
+
+  render();
+  wrap.style.display = '';
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initWorkspaceControl);
+} else {
+  initWorkspaceControl();
+}

--- a/static/style.css
+++ b/static/style.css
@@ -2248,6 +2248,90 @@ body.bg-pattern-sparkles {
       position: relative;
       z-index: 1;
     }
+    .workspace-control-wrap {
+      flex-shrink: 0;
+      position: relative;
+    }
+    .workspace-cwd-btn {
+      gap: 4px;
+      max-width: 150px;
+      padding-right: 8px;
+    }
+    #workspace-cwd-label {
+      font-size: 11px;
+      max-width: 96px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .workspace-cwd-menu {
+      position: fixed;
+      z-index: 1000;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    }
+    .workspace-cwd-menu.hidden {
+      display: none;
+    }
+    .workspace-cwd-field {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+      font-size: 11px;
+      color: color-mix(in srgb, var(--fg) 68%, transparent);
+    }
+    .workspace-cwd-field input {
+      width: 100%;
+      background: color-mix(in srgb, var(--fg) 5%, transparent);
+      color: var(--fg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 7px 8px;
+      font: inherit;
+      font-size: 12px;
+      outline: none;
+    }
+    .workspace-cwd-field input:focus {
+      border-color: color-mix(in srgb, var(--accent, var(--red)) 55%, var(--border));
+    }
+    .workspace-cwd-actions {
+      display: flex;
+      gap: 6px;
+      justify-content: flex-end;
+      margin-top: 8px;
+    }
+    .workspace-cwd-actions button {
+      background: color-mix(in srgb, var(--fg) 7%, transparent);
+      color: var(--fg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 5px 9px;
+      font: inherit;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    .workspace-cwd-actions button:hover {
+      background: color-mix(in srgb, var(--accent, var(--red)) 12%, transparent);
+    }
+    .workspace-cwd-status {
+      min-height: 15px;
+      margin-top: 6px;
+      font-size: 11px;
+      color: color-mix(in srgb, var(--fg) 58%, transparent);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .workspace-cwd-status.error {
+      color: var(--red);
+    }
+    @media (max-width: 768px) {
+      #workspace-cwd-label { display: none; }
+      .workspace-cwd-btn { max-width: none; padding-right: 6px; }
+    }
     .input-divider {
       width: 1px;
       height: 16px;

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v326';
+const CACHE_NAME = 'odysseus-v327';
 
 // Core shell precached on install so repeat opens are instant without any
 // network wait. Keep this list in sync with the <script type="module"> tags
@@ -38,6 +38,7 @@ const PRECACHE = [
   '/static/js/codeRunner.js',
   '/static/js/chatStream.js',
   '/static/js/chat.js',
+  '/static/js/workspace.js',
   '/static/js/cookbook.js',
   '/static/js/search-chat.js',
   '/static/js/compare/index.js',

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -118,7 +118,7 @@ def test_set_signup_enabled_true_is_idempotent():
     request = _fake_auth_request()
     auth.signup_enabled = False
 
-    out = asyncio.run(target(body=SetOpenRegistrationRequest(enabled=True),request=request))
+    out = asyncio.run(target(body=SetOpenRegistrationRequest(enabled=True), request=request))
 
     assert out == {"ok": True, "signup_enabled": True}
     assert auth.signup_enabled is True
@@ -127,6 +127,51 @@ def test_set_signup_enabled_true_is_idempotent():
 
     assert out == {"ok": True, "signup_enabled": True}
     assert auth.signup_enabled is True
+
+
+def _json_request(body: dict, token="session-token"):
+    req = _fake_auth_request(token)
+
+    async def _json():
+        return body
+
+    req.json = _json
+    return req
+
+
+def test_set_settings_rejects_missing_workspace_dir(monkeypatch, tmp_path):
+    auth, target = _auth_route_endpoint("/api/auth/settings", "POST")
+    auth.get_username_for_token.return_value = "admin"
+    auth.is_admin.return_value = True
+    saved = []
+
+    monkeypatch.setattr("routes.auth_routes._load_settings", lambda: {"workspace_dir": ""})
+    monkeypatch.setattr("routes.auth_routes._save_settings", lambda settings: saved.append(settings))
+
+    request = _json_request({"workspace_dir": str(tmp_path / "missing")})
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(target(request=request))
+
+    assert exc.value.status_code == 400
+    assert "does not exist" in exc.value.detail
+    assert saved == []
+
+
+def test_set_settings_accepts_existing_workspace_dir(monkeypatch, tmp_path):
+    auth, target = _auth_route_endpoint("/api/auth/settings", "POST")
+    auth.get_username_for_token.return_value = "admin"
+    auth.is_admin.return_value = True
+    saved = []
+
+    monkeypatch.setattr("routes.auth_routes._load_settings", lambda: {"workspace_dir": ""})
+    monkeypatch.setattr("routes.auth_routes._save_settings", lambda settings: saved.append(dict(settings)))
+
+    request = _json_request({"workspace_dir": str(tmp_path)})
+    out = asyncio.run(target(request=request))
+
+    assert out["workspace_dir"] == str(tmp_path)
+    assert saved == [{"workspace_dir": str(tmp_path)}]
 
 def test_set_signup_enabled_false_is_idempotent():
     from routes.auth_routes import SetOpenRegistrationRequest

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -38,6 +38,17 @@ async def test_exec_shell_uses_workspace_setting(monkeypatch, tmp_path):
     assert result["stdout"].strip() == str(tmp_path)
 
 
+async def test_exec_shell_can_call_odysseus_cli_from_workspace(monkeypatch, tmp_path):
+    import routes.shell_routes as shell_routes
+
+    monkeypatch.setattr(shell_routes, "resolve_workspace_dir", lambda cwd=None: str(tmp_path))
+
+    result = await _exec_shell("odysseus --version")
+
+    assert result["exit_code"] == 0
+    assert result["stdout"].startswith("odysseus ")
+
+
 def test_shell_routes_import_without_posix_pty_modules(monkeypatch):
     """Native Windows has no fcntl/termios; importing routes must still work."""
     real_import = builtins.__import__

--- a/tests/test_shell_routes.py
+++ b/tests/test_shell_routes.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 from routes.shell_routes import (
+    _exec_shell,
     _find_line_break,
     _running_in_container,
     _docker_row_status,
@@ -24,6 +25,17 @@ from routes.shell_routes import (
     _venv_activate_prefix,
     DOCKER_IN_CONTAINER_HINT,
 )
+
+
+async def test_exec_shell_uses_workspace_setting(monkeypatch, tmp_path):
+    import routes.shell_routes as shell_routes
+
+    monkeypatch.setattr(shell_routes, "resolve_workspace_dir", lambda cwd=None: str(tmp_path))
+
+    result = await _exec_shell("pwd")
+
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == str(tmp_path)
 
 
 def test_shell_routes_import_without_posix_pty_modules(monkeypatch):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,8 +1,16 @@
+import os
 from pathlib import Path
 
 import pytest
 
-from src.workspace import WorkspaceError, resolve_workspace_dir, resolve_workspace_path
+from src.workspace import (
+    ENV_APP_DIR,
+    ENV_WORKSPACE_DIR,
+    WorkspaceError,
+    resolve_workspace_dir,
+    resolve_workspace_path,
+    workspace_subprocess_env,
+)
 
 
 def test_resolve_workspace_dir_prefers_explicit_cwd(monkeypatch, tmp_path):
@@ -79,6 +87,25 @@ def test_resolve_workspace_path_leaves_absolute_paths(monkeypatch, tmp_path):
     assert resolve_workspace_path(str(absolute)) == str(absolute)
 
 
+def test_workspace_subprocess_env_exposes_app_and_scripts(monkeypatch, tmp_path):
+    app_dir = tmp_path / "app"
+    workspace = tmp_path / "workspace"
+    app_dir.mkdir()
+    workspace.mkdir()
+    monkeypatch.setattr("src.workspace.APP_DIR", app_dir)
+
+    env = workspace_subprocess_env(str(workspace), {"PATH": "/usr/bin"})
+
+    path_parts = env["PATH"].split(os.pathsep)
+    assert path_parts[:2] == [
+        str(app_dir / "scripts"),
+        str(app_dir / ".local" / "bin"),
+    ]
+    assert path_parts[-1] == "/usr/bin"
+    assert env[ENV_WORKSPACE_DIR] == str(workspace)
+    assert env[ENV_APP_DIR] == str(app_dir)
+
+
 async def test_agent_bash_tool_uses_workspace_setting(monkeypatch, tmp_path):
     from src.tool_execution import _direct_fallback
 
@@ -112,3 +139,14 @@ async def test_agent_file_tools_anchor_relative_paths(monkeypatch, tmp_path):
     assert written["exit_code"] == 0
     assert (tmp_path / "notes" / "todo.txt").read_text(encoding="utf-8") == "hello"
     assert read == {"output": "hello", "exit_code": 0}
+
+
+async def test_agent_bash_tool_can_call_odysseus_cli_from_workspace(monkeypatch, tmp_path):
+    from src.tool_execution import _direct_fallback
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(tmp_path))
+
+    result = await _direct_fallback("bash", "odysseus --version")
+
+    assert result["exit_code"] == 0
+    assert result["output"].startswith("odysseus ")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import pytest
+
+from src.workspace import WorkspaceError, resolve_workspace_dir, resolve_workspace_path
+
+
+def test_resolve_workspace_dir_prefers_explicit_cwd(monkeypatch, tmp_path):
+    explicit = tmp_path / "explicit"
+    setting = tmp_path / "setting"
+    env = tmp_path / "env"
+    explicit.mkdir()
+    setting.mkdir()
+    env.mkdir()
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(setting))
+    monkeypatch.setenv("ODYSSEUS_WORKSPACE_DIR", str(env))
+
+    assert resolve_workspace_dir(str(explicit)) == str(explicit.resolve())
+
+
+def test_resolve_workspace_dir_uses_setting(monkeypatch, tmp_path):
+    setting = tmp_path / "setting"
+    env = tmp_path / "env"
+    setting.mkdir()
+    env.mkdir()
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(setting))
+    monkeypatch.setenv("ODYSSEUS_WORKSPACE_DIR", str(env))
+
+    assert resolve_workspace_dir() == str(setting.resolve())
+
+
+def test_resolve_workspace_dir_uses_env_fallback(monkeypatch, tmp_path):
+    env = tmp_path / "env"
+    env.mkdir()
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: "")
+    monkeypatch.setenv("ODYSSEUS_WORKSPACE_DIR", str(env))
+
+    assert resolve_workspace_dir() == str(env.resolve())
+
+
+def test_resolve_workspace_dir_defaults_to_home(monkeypatch):
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: "")
+    monkeypatch.delenv("ODYSSEUS_WORKSPACE_DIR", raising=False)
+
+    assert resolve_workspace_dir() == str(Path.home())
+
+
+def test_resolve_workspace_dir_rejects_missing(monkeypatch, tmp_path):
+    missing = tmp_path / "missing"
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(missing))
+
+    with pytest.raises(WorkspaceError, match="does not exist"):
+        resolve_workspace_dir()
+
+
+def test_resolve_workspace_dir_rejects_files(monkeypatch, tmp_path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(file_path))
+
+    with pytest.raises(WorkspaceError, match="not a directory"):
+        resolve_workspace_dir()
+
+
+def test_resolve_workspace_path_anchors_relative_paths(monkeypatch, tmp_path):
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(tmp_path))
+
+    expected = tmp_path / "notes" / "todo.txt"
+    assert resolve_workspace_path("notes/todo.txt") == str(expected.resolve())
+
+
+def test_resolve_workspace_path_leaves_absolute_paths(monkeypatch, tmp_path):
+    absolute = tmp_path / "todo.txt"
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(tmp_path / "other"))
+
+    assert resolve_workspace_path(str(absolute)) == str(absolute)
+
+
+async def test_agent_bash_tool_uses_workspace_setting(monkeypatch, tmp_path):
+    from src.tool_execution import _direct_fallback
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(tmp_path))
+
+    result = await _direct_fallback("bash", "pwd")
+
+    assert result["exit_code"] == 0
+    assert result["output"] == str(tmp_path)
+
+
+async def test_agent_python_tool_uses_workspace_setting(monkeypatch, tmp_path):
+    from src.tool_execution import _direct_fallback
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(tmp_path))
+
+    result = await _direct_fallback("python", "import os; print(os.getcwd())")
+
+    assert result["exit_code"] == 0
+    assert result["output"] == str(tmp_path)
+
+
+async def test_agent_file_tools_anchor_relative_paths(monkeypatch, tmp_path):
+    from src.tool_execution import _direct_fallback
+
+    monkeypatch.setattr("src.workspace.get_setting", lambda key, default=None: str(tmp_path))
+
+    written = await _direct_fallback("write_file", "notes/todo.txt\nhello")
+    read = await _direct_fallback("read_file", "notes/todo.txt")
+
+    assert written["exit_code"] == 0
+    assert (tmp_path / "notes" / "todo.txt").read_text(encoding="utf-8") == "hello"
+    assert read == {"output": "hello", "exit_code": 0}


### PR DESCRIPTION
## Summary
Adds a configurable workspace cwd for admin shell and agent tools.

- Adds `workspace_dir` setting with explicit request cwd override, `ODYSSEUS_WORKSPACE_DIR` fallback, and home-directory default.
- Runs `/api/shell` exec/stream/PTY/tmux/detached commands from the resolved workspace.
- Runs agent bash/python/background jobs from the workspace; relative read/write file paths anchor there.
- Adds a compact CWD control on the main chat composer, plus the existing Settings field.
- Adds workspace save validation so a missing directory is rejected before it bricks later tool calls.
- Exposes `ODYSSEUS_APP_DIR`/`ODYSSEUS_WORKSPACE_DIR` and prepends app `scripts/` to `PATH` for workspace-launched subprocesses.

## Methodology
- Centralized workspace resolution in `src/workspace.py` instead of duplicating path logic in route/tool code.
- Scoped cwd changes to user/admin shell and agent tool execution paths.
- Left internal Odysseus feature routes on their existing path behavior unless they already manage their own cwd.
- Validates configured workspaces both at save time and at command execution time.
- Rebasing note: current branch is rebased onto upstream `main` at `0e6cbd8`; upstream's new read/write file path-confinement checks are preserved, with the configured workspace added as an allowed root while sensitive-subpath denies still apply.

## Edge Cases / Compatibility
- Empty `workspace_dir` preserves the old default behavior: use the process user's home directory.
- Explicit per-request `cwd` still overrides the persisted setting.
- Missing or file-valued workspaces return a clear error instead of launching in an unexpected directory.
- Relative file-tool paths resolve inside the workspace; absolute paths remain absolute.
- File-tool access still respects upstream sensitive path denial, including `.ssh`, `.gnupg`, shell rc files, `.env`, and SSH key filenames.
- Native CLIs continue to work from non-app workspaces through `PATH`, e.g. `odysseus --version`; repo-relative scripts can also use `$ODYSSEUS_APP_DIR/scripts/...`.
- Browser/service-worker cache was bumped and the new chat workspace module is precached.

## Validation Run
Automated validation after conflict resolution/rebase:
- `python -m py_compile routes/auth_routes.py src/workspace.py src/tool_execution.py src/bg_jobs.py routes/shell_routes.py tests/test_auth_regressions.py tests/test_workspace.py tests/test_shell_routes.py tests/test_tool_path_confinement.py`
- `node --check static/js/workspace.js && node --check static/js/settings.js`
- `docker run --rm --security-opt label=disable -v "$PWD":/app -w /app odysseus-odysseus pytest tests/test_workspace.py tests/test_shell_routes.py tests/test_auth_regressions.py tests/test_tool_path_confinement.py -q`
- Result: `113 passed`, with existing deprecation warnings.

Manual/runtime validation from the previous local rebuild remains applicable:
- Confirmed the chat HTML includes the CWD control and loads `/static/js/workspace.js` from the rebuilt app container.
- Confirmed `/api/shell/exec` starts in the configured workspace and `pwd` reports that workspace.
- Confirmed native Odysseus CLIs remain callable from a non-app workspace with `command -v odysseus` and `odysseus --version`.
- Confirmed an invalid workspace save returns HTTP 400 and does not overwrite the prior valid workspace setting.
- Confirmed the local calendar sync stack stayed healthy after rebuilding/restarting Odysseus.

Privacy validation:
- Reviewed pushed file list with `git diff --name-only origin/main...HEAD`.
- Ran a secret/personal-data scan over `git diff origin/main...HEAD` for password/token/API-key/calendar/school/local-host-path patterns.
- Scan hits were limited to generic code/test strings such as `pwd`, `session-token`, and token-budget setting names; no real credentials, personal paths, calendar feeds, or school/email data were found.

## Privacy
This branch contains source, UI, and tests only. It does not include local `data/`, `.env`, email/calendar setup, CalDAV/Radicale files, school calendar feeds, passwords, tokens, API keys, or host-specific workspace mounts.
