### PR TITLE
Ignore non-string docs CLI content lengths

### DIFF
--- a/scripts/odysseus-docs
+++ b/scripts/odysseus-docs
@@ -33,6 +33,10 @@ except ModuleNotFoundError as e:
     sys.exit(2)
 
 
+def _text_len(value) -> int:
+    return len(value) if isinstance(value, str) else 0
+
+
 def _serialize(d: "Document", include_content: bool = False) -> dict:
     out = {
         "id": d.id,
@@ -42,7 +46,7 @@ def _serialize(d: "Document", include_content: bool = False) -> dict:
         "version_count": d.version_count or 1,
         "is_active": bool(d.is_active),
         "tidy_verdict": d.tidy_verdict or "",
-        "content_length": len(d.current_content or ""),
+        "content_length": _text_len(d.current_content),
         "created_at": d.created_at.isoformat() if d.created_at else "",
         "updated_at": d.updated_at.isoformat() if d.updated_at else "",
     }
@@ -90,7 +94,7 @@ def cmd_versions(args):
                 "version_number": v.version_number,
                 "summary": v.summary or "",
                 "source": v.source or "ai",
-                "content_length": len(v.content or ""),
+                "content_length": _text_len(v.content),
             } for v in rows
         ], args)
     finally:

--- a/tests/test_docs_cli_content_length.py
+++ b/tests/test_docs_cli_content_length.py
@@ -1,0 +1,31 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli(monkeypatch):
+    db = types.ModuleType("core.database")
+    db.SessionLocal = MagicMock()
+    db.Document = MagicMock()
+    db.DocumentVersion = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    path = ROOT / "scripts" / "odysseus-docs"
+    loader = importlib.machinery.SourceFileLoader("odysseus_docs_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_text_len_ignores_non_string_values(monkeypatch):
+    cli = _load_cli(monkeypatch)
+
+    assert cli._text_len("hello") == 5
+    assert cli._text_len(None) == 0
+    assert cli._text_len({"bad": "row"}) == 0


### PR DESCRIPTION
Small guard for `odysseus-docs` summaries.

List/version views only need a length. If an old document row has non-string content, the CLI now reports `0` instead of crashing while calling `len(...)`.

Checked:
`venv/bin/python -m pytest -q tests/test_docs_cli_content_length.py`
`venv/bin/python -m py_compile scripts/odysseus-docs tests/test_docs_cli_content_length.py`
`git diff --check origin/main...HEAD`