### PR TITLE
ci: harden description checks — unfilled dropdowns, gameable test plans, non-issue links

### DIFF
--- a/.github/scripts/check-issue-description.js
+++ b/.github/scripts/check-issue-description.js
@@ -91,6 +91,33 @@ module.exports = async ({ github, context, core }) => {
     // 'untyped' → only the common body-length check applies.
   }
 
+  // ── Unfilled dropdowns ────────────────────────────────────────────────────
+  // #2068 added a "-- Please Select --" default to every template dropdown, so
+  // a contributor who never opens the dropdown submits with that literal string
+  // as the section value. The per-section checks above only verify presence, so
+  // a placeholder value passes. Scan every section and flag the ones still
+  // showing the placeholder, as a single comma-separated line item.
+  const PLACEHOLDER = '-- Please Select --';
+  const headingRe = /^#+\s+(.+?)\s*$/gm;
+  const headings = [];
+  let hm;
+  while ((hm = headingRe.exec(body)) !== null) {
+    headings.push({ name: hm[1].trim(), headStart: hm.index, contentStart: hm.index + hm[0].length });
+  }
+  const unfilled = [];
+  for (let i = 0; i < headings.length; i++) {
+    const end = i + 1 < headings.length ? headings[i + 1].headStart : body.length;
+    if (body.slice(headings[i].contentStart, end).includes(PLACEHOLDER)) {
+      unfilled.push(headings[i].name);
+    }
+  }
+  if (unfilled.length > 0) {
+    failures.push(
+      `**Unfilled dropdowns** — please choose a value; these sections still show ` +
+      `the \`${PLACEHOLDER}\` placeholder: ${unfilled.join(', ')}.`,
+    );
+  }
+
   // ── Labels ────────────────────────────────────────────────────────────────
   // These labels are expected to already exist in the repo — managing the
   // repo's label set is the maintainer's job, not this workflow's. We check a

--- a/.github/scripts/check-issue-description.js
+++ b/.github/scripts/check-issue-description.js
@@ -100,9 +100,13 @@ module.exports = async ({ github, context, core }) => {
   const PLACEHOLDER = '-- Please Select --';
   const headingRe = /^#+\s+(.+?)\s*$/gm;
   const headings = [];
-  let hm;
-  while ((hm = headingRe.exec(body)) !== null) {
-    headings.push({ name: hm[1].trim(), headStart: hm.index, contentStart: hm.index + hm[0].length });
+  let headingMatch;
+  while ((headingMatch = headingRe.exec(body)) !== null) {
+    headings.push({
+      name: headingMatch[1].trim(),
+      headStart: headingMatch.index,
+      contentStart: headingMatch.index + headingMatch[0].length,
+    });
   }
   const unfilled = [];
   for (let i = 0; i < headings.length; i++) {

--- a/.github/scripts/check-pr-description.js
+++ b/.github/scripts/check-pr-description.js
@@ -32,7 +32,7 @@ module.exports = async ({ github, context, core }) => {
   //    keyword + #NNN, or a full issue URL (e.g. .../issues/123) — the strict
   //    keyword-prefixed form previously false-flagged correctly-linked PRs.
   const linkedSection = section('Linked Issue');
-  const hasIssueRef = /#\d+/.test(linkedSection) || /\/issues\/\d+/.test(linkedSection);
+  const hasIssueRef = /#\d+\b/.test(linkedSection) || /\/issues\/\d+/.test(linkedSection);
   if (!linkedSection || !hasIssueRef) {
     problems.push('**Linked Issue** — add a reference like `Fixes #NNN`, a bare `#NNN`, or a link to the issue.');
   }
@@ -48,10 +48,12 @@ module.exports = async ({ github, context, core }) => {
     problems.push('**Checklist** — check the duplicate-search box to confirm you searched existing issues and PRs.');
   }
 
-  // 5. How to Test must have at least one numbered step.
+  // 5. How to Test must contain enough real detail for a reviewer to act on.
+  //    Any format is fine — numbered steps, prose, the commands you ran, or a
+  //    code block — so we only require non-trivial content, not a specific shape.
   const howTo = section('How to Test');
-  if (!howTo || !/\d+\.\s*\S/.test(howTo)) {
-    problems.push('**How to Test** — add at least one numbered step a reviewer can follow to verify this works.');
+  if (howTo.length < 30) {
+    problems.push('**How to Test** — explain how a reviewer can verify this change. Numbered steps, the commands you ran, or a short code block all work — give a sentence or two of real detail (not just "tested locally").');
   }
 
   // ── Comment ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up hardening for the description-check workflows merged in #1959. Three refinements surfaced once the checks ran against real traffic:

- **Issue check** — flag any section still showing the `-- Please Select --` dropdown placeholder (added in #2068) as a single comma-separated line item. The presence-only checks let an un-chosen dropdown pass (e.g. #2087, #2079).
- **PR "How to Test"** — replace the numbered-step rule with a non-trivial-content requirement (≥ 30 chars). The old `/\d+\.\s*\S/` rule both false-failed prose/code-block test plans and was satisfied by an empty `1. 2. 3.` shell (e.g. #2081, #2078). The failure message now explains what detail to provide.
- **PR "Linked Issue"** — tighten to `/#\d+\b/` so a hex colour like `#1a2b3c` (or an empty `Fixes #`, e.g. #2094, #2091) no longer counts as an issue reference.

No workflow or template changes — logic stays in the two extracted scripts.

## Linked Issue

Closes #2096

## Type of Change

- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and PRs — this is the follow-up tracked in #2096, building on merged #1959.
- [x] This PR targets `main`.
- [x] Scope is limited to the two check scripts — no unrelated changes.

## How to Test

Both scripts are pure validators over the description body, so they can be driven with a mocked `github`/`context`/`core`:

1. PR check (`.github/scripts/check-pr-description.js`): feed a body whose **How to Test** is only `1. 2. 3.` and confirm it now **fails**; feed a prose or code-block test plan and confirm it **passes**; set **Linked Issue** to `theme #1a2b3c` and confirm it **fails**, while `Closes #123` passes.
2. Issue check (`.github/scripts/check-issue-description.js`): feed a `bug`-labelled body with **Install Method** left as `-- Please Select --` and confirm a single **Unfilled dropdowns** failure names that section; two unfilled dropdowns produce one comma-separated line.

Verified locally with a mock-API driver: empty `Fixes #`, hex `#1a2b3c`, and the `1. 2. 3.` shell all fail; real numbered steps, prose, and code blocks all pass; one and two unfilled dropdowns each produce a single comma-separated line item.
