### PR TITLE
fix: search query helpers crash on non-string input

### DIFF
--- a/mcp_servers/_common.py
+++ b/mcp_servers/_common.py
@@ -13,6 +13,10 @@ SEARCH_TIMEOUT = 30
 
 def truncate(text: str, limit: int = MAX_OUTPUT_CHARS) -> str:
     """Truncate text to *limit* characters with a suffix note."""
+    if not isinstance(text, str):
+        # Tool output is occasionally None or a non-string; len(None) would
+        # raise. Coerce so this shared helper never crashes a tool response.
+        text = "" if text is None else str(text)
     if len(text) > limit:
         return text[:limit] + f"\n... (truncated, {len(text)} chars total)"
     return text

--- a/services/search/query.py
+++ b/services/search/query.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 # ----------------------------------------------------------------------
 def _detect_question_type(query: str) -> Optional[str]:
     """Return the leading question word if present (who, what, when, where, why, how)."""
+    if not isinstance(query, str):
+        return None
     q = query.strip().lower()
     for word in ("who", "what", "when", "where", "why", "how"):
         # Require a whole-word match: a bare prefix mis-flags ordinary queries
@@ -45,12 +47,16 @@ def _extract_entities(query: str) -> Dict[str, List[str]]:
 
 def _split_multi_part(query: str) -> List[str]:
     """Split a query into sub-queries on common conjunctions."""
+    if not isinstance(query, str):
+        return []
     parts = re.split(r"\s+and\s+|\s+or\s+|;", query, flags=re.I)
     return [p.strip() for p in parts if p.strip()]
 
 
 def _extract_site_filter(query: str) -> Tuple[str, Optional[str]]:
     """Detect a 'site:example.com' token. Returns (query_without_token, site_or_None)."""
+    if not isinstance(query, str):
+        return "", None
     match = re.search(r"\bsite:([^\s]+)", query, flags=re.I)
     if match:
         site = match.group(1)
@@ -71,6 +77,8 @@ def _boost_entities_in_query(base_query: str, entities: Dict[str, List[str]]) ->
 
 def enhance_query(original_query: str) -> Tuple[str, Optional[str]]:
     """Process the original query: site filter, question type boosts, entity extraction."""
+    if not isinstance(original_query, str):
+        original_query = ""
     query_without_site, site = _extract_site_filter(original_query)
     sub_queries = _split_multi_part(query_without_site)
 
@@ -120,6 +128,8 @@ def build_enhanced_query(query: str, time_filter: str = None) -> str:
 def _is_news_query(query: str) -> bool:
     """Lightweight heuristic to decide if a query is news-oriented."""
     news_terms = {"news", "latest", "breaking", "today", "today's", "current", "updates", "happening"}
+    if not isinstance(query, str):
+        return False
     tokens = set(re.findall(r"\b\w+\b", query.lower()))
     return bool(tokens & news_terms)
 

--- a/tests/test_mcp_common_truncate.py
+++ b/tests/test_mcp_common_truncate.py
@@ -1,0 +1,31 @@
+"""Regression: the shared MCP truncate() must tolerate non-string input.
+
+`truncate` did `len(text)` directly, so `truncate(None)` (tool output that came
+back None) raised TypeError. It now coerces non-strings before measuring.
+"""
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[1] / "mcp_servers" / "_common.py"
+
+
+def _load():
+    loader = importlib.machinery.SourceFileLoader("odysseus_mcp_common", str(_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_truncate_handles_none_and_nonstring():
+    c = _load()
+    assert c.truncate(None) == ""
+    assert c.truncate(12345) == "12345"
+
+
+def test_truncate_string_behaviour_unchanged():
+    c = _load()
+    assert c.truncate("hello", limit=100) == "hello"
+    out = c.truncate("x" * 50, limit=10)
+    assert out.startswith("x" * 10) and "truncated" in out

--- a/tests/test_search_query_none_guards.py
+++ b/tests/test_search_query_none_guards.py
@@ -1,0 +1,40 @@
+"""Regression: search query helpers must tolerate non-string input.
+
+Each helper called a string method (`.strip()`, `.lower()`) or `re.*` directly
+on the query, so a non-string (None / number) raised AttributeError/TypeError.
+They now coerce/short-circuit on non-strings.
+"""
+from services.search.query import (
+    _detect_question_type,
+    _split_multi_part,
+    _extract_site_filter,
+    enhance_query,
+    _is_news_query,
+)
+
+
+def test_detect_question_type_non_string():
+    assert _detect_question_type(None) is None
+    assert _detect_question_type(123) is None
+
+
+def test_split_multi_part_non_string():
+    assert _split_multi_part(None) == []
+
+
+def test_extract_site_filter_non_string():
+    assert _extract_site_filter(None) == ("", None)
+
+
+def test_is_news_query_non_string():
+    assert _is_news_query(None) is False
+
+
+def test_enhance_query_non_string_does_not_crash():
+    out = enhance_query(None)
+    assert isinstance(out, tuple) and len(out) == 2
+
+
+def test_valid_query_still_works():
+    assert _is_news_query("latest news on rates") is True
+    assert _detect_question_type("what is rust") == "what"


### PR DESCRIPTION
## Summary
The query helpers in `services/search/query.py` call string methods / `re.*` directly on the query, so a non-string value (None or a number) raises `AttributeError`/`TypeError`:
- `_detect_question_type`: `query.strip().lower()`
- `_split_multi_part`: `re.split(..., query, ...)`
- `_extract_site_filter`: `re.search(..., query, ...)`
- `_is_news_query`: `query.lower()`
- `enhance_query`: feeds `original_query` into the above

## Changes
- services/search/query.py: short-circuit/coerce each helper on non-string input (return None/[]/("", None)/False, and coerce in `enhance_query`). Valid string queries are unchanged.
- tests/test_search_query_none_guards.py: assert each helper tolerates None/non-string, and valid queries still classify correctly.