### PR TITLE
Fix RAG remove_directory wiping the entire shared collection (data loss)

### DIFF
--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -105,7 +105,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         directory = _dir.strip() if isinstance(_dir, str) else ""
         if not directory:
             return [TextContent(type="text", text="Error: add_directory needs a directory path")]
-        directory = os.path.expanduser(directory)
+        # Store an absolute path so indexed `source` metadata is absolute and
+        # remove_directory (which abspath-normalizes) can match it later (#1660).
+        directory = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(directory):
             return [TextContent(type="text", text=f"Error: Directory not found: {directory}")]
         if not _rag_manager:

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -1228,9 +1228,11 @@ async def do_manage_rag(content: str, session_id: Optional[str] = None) -> Dict:
 
         try:
             if hasattr(_personal_docs_manager, 'remove_directory'):
+                # Performs a targeted per-directory delete (#1660). The previous
+                # unconditional _rag_manager.rebuild_index() here wiped the whole
+                # collection on every remove (even for untracked dirs) and has
+                # been removed.
                 _personal_docs_manager.remove_directory(directory)
-            if _rag_manager and hasattr(_rag_manager, 'rebuild_index'):
-                _rag_manager.rebuild_index()
             return {"action": "remove_directory", "directory": directory,
                     "results": f"Directory '{directory}' removed from RAG index"}
         except Exception as e:

--- a/src/personal_docs.py
+++ b/src/personal_docs.py
@@ -306,18 +306,17 @@ class PersonalDocsManager:
             # Refresh the index to exclude the removed directory
             self.refresh_index()
             
-            # If RAG manager is available, we should rebuild the index
-            # This is a simple approach - in production you might want more sophisticated removal
+            # Targeted delete of just this directory's chunks. This previously
+            # called rag_manager.rebuild_index(), which delete+recreates the
+            # entire shared collection (every owner + the base index) and then
+            # re-indexed only the remaining tracked dirs — ownerless and never
+            # personal_dir — a catastrophic wipe (#1660). remove_directory now
+            # removes exactly this directory's chunks and leaves the rest intact.
             if self.rag_manager:
                 try:
-                    logger.info("Rebuilding RAG index after directory removal")
-                    self.rag_manager.rebuild_index()
-                    # Re-index remaining directories
-                    for dir_path in self.indexed_directories:
-                        if os.path.exists(dir_path):
-                            self.rag_manager.index_personal_documents(dir_path)
+                    self.rag_manager.remove_directory(directory)
                 except Exception as e:
-                    logger.error(f"Failed to rebuild RAG index: {e}")
+                    logger.error(f"Failed to remove directory from RAG index: {e}")
         else:
             logger.info(f"Directory not in index: {directory}")
 

--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -374,20 +374,36 @@ class VectorRAG:
             return {'success': False, 'indexed_count': indexed, 'failed_count': failed, 'message': str(e)}
 
     def remove_directory(self, directory: str) -> Dict[str, Any]:
-        """Remove all chunks from a directory. O(1) per chunk via ChromaDB."""
+        """Remove all chunks under ``directory`` (recursively), and nothing else.
+
+        Selection is a Python-side path-boundary match on each chunk's stored
+        ``source`` full path, NOT a Chroma metadata ``where`` filter. No Chroma
+        metadata operator selects a scalar string by path prefix (``$contains``
+        targets document content / list membership, not a ``source`` substring),
+        and a plain substring would over-delete siblings — removing ``/docs``
+        must not touch ``/docs2`` or ``/docs_personal``. We therefore match
+        ``source == directory`` or ``source`` startswith ``directory + os.sep``,
+        the same boundary rule add_directory uses for exclusions. ``directory``
+        is abspath-normalized so it matches the absolute ``source`` that indexing
+        always stores, regardless of how the caller passed it in.
+        """
         if not self.healthy:
             return {"success": False, "message": "Collection not initialized"}
+        directory = os.path.abspath(directory)
         try:
-            # Use ChromaDB where filter to find all docs from this directory
-            results = self._collection.get(
-                where={"source": {"$contains": directory}} if "/" in directory else {"directory": directory},
-                include=["metadatas"],
-            )
-            if not results['ids']:
+            results = self._collection.get(include=["metadatas"])
+            ids = [
+                results["ids"][i]
+                for i, m in enumerate(results["metadatas"])
+                if isinstance(m, dict)
+                and isinstance(m.get("source"), str)
+                and (m["source"] == directory or m["source"].startswith(directory + os.sep))
+            ]
+            if not ids:
                 return {"success": True, "removed_count": 0, "message": "No docs found"}
 
-            self._collection.delete(ids=results['ids'])
-            n = len(results['ids'])
+            self._collection.delete(ids=ids)
+            n = len(ids)
             logger.info(f"Removed {n} chunks from {directory}")
             return {"success": True, "removed_count": n, "message": f"Removed {n} chunks"}
         except Exception as e:

