### PR TITLE
Bound total inlined attachment text so many files don't overflow context (#1492)

### DIFF
--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -304,6 +304,15 @@ def analyze_image_with_vl(image_path: str) -> str:
     return analyze_image_with_vl_result(image_path).get("text", "")
 
 
+# Total budget for inlined attachment TEXT across all files in one message.
+# Each file is already capped per-file (~15k), but nothing bounded the SUM, so a
+# handful of files could blow the model's context and later files were silently
+# lost (issue #1492 — "more than ~5 files not recognized"). Beyond this budget,
+# remaining attachments are listed with a "ask me to read it" marker instead of
+# inlined in full. Generous enough that normal multi-file use is unaffected.
+_MAX_TOTAL_INLINE_CHARS = 48000
+
+
 def build_user_content(
     text: str,
     attachment_ids: list[str] | None,
@@ -323,6 +332,9 @@ def build_user_content(
     frontend can switch to the new doc immediately.
     """
     content = [{"type": "text", "text": text}]
+    # Running total of inlined attachment text, enforced against
+    # _MAX_TOTAL_INLINE_CHARS so many files can't overflow the context (#1492).
+    inlined_chars = 0
 
     for fid in attachment_ids or []:
         upload_info = (resolved_uploads or {}).get(fid)
@@ -485,6 +497,23 @@ def build_user_content(
             else:
                 extracted_text = _process_office_document(path, display_name)
 
+            # Enforce the TOTAL inline budget across all attachments (#1492):
+            # per-file caps already bound each file (~15k); this bounds the sum so
+            # a handful of files can't blow the model's context and drop later ones.
+            extracted_text = extracted_text or ""
+            remaining = _MAX_TOTAL_INLINE_CHARS - inlined_chars
+            if remaining <= 0:
+                extracted_text = (
+                    f"\n\n[Attachment '{display_name}' not inlined — the message's "
+                    "attachment-context budget is full. Ask me to read this file and "
+                    "I'll fetch it.]"
+                )
+            elif len(extracted_text) > remaining:
+                extracted_text = extracted_text[:remaining] + (
+                    f"\n[…'{display_name}' truncated — attachment-context budget "
+                    "reached; ask me to read more of it.]"
+                )
+            inlined_chars += len(extracted_text)
             if content and content[0]["type"] == "text":
                 content[0]["text"] += extracted_text
             else:

--- a/tests/test_attachment_inline_budget.py
+++ b/tests/test_attachment_inline_budget.py
@@ -1,0 +1,54 @@
+"""Regression test for issue #1492 — many file attachments were each inlined
+(capped per-file at ~15-30k) with no cap on the TOTAL, so a handful of files
+blew the model's context and later ones were silently dropped ("more than ~5
+files not recognized").
+
+build_user_content now enforces a total inline budget; beyond it, remaining
+attachments are listed with an "ask me to read it" marker instead of inlined.
+"""
+import types
+
+from src.document_processor import build_user_content, _MAX_TOTAL_INLINE_CHARS
+
+
+def _fake_handler(resolved):
+    return types.SimpleNamespace(
+        is_image_file=lambda n, m=None: False,
+        is_audio_file=lambda n, m=None: False,
+        is_document_file=lambda n, m=None: str(n).endswith(".txt"),
+        _inside_upload_dir=lambda p: True,
+        resolve_upload=lambda fid, owner=None: resolved.get(fid),
+    )
+
+
+def test_total_attachment_inline_is_bounded(tmp_path):
+    resolved = {}
+    for i in range(4):  # 4 × 20k = 80k >> 48k budget
+        p = tmp_path / f"f{i}.txt"
+        p.write_text("X" * 20000 + f"FILE{i}END", encoding="utf-8")
+        resolved[f"id{i}"] = {"path": str(p), "name": f"f{i}.txt", "mime": "text/plain"}
+
+    out = build_user_content("hi", list(resolved.keys()), str(tmp_path),
+                             _fake_handler(resolved), resolved_uploads=resolved)
+
+    assert isinstance(out, str)
+    # The combined inlined text is bounded (not the full 80k).
+    assert len(out) <= _MAX_TOTAL_INLINE_CHARS + 2000, len(out)
+    # The first file's content is fully present...
+    assert "FILE0END" in out
+    # ...and the budget marker appears once the cap is hit.
+    assert "attachment-context budget" in out
+
+
+def test_small_attachments_not_truncated(tmp_path):
+    # A couple of small files stay well under budget — no marker, full content.
+    resolved = {}
+    for i in range(2):
+        p = tmp_path / f"s{i}.txt"
+        p.write_text(f"small file {i} content END{i}", encoding="utf-8")
+        resolved[f"id{i}"] = {"path": str(p), "name": f"s{i}.txt", "mime": "text/plain"}
+
+    out = build_user_content("hi", list(resolved.keys()), str(tmp_path),
+                             _fake_handler(resolved), resolved_uploads=resolved)
+    assert "END0" in out and "END1" in out
+    assert "attachment-context budget" not in out


### PR DESCRIPTION
## Problem

Continuation of #1346/#1492: with the upload limits fixed (#1362), attaching several files still means the model "doesn't recognize more than ~5". Root cause is **context overflow**: `build_user_content` inlines each attachment's text into the prompt, capped **per file** (~15–30k) but with **no cap on the total**. A handful of files therefore blow the model's context and the later ones are silently truncated away (worse on small-context backends — Ollama defaults to 2048 tokens). After a refresh the user even sees their short question replaced by a file's raw text, because the bodies are inlined into the message.

## Fix

Add a **total** inline budget (`_MAX_TOTAL_INLINE_CHARS`) across all attachments in `build_user_content`:
- files inline in full until the budget is reached;
- beyond it, remaining attachments are listed with a clear *"not inlined — ask me to read this file and I'll fetch it"* marker instead of being dumped in full (visible + bounded, vs today's invisible mid-prompt truncation).

It's generous enough that normal multi-file use is unaffected, and it's a guardrail **compatible with** the read-on-demand direction discussed on #1492 (that approach also needs a bounded upfront context).

## Tests — `tests/test_attachment_inline_budget.py`

- 4×20k files → combined inlined text is bounded (not the full 80k), the first file is fully present, and the budget marker appears (red→green);
- two small files stay fully inlined with no marker.

```
./venv/bin/python -m pytest -q tests/test_attachment_inline_budget.py tests/test_document*.py tests/test_pdf*.py   # 20 passed
```

This is the contained guardrail half; happy to follow up with a read-range tool for attachments if you'd prefer that as the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)