### PR TITLE
fix(calendar): list events overlapping the window, not just starting in it (#2065)

### DIFF
--- a/scripts/odysseus-calendar
+++ b/scripts/odysseus-calendar
@@ -103,9 +103,14 @@ def cmd_list(args) -> None:
     end = _parse_dt(args.end) if args.end else (start + timedelta(days=30))
     db = SessionLocal()
     try:
+        # Overlap semantics, matching routes/calendar_routes.py: an event
+        # belongs in [start, end) if it starts before the window ends AND
+        # ends after the window begins. Filtering on dtstart alone dropped
+        # events that began before the window but are still in progress
+        # inside it (e.g. an all-day or multi-day event listed mid-span).
         q = db.query(CalendarEvent).filter(
-            CalendarEvent.dtstart >= start,
             CalendarEvent.dtstart < end,
+            CalendarEvent.dtend > start,
         )
         if args.calendar:
             cal = db.query(CalendarCal).filter(CalendarCal.name == args.calendar).first()

--- a/tests/test_calendar_cli_overlap.py
+++ b/tests/test_calendar_cli_overlap.py
@@ -1,0 +1,174 @@
+"""Issue #2065 — odysseus-calendar list dropped in-progress / multi-day events.
+
+`cmd_list` filtered on the event's START falling inside the window
+(`dtstart >= start AND dtstart < end`), so an event that began before the
+window but is still ongoing inside it was silently dropped — even though the
+web route (routes/calendar_routes.py) uses overlap semantics and shows it.
+
+These tests bind the CLI to a real temp SQLite DB, seed events relative to a
+fixed window, and assert the overlap contract (`dtstart < end AND dtend > start`).
+"""
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import uuid
+from contextlib import redirect_stdout
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+# core.database runs init_db() on import against DATABASE_URL (default
+# sqlite:///./data/app.db). Point it at an in-memory DB so the import does
+# not depend on a writable ./data directory existing.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+import core.database as cdb  # noqa: E402
+from core.database import CalendarCal, CalendarEvent  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Dedicated shared in-memory SQLite for this test's data (StaticPool keeps one
+# connection so every session sees the same schema/rows).
+_ENGINE = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+cdb.Base.metadata.create_all(_ENGINE)
+_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+
+
+def _load_cli(monkeypatch):
+    """Load scripts/odysseus-calendar with its SessionLocal pointing at the
+    temp DB. Uses the real core.database so CalendarEvent is a real model."""
+    path = ROOT / "scripts" / "odysseus-calendar"
+    loader = importlib.machinery.SourceFileLoader("odysseus_calendar_cli", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    monkeypatch.setattr(module, "SessionLocal", _TS)
+    return module
+
+
+def _make_calendar(db):
+    cal = CalendarCal(id=str(uuid.uuid4()), name="Work-" + uuid.uuid4().hex[:6])
+    db.add(cal)
+    db.flush()
+    return cal
+
+
+def _add_event(db, cal, summary, dtstart, dtend):
+    ev = CalendarEvent(
+        uid=str(uuid.uuid4()),
+        calendar_id=cal.id,
+        summary=summary,
+        dtstart=dtstart,
+        dtend=dtend,
+        is_utc=False,
+    )
+    db.add(ev)
+    db.flush()
+    return ev
+
+
+def _run_list(cli, **kwargs):
+    args = SimpleNamespace(
+        start=kwargs.get("start"),
+        end=kwargs.get("end"),
+        calendar=kwargs.get("calendar"),
+        limit=kwargs.get("limit", 100),
+        pretty=False,
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cli.cmd_list(args)
+    return json.loads(buf.getvalue())
+
+
+def test_list_includes_in_progress_event(monkeypatch):
+    """An event that started before the window but is still ongoing inside it
+    must appear — the defining symptom of #2065."""
+    cli = _load_cli(monkeypatch)
+    db = _TS()
+    try:
+        cal = _make_calendar(db)
+        # Window: 14:00–16:00. Conference runs 09:00–17:00 (started earlier,
+        # still in progress). With the old dtstart >= start filter it dropped.
+        _add_event(
+            db, cal, "All-day conference",
+            datetime(2026, 6, 1, 9, 0), datetime(2026, 6, 1, 17, 0),
+        )
+        db.commit()
+        summaries = {
+            e["summary"]
+            for e in _run_list(
+                cli, calendar=cal.name,
+                start="2026-06-01T14:00:00", end="2026-06-01T16:00:00",
+            )
+        }
+        assert "All-day conference" in summaries
+    finally:
+        db.close()
+
+
+def test_list_includes_multiday_event_spanning_window(monkeypatch):
+    cli = _load_cli(monkeypatch)
+    db = _TS()
+    try:
+        cal = _make_calendar(db)
+        _add_event(
+            db, cal, "Trip",
+            datetime(2026, 6, 1, 0, 0), datetime(2026, 6, 5, 0, 0),
+        )
+        db.commit()
+        summaries = {
+            e["summary"]
+            for e in _run_list(
+                cli, calendar=cal.name,
+                start="2026-06-03T00:00:00", end="2026-06-04T00:00:00",
+            )
+        }
+        assert "Trip" in summaries
+    finally:
+        db.close()
+
+
+def test_list_excludes_non_overlapping_events(monkeypatch):
+    """Events entirely before or after the window stay excluded. The end
+    boundary is half-open: an event ending exactly at `start` does not overlap."""
+    cli = _load_cli(monkeypatch)
+    db = _TS()
+    try:
+        cal = _make_calendar(db)
+        # Ends exactly at window start -> dtend > start is False -> excluded.
+        _add_event(
+            db, cal, "Before",
+            datetime(2026, 6, 1, 8, 0), datetime(2026, 6, 1, 14, 0),
+        )
+        # Starts at window end -> dtstart < end is False -> excluded.
+        _add_event(
+            db, cal, "After",
+            datetime(2026, 6, 1, 16, 0), datetime(2026, 6, 1, 18, 0),
+        )
+        _add_event(
+            db, cal, "Inside",
+            datetime(2026, 6, 1, 14, 30), datetime(2026, 6, 1, 15, 0),
+        )
+        db.commit()
+        summaries = {
+            e["summary"]
+            for e in _run_list(
+                cli, calendar=cal.name,
+                start="2026-06-01T14:00:00", end="2026-06-01T16:00:00",
+            )
+        }
+        assert summaries == {"Inside"}
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

`odysseus-calendar list` filtered events on their start falling inside the requested window (`dtstart >= start AND dtstart < end`), so any event that began before the window but was still in progress inside it — or any multi-day event spanning the window — was silently dropped. The web route (`routes/calendar_routes.py`) already uses overlap semantics and shows these events correctly, so the CLI and the UI disagreed. Switching the CLI filter to overlap (`dtstart < end AND dtend > start`) makes the two agree. `dtend` is `nullable=False` in the schema, so there is no null-end regression, and the `[start, end)` half-open boundary is preserved.

## Linked Issue

Fixes #2065

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I verified the change against the existing test suite and new regression tests (see How to Test).

## How to Test

1. Create (or import) a calendar with an event whose start is **before** your query window and whose end is **inside** it — e.g. `dtstart 2026-06-01T09:00`, `dtend 2026-06-01T17:00`.
2. Run the CLI with a window that overlaps but doesn't contain the start:
   ```
   odysseus-calendar list --start 2026-06-01T14:00:00 --end 2026-06-01T16:00:00
   ```
   **Before this fix:** the event is missing from output.
   **After this fix:** the event appears.
3. Repeat with a multi-day event that spans the query window entirely — it should appear in both cases.
4. Run the automated regression suite:
   ```
   python -m pytest tests/test_calendar_cli_overlap.py -v
   ```
   All 3 tests should pass (in-progress event included, multi-day spanning event included, non-overlapping event correctly excluded at the half-open boundary).

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — CLI-only change (`scripts/odysseus-calendar`). No UI, no rendering, no CSS or HTML touched.