### PR TITLE
fix: strip_thinking().strip() crashes when LLM endpoint returns None

### DIFF
--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -704,7 +704,7 @@ class DeepResearcher:
             # Reasoning models prepend a <think>...</think> block — strip it
             # before checking for YES/NO, otherwise the answer always looks
             # like it starts with "<THINK>" and the engine never stops.
-            clean = strip_thinking(response).strip()
+            clean = (strip_thinking(response) or "").strip()
             # Tolerate "**YES**", "Yes.", quotes, etc.
             answer = re.sub(r'^[\s*_`"\'>#\-]+', '', clean).upper()
             should_stop = answer.startswith("YES")

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -148,7 +148,7 @@ class ResearchHandler:
                 timeout=15,
                 max_retries=1,
             )
-            query = strip_thinking(response).strip().strip('"\'')
+            query = (strip_thinking(response) or "").strip().strip('"\'')
             if query and len(query) > 5:
                 return query
         except Exception as e:

--- a/tests/test_strip_thinking_none_crash.py
+++ b/tests/test_strip_thinking_none_crash.py
@@ -1,0 +1,22 @@
+from src.research_utils import strip_thinking
+
+
+def test_strip_thinking_none_passthrough():
+    # strip_thinking is documented to return None when the LLM call fails.
+    # Callers that chain .strip() directly would crash with AttributeError.
+    assert strip_thinking(None) is None
+
+
+def test_strip_thinking_or_empty_is_safe():
+    # The fix: (strip_thinking(response) or "").strip() must not raise.
+    result = (strip_thinking(None) or "").strip()
+    assert result == ""
+
+
+def test_strip_thinking_normal_string():
+    assert strip_thinking("hello world") == "hello world"
+
+
+def test_strip_thinking_with_think_block():
+    raw = "<think>reasoning</think>final answer"
+    assert "final answer" in strip_thinking(raw)


### PR DESCRIPTION
When an LLM endpoint times out or drops the connection, llm_call_async returns None. strip_thinking() is documented to pass None through, so two call sites that chained .strip() directly would raise:

  AttributeError: 'NoneType' object has no attribute 'strip'

- deep_research.py:707  (_should_stop_early)
- research_handler.py:151 (_synthesize_query)

Fix; wrap with (strip_thinking(response) or "") before .strip(). Both callers already handle an empty string correctly.

Fixes the crash path introduced when the endpoint is unreachable mid-research.

## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.
2.
3.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
