### PR TITLE
fix: docs RAG query crashes on a non-dict row from the index

### DIFF
--- a/services/docs/service.py
+++ b/services/docs/service.py
@@ -57,6 +57,7 @@ class DocsService:
                 metadata=r.get("metadata"),
             )
             for r in results
+            if isinstance(r, dict)
         ]
 
     async def index(self, directory: str) -> IndexResult:

--- a/tests/test_docs_query_nondict_rows.py
+++ b/tests/test_docs_query_nondict_rows.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from services.docs.service import DocsService
+
+
+class _FakeRag:
+    """Stands in for RAGManager.search. A corrupt or stale Chroma index can
+    return a non-dict row alongside the well-formed ones."""
+
+    def search(self, query, k=5):
+        return [
+            {"text": "alpha", "source": "a.txt", "score": 0.9},
+            "corrupt-row",
+            None,
+        ]
+
+
+def test_query_skips_non_dict_rag_rows():
+    # Bypass __init__ (it builds a real RAGManager / Chroma client) and inject
+    # a fake search backend.
+    svc = DocsService.__new__(DocsService)
+    svc.rag = _FakeRag()
+    out = asyncio.run(svc.query("anything"))
+    # old code called r.get(...) on the str/None rows and raised AttributeError.
+    assert [c.text for c in out] == ["alpha"]
+    assert out[0].source == "a.txt"


### PR DESCRIPTION
## Summary
`DocsService.query` maps `self.rag.search(...)` results straight into `DocChunk` objects with `r.get(...)` on every row. Those rows come back from the Chroma index, so a corrupt or stale index can return a non-dict row (None or a bare string). The old comprehension then raised `AttributeError` and the whole query failed instead of returning the well-formed chunks.

## Changes
- services/docs/service.py: filter the comprehension with `if isinstance(r, dict)` so malformed rows are skipped.
- tests/test_docs_query_nondict_rows.py: a search result mixing a valid row with a string and None returns just the valid chunk (raises on the old code).