### PR TITLE
Add Developer Mode page + Wide Chat + Always Show Speed toggles

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2414,7 +2414,7 @@ function initializeEventListeners() {
   };
 
   // Keys hidden by default on first run (no localStorage yet)
-  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn']);
+  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat']);
 
   // Keys that need admin to toggle off (reserved for future use)
   const UI_VIS_ADMIN_ONLY = new Set([]);
@@ -2449,6 +2449,12 @@ function initializeEventListeners() {
     applyTextEmojis(state['text-emojis'] !== false);
     // Hide thinking sections toggle (show-thinking: checked=show, unchecked=hide)
     document.body.classList.toggle('hide-thinking', state['show-thinking'] === false);
+    // Always-prominent tokens/sec: makes the per-message t/s metric bright and
+    // a touch larger instead of the dim muted footer text that's easy to miss.
+    document.body.classList.toggle('tps-prominent', state['prominent-tps'] === true);
+    // Wide chat: let the message column use the full window width (like
+    // ChatGPT/Claude's wide mode) instead of the default reading-width cap.
+    document.body.classList.toggle('chat-wide', state['wide-chat'] === true);
   }
 
   // Rearrange toggles in session/model sort dropdowns

--- a/static/app.js
+++ b/static/app.js
@@ -2414,7 +2414,7 @@ function initializeEventListeners() {
   };
 
   // Keys hidden by default on first run (no localStorage yet)
-  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat']);
+  const UI_VIS_DEFAULT_OFF = new Set(['models-section', 'rag-toggle-btn', 'prominent-tps', 'wide-chat', 'developer-mode']);
 
   // Keys that need admin to toggle off (reserved for future use)
   const UI_VIS_ADMIN_ONLY = new Set([]);
@@ -2455,6 +2455,10 @@ function initializeEventListeners() {
     // Wide chat: let the message column use the full window width (like
     // ChatGPT/Claude's wide mode) instead of the default reading-width cap.
     document.body.classList.toggle('chat-wide', state['wide-chat'] === true);
+    // Developer mode: off by default. When on, reveals the Developer Mode
+    // settings page (gated via this body class in CSS) that holds advanced
+    // power-user toggles, keeping them out of the way for everyone else.
+    document.body.classList.toggle('dev-mode', state['developer-mode'] === true);
   }
 
   // Rearrange toggles in session/model sort dropdowns

--- a/static/index.html
+++ b/static/index.html
@@ -1346,6 +1346,10 @@
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8"/></svg>
             <span>Appearance</span>
           </button>
+          <button class="settings-nav-item" data-settings-tab="developer">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            <span>Developer Mode</span>
+          </button>
           <button class="settings-nav-item" data-settings-tab="shortcuts">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10"/></svg>
             <span>Shortcuts</span>
@@ -1734,11 +1738,6 @@
                 <span class="vis-label">User <span class="vis-hint">Avatar &amp; name</span></span>
                 <input type="checkbox" checked data-ui-key="user-bar"><span class="vis-switch"></span>
               </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
-                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
-                <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
-              </label>
             </div>
           </div>
           <div class="admin-card" style="padding-bottom:6px;">
@@ -1760,24 +1759,9 @@
                 <input type="checkbox" checked data-ui-key="incognito-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
-                <span class="vis-icon" style="font-size:13px;line-height:14px;">Aa</span>
-                <span class="vis-label">Text-only Emojis <span class="vis-hint">Strip emojis from AI replies</span></span>
-                <input type="checkbox" data-ui-key="text-emojis"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2a7 7 0 0 0-7 7c0 3 2 5.5 4.5 7.5.7.6 1.2 1.3 1.5 2h2c.3-.7.8-1.4 1.5-2C17 14.5 19 12 19 9a7 7 0 0 0-7-7z"/><line x1="10" y1="22" x2="14" y2="22"/></svg></span>
                 <span class="vis-label">Thinking Process <span class="vis-hint">Show &lt;think&gt; collapsible bars</span></span>
                 <input type="checkbox" checked data-ui-key="show-thinking"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
