### PR TITLE
Show the serving provider in the model-info card

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -4,7 +4,7 @@
 import uiModule from './ui.js';
 import markdownModule from './markdown.js';
 import { addAITTSButton } from './tts-ai.js';
-import { providerLogo } from './providers.js';
+import { providerLogo, providerLabel } from './providers.js';
 import settingsModule from './settings.js';
 import spinnerModule from './spinner.js';
 import { bindMenuDismiss } from './escMenuStack.js';
@@ -577,6 +577,12 @@ export function applyModelColor(roleEl, modelName) {
       if (logoHtml) html += '<span class="role-provider-logo" style="opacity:0.7">' + logoHtml + '</span>';
       html += short + '</div>';
       html += '<div><span class="ctx-label">Model</span> ' + modelName.split('/').pop() + '</div>';
+      // Provider = the serving endpoint, distinct from the model vendor/logo
+      // (e.g. the same model via OpenRouter vs Copilot vs Anthropic direct).
+      const _epUrl = (window.sessionModule && window.sessionModule.getCurrentEndpointUrl)
+        ? window.sessionModule.getCurrentEndpointUrl() : null;
+      const _provLabel = providerLabel(_epUrl);
+      if (_provLabel) html += '<div><span class="ctx-label">Provider</span> ' + uiModule.esc(_provLabel) + '</div>';
       // Show static context initially, then fetch real from server
       const _realCtx = window._realContextLengths && window._realContextLengths[modelName];
       if (_realCtx) {

--- a/static/js/providers.js
+++ b/static/js/providers.js
@@ -90,4 +90,49 @@ export function providerLogo(modelId) {
   return null;
 }
 
-export default { providerLogo };
+// Host substring → friendly provider label. The model-info card shows this so
+// the SAME model name served by DIFFERENT routes is distinguishable (e.g.
+// `claude-haiku` via OpenRouter vs GitHub Copilot vs Anthropic direct) — the
+// logo only reflects the model vendor, not the actual endpoint.
+const _ENDPOINT_LABELS = [
+  [/githubcopilot\.com|copilot/i, "GitHub Copilot"],
+  [/openrouter\.ai/i, "OpenRouter"],
+  [/api\.anthropic\.com/i, "Anthropic"],
+  [/api\.openai\.com/i, "OpenAI"],
+  [/generativelanguage\.googleapis\.com|aiplatform\.googleapis\.com/i, "Google"],
+  [/bedrock.*\.amazonaws\.com/i, "AWS Bedrock"],
+  [/deepseek\.com/i, "DeepSeek"],
+  [/mistral\.ai/i, "Mistral"],
+  [/groq\.com/i, "Groq"],
+  [/together\.(ai|xyz)/i, "Together"],
+  [/fireworks\.ai/i, "Fireworks"],
+  [/perplexity\.ai/i, "Perplexity"],
+  [/x\.ai/i, "xAI"],
+];
+
+/**
+ * Friendly label for the endpoint that served a model, from its URL.
+ * Returns "Local" for loopback/LAN hosts, a known provider name when matched,
+ * else the bare host. Null when no URL is available.
+ */
+export function providerLabel(endpointUrl) {
+  if (!endpointUrl || typeof endpointUrl !== "string") return null;
+  let host;
+  try {
+    host = new URL(endpointUrl).hostname;
+  } catch (_) {
+    // Not a full URL (e.g. bare host[:port]) — strip scheme/path/port best-effort.
+    host = endpointUrl.replace(/^[a-z]+:\/\//i, "").split("/")[0].split(":")[0];
+  }
+  if (!host) return null;
+  if (/^(localhost|127\.|0\.0\.0\.0|::1|192\.168\.|10\.|172\.(1[6-9]|2\d|3[01])\.)/i.test(host)) {
+    return "Local";
+  }
+  for (const [re, label] of _ENDPOINT_LABELS) {
+    if (re.test(endpointUrl)) return label;
+  }
+  // Unknown host → drop a leading "api." for a cleaner readout.
+  return host.replace(/^api\./i, "");
+}
+
+export default { providerLogo, providerLabel };

--- a/static/js/providers.js
+++ b/static/js/providers.js
@@ -90,24 +90,26 @@ export function providerLogo(modelId) {
   return null;
 }
 
-// Host substring → friendly provider label. The model-info card shows this so
-// the SAME model name served by DIFFERENT routes is distinguishable (e.g.
-// `claude-haiku` via OpenRouter vs GitHub Copilot vs Anthropic direct) — the
-// logo only reflects the model vendor, not the actual endpoint.
+// Host suffix → friendly provider label. The model-info card shows this so the
+// SAME model name served by DIFFERENT routes is distinguishable (e.g.
+// `claude-haiku` via OpenRouter vs GitHub Copilot vs Anthropic direct); the logo
+// only reflects the model vendor, not the actual endpoint. Patterns are anchored
+// to the end of the hostname (^|.)domain$ so a host like `max.airlines.com`
+// doesn't match `x.ai`.
 const _ENDPOINT_LABELS = [
-  [/githubcopilot\.com|copilot/i, "GitHub Copilot"],
-  [/openrouter\.ai/i, "OpenRouter"],
-  [/api\.anthropic\.com/i, "Anthropic"],
-  [/api\.openai\.com/i, "OpenAI"],
-  [/generativelanguage\.googleapis\.com|aiplatform\.googleapis\.com/i, "Google"],
-  [/bedrock.*\.amazonaws\.com/i, "AWS Bedrock"],
-  [/deepseek\.com/i, "DeepSeek"],
-  [/mistral\.ai/i, "Mistral"],
-  [/groq\.com/i, "Groq"],
-  [/together\.(ai|xyz)/i, "Together"],
-  [/fireworks\.ai/i, "Fireworks"],
-  [/perplexity\.ai/i, "Perplexity"],
-  [/x\.ai/i, "xAI"],
+  [/(^|\.)githubcopilot\.com$/i, "GitHub Copilot"],
+  [/(^|\.)openrouter\.ai$/i, "OpenRouter"],
+  [/(^|\.)anthropic\.com$/i, "Anthropic"],
+  [/(^|\.)openai\.com$/i, "OpenAI"],
+  [/(^|\.)(generativelanguage|aiplatform)\.googleapis\.com$/i, "Google"],
+  [/(^|\.)bedrock[\w.-]*\.amazonaws\.com$/i, "AWS Bedrock"],
+  [/(^|\.)deepseek\.com$/i, "DeepSeek"],
+  [/(^|\.)mistral\.ai$/i, "Mistral"],
+  [/(^|\.)groq\.com$/i, "Groq"],
+  [/(^|\.)together\.(ai|xyz)$/i, "Together"],
+  [/(^|\.)fireworks\.ai$/i, "Fireworks"],
+  [/(^|\.)perplexity\.ai$/i, "Perplexity"],
+  [/(^|\.)x\.ai$/i, "xAI"],
 ];
 
 /**
@@ -129,7 +131,7 @@ export function providerLabel(endpointUrl) {
     return "Local";
   }
   for (const [re, label] of _ENDPOINT_LABELS) {
-    if (re.test(endpointUrl)) return label;
+    if (re.test(host)) return label;
   }
   // Unknown host → drop a leading "api." for a cleaner readout.
   return host.replace(/^api\./i, "");


### PR DESCRIPTION
## Summary

The model-info card (click a model name on a message) shows the model + pricing with a logo inferred from the model **name**. The same model can be served by different endpoints — e.g. `claude-haiku` via OpenRouter vs GitHub Copilot vs Anthropic direct — which the name-based logo can't distinguish. This adds a **Provider** line, derived from the session's endpoint URL, so the actual route is visible. Frontend-only, additive.

## Linked Issue

Fixes #2184

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

### Files
- `static/js/providers.js` — new `providerLabel(endpointUrl)`: host → friendly label (GitHub Copilot, OpenRouter, Anthropic, OpenAI, Google, AWS Bedrock, DeepSeek, Mistral, Groq, Together, Fireworks, Perplexity, xAI), `Local` for loopback/LAN, else the bare host (drops a leading `api.`).
- `static/js/chatRenderer.js` — render a **Provider** line under **Model** in the card, from `window.sessionModule.getCurrentEndpointUrl()` (value `esc`'d).

## How to Test

1. Configure the same model name on two endpoints (e.g. a model via OpenRouter and via GitHub Copilot / a local server).
2. Open a chat on each, click the model name on an assistant message.
3. The card shows a **Provider** line: "OpenRouter" / "GitHub Copilot" / "Local" / etc. — distinct per endpoint, while the model name (and vendor logo) is the same.
4. `node --check static/js/providers.js static/js/chatRenderer.js` — passes.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below. _(To be attached.)_
- [x] **Style match**: adds one line in the existing model-info card reusing the existing `.ctx-label` styling — no new colors, fonts, or spacing.
  - [x] **No Unicode emoji in UI or code.**
  - [x] Monospaced font / dark theme untouched.
- [x] **No new component patterns** — extends the existing card and `providers.js`.
- [x] **I am not an LLM agent submitting a bulk PR.** An issue (#2184) was opened first describing the feature, per CONTRIBUTING.

### Screenshots / clips

Existing UI element, just added the Provider line. (In this case pointing to the copilot provider I added in #1480)
<img width="683" height="230" alt="image" src="https://github.com/user-attachments/assets/8bb94db5-d94b-4589-aa92-d5c5866f8c09" />