### PR TITLE
Let preset set replace corrupt entries

### DIFF
--- a/scripts/odysseus-preset
+++ b/scripts/odysseus-preset
@@ -85,7 +85,8 @@ def cmd_set(args):
     if prompt is None and args.temperature is None:
         fail("nothing to set — pass --prompt, --prompt-file, or --temperature")
     presets = _load()
-    entry = dict(presets.get(args.name) or {})
+    current = presets.get(args.name)
+    entry = dict(current) if isinstance(current, dict) else {}
     entry.setdefault("name", args.name)
     if prompt is not None:
         entry["system_prompt"] = prompt

--- a/tests/test_preset_cli_set_corrupt_entry.py
+++ b/tests/test_preset_cli_set_corrupt_entry.py
@@ -1,0 +1,40 @@
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_preset_cli():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-preset"
+    loader = importlib.machinery.SourceFileLoader("odysseus_preset_set_corrupt", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_set_replaces_corrupt_existing_entry(monkeypatch):
+    cli = _load_preset_cli()
+    saved = {}
+    emitted = {}
+
+    monkeypatch.setattr(cli, "_load", lambda: {"broken": "raw prompt"})
+    monkeypatch.setattr(cli, "_save", lambda data: saved.update(data))
+    monkeypatch.setattr(cli, "emit", lambda payload, _args: emitted.update(payload))
+
+    args = SimpleNamespace(
+        name="broken",
+        prompt="new prompt",
+        prompt_file=None,
+        temperature=0.7,
+        display_name=None,
+    )
+
+    cli.cmd_set(args)
+
+    assert saved["broken"] == {
+        "name": "broken",
+        "system_prompt": "new prompt",
+        "temperature": 0.7,
+    }
+    assert emitted["ok"] is True


### PR DESCRIPTION
Follow-up to the preset CLI guard: `get`/`delete` already fail cleanly on corrupt entries, but `set` could still crash while doing `dict(existing)` on a non-object value. This lets `set` replace that bad entry with a clean object.

Tested:
./venv/bin/python -m pytest -q tests/test_preset_cli_set_corrupt_entry.py tests/test_preset_cli_invalid_entries.py
./venv/bin/python -m py_compile scripts/odysseus-preset tests/test_preset_cli_set_corrupt_entry.py
git diff --check origin/main...HEAD