### PR TITLE
fix(login): keep inputs >=16px on touch so iOS doesn't zoom on focus

### DIFF
--- a/static/login.html
+++ b/static/login.html
@@ -150,6 +150,14 @@
     color: var(--fg); font-size: 0.95rem; font-family: 'Fira Code', monospace;
   }
   input:focus { outline: none; border-color: var(--red); }
+  /* On touch devices keep inputs at >=16px so iOS Safari doesn't zoom the whole
+     page when a field is focused (it auto-zooms any focused input under 16px).
+     This page has its own inline styles, so it doesn't inherit the main app's
+     equivalent rule in static/style.css; mirror it here. !important also lifts
+     the dynamically-inserted 2FA input, which pins font-size:14px inline. */
+  @media (hover: none) and (pointer: coarse) {
+    input:not(.remember-check) { font-size: 16px !important; }
+  }
   /* Clear, visible focus ring for keyboard users on every focusable control. */
   input:focus-visible, a:focus-visible, button:focus-visible {
     outline: 2px solid var(--red);


### PR DESCRIPTION
## Problem

The login page is the first screen every user sees, and on iOS Safari it **zooms the whole page** when you tap the username, password, or 2FA field. iOS auto-zooms any focused input whose `font-size` is under 16px.

`login.html` has its own inline `<style>` and does **not** load `static/style.css`, so it never inherited the main app's touch-device rule that pins text inputs to 16px (`@media (hover: none) and (pointer: coarse)` in style.css). Its inputs are `0.95rem` (~15.2px), and the dynamically-inserted 2FA field pins `font-size: 14px` inline, so both trip the threshold.

## Fix

Add the same touch-device rule to login.html's inline styles:

```css
@media (hover: none) and (pointer: coarse) {
  input:not(.remember-check) { font-size: 16px !important; }
}
```

`!important` also lifts the 2FA input (which sets `font-size:14px` inline). Desktop is unchanged (inputs stay `0.95rem`).

## Verification

Measured computed `font-size` before/after (touch emulation = `hover:none`, `pointer:coarse`):

| Field | touch before | touch after | desktop after |
|---|---|---|---|
| username | 15.2px | **16px** | 15.2px (unchanged) |
| password | 15.2px | **16px** | 15.2px (unchanged) |
| 2FA (inline 14px) | 14px | **16px** | n/a |

Mirrors the approach already used app-wide in `static/style.css` (and the recently merged welcome-tip mobile fix).