### PR TITLE
Add bounded reads for direct uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ python -m uvicorn app:app --host 127.0.0.1 --port 7000
 Requirements: Python 3.11+. Cookbook also needs `tmux` for background model
 downloads and serves. The app itself is lightweight; local model serving is the
 heavy part and depends on the model, runtime, GPU, and VRAM, so small hosts can
-connect to API or remote model servers instead. Use `--host 0.0.0.0` only when
-you intentionally want LAN/reverse-proxy access.
+connect to API or remote model servers instead. Use `--host 0.0.0.0` only when you intentionally want LAN/reverse-proxy access.
 
 ### Apple Silicon
 Docker on macOS cannot use the Metal GPU. For GPU-accelerated Cookbook on an

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -13,6 +13,7 @@ from dateutil.rrule import DAILY, WEEKLY, MONTHLY, YEARLY
 
 from core.database import SessionLocal, CalendarCal, CalendarEvent
 from src.auth_helpers import get_current_user, require_user
+from src.upload_limits import read_upload_limited
 
 logger = logging.getLogger(__name__)
 
@@ -1005,9 +1006,7 @@ def setup_calendar_routes() -> APIRouter:
         owner = _require_user(request)
         db = SessionLocal()
         try:
-            content = await file.read()
-            if len(content) > _ICS_MAX_BYTES:
-                raise HTTPException(413, f"ICS file too large (max {_ICS_MAX_BYTES // (1024*1024)} MB)")
+            content = await read_upload_limited(file, _ICS_MAX_BYTES, "ICS file")
             try:
                 cal_data = iCal.from_ical(content)
             except Exception as e:

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -34,6 +34,7 @@ from fastapi import APIRouter, Query, UploadFile, File, BackgroundTasks, HTTPExc
 from fastapi.responses import FileResponse
 
 from src.llm_core import llm_call_async
