### PR TITLE
Fix: CalDAV config save double-encrypts existing password on re-submit

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -598,12 +598,12 @@ def setup_calendar_routes() -> APIRouter:
         cfg["username"] = (body.get("username") or "").strip()
         # Preserve the stored password when the client sends an empty
         # one (edit form re-submitted without re-typing the password).
+        # cfg already holds the existing (already-encrypted) password from
+        # prefs, so we only touch it when a new password is supplied —
+        # re-encrypting the stored value would double-encrypt it.
         if body.get("password"):
             from src.secret_storage import encrypt
             cfg["password"] = encrypt(body["password"])
-        elif cfg.get("password"):
-            from src.secret_storage import encrypt
-            cfg["password"] = encrypt(cfg["password"])
         prefs["caldav"] = cfg
         _save_for_user(owner, prefs)
         return {"ok": True}


### PR DESCRIPTION
## Summary

When the CalDAV settings form is re-submitted without re-typing the password (e.g. changing only the URL), the password gets encrypted a second time. Each subsequent save compounds the encryption, and sync eventually fails with a decrypt error.

## Root cause

In `routes/calendar_routes.py`, `cfg` is built from the stored prefs:

```python
cfg = dict(prefs.get("caldav") or {})
```

so `cfg["password"]` already holds the **already-encrypted** stored value. The `elif cfg.get("password")` branch then called `encrypt()` on that ciphertext again:

```python
if body.get("password"):
    cfg["password"] = encrypt(body["password"])
elif cfg.get("password"):
    cfg["password"] = encrypt(cfg["password"])   # double-encrypts the stored value
```

## Changes

- `routes/calendar_routes.py` — remove the `elif` branch. Since `cfg` already carries the stored encrypted password, leaving it untouched preserves it correctly; we only encrypt when a new password is actually supplied.

## Testing

- `python -m py_compile routes/calendar_routes.py` passes.

Fixes #1915