### PR TITLE
fix: reply-all Cc builder crashes on a non-string To or Cc field

### DIFF
--- a/static/js/emailLibrary/replyRecipients.js
+++ b/static/js/emailLibrary/replyRecipients.js
@@ -20,7 +20,7 @@ export function extractEmail(addr) {
 export function buildReplyAllCc(data, mine) {
   const list = Array.isArray(mine) ? mine : [mine];
   const me = new Set(list.map((a) => (a || '').toLowerCase()).filter(Boolean));
-  const split = (s) => (s || '').split(',').map((x) => x.trim()).filter(Boolean);
+  const split = (s) => (typeof s === 'string' ? s : '').split(',').map((x) => x.trim()).filter(Boolean);
   return [...split(data && data.to), ...split(data && data.cc)]
     .filter((addr) => !me.has(extractEmail(addr)))
     .join(', ');

--- a/tests/test_reply_all_cc_nonstring_js.py
+++ b/tests/test_reply_all_cc_nonstring_js.py
@@ -1,0 +1,40 @@
+"""Pin buildReplyAllCc (static/js/emailLibrary/replyRecipients.js) against a
+non-string To/Cc. Driven through `node --input-type=module`; skips without node.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "emailLibrary" / "replyRecipients.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _cc(data, mine):
+    js = f"""
+    import {{ buildReplyAllCc }} from '{_HELPER.as_posix()}';
+    console.log(JSON.stringify(buildReplyAllCc({json.dumps(data)}, {json.dumps(mine)})));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_build_reply_all_cc_tolerates_non_string_fields():
+    # data.to / data.cc come from a JSON message blob and are not always
+    # strings; the old (s || "").split crashed on a non-string To.
+    out = _cc({"to": 123, "cc": "a@x.com, b@x.com"}, "me@x.com")
+    assert out == "a@x.com, b@x.com"
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_build_reply_all_cc_still_excludes_self():
+    out = _cc({"to": "me@x.com, a@x.com", "cc": ""}, "me@x.com")
+    assert out == "a@x.com"


### PR DESCRIPTION
## Summary
`buildReplyAllCc` splits the original message's To and Cc with `(s || '').split(',')`. The `|| ''` fallback only catches falsy values, so a non-string-but-truthy field (e.g. a numeric or array `to` from a JSON message blob) reaches `.split` and throws `TypeError: (s || "").split is not a function`, breaking the reply-all recipient list entirely.

## Changes
- static/js/emailLibrary/replyRecipients.js: coerce non-strings to '' with `typeof s === 'string' ? s : ''` before splitting.
- tests/test_reply_all_cc_nonstring_js.py: a message with a numeric `to` still builds the Cc from the valid `cc` (throws on the old code), and self-exclusion still works (run via node, skipped when node is absent).