### PR TITLE
Ignore invalid model sort inputs

### DIFF
--- a/static/js/modelSort.js
+++ b/static/js/modelSort.js
@@ -14,8 +14,12 @@ function _compareText(a, b) {
   });
 }
 
+function _arrayOrEmpty(models) {
+  return Array.isArray(models) ? models : [];
+}
+
 export function sortModelIds(models) {
-  return (models || []).slice().sort(_compareText);
+  return _arrayOrEmpty(models).slice().sort(_compareText);
 }
 
 export function compareModelObjects(a, b) {
@@ -25,5 +29,5 @@ export function compareModelObjects(a, b) {
 }
 
 export function sortModelObjects(models) {
-  return (models || []).slice().sort(compareModelObjects);
+  return _arrayOrEmpty(models).slice().sort(compareModelObjects);
 }

--- a/tests/test_model_sort_js.py
+++ b/tests/test_model_sort_js.py
@@ -1,0 +1,59 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_model_sort_helpers_ignore_non_arrays():
+    values = _node_eval(
+        """
+        import { sortModelIds, sortModelObjects } from './static/js/modelSort.js';
+        console.log(JSON.stringify({
+          idsObject: sortModelIds({bad: true}),
+          idsString: sortModelIds('llama'),
+          objectsNull: sortModelObjects(null),
+          objectsObject: sortModelObjects({bad: true})
+        }));
+        """
+    )
+
+    assert values == {
+        "idsObject": [],
+        "idsString": [],
+        "objectsNull": [],
+        "objectsObject": [],
+    }
+
+
+def test_model_sort_helpers_keep_valid_arrays():
+    values = _node_eval(
+        """
+        import { sortModelIds, sortModelObjects } from './static/js/modelSort.js';
+        console.log(JSON.stringify({
+          ids: sortModelIds(['zeta/10', 'alpha/2', 'alpha/11']),
+          objects: sortModelObjects([{id: 'zeta/10'}, {id: 'alpha/2'}]).map(m => m.id)
+        }));
+        """
+    )
+
+    assert values == {
+        "ids": ["alpha/2", "zeta/10", "alpha/11"],
+        "objects": ["alpha/2", "zeta/10"],
+    }


### PR DESCRIPTION
Small guard for the shared model sort helpers. If a caller gets a malformed model list from cache/API state, the helpers now return an empty list instead of throwing on `.slice().sort()`.

Tested:
./venv/bin/python -m pytest -q tests/test_model_sort_js.py
node --check static/js/modelSort.js
./venv/bin/python -m py_compile tests/test_model_sort_js.py
git diff --check origin/main...HEAD