### PR TITLE
docs: clarify host Ollama with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ Ollama must listen outside its own loopback interface:
 OLLAMA_HOST=0.0.0.0:11434 ollama serve
 ```
 
+This connects Odysseus in Docker to an Ollama server that is already running on
+your host machine; it does not start Ollama inside the container.
+`host.docker.internal` is Docker's hostname for the host machine from inside the
+container. Cookbook **Serve** is a separate workflow for serving downloaded
+models through Odysseus/llama.cpp, so Windows users with an existing Ollama
+install usually only need to add the endpoint in Settings.
+
 **Useful checks.**
 
 ```bash


### PR DESCRIPTION
Refs #1292

Clarifies that host.docker.internal points from the container to the host machine when using an existing Ollama server.

Also distinguishes connecting to a host Ollama endpoint from serving downloaded Cookbook models through Odysseus/llama.cpp.