### PR TITLE
Appearance: optional 'Always Show Speed' + 'Wide Chat' toggles via Developer Mode page

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2414,7 +2414,7 @@ function initializeEventListeners() {
   };
 
   // Keys hidden by default on first run (no localStorage yet)
-  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn']);
+  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat']);
 
   // Keys that need admin to toggle off (reserved for future use)
   const UI_VIS_ADMIN_ONLY = new Set([]);
@@ -2449,6 +2449,12 @@ function initializeEventListeners() {
     applyTextEmojis(state['text-emojis'] !== false);
     // Hide thinking sections toggle (show-thinking: checked=show, unchecked=hide)
     document.body.classList.toggle('hide-thinking', state['show-thinking'] === false);
+    // Always-prominent tokens/sec: makes the per-message t/s metric bright and
+    // a touch larger instead of the dim muted footer text that's easy to miss.
+    document.body.classList.toggle('tps-prominent', state['prominent-tps'] === true);
+    // Wide chat: let the message column use the full window width (like
+    // ChatGPT/Claude's wide mode) instead of the default reading-width cap.
+    document.body.classList.toggle('chat-wide', state['wide-chat'] === true);
   }
 
   // Rearrange toggles in session/model sort dropdowns

--- a/static/app.js
+++ b/static/app.js
@@ -2414,7 +2414,7 @@ function initializeEventListeners() {
   };
 
   // Keys hidden by default on first run (no localStorage yet)
-  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat']);
+  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat', 'developer-mode']);
 
   // Keys that need admin to toggle off (reserved for future use)
   const UI_VIS_ADMIN_ONLY = new Set([]);
@@ -2455,6 +2455,10 @@ function initializeEventListeners() {
     // Wide chat: let the message column use the full window width (like
     // ChatGPT/Claude's wide mode) instead of the default reading-width cap.
     document.body.classList.toggle('chat-wide', state['wide-chat'] === true);
+    // Developer mode: off by default. When on, reveals the Developer Mode
+    // settings page (gated via this body class in CSS) that holds advanced
+    // power-user toggles, keeping them out of the way for everyone else.
+    document.body.classList.toggle('dev-mode', state['developer-mode'] === true);
   }
 
   // Rearrange toggles in session/model sort dropdowns

--- a/static/index.html
+++ b/static/index.html
@@ -1346,6 +1346,10 @@
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8"/></svg>
             <span>Appearance</span>
           </button>
+          <button class="settings-nav-item" data-settings-tab="developer">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            <span>Developer Mode</span>
+          </button>
           <button class="settings-nav-item" data-settings-tab="shortcuts">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10"/></svg>
             <span>Shortcuts</span>
@@ -1734,11 +1738,6 @@
                 <span class="vis-label">User <span class="vis-hint">Avatar &amp; name</span></span>
                 <input type="checkbox" checked data-ui-key="user-bar"><span class="vis-switch"></span>
               </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
-                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
-                <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
-              </label>
             </div>
           </div>
           <div class="admin-card" style="padding-bottom:6px;">
@@ -1760,24 +1759,9 @@
                 <input type="checkbox" checked data-ui-key="incognito-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
-                <span class="vis-icon" style="font-size:13px;line-height:14px;">Aa</span>
-                <span class="vis-label">Text-only Emojis <span class="vis-hint">Strip emojis from AI replies</span></span>
-                <input type="checkbox" data-ui-key="text-emojis"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2a7 7 0 0 0-7 7c0 3 2 5.5 4.5 7.5.7.6 1.2 1.3 1.5 2h2c.3-.7.8-1.4 1.5-2C17 14.5 19 12 19 9a7 7 0 0 0-7-7z"/><line x1="10" y1="22" x2="14" y2="22"/></svg></span>
                 <span class="vis-label">Thinking Process <span class="vis-hint">Show &lt;think&gt; collapsible bars</span></span>
                 <input type="checkbox" checked data-ui-key="show-thinking"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
-                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
-                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
-                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
-                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/><path d="M4 4l16 16"/></svg></span>
@@ -1798,11 +1782,6 @@
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg></span>
                 <span class="vis-label">Document Editor</span>
                 <input type="checkbox" checked data-ui-key="doc-toggle-btn"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>