+from src.upload_limits import read_upload_limited
 
 from routes.email_helpers import (
     _strip_think, _extract_reply, _apply_email_style_mechanics, require_owner, require_user, _assert_owns_account,
@@ -55,6 +56,7 @@ from routes.email_pollers import _start_poller
 logger = logging.getLogger(__name__)
 
 ODYSSEUS_MAIL_ORIGIN = "odysseus-ui"
+EMAIL_COMPOSE_UPLOAD_MAX_BYTES = 25 * 1024 * 1024
 
 
 def _email_tag_owner_aliases(account_id: str | None, owner: str = "") -> list[str]:
@@ -1880,16 +1882,12 @@ def setup_email_routes():
     @router.post("/compose-upload")
     async def compose_upload(file: UploadFile = File(...), owner: str = Depends(require_owner)):
         """Upload a file for attaching to a compose email. Returns a token."""
-        # 25MB cap (matches typical SMTP limits w/ base64 overhead)
-        MAX_BYTES = 25 * 1024 * 1024
         try:
             # Sanitize filename and generate a unique token
             safe_name = re.sub(r"[^\w\s\-.]", "_", file.filename or "file").strip()
             token = f"{uuid.uuid4().hex}_{safe_name}"
             filepath = COMPOSE_UPLOADS_DIR / token
-            content = await file.read()
-            if len(content) > MAX_BYTES:
-                raise HTTPException(413, f"Attachment exceeds {MAX_BYTES // (1024*1024)}MB limit")
+            content = await read_upload_limited(file, EMAIL_COMPOSE_UPLOAD_MAX_BYTES, "Attachment")
             with open(filepath, "wb") as f:
                 f.write(content)
             return {

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -13,12 +13,16 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from core.database import SessionLocal, GalleryImage, GalleryAlbum, ModelEndpoint
 from core.database import Session as DbSession
 from src.auth_helpers import get_current_user, require_privilege
+from src.upload_limits import read_upload_limited
 
 from routes.gallery_helpers import (
     GalleryPatch, _extract_exif, _image_to_dict, _owner_filter, _human_size,
 )
 
 logger = logging.getLogger(__name__)
+
+GALLERY_UPLOAD_MAX_BYTES = int(os.getenv("ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES", str(100 * 1024 * 1024)))
+GALLERY_TRANSFORM_UPLOAD_MAX_BYTES = int(os.getenv("ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES", str(25 * 1024 * 1024)))
 
 
 def _sanitize_gallery_filename(filename: str) -> str:
@@ -45,7 +49,7 @@ def setup_gallery_routes() -> APIRouter:
 
         user = get_current_user(request)
         album_id = form.get("album_id") or None
-        content = await file.read()
+        content = await read_upload_limited(file, GALLERY_UPLOAD_MAX_BYTES, "Gallery upload")
 
         # Duplicate detection via SHA-256
         file_hash = hashlib.sha256(content).hexdigest()
@@ -130,7 +134,7 @@ def setup_gallery_routes() -> APIRouter:
             if not file or not hasattr(file, 'read'):
                 raise HTTPException(400, "No image provided")
 
-            content = await file.read()
+            content = await read_upload_limited(file, GALLERY_UPLOAD_MAX_BYTES, "Gallery replacement")
             img_dir = Path("data/generated_images")
             img_dir.mkdir(parents=True, exist_ok=True)
             img_path = img_dir / _sanitize_gallery_filename(img.filename)
@@ -250,7 +254,7 @@ def setup_gallery_routes() -> APIRouter:
         if not file: raise HTTPException(400, "No image")
         scale = int(form.get("scale", "2"))
 
-        image_bytes = await file.read()
+        image_bytes = await read_upload_limited(file, GALLERY_TRANSFORM_UPLOAD_MAX_BYTES, "Image upload")
         b64 = base64.b64encode(image_bytes).decode()
 
         # Find image endpoint
@@ -294,7 +298,7 @@ def setup_gallery_routes() -> APIRouter:
         strength = float(form.get("strength", "0.55"))
         if not file: raise HTTPException(400, "No image")
 
-        image_bytes = await file.read()
+        image_bytes = await read_upload_limited(file, GALLERY_TRANSFORM_UPLOAD_MAX_BYTES, "Image upload")
         b64 = base64.b64encode(image_bytes).decode()
 
         db = SessionLocal()
@@ -1803,5 +1807,4 @@ def setup_gallery_routes() -> APIRouter:
             db.close()
 
     return router
-
 

--- a/routes/memory_routes.py
+++ b/routes/memory_routes.py
@@ -29,8 +29,11 @@ from src.llm_core import llm_call_async
 from services.memory.memory_extractor import audit_memories
 from src.auth_helpers import get_current_user, require_user
 from src.endpoint_resolver import resolve_endpoint
+from src.upload_limits import read_upload_limited
 
 logger = logging.getLogger(__name__)
+
+MEMORY_IMPORT_MAX_BYTES = int(os.getenv("ODYSSEUS_MEMORY_IMPORT_MAX_BYTES", str(10 * 1024 * 1024)))
 
 def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionManager, memory_vector=None):
     """Set up memory-related routes."""
@@ -338,8 +341,7 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
         if not endpoint_url or not model:
             raise HTTPException(400, "No LLM model configured. Set a default model in Settings.")
 
-        # Read file content
-        content = await file.read()
+        content = await read_upload_limited(file, MEMORY_IMPORT_MAX_BYTES, "Memory import")
         filename = file.filename or "upload"
         _, ext = os.path.splitext(filename.lower())
 

--- a/routes/stt_routes.py
+++ b/routes/stt_routes.py
@@ -4,7 +4,11 @@
 from fastapi import APIRouter, HTTPException, UploadFile, File
 import logging
 
+from src.upload_limits import read_upload_limited
+
 logger = logging.getLogger(__name__)
+
+STT_MAX_AUDIO_BYTES = 25 * 1024 * 1024
 
 
 def setup_stt_routes(stt_service):
@@ -30,7 +34,7 @@ def setup_stt_routes(stt_service):
                     detail={"message": "STT service not available or set to browser mode"}
                 )
 
-            audio_bytes = await file.read()
+            audio_bytes = await read_upload_limited(file, STT_MAX_AUDIO_BYTES, "Audio file")
             if not audio_bytes:
                 raise HTTPException(status_code=400, detail={"message": "Empty audio file"})
 

--- a/src/upload_limits.py
+++ b/src/upload_limits.py
@@ -1,0 +1,22 @@
+"""Small helpers for route-local upload size caps."""
+
+from fastapi import HTTPException, UploadFile
+
+
+def format_byte_limit(limit: int) -> str:
+    if limit % (1024 * 1024) == 0:
+        return f"{limit // (1024 * 1024)} MB"
+    if limit % 1024 == 0:
+        return f"{limit // 1024} KB"
+    return f"{limit} bytes"
+
+
+async def read_upload_limited(upload: UploadFile, limit: int, label: str = "Upload") -> bytes:
+    """Read an UploadFile with a hard byte cap."""
+    data = await upload.read(limit + 1)
+    if len(data) > limit:
+        raise HTTPException(
+            status_code=413,
+            detail=f"{label} exceeds {format_byte_limit(limit)} limit",
+        )
+    return data

