### PR TITLE
fix: extract_youtube_id crashes on a non-string url instead of returning None

### DIFF
--- a/services/youtube/youtube_handler.py
+++ b/services/youtube/youtube_handler.py
@@ -64,6 +64,8 @@ def is_youtube_url(url: str) -> bool:
 
 def extract_youtube_id(url: str) -> Optional[str]:
     """Extract YouTube video ID from various URL formats."""
+    if not isinstance(url, str):
+        return None
     parsed = urllib.parse.urlparse(url)
     if parsed.hostname in ("www.youtube.com", "youtube.com", "m.youtube.com"):
         if parsed.path == "/watch":

--- a/tests/test_youtube_extract_id_nonstring.py
+++ b/tests/test_youtube_extract_id_nonstring.py
@@ -1,0 +1,15 @@
+from services.youtube.youtube_handler import extract_youtube_id
+
+
+def test_extract_youtube_id_handles_non_string_url():
+    # urllib.parse.urlparse raises AttributeError on a non-string, so a non-str
+    # url (e.g. from a JSON-decoded request body) crashed the extractor instead
+    # of being treated as "not a YouTube URL".
+    assert extract_youtube_id(123) is None
+    assert extract_youtube_id({"bad": 1}) is None
+    assert extract_youtube_id(["https://youtu.be/x"]) is None
+
+
+def test_extract_youtube_id_still_parses_real_urls():
+    assert extract_youtube_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+    assert extract_youtube_id("https://www.youtube.com/watch?v=abc123") == "abc123"


### PR DESCRIPTION
## Summary
`extract_youtube_id` passes `url` straight to `urllib.parse.urlparse`, which raises `AttributeError: 'int' object has no attribute 'decode'` on a non-string value. A url arriving from a JSON-decoded request body or stored metadata could be a non-string, crashing the extractor instead of simply being treated as "not a YouTube URL".

## Changes
- services/youtube/youtube_handler.py: return None for a non-string url before calling urlparse.
- tests/test_youtube_extract_id_nonstring.py: non-string inputs return None (they raise on the old code) and real watch/youtu.be URLs still resolve to the video id.