### PR TITLE
Stop GET /api/search/config from leaking the Brave Search API key

### DIFF
--- a/services/search/core.py
+++ b/services/search/core.py
@@ -49,8 +49,18 @@ SEARCH_CONFIG: Dict[str, Any] = {
 }
 
 
+def _is_secret_key(name: str) -> bool:
+    """True for config keys that hold a credential (e.g. ``brave_api_key``)."""
+    return name.endswith(("_api_key", "_key", "_token", "_secret"))
+
+
 def get_search_config() -> Dict[str, Any]:
-    """Get current search configuration including active provider info."""
+    """Get current search configuration including active provider info.
+
+    Never returns stored API keys: callers — including the unauthenticated
+    ``GET /api/search/config`` route — only need key *presence* via
+    ``has_api_key``, not the secret itself (#1661).
+    """
     config = SEARCH_CONFIG.copy()
     settings = _get_search_settings()
     provider = settings.get("search_provider", "searxng")
@@ -60,13 +70,27 @@ def get_search_config() -> Dict[str, Any]:
     if provider == "searxng":
         from .providers import _get_search_instance
         config["search_url"] = _get_search_instance()
-    return config
+    # Strip any string-valued credential so secrets never reach the response;
+    # the boolean has_api_key flag (presence only) is preserved.
+    return {
+        k: v for k, v in config.items()
+        if not (isinstance(v, str) and _is_secret_key(k))
+    }
 
 
 def update_search_config(api_key: str = None, **kwargs):
-    """Update search configuration (e.g. Brave API key)."""
-    if api_key:
-        SEARCH_CONFIG["brave_api_key"] = api_key
+    """Merge non-secret search config into SEARCH_CONFIG.
+
+    Provider API keys are intentionally NOT cached here. They are read on demand
+    from settings/env via ``_get_provider_key`` (e.g. ``brave_search``), so the
+    previous ``SEARCH_CONFIG["brave_api_key"] = api_key`` cache was never used
+    for search and only leaked the decrypted key through ``get_search_config`` /
+    ``GET /api/search/config`` (#1661). ``api_key`` is accepted for backward
+    compatibility but no longer stored.
+    """
+    for k, v in kwargs.items():
+        if not _is_secret_key(k):
+            SEARCH_CONFIG[k] = v
 
 
 def _call_provider(provider_name: str, query: str, count: int, time_filter: str = None) -> List[dict]:

--- a/tests/test_search_config_no_key_leak.py
+++ b/tests/test_search_config_no_key_leak.py
@@ -1,0 +1,53 @@
+"""Regression guard for #1661 — GET /api/search/config must not leak API keys.
+
+`get_search_config()` returned `SEARCH_CONFIG.copy()`, and `update_search_config()`
+cached the decrypted Brave key into that shared global at startup
+(`src/app_initializer.py`), so the unauthenticated `/api/search/config` route
+exposed the operator's key. The key is read on demand via `_get_provider_key`
+(`brave_search`), so the cache was dead weight. Now the secret is never cached in
+the global, and `get_search_config` scrubs any credential field from its response
+while preserving the `has_api_key` presence flag.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import pytest
+
+from services.search import core
+
+
+def test_update_search_config_does_not_cache_secret():
+    core.update_search_config(api_key="SUPER_SECRET")
+    assert "brave_api_key" not in core.SEARCH_CONFIG
+    assert "SUPER_SECRET" not in core.SEARCH_CONFIG.values()
+
+
+@pytest.fixture
+def stub_settings(monkeypatch):
+    monkeypatch.setattr(core, "_get_search_settings", lambda: {"search_provider": "brave"})
+    monkeypatch.setattr(core, "_get_provider_key", lambda provider: "REAL_SECRET_KEY")
+    monkeypatch.setattr(core, "_get_result_count", lambda: 10)
+
+
+def test_get_search_config_never_returns_a_secret(stub_settings, monkeypatch):
+    # Even if a secret somehow sits in the shared global, the response scrubs it.
+    monkeypatch.setitem(core.SEARCH_CONFIG, "brave_api_key", "LEAKED_SECRET")
+
+    cfg = core.get_search_config()
+
+    assert "brave_api_key" not in cfg
+    assert "LEAKED_SECRET" not in cfg.values()       # the cached secret
+    assert "REAL_SECRET_KEY" not in cfg.values()     # the live provider key
+    # Presence flag and non-secret fields are preserved.
+    assert cfg["has_api_key"] is True
+    assert cfg["active_provider"] == "brave"
+
+
+def test_is_secret_key_keeps_presence_flag():
+    # has_api_key matches the *_api_key suffix, but it is a bool — the isinstance
+    # guard in get_search_config keeps it; only string-valued secrets are dropped.
+    assert core._is_secret_key("brave_api_key") is True
+    assert core._is_secret_key("has_api_key") is True
+    assert core._is_secret_key("active_provider") is False
+    assert core._is_secret_key("search_url") is False


### PR DESCRIPTION
## What & why

`GET /api/search/config` (no admin gate) returned `get_search_config()`, which did `SEARCH_CONFIG.copy()` — and at startup `src/app_initializer.py` cached the operator's **decrypted** Brave Search key into that shared global via `update_search_config`. So any user who could reach the endpoint could read a billable third-party credential. The handler added only a `has_api_key` boolean, never scrubbing the raw key.

The cache was also **functionally dead**: `brave_search` reads its key on demand via `_get_provider_key` (settings/env), never from `SEARCH_CONFIG`. The cached key's only effect was the leak.

## Fix (`services/search/core.py`)

1. **Stop caching the secret in the shared global** — `update_search_config` no longer writes the API key into `SEARCH_CONFIG`. (`api_key` is still accepted for backward compatibility but not stored; `brave_search` is unaffected because it reads `_get_provider_key`.)
2. **Scrub the response** — `get_search_config` drops any string-valued credential field (`*_api_key` / `*_key` / `*_token` / `*_secret`) before returning. `has_api_key` is a bool, so the `isinstance(str)` guard preserves it; non-secret fields (provider, result_count, search_url) are untouched. Defense-in-depth so no secret can leak even if some future code writes one into the global.

## Compatibility

- **No schema/config change.** `brave_search` and `_get_provider_key` are untouched, so search keeps working with keys configured in settings/env.
- **Response shape:** the only field removed is the raw `brave_api_key` (which should never have been exposed); `has_api_key` and all non-secret fields remain. The frontend does not read `brave_api_key` from this endpoint (`/api/search/config` isn't fetched anywhere in `static/`), so nothing breaks.
- `src/app_initializer.py` still calls `update_search_config(api_key=...)`; that call is now a no-op for the key (intentional) and could be cleaned up separately — left untouched here to keep the change scoped to the leak surface.

## Tests

`tests/test_search_config_no_key_leak.py`:

- `update_search_config(api_key=...)` does not cache the secret in `SEARCH_CONFIG`;
- `get_search_config()` never returns a secret value (even when one is injected into the global), while keeping `has_api_key` and non-secret fields;
- `_is_secret_key` classifies credential suffixes, and the bool `has_api_key` survives the `isinstance` guard.

Each fails on `main`. Existing `tests/test_search_config_provider_key.py` (asserts `has_api_key is True`) stays green.

Fixes #1661