--- a/tests/test_calendar_rrule.py
+++ b/tests/test_calendar_rrule.py
@@ -6,6 +6,7 @@ calling do_manage_calendar with an rrule stores a single event carrying that RRU
 """
 
 import json
+import sys
 import tempfile
 import uuid
 
@@ -13,6 +14,21 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
 
 import core.database as cdb
 from core.database import CalendarEvent
@@ -32,6 +48,10 @@ def _bind_temp_db(monkeypatch):
     # do_manage_calendar does `from core.database import SessionLocal` at call
     # time, so patch the module attribute to our temp DB — via monkeypatch so it
     # is RESTORED after each test and can't leak into later tests in the process.
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", cdb, raising=False)
     monkeypatch.setattr(cdb, "SessionLocal", _TS)
     yield
 

--- a/tests/test_chat_image_routing.py
+++ b/tests/test_chat_image_routing.py
@@ -1,5 +1,12 @@
 import json
+import sys
 from types import SimpleNamespace
+
+_endpoint_resolver = sys.modules.get("src.endpoint_resolver")
+if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
+    sys.modules.pop("src.endpoint_resolver", None)
+    sys.modules.pop("routes.model_routes", None)
+    sys.modules.pop("routes.chat_routes", None)
 
 from routes import chat_routes
 

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -78,7 +78,12 @@ from core.middleware import require_admin  # noqa: E402
 
 # --- token minting: shown once, hashed at rest -----------------------------
 
-def test_mint_token_returns_raw_once_and_stores_only_a_hash():
+def test_mint_token_returns_raw_once_and_stores_only_a_hash(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", _db)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", _db, raising=False)
+
     token_id, raw = P.mint_token("alice")
     assert raw.startswith("ody_")
     # The persisted row stores a bcrypt hash + prefix, never the plaintext.

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -22,7 +22,8 @@ def test_background_status_poll_reconciles_into_local_tasks():
     assert "const statusById = new Map(tasks.map(t => [t.session_id, t]));" in source
     assert "const nextStatus = live.status === 'completed'" in source
     assert "? 'done'" in source
-    assert "live.status === 'error'" in source
+    assert ": (live.status === 'error'" in source
+    assert "? 'error'" in source
     assert "_saveTasks(localTasks);" in source
     assert "completedDeps.forEach(t => _refreshDepsAfterInstall(t));" in source
 

--- a/tests/test_direct_upload_limits.py
+++ b/tests/test_direct_upload_limits.py
@@ -1,0 +1,61 @@
+import io
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from src.upload_limits import format_byte_limit, read_upload_limited
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _upload(name: str, data: bytes) -> UploadFile:
+    return UploadFile(filename=name, file=io.BytesIO(data))
+
+
+def _source(path: str) -> str:
+    return (REPO / path).read_text(encoding="utf-8")
+
+
+async def test_read_upload_limited_accepts_exact_limit():
+    assert await read_upload_limited(_upload("ok.bin", b"abcd"), 4, "Test upload") == b"abcd"
+
+
+async def test_read_upload_limited_rejects_oversized_upload():
+    with pytest.raises(HTTPException) as exc:
+        await read_upload_limited(_upload("too-big.bin", b"abcde"), 4, "Test upload")
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "Test upload exceeds 4 bytes limit"
+
+
+def test_upload_limit_formatting_is_human_readable():
+    assert format_byte_limit(25 * 1024 * 1024) == "25 MB"
+    assert format_byte_limit(512 * 1024) == "512 KB"
+    assert format_byte_limit(7) == "7 bytes"
+
+
+def test_direct_upload_routes_use_bounded_reads():
+    expectations = {
+        "routes/stt_routes.py": [
+            "read_upload_limited(file, STT_MAX_AUDIO_BYTES",
+        ],
+        "routes/gallery_routes.py": [
+            "read_upload_limited(file, GALLERY_UPLOAD_MAX_BYTES",
+            "read_upload_limited(file, GALLERY_TRANSFORM_UPLOAD_MAX_BYTES",
+        ],
+        "routes/memory_routes.py": [
+            "read_upload_limited(file, MEMORY_IMPORT_MAX_BYTES",
+        ],
+        "routes/calendar_routes.py": [
+            "read_upload_limited(file, _ICS_MAX_BYTES",
+        ],
+        "routes/email_routes.py": [
+            "read_upload_limited(file, EMAIL_COMPOSE_UPLOAD_MAX_BYTES",
+        ],
+    }
+
+    for path, needles in expectations.items():
+        text = _source(path)
+        for needle in needles:
+            assert needle in text

--- a/tests/test_document_close_clears_active_route.py
+++ b/tests/test_document_close_clears_active_route.py
@@ -13,6 +13,7 @@ while completing reliably everywhere.
 """
 
 import tempfile
