### PR TITLE
Improve chat reasoning readability and sidebar styling

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1314,7 +1314,7 @@ import createResearchSynapse from './researchSynapse.js';
                   accumulated = accumulated.replace(/<think>/i, '<think time="' + _elapsedDone + '">');
                   roundText = roundText.replace(/<think>/i, '<think time="' + _elapsedDone + '">');
                 }
-                if (_liveThinkHeader) _liveThinkHeader.textContent = 'View thinking process';
+                if (_liveThinkHeader) _liveThinkHeader.textContent = 'View reasoning';
                 if (_liveThinkSpinnerSlot) _liveThinkSpinnerSlot.remove();
                 if (_liveThinkTimerEl && _elapsedDone) {
                   _liveThinkTimerEl.textContent = _elapsedDone + 's';
@@ -1491,12 +1491,12 @@ import createResearchSynapse from './researchSynapse.js';
                   thinkContent.innerHTML = `
                     <div class="thinking-section">
                       <div class="thinking-header" data-thinking-id="${_liveThinkDomId}">
-                        <div class="thinking-header-left"><span class="live-think-header-text">Thinking\u2026</span></div>
+                        <div class="thinking-header-left"><span class="live-think-header-text" data-label="reasoning">Thinking\u2026</span></div>
                         <span class="live-think-spinner-slot" style="flex-shrink:0;margin-left:auto;"></span>
                         <span class="live-think-timer" style="font-size:11px;opacity:0.4;font-variant-numeric:tabular-nums;margin-left:6px;margin-right:5px;"></span>
                         <span class="thinking-toggle live-think-toggle" id="${_liveThinkDomId}-toggle"></span>
                       </div>
-                      <div class="thinking-content" id="${_liveThinkDomId}">
+                      <div class="thinking-content expanded" id="${_liveThinkDomId}">
                         <div class="thinking-content-inner live-think-inner"></div>
                       </div>
                     </div>`;
@@ -1507,6 +1507,9 @@ import createResearchSynapse from './researchSynapse.js';
                   _liveThinkSpinnerSlot = thinkContent.querySelector('.live-think-spinner-slot');
                   _liveThinkTimerEl = thinkContent.querySelector('.live-think-timer');
                   _liveThinkToggle = thinkContent.querySelector('.live-think-toggle');
+                  // Keep the toggle chevron in sync with the expanded live box so
+                  // it points "open" while reasoning streams.
+                  if (_liveThinkToggle) _liveThinkToggle.classList.add('expanded');
                   // Live timer
                   var _thinkTimerStart = Date.now();
                   var _thinkTimerRAF = 0;
@@ -1570,7 +1573,7 @@ import createResearchSynapse from './researchSynapse.js';
                     accumulated = accumulated.replace(/<think>/i, '<think time="' + elapsed + '">');
                     roundText = roundText.replace(/<think>/i, '<think time="' + elapsed + '">');
                   }
-                  if (_liveThinkHeader) _liveThinkHeader.textContent = 'View thinking process';
+                  if (_liveThinkHeader) _liveThinkHeader.textContent = 'View reasoning';
                   if (_liveThinkSpinnerSlot) _liveThinkSpinnerSlot.remove();
                   // Move timer to right side of header
                   if (_liveThinkTimerEl && elapsed) {
@@ -1593,6 +1596,13 @@ import createResearchSynapse from './researchSynapse.js';
                   if (_liveHdr) _liveHdr.dataset.thinkingId = _thinkId;
                   if (_liveThinkContent) _liveThinkContent.id = _thinkId;
                   if (_liveThinkToggle) _liveThinkToggle.id = _thinkId + '-toggle';
+
+                  // Collapse the reasoning now that it's complete — it streamed
+                  // live (expanded) while generating, but at rest it should be
+                  // collapsed by default so the answer leads. User clicks the
+                  // header to re-open it.
+                  if (_liveThinkContent) _liveThinkContent.classList.remove('expanded');
+                  if (_liveThinkToggle) _liveThinkToggle.classList.remove('expanded');
 
                   // Append a container for the reply text that follows thinking
                   var _streamEl = _liveThinkSection ? _liveThinkSection.parentElement : roundHolder.querySelector('.stream-content');

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -260,7 +260,7 @@ function createThinkingSection(thinkingContent, index = 0, thinkingTime = null) 
     <div class="thinking-section">
       <div class="thinking-header" data-thinking-id="${id}">
         <div class="thinking-header-left">
-          <span>View thinking process</span>
+          <span data-label="reasoning">View reasoning</span>
         </div>
         <div style="display:flex;align-items:center;gap:6px;">
           ${timeHtml}

--- a/static/style.css
+++ b/static/style.css
@@ -579,6 +579,26 @@ body.bg-pattern-sparkles {
       margin: 0;
       padding: 8px 8px;
     }
+    /* New Chat — promoted to a filled accent button (the primary action). Falls
+       back to the brand colour when no theme accent is set. White glyph/label
+       for contrast in every theme. */
+    #sidebar-new-chat-btn {
+      background: var(--accent, var(--red));
+      border-radius: 10px;
+      font-weight: 600;
+      margin-bottom: 4px;
+      box-shadow: 0 2px 8px color-mix(in srgb, var(--accent, var(--red)) 28%, transparent);
+      transition: filter 0.12s ease, box-shadow 0.12s ease;
+    }
+    #sidebar-new-chat-btn:hover {
+      background: var(--accent, var(--red));
+      filter: brightness(1.08);
+    }
+    #sidebar-new-chat-btn .grow { color: #fff; }
+    #sidebar-new-chat-btn .sidebar-action-icon {
+      stroke: #fff;
+      color: #fff;
+    }
     #sessions-section {
       margin-top: -1px;
     }
