### PR TITLE
fix: is_youtube_url crashes on a non-string url

### DIFF
--- a/src/youtube_handler.py
+++ b/src/youtube_handler.py
@@ -59,6 +59,8 @@ def init_youtube():
 
 
 def is_youtube_url(url: str) -> bool:
+    if not isinstance(url, str):
+        return False
     return "youtube.com" in url or "youtu.be" in url
 
 

--- a/tests/test_is_youtube_url_nonstring.py
+++ b/tests/test_is_youtube_url_nonstring.py
@@ -1,0 +1,14 @@
+from src.youtube_handler import is_youtube_url
+
+
+def test_is_youtube_url_handles_non_string():
+    # `"youtube.com" in url` raises TypeError on a non-string; a url field that
+    # can be None/other (e.g. from a JSON message) should just be "not YT".
+    assert is_youtube_url(123) is False
+    assert is_youtube_url(None) is False
+    assert is_youtube_url({"u": 1}) is False
+
+
+def test_is_youtube_url_detects_real_urls():
+    assert is_youtube_url("https://www.youtube.com/watch?v=x") is True
+    assert is_youtube_url("https://youtu.be/x") is True


### PR DESCRIPTION
## Summary
`is_youtube_url` does `"youtube.com" in url`, which raises `TypeError: argument of type 'NoneType'/'int' is not iterable` when `url` is not a string. A url value coming from a JSON message field or stored metadata can be None or another type, so the membership test should treat it as simply "not a YouTube URL".

## Changes
- src/youtube_handler.py: return False for a non-string url before the membership checks.
- tests/test_is_youtube_url_nonstring.py: non-string inputs return False (raise on the old code) and real watch/youtu.be URLs still return True.