### PR TITLE
Strip tz in _parse_dt dateutil fallback so non-ISO offset datetimes don't crash calendar list

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -404,7 +404,17 @@ def _parse_dt(s: str) -> datetime:
     # Last resort: dateutil's fuzzy parser
     try:
         from dateutil import parser as _du
-        return _du.parse(s)
+        parsed = _du.parse(s)
+        # Strip tz like every other return path above — this function's
+        # contract is naive datetimes (CalendarEvent.dtstart is naive). An
+        # offset-bearing non-ISO input (e.g. RFC-2822 "Mon, 05 Jan 2026
+        # 14:00:00 +0900") otherwise leaked tz-aware into the naive column and
+        # crashed read-back comparisons in _expand_rrule with "can't compare
+        # offset-naive and offset-aware datetimes".
+        if parsed.tzinfo is not None:
+            from datetime import timezone as _tz
+            return parsed.astimezone(_tz.utc).replace(tzinfo=None)
+        return parsed
     except Exception:
         raise ValueError(f"could not parse datetime: {s!r}")
 

--- a/tests/test_calendar_parse_dt_naive.py
+++ b/tests/test_calendar_parse_dt_naive.py
@@ -1,0 +1,46 @@
+"""Regression: _parse_dt's dateutil fallback must return naive datetimes.
+
+_parse_dt documents that it returns local-naive datetimes to match the DB
+schema (CalendarEvent.dtstart is naive), and every return path strips tz —
+except the last-resort dateutil branch, which returned dateutil's value
+verbatim. An offset-bearing non-ISO input (e.g. RFC-2822
+"Mon, 05 Jan 2026 14:00:00 +0900", which datetime.fromisoformat rejects but
+dateutil parses) therefore leaked a tz-aware datetime into the naive dtstart
+column. On read-back, _expand_rrule compares ev.dtstart against naive window
+bounds and raises "can't compare offset-naive and offset-aware datetimes".
+
+The fallback now normalizes to UTC and strips tz, exactly like the ISO path.
+"""
+import pytest
+
+from tests.test_null_owner_gates import _import_calendar_helpers
+
+# Inputs datetime.fromisoformat() rejects (so they hit the dateutil fallback)
+# but that carry a numeric UTC offset dateutil resolves to tz-aware.
+_OFFSET_NONISO = [
+    "Mon, 05 Jan 2026 14:00:00 +0900",
+    "January 5, 2026 14:00 +0900",
+]
+
+
+@pytest.mark.parametrize("s", _OFFSET_NONISO)
+def test_parse_dt_dateutil_fallback_returns_naive(s):
+    cal = _import_calendar_helpers()
+    d = cal._parse_dt(s)
+    assert d.tzinfo is None, f"{s!r} leaked tz-aware: {d!r}"
+    # +0900 14:00 -> 05:00 UTC, naive.
+    assert (d.hour, d.minute) == (5, 0)
+
+
+@pytest.mark.parametrize("s", _OFFSET_NONISO)
+def test_parse_dt_pair_fallback_returns_naive(s):
+    cal = _import_calendar_helpers()
+    dt, _is_utc = cal._parse_dt_pair(s)
+    assert dt.tzinfo is None, f"{s!r} leaked tz-aware via _parse_dt_pair: {dt!r}"
+
+
+def test_parse_dt_naive_input_unchanged():
+    cal = _import_calendar_helpers()
+    d = cal._parse_dt("January 5, 2026 14:00")  # no offset -> stays as parsed
+    assert d.tzinfo is None
+    assert (d.hour, d.minute) == (14, 0)


### PR DESCRIPTION
## Summary

Creating/updating a calendar event with a non-ISO, offset-bearing datetime (e.g. RFC-2822 `Mon, 05 Jan 2026 14:00:00 +0900`) stored a tz-aware value into the naive `CalendarEvent.dtstart` column. Listing a window that includes it then failed with `can't compare offset-naive and offset-aware datetimes` (500 / no events).

**Root cause:** `_parse_dt` documents that it returns naive datetimes (to match the schema), and every return path strips tz, except the last-resort dateutil fallback, which returned `_du.parse(s)` verbatim. ISO inputs are handled (and tz-stripped) by the `fromisoformat` branch, so only non-ISO offset strings reached the fallback. `create_event`/`update_event` go through `_parse_dt_pair`, whose `except` returns `_parse_dt(s)` as naive-local, so the tz-aware value landed in the naive column and crashed read-back comparison in `_expand_rrule`.

**Fix:** normalize the dateutil fallback to UTC and strip tzinfo, mirroring the `fromisoformat` branch. Naive inputs are unchanged. ~10 lines, one file.

## Linked Issue

Fixes #2010

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate. (Searched `calendar_routes` + `_parse_dt` / `dateutil` / `offset-naive`; the matches #1879 and #1875 touch other files/functions, and the fallback is unfixed on `upstream/main`.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I ran the full app end-to-end. Verified instead with a red-before/green-after repro test (see How to Test).

## How to Test

1. Run the new regression test: `./venv/bin/python -m pytest -q tests/test_calendar_parse_dt_naive.py` -> passes. It asserts `_parse_dt` and `_parse_dt_pair` return naive for offset-bearing non-ISO inputs (the `+0900 14:00` input normalizes to `05:00` UTC naive), plus a naive-input control that stays unchanged.
2. Confirm red-before / green-after: `git stash` only the `routes/calendar_routes.py` change and re-run the test - the dateutil-fallback cases fail; `git stash pop` and they pass.
3. Regression sweep: `./venv/bin/python -m pytest -q tests/test_calendar_recurrence.py tests/test_calendar_parse_dt_naive.py tests/test_calendar_parse_dt_tonight.py tests/test_calendar_update_event_tz.py tests/test_calendar_rrule.py tests/test_calendar_rrule_until_utc.py` -> 30 passed.
