### PR TITLE
fix: _extract_entities crashes on a non-string query

### DIFF
--- a/services/search/query.py
+++ b/services/search/query.py
@@ -27,6 +27,8 @@ def _detect_question_type(query: str) -> Optional[str]:
 
 def _extract_entities(query: str) -> Dict[str, List[str]]:
     """Lightweight entity extraction: capitalized words and date patterns."""
+    if not isinstance(query, str):
+        return {"names": [], "dates": []}
     entities: Dict[str, List[str]] = {"names": [], "dates": []}
     qtype = _detect_question_type(query)
     cleaned = query

--- a/tests/test_search_query_entities_nonstring.py
+++ b/tests/test_search_query_entities_nonstring.py
@@ -1,0 +1,15 @@
+from services.search.query import _extract_entities
+
+
+def test_extract_entities_handles_non_string_query():
+    # _detect_question_type already guards non-strings, but the function then
+    # runs re.findall over `query` directly, which raises TypeError on a
+    # non-string. A non-str query should yield no entities.
+    assert _extract_entities(None) == {"names": [], "dates": []}
+    assert _extract_entities(123) == {"names": [], "dates": []}
+
+
+def test_extract_entities_still_finds_names_and_years():
+    out = _extract_entities("What did Alice do in 2024")
+    assert "Alice" in out["names"]
+    assert "2024" in out["dates"]


### PR DESCRIPTION
## Summary
`_extract_entities` runs `re.findall` / `re.sub` directly over `query`. `_detect_question_type` (called first) already guards non-strings, but the subsequent `re.findall` over `query` raises `TypeError: expected string or bytes-like object` when `query` is None or another non-string, so the helper crashes instead of returning no entities.

## Changes
- services/search/query.py: return the empty entity dict when `query` is not a string.
- tests/test_search_query_entities_nonstring.py: None/int queries return `{"names": [], "dates": []}` (raise on the old code), and a real query still extracts the name and year.