### PR TITLE
fix: require_privilege 500s on a non-dict privileges blob from auth.json

### DIFF
--- a/src/auth_helpers.py
+++ b/src/auth_helpers.py
@@ -107,6 +107,8 @@ def require_privilege(request: Request, key: str) -> str:
         privs = auth_mgr.get_privileges(user) or {}
     except Exception:
         return user
+    if not isinstance(privs, dict):
+        privs = {}
     # True = permitted; missing key defaults to permitted (unknown privileges
     # fail open — the UI gates display-side).
     if not privs.get(key, True):

--- a/tests/test_auth_require_privilege_nondict.py
+++ b/tests/test_auth_require_privilege_nondict.py
@@ -1,0 +1,36 @@
+import types
+
+import pytest
+
+from src import auth_helpers
+from src.auth_helpers import require_privilege
+
+
+class _Mgr:
+    def __init__(self, privs):
+        self._privs = privs
+
+    def get_privileges(self, user):
+        return self._privs
+
+
+def _request(mgr):
+    state = types.SimpleNamespace(auth_manager=mgr)
+    return types.SimpleNamespace(app=types.SimpleNamespace(state=state))
+
+
+def test_require_privilege_tolerates_non_dict_privileges(monkeypatch):
+    # A corrupt auth.json can make get_privileges return a non-dict (e.g. a
+    # list). The privs.get(...) call sits outside the try, so the old code
+    # raised AttributeError and turned a privilege check into a 500. It should
+    # fall back to the documented fail-open behaviour.
+    monkeypatch.setattr(auth_helpers, "require_user", lambda request: "bob")
+    req = _request(_Mgr(["do_x"]))
+    assert require_privilege(req, "do_x") == "bob"
+
+
+def test_require_privilege_still_blocks_disallowed(monkeypatch):
+    monkeypatch.setattr(auth_helpers, "require_user", lambda request: "bob")
+    req = _request(_Mgr({"do_x": False}))
+    with pytest.raises(Exception):
+        require_privilege(req, "do_x")


### PR DESCRIPTION
## Summary
`require_privilege` reads a user's privilege flags with `privs = auth_mgr.get_privileges(user) or {}` inside a try/except, but the subsequent `privs.get(key, True)` is *outside* that try. If a corrupt `auth.json` makes `get_privileges` return a non-dict (e.g. a list), the `.get` raises `AttributeError` and a routine privilege check becomes an unhandled 500 instead of the documented fail-open behaviour.

## Changes
- src/auth_helpers.py: coerce a non-dict privileges value to `{}` after the try, so an unreadable privileges blob falls open (unknown privilege = permitted) as the surrounding comment already intends.
- tests/test_auth_require_privilege_nondict.py: a list privileges blob no longer raises and returns the user (raises on old code); a real `{key: False}` blob still raises 403.