### PR TITLE
fix: re-export sports hint regex from search ranking shim

### DIFF
--- a/src/search/ranking.py
+++ b/src/search/ranking.py
@@ -7,6 +7,7 @@ parallel copy; it now re-exports so the two cannot drift out of sync again.
 
 from services.search.ranking import (  # noqa: F401
     _AGE_FORMATS,
+    _SPORTS_HINT_RE,
     _utcnow_naive,
     rank_search_results,
     recency_score,


### PR DESCRIPTION
## What changed

- Re-export `_SPORTS_HINT_RE` from `src/search/ranking.py`, which is now a compatibility shim for `services.search.ranking`.

## Why

The sports ranking regression test covers both the live ranking module and the shim path. The live module defines `_SPORTS_HINT_RE`, but the shim did not re-export it, so the `src` test path failed with `AttributeError` even though the live implementation was correct.

## Validation

- `pytest tests/test_search_ranking_sports_substring.py tests/test_search_ranking.py tests/test_search_ranking_recency.py`
- `pytest tests/test_gpu_compose_standalone.py tests/test_provider_classification.py tests/test_search_ranking_sports_substring.py`
