### PR TITLE
fix: app_api blocklist misses GET/POST /api/tokens (token list + mint reachable)

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2673,7 +2673,7 @@ async def _cookbook_register_task(session_id: str, model: str, host: str,
 _APP_API_BLOCKLIST_PREFIXES = (
     "/api/auth/",          # login/logout/password
     "/api/users/",         # user CRUD
-    "/api/tokens/",        # api token mgmt
+    "/api/tokens",         # api token mgmt (collection + /{id}; no trailing slash so GET/POST /api/tokens are covered too)
     "/api/admin/",         # admin one-shots (wipe etc.)
     "/api/backup/restore", # destructive restore
 )

--- a/tests/test_app_api_tokens_blocklist.py
+++ b/tests/test_app_api_tokens_blocklist.py
@@ -1,0 +1,30 @@
+"""Regression: app_api must block the API-token management endpoints.
+
+The blocklist prefix was `/api/tokens/` (trailing slash), which only matched
+`DELETE /api/tokens/{id}`. The collection endpoints are registered slash-less
+(`GET /api/tokens` lists every token with owner + prefix, `POST /api/tokens`
+mints a new long-lived credential), so they sailed through the gate and were
+reachable via app_api with the internal admin header. The prefix is now
+slash-less so both the collection and the per-id paths are blocked.
+"""
+import asyncio
+import json
+
+from src.tool_implementations import do_app_api
+
+
+def _blocked(path, method="GET"):
+    result = asyncio.run(do_app_api(json.dumps({"path": path, "method": method})))
+    return "blocked" in (result.get("error") or "").lower() and result.get("exit_code") == 1
+
+
+def test_list_tokens_is_blocked():
+    assert _blocked("/api/tokens", "GET")
+
+
+def test_mint_token_is_blocked():
+    assert _blocked("/api/tokens", "POST")
+
+
+def test_delete_token_by_id_still_blocked():
+    assert _blocked("/api/tokens/abc123", "DELETE")


### PR DESCRIPTION
## Summary
`do_app_api` (the agent loopback to internal endpoints) refuses auth/user/admin paths via `_APP_API_BLOCKLIST_PREFIXES`. The token-management entry was `/api/tokens/` with a trailing slash, but the token endpoints are registered slash-less in `routes/api_token_routes.py` (`APIRouter(prefix="/api")` + `@router.get("/tokens")` and `@router.post("/tokens")`). The gate is `any(path.startswith(p) for p in _APP_API_BLOCKLIST_PREFIXES)`, and `"/api/tokens".startswith("/api/tokens/")` is `False`.

Result: only `DELETE /api/tokens/{id}` was blocked. `GET /api/tokens` (lists every token with owner and prefix) and `POST /api/tokens` (mints a new long-lived API credential) passed the gate. Since `do_app_api` sends with the internal tool header, which `require_admin` treats as admin, the agent could enumerate the token table and create new credentials despite the intended block.

Trigger: `app_api` with `{"path": "/api/tokens"}` or `{"path": "/api/tokens", "method": "POST", "body": {...}}`.

## Changes
- src/tool_implementations.py: drop the trailing slash so the prefix covers both `/api/tokens` and `/api/tokens/{id}`. Matches the existing slash-less `/api/backup/restore` entry.
- tests/test_app_api_tokens_blocklist.py: assert GET and POST `/api/tokens` are blocked, and the per-id DELETE stays blocked.