### PR TITLE
Scope core.* test stubs to per-test fixtures

### DIFF
--- a/tests/test_auth_event_loop.py
+++ b/tests/test_auth_event_loop.py
@@ -15,6 +15,7 @@ import os
 import sys
 import types
 import asyncio
+import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -64,8 +65,13 @@ def _ensure_stub(name: str, **attrs):
     return mod
 
 
-_ensure_stub("core.database", SessionLocal=MagicMock())
-_ensure_stub("core.auth", AuthManager=MagicMock())
+@pytest.fixture(autouse=True)
+def _event_loop_stubs(monkeypatch):
+    db = _ensure_stub("core.database", SessionLocal=MagicMock())
+    auth = _ensure_stub("core.auth", AuthManager=MagicMock())
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    monkeypatch.setitem(sys.modules, "core.auth", auth)
+
 
 from routes.auth_routes import setup_auth_routes, LoginRequest
 

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -66,21 +66,27 @@ def _ensure_stub(name: str, **attrs):
         setattr(parent, child_name, mod)
     return mod
 
-_ensure_stub("core.database",
-    SessionLocal=MagicMock(), ScheduledTask=MagicMock(), TaskRun=MagicMock(),
-    ModelEndpoint=MagicMock(), Session=MagicMock(), ChatMessage=MagicMock(),
-    CalendarCal=MagicMock(), CalendarEvent=MagicMock(),
-    Document=MagicMock(), DocumentVersion=MagicMock(),
-    GalleryImage=MagicMock(), GalleryAlbum=MagicMock(), Note=MagicMock(),
-    McpServer=MagicMock(),
-)
-_ensure_stub("core.auth", AuthManager=MagicMock())
-_ensure_stub("src.endpoint_resolver",
-    resolve_endpoint=MagicMock(return_value=("", "", {})),
-    normalize_base=MagicMock(),
-    build_chat_url=MagicMock(),
-    build_headers=MagicMock(),
-)
+@pytest.fixture(autouse=True)
+def _auth_regressions_stubs(monkeypatch):
+    db = _ensure_stub("core.database",
+        SessionLocal=MagicMock(), ScheduledTask=MagicMock(), TaskRun=MagicMock(),
+        ModelEndpoint=MagicMock(), Session=MagicMock(), ChatMessage=MagicMock(),
+        CalendarCal=MagicMock(), CalendarEvent=MagicMock(),
+        Document=MagicMock(), DocumentVersion=MagicMock(),
+        GalleryImage=MagicMock(), GalleryAlbum=MagicMock(), Note=MagicMock(),
+        McpServer=MagicMock(),
+    )
+    auth = _ensure_stub("core.auth", AuthManager=MagicMock())
+    ep = _ensure_stub("src.endpoint_resolver",
+        resolve_endpoint=MagicMock(return_value=("", "", {})),
+        normalize_base=MagicMock(),
+        build_chat_url=MagicMock(),
+        build_headers=MagicMock(),
+    )
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    monkeypatch.setitem(sys.modules, "core.auth", auth)
+    monkeypatch.setitem(sys.modules, "src.endpoint_resolver", ep)
+
 
 from fastapi import HTTPException
 

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -37,27 +37,36 @@ def _get_db_session():
 
 # core/__init__ pulls in models/session_manager which import many ORM names from
 # core.database; under conftest's sqlalchemy stubs the real module can't load.
-# A __getattr__ module resolves ANY requested name to a MagicMock, while keeping
-# our real get_db_session/ApiToken for the mint test.
+# A __getattr__ module resolves any non-dunder name to a MagicMock, while keeping
+# our real get_db_session/ApiToken for the mint test. Dunder names (e.g. __all__)
+# are NOT auto-resolved — the next test file does `from core.database import *`,
+# which would otherwise see a MagicMock where a list-of-str is required.
 class _DBStub(types.ModuleType):
     def __getattr__(self, name):  # noqa: D401
+        if name.startswith("__"):
+            raise AttributeError(name)
         return MagicMock()
 
 
 _db = _DBStub("core.database")
 _db.get_db_session = _get_db_session
 _db.ApiToken = _ApiToken
-sys.modules["core.database"] = _db  # overwrite any minimal stub from a sibling test
 
