### PR TITLE
fix: null spinner crash in _loadScheduled when opening cached scheduled folder

### DIFF
--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -1721,7 +1721,7 @@ async function _loadEmails({ force = false, useCache = true } = {}) {
 async function _loadScheduled(grid, sp) {
   const res = await fetch(`${API_BASE}/api/email/scheduled`);
   const data = await res.json();
-  sp.destroy();
+  if (sp) sp.destroy();
   const items = data.scheduled || [];
   grid.innerHTML = '';
   const stats = document.getElementById('email-lib-stats');


### PR DESCRIPTION
## Summary
- `_loadScheduled(grid, sp)` calls `sp.destroy()` unconditionally, but `sp` is `null` when the scheduled folder opens with cached data (the loading spinner is skipped for cached views)
- This crashes with `TypeError: Cannot read properties of null (reading 'destroy')` on the second open of the scheduled folder
- Fix: guard with `if (sp) sp.destroy()` — matching the pattern used in the main email loading path

## Lines changed
- `static/js/emailLibrary.js:1724`