### PR TITLE
feat(memory): user knowledge graph (Kuzu) — Phase 1

### DIFF
--- a/app.py
+++ b/app.py
@@ -471,6 +471,7 @@ from src.assistant_log import set_session_manager as _set_asst_sm
 _set_asst_sm(session_manager)
 memory_manager    = components["memory_manager"]
 memory_vector     = components.get("memory_vector")
+graph_store       = components.get("graph_store")
 upload_handler    = components["upload_handler"]
 personal_docs_mgr = components["personal_docs_manager"]
 api_key_manager   = components["api_key_manager"]
@@ -537,9 +538,14 @@ app.include_router(setup_admin_wipe_routes(session_manager))
 
 # Memory
 from routes.memory_routes import setup_memory_routes
-app.include_router(setup_memory_routes(memory_manager, session_manager, memory_vector=memory_vector))
+app.include_router(setup_memory_routes(memory_manager, session_manager, memory_vector=memory_vector, graph_store=graph_store))
 from routes.skills_routes import setup_skills_routes
 app.include_router(setup_skills_routes(skills_manager))
+
+# Knowledge graph (Kuzu) — secondary index for typed entities and relationships
+# extracted from chat. Routes always mount; they 503 if the graph is unhealthy.
+from routes.graph_routes import setup_graph_routes
+app.include_router(setup_graph_routes(graph_store))
 
 # Chat
 from routes.chat_routes import setup_chat_routes
@@ -549,6 +555,7 @@ app.include_router(setup_chat_routes(
     memory_vector=memory_vector,
     webhook_manager=webhook_manager,
     skills_manager=skills_manager,
+    graph_store=graph_store,
 ))
 
 # Research (background deep-research tasks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,10 @@ numpy
 # ChromaDB service); fastembed runs local ONNX embeddings.
 chromadb-client
 fastembed
+# Embedded graph database for the user knowledge graph (services/memory/graph_store.py).
+# Stores typed entities (Person, Place, Organization, ...) and relationships
+# extracted from chat. Local-only, no server process — persists to data/graph/.
+kuzu
 youtube-transcript-api
 # Markdown rendering for research reports (src/visual_report.py).
 # Imported at module-top so it's a hard core dep, not optional.

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -829,6 +829,7 @@ def run_post_response_tasks(
     skills_manager=None,
     owner: str = None,
     extract_skills: bool = True,
+    graph_store=None,
 ):
     """Fire background tasks after a completed response: memory extraction, webhooks, auto-name, skill extraction."""
     # Memory extraction — only every 4th message pair to avoid excess LLM calls
@@ -843,6 +844,7 @@ def run_post_response_tasks(
         asyncio.create_task(extract_and_store(
             sess, memory_manager, memory_vector,
             t_url, t_model, t_headers,
+            graph_store=graph_store,
         ))
 
     # Skill extraction from complex agent runs. Only when the user actually

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -239,6 +239,7 @@ def setup_chat_routes(
     memory_vector=None,
     webhook_manager=None,
     skills_manager=None,
+    graph_store=None,
 ) -> APIRouter:
     router = APIRouter(tags=["chat"])
 
@@ -334,6 +335,7 @@ def setup_chat_routes(
             ctx.uprefs, memory_manager, memory_vector, webhook_manager,
             character_name=ctx.preset.character_name,
             owner=ctx.user,
+            graph_store=graph_store,
         )
 
         return {"response": reply}
@@ -926,6 +928,7 @@ def setup_chat_routes(
                                     incognito=incognito, compare_mode=compare_mode,
                                     character_name=ctx.preset.character_name,
                                                             owner=_user,
+                                    graph_store=graph_store,
                                 )
                             _stream_set(session, status="done")
                             yield chunk
@@ -1025,6 +1028,7 @@ def setup_chat_routes(
                                     skills_manager=skills_manager,
                                     owner=_user,
                                     extract_skills=user_requested_agent,
+                                    graph_store=graph_store,
                                 )
                             _stream_set(session, status="done")
                             yield chunk

--- a/routes/graph_routes.py
+++ b/routes/graph_routes.py
@@ -1,0 +1,56 @@
+# routes/graph_routes.py
+"""HTTP API for the user knowledge graph (Kuzu-backed)."""
+
+from fastapi import APIRouter, HTTPException, Request
+from typing import Optional
+import logging
+
+from services.memory import GraphStore
+from src.auth_helpers import get_current_user
+
+logger = logging.getLogger(__name__)
+
+
+def setup_graph_routes(graph_store: Optional[GraphStore]):
+    """Wire up /api/graph endpoints. The router still mounts even when the
+    graph is unhealthy — endpoints respond 503 so callers can detect the
+    degraded state without crashing the server at startup."""
+    router = APIRouter(prefix="/api/graph", tags=["graph"])
+
+    def _owner(request: Request) -> Optional[str]:
+        return get_current_user(request)
+
+    def _require_healthy():
+        if graph_store is None or not graph_store.healthy:
+            raise HTTPException(503, "Graph store unavailable (kuzu missing or DB error)")
+
+    @router.get("/stats")
+    def graph_stats(request: Request):
+        """Return per-label node counts and per-relation edge counts for the
+        current user. Cheap; safe to poll from the UI."""
+        _require_healthy()
+        return graph_store.stats(owner=_owner(request))
+
+    @router.get("/entities")
+    def list_entities(request: Request, label: Optional[str] = None, limit: int = 200):
+        """List entities the graph knows about for this user.
+
+        ?label=Person filters to one entity type. Without the filter you get
+        every entity across all labels, capped at `limit`.
+        """
+        _require_healthy()
+        limit = max(1, min(int(limit or 200), 1000))
+        return {"entities": graph_store.entities(owner=_owner(request), label=label, limit=limit)}
+
+    @router.get("/neighborhood")
+    def neighborhood(request: Request, depth: int = 1, limit: int = 50):
+        """Return triples around the User node, suitable for chat-context
+        injection or front-end visualization. Depth is clamped to [1, 3]."""
+        _require_healthy()
+        return {
+            "triples": graph_store.neighborhood(
+                owner=_owner(request), depth=int(depth), limit=int(limit),
+            ),
+        }
+
+    return router

--- a/routes/memory_routes.py
+++ b/routes/memory_routes.py
@@ -32,7 +32,7 @@ from src.endpoint_resolver import resolve_endpoint
 
 logger = logging.getLogger(__name__)
 
-def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionManager, memory_vector=None):
+def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionManager, memory_vector=None, graph_store=None):
     """Set up memory-related routes."""
     router = APIRouter(prefix="/api/memory", tags=["memory"])
 
