### PR TITLE
Normalize session CLI counters

### DIFF
--- a/scripts/odysseus-sessions
+++ b/scripts/odysseus-sessions
@@ -27,6 +27,12 @@ except ModuleNotFoundError as e:
 
 
 def _serialize(s: "DbSession") -> dict:
+    def _int_or_zero(value) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
     return {
         "id": s.id,
         "name": s.name,
@@ -37,9 +43,9 @@ def _serialize(s: "DbSession") -> dict:
         "archived": bool(s.archived),
         "rag": bool(s.rag),
         "is_important": bool(s.is_important),
-        "message_count": s.message_count or 0,
-        "total_input_tokens": s.total_input_tokens or 0,
-        "total_output_tokens": s.total_output_tokens or 0,
+        "message_count": _int_or_zero(s.message_count),
+        "total_input_tokens": _int_or_zero(s.total_input_tokens),
+        "total_output_tokens": _int_or_zero(s.total_output_tokens),
         "last_accessed": s.last_accessed.isoformat() if s.last_accessed else "",
         "created_at": s.created_at.isoformat() if s.created_at else "",
     }

--- a/tests/test_sessions_cli.py
+++ b/tests/test_sessions_cli.py
@@ -1,24 +1,29 @@
 import importlib.machinery
+import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
 from types import SimpleNamespace
 
 
-def _load_sessions_cli():
+def _load_sessions_cli(monkeypatch):
     core_mod = ModuleType("core")
     database_mod = ModuleType("core.database")
     database_mod.SessionLocal = object
     database_mod.Session = object
-    sys.modules["core"] = core_mod
-    sys.modules["core.database"] = database_mod
+    monkeypatch.setitem(sys.modules, "core", core_mod)
+    monkeypatch.setitem(sys.modules, "core.database", database_mod)
+
     path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-sessions"
     loader = importlib.machinery.SourceFileLoader("odysseus_sessions_cli_under_test", str(path))
-    return loader.load_module()
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
 
 
-def test_serialize_normalizes_numeric_counters():
-    cli = _load_sessions_cli()
+def test_serialize_normalizes_numeric_counters(monkeypatch):
+    cli = _load_sessions_cli(monkeypatch)
     session = SimpleNamespace(
         id="s1",
         name="chat",

--- a/tests/test_sessions_cli.py
+++ b/tests/test_sessions_cli.py
@@ -1,0 +1,43 @@
+import importlib.machinery
+import sys
+from pathlib import Path
+from types import ModuleType
+from types import SimpleNamespace
+
+
+def _load_sessions_cli():
+    core_mod = ModuleType("core")
+    database_mod = ModuleType("core.database")
+    database_mod.SessionLocal = object
+    database_mod.Session = object
+    sys.modules["core"] = core_mod
+    sys.modules["core.database"] = database_mod
+    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-sessions"
+    loader = importlib.machinery.SourceFileLoader("odysseus_sessions_cli_under_test", str(path))
+    return loader.load_module()
+
+
+def test_serialize_normalizes_numeric_counters():
+    cli = _load_sessions_cli()
+    session = SimpleNamespace(
+        id="s1",
+        name="chat",
+        model="m",
+        endpoint_url="",
+        owner=None,
+        folder=None,
+        archived=False,
+        rag=False,
+        is_important=False,
+        message_count="12",
+        total_input_tokens="bad",
+        total_output_tokens=None,
+        last_accessed=None,
+        created_at=None,
+    )
+
+    out = cli._serialize(session)
+
+    assert out["message_count"] == 12
+    assert out["total_input_tokens"] == 0
+    assert out["total_output_tokens"] == 0


### PR DESCRIPTION
Keeps the sessions CLI JSON output a little more stable when old or odd rows have non-integer counter values.

Tested:
./venv/bin/python -m pytest -q tests/test_sessions_cli.py
./venv/bin/python -m py_compile tests/test_sessions_cli.py
git diff --check origin/main...HEAD