### PR TITLE
fix: add dedicated attach button to toolbar with drag-and-drop fix

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -128,6 +128,8 @@ function initializeEventListeners() {
   // File attachments (inside overflow menu)
   const _overflowAttach = el('overflow-attach-btn');
   if (_overflowAttach) _overflowAttach.addEventListener('click', fileHandlerModule.openPicker);
+  const _directAttach = el('direct-attach-btn');
+  if (_directAttach) _directAttach.addEventListener('click', fileHandlerModule.openPicker);
   el('file-input').addEventListener('change', (e)=>{
     for (const f of e.target.files) fileHandlerModule.addFiles([f]);
     fileHandlerModule.renderAttachStrip();
@@ -1762,7 +1764,7 @@ function initializeEventListeners() {
     function _flagRefocus(e) {
       if (e.target.closest('textarea, input')) return;
       // Don't refocus for attach — file picker needs full focus control
-      if (e.target.closest('#overflow-attach-btn')) return;
+      if (e.target.closest('#overflow-attach-btn, #direct-attach-btn')) return;
       // Don't refocus for model picker button — focus should go to picker search input
       if (e.target.closest('.model-picker-btn')) return;
       // Don't refocus when tapping the +/chevron tools button — the user
@@ -1956,7 +1958,7 @@ function initializeEventListeners() {
     if (!inputLeft || !overflowMenu || !overflowWrapper) return;
 
     // Buttons that can be collapsed (in reverse priority — last collapsed first)
-    const collapsibleIds = ['bash-toggle-btn', 'web-toggle-btn'];
+    const collapsibleIds = ['direct-attach-btn', 'bash-toggle-btn', 'web-toggle-btn'];
     const collapsibleBtns = collapsibleIds.map(id => el(id)).filter(Boolean);
     // Map of toolbar btn id → overflow mirror element (created dynamically)
     const overflowMirrors = new Map();
@@ -2028,7 +2030,13 @@ function initializeEventListeners() {
         collapsibleBtns.forEach(btn => {
           btn.classList.add('toolbar-collapsed');
           const mirror = overflowMirrors.get(btn.id);
-          if (mirror) mirror.style.display = '';
+          if (mirror) {
+            if (btn.style.display !== 'none') {
+              mirror.style.display = '';
+            } else {
+              mirror.style.display = 'none';
+            }
+          }
         });
         inputLeft.style.overflow = prevOverflow;
         inputLeft.style.flexWrap = '';
@@ -2041,7 +2049,13 @@ function initializeEventListeners() {
         for (let i = 0; i < collapsibleBtns.length; i++) {
           collapsibleBtns[i].classList.add('toolbar-collapsed');
           const mirror = overflowMirrors.get(collapsibleBtns[i].id);
-          if (mirror) mirror.style.display = '';
+          if (mirror) {
+            if (collapsibleBtns[i].style.display !== 'none') {
+              mirror.style.display = '';
+            } else {
+              mirror.style.display = 'none';
+            }
+          }
           totalWidth -= btnWidths[i];
           if (totalWidth <= available) break;
         }
@@ -2080,6 +2094,7 @@ function initializeEventListeners() {
     if (inputBottom) {
       new ResizeObserver(() => requestAnimationFrame(checkToolbarOverflow)).observe(inputBottom);
     }
+    window.checkToolbarOverflow = checkToolbarOverflow;
   })();
 
   // ── Auto-hide model picker when textarea area is too narrow ──
@@ -2399,7 +2414,7 @@ function initializeEventListeners() {
     'overflow-plus-btn':   '.overflow-wrapper',
     'mode-toggle':         '.mode-toggle',
     'preset-mini-btn':     '#overflow-preset-btn',
-    'attach-btn':          '#overflow-attach-btn',
+    'attach-btn':          '#overflow-attach-btn, #direct-attach-btn',
     'research-btn':        '#overflow-research-btn',
     'rail-new-chat':       '#rail-new-session',
   };
@@ -2427,6 +2442,9 @@ function initializeEventListeners() {
         el.style.display = visible ? '' : 'none';
       });
     });
+    if (typeof window.checkToolbarOverflow === 'function') {
+      window.checkToolbarOverflow();
+    }
     // Drag reorder: use body class so dynamically created handles are covered
     const dragEnabled = state['section-drag-reorder'] === true;
     document.body.classList.toggle('rearrange-mode', dragEnabled);
@@ -3849,8 +3867,9 @@ function startOdysseusApp() {
     const files = Array.from(e.dataTransfer.files);
     if (files.length === 0) return;
 
+    fileHandlerModule.addFiles(files);
+    fileHandlerModule.renderAttachStrip();
     uiModule.showToast(`Added ${files.length} file${files.length > 1 ? 's' : ''} to chat`);
-
   });
   
   attachStrip.addEventListener('dragleave', (e) => {

--- a/static/app.js
+++ b/static/app.js
@@ -1958,7 +1958,7 @@ function initializeEventListeners() {
     if (!inputLeft || !overflowMenu || !overflowWrapper) return;
 
     // Buttons that can be collapsed (in reverse priority — last collapsed first)
-    const collapsibleIds = ['direct-attach-btn', 'bash-toggle-btn', 'web-toggle-btn'];
+    const collapsibleIds = ['bash-toggle-btn', 'web-toggle-btn', 'direct-attach-btn'];
     const collapsibleBtns = collapsibleIds.map(id => el(id)).filter(Boolean);
     // Map of toolbar btn id → overflow mirror element (created dynamically)
     const overflowMirrors = new Map();

--- a/static/index.html
+++ b/static/index.html
@@ -1050,6 +1050,10 @@
               </button>
             </div>
           </div>
+          <!-- Dedicated attach button -->
+          <button type="button" class="input-icon-btn" title="Attach files" id="direct-attach-btn" aria-label="Attach files">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
+          </button>
           <!-- Web search (magnifying glass) -->
           <button type="button" class="input-icon-btn" title="Web search" id="web-toggle-btn" data-mode-tool="true" aria-label="Web search" aria-pressed="false">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -249,7 +249,7 @@ async function _buildCompareUI() {
   }
 
   // 4. Save toolbar indicator display states before hiding
-  const indicatorIds = ['overflow-tts-btn', 'overflow-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'research-toggle-btn'];
+  const indicatorIds = ['overflow-tts-btn', 'overflow-attach-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'research-toggle-btn'];
   state._savedIndicatorDisplay = {};
   indicatorIds.forEach(id => {
     const el = document.getElementById(id);
@@ -483,7 +483,7 @@ async function _buildCompareUI() {
   _setupEvalPicker();
 
   // 12. Hide tool buttons that don't apply during compare
-  ['overflow-tts-btn', 'overflow-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'web-toggle-btn', 'bash-toggle-btn', 'overflow-plus-btn'].forEach(id => {
+  ['overflow-tts-btn', 'overflow-attach-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'web-toggle-btn', 'bash-toggle-btn', 'overflow-plus-btn'].forEach(id => {
     const el = document.getElementById(id);
     if (el) { el.style.display = 'none'; el.style.pointerEvents = 'none'; }
   });


### PR DESCRIPTION
**Fixes #1142**

- Add #direct-attach-btn (paperclip icon) directly in the input toolbar
  so users can attach files without opening the overflow menu
- Wire click handler to fileHandlerModule.openPicker, consistent with
  overflow-attach-btn
- Fix drag-and-drop onto attach strip: files were never actually added
  (addFiles/renderAttachStrip calls were missing, only toast was shown)
- Exempt #direct-attach-btn from textarea refocus guard so the file
  picker gets full focus control (mirrors existing overflow-attach-btn fix)
- Add direct-attach-btn to collapsibleIds with highest priority (collapses
  last, after bash and web-search) so it stays visible as long as possible
- Suppress overflow mirror when the original button is hidden (settings
  visibility toggle) to avoid ghost entries in the overflow menu
- Expose checkToolbarOverflow on window so applyUIVis can re-evaluate
  toolbar layout after toggling button visibility
- Register direct-attach-btn in compare mode: save/restore its display
  state and hide it during compare (alongside overflow-attach-btn)
  
 **Tests:** python3 -m py_compile app.py ✅, node --check ✅