-                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
-                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
-                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
-                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/><path d="M4 4l16 16"/></svg></span>
@@ -1798,11 +1782,6 @@
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg></span>
                 <span class="vis-label">Document Editor</span>
                 <input type="checkbox" checked data-ui-key="doc-toggle-btn"><span class="vis-switch"></span>
-              </label>
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>
-                <span class="vis-label">Shell</span>
-                <input type="checkbox" checked data-ui-key="bash-toggle-btn"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg></span>
@@ -1831,6 +1810,16 @@
               </label>
             </div>
           </div>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>Developer Mode</h2>
+            <div class="vis-toggles">
+              <label class="vis-row" title="Reveal an Advanced settings page with power-user options">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></span>
+                <span class="vis-label">Developer Mode <span class="vis-hint">Adds an advanced settings page (off by default)</span></span>
+                <input type="checkbox" data-ui-key="developer-mode"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
           <div style="text-align:right;padding:0 4px;">
             <button type="button" class="admin-btn-sm" id="set-uiVisResetBtn" style="opacity:0.5;">Reset All</button>
           </div>
@@ -1840,6 +1829,49 @@
 
         <!-- ═══ MEMORY TAB ═══ -->
         <!-- ═══ SHORTCUTS TAB ═══ -->
+        <div data-settings-panel="developer" class="settings-appearance-panel hidden">
+          <p style="margin:0 0 14px;font-size:12px;line-height:1.5;opacity:0.6;">Advanced and power-user options, kept out of the main Appearance panel so it stays simple. Most people won't need to touch these.</p>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>Chat</h2>
+            <div class="vis-toggles">
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
+                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
+                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
+                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon" style="font-size:13px;line-height:14px;">Aa</span>
+                <span class="vis-label">Text-only Emojis <span class="vis-hint">Strip emojis from AI replies</span></span>
+                <input type="checkbox" data-ui-key="text-emojis"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><line x1="17" y1="10" x2="3" y2="10"/><line x1="21" y1="6" x2="3" y2="6"/><line x1="21" y1="14" x2="3" y2="14"/><line x1="17" y1="18" x2="3" y2="18"/></svg>Chat Bar</h2>
+            <div class="vis-toggles">
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>
+                <span class="vis-label">Shell</span>
+                <input type="checkbox" checked data-ui-key="bash-toggle-btn"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
+          <div class="admin-card" style="padding-bottom:6px;">
+            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>Sidebar</h2>
+            <div class="vis-toggles">
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
+                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
+                <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
+              </label>
+            </div>
+          </div>
+        </div>
         <div data-settings-panel="shortcuts" class="hidden">
           <div class="admin-card" style="display:flex;align-items:center;justify-content:space-between;padding:10px 16px;">
             <div>

--- a/static/index.html
+++ b/static/index.html
@@ -1770,6 +1770,16 @@
                 <input type="checkbox" checked data-ui-key="show-thinking"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>
+                <span class="vis-label">Always Show Speed <span class="vis-hint">Keep tokens/sec bright under every reply</span></span>
+                <input type="checkbox" data-ui-key="prominent-tps"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></span>
+                <span class="vis-label">Wide Chat <span class="vis-hint">Use the full window width for messages</span></span>
+                <input type="checkbox" data-ui-key="wide-chat"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/><path d="M4 4l16 16"/></svg></span>
                 <span class="vis-label">Sensitive Blur <span class="vis-hint">Blur emails, tokens, and secrets in AI output</span></span>
                 <input type="checkbox" data-privacy-key="sensitive-blur"><span class="vis-switch"></span>

--- a/static/index.html
+++ b/static/index.html
@@ -1738,6 +1738,11 @@
                 <span class="vis-label">User <span class="vis-hint">Avatar &amp; name</span></span>
                 <input type="checkbox" checked data-ui-key="user-bar"><span class="vis-switch"></span>
               </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
+                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
+                <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
+              </label>
             </div>
           </div>
           <div class="admin-card" style="padding-bottom:6px;">
