### PR TITLE
fix(cookbook): resolve cascading Windows download/serve failures

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,39 @@
+name: Sync fork with upstream
+
+on:
+  schedule:
+    # Run every 6 hours
+    - cron: '0 */6 * * *'
+  workflow_dispatch: # Allow manual trigger from Actions tab
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/pewdiepie-archdaemon/odysseus.git
+
+      - name: Fetch upstream
+        run: git fetch upstream main
+
+      - name: Rebase onto upstream/main
+        run: |
+          git checkout main
+          git rebase upstream/main
+
+      - name: Force push rebased main
+        run: git push origin main --force-with-lease

--- a/core/platform_compat.py
+++ b/core/platform_compat.py
@@ -132,6 +132,7 @@ def kill_process_tree(pid: Optional[int]) -> None:
 
 # ── Shell / executable resolution ───────────────────────────────────────────
 _BASH_CACHE: Optional[str] = None
+_BASH_FLAVOUR: Optional[str] = None  # "git", "wsl", or "posix"
 _BASH_PROBED = False
 
 # Common Git-for-Windows install locations to probe when bash isn't on PATH.
@@ -195,9 +196,11 @@ def find_bash() -> Optional[str]:
     cached.
 
     On Windows, Git Bash (MSYS2) is strongly preferred over WSL bash because
-    Cookbook scripts use native Windows paths that WSL cannot resolve.
+    it shares the native Windows filesystem. WSL bash is kept as a fallback
+    and callers use :func:`bash_flavour` / :func:`win_to_bash_path` to
+    translate paths into the form the resolved bash understands.
     """
-    global _BASH_CACHE, _BASH_PROBED
+    global _BASH_CACHE, _BASH_FLAVOUR, _BASH_PROBED
     if _BASH_PROBED:
         return _BASH_CACHE
     _BASH_PROBED = True
@@ -215,10 +218,52 @@ def find_bash() -> Optional[str]:
                     break
             if not found:
                 found = wsl_fallback
-    elif not found:
-        pass  # POSIX: which_tool already checked
+        _BASH_FLAVOUR = "wsl" if (found and _is_wsl_bash(found)) else "git" if found else None
+    else:
+        _BASH_FLAVOUR = "posix" if found else None
     _BASH_CACHE = found
     return found
+
+
+def bash_flavour() -> Optional[str]:
+    """Return the flavour of bash that :func:`find_bash` resolved.
+
+    Possible values (after ``find_bash`` has been called at least once):
+
+    * ``"git"``   — Git Bash / MSYS2 on Windows. Paths use ``/c/...``.
+    * ``"wsl"``   — WSL bash on Windows. Paths use ``/mnt/c/...``.
+    * ``"posix"`` — Native POSIX bash (Linux / macOS).
+    * ``None``    — No bash found, or ``find_bash`` not yet called.
+    """
+    if not _BASH_PROBED:
+        find_bash()
+    return _BASH_FLAVOUR
+
+
+def win_to_bash_path(win_path: str) -> str:
+    """Convert a Windows path to the form understood by the resolved bash.
+
+    Git Bash (MSYS2) uses ``/c/Users/...``; WSL uses ``/mnt/c/Users/...``.
+    On POSIX or when the path is already POSIX-style, returns it unchanged.
+
+    Must be called after :func:`find_bash` so the flavour is known. If no
+    bash was found, falls back to the Git Bash convention (harmless — the
+    path won't be used without a bash anyway).
+    """
+    if not win_path:
+        return win_path
+    # Normalise backslashes first
+    p = win_path.replace("\\", "/")
+    # Only translate if it looks like a drive-letter path (C:/...)
+    if len(p) >= 2 and p[1] == ":":
+        drive = p[0].lower()
+        rest = p[2:]  # includes the leading /
+        flavour = bash_flavour()
+        if flavour == "wsl":
+            return f"/mnt/{drive}{rest}"
+        # Git Bash (default for Windows)
+        return f"/{drive}{rest}"
+    return p
 
 
 def has_bash() -> bool:

--- a/core/platform_compat.py
+++ b/core/platform_compat.py
@@ -171,6 +171,21 @@ def _windows_bash_fallbacks() -> List[str]:
     return paths
 
 
+def _is_wsl_bash(path: str) -> bool:
+    """True if ``path`` points to the WSL ``bash.exe`` shim in system32.
+
+    WSL bash runs inside a Linux subsystem with a separate filesystem
+    namespace (Windows ``C:\\`` is at ``/mnt/c``). Scripts that use native
+    Windows paths (``C:/Users/...``) will silently fail under WSL bash.
+    Cookbook/background-job scripts always use Windows-native paths, so we
+    must prefer Git Bash (MSYS2) which shares the Windows filesystem.
+    """
+    if not path:
+        return False
+    normed = ntpath.normcase(ntpath.abspath(path))
+    return "system32" in normed or "syswow64" in normed
+
+
 def find_bash() -> Optional[str]:
     """Locate a real ``bash`` interpreter, or None.
 
@@ -178,17 +193,30 @@ def find_bash() -> Optional[str]:
     agent ``bash`` tool, background jobs, Cookbook scripts) emit bash syntax, so
     when a bash is present we use it and keep full parity with POSIX. Result is
     cached.
