### PR TITLE
fix: validate_caldav_url raises TypeError on a non-string URL

### DIFF
--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -63,7 +63,7 @@ def _validate_caldav_ip(host: str) -> None:
 
 def validate_caldav_url(raw_url: str) -> str:
     """Validate and normalize a user-provided CalDAV URL before server-side use."""
-    url = (raw_url or "").strip()
+    url = (raw_url if isinstance(raw_url, str) else "").strip()
     if not url:
         raise ValueError("CalDAV URL is required")
     parsed = urlparse(url)

--- a/tests/test_caldav_url_nonstring.py
+++ b/tests/test_caldav_url_nonstring.py
@@ -1,0 +1,22 @@
+"""Regression: validate_caldav_url must reject a non-string via its normal
+ValueError path, not crash with TypeError.
+
+It did `(raw_url or "").strip()`, so a non-string scalar (e.g. an int from a
+mis-typed config) reached `.strip()` and raised TypeError instead of the
+function\'s own ValueError.
+"""
+import pytest
+
+from src.caldav_sync import validate_caldav_url
+
+
+def test_non_string_raises_valueerror_not_typeerror():
+    with pytest.raises(ValueError):
+        validate_caldav_url(12345)
+    with pytest.raises(ValueError):
+        validate_caldav_url(None)
+
+
+def test_valid_url_passes():
+    out = validate_caldav_url("https://dav.example.com/calendars/")
+    assert "example.com" in out


### PR DESCRIPTION
## Summary
`validate_caldav_url` in `src/caldav_sync.py` does `url = (raw_url or "").strip()`. `raw_url or ""` only guards falsy values; a non-string scalar (e.g. an int from a mis-typed config/store) reaches `.strip()` and raises `TypeError` instead of the function's own `ValueError`, so callers that expect the documented `ValueError` get an unhandled crash.

## Changes
- src/caldav_sync.py: coerce non-strings to "" via `isinstance`, so a non-string URL takes the normal "URL is required" `ValueError` path.
- tests/test_caldav_url_nonstring.py: assert a non-string/None URL raises `ValueError` (not `TypeError`) and a valid URL still passes.