### PR TITLE
fix: memory audit wipes other owners from the shared vector index

### DIFF
--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -547,17 +547,21 @@ async def audit_memories(
             for e in all_entries:
                 if e.get("owner") is None and e["id"] not in audited_ids and e["id"] not in {o["id"] for o in other_entries}:
                     other_entries.append(e)
-            memory_manager.save(final_entries + other_entries)
+            saved_entries = final_entries + other_entries
         else:
-            memory_manager.save(final_entries)
+            saved_entries = final_entries
+        memory_manager.save(saved_entries)
         logger.info(
             f"Memory audit complete: {before_count} -> {after_count} entries "
             f"({before_count - after_count} removed/merged)"
         )
 
-        # Rebuild vector index
+        # Rebuild vector index from the FULL saved set, not just this owner's
+        # slice. memory_manager.save() above persists every owner's entries, so
+        # rebuilding from final_entries alone wiped all other owners out of the
+        # shared semantic-search collection until they ran their own audit.
         if memory_vector and memory_vector.healthy:
-            memory_vector.rebuild(final_entries)
+            memory_vector.rebuild(saved_entries)
 
         # Persist the post-tidy fingerprint so the next call short-circuits
         # if nothing has changed in the meantime.

--- a/tests/test_audit_memories_vector_rebuild.py
+++ b/tests/test_audit_memories_vector_rebuild.py
@@ -1,0 +1,63 @@
+"""audit_memories must rebuild the vector index from ALL owners\' memories.
+
+The JSON store correctly preserves other owners (save(final + other)), but
+the vector index was rebuilt from final_entries (only the audited owner),
+so every other owner was wiped from the shared semantic-search collection
+until they ran their own audit. The rebuild must use the same full set that
+was saved.
+"""
+import asyncio
+
+import pytest
+
+import src.llm_core as llm_core
+from services.memory.memory import MemoryManager
+from services.memory import memory_extractor
+
+
+class _FakeVector:
+    def __init__(self):
+        self.healthy = True
+        self.rebuilt_with = None
+
+    def rebuild(self, entries):
+        self.rebuilt_with = list(entries)
+
+
+def test_rebuild_includes_other_owners(monkeypatch, tmp_path):
+    mgr = MemoryManager(str(tmp_path))
+    mgr.save([
+        {"id": "a1", "text": "alice likes tea", "owner": "alice", "category": "fact"},
+        {"id": "b1", "text": "bob likes coffee", "owner": "bob", "category": "fact"},
+    ])
+
+    async def _fake_llm(url, model, messages, **kwargs):
+        # Keep alice's single memory unchanged.
+        return '[{"id": "a1", "text": "alice likes tea", "category": "fact"}]'
+
+    monkeypatch.setattr(llm_core, "llm_call_async", _fake_llm)
+
+    vec = _FakeVector()
+    res = asyncio.run(memory_extractor.audit_memories(
+        mgr, vec, "http://x", "model", owner="alice",
+    ))
+    assert "error" not in res, res
+
+    ids = {e["id"] for e in (vec.rebuilt_with or [])}
+    assert "a1" in ids
+    assert "b1" in ids, "other owner's memory was wiped from the vector index"
+
+
+def test_single_user_rebuild_uses_audited_entries(monkeypatch, tmp_path):
+    mgr = MemoryManager(str(tmp_path))
+    mgr.save([{"id": "x1", "text": "solo note", "category": "fact"}])
+
+    async def _fake_llm(url, model, messages, **kwargs):
+        return '[{"id": "x1", "text": "solo note", "category": "fact"}]'
+
+    monkeypatch.setattr(llm_core, "llm_call_async", _fake_llm)
+
+    vec = _FakeVector()
+    asyncio.run(memory_extractor.audit_memories(mgr, vec, "http://x", "model"))
+    ids = {e["id"] for e in (vec.rebuilt_with or [])}
+    assert ids == {"x1"}


### PR DESCRIPTION
## Summary
In a multi-user install, audit_memories (POST /memory/audit) correctly preserves every owner's entries in the JSON store — it saves final_entries (the audited owner's) merged with other_entries (everyone else's). But it then rebuilds the shared vector collection with memory_vector.rebuild(final_entries), i.e. only the audited owner's slice. MemoryVectorStore.rebuild deletes and recreates the single shared collection from just that list, so every other owner is wiped from semantic search until they happen to run their own audit. Keyword fallback still works, so it degrades silently rather than erroring.

## Fix
Capture the exact set that was saved (saved_entries) and rebuild the vector index from it, so the index matches the JSON store.

## Changes
- services/memory/memory_extractor.py: rebuild the vector index from the full saved set.
- tests/test_audit_memories_vector_rebuild.py: auditing alice's memories keeps bob's in the rebuilt index (fails on old code), and single-user audit rebuilds from the audited entries. Real MemoryManager + temp dir, mocked LLM.