### PR TITLE
fix(caldav): scope event upsert lookup to current calendar

### DIFF
--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -237,6 +237,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str) -> dict:
 
                         existing = pending.get(uid_val) or db.query(CalendarEvent).filter(
                             CalendarEvent.uid == uid_val,
+                            CalendarEvent.calendar_id == local_cal.id,
                         ).first()
                         if existing:
                             existing.calendar_id = local_cal.id


### PR DESCRIPTION
## Summary

When syncing a CalDAV account with multiple calendars, the event upsert
lookup filtered only by `uid`, not by `calendar_id`. If two calendars
contain events with the same UID (common on iCloud), the second
calendar's sync finds the first calendar's row and overwrites it —
silently moving the event to the wrong calendar and making it disappear
from the original.

Fix: add `CalendarEvent.calendar_id == local_cal.id` to the filter so
each calendar's events are looked up independently.

## Linked Issue

Fixes #1975

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I searched existing issues and PRs and did not find a duplicate.

## How to Test

1. Configure a CalDAV account with two or more calendars (iCloud works well).
2. Ensure both calendars contain at least one event, ideally with the same UID.
3. Trigger a sync and check that events from all calendars appear correctly.
4. Before this fix, events from later calendars would overwrite earlier ones with the same UID.