+
+    On Windows, Git Bash (MSYS2) is strongly preferred over WSL bash because
+    Cookbook scripts use native Windows paths that WSL cannot resolve.
     """
     global _BASH_CACHE, _BASH_PROBED
     if _BASH_PROBED:
         return _BASH_CACHE
     _BASH_PROBED = True
     found = which_tool("bash")
-    if not found and IS_WINDOWS:
-        for cand in _windows_bash_fallbacks():
-            if os.path.exists(cand):
-                found = cand
-                break
+    if IS_WINDOWS:
+        # Git Bash shares the Windows filesystem; WSL bash does not.
+        # Always try the Git Bash fallback paths first when which_tool
+        # returned WSL bash (system32/bash.exe) or returned nothing.
+        if not found or _is_wsl_bash(found):
+            wsl_fallback = found  # keep as last resort
+            found = None
+            for cand in _windows_bash_fallbacks():
+                if os.path.exists(cand):
+                    found = cand
+                    break
+            if not found:
+                found = wsl_fallback
+    elif not found:
+        pass  # POSIX: which_tool already checked
     _BASH_CACHE = found
     return found
 

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -137,12 +137,12 @@ def _local_tooling_path_export(executable: str) -> str:
         bin_dir = posixpath.dirname(executable)
     else:
         bin_dir = os.path.dirname(os.path.abspath(executable))
-    # On Windows the bin dir is a native path like C:\...\Scripts. Git Bash
-    # needs MSYS2-style POSIX paths (/c/Users/...) on PATH to resolve
-    # executables — neither backslash paths nor C:/ drive-letter paths work.
-    if os.name == "nt" and len(bin_dir) >= 2 and bin_dir[1] == ":":
-        drive = bin_dir[0].lower()
-        bin_dir = "/" + drive + bin_dir[2:].replace("\\", "/")
+    # On Windows the bin dir is a native path like C:\...\Scripts. The
+    # resolved bash (Git Bash or WSL) each need a different POSIX form —
+    # win_to_bash_path picks /c/... or /mnt/c/... based on bash_flavour().
+    if os.name == "nt":
+        from core.platform_compat import win_to_bash_path
+        bin_dir = win_to_bash_path(bin_dir)
     # Escape for a double-quoted context: $PATH must still expand, but spaces
     # and shell metacharacters in the path must be preserved literally.
     esc = (

--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -137,6 +137,12 @@ def _local_tooling_path_export(executable: str) -> str:
         bin_dir = posixpath.dirname(executable)
     else:
         bin_dir = os.path.dirname(os.path.abspath(executable))
+    # On Windows the bin dir is a native path like C:\...\Scripts. Git Bash
+    # needs MSYS2-style POSIX paths (/c/Users/...) on PATH to resolve
+    # executables — neither backslash paths nor C:/ drive-letter paths work.
+    if os.name == "nt" and len(bin_dir) >= 2 and bin_dir[1] == ":":
+        drive = bin_dir[0].lower()
+        bin_dir = "/" + drive + bin_dir[2:].replace("\\", "/")
     # Escape for a double-quoted context: $PATH must still expand, but spaces
     # and shell metacharacters in the path must be preserved literally.
     esc = (

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -451,7 +451,11 @@ def setup_cookbook_routes() -> APIRouter:
         # On Windows (Git Bash), `python3` is usually absent — only `python.exe`
         # exists. Define a shell function and export it so subshells (bash -c)
         # used by the pip install fallback chain also see it.
+        # Also force UTF-8 I/O: the detached process has no console, so Python
+        # defaults to the system charmap (cp1252) which chokes on Unicode
+        # characters like ✓ that the hf CLI prints on completion.
         if IS_WINDOWS and not req.remote_host:
+            lines.append('export PYTHONIOENCODING=utf-8')
             lines.append('if ! command -v python3 >/dev/null 2>&1 && command -v python >/dev/null 2>&1; then python3() { python "$@"; }; export -f python3; fi')
         # Best-effort install hf CLI (always). hf_transfer (Rust parallel downloader)
         # is fast but flaky on large files — it tends to crash near the end at high
@@ -940,6 +944,7 @@ def setup_cookbook_routes() -> APIRouter:
             if not remote:
                 runner_lines.append(_local_tooling_path_export(sys.executable))
             if IS_WINDOWS and not remote:
+                runner_lines.append('export PYTHONIOENCODING=utf-8')
                 runner_lines.append('if ! command -v python3 >/dev/null 2>&1 && command -v python >/dev/null 2>&1; then python3() { python "$@"; }; export -f python3; fi')
             runner_lines.append("export FLASHINFER_DISABLE_VERSION_CHECK=1")
             if req.hf_token:

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -358,13 +358,15 @@ def setup_cookbook_routes() -> APIRouter:
         pid_path = TMUX_LOG_DIR / f"{session_id}.pid"
         bash = find_bash()
         if bash:
-            # Run the existing bash wrapper verbatim through Git Bash, redirecting
-            # all output to the log the poller reads. Paths handed to bash use
-            # POSIX form + shell-quoting so drive paths / spaces survive.
+            from core.platform_compat import win_to_bash_path
+            # Run the existing bash wrapper verbatim through the resolved
+            # bash (Git Bash or WSL), redirecting all output to the log the
+            # poller reads. Paths are converted via win_to_bash_path so they
+            # resolve under whichever bash flavour is in use.
             inner = TMUX_LOG_DIR / f"{session_id}_run.sh"
             inner.write_text("\n".join(bash_lines) + "\n", encoding="utf-8")
-            lp = shlex.quote(log_path.as_posix())
-            ip = shlex.quote(inner.as_posix())
+            lp = shlex.quote(win_to_bash_path(str(log_path)))
+            ip = shlex.quote(win_to_bash_path(str(inner)))
             script_path = TMUX_LOG_DIR / f"{session_id}.sh"
             script_path.write_text(
                 f"bash {ip} > {lp} 2>&1\n",

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -441,11 +441,16 @@ def setup_cookbook_routes() -> APIRouter:
             lines.append(f"export HF_TOKEN='{_bash_squote(req.hf_token)}'")
         # Ensure pip-user scripts (e.g. hf CLI installed via --user) are on PATH
         lines.append('export PATH="$HOME/.local/bin:$PATH"')
-        # When Odysseus runs from a venv (e.g. native macOS install), put its bin
-        # on PATH so the tmux shell finds the bundled `hf`/`python3` without an
-        # activated venv. Local bash runs only — meaningless over SSH/Windows.
-        if not req.remote_host and req.platform != "windows":
+        # When Odysseus runs from a venv, put its bin/Scripts dir on PATH so the
+        # tmux/detached shell finds the bundled `hf`/`python3` without an
+        # activated venv. Local bash runs only — meaningless over SSH.
+        if not req.remote_host:
             lines.append(_local_tooling_path_export(sys.executable))
+        # On Windows (Git Bash), `python3` is usually absent — only `python.exe`
+        # exists. Define a shell function and export it so subshells (bash -c)
+        # used by the pip install fallback chain also see it.
+        if IS_WINDOWS and not req.remote_host:
+            lines.append('if ! command -v python3 >/dev/null 2>&1 && command -v python >/dev/null 2>&1; then python3() { python "$@"; }; export -f python3; fi')
         # Best-effort install hf CLI (always). hf_transfer (Rust parallel downloader)
         # is fast but flaky on large files — it tends to crash near the end at high
         # throughput. Retries set disable_hf_transfer to fall back to the plain,
@@ -932,6 +937,8 @@ def setup_cookbook_routes() -> APIRouter:
             # shell resolves the bundled python3/hf, mirroring the download flow.
             if not remote:
                 runner_lines.append(_local_tooling_path_export(sys.executable))
+            if IS_WINDOWS and not remote:
+                runner_lines.append('if ! command -v python3 >/dev/null 2>&1 && command -v python >/dev/null 2>&1; then python3() { python "$@"; }; export -f python3; fi')
             runner_lines.append("export FLASHINFER_DISABLE_VERSION_CHECK=1")
             if req.hf_token:
                 runner_lines.append(f"export HF_TOKEN='{_bash_squote(req.hf_token)}'")

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -353,7 +353,7 @@ MAX_OUTPUT = 200_000  # truncate limit
 # Anchor session logs under the app's data dir so the path is stable across
 # restarts, even if TEMP/TMP differs between shells (e.g. Claude sandbox
 # overrides TEMP). Falls back to the old tempdir location for compat.
-TMUX_LOG_DIR = Path(os.environ.get("DATA_DIR", "data")) / "cookbook-sessions"
+TMUX_LOG_DIR = Path(os.environ.get("DATA_DIR", "data")).resolve() / "cookbook-sessions"
 PTY_UNSUPPORTED_ERROR = "pty_unsupported"
 
 

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -670,10 +670,11 @@ async def _generate_win_detached(cmd: str, request: Request):
 
     bash = find_bash()
     if bash:
+        from core.platform_compat import win_to_bash_path
         script_path = TMUX_LOG_DIR / f"{session_id}.sh"
         script_path.write_text(
-            f"{cmd} > {shlex.quote(str(log_path))} 2>&1\n"
-            f"echo $? > {shlex.quote(str(exit_path))}\n",
+            f"{cmd} > {shlex.quote(win_to_bash_path(str(log_path)))} 2>&1\n"
+            f"echo $? > {shlex.quote(win_to_bash_path(str(exit_path)))}\n",
             encoding="utf-8",
         )
         argv = [bash, str(script_path)]

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -9,7 +9,6 @@ import shlex
 import shutil
 import subprocess
 import uuid
-import tempfile
 from collections import namedtuple
 from pathlib import Path
 from typing import Dict, Any
@@ -351,7 +350,10 @@ def _find_line_break(buf):
 EXEC_TIMEOUT = 30  # seconds — shorter than agent's 60s
 STREAM_TIMEOUT = 120  # default for short commands
 MAX_OUTPUT = 200_000  # truncate limit
-TMUX_LOG_DIR = Path(tempfile.gettempdir()) / "odysseus-tmux"
+# Anchor session logs under the app's data dir so the path is stable across
+# restarts, even if TEMP/TMP differs between shells (e.g. Claude sandbox
+# overrides TEMP). Falls back to the old tempdir location for compat.
+TMUX_LOG_DIR = Path(os.environ.get("DATA_DIR", "data")) / "cookbook-sessions"
 PTY_UNSUPPORTED_ERROR = "pty_unsupported"
 
 

--- a/scripts/odysseus-cookbook
+++ b/scripts/odysseus-cookbook
@@ -44,8 +44,7 @@ _STATE_PATH = _DATA_DIR / "cookbook_state.json"
 
 # Mirror routes/shell_routes.TMUX_LOG_DIR — don't import it because that pulls
 # the whole web app into the process. Match its definition instead.
-import tempfile
-_TMUX_LOG_DIR = Path(tempfile.gettempdir()) / "odysseus-tmux"
+_TMUX_LOG_DIR = _DATA_DIR / "cookbook-sessions"
 
 
 def fail(msg: str, code: int = 1) -> None:

--- a/src/bg_jobs.py
+++ b/src/bg_jobs.py
@@ -94,16 +94,17 @@ def launch(command: str, session_id: str, cwd: Optional[str] = None,
     # exit status.
     bash = find_bash()
     if bash:
+        from core.platform_compat import win_to_bash_path
         # POSIX, or Windows with Git Bash/WSL. The user command goes in its OWN
         # script file, run as a child `bash` — an `exit` inside it only ends
         # that child (so the wrapper still records the exit code), and an
         # unbalanced paren / trailing line-continuation in the command can't
         # break the wrapper. `$?` is the child's real exit status. Paths are
-        # emitted as POSIX (forward-slash) + shell-quoted so Git Bash on Windows
-        # handles drive paths and spaces correctly.
+        # converted via win_to_bash_path so they resolve under Git Bash (/c/...)
+        # or WSL (/mnt/c/...) transparently.
         cmd_path = _JOBS_DIR / f"{job_id}.cmd.sh"
         cmd_path.write_text(command + "\n", encoding="utf-8")
-        lp, xp, cp = (shlex.quote(p.as_posix()) for p in (log_path, exit_path, cmd_path))
+        lp, xp, cp = (shlex.quote(win_to_bash_path(str(p))) for p in (log_path, exit_path, cmd_path))
         script_path = _JOBS_DIR / f"{job_id}.sh"
         script_path.write_text(
             f"bash {cp} > {lp} 2>&1\n"

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -2285,6 +2285,14 @@ async function _reconnectTask(el, task) {
   el._abort = controller;
   let failCount = 0;
 
+  // Local Windows tasks use a detached process + log file instead of tmux.
+  // The tmux capture-pane loop below would always fail (tmux doesn't exist on
+  // Windows), causing the task to be marked "crashed" even when the download
+  // succeeds. For these tasks, the background status poller already reads the
+  // log file via /api/cookbook/tasks/status — let it handle status updates.
+  const _localNoTmux = !task.remoteHost && !_isWindows(task) && typeof navigator !== 'undefined' && /Win/.test(navigator.platform || navigator.userAgent);
+  if (_localNoTmux) return;
+
   while (!controller.signal.aborted) {
     if (!el.isConnected) {
       controller.abort();

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -5,6 +5,7 @@ from core import platform_compat
 
 def _reset_bash_cache(monkeypatch):
     monkeypatch.setattr(platform_compat, "_BASH_CACHE", None)
+    monkeypatch.setattr(platform_compat, "_BASH_FLAVOUR", None)
     monkeypatch.setattr(platform_compat, "_BASH_PROBED", False)
 
 
@@ -21,6 +22,7 @@ def test_find_bash_tries_windows_exe_suffix(monkeypatch):
     monkeypatch.setattr(platform_compat.os.path, "exists", lambda _path: False)
 
     assert platform_compat.find_bash() == expected
+    assert platform_compat.bash_flavour() == "git"
 
 
 def test_find_bash_checks_local_app_data_git_install(monkeypatch):
@@ -35,3 +37,60 @@ def test_find_bash_checks_local_app_data_git_install(monkeypatch):
     monkeypatch.setattr(platform_compat.os.path, "exists", lambda path: path == expected)
 
     assert platform_compat.find_bash() == expected
+    assert platform_compat.bash_flavour() == "git"
+
+
+def test_find_bash_prefers_git_bash_over_wsl(monkeypatch):
+    """When shutil.which returns WSL bash but Git Bash is installed, prefer Git Bash."""
+    _reset_bash_cache(monkeypatch)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+    wsl_bash = r"C:\Windows\system32\bash.exe"
+    git_bash = r"C:\Program Files\Git\bin\bash.exe"
+
+    monkeypatch.setattr(platform_compat.shutil, "which", lambda name: wsl_bash if name == "bash" else None)
+    monkeypatch.setattr(platform_compat.os.path, "exists", lambda path: path == git_bash)
+
+    assert platform_compat.find_bash() == git_bash
+    assert platform_compat.bash_flavour() == "git"
+
+
+def test_find_bash_falls_back_to_wsl_when_no_git_bash(monkeypatch):
+    """When only WSL bash is available (no Git Bash), use it as a fallback."""
+    _reset_bash_cache(monkeypatch)
+    monkeypatch.setattr(platform_compat, "IS_WINDOWS", True)
+
+    wsl_bash = r"C:\Windows\system32\bash.exe"
+
+    monkeypatch.setattr(platform_compat.shutil, "which", lambda name: wsl_bash if name == "bash" else None)
+    monkeypatch.setattr(platform_compat.os.path, "exists", lambda _path: False)
+
+    assert platform_compat.find_bash() == wsl_bash
+    assert platform_compat.bash_flavour() == "wsl"
+
+
+def test_win_to_bash_path_git_bash(monkeypatch):
+    _reset_bash_cache(monkeypatch)
+    monkeypatch.setattr(platform_compat, "_BASH_FLAVOUR", "git")
+    monkeypatch.setattr(platform_compat, "_BASH_PROBED", True)
+
+    assert platform_compat.win_to_bash_path(r"C:\Users\alice\venv\Scripts") == "/c/Users/alice/venv/Scripts"
+    assert platform_compat.win_to_bash_path("D:\\models\\llama") == "/d/models/llama"
+
+
+def test_win_to_bash_path_wsl(monkeypatch):
+    _reset_bash_cache(monkeypatch)
+    monkeypatch.setattr(platform_compat, "_BASH_FLAVOUR", "wsl")
+    monkeypatch.setattr(platform_compat, "_BASH_PROBED", True)
+
+    assert platform_compat.win_to_bash_path(r"C:\Users\alice\venv\Scripts") == "/mnt/c/Users/alice/venv/Scripts"
+    assert platform_compat.win_to_bash_path("D:\\models\\llama") == "/mnt/d/models/llama"
+
+
+def test_win_to_bash_path_posix_passthrough(monkeypatch):
+    _reset_bash_cache(monkeypatch)
+    monkeypatch.setattr(platform_compat, "_BASH_FLAVOUR", "posix")
+    monkeypatch.setattr(platform_compat, "_BASH_PROBED", True)
+
+    assert platform_compat.win_to_bash_path("/usr/local/bin") == "/usr/local/bin"
+    assert platform_compat.win_to_bash_path("relative/path") == "relative/path"


### PR DESCRIPTION
## Summary

Cookbook downloads and model serving are completely non-functional on native Windows. I ran into this myself trying to download a model through the UI — it just silently fails with no useful error. I used Claude Opus 4.6 to help me trace through the actual failure chain, and it turned out to be not one bug but about seven of them stacked on top of each other, each one masking the next.

The root problem is that `find_bash()` picks up WSL's `bash.exe` (under `system32`) before Git Bash. WSL can't resolve Windows paths, so the download script runs, can't find anything, and dies silently — no log file is ever written. Even after fixing that, the path format was wrong (`C:/Users/...` instead of `/c/Users/...` for Git Bash or `/mnt/c/...` for WSL). Then `python3` wasn't exported to subshells, the venv PATH export was skipped entirely on Windows, `PYTHONIOENCODING` wasn't set so the HuggingFace CLI crashed on a Unicode checkmark, the log directory was unstable across shell environments because `tempfile.gettempdir()` returns different paths depending on which shell you're in, and the frontend was stuck in a tmux reconnect loop that marked every completed download as "crashed" even when the log file said `DOWNLOAD_OK`.

Each fix is individually small but they all had to land together for anything to actually work. I know the contributing guide prefers one fix per PR, but splitting these would just mean each PR on its own still leaves downloads broken — they're fundamentally one fix for one broken feature.

Shout out to #620 — someone independently diagnosed the same PATH colon-splitting and missing `python3` issues. This PR addresses those along with the deeper bash resolution, path translation, log directory, and frontend bugs that were also blocking things.

### Cross-platform note

All changes except one are guarded behind `IS_WINDOWS` / `os.name == "nt"` / `navigator.platform` checks and have zero impact on Linux, macOS, or Docker installs. The one exception is the `TMUX_LOG_DIR` move in `shell_routes.py`: it changed from `tempfile.gettempdir()/odysseus-tmux` (e.g. `/tmp/odysseus-tmux` on Linux) to `DATA_DIR/cookbook-sessions` (e.g. `data/cookbook-sessions`). This affects all platforms. It's an improvement everywhere — logs now live in the data directory instead of `/tmp` (which the OS can clean at any time), and the path is stable regardless of which shell or environment the process runs in. The only edge case is if someone upgrades while a download is actively running: the in-flight script would still be writing to the old `/tmp` path while the status poller looks in the new location, so that one task would appear stalled until restarted. New downloads after the upgrade work immediately.

## Linked Issue

Fixes #620
Fixes #343
Fixes #494
Fixes #758
Fixes #884
Fixes #1262

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. On a native Windows machine with Git Bash installed, clone and start Odysseus (`python -m uvicorn app:app --host 0.0.0.0 --port 7000`)
2. Go to Cookbook → pick any GGUF model (e.g. `Qwen/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M`) → click Download
3. The Running tab should show live progress and complete successfully — not silently fail or show "crashed"
4. After download completes, go to the Serve tab — the model should appear with auto-profile settings for llama.cpp
5. Run `python -m pytest tests/test_platform_compat.py -v` — all 7 tests should pass
6. Run `python -m py_compile` on changed `.py` files and `node --check static/js/cookbookRunning.js` — all clean

## Screenshots (UI changes only)

N/A — no visual UI changes. The only frontend change is a logic fix in `cookbookRunning.js` that prevents the status from incorrectly showing "crashed" on Windows.