### PR TITLE
fix: convert text-only emoji at render time (no streaming flash)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -14,6 +14,7 @@ import compareModule from './js/compare/index.js';
 import documentModule from './js/document.js';
 import searchChatModule from './js/search-chat.js';
 import markdownModule from './js/markdown.js';
+import { emojiToText } from './js/emojiText.js';
 import chatRenderer from './js/chatRenderer.js';
 import sessionModule from './js/sessions.js';
 import memoryModule from './js/memory.js';
@@ -2495,117 +2496,10 @@ function initializeEventListeners() {
   syncRearrangeChecks();
 
   // ── Text-only emoji conversion ──
-  // Regex matching most emoji codepoints (Emoji_Presentation + common sequences)
-  const EMOJI_RE = /(?:\p{Emoji_Presentation}|\p{Extended_Pictographic})(?:\uFE0F|\u200D(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}))*/gu;
-
-  // Common emoji → text description map
-  const EMOJI_MAP = {
-    '😀':'grinning','😃':'smiley','😄':'smile','😁':'grin','😆':'laughing','😅':'sweat smile',
-    '🤣':'rofl','😂':'joy','🙂':'slightly smiling','🙃':'upside down','😉':'wink',
-    '😊':'blush','😇':'innocent','🥰':'smiling hearts','😍':'heart eyes','🤩':'star struck',
-    '😘':'kissing heart','😗':'kissing','😚':'kissing closed eyes','😙':'kissing smiling eyes',
-    '🥲':'smiling tear','😋':'yum','😛':'tongue','😜':'winking tongue','🤪':'zany',
-    '😝':'squinting tongue','🤑':'money mouth','🤗':'hugging','🤭':'hand over mouth',
-    '🤫':'shushing','🤔':'thinking','🫡':'saluting','🤐':'zipper mouth','🤨':'raised eyebrow',
-    '😐':'neutral','😑':'expressionless','😶':'no mouth','🫥':'dotted line face',
-    '😏':'smirk','😒':'unamused','🙄':'eye roll','😬':'grimacing','🤥':'lying',
-    '😌':'relieved','😔':'pensive','😪':'sleepy','🤤':'drooling','😴':'sleeping',
-    '😷':'mask','🤒':'thermometer','🤕':'head bandage','🤢':'nauseated','🤮':'vomiting',
-    '🥵':'hot','🥶':'cold','🥴':'woozy','😵':'dizzy','🤯':'exploding head',
-    '🤠':'cowboy','🥳':'party','🥸':'disguised','😎':'sunglasses','🤓':'nerd',
-    '🧐':'monocle','😕':'confused','🫤':'diagonal mouth','😟':'worried','🙁':'slightly frowning',
-    '😮':'open mouth','😯':'hushed','😲':'astonished','😳':'flushed','🥺':'pleading',
-    '🥹':'holding back tears','😦':'frowning open mouth','😧':'anguished','😨':'fearful',
-    '😰':'anxious sweat','😥':'sad relieved','😢':'crying','😭':'sobbing','😱':'screaming',
-    '😖':'confounded','😣':'persevering','😞':'disappointed','😓':'downcast sweat',
-    '😩':'weary','😫':'tired','🥱':'yawning','😤':'triumph','😡':'pouting',
-    '😠':'angry','🤬':'swearing','😈':'smiling devil','👿':'angry devil',
-    '💀':'skull','☠️':'skull crossbones','💩':'poop','🤡':'clown','👹':'ogre','👺':'goblin',
-    '👻':'ghost','👽':'alien','👾':'space invader','🤖':'robot',
-    '😺':'smiling cat','😸':'grinning cat','😹':'tears of joy cat','😻':'heart eyes cat',
-    '😼':'wry cat','😽':'kissing cat','🙀':'weary cat','😿':'crying cat','😾':'pouting cat',
-    '🙈':'see no evil','🙉':'hear no evil','🙊':'speak no evil',
-    '👋':'wave','🤚':'raised back of hand','🖐️':'hand with fingers splayed','✋':'raised hand',
-    '🖖':'vulcan salute','🫱':'rightward hand','🫲':'leftward hand',
-    '👌':'ok hand','🤌':'pinched fingers','🤏':'pinching hand','✌️':'victory',
-    '🤞':'crossed fingers','🫰':'hand with index finger and thumb crossed',
-    '🤟':'love you','🤘':'rock on','🤙':'call me','👈':'point left','👉':'point right',
-    '👆':'point up','🖕':'middle finger','👇':'point down','☝️':'index up',
-    '🫵':'point at viewer','👍':'thumbs up','👎':'thumbs down','✊':'raised fist',
-    '👊':'fist bump','🤛':'left fist','🤜':'right fist','👏':'clap','🙌':'raising hands',
-    '🫶':'heart hands','👐':'open hands','🤲':'palms up','🤝':'handshake','🙏':'pray',
-    '✍️':'writing','💅':'nail polish','🤳':'selfie','💪':'flexed biceps',
-    '❤️':'red heart','🧡':'orange heart','💛':'yellow heart','💚':'green heart',
-    '💙':'blue heart','💜':'purple heart','🖤':'black heart','🤍':'white heart',
-    '🩷':'pink heart','🩵':'light blue heart','🩶':'grey heart','🤎':'brown heart',
-    '💔':'broken heart','❤️‍🔥':'heart on fire','❤️‍🩹':'mending heart',
-    '💕':'two hearts','💞':'revolving hearts','💓':'heartbeat','💗':'growing heart',
-    '💖':'sparkling heart','💘':'heart with arrow','💝':'heart with ribbon',
-    '💟':'heart decoration','🔥':'fire','💯':'100','✨':'sparkles','⭐':'star',
-    '🌟':'glowing star','💫':'dizzy star','🎉':'party popper','🎊':'confetti ball',
-    '🎈':'balloon','🎁':'gift','🏆':'trophy','🥇':'1st place','🥈':'2nd place','🥉':'3rd place',
-    '⚡':'zap','💡':'light bulb','🔑':'key','🔒':'locked','🔓':'unlocked',
-    '🔔':'bell','🔕':'bell off','📢':'loudspeaker','📣':'megaphone',
-    '💬':'speech bubble','💭':'thought bubble','🗯️':'anger bubble',
-    '✅':'check mark','❌':'cross mark','❓':'question','❗':'exclamation',
-    '⚠️':'warning','🚫':'prohibited','⛔':'no entry','🔴':'red circle','🟢':'green circle',
-    '🔵':'blue circle','🟡':'yellow circle','⚪':'white circle','⚫':'black circle',
-    '🟠':'orange circle','🟣':'purple circle','🟤':'brown circle',
-    '📁':'folder','📂':'open folder','📄':'document','📝':'memo','📎':'paperclip',
-    '📌':'pin','📍':'round pin','🔗':'link','📊':'bar chart','📈':'chart up','📉':'chart down',
-    '🔍':'magnifying glass left','🔎':'magnifying glass right',
-    '🌐':'globe','🌍':'globe europe','🌎':'globe americas','🌏':'globe asia',
-    '🕐':'clock 1','🕑':'clock 2','🕒':'clock 3','🕓':'clock 4',
-    '⏰':'alarm clock','⏳':'hourglass flowing','⌛':'hourglass done',
-    '🚀':'rocket','✈️':'airplane','🚗':'car','🚂':'train','🚢':'ship',
-    '🏠':'house','🏢':'building','🏗️':'construction','🏭':'factory',
-    '🎵':'musical note','🎶':'musical notes','🎤':'microphone','🎧':'headphones',
-    '📷':'camera','📸':'camera flash','🎬':'clapperboard','📺':'television',
-    '💻':'laptop','🖥️':'desktop','📱':'mobile phone','☎️':'telephone',
-    '🔧':'wrench','🔨':'hammer','⚙️':'gear','🧲':'magnet','🧪':'test tube','🔬':'microscope',
-    '📚':'books','📖':'open book','✏️':'pencil','🖊️':'pen','🖋️':'fountain pen',
-    '🎯':'bullseye','♟️':'chess pawn','🎲':'game die','🧩':'puzzle piece',
-    '🍕':'pizza','🍔':'burger','🍟':'fries','🌮':'taco','🍣':'sushi','🍩':'donut',
-    '☕':'coffee','🍺':'beer','🍷':'wine','🥤':'cup with straw',
-    '🐶':'dog','🐱':'cat','🐭':'mouse','🐹':'hamster','🐰':'rabbit','🦊':'fox',
-    '🐻':'bear','🐼':'panda','🐨':'koala','🐯':'tiger','🦁':'lion','🐮':'cow',
-    '🐷':'pig','🐸':'frog','🐵':'monkey','🐔':'chicken','🐧':'penguin','🐦':'bird',
-    '🦅':'eagle','🦆':'duck','🦉':'owl','🐺':'wolf','🐗':'boar','🐴':'horse',
-    '🦄':'unicorn','🐝':'bee','🐛':'bug','🦋':'butterfly','🐌':'snail','🐞':'ladybug',
-    '🐍':'snake','🐢':'turtle','🐙':'octopus','🦀':'crab','🐠':'tropical fish',
-    '🐳':'whale','🐋':'whale','🦈':'shark','🐊':'crocodile','🦕':'sauropod','🦖':'t-rex',
-    '🌸':'cherry blossom','🌹':'rose','🌻':'sunflower','🌺':'hibiscus','🌷':'tulip',
-    '🌱':'seedling','🌲':'evergreen tree','🌳':'deciduous tree','🍀':'four leaf clover',
-    '🍎':'red apple','🍐':'pear','🍊':'tangerine','🍋':'lemon','🍌':'banana',
-    '🍉':'watermelon','🍇':'grapes','🍓':'strawberry','🫐':'blueberries','🍑':'peach',
-    '🌈':'rainbow','☀️':'sun','🌤️':'sun behind cloud','⛅':'sun behind cloud','☁️':'cloud',
-    '🌧️':'rain','⛈️':'thunder','❄️':'snowflake','🌊':'wave',
-    '👀':'eyes','👁️':'eye','👂':'ear','👃':'nose','👄':'mouth','👅':'tongue',
-    '🧠':'brain','🦴':'bone','🦷':'tooth','👶':'baby','🧒':'child','👦':'boy','👧':'girl',
-    '🧑':'person','👨':'man','👩':'woman','🧓':'older person',
-    '👮':'police officer','🧑‍💻':'technologist','👨‍💻':'man technologist',
-    '👩‍💻':'woman technologist',
-    '🎓':'graduation cap','🧢':'billed cap','👑':'crown','💎':'gem','👓':'glasses','🕶️':'sunglasses',
-    '🩸':'drop of blood','💊':'pill','🩹':'bandage','🧬':'dna','🦠':'microbe',
-    '☢️':'radioactive','☣️':'biohazard','♻️':'recycling',
-    '🏳️':'white flag','🏴':'black flag','🚩':'red flag','🏁':'checkered flag',
-    '➡️':'right arrow','⬅️':'left arrow','⬆️':'up arrow','⬇️':'down arrow',
-    '↗️':'upper right arrow','↘️':'lower right arrow','↙️':'lower left arrow','↖️':'upper left arrow',
-    '↩️':'left curve','↪️':'right curve','🔄':'counterclockwise','🔃':'clockwise',
-    '➕':'plus','➖':'minus','➗':'division','✖️':'multiply','♾️':'infinity',
-    '‼️':'double exclamation','⁉️':'exclamation question',
-    '©️':'copyright','®️':'registered','™️':'trademark',
-  };
-
-  function emojiToText(str) {
-    return str.replace(EMOJI_RE, (match) => {
-      const desc = EMOJI_MAP[match];
-      if (desc) return ':' + desc + ':';
-      // Fallback: use the emoji's Unicode name if available, or skip
-      return ':emoji:';
-    });
-  }
-
+  // EMOJI_RE / EMOJI_MAP / emojiToText live in ./js/emojiText.js, shared with
+  // the markdown renderer (which converts at render time so streamed output is
+  // already text). deEmojify below is the one-shot path that converts
+  // already-rendered messages when the toggle is flipped on.
   const _DEOJ_SKIP = '.sources-section, .thinking-toggle, .memory-used-pill';
 
   /** Walk all text nodes inside an element and replace emojis with text descriptions */
