### PR TITLE
fix: catch HTTPStatusError in fetch_webpage_content

### DIFF
--- a/src/search/content.py
+++ b/src/search/content.py
@@ -248,6 +248,10 @@ def fetch_webpage_content(url: str, timeout: int = 5, retry_attempt: int = 0) ->
             raise RateLimitError(f"Rate limit hit for {url} (attempt {retry_attempt})")
 
         response.raise_for_status()
+        
+    except httpx.HTTPStatusError as e:
+        error_logger.warning(f"HTTP {e.response.status_code} fetching {url}, skipping") # I Suggest bubbling this error as toast to user
+        return _empty_result(url, f"HTTPError: {e.response.status_code}")
     except httpx.RequestError as e:
         error_logger.error(f"NetworkError fetching {url} (attempt {retry_attempt}): {e}")
         return _empty_result(url, f"NetworkError: {e}")

--- a/tests/test_search_httperror_handling.py
+++ b/tests/test_search_httperror_handling.py
@@ -1,0 +1,57 @@
+"""Regression test for unhandled HTTPStatusError in fetch_webpage_content.
+
+fetch_webpage_content() fetches a URL and calls response.raise_for_status().
+httpx.HTTPStatusError (raised on 4xx/5xx responses) was not caught in the
+except block — only httpx.RequestError and RateLimitError were handled.
+
+This meant any URL returning a 403, 404, or similar would propagate the
+exception up through build_context_preface() and crash the entire chat
+request with a 500 Internal Server Error instead of gracefully skipping
+the URL.
+
+The fix adds an except httpx.HTTPStatusError block that returns _empty_result()
+so the caller can continue normally.
+"""
+import pytest
+import httpx
+from unittest.mock import MagicMock, patch
+
+from src.search.content import fetch_webpage_content
+
+def test_fetch_webpage_content_handles_403_gracefully():
+    """A 403 response should return an empty result, not raise."""
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "403 Forbidden",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    with patch("src.search.content._get_public_url", return_value=mock_response):
+        result = fetch_webpage_content("https://www.w3.org/2000/svg")
+
+    assert result is not None, (
+        "fetch_webpage_content raised instead of returning an empty result on a 403 response. HTTPStatusError was not caught."
+    )
+    assert result["success"] is False
+    assert result["url"] == "https://www.w3.org/2000/svg"
+    assert "error" in result
+
+def test_fetch_webpage_content_handles_404_gracefully():
+    """A 404 response should also return an empty result, not raise."""
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "404 Not Found",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    with patch("src.search.content._get_public_url", return_value=mock_response):
+        result = fetch_webpage_content("https://example.com/404maker")
+
+    assert result is not None, (
+        "fetch_webpage_content raised instead of returning an empty result on a 404 response. HTTPStatusError was not caught."
+    )
+    assert result["success"] is False


### PR DESCRIPTION
raise_for_status() was not caught for HTTPStatusError responses only RequestError and RateLimitError were handled. A 403 on any fetched URL crashed the entire chat request with a 500.

## Summary

Adds except httpx.HTTPStatusError block that returns _empty_result() so the caller continues normally.

## Linked Issue

Fixes #2148

## Type of Change

- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `main`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test


Manual:
1. Run the app locally
2. Send a message containing `http://www.w3.org/2000/svg` in chat
3. Before fix: chat returns 500 Internal Server Error
4. After fix: chat responds normally, URL fetch silently skipped

Automated:
1. run testcase for this scenario: ` python -m pytest tests/test_search_httperror_handling.py -v`



Note: This is similar to #2152 but keeps _empty_result() consistent across all error
paths instead of returning None, requiring no changes to callers.
Also adds a regression test.
