### PR TITLE
fix(calendar): negotiate Digest auth in CalDAV test endpoint

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -629,6 +629,18 @@ def setup_calendar_routes() -> APIRouter:
                     headers={"Depth": "0", "Content-Type": "application/xml"},
                     content=propfind_body,
                 )
+                # If the server demands Digest (Baïkal default, SabreDAV-based
+                # servers, Radicale with htdigest), the Basic attempt above
+                # 401s. Retry once with httpx.DigestAuth so this test matches
+                # what the real sync does via caldav.DAVClient in
+                # src/caldav_sync.py (which negotiates the scheme).
+                if r.status_code == 401 and "digest" in r.headers.get("www-authenticate", "").lower():
+                    r = await cx.request(
+                        "PROPFIND", url,
+                        auth=httpx.DigestAuth(user, pw),
+                        headers={"Depth": "0", "Content-Type": "application/xml"},
+                        content=propfind_body,
+                    )
             # 207 = Multi-Status — standard CalDAV success. 200 also
             # acceptable. Anything else (401/403/404/5xx) means trouble.
             if r.status_code in (200, 207):


### PR DESCRIPTION
`/api/calendar/test` uses raw httpx Basic auth, so it 401s against Digest-only CalDAV servers (Baïkal default, SabreDAV, Radicale w/ htdigest) even when creds are correct. Real sync via `caldav.DAVClient` already negotiates, so prod works — only the test endpoint disagrees.

Fix: on a 401 advertising `Digest`, retry once with `httpx.DigestAuth`.

Verified against Baïkal 0.11.1: pre-patch 401, post-patch 207.