### PR TITLE
fix(security): strip API keys from GET /api/search/config response

### DIFF
--- a/services/search/core.py
+++ b/services/search/core.py
@@ -49,9 +49,16 @@ SEARCH_CONFIG: Dict[str, Any] = {
 }
 
 
+_SENSITIVE_KEYS = {"brave_api_key", "google_api_key", "google_pse_key",
+                    "tavily_api_key", "serper_api_key", "api_key"}
+
+
 def get_search_config() -> Dict[str, Any]:
-    """Get current search configuration including active provider info."""
+    """Get current search configuration including active provider info.
+    Sensitive keys (API keys) are stripped from the response."""
     config = SEARCH_CONFIG.copy()
+    for k in _SENSITIVE_KEYS:
+        config.pop(k, None)
     settings = _get_search_settings()
     provider = settings.get("search_provider", "searxng")
     config["active_provider"] = provider


### PR DESCRIPTION
## Summary
- `GET /api/search/config` returned the in-memory search config verbatim, including the decrypted Brave Search API key (and potentially other provider keys)
- Any authenticated (non-admin) user could read billable third-party credentials
- Strips all known sensitive key fields (`brave_api_key`, `google_api_key`, `tavily_api_key`, `serper_api_key`, etc.) from the response
- The existing `has_api_key` boolean is preserved so the UI can still indicate whether a key is configured

Fixes #1661

## Test plan
- [ ] Configure a Brave API key in Settings
- [ ] Call `GET /api/search/config` — verify no `brave_api_key` field in response
- [ ] Verify `has_api_key: true` is still present
- [ ] Verify search still works (the key is only stripped from the config response, not from internal usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)