### PR TITLE
Recognize gemma3/llama4/mistral-small3.1+/multimodal as vision models (#1274)

### DIFF
--- a/src/chat_helpers.py
+++ b/src/chat_helpers.py
@@ -36,8 +36,16 @@ _VISION_MODEL_KEYWORDS = (
     "gpt-4o", "gpt-4.1", "gpt-4.5", "gpt-4-turbo", "gpt-4-vision",
     "claude-sonnet", "claude-opus", "claude-haiku", "gemini",
     # open / local
-    "vision", "llava", "bakllava", "moondream", "pixtral", "minicpm",
+    "vision", "multimodal", "llava", "bakllava", "moondream", "pixtral", "minicpm",
     "internvl", "cogvlm", "qwen-vl", "qwen2-vl", "qwen3-vl", "qwen3vl",
+    # multimodal families whose names don't contain "vision"/"vl" but DO accept
+    # images — without these the image is silently dropped for common Ollama tags
+    # like gemma3:4b (issue #1274). Gemma 3 (4b+), Llama 4 (all), and Mistral
+    # Small 3.1/3.2 are vision-capable; per the err-toward-True policy (#124) a
+    # rare text-only tag (e.g. gemma3:1b) being treated as vision is the safer
+    # failure than dropping a real image.
+    "gemma-3", "gemma3", "llama-4", "llama4",
+    "mistral-small-3.1", "mistral-small3.1", "mistral-small-3.2", "mistral-small3.2",
     # zhipu / glm (glm-4.5v, glm-4.6v, glm-5v-turbo, etc.)
     "glm-4.5v", "glm-4.6v", "glm-5v",
 )

--- a/tests/test_vision_model_detection.py
+++ b/tests/test_vision_model_detection.py
@@ -28,3 +28,21 @@ def test_text_only_models_not_flagged():
 
 def test_none_is_safe():
     assert is_vision_model(None) is False
+
+
+def test_recognizes_multimodal_families_without_vision_in_name():
+    # issue #1274: these are vision-capable but their names don't contain
+    # "vision"/"vl", so they were dropped and the model never saw the image.
+    for name in [
+        "gemma3:4b", "gemma3", "gemma-3-27b-it",
+        "llama4:scout", "llama4", "llama-4-maverick",
+        "mistral-small3.1", "mistral-small-3.2",
+        "phi-4-multimodal", "phi4-multimodal",
+    ]:
+        assert is_vision_model(name), f"{name!r} should be detected as vision-capable"
+
+
+def test_new_keywords_do_not_overmatch_text_models():
+    # The added families must not flag their text-only siblings.
+    for name in ["gemma2:9b", "gemma:7b", "llama3.3", "mistral-small", "phi-3-mini"]:
+        assert not is_vision_model(name), f"{name!r} should not be flagged as vision"


### PR DESCRIPTION
## Problem

Several reporters on #1274 see the model fail to read an attached image (one even got a hallucinated `PIL.Image` snippet — a tell that the image never reached the model). A common cause: `is_vision_model()` decides whether the image is passed through or stripped, and it classified genuinely **multimodal** model families as text-only because their names contain neither `vision` nor `vl`:

```
is_vision_model("gemma3:4b")        -> False   (Gemma 3 4b+ IS multimodal)
is_vision_model("llama4:scout")     -> False   (Llama 4 IS multimodal)
is_vision_model("mistral-small3.1") -> False   (3.1/3.2 added vision)
is_vision_model("phi-4-multimodal") -> False
```

For those, the image attachment is stripped before the request — so the model never sees it. `gemma3:4b` in particular is a very common Ollama vision tag.

## Fix

Add those families to the keyword list (plus a generic `multimodal`). Consistent with the file's documented **err-toward-True** policy (#124): "a false negative drops the image entirely," so a rare text-only tag (e.g. `gemma3:1b`) being treated as vision is the safer failure.

## Tests — `tests/test_vision_model_detection.py`

- the previously-dropped families are now recognized (red→green);
- **over-match guard**: text-only siblings stay text-only — `gemma2:9b`, plain `gemma:7b`, `llama3.3`, `mistral-small`, `phi-3-mini`.

```
./venv/bin/python -m pytest -q tests/test_vision_model_detection.py   # 5 passed
```

This is the vision-detection slice of #1274; provider-side passthrough quirks (e.g. specific Ollama hosts) may still need separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)