### PR TITLE
fix(security): scope send_to_session agent tool by owner

### DIFF
--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -517,7 +517,7 @@ async def do_list_sessions(content: str, session_id: Optional[str] = None, owner
         return {"error": str(e)}
 
 
-async def do_send_to_session(content: str, session_id: Optional[str] = None) -> Dict:
+async def do_send_to_session(content: str, session_id: Optional[str] = None, owner: Optional[str] = None) -> Dict:
     """Send a message to an existing session and get a response.
 
     Content format:
@@ -539,6 +539,10 @@ async def do_send_to_session(content: str, session_id: Optional[str] = None) -> 
 
     sess = _session_manager.get_session(target_sid)
     if not sess:
+        return {"error": f"Session '{target_sid}' not found"}
+
+    # Owner-scope: reject access to another user's session
+    if owner and getattr(sess, "owner", None) and sess.owner != owner:
         return {"error": f"Session '{target_sid}' not found"}
 
     if not message:
@@ -1769,7 +1773,7 @@ async def dispatch_ai_tool(
     elif tool == "send_to_session":
         sid = content.split("\n")[0].strip()[:20]
         desc = f"send_to_session: {sid}"
-        result = await do_send_to_session(content, session_id)
+        result = await do_send_to_session(content, session_id, owner=owner)
 
     elif tool == "pipeline":
         desc = "pipeline: running steps"


### PR DESCRIPTION
## Summary
- `send_to_session` was the only agent tool that didn't check session ownership — an agent acting for user A could read from and write into user B's session
- Adds `owner` parameter to `do_send_to_session()` and rejects access when the target session belongs to a different user
- Passes `owner=owner` at the dispatch call site, matching `create_session`, `list_sessions`, and `manage_session`

Fixes #1616

## Test plan
- [ ] On a multi-user instance, verify user A's agent cannot send to user B's session
- [ ] Verify send_to_session still works for the session owner's own sessions
- [ ] Run `pytest tests/ -k "session"` — existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)