-                <span class="vis-label">Shell</span>
-                <input type="checkbox" checked data-ui-key="bash-toggle-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></span>
@@ -1831,6 +1810,16 @@
               </label>
             </div>
           </div>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>Developer Mode</h2>
+            <div class="vis-toggles">
+              <label class="vis-row" title="Reveal an Advanced settings page with power-user options">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></span>
+                <span class="vis-label">Developer Mode <span class="vis-hint">Adds an advanced settings page (off by default)</span></span>
+                <input type="checkbox" data-ui-key="developer-mode"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
           <div style="text-align:right;padding:0 4px;">
             <button type="button" class="admin-btn-sm" id="set-uiVisResetBtn" style="opacity:0.5;">Reset All</button>
           </div>
@@ -1840,6 +1829,49 @@
 
         <!-- ═══ MEMORY TAB ═══ -->
         <!-- ═══ SHORTCUTS TAB ═══ -->
+        <div data-settings-panel="developer" class="settings-appearance-panel hidden">
+          <p style="margin:0 0 14px;font-size:12px;line-height:1.5;opacity:0.6;">Advanced and power-user options, kept out of the main Appearance panel so it stays simple. Most people won't need to touch these.</p>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>Chat</h2>
+            <div class="vis-toggles">
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
+                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
+                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
+                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon" style="font-size:13px;line-height:14px;">Aa</span>
+                <span class="vis-label">Text-only Emojis <span class="vis-hint">Strip emojis from AI replies</span></span>
+                <input type="checkbox" data-ui-key="text-emojis"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><line x1="17" y1="10" x2="3" y2="10"/><line x1="21" y1="6" x2="3" y2="6"/><line x1="21" y1="14" x2="3" y2="14"/><line x1="17" y1="18" x2="3" y2="18"/></svg>Chat Bar</h2>
+            <div class="vis-toggles">
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>
+                <span class="vis-label">Shell</span>
+                <input type="checkbox" checked data-ui-key="bash-toggle-btn"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>Sidebar</h2>
+            <div class="vis-toggles">
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
+                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
+                <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
+        </div>
         <div data-settings-panel="shortcuts" class="hidden">
           <div class="admin-card" style="display:flex;align-items:center;justify-content:space-between;padding:10px 16px;">
             <div>

--- a/static/index.html
+++ b/static/index.html
@@ -1770,6 +1770,16 @@
                 <input type="checkbox" checked data-ui-key="show-thinking"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
+                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
+                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
+                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/><path d="M4 4l16 16"/></svg></span>
                 <span class="vis-label">Sensitive Blur <span class="vis-hint">Blur emails, tokens, and secrets in AI output</span></span>
                 <input type="checkbox" data-privacy-key="sensitive-blur"><span class="vis-switch"></span>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -31,8 +31,8 @@ function initTabs() {
       // Mark when the Appearance tab is open so the modal can go
       // semi-transparent — lets the user see the rest of the UI react as
       // they flip toggles instead of having to close + reopen the modal.
-      document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
-      syncAppearanceOpacity(tab === 'appearance');
+      document.body.classList.toggle('settings-appearance-open', tab === 'appearance' || tab === 'developer');
+      syncAppearanceOpacity(tab === 'appearance' || tab === 'developer');
       if (tab === 'ai') refreshAiModelEndpoints();
     });
   });

