### PR TITLE
Ignore invalid editor draft payloads

### DIFF
--- a/routes/editor_draft_routes.py
+++ b/routes/editor_draft_routes.py
@@ -67,6 +67,14 @@ def _summary(d: EditorDraft) -> Dict[str, Any]:
     }
 
 
+def _load_payload(raw: Optional[str]) -> Dict[str, Any]:
+    try:
+        payload = json.loads(raw) if raw else {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 def setup_editor_draft_routes() -> APIRouter:
     router = APIRouter(tags=["editor-drafts"])
 
@@ -93,13 +101,9 @@ def setup_editor_draft_routes() -> APIRouter:
             ).first()
             if not d or not _owns(d, user):
                 raise HTTPException(404, "Draft not found")
-            try:
-                payload = json.loads(d.payload) if d.payload else {}
-            except Exception:
-                payload = {}
             return {
                 **_summary(d),
-                "payload": payload,
+                "payload": _load_payload(d.payload),
             }
         finally:
             db.close()

--- a/tests/test_editor_draft_payload.py
+++ b/tests/test_editor_draft_payload.py
@@ -1,0 +1,24 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _load_module(monkeypatch):
+    db_stub = types.ModuleType("core.database")
+    db_stub.EditorDraft = MagicMock()
+    db_stub.SessionLocal = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db_stub)
+    monkeypatch.delitem(sys.modules, "routes.editor_draft_routes", raising=False)
+
+    import routes.editor_draft_routes as mod
+
+    return mod
+
+
+def test_load_payload_rejects_non_object_json(monkeypatch):
+    mod = _load_module(monkeypatch)
+
+    assert mod._load_payload("[]") == {}
+    assert mod._load_payload('"draft"') == {}
+    assert mod._load_payload("{bad json") == {}
+    assert mod._load_payload('{"layers": []}') == {"layers": []}


### PR DESCRIPTION
Small guard for saved editor drafts.

If a draft row has malformed JSON, or JSON that is not an object, the route now returns an empty payload instead of handing the client an unexpected shape. The gallery editor already expects an object with draft data.

Checked:
`venv/bin/python -m pytest -q tests/test_editor_draft_payload.py`
`venv/bin/python -m py_compile routes/editor_draft_routes.py tests/test_editor_draft_payload.py`
`git diff --check origin/main...HEAD`