### PR TITLE
Fix Windows cookbook download UTF-8 subprocess env

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -383,11 +383,14 @@ def setup_cookbook_routes() -> APIRouter:
                 encoding="utf-8",
             )
             argv = [os.environ.get("ComSpec", "cmd.exe"), "/c", str(script_path)]
+        child_env = os.environ.copy()
+        child_env.update({"PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"})
         proc = subprocess.Popen(
             argv,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            env=child_env,
             **detached_popen_kwargs(),
         )
         pid_path.write_text(str(proc.pid), encoding="utf-8")

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -39,3 +39,10 @@ def test_local_dependency_probe_refreshes_user_site_visibility():
     assert "importlib.invalidate_caches()" in source
     assert "user_site = site.getusersitepackages()" in source
     assert "if user_site and os.path.isdir(user_site) and user_site not in sys.path:" in source
+
+
+def test_windows_local_cookbook_runner_forces_utf8_python_output():
+    source = _read("routes/cookbook_routes.py")
+
+    assert 'child_env.update({"PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"})' in source
+    assert "env=child_env" in source


### PR DESCRIPTION
## Summary
- force UTF-8 Python output for detached local cookbook runners
- add a regression assertion for the subprocess environment

Fixes #1543.

## Tests
- python -m pytest -q tests/test_cookbook_dependency_completion_regression.py::test_windows_local_cookbook_runner_forces_utf8_python_output

Note: full tests/test_cookbook_dependency_completion_regression.py currently has an unrelated source-string assertion failure in test_background_status_poll_reconciles_into_local_tasks in this checkout.