### PR TITLE
Owner-scope the send_to_session agent tool (cross-user session read/write)

### DIFF
--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -517,7 +517,7 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
         return {"error": str(e)}
 
 
-async def do_send_to_session(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_send_to_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Send a message to an existing session and get a response.
 
     Content format:
@@ -538,7 +538,12 @@ async def do_send_to_session(content: str, session_id: Optional[str] = None) -> 
     message = lines[1].strip()
 
     sess = _session_manager.get_session(target_sid)
-    if not sess:
+    # Owner-scope the lookup: an agent acting for `owner` must not read from or
+    # write into another user's session. Return the same "not found" message
+    # whether the session is missing or owned by someone else, so a caller can't
+    # probe which ids exist. `owner` is None on single-user / no-auth installs,
+    # where the guard is a no-op (behavior unchanged). Mirrors do_manage_session.
+    if not sess or (owner is not None and getattr(sess, "owner", None) != owner):
         return {"error": f"Session '{target_sid}' not found"}
 
     if not message:
@@ -1769,7 +1774,7 @@ async def dispatch_ai_tool(
     elif tool == "send_to_session":
         sid = content.split("\n")[0].strip()[:20]
         desc = f"send_to_session: {sid}"
-        result = await do_send_to_session(content, session_id)
+        result = await do_send_to_session(content, session_id, owner=owner)
 
     elif tool == "pipeline":
         desc = "pipeline: running steps"

--- a/tests/test_send_to_session_owner_scope.py
+++ b/tests/test_send_to_session_owner_scope.py
@@ -1,0 +1,91 @@
+"""Regression guard for #1616 — the send_to_session agent tool must be owner-scoped.
+
+`do_send_to_session` resolved any session id via `_session_manager.get_session()`
+with no ownership check, then read its history and appended messages. The agent
+dispatcher also did not pass `owner=` (every sibling session tool does). Together,
+an agent acting for user A could read from and write into user B's session.
+
+The fix threads `owner` through `dispatch_ai_tool` and rejects a session owned by
+someone else — returning the same "not found" message so ids can't be probed.
+`owner=None` (single-user / no-auth installs) is a no-op, preserving behavior.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+
+import src.ai_interaction as ai
+
+
+class _StubSession:
+    def __init__(self, owner):
+        self.owner = owner
+        self.name = "target"
+        self.endpoint_url = "http://x"
+        self.model = "m"
+        self.headers = {}
+        self.added = []
+
+    def get_context_messages(self):
+        return []
+
+    def add_message(self, msg):
+        self.added.append(msg)
+
+
+class _StubManager:
+    def __init__(self, session):
+        self._session = session
+
+    def get_session(self, sid):
+        return self._session
+
+
+def _patch(monkeypatch, session):
+    async def _fake_llm(*args, **kwargs):
+        return "assistant reply"
+
+    # do_send_to_session does `from src.llm_core import llm_call_async` at call
+    # time, so patching the attribute on the module is sufficient.
+    monkeypatch.setattr("src.llm_core.llm_call_async", _fake_llm)
+    monkeypatch.setattr(ai, "_session_manager", _StubManager(session))
+    return session
+
+
+async def test_dispatch_rejects_cross_owner(monkeypatch):
+    # Drives the full dispatcher path: catches BOTH the missing `owner=` at
+    # dispatch and the missing ownership guard inside do_send_to_session.
+    sess = _patch(monkeypatch, _StubSession(owner="bob"))
+    desc, result = await ai.dispatch_ai_tool(
+        "send_to_session", "sid123\nhello", None, owner="alice"
+    )
+    assert "error" in result, "alice must not reach bob's session via the agent tool"
+    assert "not found" in result["error"].lower()
+    assert sess.added == [], "no message may be written into another owner's session"
+
+
+async def test_allows_same_owner(monkeypatch):
+    sess = _patch(monkeypatch, _StubSession(owner="alice"))
+    result = await ai.do_send_to_session("sid123\nhello", owner="alice")
+    assert "error" not in result, result
+    assert result["response"] == "assistant reply"
+    assert len(sess.added) == 2  # user + assistant both persisted
+
+
+async def test_rejects_legacy_null_owner_for_named_caller(monkeypatch):
+    # Strict (mirrors do_manage_session): a named user cannot target a
+    # legacy/shared owner=None session through this tool.
+    sess = _patch(monkeypatch, _StubSession(owner=None))
+    result = await ai.do_send_to_session("sid123\nhello", owner="alice")
+    assert "error" in result
+    assert sess.added == []
+
+
+async def test_owner_none_is_noop_for_single_user(monkeypatch):
+    # No-auth / single-user installs pass owner=None -> guard skipped ->
+    # behavior unchanged even when the session carries an owner.
+    sess = _patch(monkeypatch, _StubSession(owner="bob"))
+    result = await ai.do_send_to_session("sid123\nhello", owner=None)
+    assert "error" not in result, result
+    assert len(sess.added) == 2


### PR DESCRIPTION
## What & why

The `send_to_session` agent tool was not owner-scoped. Two gaps:

1. `dispatch_ai_tool` called `do_send_to_session(content, session_id)` **without** `owner=` — every sibling session/memory tool (`do_create_session`, `do_list_sessions`, `do_manage_session`, `do_manage_memory`) passes it.
2. `do_send_to_session` resolved the target via `_session_manager.get_session(target_sid)` with **no ownership check**, then read the session's history and appended a user + assistant message to it.

Together, an agent acting for user A could **read from and write into user B's session**. The target id comes from model-supplied tool content (injectable via untrusted context the agent ingests, or simply guessed — AI-created session ids are `str(uuid.uuid4())[:8]`, 8 hex chars).

## Fix

- Thread `owner` into `do_send_to_session` and pass `owner=owner` at dispatch.
- After resolving the session, reject when it's owned by someone else — returning the same `"not found"` message so a caller can't probe which ids exist. Mirrors the existing `do_manage_session` owner filter.

```python
sess = _session_manager.get_session(target_sid)
if not sess or (owner is not None and getattr(sess, "owner", None) != owner):
    return {"error": f"Session '{target_sid}' not found"}
```

## Compatibility — no migration required

No schema or data change; the `owner` column already exists.

- **Single-user / no-auth installs**: `owner` is `None`, so the guard is skipped — behavior unchanged.
- **Multi-user installs**: access tightens to the calling owner, consistent with `do_manage_session`. Legacy/shared sessions (`owner IS NULL`) are treated strictly — a named user can't target them through this tool, the same as the sibling session tools already behave.

## Tests

`tests/test_send_to_session_owner_scope.py`:

- `test_dispatch_rejects_cross_owner` — drives the full `dispatch_ai_tool` path, so it catches **both** halves of the bug (owner dropped at dispatch + no guard). Fails on `main`, passes here; asserts no message is written to the other owner's session.
- `test_allows_same_owner` — owner match proceeds and persists both turns.
- `test_rejects_legacy_null_owner_for_named_caller` — strict null/legacy handling.
- `test_owner_none_is_noop_for_single_user` — confirms the single-user no-op.

All 4 pass.

Fixes #1616
