### PR TITLE
Cancel the backend run when stopping a Compare pane (#1508)

### DIFF
--- a/static/js/compare/backendStop.js
+++ b/static/js/compare/backendStop.js
@@ -1,0 +1,19 @@
+// compare/backendStop.js
+/**
+ * Cancel a session's in-flight run on the server.
+ *
+ * Aborting a fetch only closes the SSE reader on the client — the run is
+ * detached server-side, so the model keeps generating tokens upstream (e.g. in
+ * LM Studio) until the backend is told to cancel it (issue #1508). Every place
+ * that abandons a compare stream (the Stop buttons, closing compare, and the
+ * idle timeout) must hit this, mirroring the main chat Stop button.
+ *
+ * A leaf module with no compare/ imports so panes.js, index.js and stream.js can
+ * all use it without the circular-dependency dance, and so it's unit-testable.
+ */
+export function backendStopSession(sid) {
+  if (!sid) return;
+  return fetch(`/api/chat/stop/${encodeURIComponent(sid)}`, {
+    method: 'POST', credentials: 'same-origin',
+  }).catch(() => {});
+}

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -30,6 +30,7 @@ import {
 } from './panes.js';
 import { handleVote, buildVoteBar, addFinishBadge, spawnConfetti, _saveVote, registerCompareActions } from './vote.js';
 import { showScoreboard } from './scoreboard.js';
+import { backendStopSession } from './backendStop.js';
 
 // ── External dependency imports ──
 import Storage from '../storage.js';
@@ -116,8 +117,13 @@ async function toggleMode() {
 // ────────────────────────────────────────────────────────────────────────────
 
 async function deactivate(teardown) {
-  // Abort any in-flight streams
-  state._abortControllers.forEach(ac => { if (ac) ac.abort(); });
+  // Abort any in-flight streams. Aborting only drops the client SSE reader, so
+  // also cancel each pane's detached run server-side — otherwise closing compare
+  // mid-stream leaves the model generating (issue #1508). _paneSessionIds is
+  // still populated here; it's cleared further down.
+  state._abortControllers.forEach((ac, i) => {
+    if (ac) { ac.abort(); backendStopSession(state._paneSessionIds[i]); }
+  });
   state._abortControllers = [];
 
   // Move sessions to compare folder if saving

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -35,8 +35,21 @@ function _slotChar(i) { return state._parallel ? String.fromCharCode(65 + i) : S
 
 // ── Stop / reroll ──
 
+// Aborting the fetch only closes the SSE reader on the client; the run is
+// detached server-side, so the model keeps generating tokens upstream (e.g. in
+// LM Studio) until we tell the backend to cancel it (issue #1508). Mirror the
+// main chat Stop button: POST /api/chat/stop/<sid> for the pane's session.
+function _backendStopPane(paneIdx) {
+  const sid = state._paneSessionIds && state._paneSessionIds[paneIdx];
+  if (sid) {
+    fetch(`/api/chat/stop/${encodeURIComponent(sid)}`, {
+      method: 'POST', credentials: 'same-origin',
+    }).catch(() => {});
+  }
+}
+
 function stopAll() {
-  state._abortControllers.forEach(ac => { if (ac) ac.abort(); });
+  state._abortControllers.forEach((ac, i) => { if (ac) { ac.abort(); _backendStopPane(i); } });
   state._abortControllers = [];
   state._streaming = false;
   if (_setSendBtn) _setSendBtn('send');
@@ -52,6 +65,8 @@ function stopPane(paneIdx) {
     ac.abort();
     state._abortControllers[paneIdx] = null;
   }
+  // Cancel the detached run server-side too, or the model keeps generating (#1508).
+  _backendStopPane(paneIdx);
   // Hide stop button, show reroll
   const pane = document.querySelector(`.compare-pane[data-pane="${paneIdx}"]`);
   if (pane) {

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -7,6 +7,7 @@ import {
   ICON_PLAY, ICON_CODE, SEND_SVG,
 } from './icons.js';
 import { _clearProbeWaves } from './probe.js';
+import { backendStopSession } from './backendStop.js';
 import Storage from '../storage.js';
 import uiModule from '../ui.js';
 import spinnerModule from '../spinner.js';
@@ -35,17 +36,10 @@ function _slotChar(i) { return state._parallel ? String.fromCharCode(65 + i) : S
 
 // ── Stop / reroll ──
 
-// Aborting the fetch only closes the SSE reader on the client; the run is
-// detached server-side, so the model keeps generating tokens upstream (e.g. in
-// LM Studio) until we tell the backend to cancel it (issue #1508). Mirror the
-// main chat Stop button: POST /api/chat/stop/<sid> for the pane's session.
+// Cancel the detached server-side run for a pane's session (issue #1508) —
+// see backendStop.js. Shared with index.js (close) and stream.js (idle timeout).
 function _backendStopPane(paneIdx) {
-  const sid = state._paneSessionIds && state._paneSessionIds[paneIdx];
-  if (sid) {
-    fetch(`/api/chat/stop/${encodeURIComponent(sid)}`, {
-      method: 'POST', credentials: 'same-origin',
-    }).catch(() => {});
-  }
+  backendStopSession(state._paneSessionIds && state._paneSessionIds[paneIdx]);
 }
 
 function stopAll() {

--- a/static/js/compare/stream.js
+++ b/static/js/compare/stream.js
@@ -6,6 +6,7 @@ import markdownModule from '../markdown.js';
 import spinnerModule from '../spinner.js';
 import uiModule from '../ui.js';
 import presetsModule from '../presets.js';
+import { backendStopSession } from './backendStop.js';
 
 var escapeHtml = uiModule.esc;
 
@@ -156,10 +157,13 @@ async function streamToPane(paneIdx, sessionId, message, aiMsgEl, opts) {
   // Long generations (SVG, big code) are fine as long as the stream stays
   // active. opts.timeout may still tighten this for specific paths.
   const effectiveTimeout = opts.timeout || state._timeout;
-  let timeoutId = setTimeout(() => { timedOut = true; ac.abort(); }, effectiveTimeout * 1000);
+  // ac.abort() only drops the client SSE reader; also cancel the detached run
+  // server-side or the model keeps generating after an idle timeout (#1508).
+  const _onIdleTimeout = () => { timedOut = true; ac.abort(); backendStopSession(sessionId); };
+  let timeoutId = setTimeout(_onIdleTimeout, effectiveTimeout * 1000);
   const _resetIdleTimeout = () => {
     clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => { timedOut = true; ac.abort(); }, effectiveTimeout * 1000);
+    timeoutId = setTimeout(_onIdleTimeout, effectiveTimeout * 1000);
   };
 
   // Live timer

--- a/tests/test_compare_stop_backend.py
+++ b/tests/test_compare_stop_backend.py
@@ -1,23 +1,116 @@
-"""Regression guard for issue #1508 — Stop in Compare only closed the client SSE
-while the model kept generating tokens server-side (LM Studio etc.).
+"""Regression for issue #1508 — abandoning a Compare stream only closed the
+client SSE reader while the model kept generating tokens server-side (LM Studio
+etc.).
 
-Compare runs are detached on the backend, so aborting the fetch (`AbortController`)
-doesn't cancel them — the main chat Stop button POSTs `/api/chat/stop/<sid>` to do
-that. The compare stop handlers now do the same per pane.
+Compare runs are detached on the backend, so aborting the fetch (AbortController)
+doesn't cancel them — the main chat Stop button POSTs /api/chat/stop/<sid> to do
+that. Every place that abandons a compare stream must do the same:
+  - the Stop buttons        (panes.js: stopPane / stopAll)
+  - closing compare         (index.js: deactivate)
+  - the per-pane idle timeout (stream.js)
 
-compare/panes.js pulls in browser globals so it can't run under node; guard the
-wiring at the source level.
+The shared POST lives in a leaf module compare/backendStop.js so all three can
+use it without circular imports; it's executed under node here (real fetch
+behaviour), and the wiring into each of the three sites is guarded at the source
+so a sibling-file path can't silently regress.
 """
+
+import json
 import re
+import shutil
+import subprocess
+import textwrap
 from pathlib import Path
 
-SRC = Path(__file__).resolve().parent.parent / "static/js/compare/panes.js"
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_CMP = _REPO / "static/js/compare"
+_HAS_NODE = shutil.which("node") is not None
 
 
-def test_compare_stop_cancels_backend_run():
-    text = SRC.read_text(encoding="utf-8")
-    # A helper that hits the backend stop endpoint for a pane's session.
-    assert "/api/chat/stop/" in text, "compare stop must POST the backend stop endpoint (#1508)"
-    assert re.search(r"function _backendStopPane\(", text)
-    # Both stop paths must invoke it (per-pane and stop-all).
-    assert text.count("_backendStopPane(") >= 3  # def + stopPane + stopAll
+@pytest.fixture(scope="module")
+def node_available():
+    if not _HAS_NODE:
+        pytest.skip("node binary not on PATH")
+
+
+def _run_node(script: str) -> dict:
+    res = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO,
+        capture_output=True,
+        timeout=15,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise AssertionError(f"node failed:\n{res.stderr}")
+    out_lines = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    if not out_lines:
+        raise AssertionError("node produced no stdout")
+    return json.loads(out_lines[-1])
+
+
+def test_backend_stop_posts_correct_endpoint(node_available):
+    """backendStopSession must POST /api/chat/stop/<encoded sid> with credentials,
+    and swallow network errors (a failed stop must never throw into the caller)."""
+    script = textwrap.dedent("""
+        const calls = [];
+        globalThis.fetch = (url, opts) => { calls.push({ url, opts }); return Promise.reject(new Error('boom')); };
+        const { backendStopSession } = await import('./static/js/compare/backendStop.js');
+        let threw = null;
+        try { await backendStopSession('sess id/42'); } catch (e) { threw = String(e); }
+        console.log(JSON.stringify({
+          threw,
+          count: calls.length,
+          url: calls[0] && calls[0].url,
+          method: calls[0] && calls[0].opts && calls[0].opts.method,
+          creds: calls[0] && calls[0].opts && calls[0].opts.credentials,
+        }));
+    """)
+    out = _run_node(script)
+    assert out["threw"] is None, "a failed stop must not throw (caught .catch)"
+    assert out["count"] == 1
+    assert out["url"] == "/api/chat/stop/sess%20id%2F42", "sid must be URL-encoded into the path"
+    assert out["method"] == "POST"
+    assert out["creds"] == "same-origin"
+
+
+def test_backend_stop_noop_on_missing_sid(node_available):
+    """No session id → no request at all (don't POST to /api/chat/stop/undefined)."""
+    script = textwrap.dedent("""
+        const calls = [];
+        globalThis.fetch = (url, opts) => { calls.push(url); return Promise.resolve(); };
+        const { backendStopSession } = await import('./static/js/compare/backendStop.js');
+        backendStopSession('');
+        backendStopSession(undefined);
+        backendStopSession(null);
+        console.log(JSON.stringify({ count: calls.length }));
+    """)
+    out = _run_node(script)
+    assert out["count"] == 0
+
+
+def test_all_three_abandon_paths_cancel_the_backend():
+    """The #1508 leak is reachable from three sites; each must cancel server-side.
+    A single-file check can't see the sibling paths, so guard all three."""
+    panes = (_CMP / "panes.js").read_text(encoding="utf-8")
+    index = (_CMP / "index.js").read_text(encoding="utf-8")
+    stream = (_CMP / "stream.js").read_text(encoding="utf-8")
+
+    # Stop buttons (panes.js): _backendStopPane delegates to the shared helper and
+    # is invoked by both stopPane and stopAll.
+    assert "backendStopSession(" in panes
+    assert re.search(r"function _backendStopPane\(", panes)
+    assert panes.count("_backendStopPane(") >= 3  # def + stopPane + stopAll
+
+    # Closing compare (index.js: deactivate) cancels each in-flight pane's run.
+    assert 'from "./backendStop.js"' in index or "from './backendStop.js'" in index
+    dz = index[index.index("async function deactivate("):]
+    dz = dz[: dz.index("state._abortControllers = [];") + 40]
+    assert "backendStopSession(" in dz, "deactivate must cancel each pane's backend run (#1508)"
+
+    # Idle timeout (stream.js) cancels the pane's run, not just the client reader.
+    assert 'from "./backendStop.js"' in stream or "from './backendStop.js'" in stream
+    assert re.search(r"_onIdleTimeout\s*=\s*\(\)\s*=>\s*{[^}]*backendStopSession\(", stream), \
+        "idle timeout must cancel the backend run, not only ac.abort()"

--- a/tests/test_compare_stop_backend.py
+++ b/tests/test_compare_stop_backend.py
@@ -1,0 +1,23 @@
+"""Regression guard for issue #1508 — Stop in Compare only closed the client SSE
+while the model kept generating tokens server-side (LM Studio etc.).
+
+Compare runs are detached on the backend, so aborting the fetch (`AbortController`)
+doesn't cancel them — the main chat Stop button POSTs `/api/chat/stop/<sid>` to do
+that. The compare stop handlers now do the same per pane.
+
+compare/panes.js pulls in browser globals so it can't run under node; guard the
+wiring at the source level.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "static/js/compare/panes.js"
+
+
+def test_compare_stop_cancels_backend_run():
+    text = SRC.read_text(encoding="utf-8")
+    # A helper that hits the backend stop endpoint for a pane's session.
+    assert "/api/chat/stop/" in text, "compare stop must POST the backend stop endpoint (#1508)"
+    assert re.search(r"function _backendStopPane\(", text)
+    # Both stop paths must invoke it (per-pane and stop-all).
+    assert text.count("_backendStopPane(") >= 3  # def + stopPane + stopAll


### PR DESCRIPTION
## Summary

In Compare, clicking **Stop** mid-generation stopped the UI but the model kept generating server-side (the reporter saw LM Studio still producing output, bleeding into the next prompt) — #1508. Compare runs are detached on the backend, so `AbortController.abort()` only closes the client SSE reader; the run must be cancelled via `POST /api/chat/stop/<sid>` (like the main chat Stop). This wires that backend-stop into all three abandon paths.

## Linked Issue

Fixes #1508

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. **— Honest note: reproducing the server-side leak needs a live model generating tokens to then Stop; I verified the wiring with the node-executed test below (and `node --check`) rather than a full live model run.**

## Root cause

`compare/panes.js` `stopPane`/`stopAll` only called `AbortController.abort()`, which closes the client SSE reader but does not cancel the detached backend run. The same leak was reachable through two other abandon sites (caught in review by @lalalune): closing compare mid-stream (`index.js` `deactivate()`) and the per-pane idle timeout (`stream.js`) — both only aborted the client.

## Fix

Pull the backend-stop POST into a leaf module `static/js/compare/backendStop.js` (`backendStopSession(sid)`, no `compare/` imports → no circular dependency) and call it from all three abandon paths: the Stop buttons (`panes.js`), closing compare (`index.js` `deactivate()`), and the idle timeout (`stream.js`). Best-effort fire-and-forget, mirroring the main chat Stop.

## How to Test

```
node --check static/js/compare/{backendStop,panes,index,stream}.js   # ok
./venv/bin/python -m pytest -q tests/test_compare_stop_backend.py    # 3 passed
```

1. The test **executes** `backendStopSession` under node — asserts it POSTs `/api/chat/stop/<encoded sid>`, method POST, `same-origin` creds, no-ops on a missing sid, never throws on a network error — and guards the wiring in `panes.js`, `index.js`, and `stream.js`.
2. Verified **red→green** — reverting the idle-timeout to the old client-only `ac.abort()` turns the cross-file test red.

## Visual / UI changes

This touches `static/js/`, but the change is **purely behavioural** — a fire-and-forget `POST /api/chat/stop/<sid>` on the existing Stop / close / idle-timeout paths. It renders nothing and changes no styling, layout, CSS, HTML, SVG, colours, or components; there is no visible difference to screenshot (the user-visible Stop button is unchanged — this just also cancels the server-side run).

Two-dot diff: `static/js/compare/backendStop.js`, `static/js/compare/index.js`, `static/js/compare/panes.js`, `static/js/compare/stream.js`, `tests/test_compare_stop_backend.py`.

---

*Transparency: prepared with Claude Code assistance (noted in the commit trailer). Single targeted fix linked to #1508, not a bulk submission — so I left the "not an LLM agent" box unticked rather than tick it inaccurately.*
