### PR TITLE
fix(anthropic): clamp temperature to 1.0 maximum for Anthropic API

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -512,11 +512,15 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
             # Convert multimodal content (image_url → image) for Anthropic
             content = _convert_openai_content_to_anthropic(m["content"])
             chat_messages.append({"role": m["role"], "content": content})
+    # Anthropic API only accepts temperature in 0.0–1.0; values above 1.0
+    # return HTTP 400. Clamp silently so presets like "Nietzsche" (1.2) and
+    # the UI slider (0–2) work against Claude models without error.
+    clamped_temp = min(temperature, 1.0) if temperature is not None else temperature
     payload = {
         "model": model,
         "messages": chat_messages,
         "max_tokens": max_tokens if max_tokens and max_tokens > 0 else 4096,
-        "temperature": temperature,
+        "temperature": clamped_temp,
     }
     if system_parts:
         system_text = "\n\n".join(system_parts)

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -512,10 +512,14 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
             # Convert multimodal content (image_url → image) for Anthropic
             content = _convert_openai_content_to_anthropic(m["content"])
             chat_messages.append({"role": m["role"], "content": content})
-    # Anthropic API only accepts temperature in 0.0–1.0; values above 1.0
-    # return HTTP 400. Clamp silently so presets like "Nietzsche" (1.2) and
-    # the UI slider (0–2) work against Claude models without error.
-    clamped_temp = min(temperature, 1.0) if temperature is not None else temperature
+    # Anthropic API only accepts temperature in 0.0–1.0; values outside this
+    # range return HTTP 400. Clamp and warn so presets like "Nietzsche" (1.2)
+    # and the UI slider (0–2) work against Claude models without error.
+    clamped_temp = temperature
+    if temperature is not None:
+        clamped_temp = max(0.0, min(temperature, 1.0))
+        if clamped_temp != temperature:
+            logger.warning("Anthropic temperature clamped from %.2f to %.2f (API accepts 0.0–1.0)", temperature, clamped_temp)
     payload = {
         "model": model,
         "messages": chat_messages,


### PR DESCRIPTION
## Summary
- Anthropic's Messages API only accepts `temperature` in `0.0`–`1.0` and returns HTTP 400 for anything higher
- The shipped "Nietzsche" preset uses `temperature: 1.2` and the UI slider allows `0`–`2`, so this is trivially reachable
- Clamps temperature to `min(temperature, 1.0)` in `_build_anthropic_payload` before building the request

Fixes #1615

## Test plan
- [ ] Set temperature to 1.5 in the UI and chat with a Claude model — should work (clamped to 1.0)
- [ ] Use the "Nietzsche" preset with an Anthropic endpoint — no more 400 error
- [ ] Verify temperature ≤ 1.0 is passed through unchanged
- [ ] Verify other providers (OpenAI, Ollama) still accept temperature > 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)