### PR TITLE
Let all saved personas be added to a group chat (#1656)

### DIFF
--- a/static/js/group.js
+++ b/static/js/group.js
@@ -7,6 +7,7 @@ import chatRenderer from './chatRenderer.js';
 import spinnerModule from './spinner.js';
 import { providerLogo } from './providers.js';
 import { PROMPT_TEMPLATES, getAllPresets } from './presets.js';
+import { mergeGroupCharacters } from './groupCharacters.js';
 import { sortModelObjects } from './modelSort.js';
 import Storage from './storage.js';
 
@@ -284,32 +285,21 @@ function _initGroupTab() {
 }
 
 async function _getCharacterList() {
-  // Built-in characters from PROMPT_TEMPLATES
-  const chars = PROMPT_TEMPLATES.filter(t => t.isCharacter).map(t => ({
-    id: t.id, name: t.name, prompt: t.prompt,
-  }));
-  // User-created characters from presets
+  // The single "custom" preset slot, if it holds a persona.
+  let customPreset = null;
   try {
     const allPresets = getAllPresets();
-    if (allPresets && allPresets.custom && allPresets.custom.character_name) {
-      chars.push({
-        id: 'custom',
-        name: allPresets.custom.character_name,
-        prompt: allPresets.custom.system_prompt || allPresets.custom.prompt || '',
-      });
-    }
+    customPreset = allPresets && allPresets.custom;
   } catch (e) {}
-  // Load user templates and wait for them before returning
+  // User-saved templates — the endpoint returns a bare array. Each saved
+  // template is a persona; merge them all (see groupCharacters.js / #1656).
+  let userTemplates = [];
   try {
     const r = await fetch(API_BASE + '/api/presets/templates', { credentials: 'same-origin' });
     const data = await r.json();
-    (data.templates || []).forEach(t => {
-      if (t.isCharacter && !chars.find(c => c.id === t.id)) {
-        chars.push({ id: t.id, name: t.name, prompt: t.prompt || '' });
-      }
-    });
+    userTemplates = Array.isArray(data) ? data : (data.templates || []);
   } catch (e) {}
-  return chars;
+  return mergeGroupCharacters(PROMPT_TEMPLATES, customPreset, userTemplates);
 }
 
 export function isActive() { return _active; }

--- a/static/js/groupCharacters.js
+++ b/static/js/groupCharacters.js
@@ -1,0 +1,39 @@
+// static/js/groupCharacters.js
+/**
+ * Build the list of selectable characters/personas for the group-chat picker.
+ *
+ * Three sources, merged and de-duplicated by id:
+ *   1. built-in characters from PROMPT_TEMPLATES (flagged isCharacter)
+ *   2. the single "custom" preset slot (if it has a character_name)
+ *   3. every user-saved template — these ARE personas
+ *
+ * The group picker used to (a) read the templates response as `data.templates`
+ * though the endpoint returns a bare array, (b) gate user templates on
+ * `t.isCharacter` though the save-as-template flow never sets that flag, and
+ * (c) read the prompt from `t.prompt` though templates store `system_prompt`.
+ * The net effect was that only the just-edited "custom" persona showed up and
+ * none of the user's saved personas could be added to a group (#1656). Taking
+ * the already-parsed user-template array and treating each entry as a persona
+ * fixes all three.
+ */
+export function mergeGroupCharacters(promptTemplates, customPreset, userTemplates) {
+  const chars = (promptTemplates || [])
+    .filter((t) => t && t.isCharacter)
+    .map((t) => ({ id: t.id, name: t.name, prompt: t.prompt || '' }));
+
+  if (customPreset && customPreset.character_name) {
+    chars.push({
+      id: 'custom',
+      name: customPreset.character_name,
+      prompt: customPreset.system_prompt || customPreset.prompt || '',
+    });
+  }
+
+  (userTemplates || []).forEach((t) => {
+    if (t && t.id != null && !chars.find((c) => c.id === t.id)) {
+      chars.push({ id: t.id, name: t.name, prompt: t.system_prompt || t.prompt || '' });
+    }
+  });
+
+  return chars;
+}

--- a/tests/test_group_characters_js.py
+++ b/tests/test_group_characters_js.py
@@ -1,0 +1,103 @@
+"""Regression for issue #1656 — custom personas couldn't be added to a group:
+only the just-edited "custom" persona showed up in the group character picker.
+
+Root cause in static/js/group.js `_getCharacterList`, three compounding bugs:
+  1. it read the templates response as `data.templates`, but
+     GET /api/presets/templates returns a BARE array (preset_manager
+     .get_user_templates()), so user templates never loaded;
+  2. it gated user templates on `t.isCharacter`, but the save-as-template flow
+     (presets.js) never sets that flag;
+  3. it read the prompt from `t.prompt`, but templates store `system_prompt`.
+
+The merge now lives in a pure module (static/js/groupCharacters.js) so it can be
+executed under node — group.js itself pulls in browser-only modules. Same
+approach as tests/test_compare_js.py.
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HAS_NODE = shutil.which("node") is not None
+
+
+@pytest.fixture(scope="module")
+def node_available():
+    if not _HAS_NODE:
+        pytest.skip("node binary not on PATH")
+
+
+def _run_node(script: str) -> dict:
+    res = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO,
+        capture_output=True,
+        timeout=15,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise AssertionError(f"node failed:\n{res.stderr}")
+    out_lines = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    if not out_lines:
+        raise AssertionError("node produced no stdout")
+    return json.loads(out_lines[-1])
+
+
+def test_all_saved_personas_are_selectable(node_available):
+    """User-saved templates (no isCharacter flag, prompt in system_prompt) must
+    ALL appear — the #1656 bug surfaced only the single custom slot."""
+    script = textwrap.dedent("""
+        const { mergeGroupCharacters } = await import('./static/js/groupCharacters.js');
+        const builtins = [
+          { id: 'analyst', name: 'Analyst', prompt: 'be analytical', isCharacter: true },
+          { id: 'noncharacter', name: 'Plain Preset' },  // not a character — excluded
+        ];
+        const customPreset = { character_name: 'Just Made', system_prompt: 'newest persona' };
+        // As returned by GET /api/presets/templates — a bare array, no isCharacter:
+        const userTemplates = [
+          { id: 't1', name: 'Pirate', system_prompt: 'arr' },
+          { id: 't2', name: 'Poet', system_prompt: 'in verse' },
+          { id: 't3', name: 'Coach', system_prompt: 'motivate' },
+        ];
+        const out = mergeGroupCharacters(builtins, customPreset, userTemplates);
+        console.log(JSON.stringify({
+          names: out.map(c => c.name),
+          ids: out.map(c => c.id),
+          pirate_prompt: (out.find(c => c.id === 't1') || {}).prompt,
+          has_plain_preset: out.some(c => c.id === 'noncharacter'),
+        }));
+    """)
+    out = _run_node(script)
+    # Built-in character + custom slot + ALL THREE user personas:
+    assert out["names"] == ["Analyst", "Just Made", "Pirate", "Poet", "Coach"]
+    assert out["pirate_prompt"] == "arr", "prompt must come from system_prompt"
+    assert out["has_plain_preset"] is False, "non-character built-ins stay excluded"
+
+
+def test_dedup_by_id_and_empty_inputs(node_available):
+    """De-dupe by id (a user template id matching a built-in doesn't double up),
+    and tolerate missing/empty sources."""
+    script = textwrap.dedent("""
+        const { mergeGroupCharacters } = await import('./static/js/groupCharacters.js');
+        const builtins = [{ id: 'dup', name: 'Builtin Dup', prompt: 'x', isCharacter: true }];
+        const userTemplates = [
+          { id: 'dup', name: 'Should Not Duplicate', system_prompt: 'y' },
+          { id: 'u1', name: 'Unique', system_prompt: 'z' },
+        ];
+        const merged = mergeGroupCharacters(builtins, null, userTemplates);
+        const empty = mergeGroupCharacters(null, null, null);
+        console.log(JSON.stringify({
+          dup_count: merged.filter(c => c.id === 'dup').length,
+          ids: merged.map(c => c.id),
+          empty_len: empty.length,
+        }));
+    """)
+    out = _run_node(script)
+    assert out["dup_count"] == 1, "must not duplicate an id already present"
+    assert out["ids"] == ["dup", "u1"]
+    assert out["empty_len"] == 0


### PR DESCRIPTION
## Summary
Fixes #1656 — in the group-chat character picker you could only add the single most-recently-edited "custom" persona; other saved personas never appeared (and a freshly-made one only showed up after a refresh).

## Root cause
`static/js/group.js` `_getCharacterList()` had three compounding bugs in how it loaded user-saved personas:
1. It read the templates response as `data.templates`, but `GET /api/presets/templates` returns a **bare array** (`preset_manager.get_user_templates()`), so user templates never loaded.
2. It gated user templates on `t.isCharacter`, but the save-as-template flow (`presets.js`) never sets that flag.
3. It read the prompt from `t.prompt`, but saved templates store it under `system_prompt`.

Net effect: only built-in characters + the single `custom` preset slot were offered.

## Fix
Move the merge into a pure module `static/js/groupCharacters.js` (`mergeGroupCharacters`): take the already-parsed template array, treat **every** saved template as a persona, de-dupe by id, and read the prompt from `system_prompt` (falling back to `prompt`). `_getCharacterList` now parses the bare array (`Array.isArray(data) ? data : data.templates || []`) and delegates.

## Scope
- `static/js/groupCharacters.js` (new, pure helper)
- `static/js/group.js` (`_getCharacterList` parses bare array + delegates; one import)
- `tests/test_group_characters_js.py` (new)

## Test plan
```
node --check static/js/groupCharacters.js static/js/group.js   # OK
./venv/bin/python -m pytest -q tests/test_group_characters_js.py  # 2 passed
```
Test executes the merge under node (like `tests/test_compare_js.py`): all saved personas (no `isCharacter`, prompt in `system_prompt`) appear, prompt read correctly, non-character built-ins excluded, ids de-dupe, empty inputs tolerated. Red→green verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)