### PR TITLE
Don't attempt the same (url, model) route twice in the model fallback chains

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -868,6 +868,31 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         raise HTTPException(502, f"Unexpected schema from {target_url}: {str(data)[:400]}")
 
 
+def _dedupe_candidates(candidates):
+    """Filter malformed entries and drop a later repeat of an already-seen
+    ``(url, model)`` route, preserving order (first occurrence wins).
+
+    The chain is the primary target followed by the configured fallbacks, so a
+    fallback that repeats the session's current model — a common misconfiguration,
+    since callers prepend the live ``(url, model)`` to ``default_model_fallbacks``
+    — would otherwise make the chain re-attempt the very route that just failed:
+    a wasted round-trip plus a spurious ``fallback`` notice for a switch that did
+    not happen. Headers are not part of the key; the first tuple (with its
+    headers) is the one kept.
+    """
+    seen = set()
+    out = []
+    for c in candidates or []:
+        if not c or not c[0] or not c[1]:
+            continue
+        key = (c[0], c[1])
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(c)
+    return out
+
+
 def llm_call_with_fallback(candidates, messages, **kwargs) -> str:
     """Sync `llm_call` with an ordered fallback chain.
 
@@ -876,7 +901,7 @@ def llm_call_with_fallback(candidates, messages, **kwargs) -> str:
     the next candidate. The dead-host cooldown inside `llm_call` makes repeat
     attempts at an offline primary effectively free.
     """
-    cands = [c for c in (candidates or []) if c and c[0] and c[1]]
+    cands = _dedupe_candidates(candidates)
     if not cands:
         raise HTTPException(503, "No model endpoint configured")
     last_err = None
@@ -893,7 +918,7 @@ def llm_call_with_fallback(candidates, messages, **kwargs) -> str:
 
 async def llm_call_async_with_fallback(candidates, messages, **kwargs) -> str:
     """Async variant of `llm_call_with_fallback` — same semantics."""
-    cands = [c for c in (candidates or []) if c and c[0] and c[1]]
+    cands = _dedupe_candidates(candidates)
     if not cands:
         raise HTTPException(503, "No model endpoint configured")
     last_err = None
@@ -1430,7 +1455,7 @@ async def stream_llm_with_fallback(candidates, messages, **kwargs):
 
     Yields the same SSE chunk protocol as stream_llm.
     """
-    cands = [c for c in (candidates or []) if c and c[0] and c[1]]
+    cands = _dedupe_candidates(candidates)
     if not cands:
         yield f'event: error\ndata: {json.dumps({"error": "No model endpoint configured", "status": 503})}\n\n'
         return

--- a/tests/test_llm_core_fallback.py
+++ b/tests/test_llm_core_fallback.py
@@ -55,6 +55,44 @@ def test_no_fallback_event_when_primary_succeeds(monkeypatch):
     assert not any('"fallback"' in c for c in chunks)
 
 
+def test_dedupe_candidates_keeps_first_of_each_route():
+    """(url, model) is the route key; later repeats are dropped, order preserved,
+    the first tuple (with its headers) kept, malformed entries filtered."""
+    cands = [
+        ("u1", "m1", {"h": 1}),   # first u1/m1 — kept
+        ("u1", "m1", {"h": 2}),   # repeat route — dropped (first headers win)
+        ("u2", "m2", {}),         # distinct — kept
+        ("u1", "m1", {}),         # repeat again — dropped
+        (None, "x", {}),          # malformed (no url) — dropped
+        ("u3", "", {}),           # malformed (no model) — dropped
+    ]
+    assert llm_core._dedupe_candidates(cands) == [("u1", "m1", {"h": 1}), ("u2", "m2", {})]
+    assert llm_core._dedupe_candidates([]) == []
+    assert llm_core._dedupe_candidates(None) == []
+
+
+def test_duplicate_route_is_attempted_only_once(monkeypatch):
+    """A fallback that repeats the primary's (url, model) must NOT make the chain
+    sail back into the same dead route — each distinct route is tried once."""
+    calls = []
+
+    async def fake_stream(url, model, messages, **kw):
+        calls.append((url, model))
+        yield 'event: error\ndata: {"status": 503, "text": "down"}\n\n'
+
+    monkeypatch.setattr(llm_core, "stream_llm", fake_stream)
+
+    async def run():
+        out = []
+        cands = [("u1", "m1", {}), ("u1", "m1", {}), ("u2", "m2", {})]
+        async for c in llm_core.stream_llm_with_fallback(cands, [{"role": "user", "content": "hi"}]):
+            out.append(c)
+        return out
+
+    asyncio.run(run())
+    assert calls == [("u1", "m1"), ("u2", "m2")], f"duplicate route re-attempted: {calls}"
+
+
 def test_summarize_stream_error():
     assert "400" in llm_core._summarize_stream_error('event: error\ndata: {"status": 400, "text": "nope"}\n\n')
     assert llm_core._summarize_stream_error(None) == "primary model failed"


### PR DESCRIPTION
## Summary
The three fallback helpers in `src/llm_core.py` — `llm_call_with_fallback`, `llm_call_async_with_fallback`, and `stream_llm_with_fallback` — build their candidate list as the primary target followed by the configured fallbacks:
```python
_candidates = [(endpoint_url, model, headers)] + list(fallbacks or [])
```
Callers prepend the session's live `(url, model)` to `default_model_fallbacks` (see `endpoint_resolver.resolve_chat_fallback_candidates`, which deliberately excludes the primary so callers can prepend it). So if a user *also* lists their current model among the configured fallbacks — an easy misconfiguration — the chain re-attempts the very route that just failed:

- a wasted round-trip on a route already known to be dead, and
- for the streaming path, a spurious `fallback` event announcing a "switch" to the same model that was already selected.

## Fix
A small `_dedupe_candidates()` helper that filters malformed entries and drops a later repeat of an already-seen `(url, model)`, preserving order (first occurrence wins, keeping its headers). Applied in all three fallback chains. No behaviour change when the chain has no duplicates.

(In the spirit of the repo's namesake: chart each hazard once — don't sail back into a strait you've already run.)

## Test plan
```
./venv/bin/python -m pytest -q tests/test_llm_core_fallback.py
```
Two new tests:
- `test_dedupe_candidates_keeps_first_of_each_route` — pure unit: repeats dropped by `(url, model)`, order preserved, first headers kept, malformed/empty filtered.
- `test_duplicate_route_is_attempted_only_once` — drives `stream_llm_with_fallback` with a stubbed `stream_llm` that records calls; a duplicated primary route is attempted once, not twice.

Verified red→green (reverting the dedup makes the duplicate route get attempted twice → the behavioural test fails). Full `llm_core` suite stays green (27 passed across fallback/streaming/ollama/reasoning/metrics).

Two-dot diff: `src/llm_core.py`, `tests/test_llm_core_fallback.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)