### PR TITLE
feat(nix): NixOS flake with nixosModules.odysseus

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,41 @@ Common internal-only ports from the default docs/compose setup:
 | `11434` | Ollama |
 | `8000-8020` | Common local model/provider APIs |
 
+### NixOS
+
+A `flake.nix` is included for NixOS users. It exposes a `nixosModules.odysseus`
+that manages the full stack (Odysseus, ChromaDB, SearXNG, ntfy) via
+`podman-compose`, with data persistence under a configurable `dataDir`.
+
+Add the flake as an input:
+
+```nix
+inputs.odysseus = {
+  url = "github:pewdiepie-archdaemon/odysseus";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+Import the module and enable it:
+
+```nix
+imports = [ inputs.odysseus.nixosModules.odysseus ];
+
+services.odysseus = {
+  enable = true;
+  dataDir = "/var/lib/odysseus";   # where data lives
+  port    = 7000;                  # host-side port
+  # llamaServerEndpoint — point at your local LLM server if you have one
+  # searxngSecretKey    — change before exposing to the network
+};
+```
+
+`nixos-rebuild switch` builds the image from source, writes the compose file to
+`/etc/odysseus/`, and starts everything as a single `systemd` unit.
+
+Requires `virtualisation.podman.enable = true` (and optionally
+`hardware.nvidia-container-toolkit.enable = true` for GPU support).
+
 ## Contributing
 Help is welcome. The best entry points are fresh-install testing, provider setup
 bugs, mobile/editor polish, docs, and small focused refactors. See

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,13 +61,14 @@ services:
       # Find yours with:  id -u  /  id -g
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}
+    devices:
+      - "nvidia.com/gpu=all"
     depends_on:
       searxng:
         condition: service_healthy
       chromadb:
         condition: service_started
     restart: unless-stopped
-
   chromadb:
     image: docker.io/chromadb/chroma:latest
     ports:
@@ -77,7 +78,6 @@ services:
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
     restart: unless-stopped
-
   searxng:
     # Pinned, not :latest — odysseus waits on searxng's healthcheck
     # (depends_on: condition: service_healthy), so a broken upstream `latest`
@@ -127,7 +127,6 @@ services:
       retries: 20
       start_period: 10s
     restart: unless-stopped
-
   ntfy:
     image: docker.io/binwiederhier/ntfy
     command: serve
@@ -138,7 +137,6 @@ services:
     environment:
       - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
     restart: unless-stopped
-
 volumes:
   searxng-data:
   chromadb-data:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,163 @@
+{
+  description = "Odysseus – local AI workspace with GPU support (NixOS module). bro you wanted this, here it is.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pythonWithRembg = pkgs.python3.withPackages (ps: [
+          ps.rembg
+          ps.onnxruntime
+          ps.pillow
+        ]);
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.podman-compose
+            pkgs.podman-tui
+            pkgs.realesrgan-ncnn-vulkan
+            pkgs.playwright
+            pkgs.playwright-driver.browsers
+            pythonWithRembg
+          ];
+          shellHook = ''
+            echo "🔧 Odysseus dev environment. type 'podman-compose up' if you're a rebel."
+          '';
+        };
+      }
+    )
+    // {
+      nixosModules.odysseus =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.services.odysseus;
+        in
+        {
+          options.services.odysseus = {
+            enable = lib.mkEnableOption "Odysseus AI workspace (it's pretty cool)";
+            dataDir = lib.mkOption {
+              type = lib.types.str;
+              default = "/var/lib/odysseus";
+              description = "where all your models and memories live. don't lose it.";
+            };
+            port = lib.mkOption {
+              type = lib.types.port;
+              default = 7000;
+              description = "web ui port – change if something else uses it";
+            };
+            llamaServerEndpoint = lib.mkOption {
+              type = lib.types.str;
+              default = "http://10.89.0.1:11434";
+              description = "where your llama.cpp server is. for podman bridge it's 10.89.0.1. adjust if needed.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [
+              pkgs.podman-compose
+              pkgs.realesrgan-ncnn-vulkan
+              pkgs.playwright
+              pkgs.playwright-driver.browsers
+              (pkgs.python3.withPackages (ps: [
+                ps.rembg
+                ps.onnxruntime
+                ps.pillow
+              ]))
+            ];
+
+            systemd.tmpfiles.rules = [ "d ${cfg.dataDir} 0755 root root -" ];
+
+            environment.etc."odysseus/docker-compose.yml" = {
+              text = ''
+                services:
+                  odysseus:
+                    image: localhost/odysseus_odysseus:latest
+                    build: ${self}
+                    user: "0:0"
+                    entrypoint: [""]
+                    command: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7000"]
+                    ports:
+                      - "${toString cfg.port}:7000"
+                    volumes:
+                      - ${cfg.dataDir}/models:/app/models
+                      - ${cfg.dataDir}/vectorstore:/app/vectorstore
+                      - ${cfg.dataDir}/documents:/app/documents
+                      - ${cfg.dataDir}/email:/app/email
+                      - ${cfg.dataDir}/cache:/app/cache
+                      - /run/current-system/sw/bin/:/host-bin/:ro
+                    environment:
+                      - PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/host-bin/
+                      - OLLAMA_BASE_URL=${cfg.llamaServerEndpoint}
+                      - SEARXNG_INSTANCE=http://searxng:8080
+                    devices:
+                      - nvidia.com/gpu=all
+                    restart: unless-stopped
+
+                  chromadb:
+                    image: docker.io/chromadb/chroma:latest
+                    command: run /config.yaml
+                    ports:
+                      - "127.0.0.1:8100:8000"
+                    volumes:
+                      - ${cfg.dataDir}/chroma:/chroma/chroma
+                    restart: unless-stopped
+
+                  searxng:
+                    image: docker.io/searxng/searxng:latest
+                    ports:
+                      - "127.0.0.1:8080:8080"
+                    dns:
+                      - 8.8.8.8
+                      - 1.1.1.1
+                    restart: unless-stopped
+
+                  ntfy:
+                    image: docker.io/binwiederhier/ntfy:latest
+                    command: serve
+                    ports:
+                      - "127.0.0.1:8091:80"
+                    restart: unless-stopped
+              '';
+            };
+
+            systemd.services.odysseus = {
+              description = "Odysseus AI workspace";
+              after = [
+                "network-online.target"
+                "podman.service"
+              ];
+              wants = [ "network-online.target" ];
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = true;
+                WorkingDirectory = "/etc/odysseus";
+                Environment = "PATH=/run/current-system/sw/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin";
+                ExecStartPre = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml build";
+                ExecStart = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml up -d";
+                ExecStop = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml down";
+                ExecReload = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml restart";
+                Restart = "no";
+                TimeoutStartSec = 300;
+              };
+            };
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Odysseus – local AI workspace with GPU support (NixOS module). bro you wanted this, here it is.";
+  description = "Odysseus – local AI workspace (NixOS flake)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -16,24 +16,12 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        pythonWithRembg = pkgs.python3.withPackages (ps: [
-          ps.rembg
-          ps.onnxruntime
-          ps.pillow
-        ]);
       in
       {
         devShell = pkgs.mkShell {
-          buildInputs = [
-            pkgs.podman-compose
-            pkgs.podman-tui
-            pkgs.realesrgan-ncnn-vulkan
-            pkgs.playwright
-            pkgs.playwright-driver.browsers
-            pythonWithRembg
-          ];
+          buildInputs = [ pkgs.podman-compose ];
           shellHook = ''
-            echo "🔧 Odysseus dev environment. type 'podman-compose up' if you're a rebel."
+            echo "Odysseus dev shell. Run 'podman-compose up --build' to start."
           '';
         };
       }
@@ -51,38 +39,68 @@
         in
         {
           options.services.odysseus = {
-            enable = lib.mkEnableOption "Odysseus AI workspace (it's pretty cool)";
+            enable = lib.mkEnableOption "Odysseus AI workspace";
+
             dataDir = lib.mkOption {
               type = lib.types.str;
               default = "/var/lib/odysseus";
-              description = "where all your models and memories live. don't lose it.";
+              description = "Directory for persistent Odysseus data (database, uploads, memory, logs).";
             };
+
             port = lib.mkOption {
               type = lib.types.port;
               default = 7000;
-              description = "web ui port – change if something else uses it";
+              description = "Host port for the Odysseus web interface.";
             };
+
             llamaServerEndpoint = lib.mkOption {
               type = lib.types.str;
-              default = "http://10.89.0.1:11434";
-              description = "where your llama.cpp server is. for podman bridge it's 10.89.0.1. adjust if needed.";
+              default = "http://localhost:11434";
+              description = ''
+                Base URL of the local LLM server (Ollama, llama.cpp, vLLM, etc.).
+                On a Podman bridge network the host is reachable at the gateway
+                address, e.g. http://10.89.0.1:11434.
+              '';
+            };
+
+            searxngSecretKey = lib.mkOption {
+              type = lib.types.str;
+              default = "change-me-before-exposing-to-the-network";
+              description = ''
+                Secret key for SearXNG CSRF/session signing.
+                Override with a random string for any non-local deployment.
+                Can be managed with sops-nix or agenix.
+              '';
             };
           };
 
           config = lib.mkIf cfg.enable {
-            environment.systemPackages = [
-              pkgs.podman-compose
-              pkgs.realesrgan-ncnn-vulkan
-              pkgs.playwright
-              pkgs.playwright-driver.browsers
-              (pkgs.python3.withPackages (ps: [
-                ps.rembg
-                ps.onnxruntime
-                ps.pillow
-              ]))
+            environment.systemPackages = [ pkgs.podman-compose ];
+
+            # Create persistent data directories on first activation.
+            systemd.tmpfiles.rules = [
+              "d ${cfg.dataDir}                       0755 root root -"
+              "d ${cfg.dataDir}/data                  0755 root root -"
+              "d ${cfg.dataDir}/logs                  0755 root root -"
+              "d ${cfg.dataDir}/data/ssh              0700 root root -"
+              "d ${cfg.dataDir}/data/huggingface      0755 root root -"
+              "d ${cfg.dataDir}/data/local            0755 root root -"
+              "d ${cfg.dataDir}/chroma                0755 root root -"
             ];
 
-            systemd.tmpfiles.rules = [ "d ${cfg.dataDir} 0755 root root -" ];
+            # SearXNG settings template — the entrypoint script sed-substitutes
+            # __SEARXNG_SECRET__ with the NixOS-managed key at container start.
+            environment.etc."odysseus/searxng-settings.yml" = {
+              text = ''
+                use_default_settings: true
+                server:
+                  secret_key: "__SEARXNG_SECRET__"
+                search:
+                  formats:
+                    - html
+                    - json
+              '';
+            };
 
             environment.etc."odysseus/docker-compose.yml" = {
               text = ''
@@ -90,50 +108,96 @@
                   odysseus:
                     image: localhost/odysseus_odysseus:latest
                     build: ${self}
-                    user: "0:0"
-                    entrypoint: [""]
+                    entrypoint: []
                     command: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7000"]
                     ports:
-                      - "${toString cfg.port}:7000"
+                      - "127.0.0.1:${toString cfg.port}:7000"
                     volumes:
-                      - ${cfg.dataDir}/models:/app/models
-                      - ${cfg.dataDir}/vectorstore:/app/vectorstore
-                      - ${cfg.dataDir}/documents:/app/documents
-                      - ${cfg.dataDir}/email:/app/email
-                      - ${cfg.dataDir}/cache:/app/cache
-                      - /run/current-system/sw/bin/:/host-bin/:ro
+                      - ${cfg.dataDir}/data:/app/data:z
+                      - ${cfg.dataDir}/logs:/app/logs:z
+                      - ${cfg.dataDir}/data/ssh:/app/.ssh:z
+                      - ${cfg.dataDir}/data/huggingface:/app/.cache/huggingface:z
+                      - ${cfg.dataDir}/data/local:/app/.local:z
+                    extra_hosts:
+                      - "host.docker.internal:host-gateway"
                     environment:
-                      - PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/host-bin/
-                      - OLLAMA_BASE_URL=${cfg.llamaServerEndpoint}
+                      - LLM_HOSTS=''${LLM_HOSTS:-${cfg.llamaServerEndpoint}}
+                      - OLLAMA_BASE_URL=''${OLLAMA_BASE_URL:-${cfg.llamaServerEndpoint}}
                       - SEARXNG_INSTANCE=http://searxng:8080
+                      - CHROMADB_HOST=chromadb
+                      - CHROMADB_PORT=8000
+                      - DATABASE_URL=sqlite:///./data/app.db
+                      - AUTH_ENABLED=''${AUTH_ENABLED:-true}
+                      - LOCALHOST_BYPASS=''${LOCALHOST_BYPASS:-false}
+                      - SECURE_COOKIES=''${SECURE_COOKIES:-false}
                     devices:
                       - nvidia.com/gpu=all
+                    depends_on:
+                      searxng:
+                        condition: service_healthy
+                      chromadb:
+                        condition: service_started
                     restart: unless-stopped
 
                   chromadb:
                     image: docker.io/chromadb/chroma:latest
-                    command: run /config.yaml
                     ports:
                       - "127.0.0.1:8100:8000"
                     volumes:
-                      - ${cfg.dataDir}/chroma:/chroma/chroma
+                      - ${cfg.dataDir}/chroma:/chroma/chroma:z
+                    environment:
+                      - ANONYMIZED_TELEMETRY=FALSE
                     restart: unless-stopped
 
                   searxng:
-                    image: docker.io/searxng/searxng:latest
+                    # Pinned — see docker-compose.yml for rationale
+                    image: docker.io/searxng/searxng:2026.5.31-7159b8aed
+                    entrypoint:
+                      - /bin/sh
+                      - -c
+                      - |
+                        set -eu
+                        if [ ! -s /etc/searxng/settings.yml ] || grep -q '__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
+                          secret="${cfg.searxngSecretKey}"
+                          sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
+                        fi
+                        exec /usr/local/searxng/entrypoint.sh
                     ports:
                       - "127.0.0.1:8080:8080"
-                    dns:
-                      - 8.8.8.8
-                      - 1.1.1.1
+                    volumes:
+                      - searxng-data:/etc/searxng:z
+                      - /etc/odysseus/searxng-settings.yml:/tmp/searxng-settings.yml.template:ro,z
+                    environment:
+                      - SEARXNG_BASE_URL=http://localhost:8080/
+                    cap_drop:
+                      - ALL
+                    cap_add:
+                      - CHOWN
+                      - SETGID
+                      - SETUID
+                      - DAC_OVERRIDE
+                    healthcheck:
+                      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
+                      interval: 5s
+                      timeout: 6s
+                      retries: 20
+                      start_period: 10s
                     restart: unless-stopped
 
                   ntfy:
-                    image: docker.io/binwiederhier/ntfy:latest
+                    image: docker.io/binwiederhier/ntfy
                     command: serve
                     ports:
                       - "127.0.0.1:8091:80"
+                    volumes:
+                      - ntfy-cache:/var/cache/ntfy:z
+                    environment:
+                      - NTFY_BASE_URL=''${NTFY_BASE_URL:-http://localhost:8091}
                     restart: unless-stopped
+
+                volumes:
+                  searxng-data:
+                  ntfy-cache:
               '';
             };
 
@@ -144,6 +208,7 @@
                 "podman.service"
               ];
               wants = [ "network-online.target" ];
+              wantedBy = [ "multi-user.target" ];
               serviceConfig = {
                 Type = "oneshot";
                 RemainAfterExit = true;
@@ -154,7 +219,7 @@
                 ExecStop = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml down";
                 ExecReload = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml restart";
                 Restart = "no";
-                TimeoutStartSec = 300;
+                TimeoutStartSec = 600;
               };
             };
           };


### PR DESCRIPTION
## What

Adds `flake.nix` with a `nixosModules.odysseus` NixOS module. It deploys the full stack (Odysseus, ChromaDB, SearXNG, ntfy) via podman-compose as a single systemd unit, with data persistence under a configurable directory.

Also adds NVIDIA GPU device passthrough to `docker-compose.yml` for users on Docker/Podman with a CUDA-capable GPU.

## Usage

```nix
inputs.odysseus = {
  url = "github:pewdiepie-archdaemon/odysseus";
  inputs.nixpkgs.follows = "nixpkgs";
};

# in your NixOS configuration:
imports = [ inputs.odysseus.nixosModules.odysseus ];

services.odysseus = {
  enable  = true;
  dataDir = "/var/lib/odysseus";   # where data lives across rebuilds
  port    = 7000;
  # llamaServerEndpoint — point at your local LLM if you have one
  # searxngSecretKey    — change before exposing to the network
};
```

`nixos-rebuild switch` builds the Odysseus image from source, drops a compose file at `/etc/odysseus/`, and starts everything as a systemd unit.

Requires `virtualisation.podman.enable = true`. GPU passthrough works with `hardware.nvidia-container-toolkit.enable = true`.

## Bug fixed in the compose template

The original draft used `entrypoint: [""]` to override the image ENTRYPOINT. This doesn't work: podman-compose 1.x serialises a list with one empty string as `--entrypoint '[""]'` — which passes `""` as the entrypoint executable instead of clearing it. Changed to `entrypoint: []` which produces `--entrypoint '[]'` and actually clears it.

## Tested

- `nix flake check --no-build` passes
- `podman-compose config` validates the generated compose
- Full stack starts successfully under NixOS with podman 5.8.2, confirmed with `systemctl status`