### PR TITLE
fix(docker): invoke setup.py on first container start

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -80,6 +80,11 @@ export VLLM_USE_FLASHINFER_SAMPLER="${VLLM_USE_FLASHINFER_SAMPLER:-0}"
 # vLLM and helper scripts land here because /app is the non-root user's HOME.
 export PATH="/app/.local/bin:$PATH"
 
+# Run first-time setup as the app user so data/ files get the right ownership.
+# setup.py is idempotent — skips auth.json / .env if they already exist.
+# || true so a setup failure never prevents the container from starting.
+gosu "$PUID:$PGID" python /app/setup.py || true
+
 # Drop root and run the actual app. `gosu` is preferred over `su` /
 # `sudo` because it cleans up the process tree (no extra shell layer)
 # so signals (SIGTERM from `docker stop`) reach uvicorn directly.


### PR DESCRIPTION
Summary
  `setup.py` initialises admin credentials (`auth.json`) and app config (`.env`) on a
  fresh install, but was never called by the Docker entrypoint. New deployments started
  with no admin account and a missing config, making the app unusable out of the box.

  The fix adds a single `gosu`-wrapped call to `setup.py` in `docker/entrypoint.sh`,
  before the final `exec` drop. `setup.py` is fully idempotent — it skips files that
  already exist — so subsequent container restarts are unaffected.

  Linked Issue
  Fixes #1476

  Type of Change
  - Bug fix

  How to Test
  1. docker build -t odysseus-test .
  2. docker run --rm odysseus-test
     → logs should show "Temporary password: ..." from setup.py
  3. docker run --rm -e ODYSSEUS_ADMIN_USER=admin -e ODYSSEUS_ADMIN_PASSWORD=secret odysseus-test
     → setup.py should use the env vars instead of generating a random password
  4. Run the container a second time against the same volume
     → setup.py should log "auth.json already exists, skipping" (idempotent)
  5. docker stop <container>
     → SIGTERM should reach uvicorn cleanly (exec path unchanged)