### PR TITLE
fix: document library counter not updating on delete

### DIFF
--- a/static/js/documentLibrary.js
+++ b/static/js/documentLibrary.js
@@ -1170,9 +1170,14 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
         card.addEventListener('transitionend', () => card.remove(), { once: true });
         setTimeout(() => { if (card.parentElement) card.remove(); }, 400);
       }
+      const deletedDoc = _libraryDocs.find(d => d.id === docId);
       _libraryDocs = _libraryDocs.filter(d => d.id !== docId);
       _libraryTotal = Math.max(0, _libraryTotal - 1);
+      if (deletedDoc && deletedDoc.language && _libraryLanguages[deletedDoc.language] > 0) {
+        _libraryLanguages[deletedDoc.language]--;
+      }
       libraryRenderStats();
+      libraryRenderLangChips();
       if (uiModule) uiModule.showToast('Document deleted');
     } catch (e) {
       if (uiModule) uiModule.showError(`Failed to delete document: ${e.message || e}`);


### PR DESCRIPTION
## Summary

After deleting a document in the library, the header counter ("Documents (N)") and language filter chips show stale counts. Root cause: `_libraryLanguages` map is never decremented on delete — `libraryRenderStats()` derives the display total from this map via `Object.values(...).reduce(...)`.

## Linked Issue

Fixes #1809

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `node --check static/js/documentLibrary.js` to verify syntax.

## How to Test

1. Open document library with multiple documents
2. Note the counter in the header (e.g. "4 documents")
3. Delete one document
4. Verify the counter decrements to "3 documents"
5. Verify the language filter chips also update their counts