### PR TITLE
fix: search service crashes on a non-dict result row

### DIFF
--- a/services/search/service.py
+++ b/services/search/service.py
@@ -73,6 +73,8 @@ class SearchService:
 
         results = []
         for r in raw_results:
+            if not isinstance(r, dict):
+                continue
             results.append(SearchResult(
                 url=r.get("url", ""),
                 title=r.get("title", ""),

--- a/tests/test_search_service_nondict_rows.py
+++ b/tests/test_search_service_nondict_rows.py
@@ -1,0 +1,23 @@
+import asyncio
+
+import services.search.service as svc_mod
+from services.search.service import SearchService
+
+
+def test_search_skips_non_dict_results(monkeypatch):
+    # comprehensive_web_search aggregates external provider + cache results;
+    # a malformed row (string/None) made the old loop call r.get and crash,
+    # losing the whole search.
+    async def fake_search(query, max_results=10, fetch_content=False):
+        return [
+            {"url": "https://a.com", "title": "A", "snippet": "x"},
+            "junk-row",
+            None,
+            {"url": "https://b.com", "title": "B", "snippet": "y"},
+        ]
+
+    monkeypatch.setattr(svc_mod, "comprehensive_web_search", fake_search)
+    svc = SearchService()
+    res = asyncio.run(svc.search("anything"))
+    assert [r.url for r in res.results] == ["https://a.com", "https://b.com"]
+    assert res.total == 2


### PR DESCRIPTION
## Summary
`SearchService.search` maps `comprehensive_web_search(...)` results into `SearchResult` objects with `r.get(...)` per row. Those results aggregate external search-provider responses and on-disk cache JSON, so a malformed row (a string error or None) can appear in the list. The old loop then raised `AttributeError: 'str' object has no attribute 'get'` and the whole search failed. This mirrors the `isinstance(s, dict)` guard already used in services/research/service.py.

## Changes
- services/search/service.py: skip non-dict result rows (`if not isinstance(r, dict): continue`).
- tests/test_search_service_nondict_rows.py: a result list mixing valid rows with a string and None returns only the valid results (raises on the old code).