### PR TITLE
docs(contributing): add a 'keep your branch rebased' note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,18 @@ Good pull requests usually include:
 
 Please keep PRs small. Large PRs that mix unrelated cleanup, formatting, refactors, and behavior changes are much harder to review.
 
+### Keep your branch rebased
+
+`main` moves quickly, so the most common reason a finished PR stalls in review is a stale branch. Before you open a PR — and again before you ask for a re-review — rebase onto current `main` and check the direct (two-dot) diff:
+
+```bash
+git fetch origin
+git rebase origin/main
+git diff origin/main..HEAD --name-only   # should list ONLY the files you intended to change
+```
+
+If that diff lists files you did not touch, your branch is behind and is effectively trying to revert already-merged work — keep rebasing until the diff is just your change. A clean, current two-dot diff is much faster to review and merge.
+
 ## Issue Reports
 
 For bugs, include:


### PR DESCRIPTION
## Summary
Adds one short subsection to `CONTRIBUTING.md` on keeping a branch rebased and checking the two-dot diff before review.

In your reviews the single most frequent correction is a finished PR going stale — the direct diff (`git diff origin/main..HEAD`) ends up including already-merged files, so the branch effectively reverts merged work and has to be sent back for a rebase. `CONTRIBUTING.md` already covers "keep PRs small / one change per PR" but doesn't spell out the rebase + two-dot-diff check, so this codifies that recurring feedback as a concrete step contributors can run themselves:

```bash
git fetch origin
git rebase origin/main
git diff origin/main..HEAD --name-only   # should list ONLY the files you intended to change
```

## Type of Change
- [x] Documentation only

## Linked Issue
No specific issue — this addresses recurring review friction rather than a single bug. Closing as not-wanted is totally fine if you'd rather keep CONTRIBUTING leaner.

## Scope
- `CONTRIBUTING.md` (+12 lines, one new subsection under "Pull Requests"). Docs-only, no code or tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)