### PR TITLE
fix(chat): let X delete client-side-only bubbles when no session is active (#1428)

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -21,6 +21,7 @@ import * as emailInbox from './emailInbox.js';
 import codeRunnerModule from './codeRunner.js';
 import slashCommands, { initSlashCommands, isCommand, handleSlashCommand, handleSetupInput, handleSetupWizard, typewriterInto } from './slashCommands.js';
 import createResearchSynapse from './researchSynapse.js';
+import { computeDeleteTargets } from './chatDeleteTargets.js';
   const RESEARCH_TIMEOUT_MS = 360000;
   const DEFAULT_TIMEOUT_MS = 120000;
   const RESEARCH_SVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>';
@@ -4037,61 +4038,29 @@ import createResearchSynapse from './researchSynapse.js';
     const clickedIndex = allMsgs.indexOf(msgElement);
     if (clickedIndex < 0) return;
 
+    // sessionId can be null when the chat is showing client-side-only bubbles
+    // (e.g. the "No chat session active" error shown when no model is picked).
+    // Those bubbles carry no dbId, so the fallback at the bottom of this
+    // function handles the DOM-only delete.
     const sessionId = sessionModule.getCurrentSessionId();
-    if (!sessionId) return;
 
-    const clickedIsUser = msgElement.classList.contains('msg-user');
+    // Find the user+AI pair. Pure helper, unit-tested in tests/test_chat_delete_message_no_session.py.
+    const targets = computeDeleteTargets(allMsgs, clickedIndex);
+    if (!targets) return;
+    const { userIndex, aiIndex, msgIds } = targets;
 
-    // Find the user+AI pair
-    let userIndex = -1;
-    let aiIndex = -1;
-    if (clickedIsUser) {
-      userIndex = clickedIndex;
-      // Find the following AI message
-      for (let i = clickedIndex + 1; i < allMsgs.length; i++) {
-        if (allMsgs[i].classList.contains('msg-ai') && !allMsgs[i].classList.contains('msg-continuation')) {
-          aiIndex = i;
-          break;
-        }
-        if (allMsgs[i].classList.contains('msg-user')) break; // next user msg, no AI response
-      }
-    } else {
-      // If clicked on a continuation, walk back to the main AI message
-      let mainAiIndex = clickedIndex;
-      if (allMsgs[mainAiIndex].classList.contains('msg-continuation')) {
-        for (let i = mainAiIndex - 1; i >= 0; i--) {
-          if (allMsgs[i].classList.contains('msg-ai') && !allMsgs[i].classList.contains('msg-continuation')) {
-            mainAiIndex = i;
-            break;
-          }
-        }
-      }
-      aiIndex = mainAiIndex;
-      // Find the preceding user message
-      for (let i = aiIndex - 1; i >= 0; i--) {
-        if (allMsgs[i].classList.contains('msg-user')) {
-          userIndex = i;
-          break;
-        }
-      }
-    }
-
-    // Collect DB message IDs and DOM elements to remove
-    const msgIds = [];
+    // Collect DOM elements to remove (between the user+AI pair, continuations, tool bubbles).
+    // msgIds was already populated by the helper for any bubble that has a dbId.
     const domToRemove = [];
 
     // Add the user message if found
     if (userIndex >= 0) {
       domToRemove.push(allMsgs[userIndex]);
-      const uid = allMsgs[userIndex].dataset.dbId;
-      if (uid) msgIds.push(uid);
     }
 
     // Add the AI message if found
     if (aiIndex >= 0) {
       domToRemove.push(allMsgs[aiIndex]);
-      const aid = allMsgs[aiIndex].dataset.dbId;
-      if (aid) msgIds.push(aid);
 
       const aiEl = allMsgs[aiIndex];
       // Also remove agent-thread elements BETWEEN user and AI

--- a/static/js/chatDeleteTargets.js
+++ b/static/js/chatDeleteTargets.js
@@ -1,0 +1,68 @@
+// static/js/chatDeleteTargets.js
+//
+// Pure helper for the chat message delete flow: given the rendered message
+// list and the index of the bubble the user clicked X on, return which
+// sibling bubbles belong to the same user/AI exchange and which dbIds (if
+// any) should be deleted server-side. The caller owns the actual DOM
+// removal and the fetch.
+//
+// A message element only needs:
+//   - classList.contains(name) -> bool
+//   - dataset.dbId -> string | undefined
+//
+// Returns null if clickedIndex is out of range; otherwise
+//   { userIndex, aiIndex, msgIds: string[] }.
+// Both indices are -1 when no matching partner exists. msgIds is empty
+// when the bubbles were never persisted (e.g. client-side "No chat
+// session active" error bubbles shown when no model is selected).
+
+export function computeDeleteTargets(allMsgs, clickedIndex) {
+  if (clickedIndex < 0 || clickedIndex >= allMsgs.length) return null;
+  const clicked = allMsgs[clickedIndex];
+  const clickedIsUser = clicked.classList.contains('msg-user');
+
+  let userIndex = -1;
+  let aiIndex = -1;
+
+  if (clickedIsUser) {
+    userIndex = clickedIndex;
+    for (let i = clickedIndex + 1; i < allMsgs.length; i++) {
+      const m = allMsgs[i];
+      if (m.classList.contains('msg-ai') && !m.classList.contains('msg-continuation')) {
+        aiIndex = i;
+        break;
+      }
+      if (m.classList.contains('msg-user')) break; // next user msg, no AI response
+    }
+  } else {
+    let mainAiIndex = clickedIndex;
+    if (allMsgs[mainAiIndex].classList.contains('msg-continuation')) {
+      for (let i = mainAiIndex - 1; i >= 0; i--) {
+        const m = allMsgs[i];
+        if (m.classList.contains('msg-ai') && !m.classList.contains('msg-continuation')) {
+          mainAiIndex = i;
+          break;
+        }
+      }
+    }
+    aiIndex = mainAiIndex;
+    for (let i = aiIndex - 1; i >= 0; i--) {
+      if (allMsgs[i].classList.contains('msg-user')) {
+        userIndex = i;
+        break;
+      }
+    }
+  }
+
+  const msgIds = [];
+  if (userIndex >= 0) {
+    const uid = allMsgs[userIndex].dataset && allMsgs[userIndex].dataset.dbId;
+    if (uid) msgIds.push(uid);
+  }
+  if (aiIndex >= 0) {
+    const aid = allMsgs[aiIndex].dataset && allMsgs[aiIndex].dataset.dbId;
+    if (aid) msgIds.push(aid);
+  }
+
+  return { userIndex, aiIndex, msgIds };
+}

--- a/tests/test_chat_delete_message_no_session.py
+++ b/tests/test_chat_delete_message_no_session.py
@@ -1,0 +1,174 @@
+"""Issue #1428 — clicking X on a client-side-only chat bubble should remove it
+from the DOM, even when there is no current chat session.
+
+Repro from the issue: send a message without a model selected. The chat
+shows the "No chat session active" assistant bubble. Clicking the X in the
+footer does nothing.
+
+Root cause: ``deleteMessage()`` in ``static/js/chat.js`` early-exited when
+``getCurrentSessionId()`` returned null. The "No chat session active" bubble
+is created with no ``dbId`` (it was never persisted), so the existing
+fallback path that removes the DOM-only bubbles was unreachable.
+
+The fix: drop the ``if (!sessionId) return;`` early-exit and delegate the
+pair-finding logic to ``computeDeleteTargets()`` in
+``static/js/chatDeleteTargets.js``. The fallback at the bottom of
+``deleteMessage()`` then handles the DOM-only delete.
+
+This test pins both:
+  1. ``computeDeleteTargets()`` returns the right indices/dbIds for the
+     message-list shapes that ``deleteMessage()`` actually sees.
+  2. The static ``deleteMessage()`` source no longer early-exits on a
+     missing session id.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "chatDeleteTargets.js"
+_CHAT_JS = _REPO / "static" / "js" / "chat.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+# Wire format: array of [classes: list[str], dbId: str|null].
+def _call(messages, clicked_index):
+    """Invoke computeDeleteTargets in node and return the JSON result."""
+    js = (
+        "import { computeDeleteTargets } from '"
+        + _HELPER.as_posix()
+        + "';\n"
+        "function makeMsg([classes, dbId]) {\n"
+        "  const cls = new Set(classes);\n"
+        "  return {\n"
+        "    classList: { contains: (c) => cls.has(c) },\n"
+        "    dataset: dbId ? { dbId } : {},\n"
+        "  };\n"
+        "}\n"
+        f"const msgs = {json.dumps(messages)}.map(makeMsg);\n"
+        f"console.log(JSON.stringify(computeDeleteTargets(msgs, {clicked_index})));\n"
+    )
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js,
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+# The exact scenario from the issue screenshot: a lone assistant bubble
+# with no dbId, no user partner. computeDeleteTargets should return
+# aiIndex pointing at the clicked bubble, no user partner, and empty
+# msgIds (so the fallback path will just remove the DOM).
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_lone_assistant_bubble_no_db_id_no_user_partner():
+    result = _call([[["msg", "msg-ai"], None]], 0)
+    assert result == {"userIndex": -1, "aiIndex": 0, "msgIds": []}
+
+
+# User bubble with no AI partner (sent a message, no model selected, no
+# response was streamed). Clicking X should target the user bubble.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_user_bubble_no_ai_partner():
+    result = _call([[["msg", "msg-user"], None]], 0)
+    assert result == {"userIndex": 0, "aiIndex": -1, "msgIds": []}
+
+
+# User + AI pair, both have dbIds — clicking on the user bubble should
+# return both indices and both dbIds.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_user_ai_pair_with_db_ids_clicked_user():
+    messages = [
+        [["msg", "msg-user"], "db-user-1"],
+        [["msg", "msg-ai"], "db-ai-1"],
+    ]
+    result = _call(messages, 0)
+    assert result == {"userIndex": 0, "aiIndex": 1, "msgIds": ["db-user-1", "db-ai-1"]}
+
+
+# AI clicked — should walk back to find the user partner.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_ai_bubble_clicked_finds_preceding_user():
+    messages = [
+        [["msg", "msg-user"], "db-user-1"],
+        [["msg", "msg-ai"], "db-ai-1"],
+    ]
+    result = _call(messages, 1)
+    assert result == {"userIndex": 0, "aiIndex": 1, "msgIds": ["db-user-1", "db-ai-1"]}
+
+
+# AI bubble has no user partner (the issue scenario). msgIds should be
+# empty so the fallback removes the DOM without an API call.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_lone_ai_bubble_no_user_partner_no_db_id():
+    result = _call([[["msg", "msg-ai"], None]], 0)
+    assert result == {"userIndex": -1, "aiIndex": 0, "msgIds": []}
+
+
+# User + AI pair, neither has a dbId (optimistic renders before the
+# message_saved event fires). msgIds should be empty so the DOM-only
+# fallback fires — no API call to a not-yet-saved message.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_pair_without_db_ids_yields_empty_msg_ids():
+    messages = [
+        [["msg", "msg-user"], None],
+        [["msg", "msg-ai"], None],
+    ]
+    result = _call(messages, 0)
+    assert result == {"userIndex": 0, "aiIndex": 1, "msgIds": []}
+
+
+# User + AI pair with a continuation bubble. Clicking the continuation
+# should resolve to the main AI bubble's user/AI pair, not include the
+# continuation's own dbId.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_continuation_bubble_walks_back_to_main_ai():
+    messages = [
+        [["msg", "msg-user"], "db-user-1"],
+        [["msg", "msg-ai"], "db-ai-1"],
+        [["msg", "msg-ai", "msg-continuation"], "db-ai-1-cont"],
+    ]
+    result = _call(messages, 2)
+    assert result == {"userIndex": 0, "aiIndex": 1, "msgIds": ["db-user-1", "db-ai-1"]}
+
+
+# Out-of-range index returns null so the caller can early-exit.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_out_of_range_index_returns_null():
+    result = _call([[["msg", "msg-user"], "db-user-1"]], 5)
+    assert result is None
+
+
+# Negative index returns null.
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_negative_index_returns_null():
+    result = _call([[["msg", "msg-user"], "db-user-1"]], -1)
+    assert result is None
+
+
+# Structural regression: the early-exit guard in deleteMessage() must be
+# gone, otherwise the issue is back. Reading the actual source is the
+# only honest check — the early-exit line used to be the very first
+# thing after getCurrentSessionId(), so a surviving
+# ``if (!sessionId) return;`` (or any ``if (!sessionId) return``) means
+# the fix was lost.
+def test_delete_message_no_early_exit_on_missing_session():
+    src = _CHAT_JS.read_text()
+    start = src.find("export async function deleteMessage(")
+    assert start > 0, "deleteMessage not found in chat.js"
+    end = src.find("export async function", start + 1)
+    body = src[start:end] if end > 0 else src[start:]
+    assert "if (!sessionId) return" not in body, (
+        "deleteMessage() still early-exits on missing sessionId — "
+        "this is the bug fixed by #1428. The early-exit was reachable "
+        "for any client-side-only bubble (e.g. 'No chat session active' "
+        "error messages) and made the delete-X button silently fail."
+    )


### PR DESCRIPTION
## Summary

Clicking the X on a chat bubble that was never persisted to the server did nothing. Repro from #1428: send a message with no model selected, get the "No chat session active" assistant bubble, click its X — bubble stays.

## Why it matters

`deleteMessage()` in `static/js/chat.js` early-exited as soon as `getCurrentSessionId()` returned null. Bubbles rendered client-side (error/info messages, and any user bubble that hasn't been through the stream's `message_saved` event yet) have no `dbId`, so the DOM-only fallback at the bottom of the function was unreachable for them. The X button silently failed for an entire class of bubbles, not just the one in the screenshot.

## What I changed

Dropped the `if (!sessionId) return;` guard. With it gone, the existing fallback (`if (!msgIds.length) { domToRemove.forEach(el => el.remove()); ... return; }`) handles the DOM-only path that was the actual intent.

Moved the user/AI pair-finding into a pure helper (`static/js/chatDeleteTargets.js`) so it can be unit-tested under node without DOM/import mocking. `deleteMessage` now just collects DOM elements between the user and AI, then either fires the server delete (when we have `dbId`s) or falls back to a DOM-only remove (when we don't).

The only behavior change is the missing session path: clicking X on a client-side-only bubble now removes it from the DOM. The server-side delete path (when `dbId`s are present) is unchanged.

## Verification

- `node --check static/js/chat.js static/js/chatDeleteTargets.js` — both OK
- `pytest tests/test_chat_delete_message_no_session.py -v` — 10/10 pass
  - Lone assistant bubble, no dbId, no user partner (the exact issue scenario)
  - User bubble with no AI partner
  - User+AI pair, both with dbIds, clicked user
  - AI bubble clicked, walks back to user
  - Lone AI bubble, no user partner, no dbId
  - User+AI pair, neither has dbId (optimistic pre-`message_saved`)
  - Continuation bubble resolves to main AI pair
  - Out-of-range and negative indices return null
  - Static check: `deleteMessage()` source no longer contains `if (!sessionId) return;`

## Out of scope

- The "we have `dbId`s but no session" edge case (a bubble loaded from the server after the user navigated away). The fetch would 404, the existing catch shows an error toast, and the bubble stays. This combination doesn't occur in practice (a `dbId` implies a session existed when the bubble was rendered) so I left it for a future fix if it ever surfaces.

Closes #1428
