### PR TITLE
fix: backup import dropping a user's skill on cross-tenant title/id collision

### DIFF
--- a/routes/backup_routes.py
+++ b/routes/backup_routes.py
@@ -101,11 +101,17 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
         # ── Skills ──
         if "skills" in body and isinstance(body["skills"], list):
             existing = skills_manager.load_all()
-            existing_names = {s.get("name") for s in existing if s.get("name")}
-            existing_ids = {s.get("id") for s in existing if s.get("id")}
+            # Dedup against THIS user's own skills only. Using every tenant's
+            # rows (load_all) meant a skill whose id/name/title matched any
+            # other user's was silently skipped, so the importing user lost
+            # their own data — same cross-tenant bug fixed for memories above.
+            # The full store is still saved back below.
+            own = [s for s in existing if s.get("owner") == user]
+            existing_names = {s.get("name") for s in own if s.get("name")}
+            existing_ids = {s.get("id") for s in own if s.get("id")}
             existing_titles = {
                 (s.get("title") or s.get("description") or "").strip().lower()
-                for s in existing
+                for s in own
             }
             added = 0
             for skill in body["skills"]:

--- a/tests/test_backup_import_skills_dedup.py
+++ b/tests/test_backup_import_skills_dedup.py
@@ -1,0 +1,117 @@
+"""Regression test for routes/backup_routes.py import_data skills dedup.
+
+BUG: the skills import block deduplicates against EVERY tenant's skills
+(skills_manager.load_all()) instead of the importing user's own skills.
+So importing your own backup silently drops any skill whose title (or id)
+collides with ANOTHER user's skill — the same cross-tenant data-loss bug
+that was already fixed for memories in the block just above.
+"""
+import sys
+import types
+
+import pytest
+
+
+def _install_stubs():
+    def _stub(name, **attrs):
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[name] = m
+        return m
+
+    _stub("core")
+    _stub("core.middleware", require_admin=lambda *a, **k: None)
+    _stub("src")
+    _stub("src.auth_helpers", get_current_user=lambda req: getattr(req.state, "user", None))
+    _stub("src.settings",
+          load_settings=lambda: {}, save_settings=lambda s: None,
+          load_features=lambda: {}, save_features=lambda f: None)
+
+
+_install_stubs()
+
+from fastapi import FastAPI, Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from routes.backup_routes import setup_backup_routes  # noqa: E402
+
+
+class FakeMemoryManager:
+    def __init__(self):
+        self.rows = []
+
+    def load(self, owner=None):
+        return [r for r in self.rows if r.get("owner") == owner]
+
+    def load_all(self):
+        return list(self.rows)
+
+    def save(self, rows):
+        self.rows = list(rows)
+
+
+class FakePresetManager:
+    def get_all(self):
+        return {}
+
+    def save(self, d):
+        pass
+
+
+class FakeSkillsManager:
+    """Mimics services.memory.skills: load_all() = all owners,
+    load(owner) = that owner's skills only."""
+
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def load(self, owner=None):
+        return [s for s in self.rows if s.get("owner") == owner]
+
+    def load_all(self):
+        return list(self.rows)
+
+    def save(self, rows):
+        self.rows = list(rows)
+
+
+def _make_client(skills_mgr):
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _set_user(request: Request, call_next):
+        request.state.user = "alice"
+        return await call_next(request)
+
+    router = setup_backup_routes(FakeMemoryManager(), FakePresetManager(), skills_mgr)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_import_skill_not_dropped_by_other_users_title_collision():
+    # Bob already owns a skill titled "Deploy". Alice (the importer) has none.
+    skills_mgr = FakeSkillsManager([
+        {"id": "bob-1", "title": "Deploy", "name": "Deploy", "owner": "bob"},
+    ])
+    client = _make_client(skills_mgr)
+
+    # Alice imports HER OWN backup containing a skill also titled "Deploy".
+    payload = {
+        "skills": [
+            {"id": "alice-1", "title": "Deploy", "name": "Deploy"},
+        ],
+    }
+    resp = client.post("/api/import", json=payload)
+    assert resp.status_code == 200, resp.text
+
+    # Alice's skill must have been imported and assigned to her.
+    alice_skills = skills_mgr.load(owner="alice")
+    titles = {s["title"] for s in alice_skills}
+    assert "Deploy" in titles, (
+        "Alice's own 'Deploy' skill was silently dropped because Bob owns a "
+        "skill with the same title (cross-tenant dedup bug)."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_backup_import_skills_dedup.py
+++ b/tests/test_backup_import_skills_dedup.py
@@ -58,6 +58,13 @@ class FakeSkillsManager:
     def save(self, rows):
         self.rows = list(rows)
 
+    def add_skill(self, title=None, name=None, owner=None, **kwargs):
+        # Mirrors services.memory.skills.add_skill: persists a SKILL.md row and
+        # returns its identity. source="user" skips auto-dedup, so no _deduped.
+        entry = {"id": f"new-{len(self.rows)}", "title": title, "name": name, "owner": owner}
+        self.rows.append(entry)
+        return {"name": name, "id": entry["id"]}
+
 
 def _make_client(skills_mgr, monkeypatch):
     # Bypass the admin gate and read the importer straight off request.state.

--- a/tests/test_backup_import_skills_dedup.py
+++ b/tests/test_backup_import_skills_dedup.py
@@ -12,7 +12,19 @@ import types
 import pytest
 
 
+# Modules we temporarily override so importing routes.backup_routes binds our
+# light stubs instead of the real (heavy / auth-coupled) implementations.
+_STUBBED = ("core", "core.middleware", "src", "src.auth_helpers", "src.settings")
+
+
 def _install_stubs():
+    # Save whatever is in sys.modules now so we can put it back. backup_routes
+    # uses `from x import name`, so once it is imported it keeps its own bound
+    # references and no longer needs these entries. Leaving stub `src` / `core`
+    # modules in sys.modules would make them non-packages and break collection
+    # of every later test module that imports a real src.*/core.* submodule.
+    saved = {name: sys.modules.get(name) for name in _STUBBED}
+
     def _stub(name, **attrs):
         m = types.ModuleType(name)
         for k, v in attrs.items():
@@ -27,13 +39,24 @@ def _install_stubs():
     _stub("src.settings",
           load_settings=lambda: {}, save_settings=lambda s: None,
           load_features=lambda: {}, save_features=lambda f: None)
+    return saved
 
 
-_install_stubs()
+def _restore_stubs(saved):
+    for name, mod in saved.items():
+        if mod is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = mod
 
-from fastapi import FastAPI, Request  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
-from routes.backup_routes import setup_backup_routes  # noqa: E402
+
+_saved = _install_stubs()
+try:
+    from fastapi import FastAPI, Request  # noqa: E402
+    from fastapi.testclient import TestClient  # noqa: E402
+    from routes.backup_routes import setup_backup_routes  # noqa: E402
+finally:
+    _restore_stubs(_saved)
 
 
 class FakeMemoryManager:

--- a/tests/test_backup_import_skills_dedup.py
+++ b/tests/test_backup_import_skills_dedup.py
@@ -6,57 +6,18 @@ So importing your own backup silently drops any skill whose title (or id)
 collides with ANOTHER user's skill — the same cross-tenant data-loss bug
 that was already fixed for memories in the block just above.
 """
-import sys
-import types
-
 import pytest
 
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+import routes.backup_routes as backup_routes
+from routes.backup_routes import setup_backup_routes
 
-# Modules we temporarily override so importing routes.backup_routes binds our
-# light stubs instead of the real (heavy / auth-coupled) implementations.
-_STUBBED = ("core", "core.middleware", "src", "src.auth_helpers", "src.settings")
-
-
-def _install_stubs():
-    # Save whatever is in sys.modules now so we can put it back. backup_routes
-    # uses `from x import name`, so once it is imported it keeps its own bound
-    # references and no longer needs these entries. Leaving stub `src` / `core`
-    # modules in sys.modules would make them non-packages and break collection
-    # of every later test module that imports a real src.*/core.* submodule.
-    saved = {name: sys.modules.get(name) for name in _STUBBED}
-
-    def _stub(name, **attrs):
-        m = types.ModuleType(name)
-        for k, v in attrs.items():
-            setattr(m, k, v)
-        sys.modules[name] = m
-        return m
-
-    _stub("core")
-    _stub("core.middleware", require_admin=lambda *a, **k: None)
-    _stub("src")
-    _stub("src.auth_helpers", get_current_user=lambda req: getattr(req.state, "user", None))
-    _stub("src.settings",
-          load_settings=lambda: {}, save_settings=lambda s: None,
-          load_features=lambda: {}, save_features=lambda f: None)
-    return saved
-
-
-def _restore_stubs(saved):
-    for name, mod in saved.items():
-        if mod is None:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = mod
-
-
-_saved = _install_stubs()
-try:
-    from fastapi import FastAPI, Request  # noqa: E402
-    from fastapi.testclient import TestClient  # noqa: E402
-    from routes.backup_routes import setup_backup_routes  # noqa: E402
-finally:
-    _restore_stubs(_saved)
+# require_admin / get_current_user are bound into routes.backup_routes at import
+# time (`from x import name`). We patch them on that module directly per-test
+# via monkeypatch — robust to import order and reverted at teardown. (Stubbing
+# them through sys.modules only works if backup_routes has not been imported
+# yet, which is not guaranteed in a full-suite run.)
 
 
 class FakeMemoryManager:
@@ -98,7 +59,11 @@ class FakeSkillsManager:
         self.rows = list(rows)
 
 
-def _make_client(skills_mgr):
+def _make_client(skills_mgr, monkeypatch):
+    # Bypass the admin gate and read the importer straight off request.state.
+    monkeypatch.setattr(backup_routes, "require_admin", lambda *a, **k: None)
+    monkeypatch.setattr(backup_routes, "get_current_user",
+                        lambda req: getattr(req.state, "user", None))
     app = FastAPI()
 
     @app.middleware("http")
@@ -111,12 +76,12 @@ def _make_client(skills_mgr):
     return TestClient(app)
 
 
-def test_import_skill_not_dropped_by_other_users_title_collision():
+def test_import_skill_not_dropped_by_other_users_title_collision(monkeypatch):
     # Bob already owns a skill titled "Deploy". Alice (the importer) has none.
     skills_mgr = FakeSkillsManager([
         {"id": "bob-1", "title": "Deploy", "name": "Deploy", "owner": "bob"},
     ])
-    client = _make_client(skills_mgr)
+    client = _make_client(skills_mgr, monkeypatch)
 
     # Alice imports HER OWN backup containing a skill also titled "Deploy".
     payload = {


### PR DESCRIPTION
## Summary

`POST /api/import` (`import_data` in `routes/backup_routes.py`) restores a user's backup. The **skills** block deduped incoming skills against `skills_manager.load_all()`:

```python
existing = skills_manager.load_all()
existing_ids = {s.get("id") for s in existing}
existing_titles = {s.get("title", "").strip().lower() for s in existing}
```

`load_all()` returns **every tenant's** skills (the per-user variant is `load(owner=...)`). So when a user imports their own backup, any skill whose `id` or `title` collides with **another user's** skill is silently skipped — the importing user permanently loses their own data.

This is the exact cross-tenant bug already fixed for the **memories** block immediately above (see the comment there, shipped in #1743) — the skills block was simply left with the old pattern.

**Trigger:** Bob owns a skill titled "Deploy". Alice POSTs `/api/import` with her own backup containing a skill titled "Deploy" → it is dropped → `load(owner="alice")` never shows it.

**Fix:** dedup against the importing user's own skills only (`owner == user`), mirroring the memories fix. The full store is still saved back, so other users' skills are preserved.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->

## Linked Issue

Part of #2114

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_backup_import_skills_dedup.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

