### PR TITLE
fix(chat): clear input field when no model is selected

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -457,6 +457,8 @@ import createResearchSynapse from './researchSynapse.js';
           const ok = await sessionModule.materializePendingSession();
           if (!ok || !sessionModule.getCurrentSessionId()) { _releaseSendFlag(); return; }
         } else {
+          el('message').value = '';
+          if (uiModule.autoResize) uiModule.autoResize(el('message'));
           addMessage('assistant',
             'No chat session active. You can:\n\n' +
             '- Open the model picker in the chat box and pick a model\n' +
@@ -466,6 +468,8 @@ import createResearchSynapse from './researchSynapse.js';
           return;
         }
       } catch (e) {
+        el('message').value = '';
+        if (uiModule.autoResize) uiModule.autoResize(el('message'));
         addMessage('assistant',
           'No chat session active. You can:\n\n' +
           '- Open the model picker in the chat box and pick a model\n' +


### PR DESCRIPTION
## Summary
- When submitting a message without a model/session configured, the error path showed a help message but never cleared the textarea
- The user's text was left stuck in the input field after pressing Enter
- Clears the input and triggers `autoResize` on both the no-default-model path and the catch path

Fixes #1475

## Test plan
- [ ] With no model selected, type a message and press Enter
- [ ] Verify the help message appears AND the input field is cleared
- [ ] Verify normal send (with a model selected) still works
- [ ] Verify slash commands still clear the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)