### PR TITLE
fix(action_intents): shell verbs no longer promote informational chat to agent mode

### DIFF
--- a/src/action_intents.py
+++ b/src/action_intents.py
@@ -63,7 +63,12 @@ _TOOL_INTENT_PATTERNS: tuple[Pattern[str], ...] = tuple(
         r"\bssh\s+\w+",
         r"\b(run|execute)\s+.{1,40}\bon\s+\w+",
         r"\b(can|could|please|would)\s+you\s+(run|execute|exec)\b",
-        r"\b(deploy|build|install|restart|reboot|kill|tail|grep|cat|ls|cd|cp|mv|rm)\b\s+\S+",
+        # Shell verbs only count in imperative position (start of message,
+        # optionally after "please") or as a "can you ..." request. A bare
+        # word match promoted informational questions ("What does the grep
+        # command do?") and incidental uses ("My cat ate my homework").
+        rf"{_PLEASE}(deploy|build|install|restart|reboot|kill|tail|grep|cat|ls|cd|cp|mv|rm)\b\s+\S+",
+        rf"{_ACTION_QUESTION}(deploy|build|install|restart|reboot|kill|tail|grep|cat|ls|cd|cp|mv|rm)\b\s+\S+",
         r"\b(check|see)\s+(if|whether|what)\s+.{1,40}\b(running|process|service|port|file|exists?)\b",
     )
 )

--- a/tests/test_action_intents_shell_verbs.py
+++ b/tests/test_action_intents_shell_verbs.py
@@ -1,0 +1,35 @@
+"""Regression: shell verbs must not promote informational chat to agent mode.
+
+The shell-verb pattern used to be a bare word match
+(`\\b(deploy|build|...|rm)\\b\\s+\\S+`), so any sentence merely containing one
+of these common English words escalated a plain chat turn to agent mode via
+routes/chat_routes.py. That broke the module's stated contract ("only promote
+plain chat to agent mode when the user asks the assistant to take an action,
+not when the user asks how a feature works"). The pattern is now anchored to
+imperative position (start of message, optionally after "please") or to a
+"can/could/would/will you ..." request.
+"""
+from src.action_intents import message_needs_tools
+
+
+def test_informational_shell_questions_stay_plain_chat():
+    assert not message_needs_tools("What does the grep command do?")
+    assert not message_needs_tools("How do I tail a log file in production?")
+    assert not message_needs_tools("Is it safe to kill a process with kill -9?")
+
+
+def test_incidental_shell_words_stay_plain_chat():
+    assert not message_needs_tools("My cat ate my homework")
+    assert not message_needs_tools("The movie was a real kill joy for everyone")
+
+
+def test_imperative_shell_commands_still_promote_to_agent():
+    assert message_needs_tools("tail the nginx error log")
+    assert message_needs_tools("restart the media server")
+    assert message_needs_tools("please install docker on the host")
+    assert message_needs_tools("cat /etc/hosts")
+
+
+def test_can_you_shell_requests_still_promote_to_agent():
+    assert message_needs_tools("can you grep the logs for 500 errors")
+    assert message_needs_tools("could you tail the access log")


### PR DESCRIPTION
## The bug

The shell-verb routing pattern in src/action_intents.py was a bare word match:

```python
r"\b(deploy|build|install|restart|reboot|kill|tail|grep|cat|ls|cd|cp|mv|rm)\b\s+\S+"
```

Any chat message merely containing one of these common English words followed by another token was silently promoted from plain chat to agent mode by routes/chat_routes.py (different system prompt path, tool access). That breaks the module's own contract, stated in its docstring: patterns should only fire "when the user asks the assistant to take an action, not when the user asks how a feature works". It is the same contract the existing test test_explanatory_calendar_questions_stay_plain_chat asserts for calendar questions.

False positives (all returned True before this fix):
- "What does the grep command do?"
- "How do I tail a log file in production?"
- "Is it safe to kill a process with kill -9?"
- "My cat ate my homework" (matches "cat ate")

## The fix

The shell-verb pattern now requires imperative position (start of message, optionally after "please", reusing the existing `_PLEASE` anchor) or an explicit "can/could/would/will you ..." request (reusing `_ACTION_QUESTION`). Intended matches still promote:
- "tail the nginx error log", "restart the media server", "please install docker on the host", "cat /etc/hosts"
- "can you grep the logs for 500 errors", "could you tail the access log"

## Test

tests/test_action_intents_shell_verbs.py covers the informational and incidental negatives plus the imperative and can-you positives. It fails on the old pattern and passes on the fixed one. All cases in the existing tests/test_action_intents.py were re-verified against the new patterns.