### PR TITLE
Scope AI tool model resolution by owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ python -m uvicorn app:app --host 127.0.0.1 --port 7000
 Requirements: Python 3.11+. Cookbook also needs `tmux` for background model
 downloads and serves. The app itself is lightweight; local model serving is the
 heavy part and depends on the model, runtime, GPU, and VRAM, so small hosts can
-connect to API or remote model servers instead. Use `--host 0.0.0.0` only when
-you intentionally want LAN/reverse-proxy access.
+connect to API or remote model servers instead. Use `--host 0.0.0.0` only when you intentionally want LAN/reverse-proxy access.
 
 ### Apple Silicon
 Docker on macOS cannot use the Metal GPU. For GPU-accelerated Cookbook on an

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -58,7 +58,7 @@ def set_rag_manager(rag_mgr, personal_docs_mgr=None):
 from src.endpoint_resolver import normalize_base as _normalize_base, build_chat_url, build_headers, build_models_url
 
 
-def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
+def _resolve_model(spec: str, owner: Optional[str] = None) -> Tuple[str, str, Dict]:
     """Resolve a model specifier to (endpoint_url, model_id, headers).
 
     Accepts:
@@ -70,6 +70,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
     import httpx
     from src.database import SessionLocal, ModelEndpoint
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
+    from src.auth_helpers import owner_filter
 
     spec = spec.strip()
     target_endpoint_name = None
@@ -86,6 +87,8 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
         query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
         if target_endpoint_name:
             query = query.filter(ModelEndpoint.name.ilike(f"%{target_endpoint_name}%"))
+        if owner:
+            query = owner_filter(query, ModelEndpoint, owner)
         endpoints = query.all()
 
         if not endpoints:
@@ -141,7 +144,7 @@ def _resolve_model(spec: str) -> Tuple[str, str, Dict]:
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_chat_with_model(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Send a message to a specific model and return its response.
 
     Content format:
@@ -160,7 +163,7 @@ async def do_chat_with_model(content: str, session_id: Optional[str] = None) -> 
         return {"error": "No message provided (line 2+ is the message)"}
 
     try:
-        url, model, headers = _resolve_model(model_spec)
+        url, model, headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -190,7 +193,7 @@ _TEACHER_SYSTEM_PROMPT = (
 )
 
 
-async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_ask_teacher(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Ask a more capable model for help.
 
     Content format:
@@ -213,7 +216,7 @@ async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict
             return {"error": "No teacher model configured. Specify a model name or set teacher_model in settings."}
 
     try:
-        url, model, headers = _resolve_model(model_spec)
+        url, model, headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -235,7 +238,7 @@ async def do_ask_teacher(content: str, session_id: Optional[str] = None) -> Dict
         return {"error": f"Teacher call failed ({model_spec}): {e}"}
 
 
-async def do_second_opinion(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_second_opinion(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Get a second opinion from another model, then have the original model
     evaluate the feedback and produce a unified version.
 
@@ -259,7 +262,7 @@ async def do_second_opinion(content: str, session_id: Optional[str] = None) -> D
     focus = lines[1].strip() if len(lines) > 1 else ""
 
     try:
-        reviewer_url, reviewer_model, reviewer_headers = _resolve_model(model_spec)
+        reviewer_url, reviewer_model, reviewer_headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -400,7 +403,7 @@ async def do_create_session(content: str, session_id: Optional[str] = None, owne
         return {"error": "Session name cannot be empty"}
 
     try:
-        url, model, headers = _resolve_model(model_spec)
+        url, model, headers = _resolve_model(model_spec, owner=owner)
     except ValueError as e:
         return {"error": str(e)}
 
@@ -584,7 +587,7 @@ async def stream_ai_tool(tool: str, content: str, session_id: Optional[str] = No
     yield {"_final": True, "desc": desc, "result": result}
 
 
-async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_pipeline(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Execute a multi-step pipeline where each model's output feeds the next.
 
     Content format (JSON):
@@ -638,7 +641,7 @@ async def do_pipeline(content: str, session_id: Optional[str] = None) -> Dict:
         if not model_spec or not instruction:
             return {"error": f"Step {i + 1}: both 'model' and 'instruction' are required"}
         try:
-            url, model, headers = _resolve_model(model_spec)
+            url, model, headers = _resolve_model(model_spec, owner=owner)
             resolved.append((url, model, headers, instruction))
         except ValueError as e:
             return {"error": f"Step {i + 1}: {e}"}
@@ -1091,7 +1094,7 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
 # List models tool
 # ---------------------------------------------------------------------------
 
-async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_list_models(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """List all available models across configured endpoints.
 
     Content = optional filter keyword.
