### PR TITLE
docs: actualize README provider list and architecture map

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A self-hosted AI workspace -- meant to be the self-hosted version of the UI experience you get from ChatGPT and Claude. But with more jank and fun. Running on your own hardware, with your own data -- local-first, privacy-first, and no trojan.
 
 ## Features
-  - **Chat** -- chat with any local model or API; adding them is super simple.<br>　<sub>vLLM · llama.cpp · Ollama · OpenRouter · OpenAI</sub>
+  - **Chat** -- chat with any local model or API; adding them is super simple.<br>　<sub>vLLM · llama.cpp · Ollama · LM Studio · OpenAI · Anthropic · OpenRouter · any OpenAI-compatible endpoint</sub>
   - **Agent** -- hand it tools and let it run the whole task itself.<br>　<sub>built on [opencode](https://github.com/anomalyco/opencode) · MCP · web · files · shell · skills · memory</sub>
   - **Cookbook** -- Scans your hardware, recommends models, click to download and serve.. easy!<br>　<sub>built on [llmfit](https://github.com/AlexsJones/llmfit) · VRAM-aware · GGUF / FP8 / AWQ · fit scoring · vLLM / llama.cpp serving</sub>
   - **Deep Research** -- multi-step runs that gather, read, and synthesize sources into a nice visual report.<br>　<sub>adapted from [Tongyi DeepResearch](https://github.com/Alibaba-NLP/DeepResearch)</sub>
@@ -395,12 +395,14 @@ That installs `@playwright/mcp` plus Playwright (~300MB total). Restart Odysseus
 ## Architecture
 ```
 app.py                   # FastAPI entry point
-core/      auth, database, middleware, constants
-src/       llm_core, agent_loop, agent_tools, chat_processor, search/
-routes/    chat, session, document, memory, model … endpoints
-services/  docs, memory, search, hwfit (Cookbook) …
-static/    index.html + app.js + style.css + js/ (modular front-end)
-docs/      landing page (index.html) + preview clips
+core/         auth, database, middleware, constants
+src/          llm_core, agent_loop, agent_tools, chat_processor, search/
+routes/       chat, session, document, memory, model … endpoints
+services/     docs, memory, search, hwfit (Cookbook) …
+mcp_servers/  built-in stdio MCP servers (image_gen, memory, rag, email)
+companion/    LAN pairing bridge for the mobile/phone client
+static/       index.html + app.js + style.css + js/ (modular front-end)
+docs/         landing page (index.html) + preview clips
 ```
 
 ## Data


### PR DESCRIPTION
## What

Two small README accuracy fixes found while reviewing the docs against the code.

### Chat provider list
The Chat feature line listed only `vLLM · llama.cpp · Ollama · OpenRouter · OpenAI`, but several providers have first-class handling in the codebase:

- **LM Studio** — dedicated discovery/native model listing (`src/chat_helpers.py`, `src/model_discovery.py`) and documented `LM_STUDIO_URL` in `.env.example`.
- **Anthropic (Claude)** — dedicated endpoint resolution in `src/endpoint_resolver.py` (`/v1/messages`, `anthropic-version` header).

Updated the line to include these plus a generic "any OpenAI-compatible endpoint" note.

### Architecture map
Added two existing top-level directories that were missing:

- `mcp_servers/` — built-in stdio MCP servers (image_gen, memory, rag, email).
- `companion/` — LAN pairing bridge for the mobile/phone client.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)