-for _name, _attrs in {
-    "core.auth": {"AuthManager": MagicMock()},
-    "src.endpoint_resolver": {"build_chat_url": (lambda u: u)},
-}.items():
-    if _name not in sys.modules:
-        _mm = types.ModuleType(_name)
-        for _k, _v in _attrs.items():
-            setattr(_mm, _k, _v)
-        sys.modules[_name] = _mm
+
+@pytest.fixture(autouse=True)
+def _companion_pairing_stubs(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", _db)
+    for _name, _attrs in {
+        "core.auth": {"AuthManager": MagicMock()},
+        "src.endpoint_resolver": {"build_chat_url": (lambda u: u)},
+    }.items():
+        if _name not in sys.modules:
+            _mm = types.ModuleType(_name)
+            for _k, _v in _attrs.items():
+                setattr(_mm, _k, _v)
+            sys.modules[_name] = _mm
+        monkeypatch.setitem(sys.modules, _name, sys.modules[_name])
+
 
 from fastapi import HTTPException  # noqa: E402
 

--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -24,32 +24,38 @@ from unittest.mock import MagicMock
 # the conftest's `sqlalchemy.*` MagicMock stubs ("metaclass conflict").
 # Stub also a handful of route modules each of these targeted modules
 # happens to drag in at import-time.
-for _stub in [
-    "core.database",
-    "core.auth",
-    "src.endpoint_resolver",
-]:
-    if _stub not in sys.modules:
-        m = types.ModuleType(_stub)
-        # Provide the names the importers will look up.
-        if _stub == "core.database":
-            m.Base = MagicMock()
-            m.SessionLocal = MagicMock()
-            m.CalendarCal = MagicMock()
-            m.CalendarEvent = MagicMock()
-            m.Document = MagicMock()
-            m.DocumentVersion = MagicMock()
-            m.Session = MagicMock()
-            m.ChatMessage = MagicMock()
-            m.GalleryImage = MagicMock()
-            m.GalleryAlbum = MagicMock()
-            m.Note = MagicMock()
-            m.ScheduledTask = MagicMock()
-            m.TaskRun = MagicMock()
-            m.ModelEndpoint = MagicMock()
-        elif _stub == "core.auth":
-            m.AuthManager = MagicMock()
-        sys.modules[_stub] = m
+@pytest.fixture(autouse=True)
+def _null_owner_stubs(monkeypatch):
+    for _stub, _attrs in (
+        ("core.database", (
+            "Base", "SessionLocal", "CalendarCal", "CalendarEvent",
+            "Document", "DocumentVersion", "Session", "ChatMessage",
+            "GalleryImage", "GalleryAlbum", "Note", "ScheduledTask",
+            "TaskRun", "ModelEndpoint", "Webhook",
+        )),
+        ("core.auth", ("AuthManager",)),
+        ("src.endpoint_resolver", ()),
+    ):
+        if _stub not in sys.modules:
+            m = types.ModuleType(_stub)
+            for _name in _attrs:
+                setattr(m, _name, MagicMock())
+            sys.modules[_stub] = m
+        else:
+            m = sys.modules[_stub]
+            for _name in _attrs:
+                if not hasattr(m, _name):
+                    setattr(m, _name, MagicMock())
+        monkeypatch.setitem(sys.modules, _stub, m)
+
+    # src.webhook_manager is only dragged in by _import_webhook_helper().
+    if "src.webhook_manager" not in sys.modules:
+        wm = types.ModuleType("src.webhook_manager")
+        wm.WebhookManager = MagicMock()
+        wm.validate_webhook_url = MagicMock()
+        wm.validate_events = MagicMock()
+        sys.modules["src.webhook_manager"] = wm
+        monkeypatch.setitem(sys.modules, "src.webhook_manager", wm)
 
 from fastapi import HTTPException
 
@@ -179,18 +185,9 @@ def test_gallery_owner_filter_passes_user():
 # calendar/notes/gallery gates above and _verify_session_owner.
 
 def _import_webhook_helper():
-    """Import routes.webhook_routes without dragging in the real webhook
-    manager / database. Stub src.webhook_manager (only referenced by an
-    import line) and ensure core.database exposes the names the import chain
-    (core/__init__ → session_manager) looks up."""
-    for _name in ("Webhook", "ChatMessage"):
-        setattr(sys.modules["core.database"], _name, MagicMock())
-    if "src.webhook_manager" not in sys.modules:
-        wm = types.ModuleType("src.webhook_manager")
-        wm.WebhookManager = MagicMock()
-        wm.validate_webhook_url = MagicMock()
-        wm.validate_events = MagicMock()
-        sys.modules["src.webhook_manager"] = wm
+    """Import routes.webhook_routes. Stubs for core.database (ChatMessage,
+    Webhook) and src.webhook_manager are provided by the _null_owner_stubs
+    autouse fixture."""
     return __import__(
         "routes.webhook_routes", fromlist=["_caller_owns_session"]
     )

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -14,15 +14,14 @@ from sqlalchemy.orm import sessionmaker
 from core.database import Base, Session as DbSession
 from src.task_scheduler import TaskScheduler
 
-# TEMPORARY ISOLATION WORKAROUND — remove once test_null_owner_gates.py is
-# refactored to use a fixture-scoped stub instead of module-level sys.modules
-# patching.  When collected after test_null_owner_gates (alphabetical order),
-# core.database is already a stub whose Base attribute is a MagicMock, so
-# Base.metadata.create_all() below does nothing and the assertions fail.
-# The test passes correctly in isolation:
-#   pytest tests/test_task_scheduler_session_delivery.py   → 1 passed
-# Full-suite baseline before this PR:  9 failed, 345 passed  (pre-upstream-pull)
-# Full-suite after this PR:            1 failed, 495 passed, 1 skipped
+# This test needs the real core.database (real SQLAlchemy Base/ChatMessage).
+# test_null_owner_gates.py no longer leaks its stubs (per-test fixture cleanup
+# since PR #1513), but several other files still install core.database stubs
+# at module level without teardown (test_model_routes, test_companion_readonly,
+# test_endpoint_probing, test_vault_password_not_in_argv).  When any of those
+# are collected before us, core.database is a stub and Base is a MagicMock.
+# Skip in that case — the test passes correctly in isolation or when collected
+# before the stubbing files.
 if type(Base).__name__ == "MagicMock":
     pytest.skip("core.database is stubbed — run this file in isolation", allow_module_level=True)
 


### PR DESCRIPTION
## Symptom

`pytest tests/` aborts during collection with three errors and never runs anything in the affected files:

```
ERROR tests/test_chat_image_routing.py - ImportError: cannot import name 'Session' from 'core.database' (unknown location)
ERROR tests/test_context_compactor.py - ImportError: cannot import name 'normalize_base' from 'src.endpoint_resolver' (unknown location)
ERROR tests/test_webhook_ssrf_resilience.py - TypeError: Item in core.database.__all__ must be str, not MagicMock
```

Same files all pass in isolation. The whole suite has never run cleanly on a clean checkout.

## Why it matters

`tests/conftest.py` stubs the heavy optional deps (`sqlalchemy`, `fastapi`, `httpx`, ...) and `src.database`, but not `core.database` or `core.auth`. Every test that imports a route module that touches the real `core.*` package either has to install its own stub or fail. The four files below install stubs at **module-import time** with no teardown, so the stub persists in `sys.modules` for the rest of the test session. Whichever file runs first wins; every later file's `from core.database import X` either gets a stub missing the requested attr (ImportError) or a stub whose `__all__` got auto-resolved to a MagicMock by a too-broad `__getattr__` (TypeError on `import *`).

There is a second, more dangerous leak that is only visible once collection is unblocked: `test_auth_event_loop.py`'s module-level `core.auth` stub breaks `test_totp_failclosed.py`, which imports the real `AuthManager` and uses it for real. That interaction has been hidden behind the collection error.

A third issue (flagged by @lalalune in review): `_import_webhook_helper()` in `test_null_owner_gates.py` does bare `setattr(sys.modules["core.database"], "ChatMessage", MagicMock())`. When the real `core.database` is already loaded (e.g. by `test_admin_wipe_gallery.py` during collection), this mutates the real module object. `monkeypatch.setitem` only restores the `sys.modules` dict entry, not attributes on the module object, so `ChatMessage` stays a MagicMock for later tests — specifically breaking `test_task_scheduler_session_delivery.py`.

## Cause

Four test files install stub modules for `core.database` / `core.auth` / `src.endpoint_resolver` at import time, with no per-test teardown:

- `tests/test_auth_regressions.py`
- `tests/test_auth_event_loop.py`
- `tests/test_null_owner_gates.py`
- `tests/test_companion_pairing.py`

`test_companion_pairing.py` adds a second, independent bug: its `_DBStub(types.ModuleType)` defines `__getattr__` that returns `MagicMock` for *any* name, including dunders. The next test file that does `from core.database import *` reads `__all__` as a `MagicMock` and dies with `Item in core.database.__all__ must be str, not MagicMock`.

`test_null_owner_gates.py`'s `_import_webhook_helper()` mutates `sys.modules["core.database"]` attributes directly, which poisons the real module when it is already loaded.

## Change

Each of the four files now installs its stubs inside an `@pytest.fixture(autouse=True)` and registers them with `monkeypatch.setitem(sys.modules, ...)`. After every test, `sys.modules` is restored to its pre-test state, so later-collected files see the real `core.*` modules. This matches the pattern already used by `test_api_token_routes.py`'s `token_routes_mod` fixture.

`_DBStub.__getattr__` in `test_companion_pairing.py` now raises `AttributeError` for dunder names so `__all__` stays undefined; `from x import *` machinery then treats the module as exporting its public attrs normally.

`_import_webhook_helper()` in `test_null_owner_gates.py` no longer does bare `setattr` on `sys.modules["core.database"]`. The `ChatMessage`/`Webhook` attrs and the `src.webhook_manager` stub are already provided by the file's `_null_owner_stubs` autouse fixture, so the helper only needs to do the import.

`test_task_scheduler_session_delivery.py`'s skip guard is updated: the original "TEMPORARY ISOLATION WORKAROUND" comment blamed `test_null_owner_gates.py` specifically, but several other files (`test_model_routes`, `test_companion_readonly`, `test_endpoint_probing`, `test_vault_password_not_in_argv`) also install `core.database` stubs at module level without teardown. The skip guard is still needed for those; the comment now accurately reflects the remaining sources.

## Verification

```
$ venv/bin/python -m pytest tests/ --co -q
1370 tests collected in 1.03s

$ venv/bin/python -m pytest tests/ --tb=line
1378 passed, 14 failed, 1 skipped
```

0 collection errors (was 3). The 14 remaining failures are pre-existing on `origin/main` (verified by running the same suite on a clean checkout):

- `test_calendar_rrule.py` (2) — pre-existing, fail in isolation
- `test_cookbook_dependency_completion_regression.py` (1) — pre-existing
- `test_llm_core_sanitize_tool_calls.py` (1) — pre-existing
- `test_mcp_reconnect_args.py` (1) — pre-existing
- `test_rename_user_case_insensitive.py` (1) — pre-existing
- `test_scheduler_restart_doublefire.py` (3) — pre-existing
- `test_security_regressions.py` (1) — pre-existing (README text changed upstream)
- `test_task_scheduler_cancel.py` (1) — pre-existing
- `test_task_scheduler_session_delivery.py` (1) — pre-existing (other stubbing files pollute core.database)
- `test_audit_r1_validators.py` (2) — pre-existing in an untracked test file

Targeted re-runs of the 5 files I changed:

```
tests/test_auth_regressions.py        15 passed
tests/test_auth_event_loop.py          1 passed
tests/test_companion_pairing.py        9 passed
tests/test_null_owner_gates.py        18 passed
tests/test_task_scheduler_session_delivery.py  1 passed
```

Cross-file check — the 4 changed files + the 3 previously-uncollectable consumers + 2 files that need real `core.auth` + the file @lalalune flagged:

```
$ venv/bin/python -m pytest tests/test_auth_regressions.py tests/test_auth_event_loop.py \
    tests/test_companion_pairing.py tests/test_null_owner_gates.py \
    tests/test_totp_failclosed.py tests/test_security_regressions.py \
    tests/test_chat_image_routing.py tests/test_webhook_ssrf_resilience.py \
    tests/test_context_compactor.py tests/test_task_scheduler_session_delivery.py
137 passed, 1 failed (pre-existing: test_readme_native_quickstart_uses_loopback)
```

The reviewer's specific regression (`test_null_owner_gates → test_task_scheduler_session_delivery`) now passes — the bare `setattr` on `core.database` is gone.

## Out of scope

Several files still install `core.database` stubs at module level without teardown (`test_model_routes`, `test_companion_readonly`, `test_endpoint_probing`, `test_vault_password_not_in_argv`). These cause the `test_task_scheduler_session_delivery.py` full-suite failure that exists on `origin/main`. Each is a separate leak; tracking them separately rather than expanding this PR's surface.