### PR TITLE
fix: personal keyword search crashes on a non-dict index row

### DIFF
--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -134,10 +134,12 @@ def retrieve_personal_keyword(personal_index: List[Dict], query: str, k: int = 5
 
     scored = []
     for f in personal_index:
-        for idx, ch in enumerate(f["chunks"]):
+        if not isinstance(f, dict):
+            continue
+        for idx, ch in enumerate(f.get("chunks") or []):
             score = len(q & tokenize(ch))
             if score > 0:
-                scored.append((score, f["name"], idx, ch))
+                scored.append((score, f.get("name", ""), idx, ch))
     scored.sort(key=lambda x: x[0], reverse=True)
 
     out = []

--- a/tests/test_personal_docs_keyword_nondict.py
+++ b/tests/test_personal_docs_keyword_nondict.py
@@ -1,0 +1,21 @@
+from src.personal_docs import retrieve_personal_keyword
+
+
+def test_retrieve_personal_keyword_skips_non_dict_rows():
+    # A corrupted personal index can hold non-dict rows (partial write, bad
+    # import). The old loop did f["chunks"] which raised TypeError on a str
+    # row and aborted the whole search; now bad rows are skipped.
+    index = [
+        "bad-row",
+        None,
+        ["also", "bad"],
+        {"name": "report.txt", "chunks": ["hello world from the quarterly report"]},
+    ]
+    out = retrieve_personal_keyword(index, "hello", k=5)
+    assert out == ["[report.txt :: chunk 1]\nhello world from the quarterly report"]
+
+
+def test_retrieve_personal_keyword_tolerates_missing_chunks_key():
+    index = [{"name": "empty.txt"}, {"name": "doc.txt", "chunks": ["alpha beta gamma"]}]
+    out = retrieve_personal_keyword(index, "beta", k=5)
+    assert out == ["[doc.txt :: chunk 1]\nalpha beta gamma"]


### PR DESCRIPTION
## Summary
`retrieve_personal_keyword` iterates the loaded personal-document index and does `f["chunks"]` / `f["name"]` on each row. A corrupted or partially-written index (or a bad import) can leave a non-dict row in the list. The old loop raised `TypeError: string indices must be integers` on the first such row and aborted the entire keyword search, so one bad row took out search for every document.

## Changes
- src/personal_docs.py: skip non-dict rows (`if not isinstance(f, dict): continue`) and read `chunks`/`name` via `.get()` so a missing key degrades gracefully instead of raising.
- tests/test_personal_docs_keyword_nondict.py: a mixed index with str/None/list junk rows still returns the real match, and a row missing `chunks` is tolerated (both raise on the old code).