@@ -2623,10 +2517,8 @@ function initializeEventListeners() {
     for (const node of nodes) {
       // Skip UI elements that use unicode symbols as functional icons
       if (node.parentElement && node.parentElement.closest(_DEOJ_SKIP)) continue;
-      if (EMOJI_RE.test(node.textContent)) {
-        EMOJI_RE.lastIndex = 0; // reset regex state
-        node.textContent = emojiToText(node.textContent);
-      }
+      const converted = emojiToText(node.textContent);
+      if (converted !== node.textContent) node.textContent = converted;
     }
   }
 
@@ -2634,21 +2526,12 @@ function initializeEventListeners() {
   function applyTextEmojis(enabled) {
     document.body.classList.toggle('text-emojis', enabled);
     if (enabled) {
+      // One-shot conversion of messages already in the DOM (rendered before the
+      // toggle was on). New/streamed messages are converted at render time by
+      // the markdown renderer, so no live MutationObserver is needed.
       document.querySelectorAll('.msg .body').forEach(deEmojify);
     }
   }
-
-  // Observe chat history for new/changed messages — de-emojify on the fly
-  let _deEmojifyTimer = null;
-  const _chatObs = new MutationObserver(() => {
-    if (!document.body.classList.contains('text-emojis')) return;
-    clearTimeout(_deEmojifyTimer);
-    _deEmojifyTimer = setTimeout(() => {
-      document.querySelectorAll('.msg .body').forEach(deEmojify);
-    }, 150);
-  });
-  const _chatBox = document.getElementById('chat-history');
-  if (_chatBox) _chatObs.observe(_chatBox, { childList: true, subtree: true });
 
   // Migrate old toolbar visibility key if present
   (function migrateOldToolbarVis() {

--- a/static/js/emojiText.js
+++ b/static/js/emojiText.js
@@ -1,0 +1,125 @@
+// static/js/emojiText.js
+//
+// Shared "Text-only Emojis" conversion: maps emoji glyphs to `:description:`
+// text. Used by the markdown renderer (so streamed output is already text — no
+// flash) and by app.js's deEmojify (one-shot conversion of already-rendered
+// messages when the toggle is flipped on).
+
+// Regex matching most emoji codepoints (Emoji_Presentation + common sequences,
+// incl. ZWJ / variation-selector runs).
+//
+// The exported form is intentionally NON-global (`u` only) so callers can use
+// `.test()` safely — a `g` flag makes `.test()` stateful (advances lastIndex)
+// and would desync repeated tests. The replace-all path uses a private global.
+const _EMOJI_PATTERN = '(?:\\p{Emoji_Presentation}|\\p{Extended_Pictographic})(?:\\uFE0F|\\u200D(?:\\p{Emoji_Presentation}|\\p{Extended_Pictographic}))*';
+export const EMOJI_RE = new RegExp(_EMOJI_PATTERN, 'u');
+const _EMOJI_RE_GLOBAL = new RegExp(_EMOJI_PATTERN, 'gu');
+
+// Common emoji → text description map.
+export const EMOJI_MAP = {
+  '😀':'grinning','😃':'smiley','😄':'smile','😁':'grin','😆':'laughing','😅':'sweat smile',
+  '🤣':'rofl','😂':'joy','🙂':'slightly smiling','🙃':'upside down','😉':'wink',
+  '😊':'blush','😇':'innocent','🥰':'smiling hearts','😍':'heart eyes','🤩':'star struck',
+  '😘':'kissing heart','😗':'kissing','😚':'kissing closed eyes','😙':'kissing smiling eyes',
+  '🥲':'smiling tear','😋':'yum','😛':'tongue','😜':'winking tongue','🤪':'zany',
+  '😝':'squinting tongue','🤑':'money mouth','🤗':'hugging','🤭':'hand over mouth',
+  '🤫':'shushing','🤔':'thinking','🫡':'saluting','🤐':'zipper mouth','🤨':'raised eyebrow',
+  '😐':'neutral','😑':'expressionless','😶':'no mouth','🫥':'dotted line face',
+  '😏':'smirk','😒':'unamused','🙄':'eye roll','😬':'grimacing','🤥':'lying',
+  '😌':'relieved','😔':'pensive','😪':'sleepy','🤤':'drooling','😴':'sleeping',
+  '😷':'mask','🤒':'thermometer','🤕':'head bandage','🤢':'nauseated','🤮':'vomiting',
+  '🥵':'hot','🥶':'cold','🥴':'woozy','😵':'dizzy','🤯':'exploding head',
+  '🤠':'cowboy','🥳':'party','🥸':'disguised','😎':'sunglasses','🤓':'nerd',
+  '🧐':'monocle','😕':'confused','🫤':'diagonal mouth','😟':'worried','🙁':'slightly frowning',
+  '😮':'open mouth','😯':'hushed','😲':'astonished','😳':'flushed','🥺':'pleading',
+  '🥹':'holding back tears','😦':'frowning open mouth','😧':'anguished','😨':'fearful',
+  '😰':'anxious sweat','😥':'sad relieved','😢':'crying','😭':'sobbing','😱':'screaming',
+  '😖':'confounded','😣':'persevering','😞':'disappointed','😓':'downcast sweat',
+  '😩':'weary','😫':'tired','🥱':'yawning','😤':'triumph','😡':'pouting',
+  '😠':'angry','🤬':'swearing','😈':'smiling devil','👿':'angry devil',
+  '💀':'skull','☠️':'skull crossbones','💩':'poop','🤡':'clown','👹':'ogre','👺':'goblin',
+  '👻':'ghost','👽':'alien','👾':'space invader','🤖':'robot',
+  '😺':'smiling cat','😸':'grinning cat','😹':'tears of joy cat','😻':'heart eyes cat',
+  '😼':'wry cat','😽':'kissing cat','🙀':'weary cat','😿':'crying cat','😾':'pouting cat',
+  '🙈':'see no evil','🙉':'hear no evil','🙊':'speak no evil',
+  '👋':'wave','🤚':'raised back of hand','🖐️':'hand with fingers splayed','✋':'raised hand',
+  '🖖':'vulcan salute','🫱':'rightward hand','🫲':'leftward hand',
+  '👌':'ok hand','🤌':'pinched fingers','🤏':'pinching hand','✌️':'victory',
+  '🤞':'crossed fingers','🫰':'hand with index finger and thumb crossed',
+  '🤟':'love you','🤘':'rock on','🤙':'call me','👈':'point left','👉':'point right',
+  '👆':'point up','🖕':'middle finger','👇':'point down','☝️':'index up',
+  '🫵':'point at viewer','👍':'thumbs up','👎':'thumbs down','✊':'raised fist',
+  '👊':'fist bump','🤛':'left fist','🤜':'right fist','👏':'clap','🙌':'raising hands',
+  '🫶':'heart hands','👐':'open hands','🤲':'palms up','🤝':'handshake','🙏':'pray',
+  '✍️':'writing','💅':'nail polish','🤳':'selfie','💪':'flexed biceps',
+  '❤️':'red heart','🧡':'orange heart','💛':'yellow heart','💚':'green heart',
+  '💙':'blue heart','💜':'purple heart','🖤':'black heart','🤍':'white heart',
+  '🩷':'pink heart','🩵':'light blue heart','🩶':'grey heart','🤎':'brown heart',
+  '💔':'broken heart','❤️‍🔥':'heart on fire','❤️‍🩹':'mending heart',
+  '💕':'two hearts','💞':'revolving hearts','💓':'heartbeat','💗':'growing heart',
+  '💖':'sparkling heart','💘':'heart with arrow','💝':'heart with ribbon',
+  '💟':'heart decoration','🔥':'fire','💯':'100','✨':'sparkles','⭐':'star',
+  '🌟':'glowing star','💫':'dizzy star','🎉':'party popper','🎊':'confetti ball',
+  '🎈':'balloon','🎁':'gift','🏆':'trophy','🥇':'1st place','🥈':'2nd place','🥉':'3rd place',
+  '⚡':'zap','💡':'light bulb','🔑':'key','🔒':'locked','🔓':'unlocked',
+  '🔔':'bell','🔕':'bell off','📢':'loudspeaker','📣':'megaphone',
+  '💬':'speech bubble','💭':'thought bubble','🗯️':'anger bubble',
+  '✅':'check mark','❌':'cross mark','❓':'question','❗':'exclamation',
+  '⚠️':'warning','🚫':'prohibited','⛔':'no entry','🔴':'red circle','🟢':'green circle',
+  '🔵':'blue circle','🟡':'yellow circle','⚪':'white circle','⚫':'black circle',
+  '🟠':'orange circle','🟣':'purple circle','🟤':'brown circle',
+  '📁':'folder','📂':'open folder','📄':'document','📝':'memo','📎':'paperclip',
+  '📌':'pin','📍':'round pin','🔗':'link','📊':'bar chart','📈':'chart up','📉':'chart down',
+  '🔍':'magnifying glass left','🔎':'magnifying glass right',
+  '🌐':'globe','🌍':'globe europe','🌎':'globe americas','🌏':'globe asia',
+  '🕐':'clock 1','🕑':'clock 2','🕒':'clock 3','🕓':'clock 4',
+  '⏰':'alarm clock','⏳':'hourglass flowing','⌛':'hourglass done',
+  '🚀':'rocket','✈️':'airplane','🚗':'car','🚂':'train','🚢':'ship',
+  '🏠':'house','🏢':'building','🏗️':'construction','🏭':'factory',
+  '🎵':'musical note','🎶':'musical notes','🎤':'microphone','🎧':'headphones',
+  '📷':'camera','📸':'camera flash','🎬':'clapperboard','📺':'television',
+  '💻':'laptop','🖥️':'desktop','📱':'mobile phone','☎️':'telephone',
+  '🔧':'wrench','🔨':'hammer','⚙️':'gear','🧲':'magnet','🧪':'test tube','🔬':'microscope',
+  '📚':'books','📖':'open book','✏️':'pencil','🖊️':'pen','🖋️':'fountain pen',
+  '🎯':'bullseye','♟️':'chess pawn','🎲':'game die','🧩':'puzzle piece',
+  '🍕':'pizza','🍔':'burger','🍟':'fries','🌮':'taco','🍣':'sushi','🍩':'donut',
+  '☕':'coffee','🍺':'beer','🍷':'wine','🥤':'cup with straw',
+  '🐶':'dog','🐱':'cat','🐭':'mouse','🐹':'hamster','🐰':'rabbit','🦊':'fox',
+  '🐻':'bear','🐼':'panda','🐨':'koala','🐯':'tiger','🦁':'lion','🐮':'cow',
+  '🐷':'pig','🐸':'frog','🐵':'monkey','🐔':'chicken','🐧':'penguin','🐦':'bird',
+  '🦅':'eagle','🦆':'duck','🦉':'owl','🐺':'wolf','🐗':'boar','🐴':'horse',
+  '🦄':'unicorn','🐝':'bee','🐛':'bug','🦋':'butterfly','🐌':'snail','🐞':'ladybug',
+  '🐍':'snake','🐢':'turtle','🐙':'octopus','🦀':'crab','🐠':'tropical fish',
+  '🐳':'spouting whale','🐋':'whale','🦈':'shark','🐊':'crocodile','🦕':'sauropod','🦖':'t-rex',
+  '🌸':'cherry blossom','🌹':'rose','🌻':'sunflower','🌺':'hibiscus','🌷':'tulip',
+  '🌱':'seedling','🌲':'evergreen tree','🌳':'deciduous tree','🍀':'four leaf clover',
+  '🍎':'red apple','🍐':'pear','🍊':'tangerine','🍋':'lemon','🍌':'banana',
+  '🍉':'watermelon','🍇':'grapes','🍓':'strawberry','🫐':'blueberries','🍑':'peach',
+  '🌈':'rainbow','☀️':'sun','🌤️':'sun behind cloud','⛅':'sun behind cloud','☁️':'cloud',
+  '🌧️':'rain','⛈️':'thunder','❄️':'snowflake','🌊':'wave',
+  '👀':'eyes','👁️':'eye','👂':'ear','👃':'nose','👄':'mouth','👅':'tongue',
+  '🧠':'brain','🦴':'bone','🦷':'tooth','👶':'baby','🧒':'child','👦':'boy','👧':'girl',
+  '🧑':'person','👨':'man','👩':'woman','🧓':'older person',
+  '👮':'police officer','🧑‍💻':'technologist','👨‍💻':'man technologist',
+  '👩‍💻':'woman technologist',
+  '🎓':'graduation cap','🧢':'billed cap','👑':'crown','💎':'gem','👓':'glasses','🕶️':'sunglasses',
+  '🩸':'drop of blood','💊':'pill','🩹':'bandage','🧬':'dna','🦠':'microbe',
+  '☢️':'radioactive','☣️':'biohazard','♻️':'recycling',
+  '🏳️':'white flag','🏴':'black flag','🚩':'red flag','🏁':'checkered flag',
+  '➡️':'right arrow','⬅️':'left arrow','⬆️':'up arrow','⬇️':'down arrow',
+  '↗️':'upper right arrow','↘️':'lower right arrow','↙️':'lower left arrow','↖️':'upper left arrow',
+  '↩️':'left curve','↪️':'right curve','🔄':'counterclockwise','🔃':'clockwise',
+  '➕':'plus','➖':'minus','➗':'division','✖️':'multiply','♾️':'infinity',
+  '‼️':'double exclamation','⁉️':'exclamation question',
+  '©️':'copyright','®️':'registered','™️':'trademark',
+};
+
+/** Replace emoji glyphs in a string with `:description:` text. */
+export function emojiToText(str) {
+  return str.replace(_EMOJI_RE_GLOBAL, (match) => {
+    const desc = EMOJI_MAP[match];
+    if (desc) return ':' + desc + ':';
+    // Unmapped emoji → generic marker rather than leaving the glyph.
+    return ':emoji:';
+  });
+}

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -6,6 +6,7 @@
 
 import uiModule from './ui.js';
 import { splitTableRow } from './markdown/tableRow.js';
+import { emojiToText, EMOJI_RE } from './emojiText.js';
 
 var escapeHtml = uiModule.esc;
 
@@ -311,7 +312,8 @@ function _svgifyText(text) {
   }
   return out;
 }
-/** When "Text-only Emojis" is on, keep Unicode in HTML so deEmojify() can strip them. */
+/** True when emoji should render as monochrome SVG (default). False when the
+ *  "Text-only Emojis" toggle is on — then emoji are converted to `:text:`. */
 function _useSvgEmoji() {
   return typeof document === 'undefined' || !document.body?.classList.contains('text-emojis');
 }
@@ -330,6 +332,32 @@ export function svgifyEmoji(html) {
     if (codeDepth === 0 && _EMOJI_RE.test(parts[i])) parts[i] = _svgifyText(parts[i]);
   }
   return parts.join('');
+}
+
+/** "Text-only Emojis" mode: replace emoji in rendered HTML with `:text:`,
+ *  skipping <pre>/<code>. Done at render time so streamed output is already
+ *  text — no flash of raw emoji that later gets rewritten. */
+export function textifyEmoji(html) {
+  // Guard with the shared EMOJI_RE (non-global → safe for repeated .test) so it
+  // stays in sync with what emojiToText actually converts.
+  if (!html || !EMOJI_RE.test(html)) return html;
+  const parts = html.split(/(<[^>]*>)/);   // odd indices = tags
+  let codeDepth = 0;
+  for (let i = 0; i < parts.length; i++) {
+    if (i % 2 === 1) {
+      const t = parts[i].toLowerCase();
+      if (/^<(pre|code)[\s>]/.test(t)) codeDepth++;
+      else if (/^<\/(pre|code)\s*>/.test(t)) codeDepth = Math.max(0, codeDepth - 1);
+      continue;
+    }
+    if (codeDepth === 0 && EMOJI_RE.test(parts[i])) parts[i] = emojiToText(parts[i]);
+  }
+  return parts.join('');
+}
+
+/** Emoji-render a rendered HTML string per the active mode (SVG vs text). */
+function _renderEmoji(html) {
+  return _useSvgEmoji() ? svgifyEmoji(html) : textifyEmoji(html);
 }
 /**
  * Generic collapsible section that reuses the thinking-dropdown styling and its
@@ -365,7 +393,7 @@ export function processWithThinking(text) {
     html += mdToHtml(content);
   }
 
-  return _useSvgEmoji() ? svgifyEmoji(html) : html;
+  return _renderEmoji(html);
 }
 
 /**
@@ -625,7 +653,7 @@ export function mdToHtml(src) {
     s = s.replace(`___CODE_BLOCK_${index}___`, block);
   });
 
-  return _useSvgEmoji() ? svgifyEmoji(s) : s;
+  return _renderEmoji(s);
 }
 
 /**


### PR DESCRIPTION
## Summary

With **Text-only Emojis** enabled, emoji flashed (colorful) for the whole streamed response and only flipped to `:description:` once the message settled. Cause: the markdown renderer left emoji as raw Unicode and the conversion was done by a 150ms-debounced `MutationObserver` — during streaming the debounce kept resetting, so the rewrite only fired after the stream stopped.

Fix: convert in the **render path** instead. When the toggle is on, the renderer emits `:description:` directly, so streamed output is already text — no flash, no post-DOM rewrite.

- New shared module `static/js/emojiText.js` (`EMOJI_RE`, `EMOJI_MAP`, `emojiToText`) — was inline in `app.js`, now shared with the renderer.
- `markdown.js`: `textifyEmoji()` (mirrors `svgifyEmoji`, skips `<pre>`/`<code>`); the render paths now pick SVG vs text by mode.
- `app.js`: import the shared module; remove the redundant chat `MutationObserver` + its debounce timer. `deEmojify` stays as the one-shot path that converts messages already in the DOM when the toggle is flipped on.

Named descriptions and the default (on) are unchanged.

## Linked Issue

No existing issue.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

### Files
`static/js/emojiText.js` (new), `static/js/markdown.js`, `static/app.js`.

## How to Test

1. Settings → Appearance → Chat Area → ensure **Text-only Emojis** is on (default).
2. Send a prompt that makes the model reply with emoji (e.g. "reply with a ✅ and a 🚀").
3. While it streams, the reply shows `:check mark:` / `:rocket:` from the first paint — no colorful-emoji flash that later changes.
4. Code blocks keep raw glyphs (conversion skips `<pre>`/`<code>`).
5. Toggle the setting off/on with existing messages on screen — flipping on still converts them (one-shot `deEmojify`).

Checks run: `node --check` on the three changed files. (No JS unit-test runner in the repo; this is a render-path change verified in-browser.)

## Screenshots (UI changes only)

Text rendering only — `:check mark:` now stable during streaming instead of flashing the glyph first.