### PR TITLE
fix: make preset saves atomic

### DIFF
--- a/src/preset_manager.py
+++ b/src/preset_manager.py
@@ -1,9 +1,18 @@
 import os
 import json
 import logging
+import importlib.util
+from pathlib import Path
 from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
+
+_ATOMIC_IO_PATH = Path(__file__).resolve().parents[1] / "core" / "atomic_io.py"
+_atomic_io_spec = importlib.util.spec_from_file_location("_odysseus_atomic_io", _ATOMIC_IO_PATH)
+_atomic_io = importlib.util.module_from_spec(_atomic_io_spec)
+_atomic_io_spec.loader.exec_module(_atomic_io)
+atomic_write_json = _atomic_io.atomic_write_json
+
 
 class PresetManager:
     DEFAULT_PRESETS = {
@@ -113,11 +122,9 @@ Use precise language. Show causal relationships explicitly. Quantify uncertainty
             return self.DEFAULT_PRESETS.copy()
     
     def save(self, presets: Dict[str, Any]) -> bool:
-        """Save presets to file"""
+        """Save presets to file atomically."""
         try:
-            os.makedirs(os.path.dirname(self.presets_file), exist_ok=True)
-            with open(self.presets_file, 'w', encoding="utf-8") as f:
-                json.dump(presets, f, indent=2)
+            atomic_write_json(self.presets_file, presets, indent=2)
             self.presets = presets
             return True
         except Exception as e:
@@ -139,17 +146,20 @@ Use precise language. Show causal relationships explicitly. Quantify uncertainty
         inject_suffix: str = "",
     ) -> bool:
         """Update the custom preset"""
-        self.presets["custom"] = {
-            "name": name or "Custom",
-            "character_name": name,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "system_prompt": system_prompt,
-            "inject_prefix": inject_prefix,
-            "inject_suffix": inject_suffix,
-            "enabled": enabled,
+        presets = {
+            **self.presets,
+            "custom": {
+                "name": name or "Custom",
+                "character_name": name,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "system_prompt": system_prompt,
+                "inject_prefix": inject_prefix,
+                "inject_suffix": inject_suffix,
+                "enabled": enabled,
+            },
         }
-        return self.save(self.presets)
+        return self.save(presets)
     
     def get_all(self) -> Dict[str, Any]:
         """Get all presets"""
@@ -161,21 +171,20 @@ Use precise language. Show causal relationships explicitly. Quantify uncertainty
 
     def save_user_template(self, template: dict) -> bool:
         """Save a new user template or update existing by id."""
-        templates = self.presets.get("user_templates", [])
+        templates = list(self.presets.get("user_templates", []))
         # Update existing if same id
         existing = next((i for i, t in enumerate(templates) if t.get("id") == template.get("id")), None)
         if existing is not None:
             templates[existing] = template
         else:
             templates.append(template)
-        self.presets["user_templates"] = templates
-        return self.save(self.presets)
+        return self.save({**self.presets, "user_templates": templates})
 
     def delete_user_template(self, template_id: str) -> bool:
         """Delete a user template by id."""
         templates = self.presets.get("user_templates", [])
-        self.presets["user_templates"] = [t for t in templates if t.get("id") != template_id]
-        return self.save(self.presets)
+        updated_templates = [t for t in templates if t.get("id") != template_id]
+        return self.save({**self.presets, "user_templates": updated_templates})
 
     def get_group_presets(self) -> list:
         """Get saved group chat presets."""
@@ -183,5 +192,4 @@ Use precise language. Show causal relationships explicitly. Quantify uncertainty
 
     def save_group_presets(self, groups: list) -> bool:
         """Save group chat presets."""
-        self.presets["group_presets"] = groups
-        return self.save(self.presets)
+        return self.save({**self.presets, "group_presets": groups})

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -257,6 +257,54 @@ def test_preset_manager_persists_inject_fields(tmp_path):
     assert reloaded.presets["custom"]["inject_suffix"] == "SUFFIX"
 
 
+def test_preset_manager_save_preserves_existing_file_if_replace_fails(tmp_path, monkeypatch):
+    manager = PresetManager(str(tmp_path))
+    presets_file = tmp_path / "presets.json"
+    before = presets_file.read_text(encoding="utf-8")
+
+    import src.preset_manager as preset_manager
+
+    def fail_replace(src, dst):
+        assert str(dst) == str(presets_file)
+        raise OSError("simulated crash before replace")
+
+    monkeypatch.setattr(preset_manager._atomic_io.os, "replace", fail_replace)
+
+    ok = manager.save({
+        **manager.presets,
+        "custom": {
+            **manager.presets["custom"],
+            "enabled": True,
+            "system_prompt": "unsaved",
+        },
+    })
+
+    assert ok is False
+    assert presets_file.read_text(encoding="utf-8") == before
+    assert json.loads(presets_file.read_text(encoding="utf-8")) == json.loads(before)
+    assert manager.presets["custom"]["enabled"] is False
+    assert manager.presets["custom"]["system_prompt"] == ""
+
+
+def test_preset_manager_update_custom_keeps_memory_state_on_save_failure(tmp_path, monkeypatch):
+    manager = PresetManager(str(tmp_path))
+    before = json.loads((tmp_path / "presets.json").read_text(encoding="utf-8"))
+
+    monkeypatch.setattr("src.preset_manager.atomic_write_json", MagicMock(side_effect=OSError("disk full")))
+
+    ok = manager.update_custom(
+        temperature=0.7,
+        max_tokens=2048,
+        system_prompt="not saved",
+        name="Custom",
+        enabled=True,
+    )
+
+    assert ok is False
+    assert manager.presets == before
+    assert json.loads((tmp_path / "presets.json").read_text(encoding="utf-8")) == before
+
+
 def test_preset_manager_default_custom_preset_starts_disabled(tmp_path):
     manager = PresetManager(str(tmp_path))
 


### PR DESCRIPTION
## Summary

Make preset persistence crash-safe by writing `presets.json` atomically and only updating `PresetManager`'s in-memory state after the file is successfully persisted. This prevents a mid-write crash, disk error, or failed replace from truncating the live preset store and losing user presets.

## Linked Issue

Fixes #2167

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `/private/tmp/odysseus-preset-venv/bin/python -m pytest tests/test_review_regressions.py -k 'preset_manager' -q` and confirm the preset manager regression tests pass.
2. Run `/private/tmp/odysseus-preset-venv/bin/python -m pytest tests/test_preset_fill_missing_defaults.py tests/test_preset_store_shape.py tests/test_atomic_io.py -q` and confirm nearby preset/default and atomic I/O behavior still passes.
3. Run `python3 -m py_compile src/preset_manager.py tests/test_review_regressions.py tests/test_preset_fill_missing_defaults.py tests/test_preset_store_shape.py tests/test_atomic_io.py` and confirm the changed Python files compile.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI or visual rendering changes. This PR only touches preset persistence logic and backend tests.

### Screenshots / clips

Not applicable; no UI or visual changes.
