### PR TITLE
fix: _sanitize_export_filename crashes on a non-string session name

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -16,7 +16,7 @@ from src.auth_helpers import get_current_user, effective_user
 
 def _sanitize_export_filename(name: str) -> str:
     """Return a conservative filename safe for Content-Disposition."""
-    name = name or ""
+    name = name if isinstance(name, str) else ""
     name = re.sub(r"[^A-Za-z0-9._-]", "_", name)
     return name[:128]
 

--- a/tests/test_session_export_filename.py
+++ b/tests/test_session_export_filename.py
@@ -1,0 +1,15 @@
+"""Regression: _sanitize_export_filename must tolerate a non-string name.
+
+It did `name = name or ""` then `re.sub(..., name)`. A non-string name (e.g. an
+int session name) is truthy, so re.sub raised TypeError. Coerce non-strings.
+"""
+from routes.session_routes import _sanitize_export_filename
+
+
+def test_non_string_name_does_not_crash():
+    assert _sanitize_export_filename(12345) == ""
+    assert _sanitize_export_filename(None) == ""
+
+
+def test_valid_name_sanitized():
+    assert _sanitize_export_filename("a/b?c.txt") == "a_b_c.txt"


### PR DESCRIPTION
## Summary
`_sanitize_export_filename` in `routes/session_routes.py` does `name = name or ""` then `re.sub(r"[^A-Za-z0-9._-]", "_", name)`. `name or ""` only guards falsy values; a non-string name (e.g. a numeric session name) is truthy, so `re.sub` raises `TypeError: expected string or bytes-like object`.

## Changes
- routes/session_routes.py: coerce non-strings to "" via `isinstance`.
- tests/test_session_export_filename.py: assert a non-string/None name returns "" without raising and a valid name is still sanitized.