@@ -1099,12 +1102,16 @@ async def do_list_models(content: str, session_id: Optional[str] = None) -> Dict
     import httpx
     from src.database import SessionLocal, ModelEndpoint
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
+    from src.auth_helpers import owner_filter
 
     keyword = content.strip().lower() if content.strip() else None
 
     db = SessionLocal()
     try:
-        endpoints = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).all()
+        query = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True)
+        if owner:
+            query = owner_filter(query, ModelEndpoint, owner)
+        endpoints = query.all()
         if not endpoints:
             return {"results": "No enabled model endpoints configured."}
 
@@ -1250,7 +1257,7 @@ async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
 # UI control tool (returns events for frontend to apply)
 # ---------------------------------------------------------------------------
 
-async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_ui_control(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Control frontend UI: toggle settings, switch model, change theme.
 
     Content format:
@@ -1325,7 +1332,7 @@ async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
 
         # Resolve the model to validate it exists
         try:
-            url, model_id, headers = _resolve_model(model_spec)
+            url, model_id, headers = _resolve_model(model_spec, owner=owner)
         except ValueError as e:
             return {"error": str(e)}
 
@@ -1580,7 +1587,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
     if not model_spec:
         for candidate in ("gpt-image-1.5", "gpt-image-1", "dall-e-3"):
             try:
-                _resolve_model(candidate)
+                _resolve_model(candidate, owner=owner)
                 model_spec = candidate
                 break
             except ValueError:
@@ -1589,13 +1596,17 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
         if not model_spec:
             try:
                 from src.database import SessionLocal, ModelEndpoint
+                from src.auth_helpers import owner_filter
                 import httpx as _req
                 _idb = SessionLocal()
                 try:
-                    _img_eps = _idb.query(ModelEndpoint).filter(
+                    _img_q = _idb.query(ModelEndpoint).filter(
                         ModelEndpoint.is_enabled == True,
                         ModelEndpoint.model_type == "image",
-                    ).all()
+                    )
+                    if owner:
+                        _img_q = owner_filter(_img_q, ModelEndpoint, owner)
+                    _img_eps = _img_q.all()
                     for _iep in _img_eps:
                         _ibase = _iep.base_url.rstrip("/")
                         if not _ibase.endswith("/v1"):
@@ -1618,7 +1629,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
 
     # Resolve the model to find the right endpoint
     try:
-        url, model_id, headers = _resolve_model(model_spec)
+        url, model_id, headers = _resolve_model(model_spec, owner=owner)
     except ValueError:
         return {"error": f"No endpoint found with image model '{model_spec}'. "
                 "Configure an OpenAI-compatible endpoint with image generation support."}
@@ -1760,7 +1771,7 @@ async def dispatch_ai_tool(
     if tool == "chat_with_model":
         model_spec = content.split("\n")[0].strip()[:60]
         desc = f"chat_with_model: {model_spec}"
-        result = await do_chat_with_model(content, session_id)
+        result = await do_chat_with_model(content, session_id, owner=owner)
 
     elif tool == "create_session":
         name = content.split("\n")[0].strip()[:60]
@@ -1779,7 +1790,7 @@ async def dispatch_ai_tool(
 
     elif tool == "pipeline":
         desc = "pipeline: running steps"
-        result = await do_pipeline(content, session_id)
+        result = await do_pipeline(content, session_id, owner=owner)
 
     elif tool == "manage_session":
         action = content.split("\n")[0].strip()[:40]
@@ -1794,17 +1805,17 @@ async def dispatch_ai_tool(
     elif tool == "list_models":
         keyword = content.strip()[:40]
         desc = f"list_models{': ' + keyword if keyword else ''}"
-        result = await do_list_models(content, session_id)
+        result = await do_list_models(content, session_id, owner=owner)
 
     elif tool == "ui_control":
         action = content.split("\n")[0].strip()[:60]
         desc = f"ui_control: {action}"
-        result = await do_ui_control(content, session_id)
+        result = await do_ui_control(content, session_id, owner=owner)
 
     elif tool == "ask_teacher":
         problem = content.split("\n", 1)[-1].strip()[:60]
         desc = f"ask_teacher: {problem}"
-        result = await do_ask_teacher(content, session_id)
+        result = await do_ask_teacher(content, session_id, owner=owner)
 
     else:
         desc = f"unknown ai tool: {tool}"

--- a/tests/test_ai_interaction_owner_scope.py
+++ b/tests/test_ai_interaction_owner_scope.py
@@ -1,0 +1,75 @@
+import inspect
+
+import pytest
+
+from src import ai_interaction
+
+
+def _source(fn) -> str:
+    return inspect.getsource(fn)
+
+
+def test_model_resolver_applies_owner_filter():
+    body = _source(ai_interaction._resolve_model)
+
+    assert "owner: Optional[str] = None" in body
+    assert "from src.auth_helpers import owner_filter" in body
+    assert "owner_filter(query, ModelEndpoint, owner)" in body
+
+
+def test_model_listing_and_image_fallback_are_owner_scoped():
+    list_body = _source(ai_interaction.do_list_models)
+    image_body = _source(ai_interaction.do_generate_image)
+
+    assert "owner: Optional[str] = None" in list_body
+    assert "owner_filter(query, ModelEndpoint, owner)" in list_body
+    assert "_resolve_model(candidate, owner=owner)" in image_body
+    assert "owner_filter(_img_q, ModelEndpoint, owner)" in image_body
+    assert "_resolve_model(model_spec, owner=owner)" in image_body
+
+
+@pytest.mark.parametrize("tool,content", [
+    ("chat_with_model", "gpt-test\nhello"),
+    ("pipeline", "gpt-test | summarize this"),
+    ("list_models", ""),
+    ("ui_control", "switch_model gpt-test"),
+    ("ask_teacher", "gpt-test\nhelp me"),
+])
+async def test_dispatch_passes_owner_to_model_tools(monkeypatch, tool, content):
+    seen = {}
+
+    async def capture(name, content, session_id=None, owner=None):
+        seen[name] = {"content": content, "session_id": session_id, "owner": owner}
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        ai_interaction,
+        "do_chat_with_model",
+        lambda content, session_id=None, owner=None: capture("chat_with_model", content, session_id, owner),
+    )
+    monkeypatch.setattr(
+        ai_interaction,
+        "do_pipeline",
+        lambda content, session_id=None, owner=None: capture("pipeline", content, session_id, owner),
+    )
+    monkeypatch.setattr(
+        ai_interaction,
+        "do_list_models",
+        lambda content, session_id=None, owner=None: capture("list_models", content, session_id, owner),
+    )
+    monkeypatch.setattr(
+        ai_interaction,
+        "do_ui_control",
+        lambda content, session_id=None, owner=None: capture("ui_control", content, session_id, owner),
+    )
+    monkeypatch.setattr(
+        ai_interaction,
+        "do_ask_teacher",
+        lambda content, session_id=None, owner=None: capture("ask_teacher", content, session_id, owner),
+    )
+
+    _desc, result = await ai_interaction.dispatch_ai_tool(tool, content, session_id="sid1", owner="alice")
+
+    assert result == {"ok": True}
+    assert seen[tool]["owner"] == "alice"
+    assert seen[tool]["session_id"] == "sid1"

--- a/tests/test_calendar_rrule.py
+++ b/tests/test_calendar_rrule.py
@@ -6,6 +6,7 @@ calling do_manage_calendar with an rrule stores a single event carrying that RRU
 """
 
 import json
+import sys
 import tempfile
 import uuid
 
@@ -13,6 +14,21 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
 
 import core.database as cdb
 from core.database import CalendarEvent
@@ -32,6 +48,10 @@ def _bind_temp_db(monkeypatch):
     # do_manage_calendar does `from core.database import SessionLocal` at call
     # time, so patch the module attribute to our temp DB — via monkeypatch so it
     # is RESTORED after each test and can't leak into later tests in the process.
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", cdb, raising=False)
     monkeypatch.setattr(cdb, "SessionLocal", _TS)
     yield
 

--- a/tests/test_chat_image_routing.py
+++ b/tests/test_chat_image_routing.py
@@ -1,5 +1,12 @@
 import json
+import sys
 from types import SimpleNamespace
+
+_endpoint_resolver = sys.modules.get("src.endpoint_resolver")
+if _endpoint_resolver is not None and not getattr(_endpoint_resolver, "__file__", None):
+    sys.modules.pop("src.endpoint_resolver", None)
+    sys.modules.pop("routes.model_routes", None)
+    sys.modules.pop("routes.chat_routes", None)
 
 from routes import chat_routes
 

--- a/tests/test_companion_pairing.py
+++ b/tests/test_companion_pairing.py
@@ -78,7 +78,12 @@ from core.middleware import require_admin  # noqa: E402
 
 # --- token minting: shown once, hashed at rest -----------------------------
 
-def test_mint_token_returns_raw_once_and_stores_only_a_hash():
+def test_mint_token_returns_raw_once_and_stores_only_a_hash(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", _db)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", _db, raising=False)
+
     token_id, raw = P.mint_token("alice")
     assert raw.startswith("ody_")
     # The persisted row stores a bcrypt hash + prefix, never the plaintext.

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -22,7 +22,8 @@ def test_background_status_poll_reconciles_into_local_tasks():
     assert "const statusById = new Map(tasks.map(t => [t.session_id, t]));" in source
     assert "const nextStatus = live.status === 'completed'" in source
     assert "? 'done'" in source
-    assert "live.status === 'error'" in source
+    assert ": (live.status === 'error'" in source
+    assert "? 'error'" in source
     assert "_saveTasks(localTasks);" in source
     assert "completedDeps.forEach(t => _refreshDepsAfterInstall(t));" in source
 

--- a/tests/test_document_close_clears_active_route.py
+++ b/tests/test_document_close_clears_active_route.py
@@ -13,6 +13,7 @@ while completing reliably everywhere.
 """
 
 import tempfile
+import sys
 import uuid
 from types import SimpleNamespace
 
@@ -20,6 +21,21 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 from unittest.mock import MagicMock
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
 
 import core.database as cdb
 import routes.document_routes as droutes

--- a/tests/test_llm_core_sanitize_tool_calls.py
+++ b/tests/test_llm_core_sanitize_tool_calls.py
@@ -141,4 +141,3 @@ def test_build_anthropic_payload_alternating_roles():
 
 
 
-

--- a/tests/test_sqlite_foreign_keys.py
+++ b/tests/test_sqlite_foreign_keys.py
@@ -1,6 +1,23 @@
 import pytest
+import sys
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
 from core.database import Base, Session, ChatMessage
 from datetime import datetime
 
@@ -35,4 +52,3 @@ def test_sqlite_foreign_keys_cascade():
     assert db.query(ChatMessage).count() == 0
     
     db.close()
-

--- a/tests/test_task_scheduler_session_delivery.py
+++ b/tests/test_task_scheduler_session_delivery.py
@@ -1,5 +1,6 @@
 """Regression tests for task-result delivery into chat sessions (issue #326)."""
 import asyncio
+import sys
 import types as _types
 
 import pytest
@@ -11,6 +12,22 @@ if not isinstance(sqlalchemy, _types.ModuleType):
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
+import core.database as cdb
 from core.database import Base, Session as DbSession
 from src.task_scheduler import TaskScheduler
 
@@ -46,10 +63,15 @@ def _make_task():
     )
 
 
-def test_session_delivery_survives_empty_database():
+def test_session_delivery_survives_empty_database(monkeypatch):
     """On a fresh/wiped database there is no session to inherit endpoint/model
     from, so _resolve_defaults returns None. The delivery must still persist a
     session instead of crashing on the NOT NULL constraint (issue #326)."""
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", cdb, raising=False)
+
     db = _make_db()
     scheduler = TaskScheduler.__new__(TaskScheduler)
     scheduler._session_manager = None

--- a/tests/test_topic_analyzer.py
+++ b/tests/test_topic_analyzer.py
@@ -1,8 +1,25 @@
 """Tests for topic keyword matching (src/topic_analyzer.py)."""
+import sys
 from types import SimpleNamespace
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
 from core.database import Base, Session as DbSession, ChatMessage as DbChatMessage
 from core.session_manager import SessionManager
 from src.topic_analyzer import analyze_topics

--- a/tests/test_webhook_ssrf_resilience.py
+++ b/tests/test_webhook_ssrf_resilience.py
@@ -6,6 +6,22 @@ from datetime import datetime
 # from it, so drop the stub here to load the real module under test.
 if "src.database" in sys.modules:
     del sys.modules["src.database"]
+_core_database = sys.modules.get("core.database")
+_core_database_all = getattr(_core_database, "__all__", None) if _core_database is not None else None
+if (
+    _core_database is not None
+    and (
+        not getattr(_core_database, "__file__", None)
+        or (
+            _core_database_all is not None
+            and (
+                not isinstance(_core_database_all, (list, tuple, set))
+                or not all(isinstance(name, str) for name in _core_database_all)
+            )
+        )
+    )
+):
+    del sys.modules["core.database"]
 
 import pytest
 from src.webhook_manager import validate_webhook_url


### PR DESCRIPTION
## Summary
- owner-scope the shared AI tool model resolver before probing configured endpoints
- pass the caller owner through chat-with-model, teacher, pipeline, list-models, UI switch-model, and image generation paths
- owner-filter image endpoint fallback discovery in the image generation tool
- add regression coverage for resolver scoping and dispatcher owner propagation

## Notes
- Stacked on #1490 for the test collection cleanup.
- This is independent of #1491, #1511, #1518, and #1520.

## Tests
- PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_ai_interaction_owner_scope.py tests/test_agent_loop.py tests/test_session_endpoint_owner_scope.py tests/test_resolve_endpoint_fallbacks.py
  - 64 passed
- git diff --check
- PYTHONDONTWRITEBYTECODE=1 /home/moloch/odysseus/venv/bin/python -m py_compile src/ai_interaction.py tests/test_ai_interaction_owner_scope.py
- PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q
  - 1377 passed, 1 skipped