### PR TITLE
fix: blind compare leaks model names in session names

### DIFF
--- a/routes/compare_routes.py
+++ b/routes/compare_routes.py
@@ -48,11 +48,13 @@ def setup_compare_routes(session_manager: SessionManager):
         sid_b = str(uuid.uuid4())
 
         # Create ephemeral sessions (prefixed [CMP])
-        for sid, model, endpoint in [(sid_a, model_a, endpoint_a), (sid_b, model_b, endpoint_b)]:
+        blind = str(is_blind).lower() == "true"
+        for idx, (sid, model, endpoint) in enumerate([(sid_a, model_a, endpoint_a), (sid_b, model_b, endpoint_b)]):
             user = getattr(request.state, 'current_user', None)
+            label = f"Model {chr(65 + idx)}" if blind else model.split('/')[-1]
             session_manager.create_session(
                 session_id=sid,
-                name=f"[CMP] {model.split('/')[-1]}",
+                name=f"[CMP] {label}",
                 endpoint_url=endpoint,
                 model=model,
                 rag=False,
@@ -76,7 +78,6 @@ def setup_compare_routes(session_manager: SessionManager):
                 db.close()
 
         # Blind mapping: randomly assign left/right
-        blind = str(is_blind).lower() == "true"
         if blind:
             mapping = {"left": "a", "right": "b"}
             if random.random() > 0.5:

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -210,7 +210,7 @@ async function _buildCompareUI() {
     for (let i = 0; i < n; i++) {
       const m = state._selectedModels[i];
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + modelShorts[i]);
+      fd.append('name', '[CMP] ' + (state._blindMode ? 'Model ' + _slotChar(i) : modelShorts[i]));
       fd.append('endpoint_url', m.endpoint || '');
       fd.append('model', m.model || '');
       if (m.endpointId) {

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -382,7 +382,7 @@ async function _createAndAppendPane(m) {
 
   // Create session
   const fd = new FormData();
-  fd.append('name', '[CMP] ' + m.name);
+  fd.append('name', '[CMP] ' + (state._blindMode ? 'Model ' + _slotChar(i) : m.name));
   fd.append('endpoint_url', m.url || '');
   fd.append('model', m.id || '');
   if (m.endpointId) {
@@ -584,7 +584,7 @@ function _showModelSwapDropdown(paneIdx, titleBtn) {
         fetch(`${state.API_BASE}/api/session/${oldSid}`, { method: 'DELETE' }).catch(() => {});
       }
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + m.name);
+      fd.append('name', '[CMP] ' + (state._blindMode ? 'Model ' + _slotChar(paneIdx) : m.name));
       fd.append('endpoint_url', m.url || '');
       fd.append('model', m.id || '');
       if (m.endpointId) {


### PR DESCRIPTION
## Summary
- When blind mode is active, compare sessions are named `[CMP] gpt-4o` / `[CMP] llama-3.1-70b`, revealing model identity in the sidebar and `/api/sessions` before the user votes
- Fix: use neutral labels (`[CMP] Model A`, `[CMP] Model B`) when `blind=true`
- The `model` field on the session object still stores the real model (needed for routing), but the visible `name` no longer leaks it

Fixes #1285