### PR TITLE
fix: research source extraction crashes on a non-dict finding

### DIFF
--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -461,6 +461,8 @@ class ResearchHandler:
         seen = set()
         sources = []
         for f in findings:
+            if not isinstance(f, dict):
+                continue
             url = f.get("url", "")
             title = f.get("title", "") or url
             summary = f.get("summary", "") or f.get("evidence", "")

--- a/tests/test_research_handler_sources_nondict.py
+++ b/tests/test_research_handler_sources_nondict.py
@@ -1,0 +1,15 @@
+from src.research_handler import ResearchHandler
+
+
+def test_extract_sources_skips_non_dict_findings():
+    # findings come from the DeepResearcher result list / cached JSON; a
+    # malformed entry (None or a bare string) made the old loop call .get on a
+    # non-dict and crash, dropping every real source in the set.
+    findings = [
+        {"url": "https://a.com", "title": "A", "summary": "real analysis of the topic"},
+        "junk-row",
+        None,
+        {"url": "https://b.com", "summary": "more genuine detail here"},
+    ]
+    out = ResearchHandler._extract_sources(findings)
+    assert [s["url"] for s in out] == ["https://a.com", "https://b.com"]


### PR DESCRIPTION
## Summary
`ResearchHandler._extract_sources` iterates the findings list and calls `f.get(...)` on each one. Findings come from the DeepResearcher result list (and cached research JSON), so a malformed or partial entry can be a non-dict (None or a bare string). The old loop then raised `AttributeError: 'str' object has no attribute 'get'` and dropped every real source instead of skipping the one bad entry.

## Changes
- src/research_handler.py: skip non-dict findings (`if not isinstance(f, dict): continue`).
- tests/test_research_handler_sources_nondict.py: a findings list mixing valid dicts with a string and None returns both real sources (raises on the old code).