### PR TITLE
Ignore non-string markdown table rows

### DIFF
--- a/static/js/markdown/tableRow.js
+++ b/static/js/markdown/tableRow.js
@@ -10,7 +10,8 @@
 // cells too, so "| a |  | c |" collapsed to 2 columns and misaligned with the
 // header.
 export function splitTableRow(row) {
-  return (row || '')
+  const text = typeof row === 'string' ? row : '';
+  return text
     .replace(/^\s*\|/, '')
     .replace(/\|\s*$/, '')
     .split('|')

--- a/tests/test_markdown_table_row_js.py
+++ b/tests/test_markdown_table_row_js.py
@@ -45,3 +45,20 @@ def test_rows_without_outer_pipes():
 @pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
 def test_header_row_unaffected():
     assert _split("| h1 | h2 | h3 |") == ["h1", "h2", "h3"]
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_non_string_row_falls_back_to_empty_cell():
+    js = f"""
+    import {{ splitTableRow }} from '{_HELPER.as_posix()}';
+    console.log(JSON.stringify([
+      splitTableRow(null),
+      splitTableRow({{"bad": "row"}})
+    ]));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout.strip()) == [[""], [""]]


### PR DESCRIPTION
Small parser guard for the markdown table-row helper. If a malformed caller hands it `null` or an object, it now returns the same empty-cell fallback instead of throwing on `.replace()`.

Tested:
./venv/bin/python -m pytest -q tests/test_markdown_table_row_js.py
node --check static/js/markdown/tableRow.js
./venv/bin/python -m py_compile tests/test_markdown_table_row_js.py
git diff --check origin/main...HEAD