### PR TITLE
fix: logs CLI _resolve crashes on a non-string name

### DIFF
--- a/scripts/odysseus-logs
+++ b/scripts/odysseus-logs
@@ -58,6 +58,8 @@ def _resolve(name: str) -> Path | None:
     """Match a log by exact filename, basename-without-extension, or
     substring. Returns the most-recently-modified match if there are
     ties."""
+    if not isinstance(name, str):
+        return None
     candidates = []
     for base in (_APP_LOGS, _TMUX_LOGS):
         if not base.is_dir():

--- a/tests/test_logs_cli_resolve_nonstring.py
+++ b/tests/test_logs_cli_resolve_nonstring.py
@@ -1,0 +1,25 @@
+"""Regression: logs CLI _resolve must tolerate a non-string name.
+
+`_resolve` did `name in p.name` and `p.name == name`; a non-string `name`
+(e.g. None) raised TypeError once any *.log file existed. Non-strings now
+return None (no match).
+"""
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    loader = importlib.machinery.SourceFileLoader("odysseus_logs_cli", str(ROOT / "scripts" / "odysseus-logs"))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    m = importlib.util.module_from_spec(spec)
+    loader.exec_module(m)
+    return m
+
+
+def test_non_string_name_returns_none():
+    cli = _load()
+    assert cli._resolve(None) is None
+    assert cli._resolve(123) is None


### PR DESCRIPTION
## Summary
`_resolve(name)` in `scripts/odysseus-logs` matches with `p.name == name` / `name in p.name`. A non-string `name` (e.g. None) raises TypeError once any `*.log` file exists. Non-strings now return None (no match).

## Changes
- scripts/odysseus-logs: return None for a non-string name.
- tests/test_logs_cli_resolve_nonstring.py: None/non-string return None without raising.