### PR TITLE
fix: is_low_quality lets non-string summaries through instead of filtering them

### DIFF
--- a/src/research_utils.py
+++ b/src/research_utils.py
@@ -55,7 +55,7 @@ LOW_QUALITY_MARKERS = [
 def is_low_quality(summary: str) -> bool:
     """Check if a finding summary indicates useless or irrelevant content."""
     try:
-        if not summary:
+        if not isinstance(summary, str) or not summary:
             return True
         low = summary.lower()
         return any(marker in low for marker in LOW_QUALITY_MARKERS)

--- a/tests/test_research_utils_low_quality_nonstring.py
+++ b/tests/test_research_utils_low_quality_nonstring.py
@@ -1,0 +1,16 @@
+from src.research_utils import is_low_quality
+
+
+def test_is_low_quality_treats_non_string_as_low_quality():
+    # Old code reached summary.lower(), hit AttributeError, and the bare
+    # except returned False (fail open) so a malformed source slipped through
+    # as "good". A non-string summary has no usable content, so it should be
+    # filtered like an empty one (which already returns True).
+    assert is_low_quality(123) is True
+    assert is_low_quality({"bad": True}) is True
+    assert is_low_quality(["does not contain"]) is True
+
+
+def test_is_low_quality_still_classifies_strings():
+    assert is_low_quality("This page does not contain relevant information") is True
+    assert is_low_quality("Detailed analysis of the 2026 EV market") is False


### PR DESCRIPTION
## Summary
`is_low_quality(summary)` is the source-quality gate for deep research findings. On a non-string summary (a number, dict, or list arriving from malformed/external JSON) the function reached `summary.lower()`, raised AttributeError, and the bare `except` returned False (fail open). So a malformed finding was treated as good and kept as a cited source, while an empty summary (which hits the `if not summary` branch) is correctly dropped. The behaviour was inconsistent.

## Changes
- src/research_utils.py: guard the early return with `isinstance(summary, str)` so a non-string summary is filtered like an empty one instead of slipping through.
- tests/test_research_utils_low_quality_nonstring.py: assert non-string inputs return True and real strings still classify correctly (the non-string case fails on the old fail-open path).