### PR TITLE
Replace webhook manager datetime.utcnow calls

### DIFF
--- a/src/webhook_manager.py
+++ b/src/webhook_manager.py
@@ -7,7 +7,7 @@ import ipaddress
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -35,6 +35,11 @@ _PRIVATE_NETWORKS = [
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
 ]
+
+
+def _utcnow() -> datetime:
+    """Return naive UTC for existing DB columns while avoiding datetime.utcnow()."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def _ip_is_private(addr: ipaddress._BaseAddress) -> bool:
@@ -203,7 +208,7 @@ class WebhookManager:
             logger.warning(f"Webhook {webhook_id} has invalid URL, skipping: {e}")
             return
 
-        body = json.dumps({"event": event, "timestamp": datetime.utcnow().isoformat(), "data": payload})
+        body = json.dumps({"event": event, "timestamp": _utcnow().isoformat(), "data": payload})
         headers = {
             "Content-Type": "application/json",
             "X-Odysseus-Event": event,
@@ -217,7 +222,7 @@ class WebhookManager:
         try:
             resp = await self._client.post(url, content=body, headers=headers)
             db.query(Webhook).filter(Webhook.id == webhook_id).update({
-                "last_triggered_at": datetime.utcnow(),
+                "last_triggered_at": _utcnow(),
                 "last_status_code": resp.status_code,
                 "last_error": None,
             })
@@ -226,7 +231,7 @@ class WebhookManager:
             logger.warning(f"Webhook delivery failed for {webhook_id}")
             try:
                 db.query(Webhook).filter(Webhook.id == webhook_id).update({
-                    "last_triggered_at": datetime.utcnow(),
+                    "last_triggered_at": _utcnow(),
                     "last_status_code": None,
                     "last_error": sanitize_error(str(e)),
                 })

--- a/tests/test_webhook_ssrf_resilience.py
+++ b/tests/test_webhook_ssrf_resilience.py
@@ -1,4 +1,7 @@
 import sys
+import json
+from datetime import datetime
+
 # conftest.py stubs src.database with a fake module; webhook_manager imports
 # from it, so drop the stub here to load the real module under test.
 if "src.database" in sys.modules:
@@ -26,3 +29,66 @@ def test_webhook_url_ssrf_mitigation():
     # A clearly public IP literal must still be accepted.
     public_url = "http://93.184.216.34/"
     assert validate_webhook_url(public_url) == public_url
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_uses_naive_utc_timestamps(monkeypatch):
+    import src.webhook_manager as wm
+
+    class _Query:
+        def __init__(self, updates):
+            self.updates = updates
+
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def update(self, values):
+            self.updates.append(values)
+
+    class _Db:
+        def __init__(self):
+            self.updates = []
+            self.committed = False
+            self.closed = False
+
+        def query(self, _model):
+            return _Query(self.updates)
+
+        def commit(self):
+            self.committed = True
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    class _Response:
+        status_code = 204
+
+    class _Client:
+        def __init__(self):
+            self.content = ""
+
+        async def post(self, _url, content, headers):
+            self.content = content
+            assert headers["X-Odysseus-Event"] == "webhook.test"
+            return _Response()
+
+    db = _Db()
+    client = _Client()
+    monkeypatch.setattr(wm, "SessionLocal", lambda: db)
+
+    manager = wm.WebhookManager()
+    await manager._client.aclose()
+    manager._client = client
+
+    await manager._deliver("hook-1", "http://93.184.216.34/", None, "webhook.test", {"ok": True})
+
+    body = json.loads(client.content)
+    payload_timestamp = datetime.fromisoformat(body["timestamp"])
+    assert payload_timestamp.tzinfo is None
+    assert db.updates[0]["last_triggered_at"].tzinfo is None
+    assert db.updates[0]["last_status_code"] == 204
+    assert db.committed is True
+    assert db.closed is True


### PR DESCRIPTION
## Summary

Small #1116 slice: replaces the remaining `datetime.utcnow()` calls in `src/webhook_manager.py` with a local `_utcnow()` helper based on `datetime.now(timezone.utc).replace(tzinfo=None)`.

This keeps the existing naive-UTC DB/timestamp contract while avoiding the deprecated API that is removed in Python 3.14.

## What changed

- Adds `_utcnow()` to `src/webhook_manager.py`.
- Uses it for webhook payload timestamps.
- Uses it for successful and failed `last_triggered_at` DB updates.
- Adds a delivery regression test that verifies payload timestamps and persisted timestamps remain naive UTC.

## Testing

Ran:

```bash
./venv/bin/python -m pytest -q tests/test_webhook_ssrf_resilience.py
./venv/bin/python -m py_compile src/webhook_manager.py tests/test_webhook_ssrf_resilience.py
rg -n "datetime\.utcnow\(" src/webhook_manager.py tests/test_webhook_ssrf_resilience.py || true
git diff --check
```

Results:

```text
2 passed
py_compile passed
no datetime.utcnow() callsites remain in src/webhook_manager.py
git diff --check clean
```
