### PR TITLE
fix: inside_base_dir raises TypeError on a non-string path instead of failing closed

### DIFF
--- a/src/app_helpers.py
+++ b/src/app_helpers.py
@@ -22,6 +22,8 @@ def abs_join(base_dir: str, rel: str) -> str:
 
 def inside_base_dir(base_dir: str, path: str) -> bool:
     """Check if path is inside base directory."""
+    if not isinstance(base_dir, str) or not isinstance(path, str):
+        return False
     base = os.path.realpath(base_dir)
     p = os.path.realpath(path)
     try:

--- a/tests/test_inside_base_dir_nonstring.py
+++ b/tests/test_inside_base_dir_nonstring.py
@@ -1,0 +1,19 @@
+"""Regression: inside_base_dir must fail closed on a non-string input.
+
+The `os.path.realpath(path)` calls run before the try/except (which only wraps
+commonpath), so a None / non-string path raised TypeError out of this
+path-safety check instead of returning False.
+"""
+from src.app_helpers import inside_base_dir
+
+
+def test_non_string_fails_closed():
+    assert inside_base_dir("/tmp", None) is False
+    assert inside_base_dir("/tmp", 123) is False
+    assert inside_base_dir(None, "/tmp/x") is False
+
+
+def test_real_containment_still_works(tmp_path):
+    base = str(tmp_path)
+    assert inside_base_dir(base, str(tmp_path / "a.txt")) is True
+    assert inside_base_dir(base, "/etc/passwd") is False


### PR DESCRIPTION
## Summary
`inside_base_dir(base_dir, path)` in `src/app_helpers.py` is a path-containment safety check. It calls `os.path.realpath(base_dir)` and `os.path.realpath(path)` BEFORE the `try/except` (which only wraps `commonpath`). A `None`/non-string argument raises `TypeError` out of the check instead of returning `False`, so a caller relying on it to fail closed gets an unhandled crash.

## Changes
- src/app_helpers.py: return `False` when either argument is not a string (fail closed, matching the existing `except -> False`).
- tests/test_inside_base_dir_nonstring.py: non-string/None args return `False`; real containment still works.