### PR TITLE
Ignore non-object settings scrub inputs

### DIFF
--- a/src/settings_scrub.py
+++ b/src/settings_scrub.py
@@ -47,4 +47,6 @@ def _scrub_value(key, value):
 
 def scrub_settings(settings: dict) -> dict:
     """Return a copy of ``settings`` with secret-shaped values masked (deep)."""
+    if not isinstance(settings, dict):
+        return {}
     return {k: _scrub_value(k, v) for k, v in (settings or {}).items()}

--- a/tests/test_settings_scrub.py
+++ b/tests/test_settings_scrub.py
@@ -59,3 +59,8 @@ def test_empty_and_nonstring_secret_values_untouched():
 def test_exact_name_matches():
     out = scrub_settings({"password": "p", "token": "t", "secret": "s", "apikey": "a", "key": "k"})
     assert all(v == "" for v in out.values()), out
+
+
+def test_non_object_settings_return_empty_mapping():
+    assert scrub_settings(["not", "settings"]) == {}
+    assert scrub_settings("not settings") == {}


### PR DESCRIPTION
Small guard for the auth settings scrubber. If a caller ever passes a non-object settings value, it now returns an empty mapping instead of crashing while trying to call `.items()`.

Tested:
./venv/bin/python -m pytest -q tests/test_settings_scrub.py
./venv/bin/python -m py_compile src/settings_scrub.py tests/test_settings_scrub.py
git diff --check origin/main...HEAD