### PR TITLE
fix: guard remaining uid.decode() calls in auto-classify spam path

### DIFF
--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -886,7 +886,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                                 if is_spam and auto_spam and spam_folder:
                                     if _imap_move(uid, spam_folder, account_id=account_id, owner=account_owner):
                                         moved_to = spam_folder
-                                        logger.info(f"Auto-spam moved uid={uid.decode()} to {spam_folder}: {spam_reason}")
+                                        logger.info(f"Auto-spam moved uid={uid.decode() if isinstance(uid, bytes) else str(uid)} to {spam_folder}: {spam_reason}")
 
                                 _c = _sql3.connect(SCHEDULED_DB)
                                 _c.execute("""
@@ -894,7 +894,7 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                                     (message_id, owner, uid, folder, subject, sender, tags, spam_verdict,
                                      spam_reason, moved_to, model_used, created_at)
                                     VALUES (?, ?, ?, 'INBOX', ?, ?, ?, ?, ?, ?, ?, ?)
-                                """, (message_id, account_owner or "", uid.decode(), subject, sender,
+                                """, (message_id, account_owner or "", uid.decode() if isinstance(uid, bytes) else str(uid), subject, sender,
                                       json.dumps(tags), 1 if is_spam else 0,
                                       spam_reason, moved_to, model, datetime.utcnow().isoformat()))
                                 _c.commit()


### PR DESCRIPTION
## Summary

Two more bare `uid.decode()` calls in the auto-classify spam path (lines 889, 897) crash with `AttributeError` when `uid` is already a string from the legacy bare-UID path. Follow-up to merged #1472 which fixed the same pattern at line 832.

## Linked Issue

Fixes #1913

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `python -m py_compile routes/email_pollers.py` to verify syntax.

## How to Test

1. Enable auto-classify with spam detection
2. Have a string-type UID flow through the spam classification path (occurs with the legacy bare-UID path at line 275)
3. Verify no AttributeError in logs

Alternatively: grep for `uid.decode()` in the function — every other occurrence already uses the `isinstance(uid, bytes)` guard.