### PR TITLE
fix: use correct column name (timestamp) in history_routes queries

### DIFF
--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -265,7 +265,7 @@ def setup_history_routes(session_manager) -> APIRouter:
                 db_messages = (
                     db.query(DbChatMessage)
                     .filter(DbChatMessage.session_id == session_id, DbChatMessage.role == 'assistant')
-                    .order_by(DbChatMessage.created_at.desc())
+                    .order_by(DbChatMessage.timestamp.desc())
                     .first()
                 )
                 if db_messages:
@@ -320,7 +320,7 @@ def setup_history_routes(session_manager) -> APIRouter:
                 db_msg = (
                     db.query(DbChatMessage)
                     .filter(DbChatMessage.session_id == session_id, DbChatMessage.role == 'assistant')
-                    .order_by(DbChatMessage.created_at.desc())
+                    .order_by(DbChatMessage.timestamp.desc())
                     .first()
                 )
                 if db_msg:
@@ -401,7 +401,7 @@ def setup_history_routes(session_manager) -> APIRouter:
                 db_messages = (
                     db.query(DbChatMessage)
                     .filter(DbChatMessage.session_id == session_id)
-                    .order_by(DbChatMessage.created_at)
+                    .order_by(DbChatMessage.timestamp)
                     .all()
                 )
                 # Find last two assistant messages in DB


### PR DESCRIPTION
## Summary
- Three endpoints in `history_routes.py` ordered by `DbChatMessage.created_at`, but the `ChatMessage` model only has a `timestamp` column — causing `AttributeError` → HTTP 500
- Affects: `POST /api/session/{id}/mark-stopped`, `update-last-meta`, `merge-last-assistant`
- Simple replace: `created_at` → `timestamp` (other queries in the same file already use the correct column)

Fixes #1659

## Test plan
- [ ] Start a chat, then click Stop — no more 500 error
- [ ] Verify mark-stopped persists correctly (refresh page, stopped message should still show)
- [ ] Run `pytest tests/ -k history`

🤖 Generated with [Claude Code](https://claude.com/claude-code)