### PR TITLE
Handle missing calendar CLI relation

### DIFF
--- a/scripts/odysseus-calendar
+++ b/scripts/odysseus-calendar
@@ -69,11 +69,17 @@ def _parse_dt(s: str) -> datetime:
     return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
 
+def _calendar_name(ev: "CalendarEvent") -> str:
+    cal = getattr(ev, "calendar", None)
+    name = getattr(cal, "name", "") if cal else ""
+    return name if isinstance(name, str) else ""
+
+
 def _serialize_event(ev: "CalendarEvent") -> dict:
     return {
         "uid": ev.uid,
         "calendar_id": ev.calendar_id,
-        "calendar_name": ev.calendar.name if ev.calendar else "",
+        "calendar_name": _calendar_name(ev),
         "summary": ev.summary,
         "description": ev.description or "",
         "location": ev.location or "",

--- a/tests/test_calendar_cli_name.py
+++ b/tests/test_calendar_cli_name.py
@@ -1,0 +1,32 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli(monkeypatch):
+    db = types.ModuleType("core.database")
+    db.SessionLocal = MagicMock()
+    db.CalendarCal = MagicMock()
+    db.CalendarEvent = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    path = ROOT / "scripts" / "odysseus-calendar"
+    loader = importlib.machinery.SourceFileLoader("odysseus_calendar_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_calendar_name_handles_missing_relation(monkeypatch):
+    cli = _load_cli(monkeypatch)
+
+    assert cli._calendar_name(SimpleNamespace(calendar=None)) == ""
+    assert cli._calendar_name(SimpleNamespace(calendar=SimpleNamespace(name=123))) == ""
+    assert cli._calendar_name(SimpleNamespace(calendar=SimpleNamespace(name="Work"))) == "Work"


### PR DESCRIPTION
Small guard for `odysseus-calendar`.

If an event row has no loaded calendar relation, or the relation has a non-string name, the CLI now emits an empty `calendar_name` instead of crashing.

Checked:
`venv/bin/python -m pytest -q tests/test_calendar_cli_name.py`
`venv/bin/python -m py_compile scripts/odysseus-calendar tests/test_calendar_cli_name.py`
`git diff --check origin/main...HEAD`