### PR TITLE
fix: compose email uses stale account ID when active account is deleted

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -95,7 +95,8 @@ import * as Modals from './modalManager.js';
     if (!activeAccountId) return null;
     const accounts = await _getEmailAccountsCached();
     const activeAccount = accounts.find(a => String(a.id) === String(activeAccountId));
-    if (!activeAccount || _accountCanSend(activeAccount)) return activeAccountId;
+    if (!activeAccount) return null;
+    if (_accountCanSend(activeAccount)) return activeAccountId;
     if (uiModule) uiModule.showToast('Selected email account is receive-only; using your SMTP account.');
     return null;
   }


### PR DESCRIPTION
## Summary

`_resolveComposeSendAccountId()` in `document.js` has inverted logic that returns a stale (deleted) account ID instead of falling back to the default SMTP account. When `!activeAccount` is true (account not found), the OR condition short-circuits and returns the non-existent ID, causing email send/schedule to fail.

## Linked Issue

Fixes #1912

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `node --check static/js/document.js` to verify syntax.

## How to Test

1. Configure two email accounts, set one as active
2. Remove the active account from settings
3. Open document editor and compose an email
4. Verify the compose uses the default SMTP account (not the stale ID)

Alternatively, read the one-line logic fix — the intent is self-evident from the surrounding code and comment.