### PR TITLE
fix(compare): anonymize session names in blind mode

### DIFF
--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -210,7 +210,7 @@ async function _buildCompareUI() {
     for (let i = 0; i < n; i++) {
       const m = state._selectedModels[i];
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + modelShorts[i]);
+      fd.append('name', state._blindMode ? '[CMP] Model ' + _slotChar(i) : '[CMP] ' + modelShorts[i]);
       fd.append('endpoint_url', m.endpoint || '');
       fd.append('model', m.model || '');
       if (m.endpointId) {

--- a/static/js/compare/panes.js
+++ b/static/js/compare/panes.js
@@ -382,7 +382,7 @@ async function _createAndAppendPane(m) {
 
   // Create session
   const fd = new FormData();
-  fd.append('name', '[CMP] ' + m.name);
+  fd.append('name', state._blindMode ? '[CMP] Model ' + _slotChar(i) : '[CMP] ' + m.name);
   fd.append('endpoint_url', m.url || '');
   fd.append('model', m.id || '');
   if (m.endpointId) {
@@ -584,7 +584,7 @@ function _showModelSwapDropdown(paneIdx, titleBtn) {
         fetch(`${state.API_BASE}/api/session/${oldSid}`, { method: 'DELETE' }).catch(() => {});
       }
       const fd = new FormData();
-      fd.append('name', '[CMP] ' + m.name);
+      fd.append('name', state._blindMode ? '[CMP] Model ' + _slotChar(paneIdx) : '[CMP] ' + m.name);
       fd.append('endpoint_url', m.url || '');
       fd.append('model', m.id || '');
       if (m.endpointId) {


### PR DESCRIPTION
## Summary

In blind mode, pane headers correctly show neutral labels ("Model A", "Model B"), but the underlying chat sessions still exposed real model names like `[CMP] gpt-4o` in the sidebar and `/api/sessions` endpoint, defeating blind compare integrity.

## Changes

- `static/js/compare/index.js:213` — session creation gates name on `state._blindMode`
- `static/js/compare/panes.js:385` — add-pane session creation same gate
- `static/js/compare/panes.js:587` — swap-model session creation same gate

## Fixes

Closes #1285