### PR TITLE
fix(ui): shrink message input back down after sending

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -526,6 +526,13 @@ export function autoResize(textarea) {
   // updates the manual floor.
   if (!textarea._manualResizeObserver && typeof ResizeObserver !== 'undefined') {
     textarea._manualResizeObserver = new ResizeObserver(() => {
+      // Ignore size changes we triggered ourselves. The textarea has a CSS
+      // height transition, so after a programmatic change offsetHeight
+      // animates toward the target over several frames; those in-between
+      // frames look like a manual drag and would get locked in as a floor,
+      // so the box never shrinks again (e.g. after sending a long message).
+      // Only a genuine resize-handle drag should set the manual floor.
+      if (textarea._programmaticResize) return;
       const height = textarea.offsetHeight;
       if (Math.abs(height - (textarea._autoResizeHeight || height)) > 1) {
         textarea._manualResizeHeight = height;
@@ -556,6 +563,16 @@ export function autoResize(textarea) {
   const maxHeight = Math.max(autoMaxHeight, manualHeight);
   const newHeight = Math.min(Math.max(clone.scrollHeight, lineHeight, manualHeight), maxHeight);
   textarea._autoResizeHeight = newHeight;
+  // Suppress the manual-resize observer until this change (and its 0.12s CSS
+  // height transition) settles. Set synchronously before mutating the height
+  // so it is in place before any observer callback the change triggers, and
+  // re-armed on every call so continuous typing stays suppressed while a lone
+  // resize-handle drag — which never calls autoResize — is still detected.
+  textarea._programmaticResize = true;
+  clearTimeout(textarea._programmaticResizeTimer);
+  textarea._programmaticResizeTimer = setTimeout(() => {
+    textarea._programmaticResize = false;
+  }, 200);
   textarea.style.height = newHeight + 'px';
   textarea.style.overflow = newHeight >= autoMaxHeight ? 'auto' : 'hidden';
 }

--- a/tests/test_prompt_bar_manual_resize.py
+++ b/tests/test_prompt_bar_manual_resize.py
@@ -14,3 +14,19 @@ def test_auto_resize_preserves_a_manually_chosen_height():
     assert "textarea._manualResizeHeight = height;" in UI_JS
     assert "const manualHeight = textarea._manualResizeHeight || 0;" in UI_JS
     assert "const maxHeight = Math.max(autoMaxHeight, manualHeight);" in UI_JS
+
+
+def test_manual_resize_observer_ignores_our_own_programmatic_changes():
+    # The textarea animates its height via a CSS transition, so a programmatic
+    # resize reaches the target over several frames. Without guarding against
+    # our own changes the observer mistakes those transition frames for a drag
+    # and locks in a tall floor, leaving the box stuck large after a long
+    # message is sent. autoResize must flag programmatic changes and the
+    # observer must bail out on them.
+    assert "if (textarea._programmaticResize) return;" in UI_JS
+    assert "textarea._programmaticResize = true;" in UI_JS
+    # The flag is set before the height is mutated so it precedes any callback
+    # the mutation schedules.
+    flag_pos = UI_JS.index("textarea._programmaticResize = true;")
+    height_pos = UI_JS.index("textarea.style.height = newHeight + 'px';")
+    assert flag_pos < height_pos


### PR DESCRIPTION
## Summary

The message textarea records a manual-resize "floor" (`_manualResizeHeight`) via a `ResizeObserver` so a height chosen with the native drag handle survives auto-resize. Because the textarea animates its height with a `0.12s` CSS transition, `offsetHeight` lags the programmatically-set target for several frames after each resize, and the observer mistook those transition frames for a manual drag — locking in a tall floor. Typing a long prompt ratcheted that floor up to roughly the tallest height reached, so the input never shrank again, even after the message was sent and a shorter one was typed (issue #2040).

The fix flags programmatic resizes synchronously before mutating the height and has the observer ignore changes while the flag is set, re-arming a short timer (200ms, comfortably longer than the 0.12s transition) so continuous typing stays suppressed. A genuine resize-handle drag never calls `autoResize`, so the flag is clear during a drag and the manual floor is still recorded — drag-to-resize keeps working.

## Linked Issue

Fixes #2040

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end — created the first-run admin, logged in, typed a long prompt (input grew), pressed Enter to send (input cleared and shrank back to one line), then typed a shorter message (stayed small). Screenshots below.

## How to Test

1. Launch Odysseus (`docker compose up` or `uvicorn app:app`) and open the chat.
2. Type a long, multi-line prompt so the input box grows to its max height, then send it.
3. Type a short one-line message.
   - **Before this PR:** the input box stays tall. **After:** it shrinks back to a single line.
4. Regression: drag the input's resize handle taller, then type — the box still respects the manually chosen height.
5. `python -m pytest tests/test_prompt_bar_manual_resize.py` → 3 passed.

## Verification

Ran the real app (`uvicorn app:app`), logged in, and drove the actual chat UI in a browser. Measured the input's `offsetHeight` and its internal `_manualResizeHeight` floor through the reported sequence:

| Step | offsetHeight | `_manualResizeHeight` | Result |
|---|---|---|---|
| Type a long multi-line prompt | 24 → **144px** | **0** | Auto-grows; floor not falsely set |
| Press Enter to send | → **24px** | 0 | Input clears and shrinks back to one line |
| Type a shorter message afterwards | **24px** | — | Stays small (the reported scenario) |

No JS console/page errors during the run. Before the fix, the long-prompt step left `_manualResizeHeight ≈ 140`, which is exactly what kept the box stuck tall.

Drag-to-resize regression: a native resize-handle drag can't be scripted in the browser driver, so I confirmed that path against the real `static/js/ui.js` + `static/style.css` in an isolated render — a simulated drag recorded `_manualResizeHeight = 280` and a subsequent keystroke kept the box at 280px, so the manual floor the fix guards still works.

## Visual / UI changes

Behavioral fix to input auto-resize — no restyle. No new colors, fonts, spacing, classes, components, or emoji; no CSS was changed. Before/after screenshots of the running app below (reporter's stuck-tall screenshot is in #2040).

### Screenshots / clips

Real app (`uvicorn app:app`), before → after sending:

| Long prompt typed — input grown tall | After pressing Enter — input shrunk back |
|---|---|
| ![Input grown tall after a long prompt](https://raw.githubusercontent.com/sanjulaonline/odysseus/pr2062-assets/pr2062/grown.png) | ![Input shrunk back to one line after sending](https://raw.githubusercontent.com/sanjulaonline/odysseus/pr2062-assets/pr2062/after-send.png) |

Typing a shorter message afterwards stays on one line:

![Short message stays on a single line](https://raw.githubusercontent.com/sanjulaonline/odysseus/pr2062-assets/pr2062/short-after.png)
