### PR TITLE
fix(compare): stop leaking model names in blind mode sessions

### DIFF
--- a/routes/compare_routes.py
+++ b/routes/compare_routes.py
@@ -48,11 +48,14 @@ def setup_compare_routes(session_manager: SessionManager):
         sid_b = str(uuid.uuid4())
 
         # Create ephemeral sessions (prefixed [CMP])
-        for sid, model, endpoint in [(sid_a, model_a, endpoint_a), (sid_b, model_b, endpoint_b)]:
+        blind = str(is_blind).lower() == "true"
+        slot_labels = ["Model A", "Model B"]
+        for idx, (sid, model, endpoint) in enumerate([(sid_a, model_a, endpoint_a), (sid_b, model_b, endpoint_b)]):
             user = getattr(request.state, 'current_user', None)
+            session_name = f"[CMP] {slot_labels[idx]}" if blind else f"[CMP] {model.split('/')[-1]}"
             session_manager.create_session(
                 session_id=sid,
-                name=f"[CMP] {model.split('/')[-1]}",
+                name=session_name,
                 endpoint_url=endpoint,
                 model=model,
                 rag=False,
@@ -76,7 +79,6 @@ def setup_compare_routes(session_manager: SessionManager):
                 db.close()
 
         # Blind mapping: randomly assign left/right
-        blind = str(is_blind).lower() == "true"
         if blind:
             mapping = {"left": "a", "right": "b"}
             if random.random() > 0.5:
@@ -107,15 +109,17 @@ def setup_compare_routes(session_manager: SessionManager):
         session_left = sid_a if mapping["left"] == "a" else sid_b
         session_right = sid_a if mapping["right"] == "a" else sid_b
 
-        return {
+        resp = {
             "id": comp_id,
             "session_left": session_left,
             "session_right": session_right,
-            "model_left": model_a if mapping["left"] == "a" else model_b,
-            "model_right": model_a if mapping["right"] == "a" else model_b,
             "is_blind": blind,
             "mapping": mapping,
         }
+        if not blind:
+            resp["model_left"] = model_a if mapping["left"] == "a" else model_b
+            resp["model_right"] = model_a if mapping["right"] == "a" else model_b
+        return resp
 
     @router.post("/{comp_id}/vote")
     def vote_comparison(

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -210,7 +210,7 @@ async function _buildCompareUI() {
     for (let i = 0; i < n; i++) {
       const m = state._selectedModels[i];
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + modelShorts[i]);
+      fd.append('name', '[CMP] ' + (state._blindMode ? 'Model ' + _slotChar(i) : modelShorts[i]));
       fd.append('endpoint_url', m.endpoint || '');
       fd.append('model', m.model || '');
       if (m.endpointId) {

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -382,7 +382,7 @@ async function _createAndAppendPane(m) {
 
   // Create session
   const fd = new FormData();
-  fd.append('name', '[CMP] ' + m.name);
+  fd.append('name', '[CMP] ' + (state._blindMode ? 'Model ' + _slotChar(i) : m.name));
   fd.append('endpoint_url', m.url || '');
   fd.append('model', m.id || '');
   if (m.endpointId) {
@@ -584,7 +584,7 @@ function _showModelSwapDropdown(paneIdx, titleBtn) {
         fetch(`${state.API_BASE}/api/session/${oldSid}`, { method: 'DELETE' }).catch(() => {});
       }
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + m.name);
+      fd.append('name', '[CMP] ' + (state._blindMode ? 'Model ' + _slotChar(paneIdx) : m.name));
       fd.append('endpoint_url', m.url || '');
       fd.append('model', m.id || '');
       if (m.endpointId) {


### PR DESCRIPTION
## Summary
- In blind mode, compare sessions were named `[CMP] gpt-4o` etc., leaking real model identities in the sidebar and `/api/sessions` before the user voted
- Frontend (`index.js`, `panes.js`): use neutral `[CMP] Model A` / `[CMP] Model B` labels when `state._blindMode` is active
- Backend (`compare_routes.py`): use the same neutral labels for session creation when `is_blind=true`
- Backend: omit `model_left` / `model_right` from the `/api/compare/start` response in blind mode

Fixes #1285

## Test plan
- [ ] Enable blind mode in Compare, select two models, start a comparison
- [ ] Check the session sidebar — sessions should show `[CMP] Model A` / `[CMP] Model B`, not real model names
- [ ] Call `GET /api/sessions` — verify no model names leak for `[CMP]` sessions
- [ ] Disable blind mode — session names should show real model names as before
- [ ] Vote and verify results still show correct model attributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)