### PR TITLE
Make the first-run log tell users how to finish setup (#1476)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -101,7 +101,14 @@ class AuthManager:
                 logger.info("Auth config loaded")
             else:
                 self._config = {}
-                logger.info("No auth config found — first-run setup required")
+                # Tell Docker/headless users HOW to finish setup: it's a web
+                # flow, not a console/temporary password (issue #1476 — users
+                # grepped the logs for a "Temporary password" that never exists).
+                logger.info(
+                    "No auth config found — first-run setup required: open Odysseus "
+                    "in your browser to create the admin account (setup is done in "
+                    "the web UI; no console password is generated)."
+                )
         except Exception as e:
             logger.error(f"Failed to load auth config: {e}")
             self._config = {}

--- a/tests/test_first_run_setup_message.py
+++ b/tests/test_first_run_setup_message.py
@@ -1,0 +1,21 @@
+"""Regression test for issue #1476 — Docker/headless users grepped the first-run
+logs for a "Temporary password" that Odysseus never generates (setup is a web
+flow), and the existing log line ("first-run setup required") didn't say how to
+proceed. The message now tells them to finish setup in the browser.
+"""
+import logging
+
+from core.auth import AuthManager
+
+
+def test_first_run_message_directs_user_to_web_setup(caplog, tmp_path):
+    with caplog.at_level(logging.INFO):
+        # No auth file at this path → the first-run branch fires.
+        AuthManager(auth_path=str(tmp_path / "auth.json"))
+    first_run = [r.message for r in caplog.records if "first-run setup required" in r.message]
+    assert first_run, "expected a first-run setup log line"
+    msg = first_run[0].lower()
+    # Actionable: tells the user to use the browser/web UI...
+    assert "browser" in msg or "web ui" in msg
+    # ...and clears up the "where's my password" confusion.
+    assert "no console password" in msg


### PR DESCRIPTION
## Summary

On a fresh Docker/headless install, the first-run log only said `No auth config found — first-run setup required`, and users (expecting a `Temporary password` line like some other tools) had no idea the setup is a **web flow**. This makes that one log line actionable — it tells users to open Odysseus in a browser to create the admin account and clarifies that no console password is generated. No behaviour change; clearer onboarding guidance where users were already looking.

## Linked Issue

Fixes #1476

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. **— Honest note: this changes a single log string on the first-run code path; I verified it with the unit test below (constructs `AuthManager` with no auth file and asserts the logged message) rather than a full Docker boot.**

## Root cause

`core/auth.py`'s first-run branch logged a cryptic `No auth config found — first-run setup required` with no pointer to the web setup flow, so Docker/headless users grepped for a temporary password that is never generated.

## Fix

Replace that log line with:

```
No auth config found — first-run setup required: open Odysseus in your browser to
create the admin account (setup is done in the web UI; no console password is generated).
```

## How to Test

```
./venv/bin/python -m pytest -q tests/test_first_run_setup_message.py   # 1 passed
```

1. `tests/test_first_run_setup_message.py` constructs `AuthManager` with no auth file (triggers the first-run branch) and asserts the logged message points to the browser/web UI and clarifies there's no console password.
2. Verified **red→green** (the old message fails the assertion; the new one passes).

## Visual / UI changes

N/A — this is a server-side log message only (`core/auth.py`). No rendering, CSS, HTML, SVG, or `static/js/` changes. Two-dot diff is exactly `core/auth.py` + `tests/test_first_run_setup_message.py`.

---

*Transparency: prepared with Claude Code assistance (noted in the commit trailer) — a single targeted fix linked to #1476, not a bulk submission, so I left the "not an LLM agent" box unticked rather than tick it inaccurately.*
