### PR TITLE
fix: evaluate_turn_regex crashes on a non-string agent_reply

### DIFF
--- a/src/teacher_escalation.py
+++ b/src/teacher_escalation.py
@@ -112,7 +112,7 @@ def evaluate_turn_regex(
                     return ("failure", f"tool result matched error pattern {pat.pattern!r}: {snippet!r}")
 
     # Agent verbally gave up?
-    if agent_reply:
+    if isinstance(agent_reply, str) and agent_reply:
         for pat in _REPLY_GIVE_UP_PATTERNS:
             m = pat.search(agent_reply)
             if m:

--- a/tests/test_teacher_eval_nonstring_reply.py
+++ b/tests/test_teacher_eval_nonstring_reply.py
@@ -1,0 +1,14 @@
+from src.teacher_escalation import evaluate_turn_regex
+
+
+def test_evaluate_turn_regex_tolerates_non_string_reply():
+    # agent_reply is typed str but is the raw LLM turn output; a non-string
+    # (dict / number from a malformed turn) made pat.search(agent_reply) raise
+    # TypeError. The tool_results branch already isinstance-guards its rows.
+    assert evaluate_turn_regex([], 123) == ("ok", None)
+    assert evaluate_turn_regex([], {"text": "I cannot do that"}) == ("ok", None)
+
+
+def test_evaluate_turn_regex_still_flags_give_up_string():
+    status, _ = evaluate_turn_regex([], "I don't have a tool to do that")
+    assert status == "failure"


### PR DESCRIPTION
## Summary
`evaluate_turn_regex` runs the give-up regex patterns with `if agent_reply: ... pat.search(agent_reply)`. The truthiness check does not catch a truthy non-string, so a non-string `agent_reply` (a dict or number from a malformed turn) reaches `pat.search` and raises `TypeError: expected string or bytes-like object`. The tool-results branch in the same function already isinstance-guards its rows, so this one is the inconsistent gap.

## Changes
- src/teacher_escalation.py: guard the give-up scan with `isinstance(agent_reply, str)`.
- tests/test_teacher_eval_nonstring_reply.py: a numeric/dict reply returns ("ok", None) instead of raising (raises on the old code), and a real give-up string is still flagged as a failure.