### PR TITLE
feat: add Intel Arc GPU detection and Docker passthrough support

### DIFF
--- a/docker/gpu.intel.yml
+++ b/docker/gpu.intel.yml
@@ -1,0 +1,18 @@
+# Intel Arc / integrated GPU overlay. Enable by setting COMPOSE_FILE in .env:
+#   COMPOSE_FILE=docker-compose.yml:docker/gpu.intel.yml
+#
+# Requires the xe or i915 driver on the host and /dev/dri passed through
+# to this container (Proxmox LXC: add cgroup2.devices.allow + mount.entry
+# for /dev/dri; bare-metal Docker: works automatically if drivers are loaded).
+# The host user running Docker must be in the `video` and `render` groups.
+#
+# This overlay only passes the host GPU through to the container.
+# Install OpenCL/oneAPI or ipex-llm / llama-cpp-python (Intel build) via
+# Cookbook -> Dependencies before serving GPU models.
+services:
+  odysseus:
+    devices:
+      - /dev/dri
+    group_add:
+      - video
+      - ${RENDER_GID:-render}

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -1376,6 +1376,53 @@ def setup_cookbook_routes() -> APIRouter:
                 gpus[0]["busy"] = True
         return gpus
 
+    # PCI device ID → (name, vram_mb) for known Intel Arc discrete GPUs.
+    _INTEL_ARC_VRAM: dict[str, tuple[str, int]] = {
+        "0x56a0": ("Intel Arc A770 16GB", 16384),
+        "0x56a1": ("Intel Arc A770 8GB",   8192),
+        "0x56a2": ("Intel Arc A750 8GB",   8192),
+        "0x56a5": ("Intel Arc A380 6GB",   6144),
+        "0x56a6": ("Intel Arc A310 4GB",   4096),
+        "0x5690": ("Intel Arc A770M 16GB", 16384),
+        "0x5691": ("Intel Arc A730M 12GB", 12288),
+        "0x5692": ("Intel Arc A550M 8GB",   8192),
+        "0x5693": ("Intel Arc A370M 4GB",   4096),
+        "0x5694": ("Intel Arc A350M 4GB",   4096),
+        "0x5695": ("Intel Arc A370M 4GB",   4096),
+        "0xe202": ("Intel Arc B580 12GB",  12288),
+        "0xe20b": ("Intel Arc B570 10GB",  10240),
+    }
+
+    async def _probe_intel_sysfs(host: str | None, ssh_port: str | None) -> list[dict]:
+        out, err = await _run_gpu_shell("ls -1 /sys/class/drm 2>/dev/null", host, ssh_port, timeout=4)
+        if err is not None or not out:
+            return []
+        gpus = []
+        for entry in out.split():
+            if not entry.startswith("card") or "-" in entry:
+                continue
+            base = f"/sys/class/drm/{entry}/device"
+            vendor = await _gpu_read_file(f"{base}/vendor", host, ssh_port)
+            if vendor != "0x8086":
+                continue
+            device_id = await _gpu_read_file(f"{base}/device", host, ssh_port)
+            name, total_mb = _INTEL_ARC_VRAM.get(device_id or "", (None, 0))
+            if not name:
+                name = f"Intel GPU {device_id or entry}"
+            gpus.append({
+                "index": len(gpus), "name": name, "uuid": entry,
+                "free_mb": total_mb, "total_mb": total_mb, "used_mb": 0,
+                "util_pct": 0, "busy": False, "processes": [],
+                "backend": "xe", "source": "intel-sysfs",
+                "unified_memory": False,
+            })
+        if gpus:
+            processes = await _probe_gpu_device_processes(host, ssh_port)
+            if processes:
+                gpus[0]["processes"] = processes
+                gpus[0]["busy"] = True
+        return gpus
+
     @router.get("/api/cookbook/gpus")
     async def list_gpus(request: Request, host: str | None = None, ssh_port: str | None = None):
         """Probe GPU memory/process state locally or via SSH.
@@ -1513,6 +1560,17 @@ def setup_cookbook_routes() -> APIRouter:
                 "gpus": amd_gpus,
                 "backend": "rocm",
                 "source": "amd-sysfs",
+                "fallback_from": "nvidia-smi",
+                "nvidia_error": nvidia_error,
+            }
+
+        intel_gpus = await _probe_intel_sysfs(host, ssh_port)
+        if intel_gpus:
+            return {
+                "ok": True,
+                "gpus": intel_gpus,
+                "backend": "xe",
+                "source": "intel-sysfs",
                 "fallback_from": "nvidia-smi",
                 "nvidia_error": nvidia_error,
             }

--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -205,6 +205,79 @@ def _detect_amd():
         return None
 
 
+_INTEL_ARC_VRAM_GB: dict[str, tuple[str, float]] = {
+    "0x56a0": ("Intel Arc A770 16GB", 16.0),
+    "0x56a1": ("Intel Arc A770 8GB",   8.0),
+    "0x56a2": ("Intel Arc A750 8GB",   8.0),
+    "0x56a5": ("Intel Arc A380 6GB",   6.0),
+    "0x56a6": ("Intel Arc A310 4GB",   4.0),
+    "0x5690": ("Intel Arc A770M 16GB", 16.0),
+    "0x5691": ("Intel Arc A730M 12GB", 12.0),
+    "0x5692": ("Intel Arc A550M 8GB",   8.0),
+    "0x5693": ("Intel Arc A370M 4GB",   4.0),
+    "0x5694": ("Intel Arc A350M 4GB",   4.0),
+    "0x5695": ("Intel Arc A370M 4GB",   4.0),
+    "0xe202": ("Intel Arc B580 12GB",  12.0),
+    "0xe20b": ("Intel Arc B570 10GB",  10.0),
+}
+
+
+def _detect_intel():
+    """Detect Intel Arc / Xe discrete GPUs via /sys/class/drm (vendor 0x8086).
+    VRAM is looked up from a device-ID table since Intel doesn't expose it in sysfs."""
+    def _read(path):
+        if _remote_host:
+            val = _run(["cat", path])
+            return val.strip() if val else None
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                return f.read().strip()
+        except Exception:
+            return None
+
+    def _list_drm_cards():
+        if _remote_host:
+            out = _run(["ls", "/sys/class/drm"])
+            if not out:
+                return []
+            return [e for e in out.split() if e.startswith("card") and "-" not in e]
+        try:
+            return [e for e in os.listdir("/sys/class/drm") if e.startswith("card") and "-" not in e]
+        except Exception:
+            return []
+
+    try:
+        cards = []
+        for _cidx, entry in enumerate(_list_drm_cards()):
+            base = f"/sys/class/drm/{entry}/device"
+            vendor = _read(f"{base}/vendor")
+            if vendor != "0x8086":
+                continue
+            device_id = _read(f"{base}/device")
+            name, vram_gb = _INTEL_ARC_VRAM_GB.get(device_id or "", (None, 0.0))
+            if not name:
+                name = f"Intel GPU ({device_id or entry})"
+            if vram_gb <= 0:
+                continue
+            cards.append({"index": _cidx, "name": name, "vram_gb": vram_gb})
+
+        if not cards:
+            return None
+        total_vram = sum(c["vram_gb"] for c in cards)
+        groups = _group_gpus(cards)
+        return {
+            "gpu_name": cards[0]["name"],
+            "gpu_vram_gb": round(total_vram, 1),
+            "gpu_count": len(cards),
+            "gpus": cards,
+            "gpu_groups": groups,
+            "homogeneous": len(groups) <= 1,
+            "backend": "xe",
+        }
+    except Exception:
+        return None
+
+
 def _detect_apple_silicon():
     """Detect Apple Silicon (M-series) GPUs.
 
@@ -551,7 +624,7 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
     cpu_cores = _get_cpu_count()
     cpu_name = _get_cpu_name()
 
-    gpu_info = _detect_apple_silicon() or _detect_nvidia() or _detect_amd()
+    gpu_info = _detect_apple_silicon() or _detect_nvidia() or _detect_amd() or _detect_intel()
 
     if gpu_info:
         result = {


### PR DESCRIPTION
## Summary

- Adds `_detect_intel()` to `services/hwfit/hardware.py` so the hwfit hardware probe recognises Intel Arc/Xe discrete GPUs (vendor `0x8086`) via `/sys/class/drm`. VRAM is resolved from a PCI device-ID lookup table (A310–A770, B570/B580, and mobile variants) since Intel does not expose `mem_info_vram_total` in sysfs the way AMD does.
- Adds `_probe_intel_sysfs()` to `routes/cookbook_routes.py`, wired into the `/api/cookbook/gpus` endpoint after the AMD probe, so the Cookbook GPU picker also surfaces Intel cards.
- Adds `docker/gpu.intel.yml` compose overlay (mirrors `gpu.amd.yml`) that passes `/dev/dri` into the container and adds the `video`/`render` groups. Enable via `COMPOSE_FILE=docker-compose.yml:docker/gpu.intel.yml` in `.env`.

## Test plan

- [ ] Set `COMPOSE_FILE=docker-compose.yml:docker/gpu.intel.yml` and `RENDER_GID=<host render gid>` in `.env`
- [ ] Confirm `/dev/dri/renderD128` is visible inside the container (`docker exec odysseus-odysseus-1 ls /dev/dri`)
- [ ] Open Cookbook — GPU section should show the Intel Arc card with correct VRAM
- [ ] `/api/cookbook/gpus` endpoint should return `backend: "xe"` and the correct GPU name
- [ ] Verify no regression on NVIDIA/AMD/CPU-only setups (probe order: Apple → NVIDIA → AMD → Intel → generic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)