### PR TITLE
Save only string personal doc paths

### DIFF
--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -179,6 +179,11 @@ def retrieve_personal(personal_index: List[Dict], query: str, k: int = 5,
     # Fall back to keyword search
     return retrieve_personal_keyword(personal_index, query, k)
 
+
+def _string_list(values) -> list[str]:
+    return [value for value in values or [] if isinstance(value, str)]
+
+
 class PersonalDocsManager:
     """Manager class for personal document indexing and retrieval."""
 
@@ -202,7 +207,7 @@ class PersonalDocsManager:
                     directories = json.load(f)
                 if not isinstance(directories, list):
                     raise ValueError("indexed directories must be a list")
-                self.indexed_directories = [d for d in directories if isinstance(d, str)]
+                self.indexed_directories = _string_list(directories)
                 logger.info(f"Loaded {len(self.indexed_directories)} indexed directories")
             else:
                 self.indexed_directories = []
@@ -214,7 +219,7 @@ class PersonalDocsManager:
         """Save the list of indexed directories to persistent storage."""
         try:
             with open(self.directories_file, 'w', encoding="utf-8") as f:
-                json.dump(self.indexed_directories, f, indent=2)
+                json.dump(_string_list(self.indexed_directories), f, indent=2)
             logger.info(f"Saved {len(self.indexed_directories)} indexed directories")
         except Exception as e:
             logger.error(f"Error saving directories: {e}")
@@ -227,7 +232,7 @@ class PersonalDocsManager:
                     excluded = json.load(f)
                 if not isinstance(excluded, list):
                     raise ValueError("excluded files must be a list")
-                self.excluded_files = {p for p in excluded if isinstance(p, str)}
+                self.excluded_files = set(_string_list(excluded))
             else:
                 self.excluded_files = set()
         except Exception as e:
@@ -237,7 +242,7 @@ class PersonalDocsManager:
     def _save_excluded(self):
         try:
             with open(self._excluded_file, 'w', encoding="utf-8") as f:
-                json.dump(list(self.excluded_files), f)
+                json.dump(_string_list(self.excluded_files), f)
         except Exception as e:
             logger.error(f"Error saving excluded files: {e}")
 

--- a/tests/test_personal_docs_lists.py
+++ b/tests/test_personal_docs_lists.py
@@ -1,0 +1,6 @@
+from src import personal_docs
+
+
+def test_string_list_filters_non_strings():
+    assert personal_docs._string_list(["/tmp/a", None, 3, "/tmp/b"]) == ["/tmp/a", "/tmp/b"]
+    assert personal_docs._string_list(None) == []


### PR DESCRIPTION
Small consistency fix for personal-docs path stores.

Load already ignores non-string directory and excluded-file rows. Save now applies the same filter so a mutated in-memory list cannot persist bad values back to JSON.

Checked:
`venv/bin/python -m pytest -q tests/test_personal_docs_lists.py`
`venv/bin/python -m py_compile src/personal_docs.py tests/test_personal_docs_lists.py`
`git diff --check origin/main...HEAD`