### PR TITLE
Ignore non-string email thread bodies

### DIFF
--- a/src/email_thread_parser.py
+++ b/src/email_thread_parser.py
@@ -605,10 +605,10 @@ def _parse_html(html: str) -> list[dict[str, Any]] | None:
 def parse_thread(body_html: str | None, body_text: str | None) -> list[dict[str, Any]] | None:
     """Public entry point. Prefer HTML when available, else plaintext.
     Returns None if no quoted material found (caller renders flat)."""
-    if body_html:
+    if isinstance(body_html, str) and body_html:
         out = _parse_html(body_html)
         if out:
             return out
-    if body_text:
+    if isinstance(body_text, str) and body_text:
         return _parse_plaintext(body_text)
     return None

--- a/tests/test_email_thread_parser_nonstring.py
+++ b/tests/test_email_thread_parser_nonstring.py
@@ -1,0 +1,13 @@
+from src.email_thread_parser import parse_thread
+
+
+def test_parse_thread_ignores_non_string_bodies():
+    assert parse_thread(123, {"bad": True}) is None
+    assert parse_thread(["<blockquote>bad</blockquote>"], None) is None
+
+
+def test_parse_thread_still_handles_plaintext_quotes():
+    turns = parse_thread(None, "hi\n\nOn Tue, Alice wrote:\n> older")
+
+    assert turns
+    assert turns[0]["level"] == 0


### PR DESCRIPTION
Small guard on the public email thread parser entrypoint. If malformed email data passes a non-string HTML/text body, it now falls back to no parsed thread instead of sending the internals into string operations.

Tested:
./venv/bin/python -m pytest -q tests/test_email_thread_parser_nonstring.py tests/test_forwarded_message_divider.py
./venv/bin/python -m py_compile src/email_thread_parser.py tests/test_email_thread_parser_nonstring.py
git diff --check origin/main...HEAD