### PR TITLE
fix(tests): use current Python for RAG id stability

### DIFF
--- a/tests/test_rag_vector_id_stability.py
+++ b/tests/test_rag_vector_id_stability.py
@@ -1,10 +1,10 @@
 import os
 import subprocess
-import pytest
+import sys
 
 def test_rag_id_stability_across_processes():
     # Run helper in subprocesses with different PYTHONHASHSEED values to ensure cross-process stability
-    cmd = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
+    cmd = [sys.executable, "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
     
     env0 = os.environ.copy()
     env0["PYTHONHASHSEED"] = "0"
@@ -23,6 +23,6 @@ def test_rag_id_stability_across_processes():
     assert id0 == id_rand
     
     # Assert different inputs produce different IDs
-    cmd_diff = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
+    cmd_diff = [sys.executable, "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
     id_diff = subprocess.check_output(cmd_diff, env=env0).decode().strip()
     assert id0 != id_diff


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `./venv/bin/python` subprocess path with `sys.executable`.
- Makes `tests/test_rag_vector_id_stability.py` pass on native Windows virtualenvs.
- Removes the unused `pytest` import.

## Linked Issue

Fixes #1815

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests\test_rag_vector_id_stability.py`
2. Confirm it reports `1 passed`.

## Screenshots (UI changes only)

N/A - test-only change.