### PR TITLE
fix: guard AI tidy verdict against non-string LLM output

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -901,7 +901,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
             for i, doc in enumerate(batch):
                 if i >= len(verdicts):
                     break
-                verdict = verdicts[i].lower().strip()
+                verdict = str(verdicts[i] or "").lower().strip()
                 if verdict == "junk":
                     doc.tidy_verdict = "junk"
                     db.delete(doc)


### PR DESCRIPTION
## Summary
- `verdicts[i].lower().strip()` in the document auto-tidy endpoint crashes with `AttributeError` when the LLM returns `null` or a non-string in its JSON array
- This is plausible with any model that occasionally produces malformed structured output
- Fix: coerce to `str(verdicts[i] or "")` so null/non-string entries are treated as "keep" instead of crashing the batch

## Lines changed
- `routes/document_routes.py:904`