### PR TITLE
Re-export _SPORTS_HINT_RE from the src.search.ranking shim

### DIFF
--- a/src/search/ranking.py
+++ b/src/search/ranking.py
@@ -7,6 +7,7 @@ parallel copy; it now re-exports so the two cannot drift out of sync again.
 
 from services.search.ranking import (  # noqa: F401
     _AGE_FORMATS,
+    _SPORTS_HINT_RE,
     _utcnow_naive,
     rank_search_results,
     recency_score,


### PR DESCRIPTION
## Summary

Fixes #1995. `src/search/ranking.py` is a re-export shim of `services.search.ranking` (so the two copies cannot drift), but it dropped `_SPORTS_HINT_RE` from the re-export list. `tests/test_search_ranking_sports_substring.py` is parametrized over both modules and reaches for `ranking._SPORTS_HINT_RE`, so its two `[src]` cases failed on `main` with `AttributeError`.

## Fix

Add `_SPORTS_HINT_RE` to the shim's re-export. One line.

## Validation

- `./venv/bin/python -m pytest -q tests/test_search_ranking_sports_substring.py` -> 6 passed (was 4 passed, 2 failed on `[src]`)
- `./venv/bin/python -m py_compile src/search/ranking.py` -> passes
- `git diff --check` -> clean
