### PR TITLE
fix: ui_control rejects the advertised rag toggle

### DIFF
--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -1288,7 +1288,7 @@ async def do_ui_control(content: str, session_id: Optional[str] = None) -> Dict:
             "private": "incognito",
         }
         toggle_name = _toggle_aliases.get(toggle_name, toggle_name)
-        valid_toggles = {"web", "bash", "research", "incognito", "document_editor"}
+        valid_toggles = {"web", "bash", "rag", "research", "incognito", "document_editor"}
         if toggle_name not in valid_toggles:
             return {"error": f"Unknown toggle '{toggle_name}'. Valid: {', '.join(sorted(valid_toggles))}"}
         return {

--- a/tests/test_ui_control_rag_toggle.py
+++ b/tests/test_ui_control_rag_toggle.py
@@ -1,0 +1,36 @@
+"""The `rag` UI toggle must be accepted.
+
+do_ui_control advertises `rag` as a valid toggle in its own docstring and in
+get_toggles ("Available toggles: web, bash, rag, ..."), and the frontend
+fully wires it (chatStream.js maps rag -> rag-toggle / rag-indicator-btn).
+But valid_toggles omitted "rag", so `toggle rag on` returned an "Unknown
+toggle" error - the advertised capability was dead.
+"""
+import asyncio
+
+from src.ai_interaction import do_ui_control
+
+
+def test_toggle_rag_on_is_accepted():
+    r = asyncio.run(do_ui_control("toggle rag on"))
+    assert r.get("ui_event") == "toggle"
+    assert r.get("toggle_name") == "rag"
+    assert r.get("state") is True
+    assert "error" not in r
+
+
+def test_toggle_rag_off_is_accepted():
+    r = asyncio.run(do_ui_control("toggle rag off"))
+    assert r.get("toggle_name") == "rag"
+    assert r.get("state") is False
+    assert "error" not in r
+
+
+def test_unknown_toggle_still_rejected():
+    r = asyncio.run(do_ui_control("toggle bogus on"))
+    assert "error" in r
+
+
+def test_existing_toggle_still_works():
+    r = asyncio.run(do_ui_control("toggle web on"))
+    assert r.get("toggle_name") == "web" and r.get("state") is True


### PR DESCRIPTION
## Summary
do_ui_control's toggle action advertises rag as a valid toggle — in its own docstring ("toggle <name> ... (web, bash, rag, research, incognito, document_editor)") and in get_toggles ("Available toggles: web, bash, rag, ..."). The frontend fully wires it (chatStream.js maps rag to rag-toggle / rag-indicator-btn and special-cases _syncRagIndicator). But the server-side valid_toggles set omits "rag" and there is no alias, so toggle rag on returns {"error": "Unknown toggle 'rag'"}. The advertised capability is dead.

## Fix
Add "rag" to valid_toggles.

## Changes
- src/ai_interaction.py: rag added to the toggle allowlist.
- tests/test_ui_control_rag_toggle.py: toggle rag on/off accepted (fails on old code), unknown toggle still rejected, existing web toggle still works.