### PR TITLE
fix: chat memory extraction crashes on a non-dict message

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -51,6 +51,8 @@ class MemoryManager:
         memories = []
         
         for msg in chat_history:
+            if not isinstance(msg, dict):
+                continue
             if msg.get("role") == "assistant":
                 content = str(msg.get("content", ""))
                 lines = content.split('\n')

--- a/tests/test_memory_extract_chat_nondict.py
+++ b/tests/test_memory_extract_chat_nondict.py
@@ -1,0 +1,15 @@
+from src.memory import MemoryManager
+
+
+def test_extract_memory_from_chat_skips_non_dict_messages(tmp_path):
+    # chat_history rows can be malformed (a non-dict slipping in from a partial
+    # session blob); the old loop did msg.get(...) and crashed on the first one.
+    m = MemoryManager(str(tmp_path))
+    history = [
+        {"role": "assistant", "content": "- remember to buy milk"},
+        "junk-msg",
+        None,
+        {"role": "user", "content": "hi"},
+    ]
+    out = m.extract_memory_from_chat(history)
+    assert any(e["text"] == "remember to buy milk" for e in out)


### PR DESCRIPTION
## Summary
`MemoryManager.extract_memory_from_chat` iterates `chat_history` and calls `msg.get("role")` / `msg.get("content")` on each entry. Chat history rows can be malformed (a non-dict slipping in from a partially-decoded session blob), and the old loop then raised `AttributeError: 'str' object has no attribute 'get'` on the first one, taking out this fallback extractor entirely.

## Changes
- src/memory.py: skip non-dict messages (`if not isinstance(msg, dict): continue`).
- tests/test_memory_extract_chat_nondict.py: a history mixing valid message dicts with a string and None still extracts the bullet memory (raises on the old code).