### PR TITLE
fix(ui): stop welcome-screen tip from clipping on narrow phones

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1804,6 +1804,15 @@ body.bg-pattern-sparkles {
       max-height: 60px;
       overflow: hidden;
     }
+    /* The tip is a full sentence that wraps to 4-5 lines on narrow phones,
+       where the welcome block shrink-wraps small; the shared 60px ceiling
+       (sized for the one-line sub/version) clipped its last line. Give the tip
+       a taller ceiling so it isn't truncated. Kept above the max-height:650px
+       block below so that rule's max-height:0 still collapses it on short
+       viewports. */
+    #welcome-screen .welcome-tip {
+      max-height: 120px;
+    }
     @media (max-height: 650px) {
       #welcome-screen { top: 28%; }
       #welcome-screen .welcome-tip { opacity: 0; max-height: 0; margin: 0; }


### PR DESCRIPTION
## Problem

On narrow phones the chat empty-state ("welcome") tip is clipped — its last line ("…key into the chat.") is cut off and crowds the visibility pill below it.

The tip is a full sentence, but it shares a `max-height: 60px; overflow: hidden` ceiling with the one-line `.welcome-sub` / `.welcome-version`. On a phone the welcome block shrink-wraps narrow (~195px), so the tip wraps to 4–5 lines (~67px) and overflows the 60px ceiling. It is the only setup hint a first-run user gets, so losing the end of the sentence matters.

Mobile/narrow only: on desktop the tip is ~320px wide → ~3 lines (~50px), comfortably under the ceiling, so it never clips there.

## Fix

Give `#welcome-screen .welcome-tip` its own taller `max-height` (120px), placed **above** the `@media (max-height: 650px)` block so that rule's `max-height: 0` still collapses the tip on short viewports. `.welcome-sub` / `.welcome-version` are untouched, and desktop is unchanged.

## Verification

Measured `#welcome-tip` under touch emulation (`hover:none`, `pointer:coarse`), before vs. after:

| Viewport | before | after |
|---|---|---|
| 390×844 | clientH 60 < scrollH 67 → **clipped** | clientH 67 == scrollH 67 → **full** |
| 390×600 (≤650h) | max-height 0 (collapsed) | max-height 0 (**still collapsed**) |

No regression to the short-viewport collapse.