### PR TITLE
fix: use atomic write for user prefs to prevent file corruption on crash

### DIFF
--- a/routes/prefs_routes.py
+++ b/routes/prefs_routes.py
@@ -4,6 +4,7 @@ import os
 from typing import Optional
 from fastapi import APIRouter, Request
 from src.auth_helpers import get_current_user
+from core.atomic_io import atomic_write_json
 
 PREFS_FILE = os.path.join("data", "user_prefs.json")
 
@@ -20,8 +21,7 @@ def _load():
 
 def _save(prefs):
     os.makedirs(os.path.dirname(PREFS_FILE), exist_ok=True)
-    with open(PREFS_FILE, "w", encoding="utf-8") as f:
-        json.dump(prefs, f, indent=2)
+    atomic_write_json(PREFS_FILE, prefs, indent=2)
 
 
 def _load_for_user(user: Optional[str] = None) -> dict:


### PR DESCRIPTION
## Summary

`_save()` in `prefs_routes.py` uses `open("w")` + `json.dump` which can truncate or corrupt `user_prefs.json` on crash or concurrent requests. The codebase already has `core.atomic_io.atomic_write_json` (write to temp file, then `os.replace`) used by auth and other data files. This PR switches prefs to use it.

## Linked Issue

Fixes #1837

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `python -m py_compile routes/prefs_routes.py` to verify syntax.

## How to Test

1. Change a user preference via Settings
2. Kill the server mid-write (or simulate with a debugger breakpoint inside `_save`)
3. Restart — prefs file should not be corrupted (atomic replace guarantees this)

Alternatively: code review confirms `atomic_write_json` is the established pattern (used in `core/auth.py:130,163`).