### PR TITLE
fix: POST /api/contacts/add 500s on JSON null name/email

### DIFF
--- a/routes/contacts_routes.py
+++ b/routes/contacts_routes.py
@@ -676,8 +676,8 @@ def setup_contacts_routes():
     @router.post("/add")
     async def add_contact(data: dict, _admin: str = Depends(require_admin)):
         """Add a new contact."""
-        name = data.get("name", "").strip()
-        email = data.get("email", "").strip()
+        name = (data.get("name") or "").strip()
+        email = (data.get("email") or "").strip()
         if not email:
             return {"success": False, "error": "Email required"}
         # Check if already exists

--- a/tests/test_contacts_add_null_name.py
+++ b/tests/test_contacts_add_null_name.py
@@ -1,0 +1,42 @@
+"""Regression: POST /api/contacts/add must not crash when name/email is JSON null.
+
+The handler did `data.get("name", "").strip()`. dict.get returns the default
+only when the key is ABSENT; a body like {"name": null, "email": "x@y.com"}
+gives name=None, so None.strip() raised AttributeError -> 500. Now guarded with
+`(data.get("name") or "")`.
+"""
+import asyncio
+
+import pytest
+
+import routes.contacts_routes as cr
+
+
+def _add_handler():
+    router = cr.setup_contacts_routes()
+    for r in router.routes:
+        if getattr(r, "path", "").endswith("/add") and "POST" in getattr(r, "methods", set()):
+            return r.endpoint
+    raise AssertionError("add_contact route not found")
+
+
+@pytest.fixture
+def _stub_store(monkeypatch):
+    created = []
+    monkeypatch.setattr(cr, "_fetch_contacts", lambda *a, **k: [])
+    monkeypatch.setattr(cr, "_create_contact", lambda name, email: created.append((name, email)) or True)
+    return created
+
+
+def test_null_name_does_not_crash(_stub_store):
+    handler = _add_handler()
+    result = asyncio.run(handler({"name": None, "email": "x@y.com"}, _admin="admin"))
+    assert result["success"] is True
+    # name fell back to the email local-part instead of crashing.
+    assert _stub_store == [("x", "x@y.com")]
+
+
+def test_null_email_is_rejected_cleanly(_stub_store):
+    handler = _add_handler()
+    result = asyncio.run(handler({"name": "Bob", "email": None}, _admin="admin"))
+    assert result == {"success": False, "error": "Email required"}


### PR DESCRIPTION
## Summary
`add_contact` reads:

```python
name = data.get("name", "").strip()
email = data.get("email", "").strip()
```

`dict.get(k, default)` only returns the default when the key is ABSENT. A JSON body where the key is present but null, e.g. `{"name": null, "email": "x@y.com"}` (exactly what `JSON.stringify({name: someVar})` emits when `someVar` is null/undefined), makes `data.get("name")` return `None`, so `None.strip()` raises `AttributeError` and the endpoint 500s. Same for a null `email`.

Trigger: POST `/api/contacts/add` with `{"name": null, "email": "x@y.com"}` (or a null `email`).

## Changes
- routes/contacts_routes.py: guard both reads with `(data.get(...) or "")` so a present-but-null value behaves like an empty string (name then falls back to the email local-part, a null email is rejected with "Email required").
- tests/test_contacts_add_null_name.py: drive the extracted route handler with a null name (no crash, falls back) and a null email (clean rejection).