### PR TITLE
fix(cookbook): set UTF-8 encoding for Windows download subprocesses

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -383,11 +383,15 @@ def setup_cookbook_routes() -> APIRouter:
                 encoding="utf-8",
             )
             argv = [os.environ.get("ComSpec", "cmd.exe"), "/c", str(script_path)]
+        env = os.environ.copy()
+        env["PYTHONUTF8"] = "1"
+        env["PYTHONIOENCODING"] = "utf-8"
         proc = subprocess.Popen(
             argv,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            env=env,
             **detached_popen_kwargs(),
         )
         pid_path.write_text(str(proc.pid), encoding="utf-8")


### PR DESCRIPTION
## Summary
- On Windows, Python subprocess I/O defaults to cp1252 (active code page), which cannot encode Unicode characters like U+2713 (✓) emitted by the HuggingFace CLI during token validation
- Sets `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` in the subprocess environment passed to `_launch_local_detached()` so download and serve processes handle Unicode output correctly

Fixes #1543

## Test plan
- [ ] On Windows, configure an HF token and download a GGUF model via Cookbook
- [ ] Verify the `✓` token validation message doesn't crash the process
- [ ] Verify download completes successfully
- [ ] Verify model serve also works (same subprocess path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)