### PR TITLE
fix(email): retry calendar extraction after transient LLM errors

### DIFF
--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -45,6 +45,29 @@ from routes.email_helpers import (
 logger = logging.getLogger(__name__)
 
 
+def _record_calendar_extraction(message_id: str, uid, events_created: int, existing: set[str]) -> None:
+    """Mark an email's calendar extraction as completed.
+
+    This is intentionally called only after the extraction LLM call returns.
+    Transient LLM failures must leave the message unmarked so the next poll can
+    retry instead of permanently skipping calendar extraction.
+    """
+    try:
+        import sqlite3 as _sql3
+        _cc = _sql3.connect(SCHEDULED_DB)
+        _cc.execute(
+            "INSERT OR REPLACE INTO email_calendar_extractions "
+            "(message_id, uid, events_created, created_at) VALUES (?, ?, ?, ?)",
+            (message_id, uid.decode() if isinstance(uid, bytes) else str(uid),
+             events_created, datetime.utcnow().isoformat())
+        )
+        _cc.commit()
+        _cc.close()
+        existing.add(message_id)
+    except Exception as ce:
+        logger.debug(f"Could not cache calendar extraction: {ce}")
+
+
 def _owner_for_email_account(account_id: str | None) -> str:
     if not account_id:
         return ""
@@ -670,20 +693,11 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                                 logger.warning(f"[cal-extract] JSON parse failed: {je} on raw={cal_extract[:200]!r}")
                     except Exception as e:
                         logger.warning(f"[cal-extract] Meeting extraction LLM call failed for uid={uid}: {e}")
-                    # Record we processed this email so we don't re-LLM next run
-                    try:
-                        _cc = _sql3.connect(SCHEDULED_DB)
-                        _cc.execute(
-                            "INSERT OR REPLACE INTO email_calendar_extractions "
-                            "(message_id, uid, events_created, created_at) VALUES (?, ?, ?, ?)",
-                            (message_id, uid.decode() if isinstance(uid, bytes) else str(uid),
-                             _cal_run_count, datetime.utcnow().isoformat())
-                        )
-                        _cc.commit()
-                        _cc.close()
-                        _cal_existing.add(message_id)
-                    except Exception as ce:
-                        logger.debug(f"Could not cache calendar extraction: {ce}")
+                    else:
+                        # Record only after the extraction LLM call has returned.
+                        # If it failed transiently, leave the message unmarked so
+                        # a later poll can retry calendar extraction.
+                        _record_calendar_extraction(message_id, uid, _cal_run_count, _cal_existing)
 
                 if need_urgent:
                     try:

--- a/tests/test_email_calendar_extraction_retry.py
+++ b/tests/test_email_calendar_extraction_retry.py
@@ -1,0 +1,71 @@
+import ast
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "routes" / "email_pollers.py"
+SOURCE_TEXT = MODULE_PATH.read_text(encoding="utf-8")
+
+
+def _load_record_helper():
+    tree = ast.parse(SOURCE_TEXT)
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_record_calendar_extraction"
+    )
+    ns = {
+        "SCHEDULED_DB": "",
+        "datetime": datetime,
+        "logger": logging.getLogger("test_email_calendar_extraction_retry"),
+    }
+    ast.fix_missing_locations(helper)
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), str(MODULE_PATH), "exec"), ns)
+    return ns
+
+
+def test_record_calendar_extraction_persists_success(tmp_path):
+    ns = _load_record_helper()
+    db_path = tmp_path / "scheduled.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE email_calendar_extractions ("
+        "message_id TEXT PRIMARY KEY, uid TEXT, events_created INTEGER, created_at TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    ns["SCHEDULED_DB"] = str(db_path)
+
+    existing = set()
+    ns["_record_calendar_extraction"]("msg-1", b"42", 2, existing)
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT message_id, uid, events_created FROM email_calendar_extractions"
+    ).fetchone()
+    conn.close()
+
+    assert row == ("msg-1", "42", 2)
+    assert "msg-1" in existing
+
+
+def test_calendar_extraction_cache_is_after_llm_success_path():
+    source = ast.parse(SOURCE_TEXT)
+
+    for node in ast.walk(source):
+        if not isinstance(node, ast.Try):
+            continue
+        handler_text = "\n".join(
+            ast.get_source_segment(SOURCE_TEXT, h) or "" for h in node.handlers
+        )
+        if "Meeting extraction LLM call failed" not in handler_text:
+            continue
+
+        else_text = "\n".join(
+            ast.get_source_segment(SOURCE_TEXT, stmt) or "" for stmt in node.orelse
+        )
+        assert "_record_calendar_extraction" not in handler_text
+        assert "_record_calendar_extraction" in else_text
+        return
+
+    raise AssertionError("calendar extraction LLM try/except block not found")


### PR DESCRIPTION
## Summary

The email auto-calendar pass previously wrote to `email_calendar_extractions` after the extraction try/except, so a transient LLM failure marked the message as processed and prevented future retries.

This PR moves that cache write onto the successful extraction-call path and extracts it into a small helper, so failures leave the message eligible for the next poll.

## Linked Issue

Fixes #2165

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the smallest relevant checks listed below.

## Files

- `routes/email_pollers.py` — record calendar extraction completion only after the extraction LLM call returns.
- `tests/test_email_calendar_extraction_retry.py` — regression coverage for the cache helper and success-path placement.

## How to Test

- `python3 -m pytest tests/test_email_calendar_extraction_retry.py`
- `python3 -m py_compile routes/email_pollers.py`
- `git diff --check origin/main...HEAD`

## Duplicate preflight

Authenticated preflight found no open PRs for: `#2165`, `email poller marks calendar extraction`, `email_calendar_extractions`, `cal-extract` + `LLM call failed`, `routes/email_pollers.py` + `calendar extraction`, and `meetings permanently skipped`. Nearby email/calendar PRs inspected did not touch `routes/email_pollers.py` or this calendar-extraction retry path.
