### PR TITLE
fix: _extract_skill_json crashes on a truthy non-string teacher response

### DIFF
--- a/src/teacher_escalation.py
+++ b/src/teacher_escalation.py
@@ -327,7 +327,7 @@ def _extract_skill_json(teacher_response: str) -> Optional[Dict[str, Any]]:
     treated as "teacher declined to write a skill", per the prompt
     contract.
     """
-    if not teacher_response:
+    if not isinstance(teacher_response, str) or not teacher_response:
         return None
     import json
     m = re.search(r"```(?:json)?\s*\n(\{[\s\S]*?\})\s*\n```", teacher_response)

--- a/tests/test_extract_skill_json_nonstring.py
+++ b/tests/test_extract_skill_json_nonstring.py
@@ -1,0 +1,19 @@
+"""Regression: _extract_skill_json must tolerate a non-string response.
+
+The `if not teacher_response` guard only handled falsy values; a truthy
+non-string (e.g. a number or list from an unexpected LLM client) reached
+`re.search(..., teacher_response)` and raised TypeError. Non-strings now
+return None (treated as "no skill"), matching the documented contract.
+"""
+from src.teacher_escalation import _extract_skill_json
+
+
+def test_non_string_returns_none():
+    assert _extract_skill_json(123) is None
+    assert _extract_skill_json(["x"]) is None
+    assert _extract_skill_json(None) is None
+
+
+def test_valid_json_block_parsed():
+    resp = "sure:\n```json\n{\"name\": \"x\"}\n```\n"
+    assert _extract_skill_json(resp) == {"name": "x"}


### PR DESCRIPTION
## Summary
`_extract_skill_json(teacher_response)` in `src/teacher_escalation.py` guards only falsy values (`if not teacher_response`). A truthy non-string reaches `re.search(..., teacher_response)` and raises TypeError. Non-strings now return None, matching the documented "teacher declined" contract.

## Changes
- src/teacher_escalation.py: widen the guard to also reject non-strings.
- tests/test_extract_skill_json_nonstring.py: non-string returns None; a valid json block is still parsed.