### PR TITLE
Fix conversation export 500 on image/multimodal messages

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -37,6 +37,26 @@ def _public_model(name: str, model: str) -> str:
     return model
 
 
+def _content_to_text(content) -> str:
+    """Flatten a message's content to plain text for text-based exports.
+
+    History entries carry three shapes: a plain string, a multimodal list of
+    content blocks (vision/image attachments), or None (assistant turns that
+    persisted only native tool_calls). The txt/html/md exporters join and
+    string-munge this value, so a list crashed the export (TypeError on join,
+    AttributeError on .replace) and None rendered as the literal "None".
+    Coerce to the text blocks, returning "" for anything without text.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("text")
+        )
+    return ""
+
+
 def _verify_session_owner(request: Request, session_id: str, session_manager=None):
     """Verify the current user owns the session. Raises 404 if not.
 
@@ -708,7 +728,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             lines = []
             for m in session.history:
                 lines.append(f"[{m.role.upper()}]")
-                lines.append(m.content)
+                lines.append(_content_to_text(m.content))
                 lines.append("")
             out_name = filename or f"conversation_{safe_name}_{timestamp}.txt"
             return Response(
@@ -731,7 +751,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             ]
             for m in session.history:
                 cls = "user" if m.role == "user" else "ai"
-                content = m.content.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                content = _content_to_text(m.content).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 content = content.replace("\n", "<br>")
                 html_parts.append(f'<div class="msg {cls}"><div class="role">{m.role}</div>{content}</div>')
             html_parts.append("</body></html>")
@@ -750,7 +770,7 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         markdown_lines.append("\n---\n")
         for message in session.history:
             role = message.role.upper()
-            content = message.content
+            content = _content_to_text(message.content)
             markdown_lines.append(f"### {role}")
             markdown_lines.append(f"{content}\n")
             markdown_lines.append("---\n")

--- a/tests/test_session_export_nonstring_content.py
+++ b/tests/test_session_export_nonstring_content.py
@@ -1,0 +1,50 @@
+"""Regression: session export must tolerate non-string message content.
+
+A message's ``content`` is a plain string for normal turns, but a multimodal
+list of content blocks for image/vision turns, and ``None`` for assistant turns
+that persisted only native tool_calls. The txt/html/md exporters in
+``routes/session_routes.py`` joined and string-munged ``content`` directly, so:
+
+  - txt:  ``"\n".join([..., <list>, ...])``      -> TypeError
+  - html: ``<list>.replace("&", "&amp;")``        -> AttributeError
+  - md:   ``f"{<list>}"``                          -> raw Python repr in output
+
+``_content_to_text`` coerces all three shapes to plain text so export degrades
+gracefully instead of returning a 500.
+"""
+from routes.session_routes import _content_to_text
+
+
+def test_plain_string_passes_through_unchanged():
+    assert _content_to_text("hello world") == "hello world"
+    assert _content_to_text("") == ""
+
+
+def test_multimodal_list_flattens_to_its_text_blocks():
+    content = [
+        {"type": "text", "text": "describe this"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        {"type": "text", "text": "thanks"},
+    ]
+    assert _content_to_text(content) == "describe this\nthanks"
+
+
+def test_none_content_becomes_empty_string():
+    # Assistant turns carrying only native tool_calls persist content as None.
+    assert _content_to_text(None) == ""
+
+
+def test_list_without_text_blocks_is_empty_not_crash():
+    assert _content_to_text([{"type": "image_url", "image_url": {"url": "x"}}]) == ""
+    assert _content_to_text([]) == ""
+
+
+def test_coerced_output_survives_the_export_operations():
+    # The exact operations that previously crashed must now succeed.
+    history = ["plain", [{"type": "text", "text": "img turn"}], None]
+    texts = [_content_to_text(c) for c in history]
+    # txt export path
+    assert "\n".join(texts) == "plain\nimg turn\n"
+    # html export path
+    for t in texts:
+        assert isinstance(t.replace("&", "&amp;"), str)


### PR DESCRIPTION
## Summary

Conversation export as **txt** or **html** returned a 500 when the conversation contained a multimodal (image/vision) turn, because such a message's `content` is a `list` of content blocks, not a `str`. **md** export did not crash but emitted a raw Python list repr.

**Root cause:** history entries carry three `content` shapes - a plain string, a multimodal list of blocks (image attachments), and `None` (assistant turns that persisted only native tool_calls). The export sites string-munged `content` directly:

- txt: `lines.append(m.content)` then `"\n".join(lines)` -> `TypeError` on the list
- html: `m.content.replace("&", "&amp;")` -> `AttributeError` on the list
- md: `f"{message.content}"` -> raw list repr in the output

**Fix:** add `_content_to_text()` in `routes/session_routes.py` (mirrors the existing `_content_as_text` in `src/context_compactor.py`): flattens string/list/None to plain text, returning the text blocks for multimodal content and `""` for anything without text. Apply it at the txt, html, and md export sites. JSON export is left unchanged (it serializes structured content correctly). Plain-string content is returned unchanged, so existing exports are byte-identical.

## Linked Issue

Fixes #1983

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate. (No open PR touches the `routes/session_routes.py` export sites for non-string content.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I ran the full app end-to-end. Verified instead with a regression test covering the exact crashing operations (see How to Test).

## How to Test

1. Run the new regression test: `./venv/bin/python -m pytest -q tests/test_session_export_nonstring_content.py tests/test_session_export_filename.py` -> 7 passed. It covers string passthrough, multimodal-list flattening, `None`, text-less lists, and that the coerced output survives the exact join/replace operations that previously crashed.
2. Confirm red-before / green-after: `git stash` only the `routes/session_routes.py` change and re-run - the multimodal/None cases fail; `git stash pop` and they pass.
3. Optional manual check: export a conversation containing an image turn as txt and html and confirm a 200 with the text content (no 500).
