### PR TITLE
Clamp Anthropic temperature to [0.0, 1.0] (fixes 400 on the shipped Nietzsche preset)

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -512,6 +512,12 @@ def _build_anthropic_payload(model, messages, temperature, max_tokens, stream=Fa
             # Convert multimodal content (image_url → image) for Anthropic
             content = _convert_openai_content_to_anthropic(m["content"])
             chat_messages.append({"role": m["role"], "content": content})
+    # Anthropic only accepts temperature in [0.0, 1.0] and 400s on anything above
+    # 1.0. Clamp here (in the Anthropic builder only) so presets/sliders that use
+    # the wider OpenAI 0.0-2.0 range — e.g. the shipped "Nietzsche" preset at 1.2
+    # — don't hard-break every Claude request. OpenAI's own path is left untouched.
+    if temperature is not None:
+        temperature = max(0.0, min(temperature, 1.0))
     payload = {
         "model": model,
         "messages": chat_messages,

--- a/tests/test_llm_core_anthropic_temp_clamp.py
+++ b/tests/test_llm_core_anthropic_temp_clamp.py
@@ -1,0 +1,40 @@
+"""Regression guard for #1615 — Anthropic temperature must be clamped to [0.0, 1.0].
+
+Anthropic's Messages API rejects temperature > 1.0 with HTTP 400. The shipped
+"Nietzsche" preset uses temperature 1.2 (static/js/presets.js) and the UI slider
+allows up to 2.0 (static/index.html), so _build_anthropic_payload must clamp into
+[0.0, 1.0]. The clamp lives only in the Anthropic builder — OpenAI keeps its
+wider 0.0-2.0 range.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from src.llm_core import _build_anthropic_payload
+
+
+def _temp(t):
+    payload = _build_anthropic_payload(
+        "claude-x", [{"role": "user", "content": "hi"}], t, 100
+    )
+    return payload["temperature"]
+
+
+def test_above_range_is_clamped_to_one():
+    assert _temp(1.2) == 1.0  # the shipped "Nietzsche" preset — previously 400'd
+    assert _temp(2.0) == 1.0  # UI slider max
+
+
+def test_in_range_is_unchanged():
+    assert _temp(0.0) == 0.0
+    assert _temp(0.7) == 0.7
+    assert _temp(1.0) == 1.0
+
+
+def test_below_range_is_clamped_to_zero():
+    assert _temp(-0.5) == 0.0
+
+
+def test_none_is_passed_through_unchanged():
+    # Callers may pass None; behavior is unchanged (no clamp, no crash).
+    assert _temp(None) is None


### PR DESCRIPTION
## What & why

`_build_anthropic_payload` forwarded `temperature` to the Anthropic Messages API verbatim. Anthropic only accepts `temperature` in `[0.0, 1.0]` and returns **HTTP 400** for anything above `1.0`, so any chat using a temperature > 1.0 against a Claude/Anthropic model failed completely.

This is reachable out of the box:

- The shipped **"Nietzsche"** preset is `temperature: 1.2` (`static/js/presets.js`).
- The UI temperature slider allows `0`–`2` (`static/index.html`).

The OpenAI/generic path tolerates `1.0`–`2.0` and already special-cases its own constraints (`_restricts_temperature`); only the Anthropic builder had no range guard.

## Fix

Clamp into Anthropic's supported range inside `_build_anthropic_payload` only, so OpenAI's wider range is untouched:

```python
if temperature is not None:
    temperature = max(0.0, min(temperature, 1.0))
```

Clamping (rather than rejecting) keeps presets working and matches user intent ("max creativity") without a 400. All three Anthropic call paths (`llm_call`, `llm_call_async`, `stream_llm`) build through this one function, so this covers them all.

## Compatibility

No schema/config change. `None` is passed through unchanged (callers default to `LLMConfig.DEFAULT_TEMPERATURE = 1.0`). Only the Anthropic request payload changes; the OpenAI path is not touched.

## Tests

`tests/test_llm_core_anthropic_temp_clamp.py`:

- above-range (`1.2` Nietzsche, `2.0` slider) → clamped to `1.0`;
- in-range (`0.0`, `0.7`, `1.0`) → unchanged;
- below-range (`-0.5`) → `0.0`;
- `None` → passed through.

All pass (and fail on `main`, where `1.2` is sent verbatim).

Fixes #1615
