### PR TITLE
docs: add 'keeping your PR mergeable' rebase guidance to CONTRIBUTING (#1453)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,20 @@ Good pull requests usually include:
 
 Please keep PRs small. Large PRs that mix unrelated cleanup, formatting, refactors, and behavior changes are much harder to review.
 
+Always link the issue your PR fixes (`Fixes #123`). PRs with no linked issue are hard to triage and may be closed.
+
+### Keeping your PR mergeable
+
+`main` moves quickly, so the most common reason a finished, correct PR stalls is a **stale branch**. Before opening a PR — and again after each round of review — rebase onto the latest `main` and confirm your diff contains only your own files:
+
+```bash
+git fetch origin
+git rebase origin/main
+git diff origin/main..HEAD --name-only   # should list ONLY the files you intended to change
+```
+
+If that command lists files you never touched, your branch is stale and is silently reverting already-merged work — rebase until the list is clean. A clean two-dot diff is the difference between a quick review and a back-and-forth.
+
 ## Issue Reports
 
 For bugs, include:


### PR DESCRIPTION
## Summary
Adds a short, additive subsection to `CONTRIBUTING.md` for #1453 and the broader "contributors keep making the same review mistakes" problem.

`main` moves fast, so the most common reason a *finished, correct* PR stalls is a **stale branch** whose two-dot diff silently reverts already-merged files. The existing guide covers small/tested/issue-linked PRs but says nothing about staleness — which (anecdotally) is the most repeated review correction on this repo.

## What it adds
- An explicit `Fixes #123` link-the-issue line (the #1453 ask).
- A "Keeping your PR mergeable" subsection: rebase onto current `main` before opening and after each review round, and verify with:
  ```bash
  git diff origin/main..HEAD --name-only   # should list ONLY your intended files
  ```

## Scope
- `CONTRIBUTING.md` only — docs-only, additive, no new file, no runtime change. Kept deliberately small per the project's own "keep PRs small" guidance.

Happy to trim or drop if you'd rather keep CONTRIBUTING leaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)