### PR TITLE
Reject CalDAV writeback events without uid

### DIFF
--- a/src/caldav_writeback.py
+++ b/src/caldav_writeback.py
@@ -93,11 +93,14 @@ def push_event(calendars, local_cal_id: str, ev: dict, *, delete: bool = False) 
     Returns ``{"ok": bool, ...}``. ``calendars`` is the discovered caldav
     calendar list (injected so this is unit-testable with fakes).
     """
+    uid = (ev or {}).get("uid") if isinstance(ev, dict) else None
+    if not uid:
+        return {"ok": False, "error": "event uid is required"}
+
     remote = find_remote_calendar(calendars, local_cal_id)
     if remote is None:
         return {"ok": False, "error": "remote calendar not found"}
 
-    uid = ev["uid"]
     try:
         existing = remote.event_by_uid(uid)
     except Exception:

--- a/tests/test_caldav_writeback.py
+++ b/tests/test_caldav_writeback.py
@@ -116,3 +116,10 @@ def test_push_unknown_calendar_reports_not_found():
     cal = FakeCalendar("https://different/")
     res = push_event([cal], CAL_ID, _ev())
     assert res["ok"] is False and "not found" in res["error"]
+
+
+def test_push_missing_uid_reports_input_error_before_remote_lookup():
+    cal = FakeCalendar(REMOTE_URL, existing=FakeEvent())
+    res = push_event([cal], CAL_ID, _ev(uid=""))
+    assert res["ok"] is False and "uid" in res["error"]
+    assert cal._existing.saved is False


### PR DESCRIPTION
Makes CalDAV write-back return a clean input error when an event has no UID, before trying to look it up or write it remotely.

Tested:
./venv/bin/python -m pytest -q tests/test_caldav_writeback.py
./venv/bin/python -m py_compile src/caldav_writeback.py tests/test_caldav_writeback.py
git diff --check origin/main...HEAD