### PR TITLE
Add admin diagnostics panel and support bundle

### DIFF
--- a/app.py
+++ b/app.py
@@ -659,6 +659,7 @@ from src.agent_tools import set_mcp_manager
 from routes.mcp_routes import setup_mcp_routes
 
 mcp_manager = McpManager()
+app.state.mcp_manager = mcp_manager
 set_mcp_manager(mcp_manager)
 app.include_router(setup_mcp_routes(mcp_manager))
 logger.info("MCP routes initialized")

--- a/routes/diagnostics_routes.py
+++ b/routes/diagnostics_routes.py
@@ -1,4 +1,4 @@
-"""Diagnostics routes — /api/db/stats, /api/rag/stats, /api/test/youtube, /api/test-research."""
+"""Diagnostics routes — system status and debug/test endpoints."""
 
 import logging
 from typing import Dict, Any
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Form, Request
 from services.youtube.youtube_handler import extract_youtube_id, extract_transcript_async
 from core.constants import DEFAULT_HOST
 from core.middleware import require_admin
+from src.system_diagnostics import collect_diagnostics_support_bundle, collect_system_diagnostics
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,24 @@ def setup_diagnostics_routes(
     research_handler,
 ) -> APIRouter:
     router = APIRouter(tags=["diagnostics"])
+
+    @router.get("/api/diagnostics/status")
+    async def get_system_diagnostics(request: Request) -> Dict[str, Any]:
+        require_admin(request)
+        try:
+            return await collect_system_diagnostics(getattr(request.app.state, "mcp_manager", None))
+        except Exception as e:
+            logger.error(f"System diagnostics error: {e}", exc_info=True)
+            raise HTTPException(500, "Failed to retrieve system diagnostics")
+
+    @router.get("/api/diagnostics/support-bundle")
+    async def get_diagnostics_support_bundle(request: Request) -> Dict[str, Any]:
+        require_admin(request)
+        try:
+            return await collect_diagnostics_support_bundle(getattr(request.app.state, "mcp_manager", None))
+        except Exception as e:
+            logger.error(f"Diagnostics support bundle error: {e}", exc_info=True)
+            raise HTTPException(500, "Failed to build diagnostics support bundle")
 
     @router.get("/api/db/stats")
     async def get_database_stats(request: Request) -> Dict[str, Any]:

