### PR TITLE
fix(email): use BODY.PEEK[] so read_email works on iCloud IMAP

### DIFF
--- a/mcp_servers/email_server.py
+++ b/mcp_servers/email_server.py
@@ -666,7 +666,7 @@ def _read_email(uid=None, message_id=None, folder="INBOX", account=None):
         conn.logout()
         return {"error": "No UID or Message-ID provided"}
 
-    status, msg_data = conn.uid("FETCH", _b(uid), "(RFC822)")
+    status, msg_data = conn.uid("FETCH", _b(uid), "(BODY.PEEK[])")
     if status != "OK":
         conn.logout()
         return {"error": f"Failed to fetch email UID {uid}"}
@@ -855,7 +855,7 @@ def _reply_to_email(uid, body, folder="INBOX", reply_all=False, account=None):
     """Reply to an existing email by UID. Threads via In-Reply-To/References."""
     conn = _imap_connect(account)
     conn.select(folder, readonly=True)
-    status, msg_data = conn.uid("FETCH", _b(uid), "(RFC822)")
+    status, msg_data = conn.uid("FETCH", _b(uid), "(BODY.PEEK[])")
     conn.logout()
     if status != "OK" or not msg_data or not msg_data[0]:
         return {"error": f"Failed to fetch email UID {uid}"}
@@ -1033,7 +1033,7 @@ def _download_attachment(uid, index, folder="INBOX", account=None):
     """Extract a specific attachment to disk and return its local path."""
     conn = _imap_connect(account)
     conn.select(folder, readonly=True)
-    status, msg_data = conn.uid("FETCH", _b(uid), "(RFC822)")
+    status, msg_data = conn.uid("FETCH", _b(uid), "(BODY.PEEK[])")
     conn.logout()
     if status != "OK":
         return {"error": f"Failed to fetch email UID {uid}"}


### PR DESCRIPTION
## Summary

  iCloud's IMAP server silently ignores the legacy bare `RFC822` fetch item: `UID FETCH <uid> (RFC822)` returns status `OK` but with only `(UID <uid>)` and no message body. As a result, the tuple check in `_read_email` treated existing iCloud messages as missing and returned `Email not found with UID <uid>`. This switches the three full-message fetches in `mcp_servers/email_server.py` (`_read_email`, `_reply_to_email`, `_download_attachment`) from `(RFC822)` to `(BODY.PEEK[])`, which both iCloud and Gmail honor; `.PEEK` also avoids setting `\Seen`, matching the existing `readonly=True` selects.

  ## Linked Issue

  Fixes #1961 

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)
  - [ ] New feature (non-breaking — adds new behaviour)
  - [ ] Breaking change (changes or removes existing behaviour)
  - [ ] Refactor / cleanup (behaviour unchanged)
  - [ ] Documentation only
  - [ ] CI / tooling / configuration

  ## Checklist

  - [x] I searched open issues and open PRs — this is not a duplicate.
  - [x] This PR targets `main`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
  - [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

  ## How to Test

  1. Configure an iCloud email account (`imap.mail.me.com:993`) in Odysseus.
  2. Run `list_emails` on the iCloud INBOX and copy a message's UID.
  3. Run `read_email` with that UID. **Before:** `Error: Email not found with UID <uid>`. **After:** the full message (subject, sender, body, attachments) is returned.
  4. (Control) Repeat against different type account — works before and after, confirming the fix doesn't regress providers that honor `RFC822`.

  ## Visual / UI changes — REQUIRED if you touched anything that renders

  N/A — backend-only change in `mcp_servers/email_server.py` (IMAP fetch command). No HTML, CSS, SVG, or `static/js/` files touched; nothing about rendering changes.

  ### Screenshots / clips

  N/A — no UI changes.