### PR TITLE
Parse all AMD GPU check args

### DIFF
--- a/scripts/check-docker-amd-gpu.sh
+++ b/scripts/check-docker-amd-gpu.sh
@@ -39,19 +39,19 @@ Environment:
 USAGE
 }
 
-case "${1:-}" in
-    --help|-h)
-        _usage
-        exit 0
-        ;;
-    "")
-        ;;
-    *)
-        printf 'Unknown option: %s\n\n' "$1" >&2
-        _usage >&2
-        exit 1
-        ;;
-esac
+for _arg in "$@"; do
+    case "${_arg}" in
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+        *)
+            printf 'Unknown option: %s\n\n' "${_arg}" >&2
+            _usage >&2
+            exit 1
+            ;;
+    esac
+done
 
 _find_cmd() {
     if command -v "$1" >/dev/null 2>&1; then

--- a/tests/test_amd_gpu_check_args.py
+++ b/tests/test_amd_gpu_check_args.py
@@ -1,0 +1,21 @@
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check-docker-amd-gpu.sh"
+
+
+def test_amd_gpu_check_rejects_unknown_extra_arg_before_diagnostics():
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--bad-option"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert "Unknown option: --bad-option" in proc.stderr
+
+
+def test_amd_gpu_check_shell_syntax():
+    subprocess.run(["bash", "-n", str(SCRIPT)], check=True)


### PR DESCRIPTION
Makes the AMD Docker GPU diagnostic reject unknown arguments consistently instead of only looking at the first one.

Tested:
./venv/bin/python -m pytest -q tests/test_amd_gpu_check_args.py
./venv/bin/python -m py_compile tests/test_amd_gpu_check_args.py
git diff --check origin/main...HEAD