### PR TITLE
fix(email): Gmail quote attribution regex misses the standard US Gmail format

### DIFF
--- a/static/js/emailLibrary/signatureFold.js
+++ b/static/js/emailLibrary/signatureFold.js
@@ -154,7 +154,11 @@ export function _extractQuoteMeta(html) {
   let date = sentMatch ? sentMatch[1].trim() : '';
 
   if (!from && !date) {
-    const gmail = txt.match(/On\s+([^,]+?,[^,]+?\d{4}[^,]*),?\s+(.+?)\s+wrote\s*:/i);
+    // The date may carry up to three commas before the year: the standard
+    // US Gmail attribution is "On Mon, Apr 18, 2026 at 9:31 AM, Jane wrote:"
+    // (weekday and day-of-month each add one). A single-comma pattern never
+    // reached the year there, so the fold lost its sender/date headline.
+    const gmail = txt.match(/On\s+((?:[^,]*,){0,3}?[^,]*?\d{4}[^,]*),?\s+(.+?)\s+wrote\s*:/i);
     if (gmail) { date = gmail[1].trim(); from = gmail[2].trim(); }
   }
 

--- a/tests/test_gmail_quote_attribution_js.py
+++ b/tests/test_gmail_quote_attribution_js.py
@@ -1,0 +1,64 @@
+"""Pin _extractQuoteMeta's Gmail attribution parsing (static/js/emailLibrary/signatureFold.js).
+
+Driven through `node --input-type=module` (same approach as test_hex_to_rgb_js.py);
+skips when `node` is not installed.
+
+Regression: the Gmail-fallback date pattern allowed only ONE comma before the
+4-digit year, but the standard US Gmail attribution
+"On Mon, Apr 18, 2026 at 9:31 AM, Jane Doe <jane@example.com> wrote:" carries
+TWO (after the weekday and after the day-of-month). The match failed, so the
+collapsed "Earlier thread"/"Earlier reply" fold rendered without its
+sender/date headline for the most common Gmail reply format.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "emailLibrary" / "signatureFold.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _meta(html: str) -> str:
+    js = (
+        # _esc in the module touches `document` lazily; stub it so the module
+        # can be exercised outside a browser.
+        "globalThis.document = { createElement() { return {"
+        " set textContent(v) { this._t = v; },"
+        " get innerHTML() { return this._t || ''; } }; } };"
+        f"const {{ _extractQuoteMeta }} = await import('{_HELPER.as_posix()}');"
+        f"console.log(JSON.stringify(_extractQuoteMeta({json.dumps(html)})));"
+    )
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_us_gmail_attribution_with_weekday_extracts_sender_and_date():
+    meta = _meta("On Mon, Apr 18, 2026 at 9:31 AM, Jane Doe &lt;jane@example.com&gt; wrote:")
+    # date is clamped to 28 chars by the helper; sender must be present.
+    assert meta.startswith("Jane Doe jane@example.com")
+    assert "Mon, Apr 18, 2026" in meta
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_gmail_attribution_without_time_extracts_sender():
+    meta = _meta("On Wed, Jan 1, 2025, Jane wrote:")
+    assert meta == "Jane · Wed, Jan 1, 2025"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_previously_working_formats_still_match():
+    # No weekday (single comma before the year).
+    meta = _meta("On Apr 18, 2026 at 9:31 AM, Jane Doe wrote:")
+    assert meta.startswith("Jane Doe · Apr 18, 2026")
+    # UK/intl day-before-month order.
+    meta = _meta("On Mon, 18 Apr 2026 at 09:31, Jane Doe &lt;jane@example.com&gt; wrote:")
+    assert meta.startswith("Jane Doe jane@example.com")


### PR DESCRIPTION
## The bug

`_extractQuoteMeta` in static/js/emailLibrary/signatureFold.js falls back to the Gmail-style attribution line when there is no Outlook From:/Sent: header:

```js
/On\s+([^,]+?,[^,]+?\d{4}[^,]*),?\s+(.+?)\s+wrote\s*:/i
```

The date group permits only ONE comma before the 4-digit year. The standard US-English Gmail attribution has TWO (after the weekday and after the day-of-month):

```
On Mon, Apr 18, 2026 at 9:31 AM, Jane Doe <jane@example.com> wrote:
```

so the match fails for the most common Gmail reply format, and the collapsed "Earlier thread" / "Earlier reply" fold (built via `_foldSummary` in static/js/emailLibrary.js, and the reply-fold path through `_extractTurnMetaFromBlockquote`) renders without its sender/date headline.

Also failing before this fix: `On Wed, Jan 1, 2025, Jane wrote:` and `On Tuesday, December 3, 2024 9:00 AM Bob wrote:`.

## The fix

The date group now tolerates up to three commas before the year:

```js
/On\s+((?:[^,]*,){0,3}?[^,]*?\d{4}[^,]*),?\s+(.+?)\s+wrote\s*:/i
```

The lazy `{0,3}?` keeps the split between date and sender stable. Verified with node against the previously-working formats too, which are unchanged:
- `On Apr 18, 2026 at 9:31 AM, Jane Doe wrote:` (no weekday)
- `On Mon, 18 Apr 2026 at 09:31, Jane Doe <jane@example.com> wrote:` (UK day-before-month)

## Test

tests/test_gmail_quote_attribution_js.py drives the real module through `node --input-type=module` (same harness as test_hex_to_rgb_js.py). It fails on the old regex (empty meta for the US Gmail format) and passes on the fix, including the two previously-working formats as non-regression cases.

Note: does not textually conflict with #1655, which guards the function's input type in a separate hunk.