### PR TITLE
fix: return sorted model list on first call in group chat

### DIFF
--- a/static/js/group.js
+++ b/static/js/group.js
@@ -58,7 +58,7 @@ function _initGroupTab() {
       });
     });
     _modelsCache = sortModelObjects(result);
-    return result;
+    return _modelsCache;
   }
 
   function _render() {
@@ -410,7 +410,7 @@ export async function showModelPicker() {
         });
       });
       _cachedModels = sortModelObjects(result);
-      return result;
+      return _cachedModels;
     }
 
     async function render(filter) {


### PR DESCRIPTION
## Summary
- `_getModels()` and `getAllModels()` in group.js store the sorted copy in cache but return the unsorted original `result` on first invocation
- This causes the model picker to show models in random order on first render, then sorted on subsequent renders
- Fix: return the cache variable (which holds the sorted array) instead of the raw `result`

## Lines changed
- `static/js/group.js:61` — `return result` → `return _modelsCache`
- `static/js/group.js:413` — `return result` → `return _cachedModels`