### PR TITLE
Skip invalid research service sources

### DIFF
--- a/services/research/service.py
+++ b/services/research/service.py
@@ -92,6 +92,7 @@ class ResearchService:
                     relevance=s.get("relevance", 0.0),
                 )
                 for s in result.get("sources", [])
+                if isinstance(s, dict)
             ]
             return ResearchResult(
                 query=topic,

--- a/tests/test_research_service.py
+++ b/tests/test_research_service.py
@@ -139,6 +139,7 @@ class TestDictBackCompat:
                     "sources": [
                         {"url": "https://x.example", "title": "X",
                          "snippet": "s", "relevance": 0.9},
+                        "bad source row",
                     ],
                     "sections": ["intro"],
                     "tokens_used": 42,


### PR DESCRIPTION
Keeps the legacy dict result path from crashing if `sources` contains a non-object row. Valid source rows still come through unchanged.

Tested:
./venv/bin/python -m pytest -q tests/test_research_service.py
./venv/bin/python -m py_compile services/research/service.py tests/test_research_service.py
git diff --check origin/main...HEAD