### PR TITLE
fix: youtube comment formatter crashes on a non-dict comment entry

### DIFF
--- a/src/youtube_handler.py
+++ b/src/youtube_handler.py
@@ -263,6 +263,8 @@ def format_comments_for_context(comments_data: Dict[str, Any], url: str) -> str:
     ctx += f"URL: {url}\n\n"
 
     for i, c in enumerate(comments, 1):
+        if not isinstance(c, dict):
+            continue
         likes = c.get("likes", 0)
         likes_str = f" [{likes} likes]" if likes else ""
         ctx += f"{i}. @{c['author']}{likes_str}: {c['text']}\n\n"

--- a/tests/test_youtube_comments_nondict.py
+++ b/tests/test_youtube_comments_nondict.py
@@ -1,0 +1,17 @@
+from src.youtube_handler import format_comments_for_context
+
+
+def test_format_comments_skips_non_dict_entries():
+    # The comments list comes from json.loads of yt-dlp output; a malformed
+    # entry (None or a bare string) made the old loop call .get on a non-dict
+    # and crash, losing every well-formed comment in the same batch.
+    data = {"success": True, "comments": [
+        {"author": "alice", "text": "great video", "likes": 10},
+        "junk-row",
+        None,
+        {"author": "bob", "text": "agreed", "likes": 2},
+    ]}
+    out = format_comments_for_context(data, "https://youtu.be/x")
+    assert "@alice" in out
+    assert "@bob" in out
+    assert "junk-row" not in out


### PR DESCRIPTION
## Summary
`format_comments_for_context` iterates the comment list and calls `c.get("likes")` / `c['author']` on each entry. That list ultimately comes from `json.loads` of yt-dlp's output, so a malformed or partial response can put a non-dict (None or a bare string) in the list. The old loop then raised `AttributeError: 'str' object has no attribute 'get'` and lost every well-formed comment in the same batch.

## Changes
- src/youtube_handler.py: skip non-dict comment entries (`if not isinstance(c, dict): continue`) so one malformed entry no longer aborts formatting the rest.
- tests/test_youtube_comments_nondict.py: a comment list mixing valid dicts with a string and None still formats both real comments (raises on the old code).