### PR TITLE
Agent: configurable workspace path for bash/python/file tools

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -603,6 +603,8 @@ def _build_system_prompt(
     # matches what the user sees.
     try:
         from datetime import datetime as _dt, timezone as _tz
+        from src.tool_execution import _agent_workspace as _get_ws
+        _agent_ws = _get_ws()
         _now = _dt.now().astimezone()
         _utc = _dt.now(_tz.utc)
         _off = _now.strftime('%z')  # e.g. +0900
@@ -617,6 +619,10 @@ def _build_system_prompt(
             f"When scheduling a task (manage_tasks), scheduled_time is in UTC: "
             f"subtract the offset above from the user's local time "
             f"(local {_now.strftime('%H:%M')} = {_utc.strftime('%H:%M')} UTC right now).\n\n"
+            f"## Working directory\n"
+            f"bash and python run with cwd `{_agent_ws}`. "
+            f"write_file and read_file resolve relative paths there too. "
+            f"Always report the full path when telling the user where a file was written.\n\n"
         ) + agent_prompt
     except Exception:
         pass

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -122,6 +122,29 @@ def _tool_path_roots() -> list[str]:
     return out
 
 
+def _agent_workspace() -> str:
+    """Return the directory agents should treat as their working directory.
+
+    Uses the first entry of ``tool_path_extra_roots`` when configured (the
+    admin-facing "Workspace path" setting), falling back to DATA_DIR so
+    behaviour is identical to pre-setting installs.
+    """
+    try:
+        from src.settings import get_setting
+        extra = get_setting("tool_path_extra_roots")
+        if isinstance(extra, list):
+            for r in extra:
+                r = str(r).strip()
+                if r:
+                    expanded = os.path.expanduser(r)
+                    os.makedirs(expanded, exist_ok=True)
+                    return expanded
+    except Exception:
+        pass
+    from src.constants import DATA_DIR
+    return DATA_DIR
+
+
 def _resolve_tool_path(raw_path: str) -> str:
     """Resolve and confine a model-supplied path.
 
@@ -470,6 +493,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
+                cwd=_agent_workspace(),
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -496,6 +520,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
+                cwd=_agent_workspace(),
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -513,6 +538,8 @@ async def _direct_fallback(
 
         if tool == "read_file":
             raw_path = content.split("\n", 1)[0].strip()
+            if raw_path and not os.path.isabs(raw_path) and not raw_path.startswith("~"):
+                raw_path = os.path.join(_agent_workspace(), raw_path)
             try:
                 path = _resolve_tool_path(raw_path)
             except ValueError as e:
@@ -538,6 +565,8 @@ async def _direct_fallback(
             lines = content.split("\n", 1)
             raw_path = lines[0].strip()
             body = lines[1] if len(lines) > 1 else ""
+            if raw_path and not os.path.isabs(raw_path) and not raw_path.startswith("~"):
+                raw_path = os.path.join(_agent_workspace(), raw_path)
             try:
                 path = _resolve_tool_path(raw_path)
             except ValueError as e:

--- a/static/index.html
+++ b/static/index.html
@@ -1479,6 +1479,11 @@
                 <input id="set-agentMaxTools" type="text" inputmode="numeric" placeholder="0 = unlimited" class="settings-select" style="width:120px;">
               </div>
               <div id="set-agentMsg" style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);"></div>
+              <div class="settings-row" style="margin-top:8px">
+                <label class="settings-label">Workspace path</label>
+                <input id="set-agentWorkspace" type="text" placeholder="~/workspace" class="settings-select" style="width:220px;">
+              </div>
+              <div id="set-agentWorkspaceMsg" style="font-size:11px;color:color-mix(in srgb, var(--fg) 45%, transparent);">Where write_file, read_file, and bash/python commands run. Leave blank to use the app data directory.</div>
             </div>
           </div>
           <!-- Image Generation removed — only inpaint remains in this build,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1555,12 +1555,16 @@ async function initResearchSearchSettings() {
 async function initAgentSettings() {
   var toolsInput = el('set-agentMaxTools');
   var msg = el('set-agentMsg');
+  var wsInput = el('set-agentWorkspace');
+  var wsMsg = el('set-agentWorkspaceMsg');
   if (!toolsInput) return;
 
   try {
     var res = await fetch('/api/auth/settings', { credentials: 'same-origin' });
     var settings = await res.json();
     if (settings.agent_max_tool_calls) toolsInput.value = settings.agent_max_tool_calls;
+    if (wsInput && Array.isArray(settings.tool_path_extra_roots) && settings.tool_path_extra_roots.length)
+      wsInput.value = settings.tool_path_extra_roots[0];
   } catch (e) {}
 
   async function save() {
@@ -1575,7 +1579,26 @@ async function initAgentSettings() {
     } catch (e) { msg.textContent = 'Failed to save'; msg.style.color = 'var(--red)'; }
   }
 
+  async function saveWorkspace() {
+    if (!wsInput || !wsMsg) return;
+    var raw = wsInput.value.trim();
+    var roots = raw ? [raw] : [];
+    try {
+      await fetch('/api/auth/settings', { method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tool_path_extra_roots: roots })
+      });
+      wsMsg.textContent = raw ? 'Saved — files will go to ' + raw : 'Using app data directory';
+      wsMsg.style.color = 'var(--fg)';
+      setTimeout(function() {
+        wsMsg.textContent = raw ? 'Where write_file, read_file, and bash/python commands run.' : 'Where write_file, read_file, and bash/python commands run. Leave blank to use the app data directory.';
+        wsMsg.style.color = '';
+      }, 3000);
+    } catch (e) { wsMsg.textContent = 'Failed to save'; wsMsg.style.color = 'var(--red)'; }
+  }
+
   toolsInput.addEventListener('change', save);
+  if (wsInput) wsInput.addEventListener('change', saveWorkspace);
   var cur = parseInt(toolsInput.value, 10) || 0;
   msg.textContent = cur > 0 ? 'Limit: ' + cur + ' tool calls per message' : 'Unlimited';
 }


### PR DESCRIPTION
## Problem

When a user asks a model to create a file (e.g. `write_file hello.txt`), the file either:
- Lands in the server process cwd (`/app` inside Docker — not volume-mounted, invisible to the user, deleted on container restart)
- Gets rejected by the new path confinement check with \"outside allowed roots\"

The model reports \"Wrote 11 bytes to hello-world.txt\" with no absolute path, and the user cannot find the file.

## Solution

Builds on the `tool_path_extra_roots` setting added in the recent path confinement PR by wiring it to a user-facing UI field and using it as the actual working directory for tool calls.

- **`_agent_workspace()`** — new helper in `tool_execution.py` that returns the first entry of `tool_path_extra_roots` when configured, falling back to `DATA_DIR`. Creates the directory if needed.
- **`bash` and `python`** subprocesses now run with `cwd=_agent_workspace()` so `pwd` is consistent and predictable across deployment methods
- **`write_file` / `read_file`** resolve relative paths against the workspace before the `_resolve_tool_path()` confinement check — relative paths are accepted and land in a known location rather than being rejected
- **System prompt** is injected with the actual workspace path so models know where they are and report the full path to users
- **Settings UI** adds a \"Workspace path\" field to the Agent card — users type a path (e.g. `~/workspace`) and it saves to `tool_path_extra_roots`. No JSON editing required.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| `write_file hello.txt` in Docker | Rejected or lands in `/app` (lost) | Lands in configured workspace or `data/` |
| `bash: pwd` | Returns server process cwd (unpredictable) | Returns configured workspace |
| Model reports file location | Relative filename only | Full absolute path |
| Configuring workspace | Edit `data/settings.json` manually | Settings → Agent → Workspace path field |

## Compatibility

- No breaking changes — `tool_path_extra_roots` defaults to `[]`, falling back to `DATA_DIR` (existing behaviour for unconfigured installs)
- Works within the existing path confinement system — `_resolve_tool_path()` still validates every path
- Sensitive path deny-list still applies regardless of workspace setting