### PR TITLE
fix(sessions): await DELETE before reloading sidebar session list

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -678,10 +678,11 @@ function createSessionItem(s) {
     } else {
       _forceSidebarOpen();
     }
-    // Fire API and reload in background
-    fetch(`${API_BASE}/api/session/${s.id}`, { method: 'DELETE' })
-      .then(() => loadSessions())
-      .catch(() => loadSessions());
+    // Await API deletion, then reload the authoritative list from the server
+    try {
+      await fetch(`${API_BASE}/api/session/${s.id}`, { method: 'DELETE' });
+    } catch (e) { /* network error — session may still exist server-side */ }
+    await loadSessions();
   });
 
   archiveItem.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- The sidebar delete handler fired the DELETE API call as fire-and-forget, then called `loadSessions()` which re-fetches the session list from the server
- If the server hadn't processed the deletion yet, the session reappeared immediately — the user describes it as "flicking away for a ms but immediately showing up again"
- Fix: `await` the DELETE response before calling `loadSessions()` so the server-side deletion completes first

Fixes #1358

## Test plan
- [ ] Create a chat session and exchange a few messages
- [ ] Delete it from the sidebar dropdown menu
- [ ] Verify it disappears and does **not** reappear
- [ ] Verify deleting the currently-active session works (clears chat area)
- [ ] Verify deleting on mobile closes the sidebar properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)