### PR TITLE
chore: add missing maintainer scaffolding (install_support template + labels)

### DIFF
--- a/.github/ISSUE_TEMPLATE/install_support.yml
+++ b/.github/ISSUE_TEMPLATE/install_support.yml
@@ -1,0 +1,55 @@
+name: Installation / Setup help
+description: I can't get it running (fresh install, Docker, Windows, macOS, etc.)
+labels: ["support", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Most issues right now are fresh install problems.** Please use this template.
+
+        Before posting, try these:
+        - Check the [README](https://github.com/pewdiepie-archdaemon/odysseus#readme) Quick Start
+        - Look at existing open issues (many common problems are already reported)
+        - Try the Docker route first if possible
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: How are you trying to run it?
+      options:
+        - Docker Compose (recommended)
+        - Manual install (Linux)
+        - Manual install (macOS)
+        - Manual install (Windows)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-failed
+    attributes:
+      label: What exactly went wrong?
+      description: Paste the actual error message or describe where it got stuck.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-tried
+    attributes:
+      label: What have you already tried?
+      placeholder: "I tried X, Y, and Z..."
+
+  - type: input
+    id: os
+    attributes:
+      label: Your OS + version
+      placeholder: "macOS 15.4, Windows 11, Ubuntu 24.04, etc."
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before opening
+      options:
+        - label: I read the README quick start section
+        - label: I checked if this error is already reported in open issues
+        - label: I am okay with this being treated as lower priority than code bugs (this is a support request)

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,54 @@
+# Suggested labels for Odysseus
+# You can import these with a tool like `github-label-sync` or create them manually.
+
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+
+- name: support
+  color: 0e8a16
+  description: Installation, setup, or usage help request
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+
+- name: windows
+  color: 5319e7
+  description: Windows-specific issue
+
+- name: macos
+  color: 5319e7
+  description: macOS-specific issue
+
+- name: docker
+  color: 1d76db
+  description: Docker / compose related
+
+- name: good first issue
+  color: 7057ff
+  description: Good for newcomers
+
+- name: needs-triage
+  color: fef2c0
+  description: Needs maintainer to categorize
+
+- name: duplicate
+  color: cfd3d7
+  description: This issue or pull request already exists
+
+- name: wontfix
+  color: ffffff
+  description: This will not be worked on
+
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
+
+- name: security
+  color: b60205
+  description: Security-related issue or PR


### PR DESCRIPTION
Small follow-up to the earlier scaffolding effort (closed #112).

Adds two pieces that were prepared but not included in #1211:

- `install_support.yml`: Dedicated template for the ongoing wave of fresh install / Docker / platform issues (high volume right now).
- `labels.yml`: Suggested labels (bug, support, enhancement, windows, macos, docker, good first issue, needs-triage, duplicate, security, etc.). Can be imported with github-label-sync or created manually.

Low risk, high value for triage and keeping the issue tracker manageable.

Full context was in the now-closed #112.