### PR TITLE
fix: reset Chroma indexes on embedding changes

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -301,6 +301,12 @@ def setup_embedding_routes():
         import src.rag_singleton as _rs
         _rs.rag_instance = None
         _rs._last_attempt = 0
+        try:
+            import src.tool_index as _ti
+            _ti._tool_index = None
+            _ti._last_attempt = 0
+        except Exception:
+            pass
 
         # Clear the HTTP-embedding "down" latch so the new endpoint is re-probed
         # instead of staying on the FastEmbed fallback for the process lifetime.
@@ -334,6 +340,12 @@ def setup_embedding_routes():
         import src.rag_singleton as _rs
         _rs.rag_instance = None
         _rs._last_attempt = 0
+        try:
+            import src.tool_index as _ti
+            _ti._tool_index = None
+            _ti._last_attempt = 0
+        except Exception:
+            pass
         try:
             from src.embeddings import reset_http_embed_state
             reset_http_embed_state()

--- a/src/chroma_client.py
+++ b/src/chroma_client.py
@@ -8,6 +8,9 @@ Connects to a ChromaDB instance running as a standalone service.
 import os
 import socket
 import logging
+import hashlib
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +20,205 @@ _client = None
 # blocking on the OS connection timeout (~30-60s, WinError 10060 on Windows),
 # which otherwise stalls app startup. Tunable via CHROMADB_CONNECT_TIMEOUT.
 _CONNECT_TIMEOUT = float(os.getenv("CHROMADB_CONNECT_TIMEOUT", "2.0"))