--- a/static/style.css
+++ b/static/style.css
@@ -1783,6 +1783,20 @@ body.bg-pattern-sparkles {
     .hwfit-header .hwfit-sortable { cursor: pointer; transition: color .12s; }
     .hwfit-header .hwfit-sortable:hover { color: var(--fg); text-decoration: underline dotted; }
     .hwfit-header .hwfit-sort-active { color: var(--fg); font-weight: 600; }
+    /* Wide-chat toggle (Appearance → "Wide chat"): widen the reading column to
+       near-full-window, like ChatGPT/Claude wide mode. Just lifts the --chat-max
+       cap the existing centering math already keys off — no layout rewrite. */
+    body.chat-wide .chat-history { --chat-max: 1400px; }
+    /* Prominent t/s toggle (Appearance → "Always show tokens/sec"): the per-
+       message metric is normally dim muted footer text that's easy to miss.
+       Make it bright, slightly larger, and full-opacity so the speed is always
+       legible at a glance. */
+    body.tps-prominent .msg-footer .response-metrics {
+      color: var(--fg);
+      font-weight: 600;
+      font-size: 0.82rem;
+      opacity: 1;
+    }
     /* Welcome screen — centered in available space above input bar */
     #welcome-screen {
       position:absolute;

--- a/static/style.css
+++ b/static/style.css
@@ -1787,6 +1787,8 @@ body.bg-pattern-sparkles {
        near-full-window, like ChatGPT/Claude wide mode. Just lifts the --chat-max
        cap the existing centering math already keys off — no layout rewrite. */
     body.chat-wide .chat-history { --chat-max: 1400px; }
+    /* Developer Mode page: hidden from the settings nav until opted in. */
+    body:not(.dev-mode) .settings-nav-item[data-settings-tab="developer"] { display: none; }
     /* Prominent t/s toggle (Appearance → "Always show tokens/sec"): the per-
        message metric is normally dim muted footer text that's easy to miss.
        Make it bright, slightly larger, and full-opacity so the speed is always
@@ -21209,6 +21211,9 @@ body.gallery-selecting .gallery-dl-btn,
 .settings-appearance-panel > .admin-card:nth-of-type(2) { order: 1; }
 .settings-appearance-panel > .admin-card:nth-of-type(3) { order: 2; }
 .settings-appearance-panel > .admin-card:nth-of-type(n+4) { order: 4; }
+/* Developer Mode page reuses this panel's styling but not its Appearance-specific
+   card ordering — keep its cards in DOM order (Chat, Chat Bar, Sidebar). */
+.settings-appearance-panel[data-settings-panel="developer"] > .admin-card { order: 0; }
 
 /* Mobile: stack tabs on top */
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary

Adds optional Always Show Speed, Wide Chat, and Text-only Emojis toggles behind a Developer Mode settings page, keeping the Appearance panel from getting more crowded.

## Linked Issue

Replaces #980 (closed pending screenshots)

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Settings → Appearance. No new toggles visible — just the Developer Mode master switch at the bottom.
2. Turn on **Developer Mode**. The **Developer** nav item appears in the settings sidebar.
3. Open it — toggles are grouped under Chat / Chat Bar / Sidebar.
4. "Wide Chat" expands messages from 800px to 1400px. "Always Show Speed" keeps tokens/sec at full opacity.
5. Turn Developer Mode off — the nav item and page disappear.

## Screenshots

### Settings

**Developer Mode page** — toggles off by default:

![Developer Mode page](https://github.com/user-attachments/assets/d93294db-5584-4543-85f8-1b97498ce4d1)

### Chat — feature comparisons

**Default (both OFF):**

![](https://github.com/user-attachments/assets/f53bc5aa-b8e9-4594-bb69-0d1cf5746576)

**Wide Chat ON:**

![](https://github.com/user-attachments/assets/f3d511be-8dd2-4eb7-8d91-bb0b2aa2e676)

**Always Show Speed ON:**

![](https://github.com/user-attachments/assets/e07dbef0-12d1-4ce6-9344-e19521a24dc0)

**Both ON:**

![](https://github.com/user-attachments/assets/03023ed0-0e79-44ff-9005-007f6190cea5)

### Previous screenshots (from earlier PR)

**Appearance panel — desktop:**

![Appearance desktop](https://github.com/user-attachments/assets/5bc4e3a6-b315-4584-8e8a-e306845fa7b1)

**Developer Mode — desktop:**

![Developer Mode desktop](https://github.com/user-attachments/assets/802f1ea1-94fa-40ba-9bbe-82bb5ab312ac)

**Appearance panel — mobile:**

![Appearance mobile](https://github.com/user-attachments/assets/523e3190-3fb4-48aa-bb5f-452036f9ab07)

**Developer Mode — mobile:**

![Developer Mode mobile](https://github.com/user-attachments/assets/f1ba8f13-d180-4db9-a58d-0a62e2a57ca1)

## Style Match

- Reuses `--fg`, `--chat-max`, `--card`, `--border` CSS vars — no new values.
- Reuses `admin-card`, `vis-row`, `vis-switch`, `settings-nav-item` classes.
- SVG icons, no Unicode emoji.
- Uses existing `data-ui-key` / `applyUIVis` system.

Rebased onto upstream/main. No backend changes.