@@ -1858,16 +1863,6 @@
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>
                 <span class="vis-label">Shell</span>
                 <input type="checkbox" checked data-ui-key="bash-toggle-btn"><span class="vis-switch"></span>
-              </label>
-            </div>
-          </div>
-          <div class="admin-card" style="padding-bottom:6px;">
-            <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>Sidebar</h2>
-            <div class="vis-toggles">
-              <label class="vis-row">
-                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span>
-                <span class="vis-label">Settings Button <span class="vis-hint">Cog next to user — re-open with <code>/settings</code></span></span>
-                <input type="checkbox" checked data-ui-key="sidebar-settings-btn"><span class="vis-switch"></span>
               </label>
             </div>
           </div>

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -31,8 +31,8 @@ function initTabs() {
       // Mark when the Appearance tab is open so the modal can go
       // semi-transparent — lets the user see the rest of the UI react as
       // they flip toggles instead of having to close + reopen the modal.
-      document.body.classList.toggle('settings-appearance-open', tab === 'appearance');
-      syncAppearanceOpacity(tab === 'appearance');
+      document.body.classList.toggle('settings-appearance-open', tab === 'appearance' || tab === 'developer');
+      syncAppearanceOpacity(tab === 'appearance' || tab === 'developer');
       if (tab === 'ai') refreshAiModelEndpoints();
     });
   });

