### PR TITLE
fix: API key save corrupts other providers by writing decrypted keys to disk

### DIFF
--- a/src/api_key_manager.py
+++ b/src/api_key_manager.py
@@ -37,9 +37,20 @@ class APIKeyManager:
         f = Fernet(self.get_or_create_key())
         return f.decrypt(encrypted_key.encode()).decode()
     
+    def _load_raw(self) -> Dict[str, str]:
+        """Load raw (encrypted) API keys from disk without decrypting."""
+        if not os.path.exists(self.api_keys_file):
+            return {}
+        try:
+            with open(self.api_keys_file, 'r', encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
     def save(self, provider: str, api_key: str):
         """Save encrypted API key to file"""
-        keys = self.load()
+        keys = self._load_raw()
         keys[provider] = self.encrypt_api_key(api_key)
         with open(self.api_keys_file, 'w', encoding="utf-8") as f:
             json.dump(keys, f)


### PR DESCRIPTION
## Summary

`save()` in `api_key_manager.py` calls `self.load()` which decrypts all existing keys before returning. It then encrypts only the new key and writes the entire dict — existing keys are now plaintext on disk. On next `load()`, Fernet fails to decrypt the plaintext values (`InvalidToken`) and silently drops them. This means saving a key for one provider destroys all other stored API keys.

## Linked Issue

Fixes #1914

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `python -m py_compile src/api_key_manager.py` to verify syntax.

## How to Test

1. Save an API key for OpenAI via Settings
2. Save an API key for Anthropic via Settings
3. Restart the app
4. Verify both keys are still accessible (check Settings or attempt a chat with each provider)

Without the fix, provider A's key is silently lost after step 2.