### PR TITLE
Handle missing gallery album images

### DIFF
--- a/scripts/odysseus-gallery
+++ b/scripts/odysseus-gallery
@@ -59,6 +59,14 @@ def _serialize_image(i: "GalleryImage") -> dict:
     }
 
 
+def _album_image_count(album) -> int:
+    images = getattr(album, "images", None)
+    try:
+        return len(images) if images is not None else 0
+    except TypeError:
+        return 0
+
+
 def cmd_list(args):
     db = SessionLocal()
     try:
@@ -100,7 +108,7 @@ def cmd_albums(args):
     try:
         rows = db.query(GalleryAlbum).order_by(GalleryAlbum.name.asc()).all()
         emit([
-            {"id": a.id, "name": a.name, "image_count": len(a.images)}
+            {"id": a.id, "name": a.name, "image_count": _album_image_count(a)}
             for a in rows
         ], args)
     finally:

--- a/tests/test_gallery_cli_album_count.py
+++ b/tests/test_gallery_cli_album_count.py
@@ -1,0 +1,32 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli(monkeypatch):
+    db = types.ModuleType("core.database")
+    db.SessionLocal = MagicMock()
+    db.GalleryImage = MagicMock()
+    db.GalleryAlbum = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    path = ROOT / "scripts" / "odysseus-gallery"
+    loader = importlib.machinery.SourceFileLoader("odysseus_gallery_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_album_image_count_handles_missing_relationship(monkeypatch):
+    cli = _load_cli(monkeypatch)
+
+    assert cli._album_image_count(SimpleNamespace(images=[1, 2])) == 2
+    assert cli._album_image_count(SimpleNamespace(images=None)) == 0
+    assert cli._album_image_count(SimpleNamespace(images=object())) == 0


### PR DESCRIPTION
Small guard for `odysseus-gallery albums`.

If the album relationship is missing or not loaded as a sized collection, the CLI now reports `image_count: 0` instead of crashing on `len(...)`. Normal loaded albums keep the same count.

Checked:
`venv/bin/python -m pytest -q tests/test_gallery_cli_album_count.py`
`venv/bin/python -m py_compile scripts/odysseus-gallery tests/test_gallery_cli_album_count.py`
`git diff --check origin/main...HEAD`