### PR TITLE
fix: _parse_dt does not understand 'tonight' so calendar event start/end breaks

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -338,8 +338,8 @@ def _parse_dt(s: str) -> datetime:
             return None
         return h, mn
 
-    # today/tomorrow/yesterday [at] TIME
-    m = _re.match(r'^(today|tomorrow|tmrw|yesterday)(?:\s+at)?\s*(.*)$', lower)
+    # today/tonight/tomorrow/yesterday [at] TIME
+    m = _re.match(r'^(today|tonight|tomorrow|tmrw|yesterday)(?:\s+at)?\s*(.*)$', lower)
     if m:
         word, rest = m.group(1), m.group(2).strip()
         base = today

--- a/tests/test_calendar_parse_dt_tonight.py
+++ b/tests/test_calendar_parse_dt_tonight.py
@@ -1,0 +1,26 @@
+"""Regression: _parse_dt must understand "tonight" like parse_due_for_user does.
+
+parse_due_for_user's natural-language regex accepts
+`(today|tonight|tomorrow|tmrw|yesterday)`, but _parse_dt (the parser
+_parse_dt_pair falls back to for calendar event start/end) only had
+`(today|tomorrow|tmrw|yesterday)`. So an event start like "tonight at 9pm"
+missed the today-branch and fell through to dateutil, which does not know the
+word "tonight" and raises, breaking event creation for a phrasing that works
+fine for reminders. "tonight" is now handled, mapped to today like the sibling.
+"""
+from routes.calendar_routes import _parse_dt
+
+
+def test_tonight_with_time_parses_to_today_evening():
+    got = _parse_dt("tonight at 9pm")
+    ref = _parse_dt("today at 9pm")
+    assert got.hour == 21 and got.minute == 0
+    assert got.date() == ref.date()
+
+
+def test_bare_tonight_is_today():
+    assert _parse_dt("tonight").date() == _parse_dt("today").date()
+
+
+def test_tonight_matches_today_time_exactly():
+    assert _parse_dt("tonight at 7:30pm") == _parse_dt("today at 7:30pm")


### PR DESCRIPTION
## Summary
`parse_due_for_user` (used for reminders/tasks) accepts the natural-language word "tonight":

```python
m = _re.match(r'^(today|tonight|tomorrow|tmrw|yesterday)(?:\s+at)?\s*(.*)$', lower)
```

But `_parse_dt` (the parser `_parse_dt_pair` falls back to for calendar event start/end) only matched `(today|tomorrow|tmrw|yesterday)`. So a start/end like "tonight at 9pm" missed the today-branch, fell through to `dateutil.parser.parse`, which does not know the token "tonight" and raises. The same phrasing works for reminders but breaks calendar event creation.

Trigger: create a calendar event (e.g. via the agent's manage_calendar) with a start/end of "tonight" or "tonight at 9pm".

## Changes
- routes/calendar_routes.py: add "tonight" to the `_parse_dt` natural-language regex, mapped to today exactly as `parse_due_for_user` already does (it is not "tomorrow"/"yesterday", so the base stays today).
- tests/test_calendar_parse_dt_tonight.py: assert "tonight at 9pm" parses to today 21:00 and matches the "today at ..." result.