### PR TITLE
Owner-namespace RAG doc ids so two owners' identical chunks aren't dropped

### DIFF
--- a/src/rag_vector.py
+++ b/src/rag_vector.py
@@ -27,8 +27,14 @@ KEYWORD_WEIGHT = 0.3
 COLLECTION_NAME = "odysseus_rag"
 
 
-def _generate_doc_id(text: str) -> str:
-    return f"doc_{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
+def _generate_doc_id(text: str, owner: Optional[str] = None) -> str:
+    # Namespace the id by owner so two owners indexing byte-identical text get
+    # distinct rows (#1662). Otherwise the second owner's chunk collides with the
+    # first's id, is skipped on add, and never appears in their owner-scoped
+    # search. owner=None keeps the legacy content-only id, so existing rows and
+    # shared/legacy chunks are unchanged and need no re-index.
+    key = text if owner is None else f"{owner}\x00{text}"
+    return f"doc_{hashlib.sha256(key.encode('utf-8')).hexdigest()[:16]}"
 
 
 class VectorRAG:
@@ -104,8 +110,8 @@ class VectorRAG:
             return False
 
         try:
-            doc_id = _generate_doc_id(text)
-            # Check if already exists
+            doc_id = _generate_doc_id(text, metadata.get("owner"))
+            # Check if already exists (same owner + same text)
             existing = self._collection.get(ids=[doc_id])
             if existing["ids"]:
                 return True  # already exists
@@ -140,7 +146,7 @@ class VectorRAG:
             new_metas = []
             new_ids = []
             for t, m in valid:
-                doc_id = _generate_doc_id(t)
+                doc_id = _generate_doc_id(t, m.get("owner"))
                 existing = self._collection.get(ids=[doc_id])
                 if not existing["ids"]:
                     new_texts.append(t)

--- a/tests/test_rag_owner_scoped_doc_id.py
+++ b/tests/test_rag_owner_scoped_doc_id.py
@@ -1,0 +1,79 @@
+"""Regression guard for #1662 — RAG doc ids must be owner-namespaced.
+
+_generate_doc_id hashed the text only, and add_document / add_documents_batch
+early-return on an existing id. So when two owners indexed byte-identical text,
+the second owner's chunk collided with the first's id, was skipped, and never
+appeared in the second owner's owner-scoped search. The id now includes the
+owner; owner=None keeps the legacy content-only id, so existing rows and
+shared/legacy chunks are unchanged and need no re-index.
+"""
+import hashlib
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from src.rag_vector import _generate_doc_id, VectorRAG
+
+
+def _legacy_id(text):
+    return f"doc_{hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]}"
+
+
+def test_owner_none_keeps_legacy_id():
+    # Back-compat: existing rows / shared chunks keep their content-only id.
+    assert _generate_doc_id("hello") == _legacy_id("hello")
+    assert _generate_doc_id("hello", None) == _legacy_id("hello")
+
+
+def test_distinct_owners_get_distinct_ids_for_same_text():
+    a = _generate_doc_id("hello", "alice")
+    b = _generate_doc_id("hello", "bob")
+    shared = _generate_doc_id("hello", None)
+    assert a != b
+    assert a != shared and b != shared
+    # Deterministic per (owner, text).
+    assert a == _generate_doc_id("hello", "alice")
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.rows = {}  # id -> (text, metadata)
+
+    def get(self, ids=None, include=None):
+        if ids is not None:
+            present = [i for i in ids if i in self.rows]
+            return {"ids": present, "metadatas": [self.rows[i][1] for i in present]}
+        all_ids = list(self.rows)
+        return {"ids": all_ids, "metadatas": [self.rows[i][1] for i in all_ids]}
+
+    def add(self, ids=None, embeddings=None, documents=None, metadatas=None):
+        for i, doc, meta in zip(ids, documents, metadatas):
+            self.rows[i] = (doc, meta)
+
+
+def _make_rag():
+    rag = VectorRAG.__new__(VectorRAG)  # skip Chroma connect
+    rag._collection = _FakeCollection()
+    rag._healthy = True
+    rag._embed = lambda texts: [[0.0] for _ in texts]
+    return rag
+
+
+def test_two_owners_identical_text_both_indexed():
+    rag = _make_rag()
+    text = "shared boilerplate chunk"
+    rag.add_documents_batch([(text, {"source": "/a/f.md", "owner": "alice"})])
+    rag.add_documents_batch([(text, {"source": "/b/f.md", "owner": "bob"})])
+
+    rows = rag._collection.rows
+    assert len(rows) == 2, "both owners' identical chunk must be stored"
+    owners = sorted(m["owner"] for (_, m) in rows.values())
+    assert owners == ["alice", "bob"]  # was just ["alice"] before the fix
+
+
+def test_same_owner_same_text_still_deduped():
+    rag = _make_rag()
+    text = "dup chunk"
+    rag.add_documents_batch([(text, {"source": "/a/1.md", "owner": "alice"})])
+    rag.add_documents_batch([(text, {"source": "/a/2.md", "owner": "alice"})])
+    assert len(rag._collection.rows) == 1  # genuine per-owner dedup is preserved


### PR DESCRIPTION
## What & why

RAG document ids were derived from the chunk **text alone** (`_generate_doc_id`), and `add_document` / `add_documents_batch` early-return on an existing id. The ChromaDB collection is shared and `search` filters by `where={"owner": owner}` (exact match). So when two owners indexed byte-identical text (shared boilerplate, a license header, a file both uploaded), the second owner's chunk collided with the first's id, was skipped on add, and kept the first owner's metadata — so the second owner's owner-scoped search silently never returned it.

## Fix

Namespace the doc id by owner: `_generate_doc_id(text, owner)`. Each owner gets a distinct id for the same text, so both rows coexist and each owner's `where={"owner": ...}` search finds its own copy. `owner=None` (shared / legacy chunks) keeps the exact legacy content-only id. Owner is derived from the metadata already passed to the add functions — no signature change to `add_document` / `add_documents_batch`, and `search` is untouched.

## Why id-namespacing, not metadata-merge

Merging multiple owners into a single row's metadata does **not** fit the existing design: Chroma metadata is scalar and `search` filters `owner` by exact match, so one row can't serve two owners. Distinct per-owner rows is the change that works with the existing search path.

## Compatibility — no migration / no re-index

- `owner=None` produces the **exact** legacy id (`doc_{sha256(text)[:16]}`), so existing rows and shared/legacy chunks are unchanged. The existing `tests/test_rag_vector_id_stability.py` (text-only id) stays green.
- Existing owned rows keep their old content-only ids and remain retrievable (`search` filters on the `owner` metadata, which is unchanged). When an owner re-indexes already-present text, a new owner-namespaced row is created alongside the old one — benign duplication that self-heals, never data loss.
- Genuine per-owner dedup (same owner + same text) is preserved.

## Tests

`tests/test_rag_owner_scoped_doc_id.py`:

- `owner=None` keeps the legacy content-only id;
- distinct owners get distinct (deterministic) ids for identical text;
- two owners indexing identical text → both rows stored (was just one before the fix);
- same owner + same text → still deduped to one row.

All pass; the existing id-stability test stays green.

Fixes #1662
