### PR TITLE
fix : pin numpy to <2.4 for x86_v2  CPU non-compatibility for older cpus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ SQLAlchemy
 pypdf
 beautifulsoup4
 charset-normalizer
-numpy
+numpy<2.4
 # Vector store + local embeddings for RAG, semantic memory, and tool
 # selection. Used on core agent paths, so installed by default — the app
 # still degrades to keyword fallback if they're ever missing.


### PR DESCRIPTION
## Summary
Pinned `numpy` to `<2.4` in `requirements.txt`. Starting from version 2.4, numpy ships binaries compiled with x86-64-v2 optimization, which cause RuntimeError at import time on CPUs that do not support x86_v2.

## Linked Issue
<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #1515  |  Part of #1515  |  Closes #1515  -->
Fixes #1515 

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test
1. On a machine with a CPU that does **not** support x86-64-v2 (in my case, Intel core duo T6400), clone the repo and run `pip install -r requirements.txt`.
2. Start the app with `uvicorn app:app`.
3. Verify the app starts without numpy import failures.

ERROR IN MY CASE:
RuntimeError: NumPy was built with baseline optimizations: 
(X86_V2) but your machine doesn't support:
(X86_V2).


## Visual / UI changes — REQUIRED if you touched anything that renders
N/A — this change only affects `requirements.txt`. No UI, CSS, HTML, or JS was modified.