### PR TITLE
fix: is_youtube_url (services) crashes on a non-string url

### DIFF
--- a/services/youtube/youtube_handler.py
+++ b/services/youtube/youtube_handler.py
@@ -59,6 +59,8 @@ def init_youtube():
 
 
 def is_youtube_url(url: str) -> bool:
+    if not isinstance(url, str):
+        return False
     return "youtube.com" in url or "youtu.be" in url
 
 

--- a/tests/test_is_youtube_url_nonstring_svc.py
+++ b/tests/test_is_youtube_url_nonstring_svc.py
@@ -1,0 +1,13 @@
+from services.youtube.youtube_handler import is_youtube_url
+
+
+def test_is_youtube_url_handles_non_string():
+    # `"youtube.com" in url` raises TypeError on a non-string url.
+    assert is_youtube_url(123) is False
+    assert is_youtube_url(None) is False
+    assert is_youtube_url(["https://youtu.be/x"]) is False
+
+
+def test_is_youtube_url_detects_real_urls():
+    assert is_youtube_url("https://www.youtube.com/watch?v=x") is True
+    assert is_youtube_url("https://youtu.be/x") is True


### PR DESCRIPTION
## Summary
The `services/youtube` copy of `is_youtube_url` does `"youtube.com" in url`, which raises `TypeError` when `url` is not a string. A url from a JSON field or stored metadata can be None or another type, so it should be treated as "not a YouTube URL" rather than crashing the caller.

## Changes
- services/youtube/youtube_handler.py: return False for a non-string url before the membership checks.
- tests/test_is_youtube_url_nonstring_svc.py: non-string inputs return False (raise on the old code) and real YouTube URLs still return True.