### PR TITLE
fix(presets): persist presets atomically to avoid corruption on crash (Fixes #2167)

### DIFF
--- a/src/preset_manager.py
+++ b/src/preset_manager.py
@@ -115,9 +115,12 @@ Use precise language. Show causal relationships explicitly. Quantify uncertainty
     def save(self, presets: Dict[str, Any]) -> bool:
         """Save presets to file"""
         try:
-            os.makedirs(os.path.dirname(self.presets_file), exist_ok=True)
-            with open(self.presets_file, 'w', encoding="utf-8") as f:
-                json.dump(presets, f, indent=2)
+            # Atomic write (tmp file + os.replace) so a crash or serialization
+            # error mid-write can't truncate presets.json and lose every saved
+            # preset. Lazy import keeps this module free of the heavy core
+            # package import graph at load time.
+            from core.atomic_io import atomic_write_json
+            atomic_write_json(self.presets_file, presets, indent=2)
             self.presets = presets
             return True
         except Exception as e:

--- a/tests/test_preset_atomic_save.py
+++ b/tests/test_preset_atomic_save.py
@@ -1,0 +1,43 @@
+"""Regression: PresetManager.save() must persist presets atomically.
+
+save() used a plain open("w") + json.dump, which truncates presets.json before
+writing the new content. A crash / power loss / serialization error mid-write
+leaves the file truncated or empty — the user loses every saved preset. The
+save now goes through core.atomic_io.atomic_write_json (tmp file + os.replace),
+which the rest of the codebase already uses for JSON state files.
+"""
+import inspect
+import json
+
+from src.preset_manager import PresetManager
+
+
+class _Unserializable:
+    """json.dump cannot serialize this — stands in for a mid-write failure."""
+
+
+def test_save_uses_atomic_write_json():
+    src = inspect.getsource(PresetManager.save)
+    assert "atomic_write_json" in src, "save() must persist via atomic_write_json"
+    assert "open(" not in src, "save() must not write presets.json with a plain open('w')"
+
+
+def test_failed_save_does_not_truncate_existing_file(tmp_path):
+    mgr = PresetManager(str(tmp_path))
+    assert mgr.save({"custom": {"name": "keep"}}) is True
+    before = (tmp_path / "presets.json").read_text(encoding="utf-8")
+
+    # A payload that cannot be serialized must not clobber the good file.
+    assert mgr.save({"custom": {"obj": _Unserializable()}}) is False
+
+    after = (tmp_path / "presets.json").read_text(encoding="utf-8")
+    assert after == before
+    assert json.loads(after) == {"custom": {"name": "keep"}}
+
+
+def test_save_round_trip(tmp_path):
+    mgr = PresetManager(str(tmp_path))
+    assert mgr.save({"custom": {"name": "X", "temperature": 0.5}}) is True
+
+    reloaded = PresetManager(str(tmp_path))
+    assert reloaded.presets["custom"]["name"] == "X"


### PR DESCRIPTION
## Summary

`PresetManager.save()` wrote `presets.json` with `open("w") + json.dump`, which truncates the file before the new content is written — a crash, power loss, or serialization error mid-write leaves it truncated/empty and loses every saved preset. This routes the save through the existing `core.atomic_io.atomic_write_json` helper (temp file + `os.replace`), matching how the rest of the codebase persists JSON state. The helper is imported lazily so this leaf module stays free of the heavy `core` package import graph at module load time.

Files changed: `src/preset_manager.py`, `tests/test_preset_atomic_save.py`.

## Linked Issue

Fixes #2167

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

> Note on the last box: this is a backend persistence fix with no UI surface, verified via the unit test suite (commands below) rather than a full app run.

## How to Test

1. `python -m pytest tests/test_preset_atomic_save.py -q` — 3 tests pass.
2. `python -m pytest tests/test_preset_store_shape.py tests/test_preset_fill_missing_defaults.py -q` — existing preset tests still pass (no regression).
3. The new `test_failed_save_does_not_truncate_existing_file` simulates a failed save (an unserializable payload) and asserts the previously saved `presets.json` is left intact — this fails on `main` (the file is truncated) and passes with this change.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI or visual changes — backend persistence only (`src/preset_manager.py`). Nothing that renders to the DOM is affected.
