### PR TITLE
fix(ollama): send num_ctx to prevent silent 2048-token truncation

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -238,6 +238,7 @@ def _build_ollama_payload(
     max_tokens: int,
     stream: bool = False,
     tools: Optional[List[Dict]] = None,
+    context_length: int = 0,
 ) -> Dict:
     payload: Dict = {
         "model": model,
@@ -249,6 +250,8 @@ def _build_ollama_payload(
         options["temperature"] = temperature
     if max_tokens and max_tokens > 0:
         options["num_predict"] = max_tokens
+    if context_length and context_length > 2048:
+        options["num_ctx"] = context_length
     if options:
         payload["options"] = options
     if tools:
@@ -675,7 +678,9 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         payload = _build_anthropic_payload(model, messages_copy, temperature, max_tokens)
     elif provider == "ollama":
         target_url = _normalize_ollama_url(url)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        from src.model_context import get_context_length as _get_ctx
+        ctx_len = _get_ctx(url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False, context_length=ctx_len)
     else:
         target_url = url
         payload = {
@@ -790,7 +795,9 @@ async def llm_call_async(
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False)
+        from src.model_context import get_context_length as _get_ctx
+        ctx_len = _get_ctx(url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=False, context_length=ctx_len)
     else:
         target_url = url
         h = _provider_headers(provider, headers)
@@ -888,7 +895,9 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         h = {"Content-Type": "application/json"}
         if headers:
             h.update(headers)
-        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools)
+        from src.model_context import get_context_length as _get_ctx
+        ctx_len = _get_ctx(url, model)
+        payload = _build_ollama_payload(model, messages_copy, temperature, max_tokens, stream=True, tools=tools, context_length=ctx_len)
     else:
         target_url = url
         payload = {

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -25,6 +25,8 @@ def test_llm_call_posts_native_ollama_payload(monkeypatch):
         )
 
     monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+    # Mock get_context_length so it returns a known value
+    monkeypatch.setattr("src.model_context.get_context_length", lambda url, model: 32768)
 
     result = llm_core.llm_call(
         "https://ollama.com/api",
@@ -40,7 +42,7 @@ def test_llm_call_posts_native_ollama_payload(monkeypatch):
     assert seen["url"] == "https://ollama.com/api/chat"
     assert seen["headers"]["Authorization"] == "Bearer ollama-key"
     assert seen["json"]["stream"] is False
-    assert seen["json"]["options"] == {"temperature": 0.2, "num_predict": 7}
+    assert seen["json"]["options"] == {"temperature": 0.2, "num_predict": 7, "num_ctx": 32768}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ollama defaults `num_ctx` to 2048 when the API call omits it, silently truncating prompts regardless of the model's actual context window (128K, 1M, etc.)
- `_build_ollama_payload` now accepts a `context_length` param and emits `options.num_ctx` when the value exceeds 2048
- All three Ollama call sites in `llm_core.py` (sync, async non-streaming, async streaming) now look up the model's context length via the existing `get_context_length` helper and pass it through
- Updated existing test to verify `num_ctx` is present in the payload

Fixes #909

## Test plan
- [ ] Configure an Ollama model with a large context window (e.g. `qwen2.5:7b`)
- [ ] Send a prompt exceeding 2048 tokens — model should see the full prompt
- [ ] Verify `num_ctx` appears in the Ollama payload (check server logs or add a print)
- [ ] Verify models with default/small context still work correctly
- [ ] Run `pytest tests/test_llm_core_ollama.py` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)