### PR TITLE
fix: _lookup_bandwidth crashes on a truthy non-string gpu_name

### DIFF
--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -61,7 +61,7 @@ CONTEXT_TARGET = {
 
 
 def _lookup_bandwidth(gpu_name):
-    if not gpu_name:
+    if not isinstance(gpu_name, str) or not gpu_name:
         return None
     gn = gpu_name.lower()
     for key in _BW_KEYS_SORTED:

--- a/tests/test_hwfit_bandwidth_nonstring.py
+++ b/tests/test_hwfit_bandwidth_nonstring.py
@@ -1,0 +1,16 @@
+"""Regression: _lookup_bandwidth must tolerate a non-string gpu_name.
+
+It guarded only falsy values; a truthy non-string (e.g. a number from a
+malformed hardware probe) reached `gpu_name.lower()` and raised AttributeError.
+"""
+from services.hwfit.fit import _lookup_bandwidth
+
+
+def test_non_string_returns_none():
+    assert _lookup_bandwidth(123) is None
+    assert _lookup_bandwidth(["x"]) is None
+    assert _lookup_bandwidth(None) is None
+
+
+def test_known_gpu_resolves():
+    assert _lookup_bandwidth("NVIDIA GeForce RTX 4090") is not None


### PR DESCRIPTION
## Summary
`_lookup_bandwidth(gpu_name)` in `services/hwfit/fit.py` guards only falsy values (`if not gpu_name`). A truthy non-string (e.g. a number from a malformed hardware probe) reaches `gpu_name.lower()` and raises AttributeError during model-fit estimation.

## Changes
- services/hwfit/fit.py: widen the guard to also reject non-strings.
- tests/test_hwfit_bandwidth_nonstring.py: non-string returns None; a known GPU still resolves.