### PR TITLE
fix: check_outbound_url crashes on a truthy non-string URL

### DIFF
--- a/src/url_safety.py
+++ b/src/url_safety.py
@@ -56,6 +56,8 @@ def check_outbound_url(
     Returns ``(ok, reason)``. ``ok`` is True only when the URL is safe to fetch.
     ``resolver`` is injectable so callers/tests can avoid real DNS.
     """
+    if not isinstance(url, str):
+        return False, "URL must be a string"
     if not url or not url.strip():
         return False, "URL is required"
     try:

--- a/tests/test_check_outbound_url_nonstring.py
+++ b/tests/test_check_outbound_url_nonstring.py
@@ -1,0 +1,14 @@
+"""Regression: check_outbound_url must reject a non-string URL, not crash.
+
+The `if not url or not url.strip()` guard only handled falsy values; a truthy
+non-string (e.g. an int) reached `.strip()` and raised AttributeError out of
+this SSRF check. Non-strings now fail closed with a clear message.
+"""
+from src.url_safety import check_outbound_url
+
+
+def test_non_string_fails_closed():
+    ok, _ = check_outbound_url(123)
+    assert ok is False
+    ok2, _ = check_outbound_url(None)
+    assert ok2 is False


### PR DESCRIPTION
## Summary
`check_outbound_url(url, ...)` in `src/url_safety.py` (an SSRF guard) only checks `if not url or not url.strip()`. A truthy non-string (e.g. an int) reaches `.strip()` and raises `AttributeError` out of the safety check instead of failing closed.

## Changes
- src/url_safety.py: return `(False, "URL must be a string")` for non-string input.
- tests/test_check_outbound_url_nonstring.py: non-string/None URLs fail closed without raising.