### PR TITLE
Ignore non-string task CLI previews

### DIFF
--- a/scripts/odysseus-tasks
+++ b/scripts/odysseus-tasks
@@ -26,13 +26,18 @@ except ModuleNotFoundError as e:
     sys.exit(2)
 
 
+def _preview_text(value, limit: int = 200) -> str:
+    text = value if isinstance(value, str) else ""
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
 def _serialize_task(t: "ScheduledTask") -> dict:
     return {
         "id": t.id,
         "name": t.name,
         "task_type": t.task_type,
         "action": t.action,
-        "prompt": (t.prompt or "")[:200] + ("…" if t.prompt and len(t.prompt) > 200 else ""),
+        "prompt": _preview_text(t.prompt),
         "schedule": t.schedule,
         "scheduled_time": t.scheduled_time,
         "next_run": t.next_run.isoformat() if t.next_run else "",
@@ -51,7 +56,7 @@ def _serialize_run(r: "TaskRun") -> dict:
         "started_at": r.started_at.isoformat() if r.started_at else "",
         "completed_at": r.completed_at.isoformat() if r.completed_at else "",
         "status": r.status,
-        "output_preview": (getattr(r, "output", "") or "")[:200],
+        "output_preview": _preview_text(getattr(r, "output", "")),
     }
 
 

--- a/tests/test_tasks_cli_preview.py
+++ b/tests/test_tasks_cli_preview.py
@@ -1,0 +1,31 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli(monkeypatch):
+    db = types.ModuleType("core.database")
+    db.SessionLocal = MagicMock()
+    db.ScheduledTask = MagicMock()
+    db.TaskRun = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    path = ROOT / "scripts" / "odysseus-tasks"
+    loader = importlib.machinery.SourceFileLoader("odysseus_tasks_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_preview_text_ignores_non_string_values(monkeypatch):
+    cli = _load_cli(monkeypatch)
+
+    assert cli._preview_text(None) == ""
+    assert cli._preview_text({"bad": "row"}) == ""
+    assert cli._preview_text("x" * 201) == ("x" * 200) + "…"


### PR DESCRIPTION
Small CLI guard for scheduled-task previews.

If a legacy task row has a non-string prompt or run output, `odysseus-tasks` now emits an empty preview instead of crashing while slicing it.

Checked:
`venv/bin/python -m pytest -q tests/test_tasks_cli_preview.py`
`venv/bin/python -m py_compile scripts/odysseus-tasks tests/test_tasks_cli_preview.py`
`git diff --check origin/main...HEAD`