--- a/tests/test_rag_remove_directory_scope.py
+++ b/tests/test_rag_remove_directory_scope.py
@@ -1,0 +1,159 @@
+"""Regression guard for #1660 — removing one RAG directory must delete only that
+directory's chunks, never wipe the whole shared collection.
+
+Two compounding defects were fixed:
+  1. PersonalDocsManager.remove_directory called rag_manager.rebuild_index(),
+     which delete+recreates the entire shared "odysseus_rag" collection (all
+     owners + the base index), then re-indexed only the remaining tracked dirs
+     (ownerless, never personal_dir). Now it does a targeted per-directory delete.
+  2. VectorRAG.remove_directory selected via where={"source": {"$contains": dir}},
+     which no Chroma metadata operator supports as a path-prefix match (and a
+     substring would over-delete siblings). Now it filters stored absolute
+     `source` paths in Python with a path boundary (dir or dir + os.sep).
+
+These tests are hermetic — no chromadb; VectorRAG is exercised against a fake
+collection, PersonalDocsManager against a fake rag manager.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+
+import src.rag_vector as rag_vector
+import src.personal_docs as personal_docs
+import src.ai_interaction as ai
+
+
+# --------------------------------------------------------------------------- #
+# VectorRAG.remove_directory selection correctness (edit C)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCollection:
+    def __init__(self, rows):
+        self._ids = [r[0] for r in rows]
+        self._metas = [r[1] for r in rows]
+
+    def get(self, include=None):
+        return {"ids": list(self._ids), "metadatas": list(self._metas)}
+
+    def delete(self, ids=None):
+        drop = set(ids or [])
+        kept = [(i, m) for i, m in zip(self._ids, self._metas) if i not in drop]
+        self._ids = [i for i, _ in kept]
+        self._metas = [m for _, m in kept]
+
+
+def _make_vectorrag(rows):
+    rag = rag_vector.VectorRAG.__new__(rag_vector.VectorRAG)  # skip Chroma connect
+    rag._collection = _FakeCollection(rows)
+    rag._healthy = True
+    return rag
+
+
+def test_vectorrag_remove_is_path_bounded():
+    rows = [
+        ("a", {"source": "/a/docs/f1.md"}),
+        ("b", {"source": "/a/docs/sub/f2.md"}),   # nested -> must be removed
+        ("c", {"source": "/a/docs2/f3.md"}),       # sibling prefix -> must survive
+        ("d", {"source": "/a/docs_personal/f4.md"}),  # sibling prefix -> must survive
+        ("e", {"filename": "no-source.md"}),       # sourceless dict -> must not crash/survive
+    ]
+    rag = _make_vectorrag(rows)
+    res = rag.remove_directory("/a/docs")
+    assert res["success"] is True
+    assert res["removed_count"] == 2
+    remaining = set(rag._collection.get()["ids"])
+    assert remaining == {"c", "d", "e"}, remaining
+
+
+def test_vectorrag_remove_no_match_is_noop():
+    rag = _make_vectorrag([("a", {"source": "/a/docs/f1.md"})])
+    res = rag.remove_directory("/nowhere")
+    assert res["success"] is True
+    assert res["removed_count"] == 0
+    assert set(rag._collection.get()["ids"]) == {"a"}
+
+
+# --------------------------------------------------------------------------- #
+# PersonalDocsManager.remove_directory must delete-targeted, not wipe (edit A)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRag:
+    """Records calls and simulates a chunk store keyed by id -> metadata."""
+
+    def __init__(self, store):
+        self.store = store
+        self.rebuild_called = False
+
+    def rebuild_index(self):
+        # The catastrophic op — mimic delete_collection wiping everything.
+        self.rebuild_called = True
+        self.store.clear()
+        return True
+
+    def index_personal_documents(self, directory, owner=None):
+        return {"indexed_count": 0}  # old recovery path re-adds nothing here
+
+    def remove_directory(self, directory):
+        directory = os.path.abspath(directory)
+        doomed = [
+            i for i, m in self.store.items()
+            if isinstance(m.get("source"), str)
+            and (m["source"] == directory or m["source"].startswith(directory + os.sep))
+        ]
+        for i in doomed:
+            del self.store[i]
+        return {"success": True, "removed_count": len(doomed)}
+
+
+def test_personal_docs_remove_is_targeted(tmp_path):
+    personal = os.path.abspath(str(tmp_path / "personal"))
+    target = os.path.abspath(str(tmp_path / "target"))
+    other = os.path.abspath(str(tmp_path / "other"))
+    store = {
+        "p": {"source": os.path.join(personal, "note.md"), "owner": "alice"},
+        "t": {"source": os.path.join(target, "doc.md"), "owner": "alice"},
+        "o": {"source": os.path.join(other, "doc.md"), "owner": "bob"},
+    }
+    fake = _FakeRag(store)
+    mgr = personal_docs.PersonalDocsManager(str(tmp_path), rag_manager=fake)
+    mgr.indexed_directories = [target, other]  # personal_dir intentionally NOT tracked
+
+    mgr.remove_directory(target)
+
+    assert fake.rebuild_called is False, "must not wipe the whole collection"
+    assert "t" not in store, "target directory's chunk should be removed"
+    assert "p" in store, "base personal index must survive"
+    assert "o" in store, "another owner's chunk must survive"
+
+
+# --------------------------------------------------------------------------- #
+# do_manage_rag remove path must not fire a whole-collection rebuild (edit B)
+# --------------------------------------------------------------------------- #
+
+
+async def test_do_manage_rag_remove_does_not_rebuild(monkeypatch):
+    calls = {"rebuild": 0}
+
+    class _Rag:
+        def rebuild_index(self):
+            calls["rebuild"] += 1
+
+        def remove_directory(self, directory):
+            pass
+
+    class _PDocs:
+        def remove_directory(self, directory):
+            pass
+
+    monkeypatch.setattr(ai, "_rag_manager", _Rag())
+    monkeypatch.setattr(ai, "_personal_docs_manager", _PDocs())
+
+    # Untracked path: the old code still fired an unconditional rebuild_index().
+    result = await ai.do_manage_rag("remove_directory\n/abs/untracked/dir")
+
+    assert calls["rebuild"] == 0, "remove must not rebuild (whole-collection wipe)"
+    assert "error" not in result, result


### PR DESCRIPTION
## What & why

Calling the RAG `remove_directory` action destroyed the **entire** shared ChromaDB collection (`odysseus_rag`) — every owner's vectors and the base index — instead of just the target directory's chunks. The shared root cause is `PersonalDocsManager.remove_directory`, which both the live agent path (`mcp_servers/rag_server.py`) and the currently-unreachable `do_manage_rag` path route through.

Three compounding defects:

1. **`PersonalDocsManager.remove_directory`** (`src/personal_docs.py`) called `rag_manager.rebuild_index()`, which does `delete_collection("odysseus_rag")` + recreate (`src/rag_vector.py`) — wiping all vectors — then re-indexed only the remaining tracked dirs (ownerless, never `personal_dir`).
2. The targeted **`VectorRAG.remove_directory`** that should have been used was itself broken: it selected via `where={"source": {"$contains": directory}}`. No Chroma metadata operator selects a scalar `source` string by path prefix (`$contains` targets document content / list membership), so it matched nothing (or errored) — and a substring match would over-delete siblings (`/docs` would also hit `/docs2`).
3. The dead **`do_manage_rag`** remove branch (`src/ai_interaction.py`) fired a *second* unconditional `rebuild_index()` with no re-index, even for untracked dirs.

## Fix

- **`VectorRAG.remove_directory`** — select chunks in Python by a path-boundary match on each chunk's stored absolute `source` (`source == dir` or `source.startswith(dir + os.sep)`), abspath-normalized. Deletes exactly the directory's chunks (recursively), spares sibling-prefix dirs, and tolerates rows without a `source`. Keys on the always-written `source` metadata — never `owner` — so legacy chunks need no migration.
- **`PersonalDocsManager.remove_directory`** — replace the `rebuild_index()` + partial re-index block with a single targeted `rag_manager.remove_directory(directory)`.
- **`do_manage_rag`** (dead code) — drop the second `rebuild_index()`; hygiene/defense-in-depth so the path isn't a latent wipe if ever re-wired.
- **`rag_server.py` add path** — abspath the directory so the indexed `source` is absolute and provably matches the abspath-normalizing remove (otherwise a relative-added dir is silently un-removable — safe, but a no-op).

`personal_dir` is never vector-indexed (`index_all_directories` has no caller; base docs enter Chroma as owner-tagged tracked uploads), so no `personal_dir` re-index is needed — the fix simply stops wiping.

## Compatibility & limitations

- **No migration / no schema change.** Selection keys on the `source` full path that indexing has always written unconditionally, so existing collections work immediately; legacy chunks without an `owner` key are handled correctly because the filter never references `owner`.
- **Caveat:** this *prevents future wipes* — it does **not** recover vectors already destroyed by prior `remove_directory` calls. Affected users must re-upload / re-add those directories.
- **Known narrow limitation (called out honestly):** RAG doc ids are a content hash, so byte-identical chunks shared across two tracked dirs collapse to one row. Switching from rebuild-and-reindex to targeted-delete-without-reindex means removing one such dir can drop a row whose identical text also belonged to another dir. This is far less harmful than the current full-collection wipe and is a property of the content-hash dedup design (tracked separately — see #1662).

## Tests

`tests/test_rag_remove_directory_scope.py` (4, hermetic — no chromadb):

- `test_vectorrag_remove_is_path_bounded` — removing `/a/docs` deletes `/a/docs/f1` + nested `/a/docs/sub/f2`; spares siblings `/a/docs2` and `/a/docs_personal`; a sourceless row survives without crashing.
- `test_vectorrag_remove_no_match_is_noop` — no match → `removed_count: 0`.
- `test_personal_docs_remove_is_targeted` — removing a tracked dir deletes only its chunk; the base personal index and another owner's chunk survive; `rebuild_index()` is never called.
- `test_do_manage_rag_remove_does_not_rebuild` — the remove path never fires a whole-collection rebuild.

Each test is coupled to the fix (fails on `main`). Existing `tests/test_personal_docs_*.py` and `tests/test_rag_*.py` pass.

Fixes #1660
