### PR TITLE
fix: add 'willing to fix' dropdown to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -95,11 +95,19 @@ body:
       description: "e.g. Ollama + llama3.2:latest, vLLM + mistral-7b, OpenAI API, Anthropic API"
       placeholder: "Ollama + llama3.2:latest"
 
+  - type: dropdown
+    id: willing_to_fix
+    attributes:
+      label: Are you willing to submit a fix?
+      options:
+        - "Yes — I can open a PR"
+        - "Partially — I can help but need guidance"
+        - "No — I am only filing the report"
+    validations:
+      required: true
+
   - type: textarea
     id: additional-info
     attributes:
       label: Additional Information
       description: Anything else that might help — browser console errors, related issues, things you already tried, or environment quirks.
-      placeholder: |
-        - Any other context goes here.
-        - If you are willing to submit a PR that fixes this, mention it here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -100,6 +100,7 @@ body:
     attributes:
       label: Are you willing to submit a fix?
       options:
+        - "-- Please Select --"
         - "Yes — I can open a PR"
         - "Partially — I can help but need guidance"
         - "No — I am only filing the report"


### PR DESCRIPTION
## Summary

The feature request template has an \"Are you willing to implement this?\" dropdown but the bug report template was missing it — it had a plain textarea with a placeholder hint instead. Adds a matching dropdown for consistency between the two templates.

## Linked Issue

Fixes #2059

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets \`main\`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Go to the repo's Issues tab → New Issue → Bug Report
2. Verify the \"Are you willing to submit a fix?\" dropdown appears
3. Verify it has the same three options as the feature request template
4. Verify the Additional Information textarea still appears below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)