### PR TITLE
Persist user preferences atomically

### DIFF
--- a/routes/prefs_routes.py
+++ b/routes/prefs_routes.py
@@ -19,9 +19,13 @@ def _load():
 
 
 def _save(prefs):
-    os.makedirs(os.path.dirname(PREFS_FILE), exist_ok=True)
-    with open(PREFS_FILE, "w", encoding="utf-8") as f:
+    os.makedirs(os.path.dirname(PREFS_FILE) or ".", exist_ok=True)
+    tmp = f"{PREFS_FILE}.tmp.{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump(prefs, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, PREFS_FILE)
 
 
 def _load_for_user(user: Optional[str] = None) -> dict:

--- a/tests/test_prefs_atomic_write.py
+++ b/tests/test_prefs_atomic_write.py
@@ -1,0 +1,47 @@
+import json
+
+import routes.prefs_routes as prefs_routes
+
+
+def test_save_replaces_prefs_file_atomically(monkeypatch, tmp_path):
+    calls = []
+    real_replace = prefs_routes.os.replace
+
+    def fake_replace(src, dst):
+        calls.append((src, dst))
+        real_replace(src, dst)
+
+    prefs_file = tmp_path / "data" / "user_prefs.json"
+    monkeypatch.setattr(prefs_routes, "PREFS_FILE", str(prefs_file))
+    monkeypatch.setattr(prefs_routes.os, "replace", fake_replace)
+
+    prefs_routes._save({"theme": "dark"})
+
+    assert len(calls) == 1
+    src, dst = calls[0]
+    assert dst == str(prefs_file)
+    assert src.startswith(str(prefs_file) + ".tmp.")
+    assert json.loads(prefs_file.read_text(encoding="utf-8")) == {"theme": "dark"}
+    assert not list(prefs_file.parent.glob("*.tmp.*"))
+
+
+def test_save_for_user_preserves_scoped_user_prefs(monkeypatch, tmp_path):
+    prefs_file = tmp_path / "data" / "user_prefs.json"
+    monkeypatch.setattr(prefs_routes, "PREFS_FILE", str(prefs_file))
+
+    prefs_routes._save_for_user("alice", {"theme": "dark"})
+
+    data = json.loads(prefs_file.read_text(encoding="utf-8"))
+    assert data == {"_users": {"alice": {"theme": "dark"}}}
+    assert prefs_routes._load_for_user("alice") == {"theme": "dark"}
+
+
+def test_save_for_user_preserves_flat_prefs_when_auth_disabled(monkeypatch, tmp_path):
+    prefs_file = tmp_path / "data" / "user_prefs.json"
+    monkeypatch.setattr(prefs_routes, "PREFS_FILE", str(prefs_file))
+
+    prefs_routes._save_for_user(None, {"theme": "dark"})
+
+    data = json.loads(prefs_file.read_text(encoding="utf-8"))
+    assert data == {"theme": "dark"}
+    assert prefs_routes._load_for_user(None) == {"theme": "dark"}


### PR DESCRIPTION
## Summary

User preferences are now written through a temporary sibling file that is flushed, fsynced, and atomically moved into place. This prevents data/user_prefs.json from being left empty or partially written if the process is interrupted during a save, while preserving the existing flat and per-user preference formats.

## Linked Issue

Fixes #1837

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `python -m pytest -q tests/test_atomic_io.py tests/test_settings_scrub.py tests/test_prefs_atomic_write.py`.
2. Confirm the new prefs tests pass for atomic replacement, per-user prefs, and flat auth-disabled prefs.
3. Run `git diff --check HEAD~1..HEAD` to verify no whitespace issues.
