### PR TITLE
Fetch full messages with BODY.PEEK[] so read_email works on iCloud IMAP (#1961)

### DIFF
--- a/mcp_servers/email_server.py
+++ b/mcp_servers/email_server.py
@@ -666,7 +666,7 @@ def _read_email(uid=None, message_id=None, folder="INBOX", account=None):
         conn.logout()
         return {"error": "No UID or Message-ID provided"}
 
-    status, msg_data = conn.uid("FETCH", _b(uid), "(RFC822)")
+    status, msg_data = conn.uid("FETCH", _b(uid), "(BODY.PEEK[])")
     if status != "OK":
         conn.logout()
         return {"error": f"Failed to fetch email UID {uid}"}
@@ -855,7 +855,7 @@ def _reply_to_email(uid, body, folder="INBOX", reply_all=False, account=None):
     """Reply to an existing email by UID. Threads via In-Reply-To/References."""
     conn = _imap_connect(account)
     conn.select(folder, readonly=True)
-    status, msg_data = conn.uid("FETCH", _b(uid), "(RFC822)")
+    status, msg_data = conn.uid("FETCH", _b(uid), "(BODY.PEEK[])")
     conn.logout()
     if status != "OK" or not msg_data or not msg_data[0]:
         return {"error": f"Failed to fetch email UID {uid}"}
@@ -1033,7 +1033,7 @@ def _download_attachment(uid, index, folder="INBOX", account=None):
     """Extract a specific attachment to disk and return its local path."""
     conn = _imap_connect(account)
     conn.select(folder, readonly=True)
-    status, msg_data = conn.uid("FETCH", _b(uid), "(RFC822)")
+    status, msg_data = conn.uid("FETCH", _b(uid), "(BODY.PEEK[])")
     conn.logout()
     if status != "OK":
         return {"error": f"Failed to fetch email UID {uid}"}

--- a/tests/test_icloud_imap_full_fetch.py
+++ b/tests/test_icloud_imap_full_fetch.py
@@ -1,0 +1,41 @@
+"""Regression for issue #1961 — read_email (and reply_to_email,
+download_attachment) failed on iCloud IMAP accounts.
+
+iCloud's IMAP server silently ignores the legacy bare `RFC822` fetch item: a
+`UID FETCH <uid> (RFC822)` returns status OK but only `(UID <uid>)` with no body
+tuple, so the parse treats the message as "not found" — even though list_emails
+works (it uses `RFC822.HEADER`, which iCloud honours). The modern
+`BODY.PEEK[]` item is honoured by iCloud and Gmail alike and doesn't set \\Seen.
+
+The fix is an IMAP-protocol-string change exercised only against a live server,
+so it's guarded at the source here (per CONTRIBUTING's "guard at source" note):
+the three full-message fetches must use BODY.PEEK[], and no bare (RFC822) full
+fetch may remain. The header/uid fetches must be left untouched so listing keeps
+working.
+"""
+import re
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parent.parent / "mcp_servers/email_server.py").read_text(encoding="utf-8")
+
+
+def _full_fetches():
+    # every conn.uid("FETCH", ..., "<item>") call's fetch item
+    return re.findall(r'conn\.uid\(\s*"FETCH"\s*,[^,]+,\s*"([^"]+)"\s*\)', SRC)
+
+
+def test_full_message_fetches_use_body_peek_not_bare_rfc822():
+    items = _full_fetches()
+    assert items, "no conn.uid FETCH calls found — test anchor stale"
+    # No bare (RFC822) full-message fetch may remain (it breaks iCloud).
+    assert "(RFC822)" not in items, f"a bare (RFC822) full fetch remains: {items}"
+    # The full-message reads now use BODY.PEEK[] — at least the 3 known sites.
+    assert items.count("(BODY.PEEK[])") >= 3, f"expected >=3 BODY.PEEK[] fetches: {items}"
+
+
+def test_header_and_uid_fetches_preserved():
+    items = _full_fetches()
+    # Listing relies on RFC822.HEADER (iCloud honours it) — must stay.
+    assert "(RFC822.HEADER)" in items, "RFC822.HEADER fetch (used by listing) must be preserved"
+    # UID-only probes must stay as-is.
+    assert "(UID)" in items, "(UID) probe fetch must be preserved"


### PR DESCRIPTION
## Summary

On iCloud IMAP accounts, `read_email` (and `reply_to_email` / `download_attachment`) returned **"Email not found with UID"** for messages that actually exist. The full-message fetch used the legacy bare item `(RFC822)`, which iCloud's IMAP server silently ignores — the fetch returns `OK` but only `(UID <uid>)` with no body tuple, so the parser treats the message as missing. This switches the three full-message fetches to `(BODY.PEEK[])`, which both iCloud and Gmail honour (and which doesn't set `\Seen`).

## Linked Issue

Fixes #1961

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. **— Honest note: I do not have an iCloud account, so I could not verify the end-to-end fetch against a live iCloud server. Per CONTRIBUTING ("if you could not run a check, say so") I'm flagging this. The reporter diagnosed it against live iCloud + a Gmail control; the change is protocol-level (`RFC822` → `BODY.PEEK[]`) with an identical response shape, and is covered by the test below.**

## Root cause

`mcp_servers/email_server.py` fetched the full message with the legacy bare item:

```python
conn.uid("FETCH", _b(uid), "(RFC822)")
```

iCloud **silently ignores bare `RFC822`** — status is `OK` but the response is only `(UID <uid>)` with no body tuple, so the parse at line ~673 treats it as not found. `list_emails` works on iCloud because it uses `RFC822.HEADER`, which iCloud *does* honour. Gmail honours `(RFC822)`, which is why this only reproduced on iCloud.

## Fix

Switch the **three full-message fetches** (`read_email` :669, `reply_to_email` :858, `download_attachment` :1036) to `(BODY.PEEK[])`. The response shape is unchanged (raw bytes still at `msg_data[0][1]`), so parsing is untouched. The `RFC822.HEADER` (listing) and `(UID)` probe fetches are deliberately left as-is.

## How to Test

```
./venv/bin/python -m pytest -q tests/test_icloud_imap_full_fetch.py   # 2 passed
```

This is an IMAP-protocol-string fix only fully exercisable against a live server, so the test guards it at the source: the three full-message fetches must use `BODY.PEEK[]`, no bare `(RFC822)` full fetch may remain, and the `RFC822.HEADER` / `(UID)` fetches must be preserved so listing keeps working. Verified **red→green** — reverting any one site to `(RFC822)` turns the test red.

To verify manually with an iCloud account: configure iCloud IMAP, list emails (works today), then `read_email` on one of the listed UIDs — fails on `main`, succeeds with this change.

## Visual / UI changes

N/A — backend only (`mcp_servers/email_server.py`). No rendering, CSS, HTML, SVG, or `static/js/` changes. Two-dot diff is exactly `mcp_servers/email_server.py` + `tests/test_icloud_imap_full_fetch.py`.

---

*Transparency: this fix was prepared with Claude Code assistance (noted in the commit trailer). It is a single, targeted, human-reviewed change linked to a specific issue (#1961), not a bulk auto-generated submission — so I've left the "not an LLM agent" checkbox unticked rather than tick it inaccurately. Happy to adjust to whatever the maintainers prefer for agent-assisted contributions.*
