### PR TITLE
Test/ci failing run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save runner time.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python deps & syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Matches the python:3.12-slim base image in the Dockerfile.
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Compile-check all sources
+        # Catches syntax errors across the tree without importing modules
+        # (which would require optional services/network).
+        run: python -m compileall -q app.py core routes services src mcp_servers
+
+      - name: Run tests
+        # Don't fail the build when there are no collectable tests in a given
+        # environment; exit code 5 = "no tests ran".
+        run: |
+          pytest -q || ([ $? -eq 5 ] && echo "No tests collected, skipping.")
+
+  node:
+    name: Node deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        # package-lock.json is committed, so a reproducible install is expected.
+        run: npm ci

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Docker build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Dockerfile
+        id: dockerfile
+        run: |
+          if [ -f Dockerfile ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No Dockerfile found, skipping build."
+          fi
+
+      - name: Set up Buildx
+        if: steps.dockerfile.outputs.exists == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        if: steps.dockerfile.outputs.exists == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: odysseus:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/tests/test_ci_intentional_failure.py
+++ b/tests/test_ci_intentional_failure.py
@@ -1,0 +1,5 @@
+"""Temporary failing test used only to demonstrate CI failure reporting."""
+
+
+def test_ci_failure_demo():
+    assert False, "intentional failure for CI validation PR"


### PR DESCRIPTION
## Purpose

Temporary fork-only PR to validate that the new CI workflow reports failures correctly.

This PR intentionally adds a failing pytest test:

`tests/test_ci_intentional_failure.py`

## Expected Result

The CI workflow should fail on the Python test step.

## Notes

- This PR is not intended to be merged.
- It exists only to provide a failing workflow run for the upstream CI proposal in #1922.
- The real CI workflow PR is separate and does not include this intentional failure.