### PR TITLE
fix(cookbook): force UTF-8 child stdio so Windows downloads don't charmap-crash (#1543)

### DIFF
--- a/core/platform_compat.py
+++ b/core/platform_compat.py
@@ -61,6 +61,27 @@ def detached_popen_kwargs() -> dict:
     return {"start_new_session": True}
 
 
+def utf8_subprocess_env(base: Optional[dict] = None) -> dict:
+    """Environment dict that forces a child **Python** process to use UTF-8 for
+    its standard I/O, regardless of the host's locale.
+
+    On Windows, Python defaults its stdio encoding to the active code page
+    (e.g. ``cp1252``), which cannot represent many characters CLI tools print —
+    e.g. the ``hf`` downloader's "Token is valid (✓)" (U+2713). The child then
+    dies with ``UnicodeEncodeError`` ('charmap' codec can't encode character
+    '\\u2713'), which is exactly what crashes Cookbook downloads / dependency
+    installs on Windows native (the failure is masked as exit 0). ``PYTHONUTF8=1``
+    + ``PYTHONIOENCODING=utf-8`` make the child use UTF-8 instead; both are
+    harmless no-ops on POSIX (already UTF-8). The vars are inherited by further
+    child processes, so the bash wrapper's ``hf``/``pip`` grandchildren get them
+    too. Pass the result as ``Popen(..., env=utf8_subprocess_env())``.
+    """
+    env = dict(os.environ if base is None else base)
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
 def pid_alive(pid: Optional[int]) -> bool:
     """True if a process with ``pid`` is currently running.
 

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -21,6 +21,7 @@ from core.middleware import require_admin
 from core.platform_compat import (
     IS_WINDOWS,
     detached_popen_kwargs,
+    utf8_subprocess_env,
     find_bash,
     kill_process_tree,
     pid_alive,
@@ -388,6 +389,11 @@ def setup_cookbook_routes() -> APIRouter:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            # Force UTF-8 stdio in the child (and its hf/pip grandchildren) so
+            # non-ASCII CLI output (e.g. hf's "Token is valid (✓)", U+2713)
+            # doesn't crash the download/install with a Windows cp1252
+            # UnicodeEncodeError. No-op on POSIX. See issue #1543.
+            env=utf8_subprocess_env(),
             **detached_popen_kwargs(),
         )
         pid_path.write_text(str(proc.pid), encoding="utf-8")

--- a/tests/test_utf8_subprocess_env.py
+++ b/tests/test_utf8_subprocess_env.py
@@ -1,0 +1,43 @@
+"""Regression for the Windows Cookbook charmap crash (issue #1543).
+
+Cookbook downloads / dependency installs spawn a detached child whose hf/pip
+grandchildren print non-ASCII (e.g. hf's "Token is valid (✓)", U+2713). On
+Windows the child's stdio defaults to cp1252 and dies with a UnicodeEncodeError
+('charmap' codec can't encode '\\u2713'), masked as exit 0. `utf8_subprocess_env`
+forces UTF-8 stdio so the child survives; it's a no-op on POSIX.
+"""
+
+import os
+
+from core.platform_compat import utf8_subprocess_env
+
+
+def test_sets_utf8_io_vars_and_preserves_base():
+    env = utf8_subprocess_env({"FOO": "bar"})
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["FOO"] == "bar"  # caller's other vars survive
+
+
+def test_overrides_conflicting_locale_values():
+    env = utf8_subprocess_env({"PYTHONUTF8": "0", "PYTHONIOENCODING": "cp1252"})
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_does_not_mutate_the_passed_base():
+    base = {"X": "1"}
+    utf8_subprocess_env(base)
+    assert "PYTHONUTF8" not in base
+    assert "PYTHONIOENCODING" not in base
+
+
+def test_defaults_to_a_copy_of_os_environ(monkeypatch):
+    monkeypatch.setenv("ODY_TEST_MARKER", "present")
+    env = utf8_subprocess_env()
+    assert env.get("ODY_TEST_MARKER") == "present"  # inherits real environment
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    # it's a copy — mutating the result never touches os.environ
+    env["ODY_SHOULD_NOT_LEAK"] = "x"
+    assert "ODY_SHOULD_NOT_LEAK" not in os.environ


### PR DESCRIPTION
Fixes #1543.

## Problem

On Windows native, Cookbook downloads — and dependency installs, which use the same launch path — spawn a detached child through `_launch_local_detached` (`routes/cookbook_routes.py`). Its `hf`/`pip` grandchildren print non-ASCII status text, e.g. the hf CLI's:

```
Token is valid (✓).
```

Python's stdio on Windows defaults to the active code page (`cp1252`), which can't encode `✓` (U+2713), so the child dies with:

```
UnicodeEncodeError: 'charmap' codec can't encode character '✓' in position 5: character maps to <undefined>
```

The bash wrapper swallows the non-zero exit and the Running tab shows *"Download stopped before HuggingFace reported completion"*, with **exit 0 masking the real failure**. (Root cause identified and the fix locally confirmed by the reporter in #1543.)

## Fix

Pass `env=utf8_subprocess_env()` to the detached `Popen`. The new helper (in `core/platform_compat.py`, alongside `detached_popen_kwargs`) returns the environment with `PYTHONUTF8=1` + `PYTHONIOENCODING=utf-8`. These are **inherited by the bash wrapper's `hf`/`pip` grandchildren**, so they emit UTF-8 and no longer crash. Both are harmless no-ops on POSIX (already UTF-8).

This resolves the reported download crash and the same-path dependency-install crash (cf. #1568).

```python
proc = subprocess.Popen(
    argv, stdout=DEVNULL, stderr=DEVNULL, stdin=DEVNULL,
    env=utf8_subprocess_env(),          # <-- added
    **detached_popen_kwargs(),
)
```

## Tests

New `tests/test_utf8_subprocess_env.py`: the helper sets the two vars, overrides a conflicting locale base, and copies rather than mutating the passed base / `os.environ`. Existing `tests/test_platform_compat.py` still passes.

```
$ pytest tests/test_utf8_subprocess_env.py tests/test_platform_compat.py -q
6 passed
```

> Note (out of scope, from the issue): the wrapper reporting `DOWNLOAD_FAILED (exit 0)` instead of a non-zero exit is a separate ambiguity worth a follow-up.