### PR TITLE
fix: guard uid.decode() in auto-classify log against str UIDs

### DIFF
--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -829,7 +829,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                             _req.post, url, json=payload, headers=req_headers, timeout=120
                         )
                         if not resp.ok:
-                            logger.warning(f"Auto-classify {uid.decode()} HTTP {resp.status_code}: {resp.text[:200]}")
+                            logger.warning(f"Auto-classify {uid.decode() if isinstance(uid, bytes) else str(uid)} HTTP {resp.status_code}: {resp.text[:200]}")
                         else:
                             rdata = resp.json()
                             m = (rdata.get("choices") or [{}])[0].get("message", {})


### PR DESCRIPTION
## Summary
- `uid.decode()` at line 832 crashes with `AttributeError` when `uid` is already a string (from the legacy bare-UID path)
- Every other `uid.decode()` in this function guards with `isinstance(uid, bytes)` — this one was missed
- Fix: apply the same `uid.decode() if isinstance(uid, bytes) else str(uid)` pattern

## Lines changed
- `routes/email_pollers.py:832`