### PR TITLE
Reject non-PNG signature export data

### DIFF
--- a/scripts/odysseus-signature
+++ b/scripts/odysseus-signature
@@ -34,9 +34,12 @@ def _decode_png_data(data_png: str) -> bytes:
     if "," in raw:
         raw = raw.split(",", 1)[1]
     try:
-        return base64.b64decode(raw, validate=True)
+        decoded = base64.b64decode(raw, validate=True)
     except Exception as e:
         fail(f"data_png is not valid base64: {e}")
+    if not decoded.startswith(b"\x89PNG\r\n\x1a\n"):
+        fail("data_png is not a PNG image")
+    return decoded
 
 
 def cmd_list(args):

--- a/tests/test_signature_cli_export.py
+++ b/tests/test_signature_cli_export.py
@@ -26,7 +26,8 @@ def _load_signature_cli(monkeypatch):
 def test_decode_png_data_accepts_data_url(monkeypatch):
     cli = _load_signature_cli(monkeypatch)
 
-    assert cli._decode_png_data("data:image/png;base64,aGVsbG8=") == b"hello"
+    png = b"\x89PNG\r\n\x1a\nrest"
+    assert cli._decode_png_data("data:image/png;base64,iVBORw0KGgpyZXN0") == png
 
 
 def test_decode_png_data_rejects_invalid_base64(monkeypatch):
@@ -38,3 +39,14 @@ def test_decode_png_data_rejects_invalid_base64(monkeypatch):
         assert exc.code == 1
     else:
         raise AssertionError("expected invalid base64 to exit")
+
+
+def test_decode_png_data_rejects_non_png_bytes(monkeypatch):
+    cli = _load_signature_cli(monkeypatch)
+
+    try:
+        cli._decode_png_data("aGVsbG8=")
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected non-PNG bytes to exit")


### PR DESCRIPTION
Tightens the signature CLI decode path a bit. It already rejects invalid base64; this also rejects decoded bytes that are not actually PNG data before writing them to `--png`.

Tested:
./venv/bin/python -m pytest -q tests/test_signature_cli_export.py
./venv/bin/python -m py_compile scripts/odysseus-signature tests/test_signature_cli_export.py
git diff --check origin/main...HEAD