### PR TITLE
fix(mcp): fallback to sync check on Windows NotImplementedError

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -208,15 +208,27 @@ async def _is_npx_package_cached(npx_path, package_spec, timeout_s=5):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:
+                pass
+            return False
+        return proc.returncode == 0 and bool(stdout.strip())
+    except NotImplementedError:
+        # Fallback for Windows + Python 3.14 in reload-worker context
+        import subprocess
+        try:
+            result = subprocess.run(
+                [npx_path, "--no-install", package_spec, "--version"],
+                capture_output=True,
+                timeout=timeout_s,
+            )
+            return result.returncode == 0 and bool(result.stdout.strip())
+        except (subprocess.TimeoutExpired, OSError, ValueError):
+            return False
     except (OSError, ValueError):
         return False
-    try:
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
-    except asyncio.TimeoutError:
-        try:
-            proc.kill()
-            await proc.wait()
-        except Exception:
-            pass
-        return False
-    return proc.returncode == 0 and bool(stdout.strip())


### PR DESCRIPTION
## Summary

When running Odysseus on Windows with Python 3.14 under `uvicorn` using the `--reload` option, the reload supervisor spawns a child worker process using Python's `spawn` start method. In this spawned worker context, calling `asyncio.create_subprocess_exec` inside a background task raises a `NotImplementedError` because the active event loop is not configured to support asynchronous subprocesses on Windows. This PR patches `_is_npx_package_cached` in `src/builtin_mcp.py` to catch `NotImplementedError` and fall back to a synchronous, timeout-bounded check using standard `subprocess.run`, allowing the NPX cache probe (e.g. checking for the Playwright MCP package) to complete successfully and without crashing.

## Linked Issue

Fixes #1894

*(Note: If there is no open GitHub issue for this bug, you can leave this blank or delete this section.)*

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

To verify this works:

1. Setup the project on a Windows machine running Python 3.14 (or mock the `NotImplementedError` from `create_subprocess_exec`).
2. Run the application manually using:
   ```bash
   python -m uvicorn app:app --host 127.0.0.1 --port 7000 --reload
