### PR TITLE
fix: skip sessions younger than 5 min in auto-sort cleanup

### DIFF
--- a/src/session_actions.py
+++ b/src/session_actions.py
@@ -12,6 +12,11 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+# Sessions younger than this are never deleted, even if empty.
+# Prevents a race where auto-sort runs between session creation and the
+# first message arriving, causing the session to vanish mid-flight.
+_NEW_SESSION_GRACE_SECONDS = 300  # 5 minutes
+
 # Names that indicate a throwaway/test session
 _THROWAWAY_NAMES = {
     "test", "testing", "asdf", "asd", "hello", "hi", "hey",
@@ -52,6 +57,10 @@ async def run_auto_sort(owner: str, skip_llm: bool = False) -> str:
 
         for row in rows:
             if getattr(row, 'is_important', False):
+                continue
+            # Skip sessions that were just created — they may be mid-flight
+            # (auto-sort can fire before the first message arrives).
+            if row.created_at and (datetime.utcnow() - row.created_at).total_seconds() < _NEW_SESSION_GRACE_SECONDS:
                 continue
             if (row.name or "").strip() == "Incognito":
                 deleted_throwaway += 1

--- a/tests/test_session_grace_period.py
+++ b/tests/test_session_grace_period.py
@@ -1,0 +1,58 @@
+"""Regression guard for issue #1851 — sessions deleted mid-flight.
+
+`run_auto_sort` fires on every session-created event. A brand-new session
+has 0 messages, so it matched the `msg_count == 0 → delete` branch before
+the first chat message could arrive. The result: the session vanished between
+`POST /api/session` (201) and the first `POST /api/chat_stream`, returning 404.
+
+Fix: skip any session whose `created_at` is within `_NEW_SESSION_GRACE_SECONDS`
+(5 minutes). The guard is applied before all other deletion heuristics so that
+no newly created session can be culled regardless of name, message count, or
+content length.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src/session_actions.py"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+def test_grace_period_constant_defined():
+    text = _src()
+    assert "_NEW_SESSION_GRACE_SECONDS" in text, (
+        "_NEW_SESSION_GRACE_SECONDS constant must be defined in session_actions.py"
+    )
+    # Must be a positive integer (seconds)
+    m = re.search(r"_NEW_SESSION_GRACE_SECONDS\s*=\s*(\d+)", text)
+    assert m, "_NEW_SESSION_GRACE_SECONDS must be assigned a numeric value"
+    assert int(m.group(1)) > 0, "_NEW_SESSION_GRACE_SECONDS must be positive"
+
+
+def test_grace_period_check_before_deletion_heuristics():
+    text = _src()
+    # The grace-period continue must appear in the per-row loop and must come
+    # before the msg_count == 0 deletion branch.
+    grace_pos = text.find("_NEW_SESSION_GRACE_SECONDS")
+    empty_delete_pos = text.find("msg_count == 0")
+    assert grace_pos != -1, "grace-period guard not found"
+    assert empty_delete_pos != -1, "msg_count == 0 branch not found"
+    assert grace_pos < empty_delete_pos, (
+        "grace-period guard must appear before the msg_count == 0 delete branch"
+    )
+
+
+def test_grace_period_uses_created_at():
+    text = _src()
+    # Guard must read row.created_at and compare against utcnow()
+    assert re.search(r"row\.created_at", text), (
+        "grace-period check must read row.created_at"
+    )
+    assert re.search(r"datetime\.utcnow\(\)\s*-\s*row\.created_at", text), (
+        "grace-period check must compare datetime.utcnow() - row.created_at"
+    )
+    assert "_NEW_SESSION_GRACE_SECONDS" in text, (
+        "grace-period check must reference _NEW_SESSION_GRACE_SECONDS"
+    )


### PR DESCRIPTION
## Summary

`run_auto_sort` fires on every session-created event. A brand-new session has 0 messages, so it matched the `msg_count == 0` deletion branch before the first chat message could arrive. The session vanished between `POST /api/session` (201) and the first `POST /api/chat_stream`, returning 404. A 5-minute grace period now prevents new sessions from being culled mid-flight.

## Linked Issue

Fixes #1851

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)

## Checklist

- [x] I searched open issues and PRs - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.

## How to Test

1. Wire a `tidy_sessions` builtin task to the `session_created` event (Settings, Tasks).
2. Create a new chat and send a message immediately. Before this fix the session was sometimes deleted mid-flight, returning 404 on the stream.
3. With the fix the session survives: `POST /api/chat_stream` returns 200.
4. `python -m pytest tests/test_session_grace_period.py -q` passes (3 tests).