### PR TITLE
fix: normalize Gemma 4 thought-channel output

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -589,6 +589,8 @@ def _normalize_thinking(text: str) -> str:
     import re
     if not text:
         return text
+    from src.text_helpers import normalize_thinking_markup
+    text = normalize_thinking_markup(text)
     reasoning_prefix_re = re.compile(
         r'^\s*(?:thinking(?:\s+process)?\s*:|the user |i need |i should |i will |they are |the question |i can )',
         re.IGNORECASE,
@@ -699,6 +701,10 @@ def _extract_thinking_meta(text: str) -> dict | None:
     import re
     if not text:
         return None
+    from src.text_helpers import normalize_thinking_markup
+    original_text = text
+    text = normalize_thinking_markup(text)
+    normalized_changed = text != original_text
 
     # Check for <think> tags (native or injected)
     time_match = re.search(r'<think(?:ing)?\s+time="([\d.]+)"', text)
@@ -729,6 +735,9 @@ def _extract_thinking_meta(text: str) -> dict | None:
             if thinking and reply:
                 return {"thinking": thinking, "reply": reply, "time": think_time}
 
+    if normalized_changed and text.strip() and text.strip() != original_text.strip():
+        return {"thinking": "", "reply": text.strip(), "time": think_time}
+
     return None
 
 
@@ -737,7 +746,8 @@ def clean_thinking_for_save(content: str, metadata: dict | None = None) -> tuple
     md = dict(metadata) if metadata else {}
     info = _extract_thinking_meta(content)
     if info:
-        md["thinking"] = info["thinking"]
+        if info.get("thinking"):
+            md["thinking"] = info["thinking"]
         if info.get("time"):
             md["thinking_time"] = info["time"]
         return info["reply"], md
@@ -781,8 +791,10 @@ def save_assistant_response(
     # Extract thinking into metadata (don't pollute message content with <think> tags)
     _think_info = _extract_thinking_meta(full_response)
     if _think_info:
-        md["thinking"] = _think_info["thinking"]
-        md["thinking_time"] = _think_info.get("time")
+        if _think_info.get("thinking"):
+            md["thinking"] = _think_info["thinking"]
+        if _think_info.get("time"):
+            md["thinking_time"] = _think_info.get("time")
         _content = _think_info["reply"]
     else:
         _content = full_response

--- a/src/text_helpers.py
+++ b/src/text_helpers.py
@@ -15,18 +15,33 @@ from __future__ import annotations
 
 import re
 
+_THINK_TAG_NAME = r"(?:think(?:ing)?|thought)"
+
 # Closed reasoning blocks. Multi-pass loop in `strip_think` handles nested
 # `<think><think>...</think></think>` patterns some models emit.
-_THINK_CLOSED_RE = re.compile(r"<think(?:ing)?>[\s\S]*?</think(?:ing)?>\s*", re.IGNORECASE)
+_THINK_CLOSED_RE = re.compile(rf"<{_THINK_TAG_NAME}(?:\s+[^>]*)?>[\s\S]*?</{_THINK_TAG_NAME}>\s*", re.IGNORECASE)
 # Orphan opening or closing tags that survive after the closed-pass.
-_THINK_TAG_RE = re.compile(r"</?think(?:ing)?[^>]*>\s*", re.IGNORECASE)
+_THINK_TAG_RE = re.compile(rf"</?{_THINK_TAG_NAME}[^>]*>\s*", re.IGNORECASE)
 # Dangling opener anywhere in the response with no closer — strip everything
 # from `<think>` to the end of string.
-_THINK_OPEN_RE = re.compile(r"<think(?:ing)?>[\s\S]*$", re.IGNORECASE)
+_THINK_OPEN_RE = re.compile(rf"<{_THINK_TAG_NAME}(?:\s+[^>]*)?>[\s\S]*$", re.IGNORECASE)
 # Streaming models occasionally emit `<thinking time="0.42">`-style attributes.
 # Normalize to a plain `<think>` so the regexes above catch them.
-_THINK_ATTR_RE = re.compile(r"<think(?:ing)?\s+[^>]*>", re.IGNORECASE)
-_THINK_ATTR_CLOSE_RE = re.compile(r"</think(?:ing)?\s+[^>]*>", re.IGNORECASE)
+_THINK_ATTR_RE = re.compile(rf"<{_THINK_TAG_NAME}\s+[^>]*>", re.IGNORECASE)
+_THINK_ATTR_CLOSE_RE = re.compile(rf"</{_THINK_TAG_NAME}\s+[^>]*>", re.IGNORECASE)
+_GEMMA_THOUGHT_OPEN_RE = re.compile(r"<\|channel>thought\s*\n?[\s\S]*$", re.IGNORECASE)
+_GEMMA_RESPONSE_CHANNEL_RE = re.compile(
+    r"<\|channel>response\s*\n?([\s\S]*?)<channel\|>",
+    re.IGNORECASE,
+)
+_GEMMA_RESPONSE_OPEN_RE = re.compile(r"<\|channel>response\s*\n?", re.IGNORECASE)
+_GEMMA_CHANNEL_CLOSE_RE = re.compile(r"<channel\|>", re.IGNORECASE)
+_THOUGHT_TAG_OPEN_RE = re.compile(r"<thought(\s+[^>]*)?>", re.IGNORECASE)
+_THOUGHT_TAG_CLOSE_RE = re.compile(r"</thought>", re.IGNORECASE)
+_GEMMA_THOUGHT_CHANNEL_CAPTURE_RE = re.compile(
+    r"<\|channel>thought\s*\n?([\s\S]*?)<channel\|>\s*",
+    re.IGNORECASE,
+)
 # Qwen and a few other models prefix the response with a "Thinking Process:"
 # block before the real answer.
 _QWEN_THINKING_RE = re.compile(
@@ -78,6 +93,30 @@ def _strip_reasoning_prose(text: str) -> str:
     return "\n\n".join(keep).strip() if keep else text
 
 
+def normalize_thinking_markup(text: str) -> str:
+    """Canonicalize supported thinking wrappers to `<think>` markup.
+
+    The chat UI and persistence layer already understand `<think>...</think>`.
+    Gemma 4 may instead emit `<|channel>thought\n...<channel|>`, and some
+    gateways/models emit `<thought>...</thought>`. Normalize those shapes into
+    the existing representation and strip empty thought channels.
+    """
+    if not text:
+        return text
+    out = _THOUGHT_TAG_OPEN_RE.sub(lambda m: "<think" + (m.group(1) or "") + ">", text)
+    out = _THOUGHT_TAG_CLOSE_RE.sub("</think>", out)
+
+    def _replace_gemma_thought(match: re.Match) -> str:
+        thought = match.group(1).strip()
+        return f"<think>{thought}</think>\n" if thought else ""
+
+    out = _GEMMA_THOUGHT_CHANNEL_CAPTURE_RE.sub(_replace_gemma_thought, out)
+    out = _GEMMA_RESPONSE_CHANNEL_RE.sub(lambda m: m.group(1), out)
+    out = _GEMMA_RESPONSE_OPEN_RE.sub("", out)
+    out = _GEMMA_CHANNEL_CLOSE_RE.sub("", out)
+    return out
+
+
 def strip_think(text: str, *, prose: bool = False, prompt_echo: bool = True) -> str:
     """Strip `<think>` blocks from model output.
 
@@ -92,13 +131,21 @@ def strip_think(text: str, *, prose: bool = False, prompt_echo: bool = True) -> 
         "The user asks:" / "We need to" leaked prompt echoes.
 
     Robust to:
-      * closed `<think>...</think>` (any depth, both `<think>` and `<thinking>`)
-      * dangling unclosed `<think>...`
+      * closed `<think>...</think>` (any depth, plus `<thinking>`/`<thought>`)
+      * dangling unclosed `<think>...` / `<thought>...`
       * stray opener/closer tags
       * `<think time="0.42">`-style attributes
+      * Gemma 4 `<|channel>thought...<channel|>` wrappers
     """
     if not text:
         return ""
+    # Gemma 4 thinking-capable models use channel control tokens rather than
+    # XML tags when the runtime does not split reasoning into a separate field.
+    # The thought channel can be empty in non-thinking mode; either way it is
+    # not user-facing content. A response channel, when present, is only a
+    # wrapper around the final answer.
+    text = normalize_thinking_markup(text)
+    text = _GEMMA_THOUGHT_OPEN_RE.sub("", text)
     # Normalize attributes so the closed/open regexes can catch them.
     text = _THINK_ATTR_RE.sub("<think>", text)
     text = _THINK_ATTR_CLOSE_RE.sub("</think>", text)

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1099,7 +1099,7 @@ import createResearchSynapse from './researchSynapse.js';
       let _measureDiv = null;
 
       function _replyAfterClosedThinking(text) {
-        const closeRe = /<\/think(?:ing)?>/gi;
+        const closeRe = /<\/(?:think(?:ing)?|thought)>|<channel\|>/gi;
         let match = null;
         let last = null;
         while ((match = closeRe.exec(text || '')) !== null) last = match;
@@ -1126,7 +1126,7 @@ import createResearchSynapse from './researchSynapse.js';
             replyTrimmed = (replyText || '').trim();
           } else {
             // Non-tag: check for garbled <think> (reasoning\n<think>reply)
-            const _gm = dt.match(/^[\s\S]+?<think(?:ing)?>\s*([\s\S]*?)(?:<\/think(?:ing)?>)?\s*$/i);
+            const _gm = dt.match(/^[\s\S]+?<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>\s*([\s\S]*?)(?:<\/(?:think(?:ing)?|thought)>)?\s*$/i);
             if (_gm && _gm[1].trim()) {
               replyTrimmed = _gm[1].trim();
             } else {
@@ -1167,8 +1167,11 @@ import createResearchSynapse from './researchSynapse.js';
         const prevLen = contentEl._prevTextLen || 0;
         // If thinking is still streaming (unclosed <think>), show indicator instead of raw text
         if (markdownModule.hasUnclosedThinkTag && markdownModule.hasUnclosedThinkTag(dt)) {
-          const thinkStart = dt.search(/<think(?:ing)?>/i);
-          const thinkContent = dt.substring(thinkStart).replace(/<think(?:ing)?>/i, '').trim();
+          const thinkStart = dt.search(/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>|<\|channel>thought/i);
+          const thinkContent = dt.substring(Math.max(thinkStart, 0))
+            .replace(/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>|<\|channel>thought\s*\n?/i, '')
+            .replace(/<channel\|>/gi, '')
+            .trim();
           const lines = thinkContent.split('\n').length;
           // Don't show beforeThink text during streaming — it'll appear in the final render
           // This prevents the "split into two" duplication
@@ -1427,7 +1430,7 @@ import createResearchSynapse from './researchSynapse.js';
                 // Detect non-tag thinking patterns: "Thinking:", "Thinking Process:", Gemma-style reasoning
                 // These patterns don't use <think> tags, so we simulate unclosed thinking during streaming
                 const _replyPrefixes = ['Hey', 'Hi ', 'Hi!', 'Hello', 'Sure', 'Yes', 'No ', 'No,', 'Yo', 'OK', 'Here', 'Absolutely', 'Of course', 'Great', 'Alright', 'Thanks', 'Welcome', 'Good ', "I'm happy", "I'd be"];
-                if (!hasUnclosedThink && !roundText.includes('<think')) {
+                if (!hasUnclosedThink && !/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>|<\|channel>thought/i.test(roundText)) {
                   const _trimmedRT = roundText.trimStart();
                   const _isReasoning = markdownModule.startsWithReasoningPrefix(_trimmedRT);
                   if (_isReasoning) {
@@ -1453,10 +1456,10 @@ import createResearchSynapse from './researchSynapse.js';
                     }
                   }
                 }
-                if (!hasUnclosedThink && /^<think(?:ing)?>\s*<\/think(?:ing)?>/i.test(roundText)) {
+                if (!hasUnclosedThink && /^<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>\s*<\/(?:think(?:ing)?|thought)>/i.test(roundText)) {
                   // Empty <think></think> — the model likely put thinking outside the tags
-                  const afterEmpty = roundText.replace(/^<think(?:ing)?>\s*<\/think(?:ing)?>/i, '').trim();
-                  const closeTags = (afterEmpty.match(/<\/think(?:ing)?>/gi) || []).length;
+                  const afterEmpty = roundText.replace(/^<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>\s*<\/(?:think(?:ing)?|thought)>/i, '').trim();
+                  const closeTags = (afterEmpty.match(/<\/(?:think(?:ing)?|thought)>/gi) || []).length;
                   if (closeTags === 0 && afterEmpty.length > 0) {
                     hasUnclosedThink = true; // still waiting for real closing tag
                   }
@@ -1465,13 +1468,13 @@ import createResearchSynapse from './researchSynapse.js';
                 // Only applies when there's a second </think> later (model leaked thinking outside tags)
                 // Do NOT trigger if the text after </think> contains tool calls (that's real content)
                 if (!hasUnclosedThink && isThinking) {
-                  const _thinkMatch = roundText.match(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/i);
+                  const _thinkMatch = roundText.match(/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>([\s\S]*?)<\/(?:think(?:ing)?|thought)>/i);
                   const _thinkLen = _thinkMatch ? _thinkMatch[1].trim().length : 0;
                   if (_thinkLen < 20) {
-                    const _afterClose = roundText.replace(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/i, '').trim();
+                    const _afterClose = roundText.replace(/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>([\s\S]*?)<\/(?:think(?:ing)?|thought)>/i, '').trim();
                     // Only keep waiting if there's trailing text that looks like thinking (not tool calls)
                     const _hasToolCall = /```(?:bash|python|web_search|read_file|write_file|create_document|edit_document|manage_|generate_image)/i.test(_afterClose);
-                    const _hasOrphanClose = /<\/think(?:ing)?>/i.test(_afterClose);
+                    const _hasOrphanClose = /<\/(?:think(?:ing)?|thought)>/i.test(_afterClose);
                     if (!_hasToolCall && (_hasOrphanClose || (Date.now() - thinkingStartTime) < 500)) {
                       hasUnclosedThink = true; // keep waiting for real </think>
                     }
@@ -1528,8 +1531,12 @@ import createResearchSynapse from './researchSynapse.js';
                   }
                 } else if (hasUnclosedThink && isThinking) {
                   if (_liveThinkInner) {
-                    // Extract raw thinking text (strip all <think>/<thinking> open/close tags and prefixes)
-                    var thinkText = roundText.replace(/<\/?think(?:ing)?>/gi, '');
+                    // Extract raw thinking text (strip known thinking wrappers and prefixes)
+                    var thinkText = roundText
+                      .replace(/<\/?(?:think(?:ing)?|thought)(?:\s+[^>]*)?>/gi, '')
+                      .replace(/<\|channel>thought\s*\n?/gi, '')
+                      .replace(/<\|channel>response\s*\n?/gi, '')
+                      .replace(/<channel\|>/gi, '');
                     thinkText = thinkText.replace(/^\s*Thinking(?:\s+Process)?:\s*/i, '');
                     _liveThinkInner.innerHTML = markdownModule.mdToHtml(thinkText);
                     // Keep thinking box scrolled to bottom
@@ -2354,8 +2361,8 @@ import createResearchSynapse from './researchSynapse.js';
               _finalReply = (_extracted.content || '').trim();
             } else {
               // Non-tag thinking: extract reply from raw text
-              // Handle garbled <think> tag: "Thinking: reasoning\n<think>reply"
-              const _garbledMatch = finalDisplay.match(/^[\s\S]+?<think(?:ing)?>\s*([\s\S]*?)(?:<\/think(?:ing)?>)?\s*$/i);
+              // Handle garbled thinking tag: "Thinking: reasoning\n<think>reply"
+              const _garbledMatch = finalDisplay.match(/^[\s\S]+?<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>\s*([\s\S]*?)(?:<\/(?:think(?:ing)?|thought)>)?\s*$/i);
               if (_garbledMatch && _garbledMatch[1].trim()) {
                 _finalReply = _garbledMatch[1].trim();
               } else {
@@ -2404,8 +2411,8 @@ import createResearchSynapse from './researchSynapse.js';
           _body4b.innerHTML = _sourcesData ? _buildSourcesBox(_sourcesData, _sourcesType, _wasExpanded2) : _sourcesHtml;
         } else if (roundHolder !== holder) {
           // Check if there's thinking content worth showing
-          const _thinkMatch = roundText.match(/<think(?:ing)?>([\s\S]*?)<\/think(?:ing)?>/i);
-          if (_thinkMatch && _thinkMatch[1].trim()) {
+          const _thinkingOnly = markdownModule.extractThinkingBlocks(roundText);
+          if (_thinkingOnly.thinkingBlocks?.length && !_thinkingOnly.content) {
             // Show thinking in a collapsed section even if no visible reply text
             const _body4c = roundHolder.querySelector('.body');
             if (_body4c) _body4c.innerHTML = markdownModule.processWithThinking(roundText);
@@ -4339,9 +4346,10 @@ import createResearchSynapse from './researchSynapse.js';
       // never closes (so it would otherwise hide the whole answer). Peel all of
       // those off so what's left is just the rewritten text.
       const _stripThink = (t) => {
-        t = t.replace(/<think>[\s\S]*?<\/think>/gi, '');   // complete blocks
-        if (/<\/think>/i.test(t)) t = t.replace(/^[\s\S]*?<\/think>/i, '');  // reasoning w/o opener
-        return t.replace(/<\/?think>/gi, '').trim();        // any orphan tag
+        t = markdownModule.normalizeThinkingMarkup(t || '');
+        t = t.replace(/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>[\s\S]*?<\/(?:think(?:ing)?|thought)>/gi, '');   // complete blocks
+        if (/<\/(?:think(?:ing)?|thought)>/i.test(t)) t = t.replace(/^[\s\S]*?<\/(?:think(?:ing)?|thought)>/i, '');  // reasoning w/o opener
+        return t.replace(/<\/?(?:think(?:ing)?|thought)(?:\s+[^>]*)?>/gi, '').trim();        // any orphan tag
       };
       newText = _stripThink(newText);
 

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -116,8 +116,13 @@ function sanitizeAllowedHtml(html) {
  * Check if text has unclosed think tag
  */
 export function hasUnclosedThinkTag(text) {
-  const openCount = (text.match(/<think(?:ing)?>/gi) || []).length;
-  const closeCount = (text.match(/<\/think(?:ing)?>/gi) || []).length;
+  text = text || '';
+  const openCount =
+    (text.match(/<(?:think(?:ing)?|thought)(?:\s+[^>]*)?>/gi) || []).length
+    + (text.match(/<\|channel>thought/gi) || []).length;
+  const closeCount =
+    (text.match(/<\/(?:think(?:ing)?|thought)>/gi) || []).length
+    + (text.match(/<channel\|>/gi) || []).length;
   return openCount > closeCount;
 }
 
@@ -125,8 +130,25 @@ export function startsWithReasoningPrefix(text) {
   return /^\s*(?:thinking(?:\s+process)?\s*:|the user |i need |i should |i will |they are |the question |i can )/i.test(text || '');
 }
 
+export function normalizeThinkingMarkup(text) {
+  if (!text) return text;
+  let normalized = text;
+  normalized = normalized.replace(/<thought(\s+[^>]*)?>/gi, (_m, attrs = '') => `<think${attrs || ''}>`);
+  normalized = normalized.replace(/<\/thought>/gi, '</think>');
+  normalized = normalized.replace(/<\|channel>thought\s*\n?([\s\S]*?)<channel\|>\s*/gi, (_m, content = '') => {
+    const thought = String(content || '').trim();
+    return thought ? `<think>${thought}</think>\n` : '';
+  });
+  normalized = normalized.replace(/<\|channel>response\s*\n?([\s\S]*?)<channel\|>/gi, (_m, content = '') => content || '');
+  normalized = normalized.replace(/<\|channel>response\s*\n?/gi, '');
+  normalized = normalized.replace(/<channel\|>/gi, '');
+  return normalized;
+}
+
 function normalizePlainThinking(text) {
-  if (!text || /<think/i.test(text)) return text;
+  if (!text) return text;
+  text = normalizeThinkingMarkup(text);
+  if (/<think/i.test(text)) return text;
 
   const trimmed = text.trimStart();
   if (!startsWithReasoningPrefix(trimmed)) return text;
@@ -220,11 +242,21 @@ export function extractThinkingBlocks(text) {
   // (b) Cut-off mid-generation — there's already real reply text before the
   //     opener. Drop from the tag onward as before (it's truncated thinking).
   if (hasUnclosedThinkTag(normalized)) {
-    const strayOpener = cleanContent.match(/^\s*<think(?:ing)?(?:\s+[^>]*)?>([\s\S]*)$/i);
-    if (strayOpener) {
-      cleanContent = strayOpener[1];
+    const gemmaThoughtStart = cleanContent.search(/<\|channel>thought/i);
+    if (gemmaThoughtStart >= 0) {
+      const leakedThought = cleanContent
+        .slice(gemmaThoughtStart)
+        .replace(/^<\|channel>thought\s*\n?/i, '')
+        .trim();
+      if (gemmaThoughtStart === 0 && leakedThought) thinkingBlocks.push(leakedThought);
+      cleanContent = cleanContent.slice(0, gemmaThoughtStart);
     } else {
-      cleanContent = cleanContent.replace(/<think(?:ing)?(?:\s+[^>]*)?>[\s\S]*$/gi, '');
+      const strayOpener = cleanContent.match(/^\s*<think(?:ing)?(?:\s+[^>]*)?>([\s\S]*)$/i);
+      if (strayOpener) {
+        cleanContent = strayOpener[1];
+      } else {
+        cleanContent = cleanContent.replace(/<think(?:ing)?(?:\s+[^>]*)?>[\s\S]*$/gi, '');
+      }
     }
   }
 
@@ -686,6 +718,7 @@ const markdownModule = {
   createCollapsible,
   hasUnclosedThinkTag,
   extractThinkingBlocks,
+  normalizeThinkingMarkup,
   startsWithReasoningPrefix,
   renderMermaid
 };

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -1,5 +1,5 @@
 import pytest
-from routes.chat_helpers import needs_auto_name
+from routes.chat_helpers import clean_thinking_for_save, needs_auto_name
 
 
 @pytest.mark.parametrize("name,expected", [
@@ -27,3 +27,44 @@ from routes.chat_helpers import needs_auto_name
 ])
 def test_needs_auto_name(name, expected):
     assert needs_auto_name(name) == expected, f"needs_auto_name({name!r}) should be {expected}"
+
+
+def test_clean_thinking_for_save_extracts_gemma4_thought_channel():
+    content, metadata = clean_thinking_for_save(
+        "<|channel>thought\ninternal reasoning<channel|>Final answer.",
+        {"model": "google/gemma-4-31B-it"},
+    )
+
+    assert content == "Final answer."
+    assert metadata["thinking"] == "internal reasoning"
+    assert metadata["model"] == "google/gemma-4-31B-it"
+
+
+def test_clean_thinking_for_save_strips_empty_gemma4_thought_channel():
+    content, metadata = clean_thinking_for_save(
+        "<|channel>thought\n<channel|>Final answer.",
+        {"model": "google/gemma-4-31B-it"},
+    )
+
+    assert content == "Final answer."
+    assert "thinking" not in metadata
+
+
+def test_clean_thinking_for_save_unwraps_gemma4_response_channel():
+    content, metadata = clean_thinking_for_save(
+        "<|channel>thought\ninternal reasoning<channel|><|channel>response\nFinal answer.<channel|>",
+        {"model": "google/gemma-4-31B-it"},
+    )
+
+    assert content == "Final answer."
+    assert metadata["thinking"] == "internal reasoning"
+
+
+def test_clean_thinking_for_save_extracts_thought_tag():
+    content, metadata = clean_thinking_for_save(
+        "<thought>internal reasoning</thought>Final answer.",
+        {},
+    )
+
+    assert content == "Final answer."
+    assert metadata["thinking"] == "internal reasoning"

--- a/tests/test_markdown_rendering_js.py
+++ b/tests/test_markdown_rendering_js.py
@@ -18,7 +18,7 @@ def node_available():
         pytest.skip("node binary not on PATH")
 
 
-def _run_markdown_case(markdown: str) -> str:
+def _run_markdown_case(markdown: str, render_expr: str = "mod.mdToHtml(input)"):
     script = textwrap.dedent(
         r"""
         import fs from 'node:fs';
@@ -54,9 +54,9 @@ def _run_markdown_case(markdown: str) -> str:
         const moduleUrl = 'data:text/javascript;base64,' + Buffer.from(source).toString('base64');
         const mod = await import(moduleUrl);
         const input = JSON.parse(process.argv[1]);
-        console.log(JSON.stringify({ html: mod.mdToHtml(input) }));
+        console.log(JSON.stringify({ html: __RENDER_EXPR__ }));
         """
-    )
+    ).replace("__RENDER_EXPR__", render_expr)
     result = subprocess.run(
         ["node", "--input-type=module", "-e", script, json.dumps(markdown)],
         cwd=_REPO,
@@ -99,3 +99,51 @@ def test_table_separator_row_not_rendered_as_data(node_available):
     assert "<th" in html
     assert "<td" in html
     assert "---" not in html
+
+
+def test_process_with_thinking_handles_gemma4_thought_channel(node_available):
+    html = _run_markdown_case(
+        "<|channel>thought\ninternal reasoning<channel|>Final answer.",
+        "mod.processWithThinking(input)",
+    )
+
+    assert "thinking-section" in html
+    assert "internal reasoning" in html
+    assert "Final answer." in html
+    assert "&lt;|channel&gt;" not in html
+    assert "<|channel>" not in html
+
+
+def test_process_with_thinking_strips_empty_gemma4_thought_channel(node_available):
+    html = _run_markdown_case(
+        "<|channel>thought\n<channel|>Final answer.",
+        "mod.processWithThinking(input)",
+    )
+
+    assert "thinking-section" not in html
+    assert "Final answer." in html
+    assert "&lt;|channel&gt;" not in html
+    assert "<|channel>" not in html
+
+
+def test_process_with_thinking_unwraps_gemma4_response_channel(node_available):
+    html = _run_markdown_case(
+        "<|channel>thought\ninternal reasoning<channel|><|channel>response\nFinal answer.<channel|>",
+        "mod.processWithThinking(input)",
+    )
+
+    assert "thinking-section" in html
+    assert "internal reasoning" in html
+    assert "Final answer." in html
+    assert "&lt;|channel&gt;" not in html
+    assert "<|channel>" not in html
+
+
+def test_extract_thinking_blocks_handles_thought_tag(node_available):
+    result = _run_markdown_case(
+        "<thought>internal reasoning</thought>Final answer.",
+        "mod.extractThinkingBlocks(input)",
+    )
+
+    assert result["thinkingBlocks"] == ["internal reasoning"]
+    assert result["content"] == "Final answer."

--- a/tests/test_strip_think.py
+++ b/tests/test_strip_think.py
@@ -23,3 +23,22 @@ def test_strip_think_cases():
     
     # 6. Multiple blocks (closed + unclosed)
     assert strip_think("Hello! <think> closed </think> Here is the answer. <think> unclosed") == "Hello! Here is the answer."
+
+
+def test_strip_think_handles_thought_tags():
+    assert strip_think("<thought>internal reasoning</thought>Final answer.") == "Final answer."
+
+
+def test_strip_think_handles_gemma4_thought_channel():
+    text = "<|channel>thought\ninternal reasoning<channel|>Final answer."
+    assert strip_think(text) == "Final answer."
+
+
+def test_strip_think_handles_empty_gemma4_thought_channel():
+    text = "<|channel>thought\n<channel|>Final answer."
+    assert strip_think(text) == "Final answer."
+
+
+def test_strip_think_unwraps_gemma4_response_channel():
+    text = "<|channel>thought\ninternal reasoning<channel|><|channel>response\nFinal answer.<channel|>"
+    assert strip_think(text) == "Final answer."


### PR DESCRIPTION
## Summary

Normalize Gemma 4 raw thought-channel output and `<thought>...</thought>` wrappers into Odysseus's existing `<think>` pipeline so reasoning does not leak into visible chat text, saved message content, or reload rendering. This covers populated Gemma thought channels, empty thought-channel wrappers emitted before final answers, and optional Gemma response-channel wrappers.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2225

Related: #315, #1642, #996, #602, #1233, #1434, #968.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Use a Gemma 4 backend that emits raw final content like `<|channel>thought\ninternal reasoning<channel|>Final answer.`
2. Verify visible chat output shows only the final answer while populated reasoning appears in the existing thinking section.
3. Repeat with an empty thought-channel wrapper and with `<thought>internal reasoning</thought>Final answer.`
4. Reload the chat session and verify saved assistant content stays clean while populated thinking is restored from metadata.

## Visual / UI changes - REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like - buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM - needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) - do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first - bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<img width="796" height="376" alt="Screenshot from 2026-06-04 00-13-54" src="https://github.com/user-attachments/assets/586cc0d0-ab50-4116-a7eb-ee986e1e08df" />

## Implementation Notes

- Adds shared backend normalization in `src/text_helpers.py` for `<thought>` tags, populated/empty Gemma thought channels, and Gemma response-channel wrappers.
- Runs normalization before chat save/extraction so populated Gemma thoughts become `metadata.thinking` and empty wrappers are not persisted.
- Adds matching browser-side normalization in `static/js/markdown.js` and live-stream detection in `static/js/chat.js` while keeping the existing thinking renderer.

## Out of Scope

- Provider-native `reasoning` / `reasoning_content` routing.
- Gemma model discovery, context-window lookup, tool capability, or vision heuristics.
- New thinking UI components or prompt-history policy changes.

## Automated Testing

Latest post-rebase checks run from `/home/user/workspace/odysseus-gemma4-thinking` with the project venv:

```bash
.venv/bin/python -m pytest tests/test_chat_helpers.py tests/test_markdown_rendering_js.py tests/test_strip_think.py
.venv/bin/python -m pytest
```

Result:

```text
Focused Gemma pytest: 29 passed, 1 warning
Full pytest: 1993 passed, 2 skipped, 23 failed, 3 errors, 32 warnings
```

The full-suite failures are outside this PR's modified files and are not part of the Gemma thought-channel change.

## Files Changed

```text
routes/chat_helpers.py
src/text_helpers.py
static/js/chat.js
static/js/markdown.js
tests/test_chat_helpers.py
tests/test_markdown_rendering_js.py
tests/test_strip_think.py
```