### PR TITLE
Fix auto-memory vector dedup dropping a user's fact on cross-tenant match

### DIFF
--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -345,8 +345,17 @@ async def extract_and_store(
                     logger.warning(f"Memory dedup (vector) unavailable, using text fallback: {e}")
                     existing_id = None
                 if existing_id:
-                    logger.debug(f"Memory dedup (vector): '{fact_text[:50]}' matches {existing_id}")
-                    continue
+                    # The vector store is a single shared collection with no
+                    # owner metadata, so find_similar can return ANOTHER
+                    # tenant's memory. Only treat it as a duplicate when the
+                    # match is this user's own (or a legacy unowned) memory —
+                    # otherwise the user's freshly-extracted fact would be
+                    # silently dropped. Mirror the owner predicate used by the
+                    # text dedup below; cross-tenant/stale matches fall through.
+                    _match = next((e for e in existing if e.get("id") == existing_id), None)
+                    if _match is not None and (_match.get("owner") == _owner or _match.get("owner") is None):
+                        logger.debug(f"Memory dedup (vector): '{fact_text[:50]}' matches {existing_id}")
+                        continue
 
             # Text dedup fallback: exact match + fuzzy similarity
             user_existing = [e for e in existing if e.get("owner") == _owner or e.get("owner") is None] if _owner else existing

--- a/tests/test_memory_extractor_vector_cross_tenant.py
+++ b/tests/test_memory_extractor_vector_cross_tenant.py
@@ -32,16 +32,20 @@ def _load_extractor():
     return mod
 
 
-def _install_llm_stub(facts_json):
+def _install_llm_stub(monkeypatch, facts_json):
     mod = types.ModuleType("src.llm_core")
 
     async def llm_call_async(*a, **k):
         return facts_json
 
     mod.llm_call_async = llm_call_async
+    # Use monkeypatch.setitem so sys.modules is restored at teardown. A raw
+    # assignment here permanently replaced the real src.llm_core with this
+    # stripped stub, leaking "My home is in Lisbon" (and hiding _detect_provider)
+    # into every later-collected test that imports the real module.
     src_pkg = sys.modules.get("src") or types.ModuleType("src")
-    sys.modules["src"] = src_pkg
-    sys.modules["src.llm_core"] = mod
+    monkeypatch.setitem(sys.modules, "src", src_pkg)
+    monkeypatch.setitem(sys.modules, "src.llm_core", mod)
 
 
 class FakeSession:
@@ -95,7 +99,7 @@ def test_vector_match_from_other_tenant_does_not_drop_users_fact(monkeypatch):
     ])
     # The vector store reports user B's new fact as a near-duplicate of a1.
     vec = FakeVector(match_id="a1")
-    _install_llm_stub('["My home is in Lisbon"]')
+    _install_llm_stub(monkeypatch, '["My home is in Lisbon"]')
 
     memory_extractor = _load_extractor()
 

