### PR TITLE
fix: split_chunks emits a duplicate trailing chunk, double-indexing the tail

### DIFF
--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -77,6 +77,11 @@ def split_chunks(text: str, size: int = config.CHUNK_SIZE, overlap: int = config
     while i < n:
         j = min(i + size, n)
         chunks.append(text[i:j])
+        if j >= n:
+            # Reached the end. Without this, the next start (j - overlap) is
+            # still > i, so the loop appended one extra chunk duplicating the
+            # last `overlap` chars of the text.
+            break
         i = j - overlap if j - overlap > i else j
     return chunks
 

--- a/tests/test_split_chunks_no_duplicate_tail.py
+++ b/tests/test_split_chunks_no_duplicate_tail.py
@@ -1,0 +1,33 @@
+"""Regression: split_chunks must not emit a duplicate trailing chunk.
+
+The loop advanced `i = j - overlap` even after `j` reached the end of the text,
+so any text longer than (size - overlap) got an extra final chunk duplicating
+the last `overlap` characters. That duplicate is indexed and keyword-scored
+twice, so retrieve_personal_keyword returns the same tail content twice.
+"""
+from src.personal_docs import split_chunks
+
+
+def test_no_duplicate_tail_chunk():
+    chunks = split_chunks("x" * 1100, size=1000, overlap=200)
+    assert [len(c) for c in chunks] == [1000, 300]
+
+
+def test_no_chunk_is_contained_in_another():
+    text = "".join(chr(33 + (k % 90)) for k in range(2000))
+    chunks = split_chunks(text, size=1000, overlap=200)
+    # The buggy version produced a final 200-char chunk fully inside the prior one.
+    for a in range(len(chunks)):
+        for b in range(len(chunks)):
+            if a != b:
+                assert chunks[a] not in chunks[b]
+
+
+def test_overlap_is_preserved_between_chunks():
+    chunks = split_chunks("x" * 1100, size=1000, overlap=200)
+    # Second chunk starts 200 chars before the first one ended (offset 800).
+    assert len(chunks) == 2 and chunks[1] == ("x" * 1100)[800:1100]
+
+
+def test_short_text_single_chunk():
+    assert split_chunks("hello world", size=1000, overlap=200) == ["hello world"]


### PR DESCRIPTION
## Summary
`split_chunks` (used by `load_personal_index` to chunk every indexed document) advances `i = j - overlap` even after `j` has reached the end of the text:

```python
while i < n:
    j = min(i + size, n)
    chunks.append(text[i:j])
    i = j - overlap if j - overlap > i else j
```

On the iteration where `j == n`, `j - overlap` is still `> i`, so the loop runs once more and appends an extra chunk `text[n-overlap:n]` that is wholly contained in the previous chunk. For the defaults (size=1000, overlap=200) any text longer than 800 chars gets this duplicate tail:
- `len 1100` → chunk lengths `[1000, 300, 200]` (should be `[1000, 300]`)
- `len 2000` → `[1000, 1000, 400, 200]` (should be `[1000, 1000, 400]`)

The duplicated tail is indexed as its own chunk, so `retrieve_personal_keyword` returns the same content twice and double-counts its keyword score in ranking.

Trigger: index any personal document longer than `CHUNK_SIZE - CHUNK_OVERLAP` characters.

## Changes
- src/personal_docs.py: break out of the loop once a chunk reaches the end of the text. The anti-infinite-loop guard for the normal step is unchanged, and the overlap between real chunks is preserved.
- tests/test_split_chunks_no_duplicate_tail.py: assert no duplicate tail, no chunk contained in another, overlap preserved, and short text stays a single chunk.