### PR TITLE
fix: email search crashes on null spinner + ReferenceError in summarize catch

### DIFF
--- a/static/js/emailLibrary.js
+++ b/static/js/emailLibrary.js
@@ -1550,7 +1550,7 @@ async function _doSearch() {
     const accountQS = accountAtStart ? `&account_id=${encodeURIComponent(accountAtStart)}` : '';
     const res = await fetch(`${API_BASE}/api/email/search?folder=${encodeURIComponent(folderAtStart)}${accountQS}&q=${encodeURIComponent(q)}&limit=100`);
     const data = await res.json();
-    sp.destroy();
+    if (sp) sp.destroy();
     if (
       seq !== _libSearchSeq ||
       q !== state._libSearch.trim() ||
@@ -1569,7 +1569,7 @@ async function _doSearch() {
     const stats = document.getElementById('email-lib-stats');
     if (stats) stats.textContent = `${data.total || results.length} match${(data.total || results.length) === 1 ? '' : 'es'}`;
   } catch (e) {
-    sp.destroy();
+    if (sp) sp.destroy();
     grid.innerHTML = '<div class="email-loading">Search failed</div>';
   }
 }
@@ -4385,9 +4385,9 @@ async function _generateSummary(reader, data, btn) {
       panel.remove();
     }
   } catch (e) {
-    sp.destroy();
+    if (sp) sp.destroy();
     panel.remove();
-    if (uiModule) uiModule.showError?.('Failed to summarize');
+    import('./ui.js').then(m => m.showError && m.showError('Failed to summarize')).catch(() => {});
   } finally {
     if (btn) btn.disabled = false;
   }


### PR DESCRIPTION
## Summary

Two crashes in `static/js/emailLibrary.js`:

1. `_doSearch` (lines 1553, 1572): `sp.destroy()` called without null guard — `sp` is null when the search runs with cached folder data (spinner creation skipped). Crashes with `TypeError`.

2. `_generateSummary` catch block (line 4390): references undeclared `uiModule`, causing `ReferenceError` that crashes the error handler and swallows the original error. Rest of the file uses `import('./ui.js').then(...)` for dynamic UI access.

## Linked Issue

Fixes #1916

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I ran `node --check static/js/emailLibrary.js` to verify syntax.

## How to Test

**Crash 1:**
1. Open email library (data gets cached)
2. Switch away and back (cache hit, spinner skipped)
3. Type a search query — should complete without TypeError

**Crash 2:**
1. Open an email and click summarize
2. Disconnect network or have the fetch fail
3. Should show error toast, not crash silently