### PR TITLE
fix: TOCTOU race in personal file delete + IndexError on whitespace cmd

### DIFF
--- a/routes/personal_routes.py
+++ b/routes/personal_routes.py
@@ -286,9 +286,12 @@ def setup_personal_routes(personal_docs_manager, rag_manager, rag_available):
             except ValueError:
                 # commonpath raises on mixed drives / non-comparable paths
                 in_uploads = False
-            if in_uploads and abs_target != base_abs and os.path.exists(abs_target):
-                os.remove(abs_target)
-                deleted_from_disk = True
+            if in_uploads and abs_target != base_abs:
+                try:
+                    os.remove(abs_target)
+                    deleted_from_disk = True
+                except FileNotFoundError:
+                    pass  # already gone — race with another request or cleanup
 
             # Exclude the file from the listing (persists across restarts)
             personal_docs_manager.exclude_file(filepath)

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2659,7 +2659,7 @@ async def _cookbook_register_task(session_id: str, model: str, host: str,
     placeholder = (
         f"Launched via agent — waiting for tmux output…\n"
         f"  session: {session_id}\n"
-        f"  target:  {target}{cmd.split()[0] if cmd else ''}\n"
+        f"  target:  {target}{(cmd.split() or [''])[0] if cmd else ''}\n"
         f"  cmd:     {cmd[:200]}{'…' if len(cmd) > 200 else ''}"
     )
     tasks.append({


### PR DESCRIPTION
## Summary

Two defensive fixes:

1. **routes/personal_routes.py:289** — `os.path.exists()` then `os.remove()` is a TOCTOU race. Another request or cleanup job can delete the file between check and remove, raising `FileNotFoundError`. Replaced with `try/except FileNotFoundError`.

2. **src/tool_implementations.py:2647** — `cmd.split()[0]` crashes with `IndexError` when `cmd` is a non-empty whitespace-only string (`"   ".split()` returns `[]`). Guarded with `(cmd.split() or [""])[0]`.

## Linked Issue

Fixes #2232

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `python -m py_compile routes/personal_routes.py` — OK
2. `python -m py_compile src/tool_implementations.py` — OK
3. `python -m pytest tests/ -k "personal or tool_impl"` — 17 passed