### PR TITLE
fix: memory recall crashes on a non-dict row from the vector store

### DIFF
--- a/services/memory/service.py
+++ b/services/memory/service.py
@@ -103,6 +103,7 @@ class MemoryService:
                     metadata=r.get("metadata", {}),
                 )
                 for r in results
+                if isinstance(r, dict)
             ]
             return MemorySearchResult(memories=memories, query=query, total=len(memories))
 

--- a/tests/test_memory_recall_nondict_rows.py
+++ b/tests/test_memory_recall_nondict_rows.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from services.memory.service import MemoryService
+
+
+class _FakeVectorStore:
+    """Stands in for MemoryVectorStore.search, which reconstructs rows from a
+    vector index + metadata store. A stale or corrupt index can yield a
+    non-dict row mixed in with the good ones."""
+
+    def search(self, query, k=5):
+        return [
+            {"id": "1", "text": "real memory", "timestamp": 5},
+            "corrupt-row",
+            None,
+        ]
+
+
+def test_recall_skips_non_dict_vector_rows(tmp_path):
+    svc = MemoryService(str(tmp_path))
+    svc.vector_store = _FakeVectorStore()
+    res = asyncio.run(svc.recall("anything"))
+    # old code did r.get(...) on the str/None rows and raised AttributeError,
+    # losing the whole recall; now only the well-formed row survives.
+    assert [m.id for m in res.memories] == ["1"]
+    assert res.total == 1


### PR DESCRIPTION
## Summary
`MemoryService.recall` builds `Memory` objects from `self.vector_store.search(...)` with a comprehension that calls `r.get(...)` on every row. Those rows are reconstructed from a vector index plus a metadata store, so a stale or corrupt index can return a non-dict row (None or a bare string). The old comprehension then raised `AttributeError: 'str' object has no attribute 'get'` and the whole recall failed instead of returning the well-formed matches.

## Changes
- services/memory/service.py: filter the comprehension with `if isinstance(r, dict)` so malformed rows are skipped.
- tests/test_memory_recall_nondict_rows.py: a vector-store result mixing a valid row with a string and None returns just the valid memory (raises on the old code).