### PR TITLE
fix: canvasCoords crashes on empty touch list (mobile race)

### DIFF
--- a/static/js/editor/canvas-coords.js
+++ b/static/js/editor/canvas-coords.js
@@ -12,8 +12,8 @@ export function canvasCoords(e, canvas) {
   const rect = canvas.getBoundingClientRect();
   const scaleX = canvas.width / rect.width;
   const scaleY = canvas.height / rect.height;
-  const clientX = e.touches ? e.touches[0].clientX : e.clientX;
-  const clientY = e.touches ? e.touches[0].clientY : e.clientY;
+  const clientX = e.touches && e.touches.length ? e.touches[0].clientX : e.clientX;
+  const clientY = e.touches && e.touches.length ? e.touches[0].clientY : e.clientY;
   return {
     x: (clientX - rect.left) * scaleX,
     y: (clientY - rect.top) * scaleY,

--- a/tests/test_canvas_coords_empty_touches_js.py
+++ b/tests/test_canvas_coords_empty_touches_js.py
@@ -1,0 +1,51 @@
+"""Pin canvasCoords (static/js/editor/canvas-coords.js) against an empty
+touch list. Driven through `node --input-type=module` (same approach as
+tests/test_markdown_table_row_js.py); skips when `node` is missing.
+
+Regression: a touch event whose `touches` list is present but EMPTY (a
+real mobile race — the finger is already lifted when the handler runs)
+made `e.touches[0].clientX` throw \"Cannot read properties of undefined\".
+The guard falls back to the event's own clientX/clientY in that case.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_MOD = _REPO / "static" / "js" / "editor" / "canvas-coords.js"
+_HAS_NODE = shutil.which("node") is not None
+
+_CANVAS = "{width:800,height:600,getBoundingClientRect:()=>({width:400,height:300,left:100,top:50})}"
+
+
+def _coords(event_js):
+    js = f"""
+    import {{ canvasCoords }} from '{_MOD.as_posix()}';
+    const canvas = {_CANVAS};
+    console.log(JSON.stringify(canvasCoords({event_js}, canvas)));
+    """
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_empty_touch_list_falls_back_to_client_xy():
+    # scaleX = 800/400 = 2; (200-100)*2 = 200, (100-50)*2 = 100
+    assert _coords("{touches:[],clientX:200,clientY:100}") == {"x": 200, "y": 100}
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_mouse_event_unaffected():
+    assert _coords("{clientX:200,clientY:100}") == {"x": 200, "y": 100}
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_touch_with_finger_still_used():
+    assert _coords("{touches:[{clientX:200,clientY:100}]}") == {"x": 200, "y": 100}


### PR DESCRIPTION
## Summary

`canvasCoords` converts a pointer event into canvas pixel coordinates and reads the first finger via `e.touches ? e.touches[0].clientX : e.clientX`. The `e.touches ?` test is truthy for a present-but-EMPTY touch list, which is a real mobile race: a `touchend`/`touchstart` can fire with `touches` already empty because the finger was lifted before the handler ran. In that case `e.touches[0]` is `undefined` and `.clientX` throws `TypeError: Cannot read properties of undefined`, breaking pointer math for that gesture. This checks `e.touches.length` so an empty touch list falls back to the event's own `clientX`/`clientY`.

## Linked Issue

Part of #2125

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_canvas_coords_empty_touches_js.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->


