### PR TITLE
Fix truncate_messages persisting an inflated message_count

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -273,7 +273,10 @@ class SessionManager:
 
             db_session = db.query(DbSession).filter(DbSession.id == session_id).first()
             if db_session:
-                db_session.message_count = keep_count
+                # keep_count can exceed the real message total (e.g. the AI tool
+                # defaults to keep_count=10 on a short session); message_count must
+                # track the rows that actually remain, not the requested cap.
+                db_session.message_count = min(keep_count, len(db_messages))
                 db_session.updated_at = datetime.now(timezone.utc)
 
             db.commit()

--- a/tests/test_truncate_message_count_regression.py
+++ b/tests/test_truncate_message_count_regression.py
@@ -1,0 +1,59 @@
+"""Regression: truncate_messages must not set message_count above the real
+number of messages when keep_count exceeds the message total.
+
+The AI tool layer (src/ai_interaction.py manage_session action='truncate')
+defaults keep_count=10, so a short session (say 3 messages) gets truncated
+with keep_count=10. The DB has only 3 rows left, but truncate_messages used to
+write db_session.message_count = keep_count (=10), leaving the persisted count
+inconsistent with the actual rows. get_session relies on message_count>0 to
+decide whether to lazily hydrate from the DB, so an inflated count is a latent
+correctness hazard.
+"""
+import os
+import tempfile
+
+
+def _make_manager():
+    db_fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(db_fd)
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+    # Import after DATABASE_URL is set so the engine binds to the temp DB.
+    import importlib
+    import core.database as database
+    importlib.reload(database)
+    database.Base.metadata.create_all(bind=database.engine)
+
+    import core.session_manager as sm_mod
+    importlib.reload(sm_mod)
+    return sm_mod.SessionManager(), database, sm_mod
+
+
+def test_truncate_keep_count_exceeds_total_does_not_inflate_count():
+    from core.models import ChatMessage
+
+    sm, database, sm_mod = _make_manager()
+    sid = "short-session"
+    sm.create_session(session_id=sid, name="t", endpoint_url="x",
+                      model="m", rag=False, owner="u")
+    for i in range(3):
+        sm.add_message(sid, ChatMessage("user", f"msg{i}"))
+
+    # AI default keep_count is 10 — larger than the 3 real messages.
+    assert sm.truncate_messages(sid, 10) is True
+
+    db = database.SessionLocal()
+    try:
+        DbSession = database.Session
+        DbChatMessage = database.ChatMessage
+        rows = db.query(DbChatMessage).filter(
+            DbChatMessage.session_id == sid).count()
+        db_session = db.query(DbSession).filter(DbSession.id == sid).first()
+        # Nothing should have been deleted (only 3 messages exist).
+        assert rows == 3
+        # message_count must reflect the real number of rows, not keep_count.
+        assert db_session.message_count == 3, (
+            f"message_count={db_session.message_count} but only {rows} rows exist"
+        )
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

`SessionManager.truncate_messages(session_id, keep_count)` keeps the first `keep_count` messages. It deletes `db_messages[keep_count:]` (a no-op when `keep_count >= len(db_messages)`) and then **unconditionally** set:

```python
db_session.message_count = keep_count
```

When `keep_count` exceeds the number of messages that actually exist, the persisted `message_count` is set too high — e.g. `10` on a 3-message session — diverging from the real row count. The in-memory slice `session.history[:keep_count]` caps naturally and is correct; only the persisted column is wrong.

This is not cosmetic: `message_count` gates lazy DB-hydration in `get_session` (`message_count > 0`, also checked at lines 78/628/638) and is surfaced to the history UI.

**Live triggers:**
- `src/ai_interaction.py` `manage_session` "truncate" defaults `keep_count = 10` — so asking the agent to truncate any session with fewer than 10 messages inflates the count.
- `routes/history_routes.py` `POST /api/session/{id}/truncate` passes any client-supplied `keep_count`.

**Fix:** `db_session.message_count = min(keep_count, len(db_messages))`.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->

## Linked Issue

Part of #2121

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_truncate_message_count_regression.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

