### PR TITLE
fix: APIKeyManager.load crashes app startup on a corrupt or wrong-shape api_keys.json

### DIFF
--- a/src/api_key_manager.py
+++ b/src/api_key_manager.py
@@ -48,8 +48,18 @@ class APIKeyManager:
         """Load and decrypt API keys"""
         if not os.path.exists(self.api_keys_file):
             return {}
-        with open(self.api_keys_file, 'r', encoding="utf-8") as f:
-            encrypted_keys = json.load(f)
+        try:
+            with open(self.api_keys_file, 'r', encoding="utf-8") as f:
+                encrypted_keys = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            # A corrupt/truncated api_keys.json must not crash load() (called on
+            # startup via app_initializer) — treat it as no stored keys.
+            logger.warning("Failed to read API keys file: %s", e)
+            return {}
+        if not isinstance(encrypted_keys, dict):
+            # Legacy/wrong shape (e.g. a list) — .items() would raise. Ignore it.
+            logger.warning("API keys file has unexpected shape (%s); ignoring", type(encrypted_keys).__name__)
+            return {}
 
         decrypted = {}
         for provider, key in encrypted_keys.items():

--- a/tests/test_api_key_manager_corrupt_load.py
+++ b/tests/test_api_key_manager_corrupt_load.py
@@ -1,0 +1,32 @@
+"""Regression: APIKeyManager.load() must not crash on a corrupt/wrong-shape file.
+
+load() is called during startup (app_initializer). It had no try/except around
+`json.load` and called `encrypted_keys.items()` directly, so a corrupt/truncated
+api_keys.json raised JSONDecodeError and a legacy list-shaped file raised
+AttributeError — both crashing app startup. It now returns {} instead.
+"""
+from src.api_key_manager import APIKeyManager
+
+
+def _mgr(tmp_path):
+    return APIKeyManager(str(tmp_path))
+
+
+def test_corrupt_json_returns_empty(tmp_path):
+    (tmp_path / "api_keys.json").write_text("{not valid json", encoding="utf-8")
+    assert _mgr(tmp_path).load() == {}
+
+
+def test_list_shape_returns_empty(tmp_path):
+    (tmp_path / "api_keys.json").write_text('["openai", "anthropic"]', encoding="utf-8")
+    assert _mgr(tmp_path).load() == {}
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert _mgr(tmp_path).load() == {}
+
+
+def test_valid_roundtrip(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.save("openai", "sk-secret")
+    assert mgr.load() == {"openai": "sk-secret"}


### PR DESCRIPTION
## Summary
`APIKeyManager.load()` reads `api_keys.json` with no protection around the file read or the shape:

```python
with open(self.api_keys_file, 'r', encoding="utf-8") as f:
    encrypted_keys = json.load(f)
decrypted = {}
for provider, key in encrypted_keys.items():
    ...
```

Only the per-key `decrypt` is guarded. So:
- a corrupt/truncated `api_keys.json` makes `json.load` raise `JSONDecodeError`, and
- a legacy/wrong top-level shape (e.g. a list) makes `encrypted_keys.items()` raise `AttributeError`.

`load()` is called during startup (`src/app_initializer.py:94`), so either case crashes app boot. (The existing `test_api_key_manager_resilience` only covers per-key undecryptable tokens, not file-level corruption.)

Trigger: a partially-written or hand-edited `api_keys.json` that is invalid JSON or not a top-level object.

## Changes
- src/api_key_manager.py: wrap the read in try/except returning `{}` on `JSONDecodeError`/`OSError`, and ignore a non-dict shape. Valid files and the per-key decrypt path are unchanged.
- tests/test_api_key_manager_corrupt_load.py: corrupt JSON and list-shaped file both return `{}`; valid round-trip still works.