### PR TITLE
fix(mcp): sync subprocess fallback for Windows + Python 3.14

### DIFF
--- a/src/builtin_mcp.py
+++ b/src/builtin_mcp.py
@@ -208,6 +208,18 @@ async def _is_npx_package_cached(npx_path, package_spec, timeout_s=5):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+    except NotImplementedError:
+        # Windows + Python 3.14: ProactorEventLoop required for subprocesses but
+        # uvicorn --reload spawns workers that may use SelectorEventLoop.
+        import subprocess as _sp
+        try:
+            r = _sp.run(
+                [npx_path, "--no-install", package_spec, "--version"],
+                stdout=_sp.PIPE, stderr=_sp.PIPE, timeout=timeout_s,
+            )
+            return r.returncode == 0 and bool(r.stdout.strip())
+        except Exception:
+            return False
     except (OSError, ValueError):
         return False
     try:


### PR DESCRIPTION
## Summary

`_is_npx_package_cached` calls `asyncio.create_subprocess_exec` to probe
whether a package is in the local npx cache. On Windows with Python 3.14,
uvicorn's `--reload` mode spawns worker processes using `SelectorEventLoop`,
which cannot create subprocesses and raises `NotImplementedError`. This
caused the MCP browser startup path to crash on affected setups.

Fixed by catching `NotImplementedError` specifically and retrying with a
synchronous `subprocess.run` call. Return semantics are identical: exit 0
with non-empty stdout means the package is cached. All other exception paths
(`OSError`, `ValueError`, timeout) are unchanged.

## Linked Issue

Fixes #1894

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

**Affected path (Windows + Python 3.14 + uvicorn --reload):**
1. Run the app with `uvicorn app:app --reload` on Windows under Python 3.14.
2. Confirm the MCP browser server starts without a `NotImplementedError` traceback in the logs.
3. Confirm the npx cache probe still returns `False` for an uncached package and `True` for a cached one.

**Non-affected path (non-Windows or Python < 3.14):**
4. Run the app normally and confirm the async subprocess path is used with no regression in behaviour.

## Visual / UI changes -- REQUIRED if you touched anything that renders

Backend-only change (`src/builtin_mcp.py`). No rendering code touched.
