### PR TITLE
feat: Add dedicated buttons for direct attach and new file in chats (#1142)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -125,9 +125,7 @@ function initializeEventListeners() {
   // Chat form submission
 //  document.getElementById('chat-form').addEventListener('submit', chatModule.handleChatSubmit);
 
-  // File attachments (inside overflow menu)
-  const _overflowAttach = el('overflow-attach-btn');
-  if (_overflowAttach) _overflowAttach.addEventListener('click', fileHandlerModule.openPicker);
+  // File attachments
   const _directAttach = el('direct-attach-btn');
   if (_directAttach) _directAttach.addEventListener('click', fileHandlerModule.openPicker);
   el('file-input').addEventListener('change', (e)=>{
@@ -1782,7 +1780,7 @@ function initializeEventListeners() {
     function _flagRefocus(e) {
       if (e.target.closest('textarea, input')) return;
       // Don't refocus for attach — file picker needs full focus control
-      if (e.target.closest('#overflow-attach-btn') || e.target.closest('#direct-attach-btn')) return;
+      if (e.target.closest('#direct-attach-btn')) return;
       // Don't refocus for model picker button — focus should go to picker search input
       if (e.target.closest('.model-picker-btn')) return;
       // Don't refocus when tapping the +/chevron tools button — the user
@@ -2425,7 +2423,7 @@ function initializeEventListeners() {
     'overflow-plus-btn':   '.overflow-wrapper',
     'mode-toggle':         '.mode-toggle',
     'preset-mini-btn':     '#overflow-preset-btn',
-    'attach-btn':          '#overflow-attach-btn, #direct-attach-btn',
+    'attach-btn':          '#direct-attach-btn',
     'research-btn':        '#overflow-research-btn',
     'rail-new-chat':       '#rail-new-session',
   };

--- a/static/app.js
+++ b/static/app.js
@@ -128,6 +128,8 @@ function initializeEventListeners() {
   // File attachments (inside overflow menu)
   const _overflowAttach = el('overflow-attach-btn');
   if (_overflowAttach) _overflowAttach.addEventListener('click', fileHandlerModule.openPicker);
+  const _directAttach = el('direct-attach-btn');
+  if (_directAttach) _directAttach.addEventListener('click', fileHandlerModule.openPicker);
   el('file-input').addEventListener('change', (e)=>{
     for (const f of e.target.files) fileHandlerModule.addFiles([f]);
     fileHandlerModule.renderAttachStrip();
@@ -1687,6 +1689,15 @@ function initializeEventListeners() {
   setupToggle('web-toggle-btn', 'web-toggle', 'web');
   setupToggle('bash-toggle-btn', 'bash-toggle', 'bash');
 
+  // New file button (creates a blank document directly)
+  const newFileBtn = el('new-file-btn');
+  if (newFileBtn) {
+    newFileBtn.addEventListener('click', async () => {
+      if (!documentModule) return;
+      await documentModule.newDocument();
+    });
+  }
+
   // Document editor toggle (special: uses module panel, not a checkbox)
   const overflowDocBtn = el('overflow-doc-btn');
   if (overflowDocBtn) {
@@ -1771,7 +1782,7 @@ function initializeEventListeners() {
     function _flagRefocus(e) {
       if (e.target.closest('textarea, input')) return;
       // Don't refocus for attach — file picker needs full focus control
-      if (e.target.closest('#overflow-attach-btn')) return;
+      if (e.target.closest('#overflow-attach-btn') || e.target.closest('#direct-attach-btn')) return;
       // Don't refocus for model picker button — focus should go to picker search input
       if (e.target.closest('.model-picker-btn')) return;
       // Don't refocus when tapping the +/chevron tools button — the user
@@ -1965,7 +1976,7 @@ function initializeEventListeners() {
     if (!inputLeft || !overflowMenu || !overflowWrapper) return;
 
     // Buttons that can be collapsed (in reverse priority — last collapsed first)
-    const collapsibleIds = ['bash-toggle-btn', 'web-toggle-btn'];
+    const collapsibleIds = ['bash-toggle-btn', 'web-toggle-btn', 'new-file-btn', 'direct-attach-btn'];
     const collapsibleBtns = collapsibleIds.map(id => el(id)).filter(Boolean);
     // Map of toolbar btn id → overflow mirror element (created dynamically)
     const overflowMirrors = new Map();
@@ -2048,6 +2059,7 @@ function initializeEventListeners() {
       // Collapse from lowest priority until it fits
       if (totalWidth > available) {
         for (let i = 0; i < collapsibleBtns.length; i++) {
+          if (collapsibleBtns[i].style.display === 'none') continue;
           collapsibleBtns[i].classList.add('toolbar-collapsed');
           const mirror = overflowMirrors.get(collapsibleBtns[i].id);
           if (mirror) mirror.style.display = '';
@@ -2084,6 +2096,11 @@ function initializeEventListeners() {
     // Re-check when doc panel opens/closes (body.doc-view toggled)
     new MutationObserver(() => requestAnimationFrame(checkToolbarOverflow))
       .observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    // Re-check when inputLeft children change
+    new MutationObserver(() => requestAnimationFrame(checkToolbarOverflow))
+      .observe(inputLeft, { childList: true });
+
+    window.checkToolbarOverflow = checkToolbarOverflow;
     // Re-check when input bar itself resizes (e.g. doc panel drag)
     const inputBottom = inputLeft.parentElement;
     if (inputBottom) {
@@ -2408,7 +2425,7 @@ function initializeEventListeners() {
     'overflow-plus-btn':   '.overflow-wrapper',
     'mode-toggle':         '.mode-toggle',
     'preset-mini-btn':     '#overflow-preset-btn',
-    'attach-btn':          '#overflow-attach-btn',
+    'attach-btn':          '#overflow-attach-btn, #direct-attach-btn',
     'research-btn':        '#overflow-research-btn',
     'rail-new-chat':       '#rail-new-session',
   };
@@ -2449,6 +2466,7 @@ function initializeEventListeners() {
     applyTextEmojis(state['text-emojis'] !== false);
     // Hide thinking sections toggle (show-thinking: checked=show, unchecked=hide)
     document.body.classList.toggle('hide-thinking', state['show-thinking'] === false);
+    if (window.checkToolbarOverflow) window.checkToolbarOverflow();
   }
 
   // Rearrange toggles in session/model sort dropdowns
@@ -3854,6 +3872,9 @@ function startOdysseusApp() {
     
     const files = Array.from(e.dataTransfer.files);
     if (files.length === 0) return;
+
+    fileHandlerModule.addFiles(files);
+    fileHandlerModule.renderAttachStrip();
 
     uiModule.showToast(`Added ${files.length} file${files.length > 1 ? 's' : ''} to chat`);
 

--- a/static/index.html
+++ b/static/index.html
@@ -1014,10 +1014,7 @@
               <span class="plus-active-dot"></span>
             </button>
             <div id="overflow-menu" class="overflow-menu hidden">
-              <button type="button" class="overflow-menu-item" id="overflow-attach-btn">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-                <span>Attach files</span>
-              </button>
+
               <button type="button" class="overflow-menu-item" id="overflow-doc-btn">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>

--- a/static/index.html
+++ b/static/index.html
@@ -1050,6 +1050,14 @@
               </button>
             </div>
           </div>
+          <!-- Direct attach -->
+          <button type="button" class="input-icon-btn" title="Attach files" id="direct-attach-btn" aria-label="Attach files">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
+          </button>
+          <!-- New file (create document) -->
+          <button type="button" class="input-icon-btn" title="New file" id="new-file-btn" aria-label="New file">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="12" x2="12" y2="18"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
+          </button>
           <!-- Web search (magnifying glass) -->
           <button type="button" class="input-icon-btn" title="Web search" id="web-toggle-btn" data-mode-tool="true" aria-label="Web search" aria-pressed="false">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -249,7 +249,7 @@ async function _buildCompareUI() {
   }
 
   // 4. Save toolbar indicator display states before hiding
-  const indicatorIds = ['overflow-tts-btn', 'overflow-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'research-toggle-btn'];
+  const indicatorIds = ['overflow-tts-btn', 'overflow-attach-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'research-toggle-btn'];
   state._savedIndicatorDisplay = {};
   indicatorIds.forEach(id => {
     const el = document.getElementById(id);
@@ -483,7 +483,7 @@ async function _buildCompareUI() {
   _setupEvalPicker();
 
   // 12. Hide tool buttons that don't apply during compare
-  ['overflow-tts-btn', 'overflow-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'web-toggle-btn', 'bash-toggle-btn', 'overflow-plus-btn'].forEach(id => {
+  ['overflow-tts-btn', 'overflow-attach-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'web-toggle-btn', 'bash-toggle-btn', 'overflow-plus-btn'].forEach(id => {
     const el = document.getElementById(id);
     if (el) { el.style.display = 'none'; el.style.pointerEvents = 'none'; }
   });

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -249,7 +249,7 @@ async function _buildCompareUI() {
   }
 
   // 4. Save toolbar indicator display states before hiding
-  const indicatorIds = ['overflow-tts-btn', 'overflow-attach-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'research-toggle-btn'];
+  const indicatorIds = ['overflow-tts-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'research-toggle-btn'];
   state._savedIndicatorDisplay = {};
   indicatorIds.forEach(id => {
     const el = document.getElementById(id);
@@ -483,7 +483,7 @@ async function _buildCompareUI() {
   _setupEvalPicker();
 
   // 12. Hide tool buttons that don't apply during compare
-  ['overflow-tts-btn', 'overflow-attach-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'web-toggle-btn', 'bash-toggle-btn', 'overflow-plus-btn'].forEach(id => {
+  ['overflow-tts-btn', 'direct-attach-btn', 'overflow-rag-btn', 'overflow-research-btn', 'overflow-doc-btn', 'rag-indicator-btn', 'web-toggle-btn', 'bash-toggle-btn', 'overflow-plus-btn'].forEach(id => {
     const el = document.getElementById(id);
     if (el) { el.style.display = 'none'; el.style.pointerEvents = 'none'; }
   });


### PR DESCRIPTION
Resolves #1142 

This PR introduces dedicated UI buttons for creating new files (workspace documents) and attaching files directly in the chat input bar, moving them out from behind the overflow menu for better discoverability.

### Changes Made:
- Added `#direct-attach-btn` (paperclip) and `#new-file-btn` (document) to the `.chat-input-left` rail in `index.html` using existing inline SVG styling.
- Wired click handlers to `fileHandlerModule.openPicker` and `documentModule.newDocument`.
- Added both buttons to the `collapsibleIds` array so they gracefully hide into the overflow mirror on narrow screens (reusing existing responsive patterns).
- Exempted the new buttons from the mobile textarea refocus guard.
- Synced indicator visibility in Compare Mode.
- Fixed an underlying drag-and-drop bug on the attach strip.

## Screenshots (UI changes only)
## Visual / UI changes — REQUIRED if you touched anything that renders

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/b3e7791c-727a-4f59-ae0c-711dd3c3ff5d" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/bc2c6f7c-3875-4ae0-ad42-d2fe377faaff" />
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/bd2e8cfc-bc82-47e5-8d99-fc386b5aba43" />

- [x] **Screenshot or short clip** of the change in the running app, attached above.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
