### PR TITLE
fix(llm): clamp Anthropic temperature range

### DIFF
--- a/tests/test_llm_core_temperature.py
+++ b/tests/test_llm_core_temperature.py
@@ -66,3 +66,37 @@ def test_normal_model_payload_keeps_temperature(monkeypatch):
     payload = _capture_openai_payload(monkeypatch, "gpt-4o", 0.2)
     assert payload["temperature"] == 0.2
     assert payload["max_tokens"] == 5
+
+
+def test_normal_model_payload_keeps_temperature_above_one(monkeypatch):
+    # OpenAI/local providers may validly use temperatures above 1.0; the clamp
+    # is Anthropic-only and must not touch this path.
+    payload = _capture_openai_payload(monkeypatch, "gpt-4o", 1.2)
+    assert payload["temperature"] == 1.2
+
+
+def _anthropic_payload(temperature):
+    return llm_core._build_anthropic_payload(
+        "claude-3-5-sonnet",
+        [{"role": "user", "content": "Hi"}],
+        temperature,
+        max_tokens=5,
+    )
+
+
+def test_anthropic_payload_clamps_above_one():
+    # Anthropic rejects temperature > 1.0 (e.g. the Nietzsche preset's 1.2).
+    assert _anthropic_payload(1.2)["temperature"] == 1.0
+
+
+def test_anthropic_payload_keeps_in_range():
+    assert _anthropic_payload(0.7)["temperature"] == 0.7
+
+
+def test_anthropic_payload_clamps_negative():
+    assert _anthropic_payload(-0.5)["temperature"] == 0.0
+
+
+def test_anthropic_payload_none_temperature_does_not_crash():
+    payload = _anthropic_payload(None)
+    assert payload["temperature"] is None


### PR DESCRIPTION
## Summary

Fixes Anthropic chats failing with HTTP 400 when a preset or user-selected temperature is above Anthropic's supported range.

Fixes #1615.

## Changes

- Clamps only the temperature sent through `_build_anthropic_payload`.
- Preserves `None` behavior.
- Keeps OpenAI/local/Ollama temperature behavior unchanged.
- Extends existing temperature tests to cover Anthropic clamping and non-Anthropic passthrough.

## Why

Anthropic accepts `temperature` only in the `0.0`–`1.0` range. Odysseus supports OpenAI-style temperatures up to `2.0`, and the shipped Nietzsche preset uses `1.2`, which breaks Anthropic chats without a backend guard.

The clamp is intentionally limited to the Anthropic payload builder, so providers that allow higher values keep their existing behavior.

## Validation

- `git diff --check`
- `python3 -m py_compile src/llm_core.py tests/test_llm_core_temperature.py`
- `python3 -m pytest tests/test_llm_core_temperature.py -q` — 24 passed
- `python3 -m pytest tests/test_llm_core_anthropic_cache.py -q`

Note: `tests/test_llm_core_sanitize_tool_calls.py` currently has an unrelated pre-existing failure in `test_sanitize_merges_consecutive_user_messages` on the clean tree, so it is not included in final validation for this temperature-only PR.
