### PR TITLE
fix(ui): preserve modal drag position during class changes

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2692,9 +2692,11 @@ function initializeEventListeners() {
       if (!content || !header) return;
       let dragX, dragY, startLeft, startTop, dragging = false;
 
-      // Reset to flex-centered position each time modal opens
+      // Only recenter on open; drag class changes must keep fixed coordinates.
+      let wasHidden = m.classList.contains('hidden');
       new MutationObserver(() => {
-        if (!m.classList.contains('hidden')) {
+        const isHidden = m.classList.contains('hidden');
+        if (wasHidden && !isHidden) {
           content.style.position = '';
           content.style.left = '';
           content.style.top = '';
@@ -2702,6 +2704,7 @@ function initializeEventListeners() {
           content.style.bottom = '';
           content.style.margin = '';
         }
+        wasHidden = isHidden;
       }).observe(m, { attributes: true, attributeFilter: ['class'] });
 
       function startDrag(clientX, clientY) {


### PR DESCRIPTION
## Summary

Prevent visible draggable modals from resetting inline positioning on non-visibility class changes. This fixes Brain and Cookbook windows jumping during drag while keeping the existing recenter-on-open behavior.

## Linked Issue

Fixes #2028 #1980 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Open Odysseus.
2. Open Brain or Cookbook.
3. Drag the window by its header.
4. Verify the window follows the cursor without jumping across the viewport.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] Screenshot or short clip attached below.
- [x] Style match: no visual styling changes were introduced.
- [x] No new component patterns.
<img width="800" height="425" alt="bugRender" src="https://github.com/user-attachments/assets/4314eff3-9424-42f1-aa62-3ff3d7c3012b" />

<img width="800" height="426" alt="fixRender" src="https://github.com/user-attachments/assets/2908dbaa-a56e-453c-8167-7571f9914c41" />