+import sys
 import uuid
 from types import SimpleNamespace
 
@@ -20,6 +21,21 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 from unittest.mock import MagicMock
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
 
 import core.database as cdb
 import routes.document_routes as droutes

--- a/tests/test_llm_core_sanitize_tool_calls.py
+++ b/tests/test_llm_core_sanitize_tool_calls.py
@@ -141,4 +141,3 @@ def test_build_anthropic_payload_alternating_roles():
 
 
 
-

--- a/tests/test_sqlite_foreign_keys.py
+++ b/tests/test_sqlite_foreign_keys.py
@@ -1,6 +1,23 @@
 import pytest
+import sys
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
 from core.database import Base, Session, ChatMessage
 from datetime import datetime
 
@@ -35,4 +52,3 @@ def test_sqlite_foreign_keys_cascade():
     assert db.query(ChatMessage).count() == 0
     
     db.close()
-

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -1,5 +1,6 @@
 """Regression tests for task-result delivery into chat sessions (issue #326)."""
 import asyncio
+import sys
 import types as _types
 
 import pytest
@@ -11,6 +12,22 @@ if not isinstance(sqlalchemy, _types.ModuleType):
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
+import core.database as cdb
 from core.database import Base, Session as DbSession
 from src.task_scheduler import TaskScheduler
 
@@ -46,10 +63,15 @@ def _make_task():
     )
 
 
-def test_session_delivery_survives_empty_database():
+def test_session_delivery_survives_empty_database(monkeypatch):
     """On a fresh/wiped database there is no session to inherit endpoint/model
     from, so _resolve_defaults returns None. The delivery must still persist a
     session instead of crashing on the NOT NULL constraint (issue #326)."""
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", cdb, raising=False)
+
     db = _make_db()
     scheduler = TaskScheduler.__new__(TaskScheduler)
     scheduler._session_manager = None

--- a/tests/test_topic_analyzer.py
+++ b/tests/test_topic_analyzer.py
@@ -1,8 +1,25 @@
 """Tests for topic keyword matching (src/topic_analyzer.py)."""
+import sys
 from types import SimpleNamespace
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
 from core.database import Base, Session as DbSession, ChatMessage as DbChatMessage
 from core.session_manager import SessionManager
 from src.topic_analyzer import analyze_topics

--- a/tests/test_webhook_ssrf_resilience.py
+++ b/tests/test_webhook_ssrf_resilience.py
@@ -6,6 +6,22 @@ from datetime import datetime
 # from it, so drop the stub here to load the real module under test.
 if "src.database" in sys.modules:
     del sys.modules["src.database"]
+_core_database = sys.modules.get("core.database")
+_core_database_all = getattr(_core_database, "__all__", None) if _core_database is not None else None
+if (
+    _core_database is not None
+    and (
+        not getattr(_core_database, "__file__", None)
+        or (
+            _core_database_all is not None
+            and (
+                not isinstance(_core_database_all, (list, tuple, set))
+                or not all(isinstance(name, str) for name in _core_database_all)
+            )
+        )
+    )
+):
+    del sys.modules["core.database"]
 
 import pytest
 from src.webhook_manager import validate_webhook_url


### PR DESCRIPTION
## Summary
- add a shared helper for capped UploadFile reads
- enforce bounded reads on direct STT, gallery, memory import, calendar ICS import, and email compose uploads
- keep gallery/media limits configurable while preserving existing email and calendar cap behavior
- add regression coverage for the upload-limit helper and route usage

## Notes
- Stacked on #1490 for the test collection cleanup.
- This is independent of #1491 and #1511, though it touches some of the same gallery route file as #1511.

## Tests
- PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_direct_upload_limits.py tests/test_speech_service_toggles.py tests/test_stt_leak.py tests/test_upload_multifile.py tests/test_upload_error_surfaced.py tests/test_personal_upload_isolation.py
  - 16 passed
- git diff --check
- PYTHONDONTWRITEBYTECODE=1 /home/moloch/odysseus/venv/bin/python -m py_compile routes/stt_routes.py routes/gallery_routes.py routes/memory_routes.py routes/calendar_routes.py routes/email_routes.py src/upload_limits.py tests/test_direct_upload_limits.py
- PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q
  - 1374 passed, 1 skipped