### PR TITLE
Skip invalid memory extractor rows

### DIFF
--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -34,12 +34,18 @@ def _fingerprint_entries(entries) -> str:
     only on id+text+category. Any add/edit/delete invalidates it."""
     items = sorted(
         (str(e.get("id", "")), e.get("text", ""), e.get("category", ""))
-        for e in entries
+        for e in _memory_dicts(entries)
     )
     h = hashlib.sha256()
     for triple in items:
         h.update(("\x1f".join(triple) + "\x1e").encode("utf-8"))
     return h.hexdigest()
+
+
+def _memory_dicts(entries):
+    for entry in entries or []:
+        if isinstance(entry, dict):
+            yield entry
 
 
 def _load_tidy_state(memory_manager) -> dict:
@@ -211,7 +217,7 @@ def _is_text_duplicate(new_text: str, existing: list, threshold: float = 0.6) ->
     new_tokens = set(new_text.lower().split())
     if not new_tokens:
         return False
-    for entry in existing:
+    for entry in _memory_dicts(existing):
         old_tokens = set(entry.get("text", "").lower().split())
         if not old_tokens:
             continue

--- a/tests/test_memory_extractor_rows.py
+++ b/tests/test_memory_extractor_rows.py
@@ -1,0 +1,25 @@
+from services.memory import memory_extractor
+
+
+def test_fingerprint_entries_skips_invalid_rows():
+    value = memory_extractor._fingerprint_entries([
+        {"id": "1", "text": "User likes small PRs.", "category": "preference"},
+        "bad-row",
+        None,
+    ])
+
+    expected = memory_extractor._fingerprint_entries([
+        {"id": "1", "text": "User likes small PRs.", "category": "preference"},
+    ])
+
+    assert value == expected
+
+
+def test_duplicate_check_skips_invalid_rows():
+    existing = [
+        "bad-row",
+        {"text": "User likes small pull requests."},
+        None,
+    ]
+
+    assert memory_extractor._is_text_duplicate("User likes small pull requests.", existing)


### PR DESCRIPTION
Small resilience fix for the memory extractor helpers.

If a memory list contains a bad legacy row, fingerprinting or duplicate checks could crash because every row was assumed to be a dict. This keeps valid rows working the same way and just skips invalid ones.

Checked:
`venv/bin/python -m pytest -q tests/test_memory_extractor_rows.py`
`venv/bin/python -m py_compile services/memory/memory_extractor.py tests/test_memory_extractor_rows.py`
`git diff --check origin/main...HEAD`