### PR TITLE
fix: CalDAV write-back sends the encrypted password so every push fails

### DIFF
--- a/src/caldav_writeback.py
+++ b/src/caldav_writeback.py
@@ -161,6 +161,17 @@ async def writeback_event(owner: str, calendar_source: str, calendar_id: str,
         url = (cfg.get("url") or "").strip()
         user = (cfg.get("username") or "").strip()
         pw = cfg.get("password") or ""
+        # The stored password is encrypted (routes/calendar_routes always
+        # encrypt()s it). The pull path sync_caldav and test_connection both
+        # decrypt before use; write-back did not, so it authenticated with the
+        # literal "enc:..." ciphertext, the remote rejected it, and no local
+        # change ever reached the server. decrypt is idempotent on legacy
+        # plaintext.
+        try:
+            from src.secret_storage import decrypt
+            pw = decrypt(pw)
+        except Exception:
+            pass
         if not (url and user and pw):
             return {"skipped": "caldav not configured"}
         result = await asyncio.to_thread(_writeback_blocking, calendar_id, ev, delete, url, user, pw)

--- a/tests/test_caldav_writeback_decrypt.py
+++ b/tests/test_caldav_writeback_decrypt.py
@@ -1,0 +1,42 @@
+"""CalDAV write-back must decrypt the stored password before authenticating.
+
+The password is persisted encrypted ("enc:..."). sync_caldav and
+test_connection both decrypt it, but writeback_event passed the raw
+ciphertext into caldav.DAVClient, so every create/edit/delete write-back
+failed auth and silently never reached the server.
+"""
+import asyncio
+
+import pytest
+
+import src.caldav_writeback as wb
+from src.secret_storage import encrypt
+
+
+def test_writeback_passes_decrypted_password(monkeypatch):
+    secret = "s3cr3t-passw0rd"
+    enc = encrypt(secret)
+    assert enc != secret  # actually encrypted
+
+    monkeypatch.setattr(
+        "routes.prefs_routes._load_for_user",
+        lambda owner: {"caldav": {"url": "https://dav.example/cal", "username": "u", "password": enc}},
+        raising=False,
+    )
+
+    captured = {}
+
+    def _fake_blocking(local_cal_id, ev, delete, url, username, password):
+        captured["password"] = password
+        return {"ok": True}
+
+    monkeypatch.setattr(wb, "_writeback_blocking", _fake_blocking)
+
+    res = asyncio.run(wb.writeback_event("alice", "caldav", "cal-1", {"uid": "x"}))
+    assert res.get("ok") is True
+    assert captured["password"] == secret  # decrypted, not the enc: blob
+
+
+def test_non_caldav_calendar_is_skipped(monkeypatch):
+    res = asyncio.run(wb.writeback_event("alice", "local", "cal-1", {"uid": "x"}))
+    assert res.get("skipped")


### PR DESCRIPTION
## Summary
CalDAV credentials are stored encrypted — routes/calendar_routes always encrypt()s the password into an enc:... blob. The pull path sync_caldav and test_connection both decrypt it before use, but writeback_event reads cfg["password"] and passes it straight into caldav.DAVClient via _writeback_blocking without decrypting. So every local create/edit/delete authenticates with the literal ciphertext, the remote rejects it, and the change never reaches the server — the exact silent-write-loss this module was built to prevent.

## Fix
Decrypt the password before use, mirroring sync_caldav. decrypt is idempotent on legacy plaintext, so both encrypted and old plaintext values work.

## Changes
- src/caldav_writeback.py: decrypt the stored password in writeback_event.
- tests/test_caldav_writeback_decrypt.py: with an encrypted stored password, _writeback_blocking receives the decrypted plaintext (fails on old code, which passed the enc: blob); non-CalDAV calendars are still skipped.