### PR TITLE
feat: add placeholder option for dropdowns in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,6 +31,7 @@ body:
     attributes:
       label: Install Method
       options:
+        - "-- Please Select --"
         - Docker (docker compose up)
         - Manual Python install (pip / venv)
         - Windows native (launch-windows.ps1)
@@ -44,6 +45,7 @@ body:
     attributes:
       label: Operating System
       options:
+        - "-- Please Select --"
         - Linux
         - macOS
         - Windows

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -32,6 +32,7 @@ body:
       label: Area
       description: Which part of the application does this affect?
       options:
+        - "-- Please Select --"
         - Chat / Agent
         - Email
         - Calendar
@@ -83,6 +84,7 @@ body:
     attributes:
       label: Are you willing to implement this?
       options:
+        - "-- Please Select --"
         - "Yes — I can open a PR"
         - "Partially — I can help but need guidance"
         - "No — I am only filing the request"


### PR DESCRIPTION
## Summary

Added a `-- Please Select --` placeholder as the first option in all dropdown fields across the GitHub issue templates. GitHub's issue form dropdowns do not include a default empty/unselected state. Without this, users can inadvertently submit a form with the first real option pre-selected without consciously choosing it. This makes selection intentional and explicit.

## Linked Issue

Closes #2015

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `main`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Go to [New Issue](https://github.com/pewdiepie-archdaemon/odysseus/issues/new/choose) and select **Bug Report**.
2. Verify the **Install Method** and **Operating System** dropdowns both show `-- Please Select --` as the default first option.
3. Repeat with **Feature Request** and verify **Area** and **Are you willing to implement this?** both show `-- Please Select --` as the default first option.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — changes are limited to `.github/ISSUE_TEMPLATE/` YAML configuration files. No application UI was modified.

## Additional Info

Running/testing app is N/A