### PR TITLE
fix: memory entry validation crashes on a non-dict row from memory.json

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -135,6 +135,8 @@ class MemoryManager:
         """Ensure all entries have required fields."""
         validated = []
         for entry in entries:
+            if not isinstance(entry, dict):
+                continue
             if "id" not in entry:
                 entry["id"] = str(uuid.uuid4())
             if "timestamp" not in entry:

--- a/tests/test_memory_validate_entries_nondict.py
+++ b/tests/test_memory_validate_entries_nondict.py
@@ -1,0 +1,19 @@
+from src.memory import MemoryManager
+
+
+def test_validate_entries_skips_non_dict_rows(tmp_path):
+    # Entries come from json.load on the user-editable memory.json. A hand-edit
+    # that drops a bare string / number / null into the array made the old loop
+    # do item assignment on a non-dict and raise TypeError, losing the whole
+    # memory store. Bad rows are now skipped.
+    m = MemoryManager(str(tmp_path))
+    out = m._validate_entries([
+        {"id": "a", "text": "real memory"},
+        "corrupt-row",
+        None,
+        123,
+    ])
+    assert [e["id"] for e in out] == ["a"]
+    # the surviving entry is still backfilled with required defaults
+    assert out[0]["category"] == "fact"
+    assert out[0]["source"] == "unknown"


### PR DESCRIPTION
## Summary
`MemoryManager._validate_entries` iterates entries loaded from the user-editable `memory.json` and does item assignment (`entry["id"] = ...`) to backfill missing fields. A hand-edit (or partial write) that leaves a bare string, number, or null in the array made the loop raise `TypeError` (`argument of type 'int' is not iterable` on the membership check, or `'str' object does not support item assignment`), taking out the entire memory store rather than dropping the one bad row.

## Changes
- src/memory.py: skip non-dict entries (`if not isinstance(entry, dict): continue`) before backfilling required fields.
- tests/test_memory_validate_entries_nondict.py: an entry list mixing a valid dict with a string, None, and an int returns just the valid entry (still backfilled with defaults); raises on the old code.