@@ -526,6 +526,13 @@ def setup_memory_routes(memory_manager: MemoryManager, session_manager: SessionM
         # Sync vector index
         if memory_vector and memory_vector.healthy:
             memory_vector.remove(memory_id)
+        # Cascade-delete any graph edges introduced by this memory so the
+        # knowledge graph stays consistent with the JSON store.
+        if graph_store is not None and getattr(graph_store, "healthy", False):
+            try:
+                graph_store.delete_by_memory(memory_id)
+            except Exception as e:
+                logger.warning(f"Graph cascade delete failed for {memory_id}: {e}")
         return {"ok": True, "message": "Memory deleted successfully"}
 
     return router

--- a/scripts/bootstrap_graph.py
+++ b/scripts/bootstrap_graph.py
@@ -1,0 +1,217 @@
+"""
+bootstrap_graph.py
+
+One-shot import of existing memory.json entries into the Kuzu knowledge graph.
+
+For each owner's memories, this script runs the triple extractor over the
+flat text and writes the resulting typed entities + relationships to
+data/graph/. Safe to re-run — the graph store's upsert + idempotent edge
+checks deduplicate on re-ingest.
+
+Usage:
+    python -m scripts.bootstrap_graph                    # all owners, default settings
+    python -m scripts.bootstrap_graph --owner alice      # only one owner
+    python -m scripts.bootstrap_graph --batch-size 20    # how many memories per LLM call
+    python -m scripts.bootstrap_graph --dry-run          # extract + print, don't write
+
+Requires a configured default model in data/settings.json (same source the
+extract/audit pipeline uses).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from collections import defaultdict
+from typing import Optional
+
+# Allow running as `python -m scripts.bootstrap_graph` from the repo root and
+# as a plain `python scripts/bootstrap_graph.py` from elsewhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.constants import DATA_DIR  # noqa: E402
+from services.memory import MemoryManager, GraphStore  # noqa: E402
+from services.memory.triple_extractor import extract_triples_async, ingest_triples  # noqa: E402
+
+logger = logging.getLogger("bootstrap_graph")
+
+
+def _resolve_default_endpoint() -> tuple[Optional[str], Optional[str], dict]:
+    """Mirror routes/memory_routes.py::api_audit_memories — pick the user's
+    configured default LLM endpoint from settings.json + the DB."""
+    from routes.model_routes import _load_settings, _normalize_base, build_chat_url
+    from core.database import SessionLocal, ModelEndpoint
+
+    settings = _load_settings()
+    ep_id = settings.get("default_endpoint_id", "")
+    default_model = settings.get("default_model", "")
+    if not ep_id:
+        return None, None, {}
+
+    db = SessionLocal()
+    try:
+        ep = db.query(ModelEndpoint).filter(
+            ModelEndpoint.id == ep_id, ModelEndpoint.is_enabled == True
+        ).first()
+        if not ep:
+            return None, None, {}
+        base = _normalize_base(ep.base_url)
+        endpoint_url = build_chat_url(base)
+        model = default_model
+        if not model and ep.models:
+            try:
+                models = json.loads(ep.models) if isinstance(ep.models, str) else ep.models
+                if models:
+                    model = models[0]
+            except Exception:
+                pass
+        headers = {"Authorization": f"Bearer {ep.api_key}"} if ep.api_key else {}
+        return endpoint_url, model, headers
+    finally:
+        db.close()
+
+
+def _format_memory_as_user_message(text: str) -> dict:
+    """Wrap a flat memory entry as a synthetic user turn for the extractor.
+
+    The triple extractor expects a chat-like message list, so each memory
+    becomes a one-line 'user said' message. Phrasing it this way nudges the
+    LLM to treat the content as a first-person statement.
+    """
+    return {"role": "user", "content": text}
+
+
+async def _process_owner(
+    owner_key: Optional[str],
+    entries: list[dict],
+    graph: GraphStore,
+    endpoint_url: str,
+    model: str,
+    headers: dict,
+    batch_size: int,
+    dry_run: bool,
+) -> dict:
+    """Run extraction over one owner's memories in batches. Returns counters."""
+    total_triples = 0
+    total_edges = 0
+    skipped = 0
+
+    # Pre-create the User node so the first triple doesn't race the upsert.
+    if not dry_run:
+        graph.upsert_user(owner_key)
+
+    for i in range(0, len(entries), batch_size):
+        batch = entries[i:i + batch_size]
+        # Synthesize a "user said" turn per memory entry plus a synthetic
+        # leading assistant turn so the extractor's min-2-messages guard
+        # passes even on a single-memory batch.
+        msgs = [{"role": "assistant", "content": "(historical memories follow)"}]
+        for e in batch:
+            text = (e.get("text") or "").strip()
+            if not text:
+                skipped += 1
+                continue
+            msgs.append(_format_memory_as_user_message(text))
+
+        if len(msgs) < 2:
+            continue
+
+        triples = await extract_triples_async(
+            msgs, endpoint_url, model, headers=headers,
+            max_messages=len(msgs),  # keep all messages in this synthetic batch
+        )
+        total_triples += len(triples)
+        if not triples:
+            continue
+
+        if dry_run:
+            for t in triples:
+                logger.info(
+                    "  [DRY] %s(%s) -[%s]-> %s(%s)",
+                    t["subject_label"], t["subject_name"],
+                    t["relation"],
+                    t["object_label"], t["object_name"],
+                )
+        else:
+            # Provenance pointer: use the last memory id in the batch. Phase 1
+            # tolerates that triples within a multi-memory batch may share a
+            # source pointer — the bootstrap is a coarse-grained import, not
+            # per-turn extraction.
+            provenance = batch[-1].get("id") if batch else None
+            total_edges += ingest_triples(graph, owner_key, triples, source_memory_id=provenance)
+
+    return {
+        "memories": len(entries),
+        "triples_extracted": total_triples,
+        "edges_added": total_edges,
+        "skipped_empty": skipped,
+    }
+
+
+async def _main_async(args) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    manager = MemoryManager(DATA_DIR)
+    all_entries = manager.load_all()
+    if not all_entries:
+        logger.warning("memory.json is empty — nothing to bootstrap")
+        return 0
+
+    endpoint_url, model, headers = _resolve_default_endpoint()
+    if not endpoint_url or not model:
+        logger.error("No default LLM endpoint configured in settings.json — aborting.")
+        return 2
+
+    # Partition by owner so the graph's per-owner isolation is preserved.
+    by_owner: dict[Optional[str], list[dict]] = defaultdict(list)
+    for e in all_entries:
+        by_owner[e.get("owner")].append(e)
+
+    targets = [args.owner] if args.owner else list(by_owner.keys())
+    graph = GraphStore(DATA_DIR)
+    if not graph.healthy:
+        logger.error("GraphStore is unhealthy (kuzu missing or DB failed to open) — aborting.")
+        return 2
+
+    grand_total = {"memories": 0, "triples_extracted": 0, "edges_added": 0, "skipped_empty": 0}
+    for owner_key in targets:
+        entries = by_owner.get(owner_key, [])
+        if not entries:
+            logger.info("No memories for owner=%r — skipping", owner_key)
+            continue
+        logger.info("Bootstrapping owner=%r (%d memories)...", owner_key, len(entries))
+        result = await _process_owner(
+            owner_key, entries, graph,
+            endpoint_url, model, headers,
+            batch_size=args.batch_size, dry_run=args.dry_run,
+        )
+        logger.info("  -> %s", result)
+        for k, v in result.items():
+            grand_total[k] += v
+
+    logger.info("Done. Totals: %s", grand_total)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--owner", help="Only process this owner (default: all owners)")
+    parser.add_argument(
+        "--batch-size", type=int, default=10,
+        help="Memories per LLM extraction call (default: 10). "
+             "Lower if you hit context limits on a small model."
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Extract and print triples but do not write to the graph.",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(_main_async(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/memory/__init__.py
+++ b/services/memory/__init__.py
@@ -4,6 +4,7 @@
 from .service import MemoryService, Memory, MemorySearchResult
 from .memory import MemoryManager
 from .memory_vector import MemoryVectorStore
+from .graph_store import GraphStore
 
 __all__ = [
     "MemoryService",
@@ -11,4 +12,5 @@ __all__ = [
     "MemorySearchResult",
     "MemoryManager",
     "MemoryVectorStore",
+    "GraphStore",
 ]

--- a/services/memory/graph_store.py
+++ b/services/memory/graph_store.py
@@ -1,0 +1,486 @@
+"""
+graph_store.py
+
+User knowledge graph backed by Kuzu (embedded, file-based, openCypher).
+
+Stores typed entities (Person, Place, Organization, Concept, Goal, Project)
+and relationships extracted from chat conversations. Lives alongside the flat
+memory.json store — facts go to both places: text to memory.json for fuzzy
+recall, typed triples here for structured traversal ("who do I know in Paris?").
+
+Persists to {data_dir}/graph/. The whole module degrades gracefully: if kuzu
+is missing or the DB is unhealthy, every call becomes a no-op and `.healthy`
+reads False. Callers should not see exceptions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+ENTITY_LABELS = ("User", "Person", "Place", "Organization", "Concept", "Goal", "Project")
+
+# Relationship name -> (allowed source labels, allowed target labels).
+# Kuzu requires REL TABLE definitions to enumerate the FROM/TO pairs, so this
+# also drives schema creation. Keep the set small and well-typed — free-form
+# edge labels are a Phase 2 concern.
+RELATIONS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "KNOWS":         (("User", "Person"),       ("Person",)),
+    "LIVES_IN":      (("User", "Person"),       ("Place",)),
+    "WORKS_AT":      (("User", "Person"),       ("Organization",)),
+    "INTERESTED_IN": (("User",),                ("Concept",)),
+    "HAS_GOAL":      (("User",),                ("Goal",)),
+    "WORKING_ON":    (("User", "Person"),       ("Project",)),
+    "RELATED_TO":    (("Person",),              ("Person",)),
+}
+
+
+def _norm_key(name: str) -> str:
+    """Stable lookup key for an entity name — lowercased, whitespace-collapsed,
+    punctuation-stripped. Two memories saying 'John' and 'john.' resolve to
+    the same Person node."""
+    s = re.sub(r"\s+", " ", (name or "").strip().lower())
+    return re.sub(r"[^\w\s\-']", "", s)
+
+
+class GraphStore:
+    """Embedded Kuzu-backed graph of typed user-context entities.
+
+    Thread-safe via a single coarse lock — the Kuzu Python connection is not
+    safe for concurrent writes, and Phase 1 traffic is low (one extraction per
+    chat turn). If concurrency ever matters here, swap to a connection pool.
+    """
+
+    def __init__(self, data_dir: str):
+        self.data_dir = data_dir
+        self.db_path = os.path.join(data_dir, "graph")
+        self._lock = threading.Lock()
+        self._db = None
+        self._conn = None
+        self.healthy = False
+        self._init()
+
+    def _init(self) -> None:
+        try:
+            import kuzu  # type: ignore
+        except ImportError:
+            logger.warning("GraphStore DEGRADED: kuzu not installed (pip install kuzu)")
+            return
+
+        try:
+            os.makedirs(self.db_path, exist_ok=True)
+            self._db = kuzu.Database(self.db_path)
+            self._conn = kuzu.Connection(self._db)
+            self._ensure_schema()
+            self.healthy = True
+            logger.info("GraphStore initialized at %s", self.db_path)
+        except Exception as e:
+            logger.warning("GraphStore DEGRADED: %s", e)
+            self._db = None
+            self._conn = None
+            self.healthy = False
+
+    def _ensure_schema(self) -> None:
+        """Create node + relationship tables if missing.
+
+        Kuzu raises on duplicate CREATE; the cheapest portable check is to wrap
+        each statement in try/except and swallow the 'already exists' branch.
+        IF NOT EXISTS syntax availability varies by Kuzu version.
+        """
+        assert self._conn is not None
+
+        node_defs = [
+            # Every entity carries `owner` for multi-user isolation. Without it
+            # one user's "John" would silently merge into another user's graph.
+            ("User",         "id STRING, owner STRING, name STRING, PRIMARY KEY(id)"),
+            ("Person",       "id STRING, owner STRING, name STRING, email STRING, PRIMARY KEY(id)"),
+            ("Place",        "id STRING, owner STRING, name STRING, kind STRING, PRIMARY KEY(id)"),
+            ("Organization", "id STRING, owner STRING, name STRING, PRIMARY KEY(id)"),
+            ("Concept",      "id STRING, owner STRING, name STRING, PRIMARY KEY(id)"),
+            ("Goal",         "id STRING, owner STRING, text STRING, deadline STRING, PRIMARY KEY(id)"),
+            ("Project",      "id STRING, owner STRING, name STRING, PRIMARY KEY(id)"),
+        ]
+        for label, cols in node_defs:
+            self._safe_exec(f"CREATE NODE TABLE {label}({cols})")
+
+        # `source_memory_id` ties every edge back to the memory.json entry that
+        # introduced it — used for provenance, deletion cascade, and audit.
+        for rel, (froms, tos) in RELATIONS.items():
+            pairs = ", ".join(f"FROM {f} TO {t}" for f in froms for t in tos)
+            self._safe_exec(
+                f"CREATE REL TABLE {rel}({pairs}, source_memory_id STRING, ts INT64)"
+            )
+
+    def _safe_exec(self, cypher: str, params: Optional[dict] = None):
+        try:
+            return self._conn.execute(cypher, parameters=params or {})
+        except Exception as e:
+            msg = str(e).lower()
+            if "already exists" in msg or "duplicate" in msg:
+                return None
+            # Bubble for real errors — the caller decides whether to log/swallow.
+            raise
+
+    # ---- public API ---------------------------------------------------------
+
+    def upsert_entity(
+        self,
+        label: str,
+        name: str,
+        owner: Optional[str],
+        extra: Optional[dict] = None,
+    ) -> Optional[str]:
+        """Insert-or-fetch an entity by (label, owner, normalized name).
+
+        Returns the entity id, or None on degraded/invalid input. Name-based
+        resolution is Phase 1 — Phase 2 will add embedding similarity.
+        """
+        if not self.healthy or label not in ENTITY_LABELS:
+            return None
+        clean = (name or "").strip()
+        if not clean:
+            return None
+
+        owner_val = owner or ""
+        key = _norm_key(clean)
+        if not key:
+            return None
+
+        with self._lock:
+            try:
+                # Look up by normalized name + owner. Kuzu doesn't have a
+                # case-insensitive index, so we filter in Cypher with lower().
+                # The graph is small (hundreds-thousands of nodes), so a scan
+                # per upsert is fine for Phase 1.
+                name_field = "text" if label == "Goal" else "name"
+                result = self._conn.execute(
+                    f"MATCH (n:{label}) WHERE n.owner = $owner "
+                    f"AND lower(n.{name_field}) = $key RETURN n.id LIMIT 1",
+                    parameters={"owner": owner_val, "key": key},
+                )
+                if result.has_next():
+                    return str(result.get_next()[0])
+
+                # Insert new.
+                eid = str(uuid.uuid4())
+                if label == "Goal":
+                    deadline = (extra or {}).get("deadline") or ""
+                    self._conn.execute(
+                        "CREATE (n:Goal {id: $id, owner: $owner, text: $text, deadline: $deadline})",
+                        parameters={"id": eid, "owner": owner_val, "text": clean, "deadline": deadline},
+                    )
+                elif label == "Place":
+                    kind = (extra or {}).get("kind") or ""
+                    self._conn.execute(
+                        "CREATE (n:Place {id: $id, owner: $owner, name: $name, kind: $kind})",
+                        parameters={"id": eid, "owner": owner_val, "name": clean, "kind": kind},
+                    )
+                elif label == "Person":
+                    email = (extra or {}).get("email") or ""
+                    self._conn.execute(
+                        "CREATE (n:Person {id: $id, owner: $owner, name: $name, email: $email})",
+                        parameters={"id": eid, "owner": owner_val, "name": clean, "email": email},
+                    )
+                else:
+                    self._conn.execute(
+                        f"CREATE (n:{label} {{id: $id, owner: $owner, name: $name}})",
+                        parameters={"id": eid, "owner": owner_val, "name": clean},
+                    )
+                return eid
+            except Exception as e:
+                logger.warning("upsert_entity(%s, %r) failed: %s", label, name, e)
+                return None
+
+    def upsert_user(self, owner: Optional[str]) -> Optional[str]:
+        """Ensure the (User) node exists for this owner; returns its id.
+
+        The graph is rooted at the User node — every fact about the user is an
+        outgoing edge from here.
+        """
+        if not self.healthy:
+            return None
+        owner_val = owner or ""
+        with self._lock:
+            try:
+                result = self._conn.execute(
+                    "MATCH (u:User) WHERE u.owner = $owner RETURN u.id LIMIT 1",
+                    parameters={"owner": owner_val},
+                )
+                if result.has_next():
+                    return str(result.get_next()[0])
+                uid = str(uuid.uuid4())
+                self._conn.execute(
+                    "CREATE (u:User {id: $id, owner: $owner, name: $name})",
+                    parameters={"id": uid, "owner": owner_val, "name": owner_val or "user"},
+                )
+                return uid
+            except Exception as e:
+                logger.warning("upsert_user(%r) failed: %s", owner, e)
+                return None
+
+    def add_relation(
+        self,
+        rel: str,
+        from_id: str,
+        from_label: str,
+        to_id: str,
+        to_label: str,
+        source_memory_id: Optional[str] = None,
+    ) -> bool:
+        """Add a relationship between two existing entities.
+
+        Idempotent on (rel, from_id, to_id) — duplicate edges are filtered out
+        so re-running extraction over the same memory doesn't fan out the
+        graph. Returns True on success.
+        """
+        if not self.healthy or rel not in RELATIONS:
+            return False
+        froms, tos = RELATIONS[rel]
+        if from_label not in froms or to_label not in tos:
+            logger.debug("add_relation: type mismatch %s(%s -> %s)", rel, from_label, to_label)
+            return False
+        if not from_id or not to_id:
+            return False
+
+        with self._lock:
+            try:
+                exists = self._conn.execute(
+                    f"MATCH (a:{from_label})-[r:{rel}]->(b:{to_label}) "
+                    f"WHERE a.id = $a AND b.id = $b RETURN r LIMIT 1",
+                    parameters={"a": from_id, "b": to_id},
+                )
+                if exists.has_next():
+                    return True
+
+                self._conn.execute(
+                    f"MATCH (a:{from_label}), (b:{to_label}) "
+                    f"WHERE a.id = $a AND b.id = $b "
+                    f"CREATE (a)-[:{rel} {{source_memory_id: $mid, ts: $ts}}]->(b)",
+                    parameters={
+                        "a": from_id,
+                        "b": to_id,
+                        "mid": source_memory_id or "",
+                        "ts": int(time.time()),
+                    },
+                )
+                return True
+            except Exception as e:
+                logger.warning("add_relation(%s) failed: %s", rel, e)
+                return False
+
+    def ingest_triple(
+        self,
+        owner: Optional[str],
+        subject_label: str,
+        subject_name: str,
+        rel: str,
+        object_label: str,
+        object_name: str,
+        source_memory_id: Optional[str] = None,
+        extras: Optional[dict] = None,
+    ) -> bool:
+        """High-level convenience: upsert both endpoints, then connect them.
+
+        `extras` may carry per-node fields like {'place_kind': 'city',
+        'goal_deadline': '2026-12-01', 'person_email': '...'}. Unknown keys are
+        ignored.
+        """
+        if not self.healthy:
+            return False
+        if rel not in RELATIONS:
+            logger.debug("ingest_triple: unknown relation %s", rel)
+            return False
+        if subject_label not in ENTITY_LABELS or object_label not in ENTITY_LABELS:
+            return False
+
+        # Anchor the User node — subjects of "User" type always resolve to the
+        # single user-rooted node, regardless of what name the LLM chose.
+        if subject_label == "User":
+            from_id = self.upsert_user(owner)
+        else:
+            sub_extra = self._extract_node_extras(subject_label, extras)
+            from_id = self.upsert_entity(subject_label, subject_name, owner, sub_extra)
+
+        if object_label == "User":
+            to_id = self.upsert_user(owner)
+        else:
+            obj_extra = self._extract_node_extras(object_label, extras)
+            to_id = self.upsert_entity(object_label, object_name, owner, obj_extra)
+
+        if not from_id or not to_id:
+            return False
+        return self.add_relation(rel, from_id, subject_label, to_id, object_label, source_memory_id)
+
+    @staticmethod
+    def _extract_node_extras(label: str, extras: Optional[dict]) -> dict:
+        if not extras:
+            return {}
+        if label == "Place":
+            return {"kind": extras.get("place_kind", "")}
+        if label == "Goal":
+            return {"deadline": extras.get("goal_deadline", "")}
+        if label == "Person":
+            return {"email": extras.get("person_email", "")}
+        return {}
+
+    # ---- queries -----------------------------------------------------------
+
+    def neighborhood(self, owner: Optional[str], depth: int = 1, limit: int = 50) -> list[dict]:
+        """Return facts as triples surrounding the User node.
+
+        Output: [{"subject": {label, name}, "rel": str, "object": {label, name}}].
+        This is the form that gets serialized into the chat context prompt.
+        Depth > 1 expands to friend-of-friend relationships.
+        """
+        if not self.healthy:
+            return []
+        depth = max(1, min(int(depth), 3))
+        owner_val = owner or ""
+        triples: list[dict] = []
+
+        with self._lock:
+            try:
+                result = self._conn.execute(
+                    f"MATCH (u:User)-[r*1..{depth}]->(n) "
+                    f"WHERE u.owner = $owner "
+                    f"RETURN u, r, n LIMIT $limit",
+                    parameters={"owner": owner_val, "limit": limit},
+                )
+                while result.has_next():
+                    row = result.get_next()
+                    # row = [User node, list of rels, terminal node]
+                    # Kuzu returns nodes as dicts with `_label`, properties, etc.
+                    rels = row[1] if isinstance(row[1], list) else [row[1]]
+                    # We only surface the immediate User -> X edge for the
+                    # prompt; deeper paths are reachable by re-running with
+                    # the neighbor as anchor. Keeping the projection simple
+                    # here avoids ambiguous "rel chain" rendering.
+                    first_rel = rels[0] if rels else None
+                    if not first_rel:
+                        continue
+                    target = row[2]
+                    triples.append({
+                        "subject": {"label": "User", "name": owner_val or "user"},
+                        "rel": first_rel.get("_label") or first_rel.get("label") or "",
+                        "object": {
+                            "label": target.get("_label") or "",
+                            "name": target.get("name") or target.get("text") or "",
+                        },
+                    })
+            except Exception as e:
+                logger.warning("neighborhood query failed: %s", e)
+                return []
+
+        # Dedup: the depth>1 MATCH can return the same User->X edge multiple
+        # times once per longer path that traverses it.
+        seen = set()
+        deduped = []
+        for t in triples:
+            key = (t["rel"], t["object"]["label"], t["object"]["name"].lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(t)
+        return deduped
+
+    def entities(self, owner: Optional[str], label: Optional[str] = None, limit: int = 200) -> list[dict]:
+        """List entities for an owner, optionally filtered by label."""
+        if not self.healthy:
+            return []
+        owner_val = owner or ""
+        labels = [label] if label in ENTITY_LABELS else list(ENTITY_LABELS)
+        out: list[dict] = []
+        with self._lock:
+            for lbl in labels:
+                try:
+                    name_field = "text" if lbl == "Goal" else "name"
+                    result = self._conn.execute(
+                        f"MATCH (n:{lbl}) WHERE n.owner = $owner "
+                        f"RETURN n.id, n.{name_field} LIMIT $limit",
+                        parameters={"owner": owner_val, "limit": limit},
+                    )
+                    while result.has_next():
+                        row = result.get_next()
+                        out.append({"label": lbl, "id": str(row[0]), "name": str(row[1] or "")})
+                except Exception as e:
+                    logger.warning("entities(%s) failed: %s", lbl, e)
+        return out[:limit]
+
+    def stats(self, owner: Optional[str] = None) -> dict:
+        """Counts per node label and per relationship — useful for the UI / debug."""
+        if not self.healthy:
+            return {"healthy": False}
+        owner_val = owner or ""
+        nodes: dict[str, int] = {}
+        rels: dict[str, int] = {}
+        with self._lock:
+            for lbl in ENTITY_LABELS:
+                try:
+                    result = self._conn.execute(
+                        f"MATCH (n:{lbl}) WHERE n.owner = $owner RETURN count(n)",
+                        parameters={"owner": owner_val},
+                    )
+                    if result.has_next():
+                        nodes[lbl] = int(result.get_next()[0])
+                except Exception:
+                    nodes[lbl] = 0
+            for rel in RELATIONS:
+                try:
+                    # Count edges anchored on any node owned by this user.
+                    result = self._conn.execute(
+                        f"MATCH (a)-[r:{rel}]->(b) WHERE a.owner = $owner RETURN count(r)",
+                        parameters={"owner": owner_val},
+                    )
+                    if result.has_next():
+                        rels[rel] = int(result.get_next()[0])
+                except Exception:
+                    rels[rel] = 0
+        return {"healthy": True, "nodes": nodes, "relationships": rels}
+
+    def delete_by_memory(self, source_memory_id: str) -> int:
+        """Drop all edges that were introduced by a single memory entry.
+
+        Called when the originating memory is deleted from memory.json so the
+        graph stays consistent. Orphan nodes (no remaining edges) are NOT
+        pruned in Phase 1 — they're cheap and may get re-attached later.
+
+        Kuzu's openCypher does not support RETURN after DELETE in one query,
+        so we count first, then delete.
+        """
+        if not self.healthy or not source_memory_id:
+            return 0
+        removed = 0
+        with self._lock:
+            for rel in RELATIONS:
+                try:
+                    count_result = self._conn.execute(
+                        f"MATCH ()-[r:{rel}]->() WHERE r.source_memory_id = $mid RETURN count(r)",
+                        parameters={"mid": source_memory_id},
+                    )
+                    n = 0
+                    if count_result.has_next():
+                        n = int(count_result.get_next()[0] or 0)
+                    if n == 0:
+                        continue
+                    self._conn.execute(
+                        f"MATCH ()-[r:{rel}]->() WHERE r.source_memory_id = $mid DELETE r",
+                        parameters={"mid": source_memory_id},
+                    )
+                    removed += n
+                except Exception as e:
+                    logger.debug("delete_by_memory(%s) on %s failed: %s", source_memory_id, rel, e)
+        return removed
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn = None
+            self._db = None
+            self.healthy = False

--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -235,6 +235,7 @@ async def extract_and_store(
     endpoint_url: str,
     model: str,
     headers: Optional[dict] = None,
+    graph_store=None,
 ):
     """Extract facts from recent conversation and store them.
 
@@ -388,6 +389,34 @@ async def extract_and_store(
             except Exception:
                 logger.debug("memory_added event dispatch failed", exc_info=True)
             logger.info(f"Auto-extracted {added} memories from session")
+
+            # Knowledge-graph pass — runs in the same background task so a
+            # graph failure never poisons the flat-text extraction above. The
+            # graph is a secondary index; if it's unhealthy, callers still
+            # get full recall via the JSON store and vector search.
+            if graph_store is not None and getattr(graph_store, "healthy", False):
+                try:
+                    from services.memory.triple_extractor import (
+                        extract_triples_async,
+                        ingest_triples,
+                    )
+                    triples = await extract_triples_async(
+                        stripped_recent, endpoint_url, model, headers=headers,
+                    )
+                    if triples:
+                        # Attribute each triple to the most recently added
+                        # memory id for this turn — gives us a provenance
+                        # anchor for delete-cascade without per-triple
+                        # round-trips back to memory.json.
+                        recent_ids = [e["id"] for e in existing[-added:]]
+                        provenance = recent_ids[-1] if recent_ids else None
+                        edges = ingest_triples(
+                            graph_store, _owner, triples,
+                            source_memory_id=provenance,
+                        )
+                        logger.info("Graph ingested %d edges from %d triples", edges, len(triples))
+                except Exception as e:
+                    logger.warning("Graph triple ingestion failed: %s", e)
 
             global _extractions_since_audit
             _extractions_since_audit += added

--- a/services/memory/triple_extractor.py
+++ b/services/memory/triple_extractor.py
@@ -1,0 +1,239 @@
+"""
+triple_extractor.py
+
+LLM-driven extraction of typed (subject, relation, object) triples about the
+user. Designed to run alongside the flat-text extractor in `memory_extractor`
+so the same chat turn produces both forms — text for fuzzy recall, triples
+for graph traversal.
+
+Errors are logged, never raised. If the LLM is unavailable or returns junk,
+extraction yields zero triples and the graph stays untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Mirrors RELATIONS in graph_store.py. Kept here as a literal so the prompt
+# stays a single source of truth — if you add a relation in the graph,
+# add it here and the extractor will start using it.
+EXTRACTION_RELATIONS = (
+    "KNOWS",          # (User|Person) -> Person
+    "LIVES_IN",       # (User|Person) -> Place
+    "WORKS_AT",       # (User|Person) -> Organization
+    "INTERESTED_IN",  # User -> Concept
+    "HAS_GOAL",       # User -> Goal
+    "WORKING_ON",     # (User|Person) -> Project
+    "RELATED_TO",     # Person -> Person
+)
+
+EXTRACTION_LABELS = ("User", "Person", "Place", "Organization", "Concept", "Goal", "Project")
+
+
+SYSTEM_PROMPT = (
+    "You are a knowledge-graph extraction assistant. Read the conversation and "
+    "extract structured triples about the USER that would be useful across many "
+    "future conversations. Be conservative — better to miss a triple than to "
+    "invent one.\n\n"
+    "Output a JSON array of triples. Each triple has this shape:\n"
+    "  {\n"
+    '    "subject":      {"label": "<NODE_LABEL>", "name": "<string>"},\n'
+    '    "relation":     "<REL_NAME>",\n'
+    '    "object":       {"label": "<NODE_LABEL>", "name": "<string>"},\n'
+    '    "confidence":   0.0-1.0,\n'
+    '    "extras":       {<optional extra fields, see below>}\n'
+    "  }\n\n"
+    f"Allowed node labels: {', '.join(EXTRACTION_LABELS)}\n"
+    f"Allowed relations:   {', '.join(EXTRACTION_RELATIONS)}\n\n"
+    "Type rules (do NOT violate):\n"
+    "  - KNOWS:         User|Person -> Person\n"
+    "  - LIVES_IN:      User|Person -> Place\n"
+    "  - WORKS_AT:      User|Person -> Organization\n"
+    "  - INTERESTED_IN: User -> Concept\n"
+    "  - HAS_GOAL:      User -> Goal\n"
+    "  - WORKING_ON:    User|Person -> Project\n"
+    "  - RELATED_TO:    Person -> Person\n\n"
+    "When the subject is the user, use {\"label\": \"User\", \"name\": \"self\"}.\n\n"
+    "Optional `extras` fields:\n"
+    "  - place_kind:    'city' | 'country' | 'region' | 'neighborhood'\n"
+    "  - person_email:  the person's email if explicitly stated\n"
+    "  - goal_deadline: ISO date string if mentioned\n\n"
+    "Rules:\n"
+    "  - MAX 4 triples per extraction\n"
+    "  - Only triples the USER stated or clearly implied — never the assistant's claims\n"
+    "  - Skip transient/conversational facts (today's mood, current topic, one-off tasks)\n"
+    "  - For names, use the form the user used (don't normalize casing)\n"
+    "  - confidence >= 0.7 for explicit statements, < 0.5 for inferences\n"
+    "  - If nothing extractable, return []\n\n"
+    "Return ONLY a valid JSON array, no prose, no markdown fences."
+)
+
+
+def _strip_fences(text: str) -> str:
+    t = (text or "").strip()
+    # Strip <think> blocks emitted by reasoning models.
+    t = re.sub(r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>", "", t, flags=re.I).strip()
+    if t.startswith("```"):
+        t = t.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    return t
+
+
+def _parse_triples(raw: str) -> list[dict]:
+    """Best-effort JSON parse with the same tolerance as the audit pipeline."""
+    text = _strip_fences(raw)
+    if not text:
+        return []
+
+    candidates = [text, re.sub(r",(\s*[}\]])", r"\1", text)]
+    for cand in candidates:
+        try:
+            parsed = json.loads(cand)
+        except Exception:
+            continue
+        if isinstance(parsed, list):
+            return parsed
+
+    # Final fallback: pull the first JSON array out of the response.
+    lo, hi = text.find("["), text.rfind("]")
+    if lo >= 0 and hi > lo:
+        try:
+            parsed = json.loads(text[lo:hi + 1])
+            if isinstance(parsed, list):
+                return parsed
+        except Exception:
+            pass
+
+    return []
+
+
+# Relation type guards mirror graph_store.RELATIONS — kept here to avoid an
+# import cycle and so the extractor can pre-filter before hitting the DB.
+_REL_TYPES = {
+    "KNOWS":         ({"User", "Person"},        {"Person"}),
+    "LIVES_IN":      ({"User", "Person"},        {"Place"}),
+    "WORKS_AT":      ({"User", "Person"},        {"Organization"}),
+    "INTERESTED_IN": ({"User"},                  {"Concept"}),
+    "HAS_GOAL":      ({"User"},                  {"Goal"}),
+    "WORKING_ON":    ({"User", "Person"},        {"Project"}),
+    "RELATED_TO":    ({"Person"},                {"Person"}),
+}
+
+
+def _valid_triple(t: dict) -> bool:
+    if not isinstance(t, dict):
+        return False
+    rel = (t.get("relation") or "").upper()
+    if rel not in _REL_TYPES:
+        return False
+    s, o = t.get("subject"), t.get("object")
+    if not isinstance(s, dict) or not isinstance(o, dict):
+        return False
+    s_lbl = (s.get("label") or "").strip()
+    o_lbl = (o.get("label") or "").strip()
+    if s_lbl not in EXTRACTION_LABELS or o_lbl not in EXTRACTION_LABELS:
+        return False
+    s_allowed, o_allowed = _REL_TYPES[rel]
+    if s_lbl not in s_allowed or o_lbl not in o_allowed:
+        return False
+    if not (s.get("name") and o.get("name")):
+        return False
+    return True
+
+
+async def extract_triples_async(
+    messages: Iterable[dict],
+    endpoint_url: str,
+    model: str,
+    headers: Optional[dict] = None,
+    max_messages: int = 6,
+) -> list[dict]:
+    """Run the LLM extraction over a chat slice and return validated triples.
+
+    Returns normalized triples ready to feed into GraphStore.ingest_triple:
+        [
+          {
+            "subject_label": "User", "subject_name": "self",
+            "relation": "LIVES_IN",
+            "object_label": "Place", "object_name": "Paris",
+            "confidence": 0.95,
+            "extras": {"place_kind": "city"}
+          },
+          ...
+        ]
+    """
+    from src.llm_core import llm_call_async
+
+    msgs = list(messages or [])
+    if len(msgs) < 2:
+        return []
+    if max_messages and len(msgs) > max_messages:
+        msgs = msgs[-max_messages:]
+
+    payload = [{"role": "system", "content": SYSTEM_PROMPT}] + msgs
+
+    try:
+        raw = await llm_call_async(
+            endpoint_url, model, payload,
+            temperature=0.1, max_tokens=800, headers=headers,
+        )
+    except Exception as e:
+        logger.warning("triple extraction LLM call failed: %s", e)
+        return []
+
+    parsed = _parse_triples(raw)
+    if not parsed:
+        logger.debug("triple extraction returned no parseable triples")
+        return []
+
+    out: list[dict] = []
+    for item in parsed:
+        if not _valid_triple(item):
+            continue
+        rel = item["relation"].upper()
+        s, o = item["subject"], item["object"]
+        out.append({
+            "subject_label": s["label"],
+            "subject_name":  str(s["name"]).strip(),
+            "relation":      rel,
+            "object_label":  o["label"],
+            "object_name":   str(o["name"]).strip(),
+            "confidence":    float(item.get("confidence", 0.7) or 0.7),
+            "extras":        item.get("extras") if isinstance(item.get("extras"), dict) else {},
+        })
+        if len(out) >= 4:
+            break
+    return out
+
+
+def ingest_triples(graph_store, owner: Optional[str], triples: list[dict], source_memory_id: Optional[str] = None) -> int:
+    """Persist a batch of triples to the graph. Returns count of edges added.
+
+    Silent if graph_store is None or unhealthy — callers should not need to
+    check beforehand.
+    """
+    if not graph_store or not getattr(graph_store, "healthy", False):
+        return 0
+    added = 0
+    for t in triples or []:
+        # Drop low-confidence inferences. The threshold is conservative — the
+        # extraction prompt already nudges the model away from speculation.
+        if float(t.get("confidence", 0.0)) < 0.5:
+            continue
+        ok = graph_store.ingest_triple(
+            owner=owner,
+            subject_label=t["subject_label"],
+            subject_name=t["subject_name"],
+            rel=t["relation"],
+            object_label=t["object_label"],
+            object_name=t["object_name"],
+            source_memory_id=source_memory_id,
+            extras=t.get("extras") or {},
+        )
+        if ok:
+            added += 1
+    return added

--- a/src/app_initializer.py
+++ b/src/app_initializer.py
@@ -73,6 +73,20 @@ def initialize_managers(base_dir: str, rag_manager=None) -> Dict[str, Any]:
         logger.warning(f"MemoryVectorStore DEGRADED: {e}")
         memory_vector = None
 
+    # Knowledge graph (Kuzu, embedded). Optional — extraction and chat work
+    # without it; this is a secondary index for structured queries like
+    # "who do I know in Paris?". If kuzu isn't installed, GraphStore quietly
+    # reports unhealthy and every call is a no-op.
+    graph_store = None
+    try:
+        from services.memory import GraphStore
+        graph_store = GraphStore(DATA_DIR)
+        if not graph_store.healthy:
+            graph_store = None
+    except Exception as e:
+        logger.warning(f"GraphStore DEGRADED: {e}")
+        graph_store = None
+
     # Initialize processors
     chat_processor = ChatProcessor(memory_manager, personal_docs_manager, memory_vector=memory_vector, skills_manager=skills_manager)
     research_handler = ResearchHandler()
@@ -99,6 +113,7 @@ def initialize_managers(base_dir: str, rag_manager=None) -> Dict[str, Any]:
     return {
         "memory_manager": memory_manager,
         "memory_vector": memory_vector,
+        "graph_store": graph_store,
         "skills_manager": skills_manager,
         "session_manager": session_manager,
         "upload_handler": upload_handler,


### PR DESCRIPTION
## Summary

Adds a typed user knowledge graph (Kuzu, embedded) alongside the existing `memory.json` + ChromaDB stack so the assistant can answer relational questions ("who do I know at X?", "what places have I lived in?") instead of just recalling atomic text facts. The graph is a secondary index — the existing flat-memory pipeline is unchanged, and the whole graph layer no-ops when kuzu is missing.

## Linked Issue

Part of #1955

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

> Note on the last checkbox: I haven't yet smoke-tested end-to-end against a running model — I'd like the maintainers' sign-off on the approach (#1955) before investing in a full local serving setup for the chat-extraction path. Pure-import / `/api/graph/*` smoke tests will be added before this is marked ready for merge. Flagging openly rather than ticking the box.

## How to Test

1. `pip install -r requirements.txt` — verify `kuzu` installs cleanly.
2. Start the app: `python -m uvicorn app:app --host 127.0.0.1 --port 7000`. Logs should show `GraphStore initialized at data/graph`.
3. Hold a chat that reveals durable facts (name, city, friends, employer). After the 4th message pair, logs should show `Graph ingested N edges from M triples`.
4. `curl http://127.0.0.1:7000/api/graph/stats` — returns per-label node counts and per-relation edge counts.
5. `curl 'http://127.0.0.1:7000/api/graph/neighborhood?depth=2'` — returns triples around the User node.
6. `python -m scripts.bootstrap_graph --dry-run` — preview triples extracted from existing `memory.json`.
7. `python -m scripts.bootstrap_graph` — actually populate the graph from existing memories.
8. `DELETE /api/memory/{id}` on a memory with associated triples — confirm graph edges with that `source_memory_id` are cascade-deleted.
9. **Degradation test**: `pip uninstall kuzu` and restart — app boots normally, chat works, `/api/graph/*` returns `503`. Flat-memory pipeline unchanged.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this PR is backend-only (Python). No `static/`, no CSS, no HTML, no SVG touched.

- [ ] **Screenshot or short clip** — N/A
- [ ] **Style match** — N/A
- [ ] **No new component patterns** — N/A
- [x] **I am not an LLM agent submitting a bulk PR.** Human-directed work; not auto-generated; not a bulk submission.

### Screenshots / clips

N/A — backend only.