### PR TITLE
chore: remove unused uuid import in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,6 @@ from dotenv import load_dotenv
 # is silently ignored and the user is unexpectedly forced to log in (issue #142).
 # utf-8-sig reads plain UTF-8 (no BOM) identically, so this is safe everywhere.
 load_dotenv(encoding="utf-8-sig")
-import uuid
 
 import asyncio
 import logging


### PR DESCRIPTION
## Summary

`app.py` imports `uuid` but never uses it. This removes the dead import. No behaviour change. Scoped to a single line.

## Linked Issue

Fixes #2217

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified it still starts.

## How to Test

1. `python -m pyflakes app.py` — no longer reports "'uuid' imported but unused".
2. `grep -c uuid app.py` → `0`.
3. `python -m py_compile app.py` — passes.
4. Full suite: `python -m pytest` → 1819 passed, 19 pre-existing failures (env/isolation-dependent; unrelated to this change — they fail identically on unmodified `main`).

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes — backend-only removal of a dead import. Not applicable.