### PR TITLE
fix: close MCP AsyncExitStack on init/tool-discovery failure

### DIFF
--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -89,14 +89,18 @@ class McpManager:
             )
 
             stack = AsyncExitStack()
-            transport = await stack.enter_async_context(stdio_client(server_params))
-            read_stream, write_stream = transport
-            session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+            try:
+                transport = await stack.enter_async_context(stdio_client(server_params))
+                read_stream, write_stream = transport
+                session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
 
-            await session.initialize()
+                await session.initialize()
 
-            # Discover tools
-            tools_result = await session.list_tools()
+                # Discover tools
+                tools_result = await session.list_tools()
+            except Exception:
+                await stack.aclose()
+                raise
             tools = []
             for tool in tools_result.tools:
                 tools.append({
@@ -142,14 +146,18 @@ class McpManager:
             from contextlib import AsyncExitStack
 
             stack = AsyncExitStack()
-            transport = await stack.enter_async_context(sse_client(url))
-            read_stream, write_stream = transport
-            session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+            try:
+                transport = await stack.enter_async_context(sse_client(url))
+                read_stream, write_stream = transport
+                session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
 
-            await session.initialize()
+                await session.initialize()
 
-            # Discover tools
-            tools_result = await session.list_tools()
+                # Discover tools
+                tools_result = await session.list_tools()
+            except Exception:
+                await stack.aclose()
+                raise
             tools = []
             for tool in tools_result.tools:
                 tools.append({


### PR DESCRIPTION
## Summary
- If `session.initialize()` or `session.list_tools()` raises after the stdio subprocess (or SSE HTTP connection) is already open via `AsyncExitStack`, the stack is never closed
- The exception propagates to `connect_server`'s outer except which logs the error but doesn't have access to the stack — leaking the child process or HTTP connection
- Fix: wrap the setup phase in try/except that calls `await stack.aclose()` before re-raising

## Lines changed
- `src/mcp_manager.py` — `_connect_stdio` and `_connect_sse` methods