@@ -1130,22 +1150,23 @@ body.bg-pattern-sparkles {
       height: 29px;
       box-sizing: border-box;
     }
-    .section-header-flex:hover { background: color-mix(in srgb, var(--red) 8%, transparent); }
+    .section-header-flex:hover { background: color-mix(in srgb, var(--fg) 6%, transparent); }
     .section-header-flex::after { content: none; }
     .section-header-flex h4::before { content: none; }
 
-    /* Section title text — same font as .list-item .grow */
+    /* Section title text — quiet uppercase label so sections read as headers,
+       not list rows. Muted colour keeps them secondary to the chat titles. */
     .section-header-flex h4,
     .section-header-flex .section-title {
       flex: 1; cursor: pointer; user-select: none;
       display: flex; align-items: center; gap: 6px;
       margin: 0; padding: 0; border: none;
-      font-size: 10px; font-weight: 400; font-family: inherit;
+      font-size: 10.5px; font-weight: 700; font-family: inherit;
       /* 1.3 (not 1) so Fira Code's tall glyph box isn't vertically clipped in
          Chromium/Edge — mirrors the .list-item fix. The title is flex-centred
          in a fixed-height (29px) header, so this adds headroom without reflow. */
-      line-height: 1.3; letter-spacing: 0; text-transform: none;
-      color: var(--fg);
+      line-height: 1.3; letter-spacing: 0.05em; text-transform: uppercase;
+      color: color-mix(in srgb, var(--fg) 60%, transparent);
     }
     .section-icon,
     .sidebar-action-icon {
@@ -1320,10 +1341,12 @@ body.bg-pattern-sparkles {
     }
     @keyframes spin { to { transform: rotate(360deg); } }
     .row { display:flex; gap:6px; align-items:center; }
+    /* Calm, theme-agnostic hover — neutral fg tint instead of the brand-red
+       wash, so resting rows don't read as "alerts". Active rows still get the
+       accent treatment below. */
     .list-item:hover,
     .models-row:hover {
-      background: color-mix(in srgb, var(--red) 8%, transparent);
-      border-color: var(--red);
+      background: color-mix(in srgb, var(--fg) 6%, transparent);
     }
     /* Disabled tool — dimmed to signal its feature is turned off globally */
     .list-item.tool-disabled {
@@ -1426,17 +1449,27 @@ body.bg-pattern-sparkles {
       opacity: 1;
     }
     .list-item.active-session {
-      background: color-mix(in srgb, var(--red) 10%, transparent);
-      border-color: var(--red);
-      border-left-color: var(--red);
+      position: relative;
+      background: color-mix(in srgb, var(--accent, var(--red)) 12%, transparent);
     }
     .list-item .provider-logo { opacity: 0.4 !important; }
     .list-item:has(.session-star.processing) .provider-logo { opacity: 1 !important; }
     .list-item.stream-complete .provider-logo { opacity: 1 !important; }
     .list-item.active {
-      background: color-mix(in srgb, var(--red) 10%, transparent);
-      border-color: var(--red);
-      border-left-color: var(--red);
+      position: relative;
+      background: color-mix(in srgb, var(--accent, var(--red)) 12%, transparent);
+    }
+    /* Left accent pill marks the active chat/tool at a glance (sidebar only,
+       so the settings menu's own .active styling is untouched). */
+    .sidebar .list-item.active-session::before,
+    .sidebar .list-item.active::before {
+      content: '';
+      position: absolute;
+      left: 0; top: 6px; bottom: 6px;
+      width: 3px;
+      border-radius: 0 2px 2px 0;
+      background: var(--accent, var(--red));
+      pointer-events: none;
     }
     /* Only show the red focus ring for keyboard navigation (Tab). Mouse
        clicks shouldn't leave a sticky red outline on a sidebar item. */
@@ -1936,7 +1969,7 @@ body.bg-pattern-sparkles {
       }
     }
     .msg {
-      margin: 8px 0;
+      margin: 14px 0;
       position: relative;
       display: flex;
       flex-direction: column;
@@ -8216,48 +8249,70 @@ button.hamburger {
 /* Hide thinking sections globally via settings toggle */
 body.hide-thinking .thinking-section { display: none !important; }
 
-/* Thinking process styles — colors follow theme accent */
+/* Thinking process styles — calm "Reasoning" chip, follows theme accent.
+   Neutral by default (reasoning is normal, not an error), collapsed-friendly,
+   and gets out of the way of the answer. Class names + .expanded mechanics are
+   unchanged so the toggle JS and live-streaming keep working. */
 .msg .body .stream-content {
   width: 100%;
 }
 .thinking-section {
-  margin: 12px 0;
+  margin: 10px 0;
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
-  border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--red) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
   overflow: hidden;
-  transition: all 0.3s ease;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+/* Subtle accent ring only while expanded so it reads as "active" */
+.thinking-section:has(.thinking-content.expanded) {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 28%, transparent);
+  background: color-mix(in srgb, var(--accent, var(--red)) 5%, transparent);
 }
 
 .thinking-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 6px 12px;
+  gap: 10px;
+  padding: 7px 11px;
   cursor: pointer;
   user-select: none;
-  background: color-mix(in srgb, var(--red) 8%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--red) 20%, transparent);
-  transition: background 0.2s ease;
+  background: transparent;
+  border-bottom: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+.thinking-section:has(.thinking-content.expanded) .thinking-header {
+  border-bottom-color: color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
 }
 
 .thinking-header:hover {
-  background: color-mix(in srgb, var(--red) 12%, transparent);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
 }
 
 .thinking-header-left {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.9em;
-  color: var(--red);
-  font-weight: 500;
+  font-size: 0.82em;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  font-weight: 600;
   overflow: hidden;
   min-width: 0;
+}
+/* Accent spark — the only splash of colour, marks this as "thinking" */
+.thinking-header-left::before {
+  content: '\2726'; /* ✦ */
+  color: var(--accent, var(--red));
+  font-size: 0.95em;
+  flex-shrink: 0;
+  line-height: 1;
+}
+.thinking-header:hover .thinking-header-left {
+  color: color-mix(in srgb, var(--fg) 78%, transparent);
 }
 .thinking-header-left span {
   overflow: hidden;
@@ -8271,36 +8326,40 @@ body.hide-thinking .thinking-section { display: none !important; }
 }
 
 .thinking-toggle {
-  font-size: 0.9em;
-  color: var(--red);
-  transition: transform 0.3s ease;
+  font-size: 0.7em;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  transition: transform 0.25s ease, color 0.2s ease;
+  flex-shrink: 0;
 }
 .thinking-toggle::after {
-  content: '\25BC'; /* ▼ */
+  content: '\25B6'; /* ▶ collapsed */
+}
+.thinking-header:hover .thinking-toggle {
+  color: var(--accent, var(--red));
 }
 
 .thinking-toggle.expanded {
-  transform: rotate(180deg);
+  transform: rotate(90deg);
+  color: var(--accent, var(--red));
 }
 
 .thinking-content {
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.3s ease, padding 0.3s ease;
-  padding: 0 12px;
+  padding: 0 13px 0 32px;
 }
 
 .thinking-content.expanded {
-  max-height: 300px;
+  max-height: 320px;
   overflow-y: auto;
-  padding: 12px;
+  padding: 10px 13px 12px 32px;
 }
 
 .thinking-content-inner {
   font-size: 0.85em;
-  color: var(--fg);
-  opacity: 0.9;
-  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 72%, transparent);
+  line-height: 1.6;
 }
 .live-reply-content {
   animation: fadeSlideIn 0.3s ease-out;


### PR DESCRIPTION
## Summary
- Rename thinking labels to 'View reasoning' and keep the live box expanded while reasoning streams, then collapse it by default once complete so the answer leads
- Restyle the thinking section (neutral header, accent spark, rotating chevron, indented content) to fit the existing theme
- Calmer sidebar: theme-tinted hovers instead of red washes, accent left-pill for the active chat/tool, filled New Chat button, and quieter uppercase section titles
- Add interactive UI prototypes under docs/ui-prototypes for reference


## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [x] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.
2.
3.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
<img width="3456" height="2006" alt="image" src="https://github.com/user-attachments/assets/1d9ac711-342f-4b1c-a89d-60a75730550b" />

