### PR TITLE
Skip invalid personal CLI index rows

### DIFF
--- a/scripts/odysseus-personal
+++ b/scripts/odysseus-personal
@@ -42,8 +42,12 @@ def _manager() -> PersonalDocsManager:
     return _mgr
 
 
+def _file_rows(files):
+    return [f for f in files or [] if isinstance(f, dict)]
+
+
 def cmd_list(args):
-    files = getattr(_manager(), "index", []) or []
+    files = _file_rows(getattr(_manager(), "index", []) or [])
     out = [
         {"name": f.get("name"), "size": f.get("size"), "path": f.get("path", "")}
         for f in files

--- a/tests/test_personal_cli_rows.py
+++ b/tests/test_personal_cli_rows.py
@@ -1,0 +1,31 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli(monkeypatch):
+    personal_docs = types.ModuleType("src.personal_docs")
+    personal_docs.PersonalDocsManager = MagicMock()
+    monkeypatch.setitem(sys.modules, "src.personal_docs", personal_docs)
+    path = ROOT / "scripts" / "odysseus-personal"
+    loader = importlib.machinery.SourceFileLoader("odysseus_personal_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_file_rows_skips_invalid_rows(monkeypatch):
+    cli = _load_cli(monkeypatch)
+
+    assert cli._file_rows([
+        {"name": "notes.txt", "path": "/tmp/notes.txt"},
+        "bad-row",
+        None,
+    ]) == [{"name": "notes.txt", "path": "/tmp/notes.txt"}]


### PR DESCRIPTION
Small guard for `odysseus-personal list`.

If the in-memory personal-doc index has a stray non-object row, the CLI now skips it and keeps emitting valid file rows instead of crashing on `.get(...)`.

Checked:
`venv/bin/python -m pytest -q tests/test_personal_cli_rows.py`
`venv/bin/python -m py_compile scripts/odysseus-personal tests/test_personal_cli_rows.py`
`git diff --check origin/main...HEAD`