### PR TITLE
Add Codex provider config shell

### DIFF
--- a/app.py
+++ b/app.py
@@ -652,6 +652,9 @@ app.include_router(setup_backup_routes(memory_manager, preset_manager, skills_ma
 from routes.font_routes import setup_font_routes
 app.include_router(setup_font_routes())
 
+from routes.codex_model_provider_routes import setup_codex_model_provider_routes
+app.include_router(setup_codex_model_provider_routes())
+
 
 # MCP (Model Context Protocol)
 from src.mcp_manager import McpManager

--- a/routes/codex_model_provider_routes.py
+++ b/routes/codex_model_provider_routes.py
@@ -1,0 +1,20 @@
+"""Admin-gated Codex model-provider routes."""
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+from src.codex_model_provider import CodexModelProvider
+
+
+def setup_codex_model_provider_routes(provider: CodexModelProvider | None = None) -> APIRouter:
+    router = APIRouter(prefix="/api/codex-model-provider", tags=["codex-model-provider"])
+    provider = provider or CodexModelProvider()
+
+    @router.get("/status")
+    async def status(request: Request) -> dict[str, Any]:
+        require_admin(request)
+        return await provider.status()
+
+    return router

--- a/src/codex_model_provider.py
+++ b/src/codex_model_provider.py
@@ -1,0 +1,92 @@
+"""Codex provider status shell backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+CODEX_MODEL_PROVIDER_FLAG = "ODYSSEUS_CODEX_MODEL_PROVIDER_ENABLED"
+CODEX_EXPERIMENTAL_MODEL_ID = "codex-cli/chatgpt-experimental"
+_CODEX_EXPERIMENTAL_MODEL_LABEL = "Codex CLI / ChatGPT (experimental)"
+_BASE_LIMITATIONS = [
+    "Admin-only provider status shell.",
+    "Feature flag defaults to disabled.",
+    "CLI capability probing, model configuration, and chat routing are not wired in this branch.",
+]
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def codex_model_provider_enabled() -> bool:
+    return _truthy(os.getenv(CODEX_MODEL_PROVIDER_FLAG, "false"))
+
+
+def _synthetic_model() -> dict[str, Any]:
+    return {
+        "id": CODEX_EXPERIMENTAL_MODEL_ID,
+        "display": _CODEX_EXPERIMENTAL_MODEL_LABEL,
+        "label": _CODEX_EXPERIMENTAL_MODEL_LABEL,
+        "description": "Synthetic provider shell only. Capability probing is not wired yet.",
+        "source": "synthetic",
+        "experimental": True,
+        "hidden": False,
+        "enabled": True,
+        "thinking_effort": None,
+        "streaming_supported": False,
+        "thinking_supported": False,
+        "thinking_effort_levels": [],
+        "thinking_activity_supported": False,
+        "session_resume_supported": False,
+        "tool_calling_supported": False,
+        "agent_tools_supported": False,
+    }
+
+
+class CodexModelProvider:
+    """Admin-only provider status shell."""
+
+    async def status(self) -> dict[str, Any]:
+        enabled = codex_model_provider_enabled()
+        base = {
+            "feature_enabled": enabled,
+            "feature_flag": CODEX_MODEL_PROVIDER_FLAG,
+            "provider": "codex_cli",
+            "experimental": True,
+            "connector_enabled": False,
+            "selected_models": [],
+            "manual_models": [],
+            "hidden_models": [],
+            "disabled_models": [],
+            "recommended_models": [],
+            "models": [],
+            "chat_supported": False,
+            "streaming_supported": False,
+            "session_resume_supported": False,
+            "tool_execution_allowed": False,
+            "thinking_supported": False,
+            "thinking_effort_levels": [],
+            "thinking_activity_supported": False,
+            "model_discovery": {"source": "disabled" if not enabled else "static"},
+            "limitations": list(_BASE_LIMITATIONS),
+            "auth": {"status": "", "auth_mode": ""},
+        }
+        if not enabled:
+            return {
+                **base,
+                "status": "disabled",
+                "cli_available": False,
+                "authenticated": False,
+                "requires_sign_in": False,
+            }
+
+        return {
+            **base,
+            "status": "enabled",
+            "cli_available": None,
+            "authenticated": None,
+            "requires_sign_in": False,
+            "models": [_synthetic_model()],
+        }

--- a/tests/test_codex_model_provider.py
+++ b/tests/test_codex_model_provider.py
@@ -1,0 +1,175 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+_MISSING = object()
+
+from src.codex_model_provider import (
+    CODEX_EXPERIMENTAL_MODEL_ID,
+    CODEX_MODEL_PROVIDER_FLAG,
+    CodexModelProvider,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class _HTTPException(Exception):
+    def __init__(self, status_code, detail):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class _APIRouter:
+    def __init__(self, prefix="", tags=None):
+        self.prefix = prefix
+        self.tags = tags or []
+        self.routes = []
+
+    def _register(self, path, method):
+        def decorator(endpoint):
+            self.routes.append(
+                SimpleNamespace(
+                    path=f"{self.prefix}{path}",
+                    methods={method},
+                    endpoint=endpoint,
+                )
+            )
+            return endpoint
+
+        return decorator
+
+    def get(self, path):
+        return self._register(path, "GET")
+
+
+def _restore_modules(saved):
+    for name, module in saved.items():
+        if module is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _load_routes_module():
+    saved = {name: sys.modules.get(name, _MISSING) for name in ("fastapi", "core", "core.middleware")}
+    try:
+        fastapi_stub = types.ModuleType("fastapi")
+        fastapi_stub.APIRouter = _APIRouter
+        fastapi_stub.HTTPException = _HTTPException
+        fastapi_stub.Request = object
+        sys.modules["fastapi"] = fastapi_stub
+
+        core_pkg = types.ModuleType("core")
+        core_pkg.__path__ = [str(ROOT / "core")]
+        sys.modules["core"] = core_pkg
+        middleware_spec = importlib.util.spec_from_file_location("core.middleware", ROOT / "core" / "middleware.py")
+        middleware = importlib.util.module_from_spec(middleware_spec)
+        sys.modules["core.middleware"] = middleware
+        assert middleware_spec and middleware_spec.loader
+        middleware_spec.loader.exec_module(middleware)
+
+        routes_spec = importlib.util.spec_from_file_location(
+            "_codex_model_provider_routes_under_test",
+            ROOT / "routes" / "codex_model_provider_routes.py",
+        )
+        routes_module = importlib.util.module_from_spec(routes_spec)
+        assert routes_spec and routes_spec.loader
+        routes_spec.loader.exec_module(routes_module)
+        return routes_module
+    finally:
+        _restore_modules(saved)
+
+
+class _AuthManager:
+    is_configured = True
+
+    def is_admin(self, user):
+        return user == "admin"
+
+
+def _request(user="admin"):
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user=user),
+        headers={},
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=_AuthManager())),
+    )
+
+
+def _endpoint(router, path, method):
+    for route in router.routes:
+        if getattr(route, "path", "") == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_codex_model_provider_hidden_when_flag_disabled(monkeypatch):
+    monkeypatch.delenv(CODEX_MODEL_PROVIDER_FLAG, raising=False)
+
+    out = run(CodexModelProvider().status())
+
+    assert out["feature_enabled"] is False
+    assert out["status"] == "disabled"
+    assert out["models"] == []
+    assert out["model_discovery"] == {"source": "disabled"}
+
+
+def test_codex_model_provider_reports_static_payload_when_enabled(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+
+    out = run(CodexModelProvider().status())
+
+    assert out["feature_enabled"] is True
+    assert out["status"] == "enabled"
+    assert out["cli_available"] is None
+    assert out["authenticated"] is None
+    assert out["requires_sign_in"] is False
+    assert out["connector_enabled"] is False
+    assert out["selected_models"] == []
+    assert out["manual_models"] == []
+    assert out["hidden_models"] == []
+    assert out["disabled_models"] == []
+    assert out["recommended_models"] == []
+    assert out["model_discovery"] == {"source": "static"}
+    assert out["auth"] == {"status": "", "auth_mode": ""}
+    assert "sign_in_route" not in out
+
+    model = out["models"][0]
+    assert model["id"] == CODEX_EXPERIMENTAL_MODEL_ID
+    assert model["experimental"] is True
+    assert model["streaming_supported"] is False
+    assert model["thinking_supported"] is False
+    assert model["thinking_effort_levels"] == []
+    assert model["thinking_activity_supported"] is False
+    assert model["session_resume_supported"] is False
+    assert model["tool_calling_supported"] is False
+    assert model["agent_tools_supported"] is False
+    assert out["chat_supported"] is False
+    assert out["streaming_supported"] is False
+    assert out["session_resume_supported"] is False
+    assert out["tool_execution_allowed"] is False
+    assert out["thinking_supported"] is False
+    assert out["thinking_effort_levels"] == []
+    assert out["thinking_activity_supported"] is False
+
+
+def test_codex_model_provider_route_is_admin_gated(monkeypatch):
+    monkeypatch.setenv(CODEX_MODEL_PROVIDER_FLAG, "true")
+    routes_module = _load_routes_module()
+    router = routes_module.setup_codex_model_provider_routes(CodexModelProvider())
+    status = _endpoint(router, "/api/codex-model-provider/status", "GET")
+
+    out = run(status(_request(user="admin")))
+    assert out["status"] == "enabled"
+
+    with pytest.raises(Exception) as exc_info:
+        run(status(_request(user="bob")))
+    assert getattr(exc_info.value, "status_code", None) == 403


### PR DESCRIPTION
This is Phase 1 of the maintainer-requested Codex provider integration split.

Scope:
- Adds a small Codex provider config/status shell.
- Adds static/synthetic provider metadata.
- Adds a status route.
- Adds focused provider config tests.
- This is intended as part of a multi-part follow-up to the Codex auth/device-code foundation in https://github.com/pewdiepie-archdaemon/odysseus/pull/183.

Intentional exclusions:
- No Codex auth flow.
- No CLI device login.
- No token handling.
- No Settings UI.
- No Add Models/model picker UI.
- No chat dispatch.
- No agent-mode tool support.
- No Docker/platform changes.
- No docs or guardrail changes.

Tested:
- `pytest tests/test_codex_model_provider.py`

Notes:
This PR is intentionally narrow so the follow-up work can be reviewed separately as provider config, auth flow, UI wiring, and agent-mode tool support.