### PR TITLE
DELETED ISSUE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy
 pypdf
 beautifulsoup4
 charset-normalizer
-numpy
+"numpy<2.4:
 # Vector store + local embeddings for RAG, semantic memory, and tool
 # selection. Used on core agent paths, so installed by default — the app
 # still degrades to keyword fallback if they're ever missing.


### PR DESCRIPTION
## Changes
Pin `numpy` to `<2.4` to fix compatibility with older CPUs that do not support X86_V2 instructions.

## Linked Issue
Fixes #1515 

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test
1. Install on a machine without X86_V2 CPU instructions
2. Run Odysseus normally
3. Verify it starts without the NumPy RuntimeError
