### PR TITLE
chore: remove unused imports in calendar_routes

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -3,16 +3,15 @@
 import logging
 import uuid
 from datetime import datetime, date, timedelta
-from typing import Optional, List, Tuple
+from typing import Optional, List
 
 from fastapi import APIRouter, HTTPException, Request, UploadFile, File
 from pydantic import BaseModel
 from sqlalchemy import or_, and_
-from dateutil.rrule import rrulestr, rruleset
-from dateutil.rrule import DAILY, WEEKLY, MONTHLY, YEARLY
+from dateutil.rrule import rrulestr
 
 from core.database import SessionLocal, CalendarCal, CalendarEvent
-from src.auth_helpers import get_current_user, require_user
+from src.auth_helpers import require_user
 from src.upload_limits import read_upload_limited
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

`routes/calendar_routes.py` imports `typing.Tuple`, `dateutil.rrule.{rruleset,DAILY,WEEKLY,MONTHLY,YEARLY}`, and `src.auth_helpers.get_current_user` but never uses them. This removes the dead imports (keeping `Optional`, `List`, `rrulestr`, `require_user`, which are used). No behaviour change. Scoped to one file.

## Linked Issue

Fixes #2220

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the calendar routes still work.

## How to Test

1. `python -m pyflakes routes/calendar_routes.py` — no longer reports the unused imports.
2. `python -m py_compile routes/calendar_routes.py` — passes.
3. Full suite: `python -m pytest` → 1819 passed, 19 pre-existing failures (env/isolation-dependent; unrelated — identical on unmodified `main`).
4. App starts; calendar list/create/recurring-event endpoints work as before (`rrulestr` + `require_user`, the kept symbols, are the ones actually used).

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes — backend-only removal of dead imports. Not applicable.