### PR TITLE
feat(ci): add CI workflow (syntax + tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege: none of the jobs write to the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref to save Actions minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-syntax:
+    name: Python syntax (compileall)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.11"
+      # Byte-compile sources — catches syntax errors without installing deps.
+      - run: python -m compileall -q app.py core routes src services scripts tests
+
+  node-syntax:
+    name: JS syntax (node --check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "20"
+      # Syntax-check our own JS (skip vendored libs in static/lib).
+      - name: node --check
+        run: |
+          shopt -s globstar nullglob
+          for f in static/app.js static/js/**/*.js; do
+            node --check "$f"
+          done
+
+  python-tests:
+    name: Python tests (pytest)
+    runs-on: ubuntu-latest
+    # Informational for now: the suite has known flaky / environment-dependent
+    # failures (test isolation + embedding-model assertions). Tracked under the
+    # ROADMAP "fresh install smoke tests" item; make this required once green.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -r requirements.txt
+      - run: mkdir -p data  # sqlite DB lives at ./data/app.db
+      - run: python -m pytest -q


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` (push to `main` + PRs) running exactly the checks `CONTRIBUTING.md` already asks contributors to run, so they're enforced automatically:

- **python-syntax** — `compileall` over `app.py` + `core/ routes/ src/ services/ scripts/ tests/` (stdlib only).
- **node-syntax** — `node --check` on `static/app.js` + `static/js/**` (skips vendored `static/lib`).
- **python-tests** — `pip install -r requirements.txt` + `pytest`, `continue-on-error` for now (the suite has known test-isolation/env-dependent collection failures), so it's informational until stabilized.

Hardened: `permissions: contents: read`, `concurrency` with cancel-in-progress, actions pinned to commit SHAs (version in a comment). No security-scanning suites, packaging, or extra tooling — just the documented checks.

## Linked Issue

Part of #1965 (opened first to discuss the gap, per CONTRIBUTING's issue-first rule for tooling). Supersedes the earlier #1015, which was closed pending an issue.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

### Files
`.github/workflows/ci.yml`

## How to Test

1. Open this PR / push to a branch → the workflow runs on GitHub Actions.
2. Confirm **python-syntax** and **node-syntax** pass; **python-tests** runs (non-blocking).

Validated locally: YAML parses; `compileall` and `node --check` (~200 files) pass.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes — this PR is backend/tooling only (no `static/`, HTML, CSS, SVG, or `static/js/` DOM changes). Not applicable.