### PR TITLE
Replace cleanup service datetime.utcnow calls

### DIFF
--- a/src/cleanup_service.py
+++ b/src/cleanup_service.py
@@ -1,9 +1,19 @@
 # src/cleanup_service.py
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Tuple, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    """Naive UTC for this module's DB-bound timestamps.
+
+    Mirrors the naive DateTime columns these values are compared against,
+    without the deprecated stdlib UTC-now call (removed in Python 3.14).
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
 
 class CleanupConfig:
     """Configuration constants for cleanup operations."""
@@ -38,7 +48,7 @@ async def archive_inactive_sessions(session_manager, owner: Optional[str] = None
     Returns:
         Number of sessions archived
     """
-    cutoff_date = datetime.utcnow() - timedelta(days=CleanupConfig.ARCHIVE_AFTER_DAYS)
+    cutoff_date = _utcnow() - timedelta(days=CleanupConfig.ARCHIVE_AFTER_DAYS)
     archived_count = 0
 
     from src.database import SessionLocal, Session as DbSession
@@ -53,7 +63,7 @@ async def archive_inactive_sessions(session_manager, owner: Optional[str] = None
 
         for session in sessions_to_archive:
             session.archived = True
-            session.updated_at = datetime.utcnow()
+            session.updated_at = _utcnow()
             archived_count += 1
 
         if archived_count > 0:
@@ -79,7 +89,7 @@ async def cleanup_old_sessions(session_manager, owner: Optional[str] = None) -> 
     Returns:
         Tuple of (number of sessions deleted, space freed in MB)
     """
-    cutoff_date = datetime.utcnow() - timedelta(days=CleanupConfig.DELETE_AFTER_DAYS)
+    cutoff_date = _utcnow() - timedelta(days=CleanupConfig.DELETE_AFTER_DAYS)
     deleted_count = 0
     space_freed = 0
 
@@ -158,8 +168,8 @@ async def get_cleanup_preview(owner: Optional[str] = None) -> Dict[str, Any]:
     Returns:
         Dictionary containing preview information
     """
-    cutoff_archive = datetime.utcnow() - timedelta(days=CleanupConfig.ARCHIVE_AFTER_DAYS)
-    cutoff_delete = datetime.utcnow() - timedelta(days=CleanupConfig.DELETE_AFTER_DAYS)
+    cutoff_archive = _utcnow() - timedelta(days=CleanupConfig.ARCHIVE_AFTER_DAYS)
+    cutoff_delete = _utcnow() - timedelta(days=CleanupConfig.DELETE_AFTER_DAYS)
 
     sessions_to_archive = []
     sessions_to_delete = []

--- a/tests/test_cleanup_service_utcnow.py
+++ b/tests/test_cleanup_service_utcnow.py
@@ -1,0 +1,25 @@
+"""Regression tests for the datetime.utcnow() removal in src/cleanup_service.py (#1116).
+
+Importing src.cleanup_service is cheap and dependency-free: its only module-level
+imports are logging/datetime/typing, and the `from src.database import ...` calls are
+lazy (inside the functions), so no DB/sqlalchemy stack is pulled in here.
+"""
+from datetime import datetime, timedelta, timezone
+
+from src.cleanup_service import _utcnow
+
+
+def test_utcnow_returns_naive_utc():
+    now = _utcnow()
+    # Must be naive to match the naive DateTime columns this module compares against.
+    assert now.tzinfo is None
+    ref = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert abs((ref - now).total_seconds()) < 5
+
+
+def test_cutoff_math_stays_naive_and_comparable():
+    # Guards the archive/delete cutoffs against a naive/aware TypeError regression:
+    # an aware _utcnow() would raise when compared with the naive last_accessed column.
+    cutoff = _utcnow() - timedelta(days=7)
+    assert cutoff.tzinfo is None
+    assert cutoff < _utcnow()


### PR DESCRIPTION
## Summary

`datetime.utcnow()` is deprecated in Python 3.12 and removed in 3.14. This replaces the five calls in `src/cleanup_service.py` with a local `_utcnow()` helper that returns **naive** UTC (`datetime.now(timezone.utc).replace(tzinfo=None)`), so the archive/delete cutoffs keep comparing correctly against the naive `Session.last_accessed` / `created_at` / `updated_at` DateTime columns. Behaviour is unchanged — this is one small, audited slice of the broader migration, matching the approach already used for the task-scheduler and core-database slices.

## Linked Issue

Part of #1116

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. (Only the task-scheduler and core-database slices are in flight; `cleanup_service.py` is untouched by them.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. `python -m pytest tests/test_cleanup_service_utcnow.py -v` — 2 tests pass (helper returns naive UTC; cutoff math stays naive/comparable, guarding against a naive-vs-aware `TypeError`).
2. `rg "datetime\.utcnow" src/cleanup_service.py` — no matches; the deprecated call is fully removed from this module.
3. Confirm semantics are unchanged: the cutoffs remain naive UTC, so the SQLAlchemy filters against the naive `last_accessed` column behave exactly as before.