--- a/static/style.css
+++ b/static/style.css
@@ -1783,6 +1783,20 @@ body.bg-pattern-sparkles {
     .hwfit-header .hwfit-sortable { cursor: pointer; transition: color .12s; }
     .hwfit-header .hwfit-sortable:hover { color: var(--fg); text-decoration: underline dotted; }
     .hwfit-header .hwfit-sort-active { color: var(--fg); font-weight: 600; }
+    /* Wide-chat toggle (Appearance → "Wide chat"): widen the reading column to
+       near-full-window, like ChatGPT/Claude wide mode. Just lifts the --chat-max
+       cap the existing centering math already keys off — no layout rewrite. */
+    body.chat-wide .chat-history { --chat-max: 1400px; }
+    /* Prominent t/s toggle (Appearance → "Always show tokens/sec"): the per-
+       message metric is normally dim muted footer text that's easy to miss.
+       Make it bright, slightly larger, and full-opacity so the speed is always
+       legible at a glance. */
+    body.tps-prominent .msg-footer .response-metrics {
+      color: var(--fg);
+      font-weight: 600;
+      font-size: 0.82rem;
+      opacity: 1;
+    }
     /* Welcome screen — centered in available space above input bar */
     #welcome-screen {
       position:absolute;

--- a/static/style.css
+++ b/static/style.css
@@ -1787,6 +1787,8 @@ body.bg-pattern-sparkles {
        near-full-window, like ChatGPT/Claude wide mode. Just lifts the --chat-max
        cap the existing centering math already keys off — no layout rewrite. */
     body.chat-wide .chat-history { --chat-max: 1400px; }
+    /* Developer Mode page: hidden from the settings nav until opted in. */
+    body:not(.dev-mode) .settings-nav-item[data-settings-tab="developer"] { display: none; }
     /* Prominent t/s toggle (Appearance → "Always show tokens/sec"): the per-
        message metric is normally dim muted footer text that's easy to miss.
        Make it bright, slightly larger, and full-opacity so the speed is always
@@ -21209,6 +21211,9 @@ body.gallery-selecting .gallery-dl-btn,
 .settings-appearance-panel > .admin-card:nth-of-type(2) { order: 1; }
 .settings-appearance-panel > .admin-card:nth-of-type(3) { order: 2; }
 .settings-appearance-panel > .admin-card:nth-of-type(n+4) { order: 4; }
+/* Developer Mode page reuses this panel's styling but not its Appearance-specific
+   card ordering — keep its cards in DOM order (Chat, Chat Bar, Sidebar). */
+.settings-appearance-panel[data-settings-panel="developer"] > .admin-card { order: 0; }
 
 /* Mobile: stack tabs on top */
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary

This PR adds three things:

### 1. Developer Mode
A new master toggle in Settings → Appearance that reveals a **Developer** settings tab for power-user features, keeping the main Appearance panel clean. The Settings Button stays in Appearance — only the advanced toggles move behind Developer Mode.

### 2. Wide Chat
Lets messages use the full viewport width instead of a centered reading column. Similar to ChatGPT/Claude wide mode. Off by default.

### 3. Always Show Speed
Makes the per-message tokens/sec metric bright and prominent under each reply, instead of dim footer text that is easy to miss. Off by default.

### What moves into Developer Mode
| Toggle | Description | New or existing? |
|--------|------------|--|
| **Wide Chat** | Full viewport width for messages | New |
| **Always Show Speed** | Prominent t/s under every reply | New |
| **Text-only Emojis** | Strips emojis from AI replies | Existing (moved) |
| **Shell** | Shows/hides shell button in chat bar | Existing (moved) |

Open to feedback on which toggles belong in Developer Mode vs Appearance.

## Linked Issue

Fixes #980

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets main
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (docker compose up or uvicorn app:app) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open Settings → Appearance → toggle **Developer Mode** ON at the bottom
2. A new **Developer** tab appears — click it
3. Toggle **Wide Chat** ON → messages span full viewport width
4. Toggle **Always Show Speed** ON → t/s becomes bright under replies
5. Toggle OFF to verify defaults are unchanged

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

#### Before → After: Appearance panel cleaned up

<img width="400" alt="Before/after — advanced toggles moved to Developer Mode" src="https://github.com/user-attachments/assets/3756145d-f38c-42ae-bf03-b4e44098a16c" />

#### Appearance Panel — Settings Button + Developer Mode toggle, no advanced toggles

**Desktop**
<img width="320" alt="Desktop: Appearance panel" src="https://github.com/user-attachments/assets/0ff2ed39-8774-4dfe-8a50-0fb93f84106a" />

**Mobile**
<img width="200" alt="Mobile: Appearance panel" src="https://github.com/user-attachments/assets/c54c4201-e276-4921-9fbd-5d8a902e60e2" />

#### Developer Mode Page — Wide Chat, Speed, Text-only Emojis, Shell

**Desktop**
<img width="320" alt="Desktop: Developer Mode page" src="https://github.com/user-attachments/assets/cdf3d9c7-de4d-41b6-a197-0ecad1ff885c" />

**Mobile**
<img width="200" alt="Mobile: Developer Mode page" src="https://github.com/user-attachments/assets/1cd037c4-ad6e-4e65-9175-cf81f94f6ca5" />

#### Default chat — all toggles OFF

**Desktop**
<img width="320" alt="Desktop: Default chat" src="https://github.com/user-attachments/assets/b38de2f3-8303-48f6-b126-cbec5aae7a9e" />

#### Wide Chat ON — full viewport width

**Desktop**
<img width="320" alt="Desktop: Wide Chat only" src="https://github.com/user-attachments/assets/c9bac901-a5a5-4ae2-bd5f-fedb4516e5e2" />

**Mobile**
<img width="200" alt="Mobile: Wide Chat enabled" src="https://github.com/user-attachments/assets/b1449028-6ace-4a01-9403-a6c56493df81" />

#### Always Show Speed ON — t/s bright under replies

**Desktop**
<img width="320" alt="Desktop: Speed only" src="https://github.com/user-attachments/assets/50f9a272-2ca1-47c6-b5a9-855d0b66e271" />

**Mobile**
<img width="200" alt="Mobile: Speed only" src="https://github.com/user-attachments/assets/78a899df-730c-40ff-b6c7-c2307fd4e8f4" />

#### Both Wide Chat + Always Show Speed ON

**Desktop**
<img width="320" alt="Desktop: Both ON" src="https://github.com/user-attachments/assets/30cea683-ac19-4a3a-ab08-874d2a6fe8f1" />

**Mobile**
<img width="200" alt="Mobile: Both ON" src="https://github.com/user-attachments/assets/9f8bdf84-c26a-4093-84df-77fe6a2b7c07" />