### PR TITLE
fix: CalDAV config save double-encrypts existing password

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -601,9 +601,6 @@ def setup_calendar_routes() -> APIRouter:
         if body.get("password"):
             from src.secret_storage import encrypt
             cfg["password"] = encrypt(body["password"])
-        elif cfg.get("password"):
-            from src.secret_storage import encrypt
-            cfg["password"] = encrypt(cfg["password"])
         prefs["caldav"] = cfg
         _save_for_user(owner, prefs)
         return {"ok": True}


### PR DESCRIPTION
## Summary

When the CalDAV settings form is re-submitted without re-typing the password, the `elif` branch at line 604 calls `encrypt()` on the value already stored in prefs — which is already encrypted from the prior save. Each save-without-retyping compounds the encryption, eventually corrupting the credential so CalDAV sync fails.

## Linked Issue

Fixes #1915

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `python -m py_compile routes/calendar_routes.py` to verify syntax.

## How to Test

1. Configure CalDAV with URL, username, and password
2. Go back to CalDAV settings, change only the URL (leave password blank)
3. Save
4. Verify CalDAV sync still works (the original password is preserved, not double-encrypted)