### PR TITLE
fix: skill test-task / precision helpers crash on a non-dict skill

### DIFF
--- a/routes/skills_routes.py
+++ b/routes/skills_routes.py
@@ -79,6 +79,8 @@ def _skill_test_task(skill: dict) -> str:
     an email); if we just hand over the 'when to use' text the agent has nothing
     to work on and stalls asking for input. So we tell it to create its own
     realistic fixture first, then apply the skill end-to-end."""
+    if not isinstance(skill, dict):
+        skill = {}
     ctx = (skill.get("when_to_use") or skill.get("description") or skill.get("name") or "").strip()
     return (
         "Test this skill end-to-end. FIRST, set up a small realistic scenario it "
@@ -310,6 +312,8 @@ def _should_check_retrieval_precision(skill: dict) -> bool:
         "installation", "install", "system", "ssh", "document", "documents",
         "search", "email", "calendar", "gpu", "server", "python",
     }
+    if not isinstance(skill, dict):
+        return False
     tags = {str(t or "").strip().lower() for t in (skill.get("tags") or [])}
     if tags & broad:
         return True

--- a/tests/test_skills_routes_nondict.py
+++ b/tests/test_skills_routes_nondict.py
@@ -1,0 +1,14 @@
+"""Regression: skill helpers must tolerate a non-dict skill.
+
+_skill_test_task did `skill.get(...)` and _should_check_retrieval_precision did
+`skill.get("tags")`; a skill row that loaded as a bare string/None raised
+AttributeError. They now treat a non-dict as empty / not-applicable.
+"""
+from routes.skills_routes import _skill_test_task, _should_check_retrieval_precision
+
+
+def test_non_dict_skill_does_not_crash():
+    assert isinstance(_skill_test_task("not a dict"), str)
+    assert isinstance(_skill_test_task(None), str)
+    assert _should_check_retrieval_precision("x") is False
+    assert _should_check_retrieval_precision(None) is False


### PR DESCRIPTION
## Summary
`_skill_test_task(skill)` and `_should_check_retrieval_precision(skill)` in `routes/skills_routes.py` call `skill.get(...)`. A skill row that loaded as a bare string/None (corrupt/legacy store) raises AttributeError. They now treat a non-dict skill as empty / not-applicable.

## Changes
- routes/skills_routes.py: guard both helpers against a non-dict skill.
- tests/test_skills_routes_nondict.py: non-dict/None skills no longer crash.