### PR TITLE
fix(group): show all user-created personas in the participant selector

### DIFF
--- a/static/js/group.js
+++ b/static/js/group.js
@@ -299,13 +299,16 @@ async function _getCharacterList() {
       });
     }
   } catch (e) {}
-  // Load user templates and wait for them before returning
+  // Load user templates and wait for them before returning.
+  // The endpoint returns a JSON array directly (not {templates:[...]}).
+  // All user templates are personas by definition — no isCharacter filter needed.
   try {
     const r = await fetch(API_BASE + '/api/presets/templates', { credentials: 'same-origin' });
     const data = await r.json();
-    (data.templates || []).forEach(t => {
-      if (t.isCharacter && !chars.find(c => c.id === t.id)) {
-        chars.push({ id: t.id, name: t.name, prompt: t.prompt || '' });
+    const templates = Array.isArray(data) ? data : (data.templates || []);
+    templates.forEach(t => {
+      if (t.id && t.name && !chars.find(c => c.id === t.id)) {
+        chars.push({ id: t.id, name: t.name, prompt: t.system_prompt || t.prompt || '' });
       }
     });
   } catch (e) {}


### PR DESCRIPTION
 Summary

  _getCharacterList() in group.js had two bugs that silently dropped every user-created persona from the group
   participant picker:

  1. Wrong response shape: /api/presets/templates returns a JSON array directly, but the code read
  data.templates (always undefined). The forEach iterated over data.templates || [] — an empty array every
  time — so no user templates were ever loaded.
  2. isCharacter guard: Even if the array had been read correctly, t.isCharacter would have filtered
  everything out. That flag only exists on built-in PROMPT_TEMPLATES entries; user templates are saved by
  presets.js without it.

  Also fixed: t.prompt → t.system_prompt so the actual character prompt reaches the group chat (user templates
   store the prompt under system_prompt).

  Linked Issue: Fixes #1656

  Type of Change: Bug fix

  How to Test
  1. Go to Settings → Presets and create two or more custom personas with names and system prompts
  2. Open the Group chat tab
  3. Click "Add participant" — the character selector should now list all your saved personas
  4. Add participants using different personas and start a group chat
  5. Verify each participant uses the correct persona prompt