### PR TITLE
fix: computeSnap throws when ctx.otherLayers is not an array

### DIFF
--- a/static/js/editor/snap.js
+++ b/static/js/editor/snap.js
@@ -37,7 +37,8 @@ export function computeSnap(layer, nx, ny, ctx) {
     { y: ch, label: 'canvas-b' },
     { y: ch / 2, label: 'canvas-cy' },
   ];
-  for (const other of ctx.otherLayers) {
+  const otherLayers = Array.isArray(ctx.otherLayers) ? ctx.otherLayers : [];
+  for (const other of otherLayers) {
     if (!other.visible || other.id === layer.id) continue;
     const o = other.offset || { x: 0, y: 0 };
     const ow = other.canvas.width, oh = other.canvas.height;

--- a/tests/test_snap_other_layers_nonarray_js.py
+++ b/tests/test_snap_other_layers_nonarray_js.py
@@ -1,0 +1,44 @@
+"""Pin computeSnap (static/js/editor/snap.js) against a non-array otherLayers.
+Driven through `node --input-type=module`; skips without node.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "editor" / "snap.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _snap(other_layers):
+    js = f"""
+    import {{ computeSnap }} from '{_HELPER.as_posix()}';
+    const layer = {{ id: 'L1', canvas: {{ width: 100, height: 50 }} }};
+    const ctx = {{ zoom: 1, canvasW: 800, canvasH: 600, otherLayers: {json.dumps(other_layers)} }};
+    console.log(JSON.stringify(computeSnap(layer, 10, 10, ctx)));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_compute_snap_tolerates_non_array_other_layers():
+    # ctx.otherLayers should be an array, but during init / error recovery it
+    # can be missing or wrong-typed; the old `for...of` threw on a non-iterable.
+    r = _snap(123)
+    assert r["x"] == 10 and r["y"] == 10 and r["guides"] == []
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_compute_snap_still_snaps_to_a_layer_edge():
+    other = [{"id": "L2", "visible": True, "offset": {"x": 12, "y": 300},
+              "canvas": {"width": 100, "height": 50}}]
+    r = _snap(other)
+    assert r["x"] == 12


### PR DESCRIPTION
## Summary
`computeSnap` iterates `ctx.otherLayers` with a `for...of` loop. That field should be an array of layers, but during editor init or error recovery it can be missing or wrong-typed, and `for...of` on a non-iterable throws `TypeError: ctx.otherLayers is not iterable`, breaking snap-while-dragging entirely.

## Changes
- static/js/editor/snap.js: coerce `ctx.otherLayers` to `[]` when it is not an array before iterating.
- tests/test_snap_other_layers_nonarray_js.py: a non-array otherLayers returns the unsnapped position with no guides (throws on the old code), and snapping to a real layer edge still works (run via node, skipped when node is absent).