### PR TITLE
fix(documents): use strip_pdf_content_marker instead of lstrip for PDF auto-open

### DIFF
--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -394,9 +394,7 @@ def build_user_content(
                         # Pull the PDF prose once — used as either intro_text
                         # (form path) or the doc body (plain path).
                         try:
-                            pdf_body_text = _process_pdf(path).lstrip(
-                                "\n[PDF content]:"
-                            ).strip()
+                            pdf_body_text = strip_pdf_content_marker(_process_pdf(path))
                         except Exception:
                             pdf_body_text = None
 


### PR DESCRIPTION
## Summary
- `_process_pdf(path).lstrip("\n[PDF content]:")` treats the argument as a character **set**, eating into the next `[Page N text]:` marker (e.g. `[Page 1 text]:` becomes `age 1 text]:`)
- Replaces with the existing `strip_pdf_content_marker()` helper which uses `removeprefix` — other call sites already use it

Fixes #1663

## Test plan
- [ ] Upload/auto-open a PDF document
- [ ] Verify the `[Page 1 text]:` marker is preserved intact in the document body
- [ ] Run `pytest tests/ -k pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)