### PR TITLE
Add hover tooltips for clipped model names (#1982)

### DIFF
--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -311,6 +311,9 @@ function _initModelPickerDropdown() {
       const nameSpan = document.createElement('span');
       nameSpan.className = 'mp-model-name';
       nameSpan.textContent = m.display;
+      // Long model names are clipped with ellipsis — expose the full name on
+      // hover so the suffix/variant tag is still discoverable (#1982).
+      nameSpan.title = m.display;
       row.appendChild(nameSpan);
       if (m.stale) {
         const badge = document.createElement('span');
@@ -686,6 +689,9 @@ export function updateModelPicker() {
   }
 
   const displayName = modelId ? modelId.split('/').pop() : 'Select model';
+  // The header indicator clips long names with ellipsis; show the full model
+  // identifier on hover (#1982). No tooltip on the "Select model" placeholder.
+  label.title = modelId || '';
   const logo = modelId ? providerLogo(modelId) : null;
   if (logo) {
     label.innerHTML = '<span class="model-picker-logo">' + logo + '</span> ' + displayName;

--- a/tests/test_model_name_tooltip.py
+++ b/tests/test_model_name_tooltip.py
@@ -1,0 +1,26 @@
+"""Regression for issue #1982 — long model names are clipped with ellipsis in
+two surfaces (the model-picker dropdown items and the chat-header model
+indicator) with no tooltip, so the suffix/variant tag is undiscoverable.
+
+The fix adds a `title` (native hover tooltip) carrying the full name to both
+render sites in static/js/modelPicker.js. The module pulls in browser globals so
+it can't be imported under node; this guards the two title assignments at source.
+"""
+import re
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parent.parent / "static/js/modelPicker.js").read_text(encoding="utf-8")
+
+
+def test_dropdown_item_has_title_tooltip():
+    # The dropdown item name span must carry a title with the full display name.
+    assert re.search(r"nameSpan\.title\s*=\s*m\.display", SRC), \
+        "dropdown model-name span needs a title tooltip (#1982)"
+
+
+def test_header_indicator_has_title_tooltip():
+    # updateModelPicker must set the header label's title to the full model id
+    # (empty for the 'Select model' placeholder).
+    body = SRC[SRC.index("export function updateModelPicker()"):]
+    assert re.search(r"label\.title\s*=\s*modelId\b", body), \
+        "header model indicator needs a title tooltip (#1982)"


### PR DESCRIPTION
## Summary

Long model names are truncated with an ellipsis in two places with no way to read the full name (#1982): the **model-picker dropdown items** and the **chat-header model indicator**. This adds a native `title` tooltip carrying the full name to both render sites.

## Linked Issue

Fixes #1982

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. **— Honest note: I booted the app and opened the model picker, but populating it with a (long-named) model requires a configured backend — a reachable Ollama instance or a valid OpenAI/API key — which I don't have in this environment, so I couldn't capture the native hover tooltip live. The change is two `title` attribute assignments, covered by the source-guard test below; happy for a maintainer with a model configured to confirm the hover.**

## Root cause

`static/js/modelPicker.js` rendered the dropdown item name span and the header label with no `title` attribute, so truncated names had no hover affordance.

## Fix

Add a native `title` tooltip with the full name at both render sites:
- dropdown item name span: `nameSpan.title = m.display`
- header label (`updateModelPicker`): `label.title = modelId` (empty for the "Select model" placeholder, so no stray tooltip there).

Tiny, additive, no layout change.

## How to Test

```
node --check static/js/modelPicker.js
./venv/bin/python -m pytest -q tests/test_model_name_tooltip.py   # 2 passed
```

1. The module pulls in browser globals so it can't be imported under node; the two `title` assignments are guarded at source. Verified **red→green** (removing either assignment fails the test).
2. Manual: with a model configured, open the picker on a long model family (e.g. `nemotron`) and hover a clipped name — the full name shows as a tooltip; likewise the clipped header indicator.

## Visual / UI changes

This touches `static/js/`. The change adds **no visible styling** — it sets the standard HTML `title` attribute, which the browser renders as its native hover tooltip; there are no new CSS variables, colours, sizes, classes, components, or emoji, and no layout change.

- [ ] Screenshot — **honest note**: capturing the native hover tooltip requires the picker to contain a long-named model, which needs a configured model backend I don't have in this sandbox (see the checklist note). The fix is purely a `title=` attribute; I've described the exact render sites above. A maintainer with a model configured can confirm the hover in seconds.

Two-dot diff: `static/js/modelPicker.js`, `tests/test_model_name_tooltip.py`.

---

*Transparency: prepared with Claude Code assistance (noted in the commit trailer). Single targeted fix linked to #1982, not a bulk submission — so I left the "not an LLM agent" box unticked rather than tick it inaccurately. I drove the running app with a browser automation tool to verify the picker but could not populate a model without a backend.*
