### PR TITLE
Fix/rag test windows path and prefs atomic write

### DIFF
--- a/routes/prefs_routes.py
+++ b/routes/prefs_routes.py
@@ -4,6 +4,7 @@ import os
 from typing import Optional
 from fastapi import APIRouter, Request
 from src.auth_helpers import get_current_user
+from core.atomic_io import atomic_write_json
 
 PREFS_FILE = os.path.join("data", "user_prefs.json")
 
@@ -19,9 +20,7 @@ def _load():
 
 
 def _save(prefs):
-    os.makedirs(os.path.dirname(PREFS_FILE), exist_ok=True)
-    with open(PREFS_FILE, "w", encoding="utf-8") as f:
-        json.dump(prefs, f, indent=2)
+    atomic_write_json(PREFS_FILE, prefs, indent=2)
 
 
 def _load_for_user(user: Optional[str] = None) -> dict:

--- a/tests/test_rag_vector_id_stability.py
+++ b/tests/test_rag_vector_id_stability.py
@@ -1,10 +1,11 @@
 import os
 import subprocess
+import sys
 import pytest
 
 def test_rag_id_stability_across_processes():
     # Run helper in subprocesses with different PYTHONHASHSEED values to ensure cross-process stability
-    cmd = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
+    cmd = [sys.executable, "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('test_text_hash'))"]
     
     env0 = os.environ.copy()
     env0["PYTHONHASHSEED"] = "0"
@@ -23,6 +24,6 @@ def test_rag_id_stability_across_processes():
     assert id0 == id_rand
     
     # Assert different inputs produce different IDs
-    cmd_diff = ["./venv/bin/python", "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
+    cmd_diff = [sys.executable, "-c", "from src.rag_vector import _generate_doc_id; print(_generate_doc_id('different_text_hash'))"]
     id_diff = subprocess.check_output(cmd_diff, env=env0).decode().strip()
     assert id0 != id_diff


### PR DESCRIPTION
Two independent portability / crash-safety fixes.

## Linked Issue

Fixes #1815
Fixes #1837

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] Searched open issues and PRs — not a duplicate
- [x] Targets `main`
- [x] Scoped to 2 files, no unrelated changes
- [x] I actually ran the app and verified the change works end-to-end

## Changes

**`tests/test_rag_vector_id_stability.py`** (#1815)
Replaced `"./venv/bin/python"` with `sys.executable`. The hardcoded path
only works on Linux/macOS; Windows virtualenvs put the interpreter at
`venv\Scripts\python.exe`. `sys.executable` resolves to the current
interpreter on all platforms.

**`routes/prefs_routes.py`** (#1837)
Replaced `open("w") + json.dump` with `atomic_write_json` from
`core.atomic_io` (already used for `auth.json`, `settings.json`, and
other critical state). A process crash during the plain write truncates
`user_prefs.json` to an empty file. The atomic helper writes to a sibling
`.tmp.<pid>` file, fsyncs, then `os.replace()`s into place.

## How to Test

1. On Windows: `python -m pytest tests/test_rag_vector_id_stability.py -v` —
   previously failed with `FileNotFoundError: ./venv/bin/python`; now passes
2. `python -m py_compile routes/prefs_routes.py` → no output
3. Save a pref (`PUT /api/prefs/theme`), kill the server mid-write, restart —
   `data/user_prefs.json` survives intact