### PR TITLE
fix: catch NotImplementedError in npx cache check on Windows

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -208,6 +208,20 @@ async def _is_npx_package_cached(npx_path, package_spec, timeout_s=5):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+    except NotImplementedError:
+        # Windows + Python 3.14: SelectorEventLoop (used in uvicorn --reload
+        # worker processes) does not support async subprocesses. Fall back to
+        # a blocking subprocess.run with the same timeout so startup continues.
+        import subprocess
+        try:
+            result = subprocess.run(
+                [npx_path, "--no-install", package_spec, "--version"],
+                capture_output=True,
+                timeout=timeout_s,
+            )
+            return result.returncode == 0 and bool(result.stdout.strip())
+        except (subprocess.TimeoutExpired, OSError, ValueError):
+            return False
     except (OSError, ValueError):
         return False
     try:

--- a/tests/test_npx_cache_check_notimplemented.py
+++ b/tests/test_npx_cache_check_notimplemented.py
@@ -1,0 +1,53 @@
+"""Regression guard for issue #1894 — NotImplementedError on Windows + Python 3.14.
+
+asyncio.create_subprocess_exec raises NotImplementedError when the running
+event loop is a SelectorEventLoop (the default on Windows, and the loop used
+by uvicorn --reload worker processes). The previous code only caught OSError
+and ValueError, so the exception propagated and crashed the _start_npx_servers
+background task on every Windows startup.
+
+Fix: catch NotImplementedError in _is_npx_package_cached and fall back to a
+synchronous subprocess.run with the same timeout bound.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src/builtin_mcp.py"
+
+
+def _cached_fn_body() -> str:
+    text = SRC.read_text(encoding="utf-8")
+    start = text.index("async def _is_npx_package_cached(")
+    rest = text[start:]
+    # Find the next top-level function/class definition
+    m = re.search(r"\n(async def |def |class )", rest[1:])
+    return rest[: m.start() + 1] if m else rest
+
+
+def test_notimplemented_is_caught():
+    body = _cached_fn_body()
+    assert "NotImplementedError" in body, (
+        "_is_npx_package_cached must catch NotImplementedError "
+        "(raised by SelectorEventLoop on Windows when creating async subprocesses)"
+    )
+
+
+def test_sync_fallback_uses_subprocess_run():
+    body = _cached_fn_body()
+    assert "subprocess.run" in body, (
+        "fallback path must use subprocess.run for synchronous execution"
+    )
+
+
+def test_sync_fallback_passes_timeout():
+    body = _cached_fn_body()
+    assert re.search(r"subprocess\.run\(.*timeout=timeout_s", body, re.DOTALL), (
+        "subprocess.run fallback must pass timeout=timeout_s to stay bounded"
+    )
+
+
+def test_oserror_still_caught():
+    body = _cached_fn_body()
+    assert "OSError" in body, (
+        "OSError must still be caught after adding NotImplementedError handler"
+    )


### PR DESCRIPTION
`asyncio.create_subprocess_exec` raises `NotImplementedError` when the
running event loop is a `SelectorEventLoop` — the default on Windows, and
the loop used by uvicorn `--reload` worker processes. Only `OSError` and
`ValueError` were caught before, so the exception propagated and crashed
the `_start_npx_servers` background task on every Windows startup with
Python 3.14.

## Linked Issue

Fixes #1894

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] Searched open issues and PRs — not a duplicate
- [x] Targets `main`
- [x] Scoped to 2 files — `src/builtin_mcp.py` and the regression test
- [x] I actually ran the app and verified the change works end-to-end

## How to Test

1. On Windows with `uvicorn --reload`, start Odysseus — previously
   `_start_npx_servers` crashed with `NotImplementedError` in the log
2. With the fix the exception is caught, the sync fallback runs, and
   startup continues cleanly
3. `python -m pytest tests/test_npx_cache_check_notimplemented.py -v` → 4 passed
4. `python -m py_compile src/builtin_mcp.py` → no output (syntax OK)

## What changed

Added `NotImplementedError` to the `except` clause in `_is_npx_package_cached`.
When caught, falls back to a blocking `subprocess.run` with the same
`timeout_s` so the cache probe completes without touching the event loop.