### PR TITLE
Guard message persistence after session delete

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -202,6 +202,15 @@ class SessionManager:
         """Persist a single message to the database."""
         db = SessionLocal()
         try:
+            db_session = db.query(DbSession).filter(DbSession.id == session_id).first()
+            if db_session is None:
+                # A stream/tool callback can outlive a session delete. Do not
+                # create a chat_messages row with no parent session; also drop
+                # any stale cached session so later writes fail closed too.
+                self.sessions.pop(session_id, None)
+                logger.warning("Dropping message for deleted session %s", session_id)
+                return
+
             msg_id = str(uuid.uuid4())
             msg_time = datetime.utcnow()
             if message.metadata is None:
@@ -223,15 +232,13 @@ class SessionManager:
             )
             db.add(db_message)
 
-            db_session = db.query(DbSession).filter(DbSession.id == session_id).first()
-            if db_session:
-                db_session.message_count = len(self.sessions.get(session_id, {}).history) if session_id in self.sessions else 0
-                _now = datetime.now(timezone.utc)
-                db_session.last_accessed = _now
-                # Clean "last conversation" timestamp — only bumped here on a
-                # real message persist, so it powers an accurate "Last active"
-                # sort that ignores renames / model swaps / mere opens.
-                db_session.last_message_at = _now
+            db_session.message_count = len(self.sessions.get(session_id, {}).history) if session_id in self.sessions else 0
+            _now = datetime.now(timezone.utc)
+            db_session.last_accessed = _now
+            # Clean "last conversation" timestamp — only bumped here on a
+            # real message persist, so it powers an accurate "Last active"
+            # sort that ignores renames / model swaps / mere opens.
+            db_session.last_message_at = _now
 
             db.commit()
 

--- a/tests/test_session_manager_persist_guard.py
+++ b/tests/test_session_manager_persist_guard.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.models import ChatMessage
+from core.session_manager import SessionManager
+import core.session_manager as SM
+
+
+def _manager_with(sessions):
+    manager = SessionManager.__new__(SessionManager)
+    manager.sessions = dict(sessions)
+    return manager
+
+
+def _session_local(parent_row):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = parent_row
+    return MagicMock(return_value=db), db
+
+
+def test_persist_message_drops_write_when_parent_session_is_gone(monkeypatch):
+    session_local, db = _session_local(None)
+    monkeypatch.setattr(SM, "SessionLocal", session_local)
+
+    manager = _manager_with({"deleted": SimpleNamespace(history=[])})
+    message = ChatMessage("assistant", "late token")
+
+    manager._persist_message("deleted", message)
+
+    assert "deleted" not in manager.sessions
+    db.add.assert_not_called()
+    db.commit.assert_not_called()
+    db.rollback.assert_not_called()
+
+
+def test_persist_message_still_writes_when_parent_session_exists(monkeypatch):
+    parent = SimpleNamespace(message_count=0, last_accessed=None, last_message_at=None)
+    session_local, db = _session_local(parent)
+    monkeypatch.setattr(SM, "SessionLocal", session_local)
+
+    message = ChatMessage("user", "hello")
+    manager = _manager_with({"sid": SimpleNamespace(history=[message])})
+
+    manager._persist_message("sid", message)
+
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    assert parent.message_count == 1
+    assert parent.last_accessed is not None
+    assert parent.last_message_at is not None
+    assert message.metadata["_db_id"]
+    assert message.metadata["timestamp"].endswith("Z")


### PR DESCRIPTION
## Summary

Related to #1358. This hardens `SessionManager._persist_message()` so a late stream/tool callback cannot create a `chat_messages` row after its parent session row has already been deleted.

The current code builds and adds the `ChatMessage` row first, then looks up the parent `Session` row only to update counters/timestamps. If the session row is gone, the write can become an orphan row on stores that do not enforce the FK, or a failed commit on stores that do. Either way, it is better to fail closed before adding the message.

This PR:

- checks that the parent `sessions` row exists before adding the message row
- drops any stale cached in-memory session when the DB row is gone
- leaves normal message persistence behavior unchanged when the parent session exists
- adds focused regression tests for both paths

This does not replace the broader DB-driven session-list work in #1361; it closes the adjacent residue/orphan-message path so deleted sessions cannot keep accumulating late writes.

## Validation

- `./venv/bin/python -m pytest -q tests/test_session_manager_persist_guard.py tests/test_session_ghost_delete.py tests/test_deleted_session_sidebar_regression.py` -> 12 passed
- `./venv/bin/python -m py_compile core/session_manager.py tests/test_session_manager_persist_guard.py` -> passes
- `git diff --check upstream/main...HEAD` -> clean
- Direct diff against current main contains only `core/session_manager.py` and `tests/test_session_manager_persist_guard.py`