### PR TITLE
fix(app): /backgrounds returns 404 instead of 500 when the asset is absent

### DIFF
--- a/app.py
+++ b/app.py
@@ -757,7 +757,12 @@ async def serve_library(request: Request):
 @app.get("/backgrounds")
 async def serve_backgrounds(request: Request):
     """Sandbox page for prototyping background effects. No auth required."""
-    return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/backgrounds.html"))
+    bg_path = abs_join(BASE_DIR, "static/backgrounds.html")
+    # Guard like serve_index: the asset is not always shipped, and an
+    # unguarded open() here 500s the route instead of returning a clean 404.
+    if not os.path.exists(bg_path):
+        raise HTTPException(404, "backgrounds.html not found")
+    return _serve_html_with_nonce(request, bg_path)
 
 @app.get("/login")
 async def serve_login(request: Request):


### PR DESCRIPTION
## Problem
`GET /backgrounds` — a public, no-auth page route — returns **HTTP 500** on every request. Found by smoke-testing the registered GET routes against a freshly-booted app.

## Root cause
```python
@app.get("/backgrounds")
async def serve_backgrounds(request: Request):
    return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/backgrounds.html"))
```
`_serve_html_with_nonce` does an unguarded `open(file_path)`. `static/backgrounds.html` is **not shipped** (never committed, referenced nowhere in the codebase), so the call raises `FileNotFoundError` → unhandled → 500.

The sibling `serve_index` three lines below already guards this exact situation with `os.path.exists` and raises a clean `404`.

## Fix
Apply the same guard to `serve_backgrounds`: return a `404` when the asset is missing instead of 500-ing. Behaviour is unchanged when the file is present. Three-line change mirroring the established in-file pattern.

## Verification
App-level top-level routes can't be imported under the test `conftest.py` (it stubs `src.database`), so this is verified by booting the real app via `TestClient`:

```
GET /backgrounds  -> 404   (was 500)
GET /              -> 200   (unchanged — shared HTML-serving path still works)
```
plus `python -m py_compile app.py` clean. No dependency, schema, or behavioural change beyond the missing-asset path.