### PR TITLE
Pin numpy<2.4 so it runs on CPUs without x86-64-v2 (#1515)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,13 @@ SQLAlchemy
 pypdf
 beautifulsoup4
 charset-normalizer
-numpy
+# Cap below 2.4: numpy 2.4+ is built with an x86-64-v2 baseline and crashes on
+# older CPUs that lack those instructions ("NumPy was built with baseline
+# optimizations (X86_V2) but your machine doesn't support (X86_V2)", issue #1515).
+# 2.3.x is the last line that runs on pre-x86-64-v2 hardware. Self-hosted users
+# often run exactly that older hardware. Bump deliberately once a newer line
+# drops the baseline requirement (or the project stops targeting old CPUs).
+numpy<2.4
 # Vector store + local embeddings for RAG, semantic memory, and tool
 # selection. Used on core agent paths, so installed by default — the app
 # still degrades to keyword fallback if they're ever missing.

--- a/tests/test_numpy_cpu_compat_pin.py
+++ b/tests/test_numpy_cpu_compat_pin.py
@@ -1,0 +1,23 @@
+"""Regression guard for issue #1515 — numpy 2.4+ ships an x86-64-v2 baseline that
+crashes on older CPUs ("NumPy was built with baseline optimizations (X86_V2) but
+your machine doesn't support (X86_V2)"). 2.3.x is the last line that runs on
+pre-x86-64-v2 hardware, which self-hosted users often have.
+
+Pin numpy below 2.4 so a fresh install doesn't pull a build that won't run.
+"""
+import re
+from pathlib import Path
+
+REQ = Path(__file__).resolve().parent.parent / "requirements.txt"
+
+
+def test_numpy_pinned_below_2_4():
+    lines = [
+        ln.split("#", 1)[0].strip()
+        for ln in REQ.read_text(encoding="utf-8").splitlines()
+        if ln.split("#", 1)[0].strip().lower().startswith("numpy")
+    ]
+    assert lines, "numpy requirement not found"
+    spec = lines[0]
+    # Must carry an explicit upper bound, not a bare/unpinned `numpy`.
+    assert re.search(r"<\s*2\.4|<=\s*2\.3", spec), f"numpy must be capped <2.4 (#1515): {spec!r}"


### PR DESCRIPTION
## Problem

On a CPU without x86-64-v2 instructions, Odysseus crashes at startup:

```
RuntimeError: NumPy was built with baseline optimizations:
(X86_V2) but your machine doesn't support:
(X86_V2).
```

numpy 2.4+ raised its build baseline to x86-64-v2. `requirements.txt` had an **unpinned** `numpy`, so a fresh `pip install` pulls 2.4+ and the app won't start on older hardware — which self-hosted users often run. The reporter verified that **2.3.x** is the last line that runs on pre-x86-64-v2 CPUs.

## Fix

Cap `numpy<2.4` in `requirements.txt` (with a comment to bump deliberately once a newer line drops the baseline requirement). Nothing in the project requires numpy 2.4+, so this is a safe compatibility constraint — same spirit as the SearXNG image pin (#1419).

## Test — `tests/test_numpy_cpu_compat_pin.py`

Guards that the numpy requirement keeps an explicit `<2.4` upper bound (not a bare `numpy`). Proven red→green.

```
./venv/bin/python -m pytest -q tests/test_numpy_cpu_compat_pin.py   # 1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)