### PR TITLE
docs: fix stale documentation references

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -33,8 +33,8 @@ The full license texts are kept in [`licenses/`](licenses/).
 - **[Tongyi DeepResearch](https://github.com/Alibaba-NLP/DeepResearch)** by
   **Alibaba-NLP / Tongyi Lab** — the multi-step deep-research agent pipeline.
   Copyright © Alibaba-NLP / Tongyi Lab. **Apache-2.0.** Adapted for Odysseus's
-  Deep Research feature (`api/research_*.py`, `routes/research_routes.py`,
-  `services/search/`). Full text in
+  Deep Research feature (`services/research/`, `src/research_handler.py`,
+  `routes/research_routes.py`, `services/search/`). Full text in
   [`licenses/DeepResearch-Apache-2.0.txt`](licenses/DeepResearch-Apache-2.0.txt).
 
 ---
@@ -47,7 +47,7 @@ just composed.
 
 | Service | Image | Purpose | License |
 |---|---|---|---|
-| [SearXNG](https://github.com/searxng/searxng) | `searxng/searxng:latest` | Default metasearch backend | AGPL-3.0 |
+| [SearXNG](https://github.com/searxng/searxng) | `searxng/searxng:2026.5.31-7159b8aed` (pinned tag; see compose) | Default metasearch backend | AGPL-3.0 |
 | [ChromaDB](https://github.com/chroma-core/chroma) | `chromadb/chroma:latest` | Vector store for memory / RAG | Apache-2.0 |
 | [ntfy](https://github.com/binwiederhier/ntfy) | `binwiederhier/ntfy` | Push notifications (self-hosted reminders) | Apache-2.0 / GPL-2.0 |
 

--- a/static/js/MODULE_SUMMARY.md
+++ b/static/js/MODULE_SUMMARY.md
@@ -3,6 +3,14 @@
 ## Purpose
 This document describes what each JavaScript module is responsible for.
 
+> **Note:** This file is a partial, historical overview — not a complete authoritative
+> inventory. The authoritative module set is the current `static/js/` tree plus the
+> scripts loaded by `static/index.html`. As of this writing that tree holds **65 `.js`
+> files** across **8 subdirectories** (`calendar/`, `color/`, `compare/`, `editor/`,
+> `emailLibrary/`, `markdown/`, `research/`, `util/`), and `static/index.html` loads
+> **35** `/static…` script tags. The catalog below covers only the original core
+> modules and is not kept in sync with every module.
+
 ---
 
 ## Core Modules (in static/js/)
@@ -23,7 +31,7 @@ This document describes what each JavaScript module is responsible for.
 - Content rendering for message arrays
 - Text cleanup (`squashOutsideCode`)
 
-### 3. **session.js**
+### 3. **sessions.js**
 - Session/chat management
 - Create, load, delete, switch sessions
 - Session history loading
@@ -54,7 +62,7 @@ This document describes what each JavaScript module is responsible for.
 
 ### 7. **models.js**
 - Model scanning and display
-- Local model discovery (ports 8000-8010)
+- Local model discovery (ports 8000-8020)
 - Provider management (OpenAI)
 - Model selection UI
 


### PR DESCRIPTION
## Summary

Fixes a few small, verified stale documentation references.

## Changes

- Marks `static/js/MODULE_SUMMARY.md` as a partial/historical overview rather than a complete frontend inventory.
- Corrects `session.js` → `sessions.js`.
- Corrects local model discovery range `8000-8010` → `8000-8020`.
- Corrects the stale `api/research_*.py` reference in `ACKNOWLEDGMENTS.md`.
- Updates the SearXNG acknowledgment to reflect that the Compose stack uses a pinned image tag, not `latest`.

## Validation

- `git diff --check`
- Verified `static/js/sessions.js` exists.
- Verified `src/model_discovery.py` scans `range(8000, 8021)`.
- Verified `static/index.html` currently loads 35 `/static...` script tags.
- Verified there is no `api/` directory and current research code lives under `services/research/`, `src/research_handler.py`, `src/research_utils.py`, and `routes/research_routes.py`.
- Verified SearXNG is pinned in the Compose file.