--- a/tests/test_memory_extractor_vector_cross_tenant.py
+++ b/tests/test_memory_extractor_vector_cross_tenant.py
@@ -1,0 +1,111 @@
+"""Regression: auto-memory vector dedup must not drop a user's fact because it
+matches ANOTHER tenant's memory.
+
+`extract_and_store` dedups each extracted fact against the vector store first.
+The vector store (`memory_vector`) is a single shared ChromaDB collection with
+no owner in its metadata, so `find_similar` can return a memory_id belonging to
+a different user. The old code `continue`d (skipped storing) on any vector hit
+without checking ownership, so user B's freshly-extracted fact was silently
+dropped when it was merely semantically similar to user A's memory. The text
+dedup fallback right below is already owner-scoped; the vector path must be too.
+"""
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_extractor():
+    # Load services/memory/memory_extractor.py directly by path so we don't
+    # trigger services/__init__ (which imports the search stack and its heavy
+    # optional deps). The module's only module-level imports are stdlib; its
+    # src.llm_core / src.event_bus imports are lazy and stubbed/guarded.
+    path = ROOT / "services" / "memory" / "memory_extractor.py"
+    spec = importlib.util.spec_from_file_location("memory_extractor_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _install_llm_stub(facts_json):
+    mod = types.ModuleType("src.llm_core")
+
+    async def llm_call_async(*a, **k):
+        return facts_json
+
+    mod.llm_call_async = llm_call_async
+    src_pkg = sys.modules.get("src") or types.ModuleType("src")
+    sys.modules["src"] = src_pkg
+    sys.modules["src.llm_core"] = mod
+
+
+class FakeSession:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def get_context_messages(self):
+        return [
+            {"role": "user", "content": "Tell me where I live."},
+            {"role": "assistant", "content": "Noted."},
+        ]
+
+
+class FakeMemoryManager:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self._n = 0
+
+    def load_all(self):
+        return list(self.rows)
+
+    def load(self, owner=None):
+        return [r for r in self.rows if r.get("owner") == owner]
+
+    def find_duplicates(self, text, subset):
+        t = text.strip().lower()
+        return [r for r in subset if r.get("text", "").strip().lower() == t]
+
+    def add_entry(self, text, source="auto", category="fact", owner=None):
+        self._n += 1
+        entry = {"id": f"new-{self._n}", "text": text, "owner": owner,
+                 "source": source, "category": category}
+        self.rows.append(entry)
+        return entry
+
+
+class FakeVector:
+    """Healthy vector store whose find_similar always matches user A's memory."""
+    def __init__(self, match_id):
+        self.healthy = True
+        self._match_id = match_id
+
+    def find_similar(self, text, threshold=0.92):
+        return self._match_id
+
+
+def test_vector_match_from_other_tenant_does_not_drop_users_fact(monkeypatch):
+    # User A already owns a semantically-similar memory.
+    mm = FakeMemoryManager([
+        {"id": "a1", "text": "I live in Lisbon", "owner": "userA"},
+    ])
+    # The vector store reports user B's new fact as a near-duplicate of a1.
+    vec = FakeVector(match_id="a1")
+    _install_llm_stub('["My home is in Lisbon"]')
+
+    memory_extractor = _load_extractor()
+
+    asyncio.run(memory_extractor.extract_and_store(
+        FakeSession(owner="userB"), mm, vec,
+        endpoint_url="http://x", model="m",
+    ))
+
+    b_texts = {r["text"] for r in mm.load(owner="userB")}
+    assert "My home is in Lisbon" in b_texts, (
+        "User B's own extracted fact was dropped because the shared vector "
+        "store matched user A's memory (cross-tenant dedup)."
+    )

--- a/tests/test_memory_extractor_vector_degraded.py
+++ b/tests/test_memory_extractor_vector_degraded.py
@@ -86,8 +86,12 @@ def test_extraction_persists_facts_when_vector_store_fails_at_runtime(monkeypatc
 
 
 def test_healthy_vector_store_still_dedups_normally(monkeypatch):
-    """Control: when find_similar reports a match, that fact is skipped — the
-    try/except added around it must not swallow a legitimate dedup hit."""
+    """Control: a vector hit on the user's OWN memory is honored (deduped) and
+    add is not called. The vector store is a shared collection with no owner
+    metadata, so a hit is only treated as a duplicate when the matched id
+    resolves to this user's own (or legacy unowned) memory — otherwise the
+    fact would be a cross-tenant false drop. Here the match is alice's own
+    memory, so the dedup must still fire."""
 
     async def _fake_llm(url, model, messages, **kwargs):
         return '[{"text": "Alice lives in Lisbon", "category": "fact"}]'
@@ -95,19 +99,27 @@ def test_healthy_vector_store_still_dedups_normally(monkeypatch):
     monkeypatch.setattr(src.llm_core, "llm_call_async", _fake_llm)
     monkeypatch.setattr(src.event_bus, "fire_event", lambda *a, **k: None)
 
-    class _DedupVectorStore:
-        healthy = True
-
-        def find_similar(self, text, threshold=0.72):
-            return "existing-id"  # claim it already exists
-
-        def add(self, memory_id, text):  # pragma: no cover - should not run
-            raise AssertionError("add should not be called for a deduped fact")
-
     with tempfile.TemporaryDirectory() as data_dir:
         mgr = MemoryManager(data_dir)
+        # Seed alice's own memory (persisted so load_all sees it) and point
+        # find_similar at its real id.
+        seeded = mgr.add_entry("Alice's home city is Lisbon", source="auto",
+                               category="fact", owner="alice")
+        mgr.save([seeded])
+
+        class _DedupVectorStore:
+            healthy = True
+
+            def find_similar(self, text, threshold=0.72):
+                return seeded["id"]  # matches alice's own seeded memory
+
+            def add(self, memory_id, text):  # pragma: no cover - should not run
+                raise AssertionError("add should not be called for a deduped fact")
+
         _run(extract_and_store(
             _FakeSession(), mgr, _DedupVectorStore(),
             endpoint_url="http://x", model="m", headers=None,
         ))
-        assert mgr.load(owner="alice") == []
+        # The new fact was deduped against alice's own memory, so only the
+        # seeded entry remains (no duplicate added).
+        assert [e["text"] for e in mgr.load(owner="alice")] == ["Alice's home city is Lisbon"]


### PR DESCRIPTION
## Summary

`extract_and_store` (`services/memory/memory_extractor.py`) is the auto-memory extraction that runs after a session (with `session.owner`). For each extracted fact it dedups against the vector store first, then falls back to an owner-scoped text dedup:

```python
existing = memory_manager.load_all()          # ALL tenants
...
if memory_vector and memory_vector.healthy:
    existing_id = memory_vector.find_similar(fact_text, threshold=0.72)
    if existing_id:
        continue                               # skip — NO owner check
# text fallback below is owner-scoped:
user_existing = [e for e in existing if e.get("owner") == _owner or e.get("owner") is None] if _owner else existing
```

The vector store is a **single shared ChromaDB collection** that stores only `{"source": "memory"}` — no owner — and `find_similar` queries it with no owner filter. So it can return a `memory_id` belonging to a **different tenant**. When it does, the importing user's freshly-extracted fact is silently `continue`d away and never stored — the user loses their own data. Because this runs whenever ChromaDB is healthy (the common path), the owner-scoped text fallback right below never executes.

**Trigger:** User A has memory "I live in Lisbon". User B's session extracts the similar fact "My home is in Lisbon" (cosine ≥ 0.72) → `find_similar` returns A's id → B's fact is dropped.

This is the same cross-tenant data-loss class fixed for backup import (#1743); the maintainer already owner-scoped the text path here but left the vector path unscoped.

**Fix:** only treat a vector hit as a duplicate when the matched memory is this user's own (or a legacy unowned) memory, mirroring the text-dedup owner predicate. Cross-tenant or stale matches fall through to the owner-scoped text dedup. No vector-store schema change or migration needed.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->

## Linked Issue

Part of #2114

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_memory_extractor_vector_cross_tenant.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

