### PR TITLE
fix: _resolve_user_upload_path crashes on a non-dict resolve_upload result

### DIFF
--- a/routes/document_helpers.py
+++ b/routes/document_helpers.py
@@ -152,7 +152,7 @@ def _resolve_user_upload_path(
         owner=owner,
         auth_manager=auth_manager,
     )
-    if not resolved:
+    if not isinstance(resolved, dict) or not resolved:
         return None
     path = resolved.get("path")
     upload_dir = getattr(upload_handler, "upload_dir", None)

--- a/tests/test_resolve_upload_path_nondict.py
+++ b/tests/test_resolve_upload_path_nondict.py
@@ -1,0 +1,23 @@
+from routes.document_helpers import _resolve_user_upload_path
+
+
+class _FakeHandler:
+    upload_dir = "/tmp/uploads"
+
+    def __init__(self, resolved):
+        self._resolved = resolved
+
+    def resolve_upload(self, upload_id, owner=None, auth_manager=None):
+        return self._resolved
+
+
+def test_resolve_user_upload_path_handles_non_dict_resolution():
+    # resolve_upload normally returns a dict or None; a corrupt store could
+    # hand back a list/str, and the old resolved.get(...) then crashed.
+    assert _resolve_user_upload_path(_FakeHandler(["not", "a", "dict"]), "id1", None) is None
+    assert _resolve_user_upload_path(_FakeHandler("oops"), "id1", None) is None
+
+
+def test_resolve_user_upload_path_tolerates_dict_without_path():
+    # a well-formed dict still flows through and returns None when no path
+    assert _resolve_user_upload_path(_FakeHandler({"other": 1}), "id1", None) is None


### PR DESCRIPTION
## Summary
`_resolve_user_upload_path` guards `if not resolved: return None` and then calls `resolved.get("path")`. The falsy check does not catch a truthy non-dict, so if `upload_handler.resolve_upload(...)` ever returns a list or string (corrupt/legacy store), `.get` raises `AttributeError` instead of the function simply resolving to no path.

## Changes
- routes/document_helpers.py: tighten the guard to `if not isinstance(resolved, dict) or not resolved: return None`.
- tests/test_resolve_upload_path_nondict.py: a list/str resolution returns None (raises on the old code), and a dict without a path key still flows through and returns None.