### PR TITLE
Fix HTTP 500 in history routes: order ChatMessage by timestamp, not the non-existent created_at

### DIFF
--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -265,7 +265,7 @@ def setup_history_routes(session_manager) -> APIRouter:
                 db_messages = (
                     db.query(DbChatMessage)
                     .filter(DbChatMessage.session_id == session_id, DbChatMessage.role == 'assistant')
-                    .order_by(DbChatMessage.created_at.desc())
+                    .order_by(DbChatMessage.timestamp.desc())
                     .first()
                 )
                 if db_messages:
@@ -320,7 +320,7 @@ def setup_history_routes(session_manager) -> APIRouter:
                 db_msg = (
                     db.query(DbChatMessage)
                     .filter(DbChatMessage.session_id == session_id, DbChatMessage.role == 'assistant')
-                    .order_by(DbChatMessage.created_at.desc())
+                    .order_by(DbChatMessage.timestamp.desc())
                     .first()
                 )
                 if db_msg:
@@ -401,7 +401,7 @@ def setup_history_routes(session_manager) -> APIRouter:
                 db_messages = (
                     db.query(DbChatMessage)
                     .filter(DbChatMessage.session_id == session_id)
-                    .order_by(DbChatMessage.created_at)
+                    .order_by(DbChatMessage.timestamp)
                     .all()
                 )
                 # Find last two assistant messages in DB

--- a/tests/test_history_order_by_timestamp_regression.py
+++ b/tests/test_history_order_by_timestamp_regression.py
@@ -1,0 +1,77 @@
+"""Regression guard for #1659.
+
+`routes/history_routes.py` ordered three ChatMessage queries by
+``DbChatMessage.created_at`` — the mark-stopped (`:268`), update-last-meta
+(`:323`) and merge-last-assistant (`:404`) handlers. The ``ChatMessage`` model
+does **not** inherit ``TimestampMixin`` and exposes only a ``timestamp`` column,
+so ``DbChatMessage.created_at`` raised ``AttributeError`` at query-build time ->
+HTTP 500 on Stop, last-message metadata updates, and Continue/merge.
+
+This test pins three things:
+  1. the model genuinely has ``timestamp`` and no ``created_at`` (justifies the fix);
+  2. the corrected ``order_by(DbChatMessage.timestamp)`` query builds and runs;
+  3. ``routes/history_routes.py`` never orders a ChatMessage query by the
+     non-existent ``created_at`` column again.
+"""
+import os
+from pathlib import Path
+
+# Keep the import-time engine hermetic — no on-disk app.db.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import Base, ChatMessage as DbChatMessage, Session as DbSession
+
+
+HISTORY_ROUTES = Path(__file__).resolve().parent.parent / "routes" / "history_routes.py"
+
+
+def test_chatmessage_model_has_timestamp_not_created_at():
+    assert hasattr(DbChatMessage, "timestamp"), "ChatMessage should expose a `timestamp` column"
+    assert not hasattr(DbChatMessage, "created_at"), (
+        "ChatMessage does not inherit TimestampMixin; ordering by `created_at` "
+        "raises AttributeError -> HTTP 500 (#1659)"
+    )
+
+
+def test_order_by_timestamp_query_executes():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    try:
+        sid = "sess1234"
+        # FK enforcement is on (PRAGMA foreign_keys), so seed the parent session.
+        db.add(DbSession(id=sid, name="t", endpoint_url="http://x", model="m"))
+        db.add(DbChatMessage(id="m1", session_id=sid, role="assistant", content="first"))
+        db.add(DbChatMessage(id="m2", session_id=sid, role="assistant", content="second"))
+        db.commit()
+
+        # Mirrors mark_stopped / update_last_meta (descending, .first()).
+        last_assistant = (
+            db.query(DbChatMessage)
+            .filter(DbChatMessage.session_id == sid, DbChatMessage.role == "assistant")
+            .order_by(DbChatMessage.timestamp.desc())
+            .first()
+        )
+        assert last_assistant is not None
+
+        # Mirrors merge_last_assistant (ascending, .all()).
+        all_rows = (
+            db.query(DbChatMessage)
+            .filter(DbChatMessage.session_id == sid)
+            .order_by(DbChatMessage.timestamp)
+            .all()
+        )
+        assert len(all_rows) == 2
+    finally:
+        db.close()
+
+
+def test_history_routes_do_not_order_by_created_at():
+    text = HISTORY_ROUTES.read_text(encoding="utf-8")
+    assert "DbChatMessage.created_at" not in text, (
+        "history_routes must order ChatMessage queries by `.timestamp`, not the "
+        "non-existent `.created_at` column (raises AttributeError -> HTTP 500, #1659)"
+    )


### PR DESCRIPTION
## What & why

Three `POST` handlers in `routes/history_routes.py` ordered their `ChatMessage` query by `DbChatMessage.created_at`:

- `mark-stopped` (`:268`)
- `update-last-meta` (`:323`)
- `merge-last-assistant` (`:404`)

But the `ChatMessage` model (`core/database.py:155`) does **not** inherit `TimestampMixin` — it has only a `timestamp` column. Accessing `DbChatMessage.created_at` raises `AttributeError` while SQLAlchemy builds the query, so all three endpoints return **HTTP 500** (on **Stop**, last-message metadata updates, and **Continue**/merge). None of the local `except` blocks catch it.

There's a second-order effect: each handler mutates the **in-memory** session history *before* the failing query and never reaches `save_sessions()`, so a request that reports failure (500) still silently changes in-memory state while the database is left untouched — the two stores diverge.

The rest of the file already orders `ChatMessage` queries by `.timestamp` (lines 57, 156, 564); these three diverged.

## Fix

Order by `DbChatMessage.timestamp` at all three sites — the existing `ix_messages_session_time` composite index on `(session_id, timestamp)` keeps the sort efficient.

```diff
-                    .order_by(DbChatMessage.created_at.desc())   # mark-stopped, update-last-meta
+                    .order_by(DbChatMessage.timestamp.desc())
-                    .order_by(DbChatMessage.created_at)          # merge-last-assistant
+                    .order_by(DbChatMessage.timestamp)
```

## Tests

`tests/test_history_order_by_timestamp_regression.py` pins:

1. the model genuinely exposes `timestamp` and has no `created_at` (justifies the fix);
2. the corrected `order_by(DbChatMessage.timestamp)` query builds and executes against an in-memory SQLite DB (both `.desc().first()` and ascending `.all()` shapes);
3. `routes/history_routes.py` never orders a `ChatMessage` query by `created_at` again.

Guard #3 fails on the current `main` (3 occurrences of the bad column) and passes with this change (0). All three tests pass; the existing `tests/test_history_topics_owner_scope.py` stays green.

## Compatibility — no migration required

This changes only which **existing** column an ORM query reads; there is **no schema change, no `ALTER TABLE`, and no data backfill**:

- `chat_messages.timestamp` has always been part of the table — it's in the original `ChatMessage` model (never added by a `_migrate_*` step) and is already relied on elsewhere, e.g. `SELECT MAX(timestamp) FROM chat_messages` inside `_migrate_add_last_message_at_column`. It's always populated (`default=datetime.utcnow`).
- `created_at` never existed on `chat_messages`, so there is no historical data to migrate *from*.

On upgrade, the three affected endpoints (**Stop** / **update-last-meta** / **Continue**) simply start working; previously they raised `AttributeError` → HTTP 500 on every install. The test's `create_all` is test scaffolding only, not a runtime migration.

Fixes #1659