+
+EMBEDDING_DIMENSION_KEY = "odysseus:embedding_dimension"
+EMBEDDING_MODEL_KEY = "odysseus:embedding_model"
+EMBEDDING_URL_KEY = "odysseus:embedding_url"
+EMBEDDING_BACKEND_KEY = "odysseus:embedding_backend"
+EMBEDDING_SIGNATURE_KEY = "odysseus:embedding_signature"
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def embedding_dimension(embedding_model: Any) -> int | None:
+    """Return the active embedding dimension, probing if needed."""
+    if embedding_model is None:
+        return None
+
+    dim = _int_or_none(getattr(embedding_model, "_dim", None))
+    if dim:
+        return dim
+
+    getter = getattr(embedding_model, "get_sentence_embedding_dimension", None)
+    if callable(getter):
+        return _int_or_none(getter())
+
+    return None
+
+
+def embedding_signature(embedding_model: Any, dimension: int | None = None) -> str:
+    """Stable fingerprint for the active embedding backend."""
+    dim = embedding_dimension(embedding_model) if dimension is None else dimension
+    parts = [
+        embedding_model.__class__.__name__ if embedding_model is not None else "",
+        str(getattr(embedding_model, "url", "") or ""),
+        str(getattr(embedding_model, "model", "") or ""),
+        str(dim or ""),
+    ]
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+
+
+def embedding_metadata(embedding_model: Any, base_metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Metadata stamped on Chroma collections created by Odysseus."""
+    metadata = dict(base_metadata or {})
+    dim = embedding_dimension(embedding_model)
+    if dim:
+        metadata[EMBEDDING_DIMENSION_KEY] = dim
+    if embedding_model is not None:
+        metadata[EMBEDDING_BACKEND_KEY] = embedding_model.__class__.__name__
+    model = getattr(embedding_model, "model", None)
+    if model:
+        metadata[EMBEDDING_MODEL_KEY] = str(model)
+    url = getattr(embedding_model, "url", None)
+    if url:
+        metadata[EMBEDDING_URL_KEY] = str(url)
+    metadata[EMBEDDING_SIGNATURE_KEY] = embedding_signature(embedding_model, dim)
+    return metadata
+
+
+def _collection_metadata(collection: Any) -> dict[str, Any]:
+    metadata = getattr(collection, "metadata", None)
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _metadata_dimension(metadata: Mapping[str, Any]) -> int | None:
+    return _int_or_none(metadata.get(EMBEDDING_DIMENSION_KEY))
+
+
+def _metadata_signature(metadata: Mapping[str, Any]) -> str | None:
+    sig = metadata.get(EMBEDDING_SIGNATURE_KEY)
+    return str(sig) if sig else None
+
+
+def _sequence_len(value: Any) -> int | None:
+    shape = getattr(value, "shape", None)
+    if shape is not None and len(shape) >= 1:
+        try:
+            return int(shape[-1])
+        except (TypeError, ValueError):
+            pass
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return len(value)
+    try:
+        return len(value)
+    except TypeError:
+        return None
+
+
+def _first_embedding_dimension(collection: Any) -> int | None:
+    """Infer legacy collection dimensionality from the first stored vector."""
+    try:
+        if collection.count() <= 0:
+            return None
+    except Exception:
+        return None
+
+    try:
+        data = collection.get(limit=1, include=["embeddings"])
+    except TypeError:
+        data = collection.get(include=["embeddings"])
+    except Exception:
+        return None
+
+    embeddings = (data or {}).get("embeddings")
+    if embeddings is None:
+        return None
+
+    shape = getattr(embeddings, "shape", None)
+    if shape is not None and len(shape) == 2:
+        return _int_or_none(shape[1])
+
+    try:
+        if len(embeddings) == 0:
+            return None
+        first = embeddings[0]
+    except Exception:
+        return None
+
+    return _sequence_len(first)
+
+
+def _stamp_collection_metadata(collection: Any, desired_metadata: Mapping[str, Any]) -> None:
+    current = _collection_metadata(collection)
+    merged = {**current, **dict(desired_metadata)}
+    if merged == current:
+        return
+    modifier = getattr(collection, "modify", None)
+    if callable(modifier):
+        try:
+            modifier(metadata=merged)
+            return
+        except Exception as exc:
+            logger.debug("Could not stamp Chroma collection metadata: %s", exc)
+    try:
+        collection.metadata = merged
+    except Exception:
+        pass
+
+
+def _get_or_create_collection(client: Any, name: str, metadata: Mapping[str, Any]) -> Any:
+    getter = getattr(client, "get_collection", None)
+    if callable(getter):
+        try:
+            return getter(name=name)
+        except Exception:
+            return client.get_or_create_collection(name=name, metadata=metadata)
+    return client.get_or_create_collection(name=name, metadata=metadata)
+
+
+def ensure_embedding_collection(
+    client: Any,
+    name: str,
+    embedding_model: Any,
+    metadata: Mapping[str, Any] | None = None,
+) -> Any:
+    """Return a Chroma collection compatible with ``embedding_model``.
+
+    ChromaDB fixes collection dimensionality on first insert. If Odysseus later
+    switches embedding backends, reusing that collection can fail at add/query
+    time, or silently compare vectors from incompatible models when dimensions
+    happen to match. Existing legacy collections without this metadata are
+    checked by reading one stored embedding.
+    """
+    desired_metadata = embedding_metadata(embedding_model, metadata)
+    desired_dim = _metadata_dimension(desired_metadata)
+    desired_sig = _metadata_signature(desired_metadata)
+
+    collection = _get_or_create_collection(client, name, desired_metadata)
+    current_metadata = _collection_metadata(collection)
+    current_sig = _metadata_signature(current_metadata)
+    current_dim = _metadata_dimension(current_metadata)
+
+    needs_reset = False
+    reason = ""
+
+    if current_sig and desired_sig and current_sig != desired_sig:
+        needs_reset = True
+        reason = "embedding signature changed"
+    else:
+        if current_dim is None:
+            current_dim = _first_embedding_dimension(collection)
+        if desired_dim and current_dim and desired_dim != current_dim:
+            needs_reset = True
+            reason = f"embedding dimension changed ({current_dim} -> {desired_dim})"
+
+    if needs_reset:
+        logger.warning("Resetting Chroma collection %s: %s", name, reason)
+        try:
+            client.delete_collection(name)
+        except Exception as exc:
+            logger.debug("delete_collection(%s) before reset failed: %s", name, exc)
+        return client.get_or_create_collection(name=name, metadata=desired_metadata)
+
+    _stamp_collection_metadata(collection, desired_metadata)
+    return collection
 
 
 def _port_open(host: str, port: int, timeout: float = None) -> bool:

--- a/src/memory_vector.py
+++ b/src/memory_vector.py
@@ -26,7 +26,7 @@ class MemoryVectorStore:
 
     def _initialize(self):
         try:
-            from src.chroma_client import get_chroma_client
+            from src.chroma_client import get_chroma_client, ensure_embedding_collection
 
             if self._model is None:
                 from src.embeddings import get_embedding_client
@@ -36,8 +36,10 @@ class MemoryVectorStore:
                 logger.info(f"MemoryVectorStore using embeddings: {self._model.url}")
 
             client = get_chroma_client()
-            self._collection = client.get_or_create_collection(
-                name=self.COLLECTION_NAME,
+            self._collection = ensure_embedding_collection(
+                client,
+                self.COLLECTION_NAME,
+                self._model,
                 metadata={"hnsw:space": "cosine"},
             )
 
@@ -137,7 +139,7 @@ class MemoryVectorStore:
         if not self._healthy:
             return
 
-        from src.chroma_client import get_chroma_client
+        from src.chroma_client import get_chroma_client, embedding_metadata
 
         # Delete and recreate collection for a clean rebuild
         client = get_chroma_client()
@@ -147,7 +149,7 @@ class MemoryVectorStore:
             pass
         self._collection = client.get_or_create_collection(
             name=self.COLLECTION_NAME,
-            metadata={"hnsw:space": "cosine"},
+            metadata=embedding_metadata(self._model, {"hnsw:space": "cosine"}),
         )
 
         texts = []

--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -55,7 +55,7 @@ class VectorRAG:
 
     def _initialize_system(self) -> bool:
         try:
-            from src.chroma_client import get_chroma_client
+            from src.chroma_client import get_chroma_client, ensure_embedding_collection
             from src.embeddings import get_embedding_client
 
             self._model = get_embedding_client()
@@ -64,8 +64,10 @@ class VectorRAG:
             logger.info(f"Embedding: {self._model.url} model={self._model.model}")
 
             client = get_chroma_client()
-            self._collection = client.get_or_create_collection(
-                name=COLLECTION_NAME,
+            self._collection = ensure_embedding_collection(
+                client,
+                COLLECTION_NAME,
+                self._model,
                 metadata={"hnsw:space": "cosine"},
             )
 
@@ -290,7 +292,7 @@ class VectorRAG:
 
     def rebuild_index(self) -> bool:
         try:
-            from src.chroma_client import get_chroma_client
+            from src.chroma_client import get_chroma_client, embedding_metadata
             client = get_chroma_client()
             try:
                 client.delete_collection(COLLECTION_NAME)
@@ -298,7 +300,7 @@ class VectorRAG:
                 pass
             self._collection = client.get_or_create_collection(
                 name=COLLECTION_NAME,
-                metadata={"hnsw:space": "cosine"},
+                metadata=embedding_metadata(self._model, {"hnsw:space": "cosine"}),
             )
             self._healthy = True
             return True

--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -152,7 +152,7 @@ class ToolIndex:
     """ChromaDB-backed tool index for RAG-based tool selection."""
 
     def __init__(self):
-        from src.chroma_client import get_chroma_client
+        from src.chroma_client import get_chroma_client, ensure_embedding_collection
         from src.embeddings import get_embedding_client
 
         self._embedder = get_embedding_client()
@@ -160,8 +160,10 @@ class ToolIndex:
             raise RuntimeError("No embedding client available")
 
         client = get_chroma_client()
-        self._collection = client.get_or_create_collection(
-            name=COLLECTION_NAME,
+        self._collection = ensure_embedding_collection(
+            client,
+            COLLECTION_NAME,
+            self._embedder,
             metadata={"hnsw:space": "cosine"},
         )
         self._fingerprint = ""

--- a/tests/test_chroma_client.py
+++ b/tests/test_chroma_client.py
@@ -12,6 +12,60 @@ import pytest
 import src.chroma_client as cc
 
 
+class _FakeEmbeddingModel:
+    url = "http://embeddings.test/v1"
+
+    def __init__(self, model: str, dim: int):
+        self.model = model
+        self._dim = dim
+
+    def get_sentence_embedding_dimension(self):
+        return self._dim
+
+
+class _FakeCollection:
+    def __init__(self, name: str, metadata=None, embeddings=None):
+        self.name = name
+        self.metadata = dict(metadata or {})
+        self.embeddings = embeddings or []
+
+    def count(self):
+        return len(self.embeddings)
+
+    def get(self, **kwargs):
+        limit = kwargs.get("limit")
+        embeddings = self.embeddings[:limit] if limit else self.embeddings
+        return {"ids": [f"id-{i}" for i in range(len(embeddings))], "embeddings": embeddings}
+
+    def modify(self, metadata=None):
+        self.metadata = dict(metadata or {})
+
+
+class _FakeClient:
+    def __init__(self, collection=None, overwrite_existing_metadata=False):
+        self.collections = {}
+        self.deleted = []
+        self.overwrite_existing_metadata = overwrite_existing_metadata
+        if collection is not None:
+            self.collections[collection.name] = collection
+
+    def get_collection(self, name):
+        if name not in self.collections:
+            raise KeyError(name)
+        return self.collections[name]
+
+    def get_or_create_collection(self, name, metadata=None):
+        if name not in self.collections:
+            self.collections[name] = _FakeCollection(name, metadata=metadata)
+        elif self.overwrite_existing_metadata:
+            self.collections[name].metadata = dict(metadata or {})
+        return self.collections[name]
+
+    def delete_collection(self, name):
+        self.deleted.append(name)
+        self.collections.pop(name, None)
+
+
 def _free_port() -> int:
     """Bind to port 0, grab the assigned port, release it — nothing listens."""
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -50,3 +104,89 @@ def test_get_chroma_client_does_not_cache_when_unreachable(monkeypatch):
     # A failed connection must leave the singleton unset so a later call
     # (once ChromaDB is up) can succeed.
     assert cc._client is None
+
+
+def test_embedding_collection_stamps_new_collection_metadata():
+    model = _FakeEmbeddingModel("embed-small", 384)
+    client = _FakeClient()
+
+    collection = cc.ensure_embedding_collection(
+        client,
+        "odysseus_test",
+        model,
+        metadata={"hnsw:space": "cosine"},
+    )
+
+    assert collection.metadata["hnsw:space"] == "cosine"
+    assert collection.metadata[cc.EMBEDDING_DIMENSION_KEY] == 384
+    assert collection.metadata[cc.EMBEDDING_MODEL_KEY] == "embed-small"
+    assert collection.metadata[cc.EMBEDDING_SIGNATURE_KEY] == cc.embedding_signature(model)
+
+
+def test_embedding_collection_resets_when_stored_dimension_differs():
+    old = _FakeCollection(
+        "odysseus_test",
+        metadata={cc.EMBEDDING_DIMENSION_KEY: 384},
+        embeddings=[[0.0] * 384],
+    )
+    client = _FakeClient(old)
+
+    collection = cc.ensure_embedding_collection(
+        client,
+        "odysseus_test",
+        _FakeEmbeddingModel("embed-large", 768),
+    )
+
+    assert client.deleted == ["odysseus_test"]
+    assert collection.count() == 0
+    assert collection.metadata[cc.EMBEDDING_DIMENSION_KEY] == 768
+
+
+def test_embedding_collection_resets_on_same_dimension_signature_change():
+    old_model = _FakeEmbeddingModel("embed-a", 384)
+    old_metadata = cc.embedding_metadata(old_model)
+    old = _FakeCollection("odysseus_test", metadata=old_metadata, embeddings=[[0.0] * 384])
+    client = _FakeClient(old)
+
+    collection = cc.ensure_embedding_collection(
+        client,
+        "odysseus_test",
+        _FakeEmbeddingModel("embed-b", 384),
+    )
+
+    assert client.deleted == ["odysseus_test"]
+    assert collection.count() == 0
+    assert collection.metadata[cc.EMBEDDING_MODEL_KEY] == "embed-b"
+
+
+def test_embedding_collection_infers_legacy_dimension_before_reuse():
+    old = _FakeCollection("odysseus_test", metadata={}, embeddings=[[0.0] * 384])
+    client = _FakeClient(old)
+
+    collection = cc.ensure_embedding_collection(
+        client,
+        "odysseus_test",
+        _FakeEmbeddingModel("embed-large", 768),
+    )
+
+    assert client.deleted == ["odysseus_test"]
+    assert collection.metadata[cc.EMBEDDING_DIMENSION_KEY] == 768
+
+
+def test_embedding_collection_reads_existing_metadata_before_get_or_create():
+    old_model = _FakeEmbeddingModel("embed-a", 384)
+    old = _FakeCollection(
+        "odysseus_test",
+        metadata=cc.embedding_metadata(old_model),
+        embeddings=[[0.0] * 384],
+    )
+    client = _FakeClient(old, overwrite_existing_metadata=True)
+
+    collection = cc.ensure_embedding_collection(
+        client,
+        "odysseus_test",
+        _FakeEmbeddingModel("embed-b", 384),
+    )
+
+    assert client.deleted == ["odysseus_test"]
+    assert collection.metadata[cc.EMBEDDING_MODEL_KEY] == "embed-b"


### PR DESCRIPTION
## Summary

Odysseus could reuse existing ChromaDB vector collections after the embedding backend or model was changed, even though Chroma collections are tied to the vector dimension and embedding space they were originally populated with. That could make RAG, memory recall, or tool-index retrieval fail with dimension mismatch errors after switching to a different-sized embedding model, or produce unreliable retrieval if a different model with the same dimension reused the old vectors. 

This PR records the active embedding backend signature and vector dimension on each Chroma-backed collection, then recreates incompatible vector indexes when the embedding configuration changes.

## Linked Issue
Fixes #2889 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [ ] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `pytest tests\test_chroma_client.py` and confirm the embedding collection guard tests pass.
2. Run `python -m py_compile src\chroma_client.py src\rag_vector.py src\memory_vector.py services\memory\memory_vector.py src\tool_index.py routes\embedding_routes.py tests\test_chroma_client.py`.
3. Optional manual check: configure one embedding backend/model, initialize a Chroma-backed RAG or memory collection, then switch to a different embedding model/dimension and verify Odysseus recreates the affected collection instead of reusing the incompatible one.