### PR TITLE
feat(automation): add data-testid selectors to model picker

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,68 @@
+# Automation selectors
+
+Odysseus is starting to mark its dynamically-rendered UI elements with
+stable `data-*` attributes so RPA tools (UiPath, Power Automate,
+Playwright, Selenium, etc.) can target them reliably.
+
+The static layout in `static/index.html` already uses semantic `id`s
+(e.g. `#memory-bulk-delete`, `#add-skill-btn`). Those work as-is.
+This page covers the *dynamic* surfaces — lists and rows that JS builds
+at runtime — where there was no stable hook before.
+
+## Convention
+
+| Attribute | Purpose |
+|---|---|
+| `data-testid` | What kind of element it is. Stable across releases. Use this as the primary selector. |
+| `data-<entity>-id` | The instance ID when there's a meaningful one (e.g. `data-model-id`, `data-endpoint-id`). |
+| Other `data-*` | State flags like `data-stale="true"`, `data-collapsed="true"`. |
+
+Two design rules:
+
+1. `data-testid` values are **kebab-case** and namespaced by the
+   surface they live in (e.g. `model-picker-option`,
+   `model-picker-provider-header`). This keeps selectors readable and
+   avoids cross-surface collisions.
+2. **Never put a translation-dependent string in `data-testid`.** Use
+   IDs or slugs, not user-facing labels.
+
+## Currently covered
+
+### Model picker (`static/js/modelPicker.js`)
+
+| Selector | Element |
+|---|---|
+| `[data-testid="model-picker-option"]` | A clickable model row |
+| `[data-testid="model-picker-option"][data-model-id="<mid>"]` | A specific model |
+| `[data-testid="model-picker-favorite"][data-model-id="<mid>"]` | Favorite toggle on a model row |
+| `[data-testid="model-picker-section"][data-section="recent\|favorites\|all models"]` | Section header inside the picker |
+| `[data-testid="model-picker-empty"]` | "No matching models" state |
+| `[data-testid="model-picker-provider-header"][data-provider="<slug>"]` | Collapsible provider group header |
+| `[data-testid="model-picker-provider-group"][data-provider="<slug>"]` | Container for a provider's models |
+
+### Example: Playwright
+
+```js
+// Open the model picker (static element, has an id)
+await page.click('#model-picker-btn');
+
+// Pick a specific model
+await page.click('[data-testid="model-picker-option"][data-model-id="llama3.2:3b"]');
+
+// Or just star/unstar a model
+await page.click('[data-testid="model-picker-favorite"][data-model-id="llama3.2:3b"]');
+```
+
+## Roadmap
+
+This is a starting point. Other surfaces that would benefit most from
+the same treatment, in rough priority order:
+
+- Session list in the sidebar (each chat row)
+- Chat message rendering (each rendered message)
+- Cookbook model rows (scan / download / serve)
+- Email inbox rows
+- Notes / Tasks / Calendar rows
+
+Contributions welcome — keep the convention consistent and prefer
+small, surface-by-surface PRs over sweeping edits.

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -284,17 +284,28 @@ function _initModelPickerDropdown() {
       const el = document.createElement('div');
       el.className = 'mp-section-label';
       el.textContent = label;
+      // Stable selector for automation: target a specific section by name.
+      el.setAttribute('data-testid', 'model-picker-section');
+      el.setAttribute('data-section', label.toLowerCase());
       listEl.appendChild(el);
     }
     function _addEmpty(text) {
       const empty = document.createElement('div');
       empty.className = 'model-switch-empty';
       empty.textContent = text;
+      empty.setAttribute('data-testid', 'model-picker-empty');
       listEl.appendChild(empty);
     }
     function _addRow(m) {
       const row = document.createElement('div');
       row.className = 'model-switch-item';
+      // Stable selectors for automation:
+      //   [data-testid="model-picker-option"]                  → all options
+      //   [data-testid="model-picker-option"][data-model-id=X] → a specific model
+      row.setAttribute('data-testid', 'model-picker-option');
+      row.setAttribute('data-model-id', m.mid);
+      if (m.endpointId) row.setAttribute('data-endpoint-id', String(m.endpointId));
+      if (m.stale) row.setAttribute('data-stale', 'true');
       if (m.stale) {
         row.classList.add('model-switch-stale');
         row.style.opacity = '0.45';
@@ -331,6 +342,8 @@ function _initModelPickerDropdown() {
       favDot.type = 'button';
       favDot.className = 'mp-fav-dot' + (favs.includes(m.mid) ? ' active' : '');
       favDot.textContent = '●';
+      favDot.setAttribute('data-testid', 'model-picker-favorite');
+      favDot.setAttribute('data-model-id', m.mid);
       const _setFavState = (on) => {
         favDot.classList.toggle('active', on);
         favDot.title = on ? 'Remove from favorites' : 'Add to favorites';
@@ -418,6 +431,11 @@ function _initModelPickerDropdown() {
         const isCollapsed = _collapsedProviders.has(provider);
         const header = document.createElement('div');
         header.className = 'mp-provider-header';
+        // Stable selectors for automation:
+        //   [data-testid="model-picker-provider-header"][data-provider=X]
+        header.setAttribute('data-testid', 'model-picker-provider-header');
+        header.setAttribute('data-provider', provider);
+        header.setAttribute('data-collapsed', isCollapsed ? 'true' : 'false');
         header.innerHTML =
           `<svg class="mp-provider-chevron${isCollapsed ? ' collapsed' : ''}" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>`
           + `<span class="mp-provider-name">${_providerDisplayName(provider)}</span>`
@@ -440,6 +458,8 @@ function _initModelPickerDropdown() {
         if (!isCollapsed) {
           const group = document.createElement('div');
           group.className = 'mp-provider-group' + (_justExpandedProvider === provider ? ' mp-just-expanded' : '');
+          group.setAttribute('data-testid', 'model-picker-provider-group');
+          group.setAttribute('data-provider', provider);
           models.forEach(m => {
             _addRow(m);
             // Move the just-appended row into the group container


### PR DESCRIPTION
Fixes #2089

Add stable data-testid + data-* attributes to the dynamically-rendered elements in the model picker so RPA tools (UiPath, Power Automate, Playwright, Selenium) can target a specific model row deterministically.

Static elements in index.html already carry semantic ids; the gap was in dynamic content. This PR is a small proof-of-concept covering one surface (the model picker) and a docs page describing the convention, so the same pattern can be extended to other dynamic surfaces in focused follow-up PRs (session list, chat messages, cookbook rows, etc.).

Selectors added in static/js/modelPicker.js:

  [data-testid='model-picker-option'][data-model-id=X]
  [data-testid='model-picker-favorite'][data-model-id=X]
  [data-testid='model-picker-section'][data-section=recent|favorites|...]
  [data-testid='model-picker-empty']
  [data-testid='model-picker-provider-header'][data-provider=X]
  [data-testid='model-picker-provider-group'][data-provider=X]

docs/automation.md documents the convention and lists current coverage.

## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.
2.
3.

## Screenshots (UI changes only)

<!-- Drag and drop images or a screen recording here. Delete this section if not a UI change. -->

