### PR TITLE
fix: re-export missing _SPORTS_HINT_RE, fix search mock, fix second PDF lstrip site

### DIFF
--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -516,7 +516,7 @@ def build_user_content(
                     except Exception as e:
                         logger.warning(f"PDF auto-doc creation failed for {path}: {e}")
                 if extracted_text is None:
-                    extracted_text = _process_pdf(path)
+                    extracted_text = strip_pdf_content_marker(_process_pdf(path))
             elif mime.startswith("text/") or _is_text_file(path):
                 extracted_text = _process_text_file(path)
             else:

--- a/src/search/ranking.py
+++ b/src/search/ranking.py
@@ -7,6 +7,7 @@ parallel copy; it now re-exports so the two cannot drift out of sync again.
 
 from services.search.ranking import (  # noqa: F401
     _AGE_FORMATS,
+    _SPORTS_HINT_RE,
     _utcnow_naive,
     rank_search_results,
     recency_score,

--- a/tests/test_build_user_content_pdf_marker.py
+++ b/tests/test_build_user_content_pdf_marker.py
@@ -53,5 +53,6 @@ def test_pdf_body_marker_stripped_without_eating_text(monkeypatch, tmp_path):
     # The leading page text must survive intact.
     assert "[Page 1 text]:" in body
     assert "to the board, the agenda is set" in body
-    # The old lstrip(chars) corruption ate "[P" then "to" -> "age 1 text]: the board".
-    assert "age 1 text" not in body
+    # The old lstrip(chars) corruption ate "[P" -> "]age 1 text]: the board".
+    # Check the marker is fully intact (starts with "[Page", not "]age" or "age").
+    assert "]age 1 text]:" not in body

--- a/tests/test_search_service_nondict_rows.py
+++ b/tests/test_search_service_nondict_rows.py
@@ -8,13 +8,13 @@ def test_search_skips_non_dict_results(monkeypatch):
     # comprehensive_web_search aggregates external provider + cache results;
     # a malformed row (string/None) made the old loop call r.get and crash,
     # losing the whole search.
-    async def fake_search(query, max_results=10, fetch_content=False):
-        return [
+    def fake_search(query, **kwargs):
+        return ("context", [
             {"url": "https://a.com", "title": "A", "snippet": "x"},
             "junk-row",
             None,
             {"url": "https://b.com", "title": "B", "snippet": "y"},
-        ]
+        ])
 
     monkeypatch.setattr(svc_mod, "comprehensive_web_search", fake_search)
     svc = SearchService()


### PR DESCRIPTION
## Summary

Three related test/code alignment fixes:

1. **src/search/ranking.py** — the re-export shim forgot `_SPORTS_HINT_RE`, so `src.search.ranking._SPORTS_HINT_RE` raised `AttributeError`
2. **tests/test_search_service_nondict_rows.py** — the mock was `async` but `SearchService.search` calls it via `asyncio.to_thread` (sync); also missed the `max_pages` kwarg and `return_sources` tuple return shape
3. **src/document_processor.py:519** — second `_process_pdf` call site in `build_user_content` (non-form fallback) was not wrapped with `strip_pdf_content_marker`, same `lstrip(chars)` bug as #1663. Also fixed the test assertion that false-positived on the valid substring.

## Linked Issue

Part of #1995 (sports regex), follow-up to #1663 (PDF lstrip)

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run `python -m pytest tests/test_search_ranking_sports_substring.py` — all 6 pass (was 2 failing)
2. Run `python -m pytest tests/test_search_service_nondict_rows.py` — 1 pass (was failing)
3. Run `python -m pytest tests/test_build_user_content_pdf_marker.py` — 1 pass (was failing)