### PR TITLE
fix: local _q import shadows module-level IMAP folder quoter, breaking auto-summarize

### DIFF
--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -731,8 +731,8 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                                     from src.settings import load_settings as _ls
                                     _pub = (_ls().get("app_public_url") or "").rstrip("/")
                                     uid_str = uid.decode() if isinstance(uid, bytes) else str(uid)
-                                    from urllib.parse import quote as _q
-                                    open_url = f"{_pub}/#email={_q(_folder, safe='')}:{uid_str}" if _pub else ""
+                                    from urllib.parse import quote as _url_q
+                                    open_url = f"{_pub}/#email={_url_q(_folder, safe='')}:{uid_str}" if _pub else ""
 
                                     alert_subject = f"[{urgency.upper()}] {subject}"
                                     alert_body = (


### PR DESCRIPTION
## Summary
- `from urllib.parse import quote as _q` at line 734 inside `_auto_summarize_pass_single` shadows the module-level `_q` (IMAP folder quoting utility imported from `email_helpers`)
- Python treats `_q` as a local variable for the entire function scope, so lines 191 and 278 (`conn.select(_q(folder), readonly=True)`) raise `UnboundLocalError` before the local import executes
- This silently breaks every auto-summarize/reply/classify pass (the outer `except` catches it and returns `"Error: ..."`)
- Fix: rename the local import to `_url_q` so the module-level `_q` remains accessible

## Lines changed
- `routes/email_pollers.py:734-735` — renamed `_q` → `_url_q`