### PR TITLE
Fix: API key save() corrupts other providers by writing decrypted keys to disk

### DIFF
--- a/src/api_key_manager.py
+++ b/src/api_key_manager.py
@@ -37,15 +37,12 @@ class APIKeyManager:
         f = Fernet(self.get_or_create_key())
         return f.decrypt(encrypted_key.encode()).decode()
     
-    def save(self, provider: str, api_key: str):
-        """Save encrypted API key to file"""
-        keys = self.load()
-        keys[provider] = self.encrypt_api_key(api_key)
-        with open(self.api_keys_file, 'w', encoding="utf-8") as f:
-            json.dump(keys, f)
-    
-    def load(self) -> Dict[str, str]:
-        """Load and decrypt API keys"""
+    def _load_raw(self) -> Dict[str, str]:
+        """Load the raw, still-encrypted keys dict from disk.
+
+        Tolerates a missing/corrupt/wrong-shaped file by returning {} — the
+        same robustness load() relies on at startup.
+        """
         if not os.path.exists(self.api_keys_file):
             return {}
         try:
@@ -60,7 +57,24 @@ class APIKeyManager:
             # Legacy/wrong shape (e.g. a list) — .items() would raise. Ignore it.
             logger.warning("API keys file has unexpected shape (%s); ignoring", type(encrypted_keys).__name__)
             return {}
+        return encrypted_keys
 
+    def save(self, provider: str, api_key: str):
+        """Save encrypted API key to file.
+
+        Operates on the raw (still-encrypted) on-disk dict so other providers'
+        keys stay encrypted. Loading via load() first would decrypt them and
+        write them back as plaintext, which then fails to decrypt on the next
+        load() and silently drops those providers.
+        """
+        keys = self._load_raw()
+        keys[provider] = self.encrypt_api_key(api_key)
+        with open(self.api_keys_file, 'w', encoding="utf-8") as f:
+            json.dump(keys, f)
+
+    def load(self) -> Dict[str, str]:
+        """Load and decrypt API keys"""
+        encrypted_keys = self._load_raw()
         decrypted = {}
         for provider, key in encrypted_keys.items():
             try:


### PR DESCRIPTION
## Summary

Saving an API key for one provider silently drops every other provider's key after the next restart. `load()` logs `Failed to decrypt API key for <provider>: InvalidToken`.

## Root cause

In `src/api_key_manager.py`, `save()` called `self.load()`, which **decrypts** all stored keys. It then re-encrypted only the key being saved and wrote the entire dict back — so the other providers' keys were written to disk as **plaintext**. On the next `load()`, Fernet raises `InvalidToken` on those plaintext values and they are silently dropped.

```python
def save(self, provider, api_key):
    keys = self.load()                       # returns DECRYPTED keys
    keys[provider] = self.encrypt_api_key(api_key)   # only new key encrypted
    json.dump(keys, f)                        # writes plaintext + ciphertext mix
```

## Changes

- Add `_load_raw()` — returns the raw, still-encrypted on-disk dict, reusing the existing missing/corrupt/wrong-shape guards.
- `save()` now builds on `_load_raw()`, so other providers' keys keep their ciphertext untouched.
- `load()` also routes through `_load_raw()`, leaving its decrypt behavior identical (no duplicated file-handling logic).

## Testing

- `python -m py_compile src/api_key_manager.py` passes.
- Functional check: save two providers, instantiate a fresh manager (simulating restart), `load()` — both keys decrypt back to their original values.

Fixes #1914