### PR TITLE
Fix: owner-scope /api/memory routes that resolve a session by id

### DIFF
--- a/routes/memory_routes.py
+++ b/routes/memory_routes.py
@@ -27,7 +27,7 @@ from src.request_models import MemoryAddRequest
 from core.database import SessionLocal
 from src.llm_core import llm_call_async
 from services.memory.memory_extractor import audit_memories
-from src.auth_helpers import get_current_user, require_user
+from src.auth_helpers import get_current_user, require_user, effective_user
 from src.endpoint_resolver import resolve_endpoint
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,40 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
             return  # Auth disabled
         if memory.get("owner") != user:
             raise HTTPException(404, "Memory not found")
+
+    def _verify_session_owner(request: Request, session_id: str):
+        """Raise 404 if the caller doesn't own this session.
+
+        SECURITY: session_manager.get_session() is NOT owner-scoped — it
+        returns any session by id. Without this gate an authenticated user
+        could pass another tenant's session id to /extract, /audit, /import,
+        or /by-session and read that session's data or run LLM calls with the
+        victim's session-scoped credentials/quota.
+
+        Mirrors the owner gate in session_routes._verify_session_owner
+        (DB Session.owner is authoritative, with an in-memory "ghost" session
+        fallback) but follows this module's auth-disabled convention: when no
+        user resolves (AUTH_ENABLED=false / single-user), ownership isn't
+        enforced, exactly like _verify_memory_owner above.
+        """
+        user = effective_user(request)
+        if not user:
+            return  # Auth disabled / single-user — nothing to scope against
+        from core.database import Session as DbSession
+        db = SessionLocal()
+        try:
+            row = db.query(DbSession.owner).filter(DbSession.id == session_id).first()
+        finally:
+            db.close()
+        if row is not None:
+            if row.owner != user:
+                raise HTTPException(404, "Session not found")
+            return
+        # No DB row — allow only if the caller owns the in-memory ghost session.
+        ghost = getattr(session_manager, "sessions", {}).get(session_id)
+        if ghost is not None and getattr(ghost, "owner", None) == user:
+            return
+        raise HTTPException(404, "Session not found")
 
     @router.post("/debug")
     def debug_memory_relevance(request: Request, query: str = Form(...)):
@@ -161,6 +195,7 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
     @router.get("/by-session/{session_id}")
     def get_memory_by_session(request: Request, session_id: str):
         """Get all memories associated with a specific session."""
+        _verify_session_owner(request, session_id)
         try:
             session_manager.get_session(session_id)
         except KeyError:
@@ -192,6 +227,7 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
     async def extract_memory(request: Request, session: str = Form(...)) -> Dict[str, List[str]]:
         """Analyze a session's chat history and return memory suggestions."""
         require_user(request)
+        _verify_session_owner(request, session)
         try:
             sess = session_manager.get_session(session)
         except KeyError:
@@ -275,6 +311,7 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
 
         # Fall back to session model if no default configured
         if not endpoint_url and session:
+            _verify_session_owner(request, session)
             try:
                 sess = session_manager.get_session(session)
                 endpoint_url = sess.endpoint_url
@@ -325,6 +362,7 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
         headers = {}
 
         if session:
+            _verify_session_owner(request, session)
             try:
                 sess = session_manager.get_session(session)
                 endpoint_url = sess.endpoint_url


### PR DESCRIPTION
## Summary

Several `/api/memory/*` endpoints resolve a caller-supplied session id via `SessionManager.get_session(session)`, which is **not owner-scoped** — it returns any session by id — and then use it without checking ownership. An authenticated user can target another tenant's session and:

- `POST /api/memory/extract` — sends the victim's full chat history to the LLM and returns extracted contacts/PII to the caller.
- `POST /api/memory/audit` and `POST /api/memory/import` — fall back to the victim's session-scoped `endpoint_url`/`model`/`headers`, running LLM calls with the victim's credentials/quota.
- `GET /api/memory/by-session/{id}` — returns the victim's session title (existence/title disclosure).

Sibling route groups (`session_routes`, `webhook_routes`, `task_routes`) already enforce an owner gate; the memory routes did not.

## Changes

`routes/memory_routes.py`:

- Add a `_verify_session_owner(request, session_id)` helper that raises `404` when the caller doesn't own the session. It mirrors `session_routes._verify_session_owner` — `Session.owner` in the DB is authoritative, with an in-memory "ghost" session fallback for unpersisted sessions — and follows this module's existing auth-disabled convention (see `_verify_memory_owner`): when no user resolves (`AUTH_ENABLED=false` / single-user), ownership isn't enforced, so those deployments are unaffected.
- Call the gate before the session lookup in `get_memory_by_session`, `extract_memory`, `api_audit_memories` (session-fallback branch), and `import_memories_from_file`.

Identity is resolved with `effective_user()` (same as the canonical session gate), so cookie sessions and owner-attributed bearer tokens both compare against the right owner.

## Expected behavior

A caller who doesn't own the session now gets `404 Session not found`, matching the other route groups.

## Testing

- `python -m py_compile routes/memory_routes.py routes/session_routes.py` passes.
- I could not run the pytest suite in this environment: the dev dependencies (e.g. `sqlalchemy`, `fastapi`) are not installed here, so the route/integration tests can't be collected. The change is a focused ownership gate that reuses the established pattern from `session_routes`.

Fixes #1918