### PR TITLE
fix: _derive_title crashes on non-string content instead of returning Untitled

### DIFF
--- a/routes/document_helpers.py
+++ b/routes/document_helpers.py
@@ -203,6 +203,8 @@ def _assert_pdf_marker_upload_owned(
 def _derive_title(content: str) -> str:
     """Derive a title from document content."""
     import re
+    if not isinstance(content, str):
+        return "Untitled"
     text = content.strip()
     if not text:
         return "Untitled"

--- a/tests/test_derive_title_nonstring.py
+++ b/tests/test_derive_title_nonstring.py
@@ -1,0 +1,13 @@
+from routes.document_helpers import _derive_title
+
+
+def test_derive_title_handles_non_string_content():
+    # content normally comes from a document text column, but the helper is
+    # public and a non-string (None / int) made content.strip() raise
+    # AttributeError instead of falling back to a default title.
+    assert _derive_title(None) == "Untitled"
+    assert _derive_title(123) == "Untitled"
+
+
+def test_derive_title_still_reads_markdown_heading():
+    assert _derive_title("# Heading Title\nbody text") == "Heading Title"


### PR DESCRIPTION
## Summary
`_derive_title(content)` calls `content.strip()` immediately. The helper is public (used to backfill missing document titles), and a non-string `content` (None or another type from a partially-populated document row) raises `AttributeError` instead of falling back to the "Untitled" default the function already returns for empty content.

## Changes
- routes/document_helpers.py: return "Untitled" when `content` is not a string.
- tests/test_derive_title_nonstring.py: None/int content returns "Untitled" (raises on the old code), and a markdown heading is still parsed into the title.