### PR TITLE
fix(library): update language facet counts on delete and archive

### DIFF
--- a/static/js/documentLibrary.js
+++ b/static/js/documentLibrary.js
@@ -711,6 +711,13 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
         // Drop it from the current view (it no longer belongs here) and refresh.
         _libraryDocs = _libraryDocs.filter(d => d.id !== doc.id);
         _libraryTotal = Math.max(0, _libraryTotal - 1);
+        if (doc.language && _libraryLanguages[doc.language] !== undefined) {
+          const n = Math.max(0, _libraryLanguages[doc.language] - 1);
+          if (n === 0) delete _libraryLanguages[doc.language];
+          else _libraryLanguages[doc.language] = n;
+        }
+        libraryRenderStats();
+        libraryRenderLangChips();
         libraryRenderGrid();
         if (uiModule) uiModule.showToast(toArchived ? 'Archived' : 'Restored');
       } catch { if (uiModule) uiModule.showError('Failed to ' + (toArchived ? 'archive' : 'restore')); }
@@ -804,6 +811,13 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
         if (!res.ok) throw new Error('failed');
         _libraryDocs = _libraryDocs.filter(d => d.id !== doc.id);
         _libraryTotal = Math.max(0, _libraryTotal - 1);
+        if (doc.language && _libraryLanguages[doc.language] !== undefined) {
+          const n = Math.max(0, _libraryLanguages[doc.language] - 1);
+          if (n === 0) delete _libraryLanguages[doc.language];
+          else _libraryLanguages[doc.language] = n;
+        }
+        libraryRenderStats();
+        libraryRenderLangChips();
         libraryRenderGrid();
         if (uiModule) uiModule.showToast(toArchived ? 'Archived' : 'Restored');
       } catch { if (uiModule) uiModule.showError('Failed to ' + (toArchived ? 'archive' : 'restore')); }
@@ -1170,9 +1184,16 @@ let _libraryArchivedView = false;   // Documents tab showing archived docs?
         card.addEventListener('transitionend', () => card.remove(), { once: true });
         setTimeout(() => { if (card.parentElement) card.remove(); }, 400);
       }
+      const deletedDoc = _libraryDocs.find(d => d.id === docId);
       _libraryDocs = _libraryDocs.filter(d => d.id !== docId);
       _libraryTotal = Math.max(0, _libraryTotal - 1);
+      if (deletedDoc?.language && _libraryLanguages[deletedDoc.language] !== undefined) {
+        const n = Math.max(0, _libraryLanguages[deletedDoc.language] - 1);
+        if (n === 0) delete _libraryLanguages[deletedDoc.language];
+        else _libraryLanguages[deletedDoc.language] = n;
+      }
       libraryRenderStats();
+      libraryRenderLangChips();
       if (uiModule) uiModule.showToast('Document deleted');
     } catch (e) {
       if (uiModule) uiModule.showError(`Failed to delete document: ${e.message || e}`);


### PR DESCRIPTION
## Summary

`libraryDeleteSingle` and the two archive handlers (dropdown menu and card
footer) decremented `_libraryTotal` but never updated `_libraryLanguages`.
`libraryRenderStats` derives its displayed total from that map via
`Object.values(_libraryLanguages).reduce(...)`, and `libraryRenderLangChips`
uses it to render the "all (N)" chip and per-language chips -- so both
stayed stale after any remove or archive operation until a full page reload.

Fixed by capturing the document's language before filtering it out of
`_libraryDocs`, decrementing (or deleting) its key in `_libraryLanguages`,
then calling `libraryRenderStats()` and `libraryRenderLangChips()` alongside
the existing render calls.

## Linked Issue

Fixes #1809

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start the app and open the document library.
2. Add several documents of at least two different file types (e.g. PDF and plain text) so the language chips show non-zero counts.
3. Note the "all (N)" chip count and the individual language chip counts.
4. Delete one document via the three-dot (kebab) menu > Delete. Expected: the "all" chip and the matching language chip decrement immediately without a page reload.
5. Archive one document via the three-dot menu > Archive. Expected: same immediate decrement.
6. Expand a card and click Archive in the card footer. Expected: same.
7. Bulk-delete several documents (select mode > Delete). Expected: still works correctly (this path calls `libraryFetch` and was not affected).

## Visual / UI changes -- REQUIRED if you touched anything that renders

This fix calls existing render functions (`libraryRenderStats`, `libraryRenderLangChips`) that were already being called on every fresh fetch -- no new DOM structure, no new CSS, no new colour values, no emoji.

- [x] **Style match**: no new CSS variables, font sizes, spacing units, or component patterns introduced -- only existing render functions are called.
- [x] **No Unicode emoji in UI or code.**
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

No visual change to the layout or style -- only the counter numbers update correctly on delete/archive, which is the expected behaviour described in the issue.
