### PR TITLE
fix: use sys.executable in RAG id stability test for Windows compat

### DIFF
--- a/tests/test_rag_vector_id_stability.py
+++ b/tests/test_rag_vector_id_stability.py
@@ -1,10 +1,12 @@
 import os
 import subprocess
+import sys
 import pytest
 
 def test_rag_id_stability_across_processes():
     # Run helper in subprocesses with different PYTHONHASHSEED values to ensure cross-process stability
-    cmd = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
+    python = sys.executable
+    cmd = [python, "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
     
     env0 = os.environ.copy()
     env0["PYTHONHASHSEED"] = "0"
@@ -23,6 +25,6 @@ def test_rag_id_stability_across_processes():
     assert id0 == id_rand
     
     # Assert different inputs produce different IDs
-    cmd_diff = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
+    cmd_diff = [python, "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
     id_diff = subprocess.check_output(cmd_diff, env=env0).decode().strip()
     assert id0 != id_diff


### PR DESCRIPTION
## Summary

`test_rag_vector_id_stability.py` hardcodes `./venv/bin/python` which doesn't exist on Windows (where it's `venv\Scripts\python.exe`). Uses `sys.executable` so the test works on all platforms while still verifying cross-process hash stability.

## Linked Issue

Fixes #1815

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `python -m py_compile tests/test_rag_vector_id_stability.py` to verify syntax.

## How to Test

1. On Windows: `python -m pytest tests/test_rag_vector_id_stability.py`
2. On Linux/macOS: same command — should still pass as before
3. Verify `sys.executable` resolves to the current interpreter