--- a/src/system_diagnostics.py
+++ b/src/system_diagnostics.py
@@ -1,0 +1,597 @@
+"""Read-only system diagnostics used by the admin System settings tab."""
+
+import asyncio
+import json
+import os
+import platform
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import httpx
+from sqlalchemy import text
+
+import core.database as database
+from core.constants import SEARXNG_INSTANCE
+from src.integrations import load_integrations
+from src.settings import load_features, load_settings
+
+CHECK_TIMEOUT = 1.25
+SessionLocal = database.SessionLocal
+EmailAccount = getattr(database, "EmailAccount", object())
+McpServer = getattr(database, "McpServer", object())
+ModelEndpoint = getattr(database, "ModelEndpoint", object())
+_SECRET_KEY_RE = re.compile(r"(api[_-]?key|authorization|bearer|cookie|password|secret|token)", re.I)
+_SECRET_VALUE_PATTERNS = [
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\b[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"(?i)\b(bearer|authorization)\s+([A-Za-z0-9._~+/=-]{12,})"),
+    re.compile(r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*([^\s,;]+)"),
+]
+
+
+def _check(
+    check_id: str,
+    label: str,
+    status: str,
+    message: str,
+    hint: Optional[str] = None,
+    action: Optional[Dict[str, str]] = None,
+    detail: Optional[str] = None,
+) -> Dict[str, Any]:
+    item: Dict[str, Any] = {
+        "id": check_id,
+        "label": label,
+        "status": status,
+        "message": message,
+    }
+    if hint:
+        item["hint"] = hint
+    if action:
+        item["action"] = action
+    if detail:
+        item["detail"] = detail
+    return item
+
+
+def _group(group_id: str, label: str, checks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {"id": group_id, "label": label, "checks": checks}
+
+
+def _overall(groups: List[Dict[str, Any]]) -> str:
+    statuses = [c.get("status") for g in groups for c in g.get("checks", [])]
+    if "error" in statuses:
+        return "error"
+    if "warning" in statuses:
+        return "degraded"
+    return "healthy"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+async def _probe_http(url: str, timeout: float = CHECK_TIMEOUT) -> httpx.Response:
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        return await client.get(url)
+
+
+def _in_docker() -> bool:
+    if os.path.exists("/.dockerenv"):
+        return True
+    try:
+        with open("/proc/1/cgroup", "r", encoding="utf-8", errors="ignore") as fh:
+            return any(marker in fh.read() for marker in ("docker", "containerd", "kubepods"))
+    except Exception:
+        return False
+
+
+def _ollama_base_url() -> str:
+    return (
+        os.getenv("OLLAMA_BASE_URL")
+        or os.getenv("OLLAMA_URL")
+        or ("http://host.docker.internal:11434/v1" if _in_docker() else "http://127.0.0.1:11434/v1")
+    )
+
+
+def _ollama_api_root(base_url: str) -> str:
+    base = (base_url or "").strip().rstrip("/")
+    if base.endswith("/v1"):
+        return base[:-3].rstrip("/")
+    if base.endswith("/api"):
+        return base[:-4].rstrip("/")
+    return base
+
+
+def _host_is_localish(host: str) -> bool:
+    host = (host or "").lower()
+    if host in {"localhost", "127.0.0.1", "::1", "0.0.0.0", "host.docker.internal"}:
+        return True
+    if host.startswith(("10.", "192.168.", "100.")):
+        return True
+    if host.startswith("172."):
+        try:
+            second = int(host.split(".", 2)[1])
+            return 16 <= second <= 31
+        except Exception:
+            return False
+    return False
+
+
+def _is_local_endpoint(base_url: str) -> bool:
+    try:
+        parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
+        return _host_is_localish(parsed.hostname or "")
+    except Exception:
+        return False
+
+
+def _git_revision() -> Optional[str]:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _redact_text(value: str) -> str:
+    text_value = value
+    home = str(Path.home())
+    if home and home != ".":
+        text_value = text_value.replace(home, "~")
+    for pattern in _SECRET_VALUE_PATTERNS:
+        if pattern.groups >= 2:
+            text_value = pattern.sub(lambda match: f"{match.group(1)} <redacted>", text_value)
+        else:
+            text_value = pattern.sub("<redacted>", text_value)
+    return text_value
+
+
+def _redact_obj(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_str = str(key)
+            redacted[key_str] = "<redacted>" if _SECRET_KEY_RE.search(key_str) else _redact_obj(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_obj(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_obj(item) for item in value]
+    if isinstance(value, str):
+        return _redact_text(value)
+    return value
+
+
+def _runtime_snapshot(settings: Dict[str, Any], features: Dict[str, Any]) -> Dict[str, Any]:
+    return _redact_obj({
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "in_docker": _in_docker(),
+        "cwd": str(Path.cwd()),
+        "git_revision": _git_revision(),
+        "data_dir_exists": Path("data").exists(),
+        "features": {
+            "rag": features.get("rag", True),
+            "web_search": features.get("web_search", True),
+        },
+        "local_services": {
+            "chroma": f"http://{os.getenv('CHROMADB_HOST', 'localhost')}:{os.getenv('CHROMADB_PORT', '8100')}",
+            "ollama": _ollama_api_root(_ollama_base_url()),
+        },
+        "search": {
+            "provider": settings.get("search_provider") or "default",
+            "url": settings.get("search_url") or SEARXNG_INSTANCE or "",
+        },
+        "notifications": {
+            "reminder_channel": settings.get("reminder_channel") or "browser",
+        },
+    })
+
+
+def _models_url(base_url: str) -> str:
+    base = (base_url or "").strip().rstrip("/")
+    if base.endswith("/chat/completions"):
+        base = base[: -len("/chat/completions")]
+    if base.endswith("/v1"):
+        return f"{base}/models"
+    if base.endswith("/api"):
+        return f"{base}/tags"
+    return f"{base}/models"
+
+
+def _safe_endpoint_label(ep: Any) -> str:
+    name = getattr(ep, "name", "") or "endpoint"
+    try:
+        parsed = urlparse(getattr(ep, "base_url", "") or "")
+        location = parsed.netloc or parsed.path
+    except Exception:
+        location = ""
+    return f"{name} ({location})" if location else name
+
+
+def _core_checks() -> List[Dict[str, Any]]:
+    checks: List[Dict[str, Any]] = []
+    db = None
+    try:
+        db = SessionLocal()
+        db.execute(text("SELECT 1"))
+        checks.append(_check("database", "Database", "ok", "SQLite is reachable."))
+    except Exception as exc:
+        checks.append(_check(
+            "database",
+            "Database",
+            "error",
+            "Database query failed.",
+            "Check that data/app.db exists and the app process can read it.",
+            detail=str(exc),
+        ))
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    data_dir = Path("data")
+    try:
+        if not data_dir.exists():
+            checks.append(_check(
+                "data_dir",
+                "Data directory",
+                "warning",
+                "data/ does not exist yet.",
+                "Run setup.py or restart Odysseus so it can create its data directory.",
+            ))
+        elif os.access(data_dir, os.R_OK | os.W_OK):
+            checks.append(_check("data_dir", "Data directory", "ok", "data/ is readable and writable."))
+        else:
+            checks.append(_check(
+                "data_dir",
+                "Data directory",
+                "error",
+                "data/ is not readable and writable by this process.",
+                "Fix the ownership or permissions on the data directory.",
+            ))
+    except Exception as exc:
+        checks.append(_check("data_dir", "Data directory", "error", "Could not inspect data/.", detail=str(exc)))
+    return checks
+
+
+async def _chroma_check(features: Dict[str, Any]) -> Dict[str, Any]:
+    if not features.get("rag", True):
+        return _check("chroma", "ChromaDB", "skipped", "RAG is disabled.")
+    host = os.getenv("CHROMADB_HOST", "localhost")
+    port = os.getenv("CHROMADB_PORT", "8100")
+    base = f"http://{host}:{port}"
+    for path in ("/api/v2/heartbeat", "/api/v1/heartbeat"):
+        try:
+            resp = await _probe_http(f"{base}{path}")
+            if resp.is_success:
+                return _check("chroma", "ChromaDB", "ok", f"Heartbeat succeeded at {base}.")
+        except Exception:
+            pass
+    return _check(
+        "chroma",
+        "ChromaDB",
+        "error",
+        f"No heartbeat response from {base}.",
+        "Start ChromaDB or update CHROMADB_HOST/CHROMADB_PORT in .env.",
+    )
+
+
+async def _ollama_check() -> Dict[str, Any]:
+    base = _ollama_base_url()
+    root = _ollama_api_root(base)
+    try:
+        resp = await _probe_http(f"{root}/api/tags")
+        if not resp.is_success:
+            return _check("ollama", "Ollama", "warning", f"Ollama returned HTTP {resp.status_code} at {root}.")
+        data = resp.json() if resp.content else {}
+        count = len(data.get("models") or [])
+        return _check("ollama", "Ollama", "ok", f"{count} local model{'s' if count != 1 else ''} available at {root}.")
+    except Exception as exc:
+        return _check(
+            "ollama",
+            "Ollama",
+            "warning",
+            f"Ollama was not reachable at {root}.",
+            "If you use Ollama, start it and add http://localhost:11434/v1 in Add Models.",
+            action={"tab": "services", "label": "Add Models"},
+            detail=str(exc),
+        )
+
+
+async def _model_endpoint_checks() -> List[Dict[str, Any]]:
+    db = None
+    try:
+        db = SessionLocal()
+        endpoints = db.query(ModelEndpoint).all()
+    except Exception as exc:
+        return [_check("model_endpoints", "Model endpoints", "error", "Could not read configured model endpoints.", detail=str(exc))]
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    enabled = [ep for ep in endpoints if getattr(ep, "is_enabled", True)]
+    if not enabled:
+        return [_check(
+            "model_endpoints",
+            "Model endpoints",
+            "warning",
+            "No enabled model endpoints are configured.",
+            "Add a local Ollama/vLLM endpoint or a cloud provider before starting a chat.",
+            action={"tab": "services", "label": "Add Models"},
+        )]
+
+    local_eps = [ep for ep in enabled if _is_local_endpoint(getattr(ep, "base_url", ""))]
+    remote_count = len(enabled) - len(local_eps)
+    summary = f"{len(enabled)} enabled endpoint{'s' if len(enabled) != 1 else ''}"
+    if local_eps or remote_count:
+        summary += f" ({len(local_eps)} local, {remote_count} remote/API)"
+
+    checks = [_check("model_endpoints", "Model endpoints", "ok", summary, action={"tab": "services", "label": "Manage"})]
+
+    async def probe(ep: Any) -> Dict[str, Any]:
+        label = _safe_endpoint_label(ep)
+        try:
+            resp = await _probe_http(_models_url(getattr(ep, "base_url", "")))
+            if resp.is_success:
+                return _check(f"model_endpoint:{getattr(ep, 'id', label)}", label, "ok", "Model list endpoint responded.")
+            return _check(
+                f"model_endpoint:{getattr(ep, 'id', label)}",
+                label,
+                "warning",
+                f"Model list returned HTTP {resp.status_code}.",
+                "Use Add Models to test or update this endpoint.",
+                action={"tab": "services", "label": "Open"},
+            )
+        except Exception as exc:
+            return _check(
+                f"model_endpoint:{getattr(ep, 'id', label)}",
+                label,
+                "warning",
+                "Local model endpoint did not respond.",
+                "Use Add Models to test or update this endpoint.",
+                action={"tab": "services", "label": "Open"},
+                detail=str(exc),
+            )
+
+    if local_eps:
+        checks.extend(await asyncio.gather(*(probe(ep) for ep in local_eps[:5])))
+        if len(local_eps) > 5:
+            checks.append(_check("model_endpoint_extra", "More local endpoints", "skipped", f"{len(local_eps) - 5} additional local endpoints not probed."))
+    return checks
+
+
+async def _search_check(settings: Dict[str, Any], features: Dict[str, Any]) -> Dict[str, Any]:
+    if not features.get("web_search", True):
+        return _check("search", "Search", "skipped", "Web search is disabled.")
+    provider = (settings.get("search_provider") or "").lower()
+    if provider == "searxng":
+        base = (settings.get("search_url") or SEARXNG_INSTANCE or "").strip().rstrip("/")
+        if not base:
+            return _check("search", "SearXNG", "warning", "SearXNG is selected but no URL is configured.", action={"tab": "search", "label": "Search"})
+        try:
+            resp = await _probe_http(base)
+            if resp.is_success:
+                return _check("search", "SearXNG", "ok", f"SearXNG is reachable at {base}.")
+            return _check("search", "SearXNG", "warning", f"SearXNG returned HTTP {resp.status_code} at {base}.", action={"tab": "search", "label": "Search"})
+        except Exception as exc:
+            return _check(
+                "search",
+                "SearXNG",
+                "warning",
+                f"SearXNG was not reachable at {base}.",
+                "Start SearXNG, change the search provider, or configure a fallback.",
+                action={"tab": "search", "label": "Search"},
+                detail=str(exc),
+            )
+
+    key_requirements = {
+        "brave": ("brave_api_key", "Brave API key"),
+        "google": ("google_pse_key", "Google PSE key"),
+        "tavily": ("tavily_api_key", "Tavily API key"),
+        "serper": ("serper_api_key", "Serper API key"),
+    }
+    if provider in key_requirements:
+        key, label = key_requirements[provider]
+        if settings.get(key):
+            return _check("search", "Search", "ok", f"{provider} is configured.")
+        return _check("search", "Search", "warning", f"{provider} is selected but {label} is missing.", action={"tab": "search", "label": "Search"})
+    return _check("search", "Search", "ok", f"{provider or 'default'} search provider selected.")
+
+
+def _email_check() -> Dict[str, Any]:
+    db = None
+    try:
+        db = SessionLocal()
+        accounts = db.query(EmailAccount).all()
+    except Exception as exc:
+        return _check("email", "Email", "error", "Could not read email accounts.", detail=str(exc))
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    enabled = [a for a in accounts if getattr(a, "enabled", True)]
+    if not enabled:
+        return _check("email", "Email", "skipped", "No enabled email accounts configured.", action={"tab": "integrations", "label": "Integrations"})
+    complete = [a for a in enabled if getattr(a, "imap_host", "") or getattr(a, "smtp_host", "")]
+    if len(complete) == len(enabled):
+        return _check("email", "Email", "ok", f"{len(enabled)} enabled email account{'s' if len(enabled) != 1 else ''} configured.", action={"tab": "integrations", "label": "Integrations"})
+    return _check("email", "Email", "warning", "One or more enabled email accounts are missing IMAP/SMTP hosts.", action={"tab": "integrations", "label": "Integrations"})
+
+
+async def _ntfy_check(settings: Dict[str, Any]) -> Dict[str, Any]:
+    channel = (settings.get("reminder_channel") or "browser").lower()
+    integrations = [
+        i for i in load_integrations()
+        if i.get("enabled", True)
+        and (i.get("preset") == "ntfy" or (i.get("name") or "").lower() == "ntfy")
+        and i.get("base_url")
+    ]
+    if not integrations:
+        status = "warning" if channel == "ntfy" else "skipped"
+        message = "Reminder channel is ntfy but no enabled ntfy integration exists." if channel == "ntfy" else "No enabled ntfy integration configured."
+        return _check("ntfy", "ntfy", status, message, action={"tab": "integrations", "label": "Integrations"})
+
+    base = (integrations[0].get("base_url") or "").strip().rstrip("/")
+    try:
+        resp = await _probe_http(base)
+        if resp.is_success:
+            return _check("ntfy", "ntfy", "ok", f"ntfy server is reachable at {base}.", action={"tab": "integrations", "label": "Integrations"})
+        return _check("ntfy", "ntfy", "warning", f"ntfy returned HTTP {resp.status_code} at {base}.", action={"tab": "integrations", "label": "Integrations"})
+    except Exception as exc:
+        return _check(
+            "ntfy",
+            "ntfy",
+            "warning",
+            f"ntfy was not reachable at {base}.",
+            "Check the ntfy integration URL. This diagnostic does not publish a test notification.",
+            action={"tab": "integrations", "label": "Integrations"},
+            detail=str(exc),
+        )
+
+
+def _mcp_checks(mcp_manager: Any = None) -> List[Dict[str, Any]]:
+    checks: List[Dict[str, Any]] = []
+    if os.getenv("ODYSSEUS_DISABLE_MCP", "").lower() in {"1", "true", "yes"}:
+        checks.append(_check("browser_mcp", "Browser MCP", "skipped", "Built-in MCP startup is disabled by ODYSSEUS_DISABLE_MCP."))
+    elif mcp_manager and hasattr(mcp_manager, "get_all_statuses"):
+        statuses = mcp_manager.get_all_statuses()
+        browser = statuses.get("builtin_browser")
+        if browser and browser.get("status") == "connected":
+            tool_count = browser.get("tool_count", 0)
+            checks.append(_check("browser_mcp", "Browser MCP", "ok", f"Browser MCP connected with {tool_count} tools."))
+        elif browser:
+            checks.append(_check(
+                "browser_mcp",
+                "Browser MCP",
+                "warning",
+                browser.get("error") or "Browser MCP is not connected.",
+                "Run npx -y @playwright/mcp@latest --version once, then restart Odysseus.",
+                action={"tab": "tools", "label": "Agent Tools"},
+            ))
+        else:
+            checks.append(_check(
+                "browser_mcp",
+                "Browser MCP",
+                "warning",
+                "Browser MCP is not connected yet.",
+                "It starts a few seconds after app startup if @playwright/mcp is available in the npx cache.",
+                action={"tab": "tools", "label": "Agent Tools"},
+            ))
+    else:
+        checks.append(_check("browser_mcp", "Browser MCP", "skipped", "Live MCP status is unavailable during this request."))
+
+    db = None
+    try:
+        db = SessionLocal()
+        servers = db.query(McpServer).all()
+    except Exception as exc:
+        checks.append(_check("mcp", "User MCP servers", "error", "Could not read MCP server config.", detail=str(exc)))
+        return checks
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+    enabled = [s for s in servers if getattr(s, "is_enabled", True)]
+    if enabled:
+        checks.append(_check("mcp", "User MCP servers", "ok", f"{len(enabled)} user MCP server{'s' if len(enabled) != 1 else ''} configured.", action={"tab": "tools", "label": "Agent Tools"}))
+    else:
+        checks.append(_check("mcp", "User MCP servers", "ok", "No user MCP servers configured.", action={"tab": "tools", "label": "Agent Tools"}))
+    return checks
+
+
+async def collect_system_diagnostics(mcp_manager: Any = None) -> Dict[str, Any]:
+    settings = load_settings()
+    features = load_features()
+    ai_checks = await asyncio.gather(
+        _chroma_check(features),
+        _ollama_check(),
+    )
+    groups = [
+        _group("core", "Core", _core_checks()),
+        _group("local_ai", "Local AI", [*ai_checks, *(await _model_endpoint_checks())]),
+        _group("research", "Research", [await _search_check(settings, features)]),
+        _group("notifications", "Notifications", [_email_check(), await _ntfy_check(settings)]),
+        _group("tools", "Tools", _mcp_checks(mcp_manager)),
+    ]
+    return {
+        "overall": _overall(groups),
+        "checked_at": _utc_timestamp(),
+        "groups": groups,
+    }
+
+
+def _format_support_bundle(bundle: Dict[str, Any]) -> str:
+    diagnostics = bundle.get("diagnostics") or {}
+    runtime = bundle.get("runtime") or {}
+    lines = [
+        "Odysseus diagnostics support bundle",
+        f"Generated: {bundle.get('generated_at', '')}",
+        f"Overall: {diagnostics.get('overall', 'unknown')}",
+        "",
+        "Runtime:",
+        f"- Platform: {runtime.get('platform', 'unknown')}",
+        f"- Python: {runtime.get('python', 'unknown')}",
+        f"- Docker: {runtime.get('in_docker', False)}",
+        f"- Git revision: {runtime.get('git_revision') or 'unknown'}",
+        "",
+        "Checks:",
+    ]
+    for group in diagnostics.get("groups") or []:
+        lines.append(f"[{group.get('label') or group.get('id') or 'Group'}]")
+        for check in group.get("checks") or []:
+            status = str(check.get("status") or "unknown").upper()
+            label = check.get("label") or check.get("id") or "Check"
+            message = check.get("message") or ""
+            lines.append(f"- {status} {label}: {message}")
+            if check.get("hint"):
+                lines.append(f"  Hint: {check['hint']}")
+            if check.get("detail"):
+                lines.append(f"  Detail: {check['detail']}")
+    lines.extend([
+        "",
+        "Redacted JSON:",
+        json.dumps(bundle, indent=2, sort_keys=True),
+    ])
+    return "\n".join(_redact_text(line) for line in lines)
+
+
+async def collect_diagnostics_support_bundle(mcp_manager: Any = None) -> Dict[str, Any]:
+    settings = load_settings()
+    features = load_features()
+    diagnostics = await collect_system_diagnostics(mcp_manager)
+    bundle = _redact_obj({
+        "kind": "odysseus_diagnostics_support_bundle",
+        "generated_at": _utc_timestamp(),
+        "runtime": _runtime_snapshot(settings, features),
+        "diagnostics": diagnostics,
+    })
+    return {
+        "bundle": bundle,
+        "text": _format_support_bundle(bundle),
+    }

--- a/static/index.html
+++ b/static/index.html
@@ -2137,6 +2137,25 @@
         <!-- ═══ SYSTEM TAB ═══ -->
         <div data-settings-panel="system" class="hidden">
 
+          <div class="admin-card admin-diag-card">
+            <div class="admin-diag-head">
+              <div style="min-width:0;">
+                <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M22 12h-4l-3 8L9 4l-3 8H2"/></svg>System Diagnostics</h2>
+                <div class="admin-toggle-sub" id="adm-diagSummary">Check local services and admin-managed integrations.</div>
+              </div>
+              <div class="admin-diag-actions">
+                <button class="admin-btn-sm" id="adm-diagRefreshBtn" style="white-space:nowrap;">Refresh</button>
+                <button class="admin-btn-sm" id="adm-diagCopyBtn" style="white-space:nowrap;" title="Copy a redacted troubleshooting bundle">Copy Bundle</button>
+                <button class="admin-btn-sm" id="adm-diagToggleBtn" aria-expanded="false" style="white-space:nowrap;">Details</button>
+              </div>
+            </div>
+            <div class="admin-diag-brief" id="adm-diagBrief">Run diagnostics to check the local stack.</div>
+            <div class="admin-diag-meta" id="adm-diagMeta"></div>
+            <div id="adm-diagList" class="admin-diag-list hidden">
+              <div class="admin-empty">Open System or click Refresh to run diagnostics.</div>
+            </div>
+          </div>
+
           <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>Data Backup</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">Export or import your user data (memories, presets, settings, skills, preferences) as a JSON file.</div>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2040,11 +2040,164 @@ function initDangerZone() {
 }
 
 /* ═══════════════════════════════════════════
+   SYSTEM DIAGNOSTICS
+   ═══════════════════════════════════════════ */
+let diagnosticsLoaded = false;
+let diagnosticsExpanded = false;
+
+function _diagOverallLabel(status) {
+  if (status === 'healthy') return 'Healthy';
+  if (status === 'error') return 'Needs attention';
+  return 'Degraded';
+}
+
+function _diagStatusLabel(status) {
+  if (status === 'ok') return 'OK';
+  if (status === 'warning') return 'Check';
+  if (status === 'error') return 'Error';
+  if (status === 'skipped') return 'Skipped';
+  return status || '';
+}
+
+function _diagBrief(data) {
+  const groups = Array.isArray(data?.groups) ? data.groups : [];
+  const checks = groups.flatMap(g => Array.isArray(g.checks) ? g.checks : []);
+  const errors = checks.filter(c => c.status === 'error').length;
+  const warnings = checks.filter(c => c.status === 'warning').length;
+  const skipped = checks.filter(c => c.status === 'skipped').length;
+  const ok = checks.filter(c => c.status === 'ok').length;
+  if (errors) return `${errors} ${errors === 1 ? 'needs' : 'need'} attention, ${ok} healthy.`;
+  if (warnings) return `${warnings} degraded, ${ok} healthy.`;
+  if (skipped) return `${ok} healthy, ${skipped} optional not configured.`;
+  return `${ok} checks healthy.`;
+}
+
+function setDiagnosticsExpanded(expanded) {
+  diagnosticsExpanded = !!expanded;
+  const list = el('adm-diagList');
+  const btn = el('adm-diagToggleBtn');
+  if (list) list.classList.toggle('hidden', !diagnosticsExpanded);
+  if (btn) {
+    btn.setAttribute('aria-expanded', diagnosticsExpanded ? 'true' : 'false');
+    btn.textContent = diagnosticsExpanded ? 'Hide Details' : 'Details';
+  }
+}
+
+function renderDiagnostics(data) {
+  const list = el('adm-diagList');
+  const meta = el('adm-diagMeta');
+  const summary = el('adm-diagSummary');
+  const brief = el('adm-diagBrief');
+  if (!list) return;
+  const overall = data?.overall || 'degraded';
+  if (summary) {
+    summary.innerHTML = `<span class="admin-diag-overall" data-status="${esc(overall)}">${esc(_diagOverallLabel(overall))}</span>`;
+  }
+  if (brief) brief.textContent = _diagBrief(data);
+  if (meta) {
+    const when = data?.checked_at ? new Date(data.checked_at) : null;
+    meta.textContent = when && !Number.isNaN(when.getTime()) ? `Checked ${when.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}` : '';
+  }
+  const groups = Array.isArray(data?.groups) ? data.groups : [];
+  if (!groups.length) {
+    list.innerHTML = '<div class="admin-empty">No diagnostics returned.</div>';
+    return;
+  }
+  list.innerHTML = groups.map(group => {
+    const checks = Array.isArray(group.checks) ? group.checks : [];
+    return `
+      <div class="admin-diag-group">
+        <div class="admin-diag-group-title">${esc(group.label || group.id || 'Group')}</div>
+        ${checks.map(check => {
+          const action = check.action && check.action.tab
+            ? `<button class="admin-btn-sm" data-adm-diag-tab="${esc(check.action.tab)}">${esc(check.action.label || 'Open')}</button>`
+            : '';
+          return `
+            <div class="admin-diag-row" data-status="${esc(check.status || '')}">
+              <span class="admin-diag-dot" title="${esc(_diagStatusLabel(check.status))}"></span>
+              <div class="admin-diag-label">${esc(check.label || check.id || 'Check')}</div>
+              <div class="admin-diag-message">
+                <div>${esc(check.message || '')}</div>
+                ${check.hint ? `<div class="admin-diag-hint">${esc(check.hint)}</div>` : ''}
+              </div>
+              <div class="admin-diag-action">${action}</div>
+            </div>
+          `;
+        }).join('')}
+      </div>
+    `;
+  }).join('');
+  list.querySelectorAll('[data-adm-diag-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.admDiagTab;
+      if (tab) open(tab);
+    });
+  });
+  setDiagnosticsExpanded(diagnosticsExpanded);
+}
+
+async function loadDiagnostics(force = false) {
+  const list = el('adm-diagList');
+  const btn = el('adm-diagRefreshBtn');
+  const brief = el('adm-diagBrief');
+  if (!list) return;
+  if (diagnosticsLoaded && !force) return;
+  const prev = btn ? btn.textContent : '';
+  if (btn) { btn.disabled = true; btn.textContent = 'Checking...'; }
+  if (brief) brief.innerHTML = '<span class="admin-spinner"></span>Running diagnostics...';
+  list.innerHTML = '<div class="admin-empty"><span class="admin-spinner"></span>Running diagnostics...</div>';
+  try {
+    const res = await fetch('/api/diagnostics/status', { credentials: 'same-origin' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.detail || data.error || 'Failed to load diagnostics');
+    diagnosticsLoaded = true;
+    renderDiagnostics(data);
+  } catch (e) {
+    if (brief) brief.textContent = 'Diagnostics failed.';
+    list.innerHTML = `<div class="admin-error">Diagnostics failed: ${esc(e.message || 'Request failed')}</div>`;
+    setDiagnosticsExpanded(true);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = prev || 'Refresh'; }
+  }
+}
+
+async function copyDiagnosticsSupportBundle() {
+  const btn = el('adm-diagCopyBtn');
+  const prev = btn ? btn.textContent : '';
+  if (btn) { btn.disabled = true; btn.textContent = 'Copying...'; }
+  try {
+    const res = await fetch('/api/diagnostics/support-bundle', { credentials: 'same-origin' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.detail || data.error || 'Failed to build diagnostics bundle');
+    if (!data.text) throw new Error('Diagnostics bundle was empty');
+    await uiModule.copyToClipboard(data.text);
+    if (btn) btn.textContent = 'Copied';
+    uiModule.showToast('Diagnostics bundle copied');
+    setTimeout(() => { if (btn) btn.textContent = prev || 'Copy Bundle'; }, 1200);
+  } catch (e) {
+    uiModule.showError('Copy failed: ' + (e.message || 'Request failed'));
+    if (btn) btn.textContent = prev || 'Copy Bundle';
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+function initDiagnostics() {
+  const refreshBtn = el('adm-diagRefreshBtn');
+  const toggleBtn = el('adm-diagToggleBtn');
+  const copyBtn = el('adm-diagCopyBtn');
+  if (refreshBtn) refreshBtn.addEventListener('click', () => loadDiagnostics(true));
+  if (toggleBtn) toggleBtn.addEventListener('click', () => setDiagnosticsExpanded(!diagnosticsExpanded));
+  if (copyBtn) copyBtn.addEventListener('click', copyDiagnosticsSupportBundle);
+  setDiagnosticsExpanded(false);
+}
+
+/* ═══════════════════════════════════════════
    INIT & REFRESH
    ═══════════════════════════════════════════ */
 function initAll() {
   modalEl = el('settings-modal');
-  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
+  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, initDiagnostics, () => settingsModule.initIntegrations()];
   for (const fn of inits) {
     try { fn(); } catch (e) { console.error('Admin init error in', fn.name || 'anonymous', e); }
   }
@@ -2070,6 +2223,7 @@ export function _initData() {
 export function open(tab) {
   _initData();
   settingsModule.open(tab || 'services');
+  if ((tab || 'services') === 'system') loadDiagnostics();
 }
 
 export function close() {

--- a/static/style.css
+++ b/static/style.css
@@ -13244,6 +13244,150 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
   padding-bottom: 6px;
   border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
 }
+.admin-diag-card {
+  padding: 14px 16px;
+}
+.admin-diag-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.admin-diag-head h2 {
+  margin-bottom: 4px;
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+.admin-diag-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.admin-diag-actions .admin-btn-sm {
+  min-width: 96px;
+  text-align: center;
+}
+.admin-diag-brief {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.admin-diag-meta {
+  min-height: 16px;
+  margin: 6px 0 0;
+  color: color-mix(in srgb, var(--fg) 42%, transparent);
+  font-size: 11px;
+}
+.admin-diag-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 10px;
+}
+.admin-diag-list.hidden {
+  display: none;
+}
+.admin-diag-group {
+  border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  border-radius: 6px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--bg) 65%, transparent);
+}
+.admin-diag-group-title {
+  padding: 4px 9px;
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.admin-diag-row {
+  display: grid;
+  grid-template-columns: 10px minmax(118px, 136px) minmax(0, 1fr) 92px;
+  gap: 8px;
+  align-items: start;
+  padding: 6px 9px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+  font-size: 11px;
+}
+.admin-diag-dot {
+  width: 8px;
+  height: 8px;
+  margin-top: 3px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--fg) 28%, transparent);
+}
+.admin-diag-row[data-status="ok"] .admin-diag-dot { background: var(--color-success); }
+.admin-diag-row[data-status="warning"] .admin-diag-dot { background: var(--color-warning); }
+.admin-diag-row[data-status="error"] .admin-diag-dot { background: var(--color-error); }
+.admin-diag-row[data-status="skipped"] { opacity: 0.68; }
+.admin-diag-label {
+  color: var(--fg);
+  font-weight: 500;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.admin-diag-message {
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.admin-diag-action {
+  display: flex;
+  justify-content: flex-end;
+  min-width: 0;
+}
+.admin-diag-action .admin-btn-sm {
+  width: 100%;
+  text-align: center;
+}
+.admin-diag-hint {
+  margin-top: 2px;
+  color: color-mix(in srgb, var(--fg) 46%, transparent);
+  font-size: 11px;
+}
+.admin-diag-overall {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.admin-diag-overall::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--fg) 28%, transparent);
+}
+.admin-diag-overall[data-status="healthy"]::before { background: var(--color-success); }
+.admin-diag-overall[data-status="degraded"]::before { background: var(--color-warning); }
+.admin-diag-overall[data-status="error"]::before { background: var(--color-error); }
+@media (max-width: 760px) {
+  .admin-diag-row {
+    grid-template-columns: 12px minmax(0, 1fr) 92px;
+  }
+  .admin-diag-message {
+    grid-column: 2 / 4;
+  }
+}
+@media (max-width: 520px) {
+  .admin-diag-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .admin-diag-actions {
+    justify-content: flex-start;
+  }
+}
 .admin-danger-card {
   border-color: color-mix(in srgb, var(--color-error) 27%, transparent);
 }

--- a/tests/test_system_diagnostics.py
+++ b/tests/test_system_diagnostics.py
@@ -1,0 +1,183 @@
+import pytest
+from pathlib import Path
+
+
+class _Response:
+    def __init__(self, status_code=200, data=None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.content = b"{}"
+
+    @property
+    def is_success(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._data
+
+
+class _Endpoint:
+    def __init__(self, base_url, name="Local", enabled=True, endpoint_id="ep1"):
+        self.id = endpoint_id
+        self.name = name
+        self.base_url = base_url
+        self.is_enabled = enabled
+
+
+class _Query:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def all(self):
+        return list(self.rows)
+
+
+class _Db:
+    def __init__(self, rows_by_model=None):
+        self.rows_by_model = rows_by_model or {}
+        self.closed = False
+
+    def execute(self, *_args, **_kwargs):
+        return None
+
+    def query(self, model):
+        return _Query(self.rows_by_model.get(model, []))
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_ollama_check_reports_model_count(monkeypatch):
+    import src.system_diagnostics as diag
+
+    async def fake_probe(url, timeout=diag.CHECK_TIMEOUT):
+        assert url == "http://127.0.0.1:11434/api/tags"
+        return _Response(data={"models": [{"name": "qwen"}, {"name": "gemma"}]})
+
+    monkeypatch.setattr(diag, "_probe_http", fake_probe)
+    monkeypatch.setattr(diag, "_ollama_base_url", lambda: "http://127.0.0.1:11434/v1")
+
+    check = await diag._ollama_check()
+
+    assert check["status"] == "ok"
+    assert "2 local models" in check["message"]
+
+
+@pytest.mark.asyncio
+async def test_model_endpoint_checks_warn_when_none_enabled(monkeypatch):
+    import src.system_diagnostics as diag
+
+    monkeypatch.setattr(diag, "SessionLocal", lambda: _Db({
+        diag.ModelEndpoint: [_Endpoint("http://127.0.0.1:11434/v1", enabled=False)]
+    }))
+
+    checks = await diag._model_endpoint_checks()
+
+    assert checks[0]["status"] == "warning"
+    assert checks[0]["action"]["tab"] == "services"
+
+
+@pytest.mark.asyncio
+async def test_model_endpoint_checks_probe_local_endpoints_only(monkeypatch):
+    import src.system_diagnostics as diag
+
+    calls = []
+
+    async def fake_probe(url, timeout=diag.CHECK_TIMEOUT):
+        calls.append(url)
+        return _Response(status_code=503)
+
+    monkeypatch.setattr(diag, "_probe_http", fake_probe)
+    monkeypatch.setattr(diag, "SessionLocal", lambda: _Db({
+        diag.ModelEndpoint: [
+            _Endpoint("http://127.0.0.1:11434/v1", name="Ollama", endpoint_id="local"),
+            _Endpoint("https://api.openai.com/v1", name="OpenAI", endpoint_id="remote"),
+        ]
+    }))
+
+    checks = await diag._model_endpoint_checks()
+
+    assert calls == ["http://127.0.0.1:11434/v1/models"]
+    assert checks[0]["status"] == "ok"
+    assert checks[1]["status"] == "warning"
+    assert "Ollama" in checks[1]["label"]
+
+
+def test_diagnostics_overall_rollup():
+    import src.system_diagnostics as diag
+
+    assert diag._overall([{"checks": [{"status": "ok"}, {"status": "skipped"}]}]) == "healthy"
+    assert diag._overall([{"checks": [{"status": "warning"}]}]) == "degraded"
+    assert diag._overall([{"checks": [{"status": "error"}]}]) == "error"
+
+
+def test_mcp_checks_include_live_browser_status(monkeypatch):
+    import src.system_diagnostics as diag
+
+    class _McpManager:
+        def get_all_statuses(self):
+            return {"builtin_browser": {"status": "connected", "tool_count": 29}}
+
+    monkeypatch.setattr(diag, "SessionLocal", lambda: _Db({diag.McpServer: []}))
+
+    checks = diag._mcp_checks(_McpManager())
+
+    assert checks[0]["id"] == "browser_mcp"
+    assert checks[0]["status"] == "ok"
+    assert "29 tools" in checks[0]["message"]
+
+
+def test_support_bundle_redacts_secret_keys_and_tokens():
+    import src.system_diagnostics as diag
+
+    secret = "sk-" + ("a" * 28)
+    payload = {
+        "api_key": secret,
+        "message": f"{Path.home()}/Projects/odysseus failed with token=super-secret-token",
+        "nested": {"authorization": "Bearer " + ("b" * 24)},
+    }
+
+    redacted = diag._redact_obj(payload)
+
+    assert redacted["api_key"] == "<redacted>"
+    assert str(Path.home()) not in redacted["message"]
+    assert "super-secret-token" not in redacted["message"]
+    assert redacted["nested"]["authorization"] == "<redacted>"
+
+
+@pytest.mark.asyncio
+async def test_support_bundle_text_includes_redacted_diagnostics(monkeypatch):
+    import src.system_diagnostics as diag
+
+    secret = "sk-" + ("c" * 28)
+
+    async def fake_collect(_mcp_manager=None):
+        return {
+            "overall": "error",
+            "checked_at": "2026-06-02T00:00:00Z",
+            "groups": [{
+                "id": "core",
+                "label": "Core",
+                "checks": [diag._check(
+                    "database",
+                    "Database",
+                    "error",
+                    "Database failed.",
+                    detail=f"{Path.home()}/data/app.db {secret}",
+                )],
+            }],
+        }
+
+    monkeypatch.setattr(diag, "collect_system_diagnostics", fake_collect)
+    monkeypatch.setattr(diag, "load_settings", lambda: {"search_provider": "searxng", "search_url": "https://example.test?q=1"})
+    monkeypatch.setattr(diag, "load_features", lambda: {"rag": True, "web_search": True})
+    monkeypatch.setattr(diag, "_git_revision", lambda: "abc123")
+
+    result = await diag.collect_diagnostics_support_bundle()
+
+    assert result["bundle"]["kind"] == "odysseus_diagnostics_support_bundle"
+    assert "Database failed." in result["text"]
+    assert secret not in result["text"]
+    assert str(Path.home()) not in result["text"]
+    assert "<redacted>" in result["text"]


### PR DESCRIPTION
## Why consider this

Odysseus is increasingly a self-hosted local stack, not just a single web app. A user can have the web server, SQLite, ChromaDB, Ollama or another local model endpoint, SearXNG, ntfy/email, Browser MCP, and user MCP servers all involved in whether a workflow feels healthy.

Right now, when something is wrong, the useful debugging context tends to arrive piecemeal: a screenshot of one settings page, a pasted log line, a claim that `nvidia-smi` or Ollama works, or a comment that "search is broken" without enough local topology to reproduce. That creates extra maintainer round-trips and also encourages users to paste raw logs that may include paths or secrets.

This PR proposes a small admin-only diagnostics surface that gives maintainers something safer and more consistent to ask for: **open Settings -> System, check the compact status, and copy the redacted diagnostics bundle**.

## Screenshots

Compact default state:

![Compact admin diagnostics card](https://raw.githubusercontent.com/ghreprimand/odysseus/pr-assets-diagnostics-1481/diagnostics-1481/admin-diagnostics-card-compact.png)

Expanded details:

![Expanded admin diagnostics card](https://raw.githubusercontent.com/ghreprimand/odysseus/pr-assets-diagnostics-1481/diagnostics-1481/admin-diagnostics-card-expanded.png)

Narrow/mobile layout:

![Narrow admin diagnostics card](https://raw.githubusercontent.com/ghreprimand/odysseus/pr-assets-diagnostics-1481/diagnostics-1481/admin-diagnostics-card-mobile.png)

## What changes

Adds an admin-only **System Diagnostics** card under **Settings -> Admin -> System**.

The card is compact by default and shows:

- overall health
- a one-line summary
- last check time
- `Refresh`, `Copy Bundle`, and `Details` actions

Expanding details shows grouped read-only checks for:

- **Core**: database reachability and `data/` read/write access
- **Local AI**: ChromaDB heartbeat, Ollama reachability, configured model endpoints
- **Research**: configured search provider, including SearXNG reachability
- **Notifications**: email account presence and ntfy integration reachability
- **Tools**: live Browser MCP status and configured user MCP servers

The new support bundle endpoint returns both structured JSON and a plain text report designed for issue comments. It includes the diagnostics report plus a narrow runtime snapshot: platform, Python version, Docker detection, git revision, selected feature flags, and local service URLs.

## Safety and scope

- The detailed diagnostics and support bundle routes are guarded by `require_admin(request)`.
- Probes are read-only and use short timeouts so the settings modal is not held hostage by a missing local service.
- The support bundle uses an allowlisted runtime snapshot instead of dumping env vars, settings files, or raw process state.
- The bundle redacts secret-looking keys and token-looking values, including common API key, bearer token, GitHub token, JWT-shaped, OpenAI-style, and Anthropic-style strings.
- Home directory paths are normalized before output so reports do not need to expose a user's local username.
- API/cloud provider checks report configuration presence rather than validating or exposing credentials.
- `/api/health` stays as the cheap liveness endpoint; this is a separate admin diagnostics endpoint.

## Why this is useful for support

This should make issue triage less ambiguous without turning the UI into a permanent dashboard. For example, maintainers could ask for one copied bundle when debugging:

- local model endpoint setup
- ChromaDB/RAG availability
- SearXNG/search configuration
- Browser MCP startup
- ntfy/email reminder configuration
- Docker vs host-local service confusion

The important part is not that every possible diagnostic is solved here. The useful part is the pattern: a compact admin status plus a redacted bundle that can grow as recurring support questions become clear.

## Implementation notes

- Adds `src/system_diagnostics.py` as the read-only diagnostics collector.
- Adds `/api/diagnostics/status` and `/api/diagnostics/support-bundle`.
- Stores the existing MCP manager on `app.state` so diagnostics can report live Browser MCP status without changing MCP route behavior.
- Reuses existing admin card/button styling and keeps details collapsed by default.
- Adds focused tests for diagnostics rollup, local endpoint probing, MCP status, and support-bundle redaction.
- Screenshots above are hosted from a fork-only assets branch so the PR diff stays code/test only.

This replaces the older, narrower diagnostics-panel PR #523 with a more complete proposal and cleaner branch from current `main`.

## Testing

Ran:

```bash
./venv/bin/python -m pytest -q tests/test_system_diagnostics.py
./venv/bin/python -m pytest -q tests/test_system_diagnostics.py tests/test_auth_regressions.py tests/test_model_routes.py
./venv/bin/python -m py_compile src/system_diagnostics.py routes/diagnostics_routes.py tests/test_system_diagnostics.py
node --check static/js/admin.js
git diff --check upstream/main...HEAD
```

Results:

```text
tests/test_system_diagnostics.py -> 7 passed
focused route/auth/model regression set -> 96 passed
py_compile -> passed
node --check static/js/admin.js -> passed
git diff --check -> clean
```
