### PR TITLE
fix: a non-dict finding silently drops all raw research findings

### DIFF
--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -479,6 +479,8 @@ class ResearchHandler:
         try:
             items = []
             for f in findings:
+                if not isinstance(f, dict):
+                    continue
                 url = f.get("url", "")
                 title = f.get("title", "") or "Untitled"
                 summary = f.get("summary", "")

--- a/tests/test_research_handler_raw_nondict.py
+++ b/tests/test_research_handler_raw_nondict.py
@@ -1,0 +1,14 @@
+from src.research_handler import ResearchHandler
+
+
+def test_extract_raw_findings_skips_non_dict_without_losing_all():
+    # The body is wrapped in a try/except that returns [] on any error, so a
+    # single non-dict finding made the AttributeError from f.get swallow EVERY
+    # good finding (silent total data loss), not just the bad row.
+    findings = [
+        {"url": "https://a.com", "summary": "a real and useful finding here"},
+        "junk-row",
+        {"url": "https://b.com", "summary": "another genuine finding with detail"},
+    ]
+    out = ResearchHandler._extract_raw_findings(findings)
+    assert [i["url"] for i in out] == ["https://a.com", "https://b.com"]


### PR DESCRIPTION
## Summary
`ResearchHandler._extract_raw_findings` wraps its loop in a `try/except` that returns `[]` on any error. Findings come from the researcher result list / cached JSON, so a single malformed entry (None or a bare string) makes `f.get(...)` raise `AttributeError`, which the except swallows and returns `[]` — silently discarding every well-formed finding, not just the bad one.

## Changes
- src/research_handler.py: skip non-dict findings (`if not isinstance(f, dict): continue`) so one bad entry no longer wipes the whole list.
- tests/test_research_handler_raw_nondict.py: a findings list with a junk string between two valid dicts now returns both (the old code returned []).