### PR TITLE
fix: use naive UTC cutoff in cleanup_empty_sessions to prevent TypeError

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -616,7 +616,10 @@ class SessionManager:
 
         try:
             all_sessions = db.query(DbSession).all()
-            cutoff_date = datetime.now(timezone.utc) - timedelta(days=auto_archive_days)
+            # Use naive UTC to match the naive last_accessed column. SQLite
+            # drops tzinfo on round-trip, so comparing an aware cutoff against
+            # a naive last_accessed raises TypeError and silently aborts cleanup.
+            cutoff_date = datetime.utcnow() - timedelta(days=auto_archive_days)
 
             for db_session in all_sessions:
                 stats['total_checked'] += 1


### PR DESCRIPTION
## Summary

`cleanup_empty_sessions` compared an aware cutoff (`datetime.now(timezone.utc)`) against the naive `last_accessed` column. SQLite drops `tzinfo` on round-trip, so the comparison raises `TypeError: can't compare offset-naive and offset-aware datetimes`. The broad `except Exception` silently swallows the error and rolls back the entire cleanup — both auto-archive and empty-session deletion become a no-op.

Uses `datetime.utcnow()` (naive) to match the naive column, consistent with `cleanup_service`, `webhook_manager`, and `event_bus`.

## Linked Issue

Fixes #2039

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `python -m py_compile core/session_manager.py` — compiles cleanly
2. Create sessions, wait for cleanup interval
3. Verify no more `TypeError: can't compare offset-naive and offset-aware` in logs
4. Verify empty sessions are deleted and old sessions auto-archive