### PR TITLE
fix: visual_report markdown helpers crash on a non-string input

### DIFF
--- a/src/visual_report.py
+++ b/src/visual_report.py
@@ -37,6 +37,8 @@ def _autolink_urls(md_text: str) -> str:
 
     Skips URLs already inside markdown link syntax [text](url).
     """
+    if not isinstance(md_text, str):
+        return md_text
     # Match bare URLs not already inside ](...)
     return re.sub(
         r'(?<!\]\()(?<!\()(https?://[^\s\)<>]+)',
@@ -67,6 +69,8 @@ def _md_to_html(md_text: str) -> str:
 
 def _extract_headings(md_text: str) -> List[Dict[str, str]]:
     """Pull h2/h3 headings from markdown for table of contents."""
+    if not isinstance(md_text, str):
+        return []
     headings = []
     seen_slugs: Dict[str, int] = {}
 

--- a/tests/test_visual_report_nonstring.py
+++ b/tests/test_visual_report_nonstring.py
@@ -1,0 +1,18 @@
+"""Regression: visual_report markdown helpers must tolerate a non-string.
+
+_autolink_urls did `re.sub(..., md_text)` and _extract_headings did
+`re.finditer(..., md_text)`; a None/non-string raised TypeError. They now
+return the input / [] respectively.
+"""
+from src.visual_report import _autolink_urls, _extract_headings
+
+
+def test_non_string_does_not_crash():
+    assert _autolink_urls(None) is None
+    assert _extract_headings(None) == []
+    assert _extract_headings(123) == []
+
+
+def test_valid_markdown_unchanged():
+    assert "](https://x.com)" in _autolink_urls("see https://x.com")
+    assert _extract_headings("## Title")[0]["text"] == "Title"


### PR DESCRIPTION
## Summary
`_autolink_urls` (`re.sub(..., md_text)`) and `_extract_headings` (`re.finditer(..., md_text)`) in `src/visual_report.py` raise TypeError when `md_text` is None/non-string. They now return the input / `[]`.

## Changes
- src/visual_report.py: guard both helpers against non-string input.
- tests/test_visual_report_nonstring.py: None/non-string no longer crash; valid markdown unchanged.