### PR TITLE
fix(ui): reset textarea manual-resize height after sending a message

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -552,6 +552,10 @@ export function autoResize(textarea) {
   clone.style.width = textarea.offsetWidth + 'px';
   clone.value = textarea.value;
   clone.style.height = '0';
+  // Reset the manual-drag floor when the field is empty (e.g. after
+  // sending a message) so the textarea shrinks back to its default
+  // height instead of staying stuck at the size of the last message.
+  if (!textarea.value) textarea._manualResizeHeight = 0;
   const manualHeight = textarea._manualResizeHeight || 0;
   const maxHeight = Math.max(autoMaxHeight, manualHeight);
   const newHeight = Math.min(Math.max(clone.scrollHeight, lineHeight, manualHeight), maxHeight);


### PR DESCRIPTION
## Summary

When a user manually resized the textarea (drag handle) or it auto-grew for a long message, the `_manualResizeHeight` floor persisted after the value was cleared on send. `autoResize()` used `Math.max(scrollHeight, lineHeight, manualHeight)` so the textarea stayed stuck at the old height even with an empty value.

Resets `_manualResizeHeight` to 0 when `textarea.value` is empty.

## Linked Issue

Fixes #2040

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `node --check static/js/ui.js` — OK
2. Type a long multi-line message in the chat input
3. Manually drag the textarea resize handle to make it taller
4. Send the message
5. Verify the textarea shrinks back to its default single-line height

Note: This is a behavior fix in the resize logic, not a visual/CSS change.