### PR TITLE
fix: quote MCP email archive mailbox names

### DIFF
--- a/mcp_servers/email_server.py
+++ b/mcp_servers/email_server.py
@@ -38,6 +38,11 @@ def _b(value) -> bytes:
     return str(value).encode()
 
 
+def _q(name: str) -> str:
+    """Quote an IMAP mailbox name for SELECT / COPY / MOVE commands."""
+    return '"' + (name or "").replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 def _uid_fetch_rows(data) -> list:
     return [d for d in (data or []) if isinstance(d, bytes) and b"UID " in d]
 
@@ -956,10 +961,10 @@ def _bulk_move(uids, source_folder, dest_folder, account=None, role: str = ""):
         if not existing:
             return 0
         moved = len(existing)
-        status, _ = conn.uid("MOVE", _b(msg_set), dest_folder)
+        status, _ = conn.uid("MOVE", _b(msg_set), _q(dest_folder))
         if status != "OK":
             # Fallback: UID copy + flag-delete + expunge
-            status, _ = conn.uid("COPY", _b(msg_set), dest_folder)
+            status, _ = conn.uid("COPY", _b(msg_set), _q(dest_folder))
             if status != "OK":
                 return 0
             status, _ = conn.uid("STORE", _b(msg_set), "+FLAGS", "\\Deleted")
@@ -998,11 +1003,11 @@ def _move_message(uid, source_folder, dest_folder, account=None, role: str = "")
         existing = _uid_fetch_rows(data)
         if status != "OK" or not existing:
             return False
-        status, _ = conn.uid("MOVE", _b(uid), dest_folder)
+        status, _ = conn.uid("MOVE", _b(uid), _q(dest_folder))
         if status == "OK":
             return True
         # Fallback: UID copy + delete
-        status, _ = conn.uid("COPY", _b(uid), dest_folder)
+        status, _ = conn.uid("COPY", _b(uid), _q(dest_folder))
         if status != "OK":
             return False
         status, _ = conn.uid("STORE", _b(uid), "+FLAGS", "\\Deleted")

--- a/tests/test_mcp_email_archive_quoting.py
+++ b/tests/test_mcp_email_archive_quoting.py
@@ -1,0 +1,54 @@
+"""Regression tests for MCP email archive mailbox quoting.
+
+Gmail folder names such as [Gmail]/All Mail contain spaces. The GUI email
+routes quote destination mailboxes before UID MOVE/COPY; the MCP email server
+must do the same or Gmail returns BAD "Could not parse command".
+"""
+
+import pytest
+
+pytest.importorskip("mcp")
+
+import mcp_servers.email_server as es
+
+
+class FakeImap:
+    def __init__(self):
+        self.calls = []
+
+    def select(self, folder, readonly=False):
+        self.calls.append(("select", folder, readonly))
+        return "OK", []
+
+    def uid(self, command, *args):
+        self.calls.append(("uid", command, *args))
+        if command == "FETCH":
+            return "OK", [b"1 (UID 123)"]
+        if command == "MOVE":
+            return "OK", []
+        return "BAD", []
+
+    def logout(self):
+        self.calls.append(("logout",))
+
+
+def test_move_message_quotes_gmail_archive_folder(monkeypatch):
+    conn = FakeImap()
+    monkeypatch.setattr(es, "_imap_connect", lambda account=None: conn)
+    monkeypatch.setattr(es, "_resolve_folder", lambda conn, dest, role: "[Gmail]/All Mail")
+
+    assert es._move_message("123", "INBOX", "Archive", role="archive") is True
+
+    move_calls = [call for call in conn.calls if call[:2] == ("uid", "MOVE")]
+    assert move_calls == [("uid", "MOVE", b"123", '"[Gmail]/All Mail"')]
+
+
+def test_bulk_move_quotes_gmail_archive_folder(monkeypatch):
+    conn = FakeImap()
+    monkeypatch.setattr(es, "_imap_connect", lambda account=None: conn)
+    monkeypatch.setattr(es, "_resolve_folder", lambda conn, dest, role: "[Gmail]/All Mail")
+
+    assert es._bulk_move(["123", "124"], "INBOX", "Archive", role="archive") == 1
+
+    move_calls = [call for call in conn.calls if call[:2] == ("uid", "MOVE")]
+    assert move_calls == [("uid", "MOVE", b"123,124", '"[Gmail]/All Mail"')]


### PR DESCRIPTION
## Summary

Superseded by #2170, which consolidates this archive-specific mailbox quoting fix with the broader IMAP mailbox quoting fixes.

This PR originally fixed MCP email archive moves for Gmail-style archive folders by quoting destination mailbox names before IMAP `UID MOVE` / `UID COPY`. The same scope is now covered in #2170 so the related mailbox quoting changes can be reviewed as one PR.

## Linked Issue

Refs #2151; consolidated into #2170.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `python3 -m pytest tests/test_mcp_email_archive_quoting.py -q`
2. `python3 -m pytest tests/test_mcp_email_decode_header_spaces.py -q`
3. `python3 -m py_compile mcp_servers/email_server.py`
4. `git diff --check`

I did not run the full app or connect to a real Gmail account in this environment. The regression test uses a fake IMAP connection to verify the MCP archive path sends the destination mailbox as `"[Gmail]/All Mail"` for both single-message archive and bulk archive moves.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes.
