### PR TITLE
fix: youtube (services) comment formatter crashes on a non-dict comment

### DIFF
--- a/services/youtube/youtube_handler.py
+++ b/services/youtube/youtube_handler.py
@@ -254,6 +254,8 @@ def format_comments_for_context(comments_data: Dict[str, Any], url: str) -> str:
     ctx += f"URL: {url}\n\n"
 
     for i, c in enumerate(comments, 1):
+        if not isinstance(c, dict):
+            continue
         likes = c.get("likes", 0)
         likes_str = f" [{likes} likes]" if likes else ""
         ctx += f"{i}. @{c['author']}{likes_str}: {c['text']}\n\n"

--- a/tests/test_youtube_svc_comments_nondict.py
+++ b/tests/test_youtube_svc_comments_nondict.py
@@ -1,0 +1,15 @@
+from services.youtube.youtube_handler import format_comments_for_context
+
+
+def test_format_comments_skips_non_dict_entries():
+    # comments come from json.loads of yt-dlp output; a malformed entry (None
+    # or a bare string) made the old loop call .get on a non-dict and crash.
+    data = {"success": True, "comments": [
+        {"author": "alice", "text": "great", "likes": 4},
+        "junk-row",
+        None,
+        {"author": "bob", "text": "nice", "likes": 1},
+    ]}
+    out = format_comments_for_context(data, "https://youtu.be/x")
+    assert "@alice" in out and "@bob" in out
+    assert "junk-row" not in out


### PR DESCRIPTION
## Summary
The `services/youtube` copy of `format_comments_for_context` iterates the comment list calling `c.get("likes")` / `c['author']` per entry. That list comes from `json.loads` of yt-dlp output, so a malformed entry (None or a bare string) made the loop raise `AttributeError: 'str' object has no attribute 'get'`, losing every well-formed comment.

## Changes
- services/youtube/youtube_handler.py: skip non-dict comment entries (`if not isinstance(c, dict): continue`).
- tests/test_youtube_svc_comments_nondict.py: a comment list mixing valid dicts with a string and None still formats both real comments (raises on the old code).