### PR TITLE
fix: odysseus-calendar list dropping in-progress / multi-day events

### DIFF
--- a/scripts/odysseus-calendar
+++ b/scripts/odysseus-calendar
@@ -103,9 +103,13 @@ def cmd_list(args) -> None:
     end = _parse_dt(args.end) if args.end else (start + timedelta(days=30))
     db = SessionLocal()
     try:
+        # Overlap semantics, matching the web route (routes/calendar_routes.py)
+        # and the recurring-expansion contract: an event is in the window when
+        # it starts before the window end AND ends after the window start. This
+        # includes multi-day / in-progress events that began before `start`.
         q = db.query(CalendarEvent).filter(
-            CalendarEvent.dtstart >= start,
             CalendarEvent.dtstart < end,
+            CalendarEvent.dtend > start,
         )
         if args.calendar:
             cal = db.query(CalendarCal).filter(CalendarCal.name == args.calendar).first()

--- a/tests/test_calendar_cli_overlap.py
+++ b/tests/test_calendar_cli_overlap.py
@@ -1,0 +1,130 @@
+"""Regression: `odysseus-calendar list` must select events that OVERLAP the
+query window, matching the canonical web-route filter in
+routes/calendar_routes.py (`dtstart < end AND dtend > start`) and the
+recurring-expansion contract asserted in test_calendar_recurrence.py
+(test_expand_multi_day_crossing_range_start).
+
+The buggy CLI filtered on `dtstart >= start AND dtstart < end`, which drops a
+multi-day / in-progress event that started before the window but is still
+running inside it (e.g. an all-day-running conference when you call
+`odysseus-calendar list` with the default start=now()).
+"""
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Col:
+    """A fake SQLAlchemy column that records comparison clauses instead of
+    building SQL. `Col >= x` / `Col < x` / `Col > x` evaluate against a row
+    later via .matches(row)."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __ge__(self, other):
+        return _Clause(self.name, ">=", other)
+
+    def __lt__(self, other):
+        return _Clause(self.name, "<", other)
+
+    def __gt__(self, other):
+        return _Clause(self.name, ">", other)
+
+    # asc()/order_by helpers used by cmd_list — return self, harmless.
+    def asc(self):
+        return self
+
+
+class _Clause:
+    def __init__(self, col, op, value):
+        self.col = col
+        self.op = op
+        self.value = value
+
+    def matches(self, row):
+        actual = getattr(row, self.col)
+        if self.op == ">=":
+            return actual >= self.value
+        if self.op == "<":
+            return actual < self.value
+        if self.op == ">":
+            return actual > self.value
+        raise AssertionError(self.op)
+
+
+class _Query:
+    def __init__(self, rows):
+        self.rows = rows
+        self.clauses = []
+
+    def filter(self, *conds):
+        self.clauses.extend(conds)
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def limit(self, n):
+        return self
+
+    def first(self):
+        return None
+
+    def all(self):
+        out = []
+        for r in self.rows:
+            if all(c.matches(r) for c in self.clauses if isinstance(c, _Clause)):
+                out.append(r)
+        return out
+
+
+def _load_cli(monkeypatch, rows):
+    db = types.ModuleType("core.database")
+    session = MagicMock()
+    session.query.return_value = _Query(rows)
+    db.SessionLocal = MagicMock(return_value=session)
+    cal_event = types.SimpleNamespace(dtstart=_Col("dtstart"), dtend=_Col("dtend"))
+    db.CalendarEvent = cal_event
+    db.CalendarCal = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db)
+    path = ROOT / "scripts" / "odysseus-calendar"
+    loader = importlib.machinery.SourceFileLoader("odysseus_calendar_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_list_includes_event_overlapping_window_start(monkeypatch, capsys):
+    # Conference running 09:00–17:00; we list from 14:00 onward (default now()).
+    ongoing = types.SimpleNamespace(
+        dtstart=datetime(2026, 6, 3, 9, 0),
+        dtend=datetime(2026, 6, 3, 17, 0),
+    )
+    cli = _load_cli(monkeypatch, [ongoing])
+
+    # Serialize to something trivial so emit() doesn't choke on the namespace.
+    cli._serialize_event = lambda e: {"dtstart": e.dtstart.isoformat()}
+
+    args = types.SimpleNamespace(
+        start="2026-06-03T14:00:00",
+        end="2026-06-03T23:00:00",
+        calendar=None,
+        limit=100,
+        pretty=False,
+    )
+    cli.cmd_list(args)
+    out = capsys.readouterr().out
+    assert "2026-06-03T09:00:00" in out, (
+        "An event that started before the window but is still running inside "
+        "it must be listed (overlap semantics), but it was dropped."
+    )


### PR DESCRIPTION
## Summary

`odysseus-calendar list` filtered events by whether their **start** falls inside the requested window:

```python
q = db.query(CalendarEvent).filter(
    CalendarEvent.dtstart >= start,
    CalendarEvent.dtstart < end,
)
```

But the canonical web route (`routes/calendar_routes.py`) uses **overlap** semantics for non-recurring events — `dtstart < end_dt AND dtend > start_dt` — and the codebase documents this contract in `tests/test_calendar_recurrence.py` ("must be included … matching non-recurring overlap: `dtend > start`").

So any event that **started before the window but is still ongoing inside it** is silently dropped by the CLI. The default `odysseus-calendar list` sets `start = now`, so a 09:00–17:00 conference listed at 14:00 has `dtstart (09:00) < now`, fails `dtstart >= start`, and disappears — even though it is happening right now and the web UI shows it. Same for any multi-day event spanning the window.

**Fix:** use overlap (`dtstart < end AND dtend > start`), matching the route. `dtend` is `nullable=False` in the schema, so there is no null-end regression. The `[start, end)` half-open end boundary is preserved.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->

## Linked Issue

Part of #2122

## How to Test

1. Run the regression test added in this PR: `pytest tests/test_calendar_cli_overlap.py`. It fails on the pre-fix code and passes after the fix.
2. See the Summary above for the exact before/after behaviour the test exercises.

