### PR TITLE
Scope RAG doc ids by owner so identical chunks from different owners aren't dropped (#1662)

### DIFF
--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -27,8 +27,15 @@ KEYWORD_WEIGHT = 0.3
 COLLECTION_NAME = "odysseus_rag"
 
 
-def _generate_doc_id(text: str) -> str:
-    return f"doc_{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
+def _generate_doc_id(text: str, owner: str = "") -> str:
+    # Scope the id by owner so two owners indexing a byte-identical chunk get
+    # distinct ids in the shared collection — otherwise the second owner's add
+    # collides with the first's id, early-returns, and is never stored under
+    # their owner, so their owner-filtered search silently omits it (#1662).
+    # An empty owner reproduces the legacy text-only id, so the unowned/base
+    # index keeps its existing ids and isn't re-churned.
+    key = f"{owner}\x00{text}" if owner else text
+    return f"doc_{hashlib.sha256(key.encode('utf-8')).hexdigest()[:16]}"
 
 
 class VectorRAG:
@@ -104,7 +111,7 @@ class VectorRAG:
             return False
 
         try:
-            doc_id = _generate_doc_id(text)
+            doc_id = _generate_doc_id(text, (metadata.get("owner") or ""))
             # Check if already exists
             existing = self._collection.get(ids=[doc_id])
             if existing["ids"]:
@@ -140,7 +147,7 @@ class VectorRAG:
             new_metas = []
             new_ids = []
             for t, m in valid:
-                doc_id = _generate_doc_id(t)
+                doc_id = _generate_doc_id(t, (m.get("owner") or ""))
                 existing = self._collection.get(ids=[doc_id])
                 if not existing["ids"]:
                     new_texts.append(t)

--- a/tests/test_rag_doc_id_owner_scope.py
+++ b/tests/test_rag_doc_id_owner_scope.py
@@ -1,0 +1,66 @@
+"""Regression for issue #1662 — RAG doc ids were derived from the chunk text
+alone, so when two owners indexed a byte-identical chunk the second owner's add
+collided with the first's id, early-returned, and was never stored under their
+owner. Their owner-filtered search then silently omitted it.
+
+The id is now scoped by owner (empty owner reproduces the legacy text-only id so
+the unowned/base index is unchanged). rag_vector needs ChromaDB + an embedding
+backend to construct normally, so the behavioural test builds an instance via
+__new__ with a fake collection and a stubbed _embed — no live services.
+"""
+from src import rag_vector
+from src.rag_vector import _generate_doc_id
+
+
+def test_doc_id_is_owner_scoped_and_legacy_compatible():
+    text = "the same chunk of text"
+    # Empty owner == legacy text-only id (base index keeps its existing ids).
+    assert _generate_doc_id(text, "") == _generate_doc_id(text)
+    assert _generate_doc_id(text).startswith("doc_")
+    # Different owners -> different ids for identical text (the fix).
+    assert _generate_doc_id(text, "alice") != _generate_doc_id(text, "bob")
+    # Owned id differs from the legacy/base id, and is deterministic.
+    assert _generate_doc_id(text, "alice") != _generate_doc_id(text)
+    assert _generate_doc_id(text, "alice") == _generate_doc_id(text, "alice")
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.added_ids = []
+        self._store = set()
+
+    def get(self, ids=None, **kw):
+        return {"ids": [i for i in (ids or []) if i in self._store]}
+
+    def add(self, ids, embeddings, documents, metadatas):
+        for i in ids:
+            self._store.add(i)
+            self.added_ids.append(i)
+
+
+def _rag_with_fake():
+    r = rag_vector.VectorRAG.__new__(rag_vector.VectorRAG)
+    r._collection = _FakeCollection()
+    r._healthy = True
+    r._model = object()
+    r._embed = lambda texts: [[0.0, 0.0] for _ in texts]
+    return r
+
+
+def test_identical_chunk_two_owners_both_stored():
+    r = _rag_with_fake()
+    text = "shared knowledge base chunk"
+    assert r.add_document(text, {"owner": "alice", "source": "a.txt"})
+    assert r.add_document(text, {"owner": "bob", "source": "b.txt"})
+    # Both owners' copies stored under distinct ids (pre-fix: bob collided with
+    # alice's id and was dropped, leaving a single stored id).
+    assert len(set(r._collection.added_ids)) == 2, r._collection.added_ids
+
+
+def test_same_owner_identical_chunk_still_deduped():
+    r = _rag_with_fake()
+    text = "shared knowledge base chunk"
+    assert r.add_document(text, {"owner": "alice", "source": "a.txt"})
+    assert r.add_document(text, {"owner": "alice", "source": "a2.txt"})
+    # Same owner + identical text is still one id (dedup preserved).
+    assert len(set(r._collection.added_ids)) == 1, r._collection.added_ids


### PR DESCRIPTION
## Summary
Fixes #1662. RAG document ids are derived from the chunk **text alone**, and `add_document` / `add_documents_batch` early-return when an id already exists. The ChromaDB collection is shared and search is owner-filtered, so when two owners index a byte-identical chunk, the second owner's add collides with the first's id, early-returns, and is **never stored under their owner** — their owner-scoped search then silently omits it.

## Root cause
`src/rag_vector.py`:
```python
def _generate_doc_id(text: str) -> str:                                    # content only
    return f"doc_{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
...
doc_id = _generate_doc_id(text)
if existing["ids"]:
    return True   # owner B's identical chunk lands here and is dropped
```
Owner lives in `metadata['owner']` and search filters `{"owner": owner}`, so a doc stored only under owner A is invisible to owner B even though B also indexed it.

## Fix
Scope the id by owner:
```python
def _generate_doc_id(text: str, owner: str = "") -> str:
    key = f"{owner}\x00{text}" if owner else text
    return f"doc_{hashlib.sha256(key.encode('utf-8')).hexdigest()[:16]}"
```
and pass `metadata.get("owner")` from `add_document` / `add_documents_batch`. An **empty owner reproduces the legacy text-only id**, so the unowned/base index keeps its existing ids and isn't re-churned; same-owner identical chunks still dedupe.

This is independent of #1734 (which fixes `remove_directory` in the same file but does not touch `_generate_doc_id`).

## Test plan
```
./venv/bin/python -m pytest -q tests/test_rag_doc_id_owner_scope.py   # 3 passed
```
- pure: empty owner == legacy id; different owners → different ids; deterministic.
- behavioural (fake collection, stubbed `_embed`, no live ChromaDB/embeddings): two owners' identical chunk → two distinct stored ids; same owner identical chunk → still one (dedup preserved).

Verified red→green: with the text-only id restored, the two-owner test fails (both collide into one id). Two-dot diff: `src/rag_vector.py`, `tests/test_rag_doc_id_owner_scope.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)