### PR TITLE
Ignore non-string background stream deltas

### DIFF
--- a/src/bg_monitor.py
+++ b/src/bg_monitor.py
@@ -53,7 +53,9 @@ async def _drain_agent(sess, messages):
         if not isinstance(d, dict):
             continue
         if "delta" in d:
-            full += d["delta"]
+            delta = d.get("delta")
+            if isinstance(delta, str):
+                full += delta
         elif d.get("type") == "agent_step":
             round_num = d.get("round", round_num)
         elif d.get("type") == "tool_output":

--- a/tests/test_bg_monitor_stream.py
+++ b/tests/test_bg_monitor_stream.py
@@ -1,0 +1,39 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+from src import bg_monitor
+
+
+def test_drain_agent_ignores_non_string_deltas(monkeypatch):
+    async def fake_stream_agent_loop(*args, **kwargs):
+        yield 'data: {"delta": null}'
+        yield 'data: {"delta": ["bad"]}'
+        yield 'data: {"delta": "ok"}'
+        yield 'data: {"type": "agent_step", "round": 2}'
+        yield 'data: {"type": "tool_output", "tool": "shell", "output": "done"}'
+        yield "data: [DONE]"
+
+    agent_loop = types.ModuleType("src.agent_loop")
+    agent_loop.stream_agent_loop = fake_stream_agent_loop
+    monkeypatch.setitem(sys.modules, "src.agent_loop", agent_loop)
+
+    sess = SimpleNamespace(
+        endpoint_url="http://example.test",
+        model="model",
+        headers=None,
+        context_length=0,
+        id="s1",
+    )
+
+    full, events = asyncio.run(bg_monitor._drain_agent(sess, []))
+
+    assert full == "ok"
+    assert events == [{
+        "round": 2,
+        "tool": "shell",
+        "command": None,
+        "output": "done",
+        "exit_code": None,
+    }]


### PR DESCRIPTION
Small guard for the background follow-up monitor.

The monitor already skips malformed stream chunks, but a valid JSON chunk with a non-string `delta` could still crash string accumulation. This keeps normal text deltas working and ignores the bad shape.

Checked:
`venv/bin/python -m pytest -q tests/test_bg_monitor_stream.py`
`venv/bin/python -m py_compile src/bg_monitor.py tests/test_bg_monitor_stream.py`
`git diff --check origin/main...HEAD`

The focused pytest run passes with the existing SQLAlchemy deprecation warning.