### PR TITLE
fix: research CLI summary crashes on a non-string query

### DIFF
--- a/scripts/odysseus-research
+++ b/scripts/odysseus-research
@@ -36,10 +36,18 @@ def _load(rp_id: str) -> dict | None:
         return None
 
 
+def _preview_text(value, limit: int = 200) -> str:
+    """Truncated preview tolerant of non-string values. A stored research
+    record whose ``query`` is a non-string (legacy/corrupt JSON) would crash
+    ``(value or "")[:200]`` with a TypeError; coerce non-strings to ""."""
+    text = value if isinstance(value, str) else ""
+    return text[:limit]
+
+
 def _summarize(rp_id: str, data: dict) -> dict:
     return {
         "id": rp_id,
-        "query": (data.get("query") or "")[:200],
+        "query": _preview_text(data.get("query")),
         "category": data.get("category") or "",
         "status": data.get("status") or "",
         "started_at": data.get("started_at") or "",

--- a/tests/test_research_cli_preview.py
+++ b/tests/test_research_cli_preview.py
@@ -1,0 +1,34 @@
+"""Regression: research CLI summary must tolerate a non-string query.
+
+`_summarize` did `(data.get("query") or "")[:200]`. A non-string query from a
+legacy/corrupt research JSON is truthy, so `123[:200]` raised TypeError.
+"""
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_cli():
+    path = ROOT / "scripts" / "odysseus-research"
+    loader = importlib.machinery.SourceFileLoader("odysseus_research_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_preview_text_ignores_non_string():
+    cli = _load_cli()
+    assert cli._preview_text(None) == ""
+    assert cli._preview_text(123) == ""
+    assert cli._preview_text(["x"]) == ""
+    assert cli._preview_text("q" * 250) == "q" * 200
+
+
+def test_summarize_does_not_crash_on_non_string_query():
+    cli = _load_cli()
+    out = cli._summarize("rp1", {"query": 123, "status": "done"})
+    assert out["query"] == ""
+    assert out["id"] == "rp1"


### PR DESCRIPTION
## Summary
`_summarize` in `scripts/odysseus-research` builds the query preview with `(data.get("query") or "")[:200]`. A non-string `query` from a legacy/corrupt research JSON record is truthy, so `123[:200]` raises `TypeError` and `research list` fails.

## Changes
- scripts/odysseus-research: add `_preview_text(value)` coercing non-strings to "" before slicing, and use it for the query.
- tests/test_research_cli_preview.py: assert non-string previews to "" and `_summarize` no longer crashes on a numeric query.