### PR TITLE
Ignore censor preference storage errors

### DIFF
--- a/static/js/censor.js
+++ b/static/js/censor.js
@@ -8,7 +8,13 @@
 let _enabled = true;
 let _observer = null;
 const PREF_KEY = 'odysseus-sensitive-blur';
-const _prefEnabled = () => localStorage.getItem(PREF_KEY) === 'on';
+export const _prefEnabled = () => {
+  try {
+    return localStorage.getItem(PREF_KEY) === 'on';
+  } catch (_) {
+    return false;
+  }
+};
 
 // Patterns that indicate sensitive data
 const PATTERNS = [

--- a/tests/test_censor_pref_js.py
+++ b/tests/test_censor_pref_js.py
@@ -1,0 +1,49 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_censor_pref_falls_back_when_storage_throws():
+    values = _node_eval(
+        """
+        globalThis.localStorage = {
+          getItem() { throw new Error('blocked'); }
+        };
+        const { _prefEnabled } = await import('./static/js/censor.js');
+        console.log(JSON.stringify({ enabled: _prefEnabled() }));
+        """
+    )
+
+    assert values == {"enabled": False}
+
+
+def test_censor_pref_reads_enabled_flag():
+    values = _node_eval(
+        """
+        globalThis.localStorage = {
+          getItem(key) { return key === 'odysseus-sensitive-blur' ? 'on' : null; }
+        };
+        const { _prefEnabled } = await import('./static/js/censor.js');
+        console.log(JSON.stringify({ enabled: _prefEnabled() }));
+        """
+    )
+
+    assert values == {"enabled": True}


### PR DESCRIPTION
Small browser hardening for the sensitive-text censor. If localStorage is blocked or throws, the preference helper now falls back to disabled instead of crashing the censor init path.

Tested:
./venv/bin/python -m pytest -q tests/test_censor_pref_js.py
node --check static/js/censor.js
./venv/bin/python -m py_compile tests/test_censor_pref_js.py
git diff --check origin/main...HEAD