### PR TITLE
fix: extract_memory_from_chat crashes on bullet lines (services.memory copy)

### DIFF
--- a/services/memory/memory.py
+++ b/services/memory/memory.py
@@ -59,8 +59,12 @@ class MemoryManager:
                     line = line.strip()
                     # Look for bullet points or numbered lists that might contain memories
                     if re.match(r'^[-*•]|\d+\.', line):
-                        # Extract the text after the bullet/number
-                        text_match = re.match(r'^[-*•]|\d+\.\s*(.*)', line)
+                        # Extract the text after the bullet/number. Group both
+                        # markers so the capture applies to either. The previous
+                        # `^[-*•]|\d+\.\s*(.*)` put the group on the numbered
+                        # branch only, so a bullet line matched with group(1)=None
+                        # and crashed on .strip().
+                        text_match = re.match(r'^(?:[-*•]|\d+\.)\s*(.*)', line)
                         if text_match:
                             text = text_match.group(1).strip()
                             if text:

--- a/tests/test_memory_bullet_extraction.py
+++ b/tests/test_memory_bullet_extraction.py
@@ -7,12 +7,22 @@ capture group lives only in the numbered-list branch. A bullet line ("- ...")
 matches the first branch, so ``group(1)`` is ``None`` and ``.strip()`` raised
 ``AttributeError``, crashing extraction for any assistant message that contains
 a bullet list (the dominant case).
+
+There are two copies of ``MemoryManager``: ``src.memory`` and the
+``services.memory`` package that ``routes/memory_routes.py`` actually imports.
+The fix first landed only in ``src.memory`` while the live route path kept the
+broken copy, and this test imported ``src.memory`` so it stayed green. It now
+exercises both copies so the two cannot drift back apart.
 """
-from src.memory import MemoryManager
+import pytest
+
+from src.memory import MemoryManager as SrcMemoryManager
+from services.memory.memory import MemoryManager as ServiceMemoryManager
 
 
-def test_extract_memory_from_chat_handles_bullets(tmp_path):
-    mgr = MemoryManager(str(tmp_path))
+@pytest.mark.parametrize("manager_cls", [SrcMemoryManager, ServiceMemoryManager])
+def test_extract_memory_from_chat_handles_bullets(manager_cls, tmp_path):
+    mgr = manager_cls(str(tmp_path))
     chat = [{
         "role": "assistant",
         "content": "- User likes coffee\n* Prefers tea in winter\n1. Wakes at 6am",


### PR DESCRIPTION
## What

`extract_memory_from_chat` (the fallback memory extractor) crashes with `AttributeError: 'NoneType' object has no attribute 'strip'` on any bullet line (`-`, `*`, `•`).

## Why

The extraction did:

```python
text_match = re.match(r'^[-*•]|\d+\.\s*(.*)', line)
...
text = text_match.group(1).strip()
```

`|` has the lowest precedence, so the pattern parses as `(^[-*•]) | (\d+\.\s*(.*))`. The capture group only exists on the numbered-list branch. A bullet line matches the first branch, so `group(1)` is `None` and `.strip()` raises.

This is the **same bug already fixed in `src/memory.py`** (the fix comment there documents it). The two `MemoryManager` copies drifted: `routes/memory_routes.py` imports the `services.memory` copy in its LLM-failure fallback (the `except` branch of the memory-extraction endpoint), so the live path was still broken. The existing regression test `tests/test_memory_bullet_extraction.py` only imported `src.memory`, so CI stayed green while the route's copy kept crashing.

Numbered lines (`1.`) happened to work; bullet lists (the dominant shape of assistant output) crashed.

## Reproduce

```python
import tempfile
from services.memory.memory import MemoryManager

MemoryManager(tempfile.mkdtemp()).extract_memory_from_chat(
    [{"role": "assistant", "content": "- User likes coffee"}]
)
# AttributeError: 'NoneType' object has no attribute 'strip'
```

## Fix

- Group the alternation: `^(?:[-*•]|\d+\.)\s*(.*)` in `services/memory/memory.py` (identical to the existing `src/memory.py` fix; the two copies are now byte-identical on this line).
- Parametrize the existing regression test over **both** `MemoryManager` copies so the drift cannot silently return.

## Test

```
$ pytest tests/test_memory_bullet_extraction.py -v
test_extract_memory_from_chat_handles_bullets[MemoryManager0] PASSED   # src.memory
test_extract_memory_from_chat_handles_bullets[MemoryManager1] PASSED   # services.memory (was AttributeError before this fix)
```

> Follow-up (out of scope): the two `MemoryManager` implementations (`src.memory` and `services.memory`) are near-duplicates that have already drifted once. De-duplicating them would prevent this whole class of "fixed in one copy only" bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
