### PR TITLE
 fix(ui): prevent settings widget from resetting position on tab change. (IMPORTANT)

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -4348,7 +4348,9 @@ function syncAdminVisibility() {
 export function open(tab) {
   if (!initialized) initAll();
   syncAppearanceCheckboxes();
-  resetWindowPlacement();
+  if (modalEl.classList.contains('hidden')) {
+    resetWindowPlacement();
+  }
   modalEl.classList.remove('hidden');
   syncAdminVisibility();
   const content = modalEl.querySelector('.settings-modal-content');


### PR DESCRIPTION
## Summary

This PR fixes a UI bug where the settings widget resets its position and snaps back to the center of the screen when navigating between tabs. The position reset was consistently triggered when clicking on any of the following tabs: "Add Models", "Integrations", "Agent Tools", "Users", and "System".

## Linked Issue

Fixes #2106

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Launch the application and open the Settings widget.
2. Drag and move the settings widget to any custom position on the screen.
3. Click through the different tabs: "Add Models", "Integrations", "Agent Tools", "Users", and "System".
4. **Verify** that the widget preserves its dragged position and no longer snaps back to the center of the screen on any of those tab changes.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips
<img width="890" height="512" alt="image" src="https://github.com/user-attachments/assets/dcfaa52e-1cda-43e8-a97f-bdd74c0f99bc" />
<img width="893" height="548" alt="image" src="https://github.com/user-attachments/assets/1af57866-b778-4264-8740-1df0afdd8a79" />
NOTICE that after clicking "Add models" the widget resetted its position.