### PR TITLE
refactor(tours): add shared tour core helper

### DIFF
--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -20,6 +20,7 @@ import documentModule from './document.js';
 import settingsModule from './settings.js';
 import cookbookModule from './cookbook.js';
 import { EVAL_PROMPTS } from './compare/index.js';
+import { clearTourCommandInput, createTourSession, showTourStep } from './tourCore.js';
 
 // ── Module state ──────────────────────────────────────────────────────
 
@@ -2535,36 +2536,7 @@ async function _cmdTourCompare(args, ctx) {
 
 // ── Cookbook tour ──
 async function _cmdTourCookbook(args, ctx) {
-  // Clear the chat input so "/tour-cookbook" doesn't linger.
-  const _msgEl = document.getElementById('message');
-  if (_msgEl) {
-    _msgEl.value = '';
-    _msgEl.dispatchEvent(new Event('input', { bubbles: true }));
-  }
-
-  // Idempotent tour-styles injection (shared with /tour and /tour-compare).
-  if (!document.getElementById('tour-styles')) {
-    const s = document.createElement('style');
-    s.id = 'tour-styles';
-    s.textContent =
-      '#tour-tooltip{position:fixed;z-index:10001;background:var(--bg);color:var(--fg);' +
-      'border:1px solid var(--border);border-radius:8px;padding:12px 14px;max-width:280px;' +
-      'font-family:inherit;font-size:0.8rem;line-height:1.5;' +
-      'box-shadow:0 2px 12px rgba(0,0,0,0.3);pointer-events:auto;' +
-      'opacity:0;transform:translateY(4px);transition:opacity 0.3s ease-out,transform 0.3s ease-out}' +
-      '#tour-tooltip.tour-fade-in{opacity:1;transform:translateY(0)}' +
-      '#tour-tooltip .tour-text{margin-bottom:8px;opacity:0.8}' +
-      '.tour-nav{display:flex;align-items:center;justify-content:space-between}' +
-      '.tour-nav button{background:none;border:1px solid var(--border);color:var(--fg);' +
-      'cursor:pointer;font-family:inherit;border-radius:4px;transition:all .1s}' +
-      '.tour-nav button:hover{background:color-mix(in srgb,var(--fg) 8%,transparent)}' +
-      '.tour-btn-arrow{font-size:1rem;padding:4px 12px;opacity:0.6}' +
-      '.tour-btn-arrow:hover{opacity:1}' +
-      '.tour-btn-arrow.disabled{opacity:0.15;pointer-events:none}' +
-      '.tour-btn-skip{font-size:0.72rem;padding:3px 10px;opacity:0.35;border-color:transparent!important}' +
-      '.tour-btn-skip:hover{opacity:0.6}';
-    document.head.appendChild(s);
-  }
+  clearTourCommandInput();
 
   // Open the cookbook modal if it's not already up.
   let modal = document.getElementById('cookbook-modal');
@@ -2582,118 +2554,7 @@ async function _cmdTourCookbook(args, ctx) {
     return true;
   }
 
-  document.body.classList.add('tour-active');
-  const tooltip = document.createElement('div');
-  tooltip.id = 'tour-tooltip';
-  document.body.appendChild(tooltip);
-
-  let _halos = [];
-  function _makeHalo(target) {
-    const halo = document.createElement('div');
-    halo.className = 'tour-halo';
-    document.body.appendChild(halo);
-    const update = () => {
-      const r = target.getBoundingClientRect();
-      halo.style.top    = (r.top - 4) + 'px';
-      halo.style.left   = (r.left - 4) + 'px';
-      halo.style.width  = (r.width + 8) + 'px';
-      halo.style.height = (r.height + 8) + 'px';
-    };
-    update();
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    requestAnimationFrame(() => halo.classList.add('tour-fade-in'));
-    return { destroy() {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-      halo.remove();
-    } };
-  }
-  function _clearHalos() {
-    _halos.forEach(h => h.destroy());
-    _halos = [];
-    document.querySelectorAll('.tour-halo').forEach(e => e.remove());
-  }
-  const _clear = () => {
-    document.querySelectorAll('.odysseus-highlight').forEach(e => e.classList.remove('odysseus-highlight'));
-    _clearHalos();
-    tooltip.remove();
-    document.body.classList.remove('tour-active');
-  };
-
-  function _positionTooltip(target, placement) {
-    tooltip.style.visibility = 'hidden';
-    tooltip.style.display = '';
-    const tw = tooltip.offsetWidth || 260;
-    const th = tooltip.offsetHeight || 100;
-    if (placement === 'center-above') {
-      // Centered horizontally, sitting in the upper third of the viewport.
-      const top = Math.max(10, window.innerHeight * 0.32 - th / 2);
-      const left = Math.max(10, window.innerWidth / 2 - tw / 2);
-      tooltip.style.top = top + 'px';
-      tooltip.style.left = left + 'px';
-      tooltip.style.visibility = '';
-      return;
-    }
-    const r = target.getBoundingClientRect();
-    const gap = 12;
-    let top, left;
-    if (r.bottom + gap + th < window.innerHeight - 10) {
-      top = r.bottom + gap;
-      left = r.left + r.width / 2 - tw / 2;
-    } else if (r.top - gap - th > 10) {
-      top = r.top - gap - th;
-      left = r.left + r.width / 2 - tw / 2;
-    } else {
-      top = r.top + r.height / 2 - th / 2;
-      left = r.right + gap;
-      if (left + tw > window.innerWidth - 10) left = r.left - tw - gap;
-    }
-    if (left + tw > window.innerWidth - 10) left = window.innerWidth - tw - 10;
-    if (left < 10) left = 10;
-    if (top < 10) top = 10;
-    tooltip.style.top = top + 'px';
-    tooltip.style.left = left + 'px';
-    tooltip.style.visibility = '';
-  }
-
-  function _showStep(sel, text, opts) {
-    opts = opts || {};
-    const isFirst = !!opts.isFirst;
-    const isLast = !!opts.isLast;
-    const before = opts.before;
-    const placement = opts.placement;
-    return new Promise(resolve => {
-      _clearHalos();
-      if (before) { try { before(); } catch (_) {} }
-      const target = document.querySelector(sel);
-      if (!target) return resolve('skip');
-      _halos.push(_makeHalo(target));
-      target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-
-      tooltip.classList.remove('tour-fade-in');
-      tooltip.innerHTML =
-        '<div class="tour-text">' + text + '</div>' +
-        '<div class="tour-nav">' +
-          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
-          '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-          '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
-        '</div>';
-      requestAnimationFrame(() => {
-        _positionTooltip(target, placement);
-        tooltip.classList.add('tour-fade-in');
-      });
-
-      const onClick = (e) => {
-        const hit = e.target.closest && e.target.closest('[data-act]');
-        const act = hit && hit.dataset.act;
-        if (!act) return;
-        tooltip.removeEventListener('click', onClick);
-        resolve(act);
-      };
-      tooltip.addEventListener('click', onClick);
-    });
-  }
+  const tour = createTourSession();
 
   function _clickTab(name) {
     const tab = modal.querySelector('.cookbook-tab[data-backend="' + name + '"]');
@@ -2742,55 +2603,26 @@ async function _cmdTourCookbook(args, ctx) {
 
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
-    const res = await _showStep(step.sel, step.text, {
+    const res = await showTourStep(tour, step.sel, step.text, {
       isFirst: i === 0,
       isLast: i === steps.length - 1,
       before: step.before,
       placement: step.placement,
     });
-    if (res === 'skip') { _clear(); return true; }
+    if (res === 'skip') { tour.clear(); return true; }
     if (res === 'back') { if (i > 0) i -= 2; continue; }
   }
 
   // Leave Cookbook on the Download tab so the user can start downloading immediately.
   _clickTab('Search');
-  _clear();
+  tour.clear();
   await typewriterReply('That’s Cookbook. Pick a model that catches your eye and let it cook.');
   return true;
 }
 
 // ── Theme tour ──
 async function _cmdTourTheme(args, ctx) {
-  // Clear the chat input so "/tour-theme" doesn't linger.
-  const _msgEl = document.getElementById('message');
-  if (_msgEl) {
-    _msgEl.value = '';
-    _msgEl.dispatchEvent(new Event('input', { bubbles: true }));
-  }
-
-  // Idempotent tour-styles injection (shared with other tours).
-  if (!document.getElementById('tour-styles')) {
-    const s = document.createElement('style');
-    s.id = 'tour-styles';
-    s.textContent =
-      '#tour-tooltip{position:fixed;z-index:10001;background:var(--bg);color:var(--fg);' +
-      'border:1px solid var(--border);border-radius:8px;padding:12px 14px;max-width:280px;' +
-      'font-family:inherit;font-size:0.8rem;line-height:1.5;' +
-      'box-shadow:0 2px 12px rgba(0,0,0,0.3);pointer-events:auto;' +
-      'opacity:0;transform:translateY(4px);transition:opacity 0.3s ease-out,transform 0.3s ease-out}' +
-      '#tour-tooltip.tour-fade-in{opacity:1;transform:translateY(0)}' +
-      '#tour-tooltip .tour-text{margin-bottom:8px;opacity:0.8}' +
-      '.tour-nav{display:flex;align-items:center;justify-content:space-between}' +
-      '.tour-nav button{background:none;border:1px solid var(--border);color:var(--fg);' +
-      'cursor:pointer;font-family:inherit;border-radius:4px;transition:all .1s}' +
-      '.tour-nav button:hover{background:color-mix(in srgb,var(--fg) 8%,transparent)}' +
-      '.tour-btn-arrow{font-size:1rem;padding:4px 12px;opacity:0.6}' +
-      '.tour-btn-arrow:hover{opacity:1}' +
-      '.tour-btn-arrow.disabled{opacity:0.15;pointer-events:none}' +
-      '.tour-btn-skip{font-size:0.72rem;padding:3px 10px;opacity:0.35;border-color:transparent!important}' +
-      '.tour-btn-skip:hover{opacity:0.6}';
-    document.head.appendChild(s);
-  }
+  clearTourCommandInput();
 
   // Open the theme modal if it isn't already up. Same hamburger / rail
   // opener pattern as the other tours.
@@ -2811,143 +2643,7 @@ async function _cmdTourTheme(args, ctx) {
     return true;
   }
 
-  document.body.classList.add('tour-active');
-  const tooltip = document.createElement('div');
-  tooltip.id = 'tour-tooltip';
-  document.body.appendChild(tooltip);
-
-  let _halos = [];
-  function _makeHalo(target) {
-    const halo = document.createElement('div');
-    halo.className = 'tour-halo';
-    document.body.appendChild(halo);
-    const update = () => {
-      const r = target.getBoundingClientRect();
-      halo.style.top    = (r.top - 4) + 'px';
-      halo.style.left   = (r.left - 4) + 'px';
-      halo.style.width  = (r.width + 8) + 'px';
-      halo.style.height = (r.height + 8) + 'px';
-    };
-    update();
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    requestAnimationFrame(() => halo.classList.add('tour-fade-in'));
-    return { destroy() {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-      halo.remove();
-    } };
-  }
-  function _clearHalos() {
-    _halos.forEach(h => h.destroy());
-    _halos = [];
-    document.querySelectorAll('.tour-halo').forEach(e => e.remove());
-  }
-  const _clear = () => {
-    document.querySelectorAll('.odysseus-highlight').forEach(e => e.classList.remove('odysseus-highlight'));
-    _clearHalos();
-    tooltip.remove();
-    document.body.classList.remove('tour-active');
-  };
-
-  function _positionTooltip(target, placement) {
-    tooltip.style.visibility = 'hidden';
-    tooltip.style.display = '';
-    const tw = tooltip.offsetWidth || 260;
-    const th = tooltip.offsetHeight || 100;
-    if (placement === 'center-above') {
-      const top = Math.max(10, window.innerHeight * 0.32 - th / 2);
-      const left = Math.max(10, window.innerWidth / 2 - tw / 2);
-      tooltip.style.top = top + 'px';
-      tooltip.style.left = left + 'px';
-      tooltip.style.visibility = '';
-      return;
-    }
-    const r = target.getBoundingClientRect();
-    const gap = 12;
-    let top, left;
-    if (r.bottom + gap + th < window.innerHeight - 10) {
-      top = r.bottom + gap;
-      left = r.left + r.width / 2 - tw / 2;
-    } else if (r.top - gap - th > 10) {
-      top = r.top - gap - th;
-      left = r.left + r.width / 2 - tw / 2;
-    } else {
-      top = r.top + r.height / 2 - th / 2;
-      left = r.right + gap;
-      if (left + tw > window.innerWidth - 10) left = r.left - tw - gap;
-    }
-    if (left + tw > window.innerWidth - 10) left = window.innerWidth - tw - 10;
-    if (left < 10) left = 10;
-    if (top < 10) top = 10;
-    tooltip.style.top = top + 'px';
-    tooltip.style.left = left + 'px';
-    tooltip.style.visibility = '';
-  }
-
-  // Interactive step — show tooltip + halo over one or more targets and
-  // resolve 'next' when the user actually clicks one of the highlighted
-  // elements. Skip button still exits. `extraSel` (optional) adds a
-  // second highlight target whose click also advances the step.
-  function _showStep(sel, text, opts) {
-    opts = opts || {};
-    const isFirst = !!opts.isFirst;
-    const isLast = !!opts.isLast;
-    const before = opts.before;
-    const placement = opts.placement;
-    const extraSel = opts.extraSel;
-    const interactive = !!opts.interactive;
-    return new Promise(resolve => {
-      _clearHalos();
-      if (before) { try { before(); } catch (_) {} }
-      setTimeout(() => {
-        const target = document.querySelector(sel);
-        if (!target) return resolve('skip');
-        _halos.push(_makeHalo(target));
-        const extra = extraSel ? document.querySelector(extraSel) : null;
-        if (extra) _halos.push(_makeHalo(extra));
-        target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-
-        tooltip.classList.remove('tour-fade-in');
-        tooltip.innerHTML =
-          '<div class="tour-text">' + text + '</div>' +
-          '<div class="tour-nav">' +
-            '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
-            '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
-            '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
-          '</div>';
-        requestAnimationFrame(() => {
-          _positionTooltip(target, placement);
-          tooltip.classList.add('tour-fade-in');
-        });
-
-        let _onTarget;
-        const cleanup = () => {
-          tooltip.removeEventListener('click', onClick);
-          if (_onTarget) {
-            target.removeEventListener('click', _onTarget, true);
-            if (extra) extra.removeEventListener('click', _onTarget, true);
-          }
-        };
-        const onClick = (e) => {
-          const hit = e.target.closest && e.target.closest('[data-act]');
-          const act = hit && hit.dataset.act;
-          if (!act) return;
-          cleanup();
-          resolve(act);
-        };
-        tooltip.addEventListener('click', onClick);
-        // Interactive: clicking the highlighted target advances. We let
-        // the original click propagate so the user's real action (apply
-        // theme, switch tab, etc.) actually happens.
-        if (interactive) {
-          _onTarget = () => { cleanup(); resolve('next'); };
-          target.addEventListener('click', _onTarget, true);
-          if (extra) extra.addEventListener('click', _onTarget, true);
-        }
-      }, before ? 160 : 0);
-    });
-  }
+  const tour = createTourSession();
 
   // Clicks one of the theme modal's top-level tabs by data-tab id.
   function _clickTab(tabId) {
@@ -2988,19 +2684,20 @@ async function _cmdTourTheme(args, ctx) {
 
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
-    const res = await _showStep(step.sel, step.text, {
+    const res = await showTourStep(tour, step.sel, step.text, {
       isFirst: i === 0,
       isLast: i === steps.length - 1,
       before: step.before,
       placement: step.placement,
       extraSel: step.extraSel,
       interactive: step.interactive,
+      delayMs: step.before ? 160 : 0,
     });
-    if (res === 'skip') { _clear(); return true; }
+    if (res === 'skip') { tour.clear(); return true; }
     if (res === 'back') { if (i > 0) i -= 2; continue; }
   }
 
-  _clear();
+  tour.clear();
   await typewriterReply('That’s Theme. Make it yours.');
   return true;
 }

--- a/static/js/tourCore.js
+++ b/static/js/tourCore.js
@@ -1,0 +1,197 @@
+// Shared helpers for guided slash-command tours.
+
+const TOUR_STYLES =
+  '#tour-tooltip{position:fixed;z-index:10001;background:var(--bg);color:var(--fg);' +
+  'border:1px solid var(--border);border-radius:8px;padding:12px 14px;max-width:280px;' +
+  'font-family:inherit;font-size:0.8rem;line-height:1.5;' +
+  'box-shadow:0 2px 12px rgba(0,0,0,0.3);pointer-events:auto;' +
+  'opacity:0;transform:translateY(4px);transition:opacity 0.3s ease-out,transform 0.3s ease-out}' +
+  '#tour-tooltip.tour-fade-in{opacity:1;transform:translateY(0)}' +
+  '#tour-tooltip .tour-text{margin-bottom:8px;opacity:0.8}' +
+  '.tour-nav{display:flex;align-items:center;justify-content:space-between}' +
+  '.tour-nav button{background:none;border:1px solid var(--border);color:var(--fg);' +
+  'cursor:pointer;font-family:inherit;border-radius:4px;transition:all .1s}' +
+  '.tour-nav button:hover{background:color-mix(in srgb,var(--fg) 8%,transparent)}' +
+  '.tour-btn-arrow{font-size:1rem;padding:4px 12px;opacity:0.6}' +
+  '.tour-btn-arrow:hover{opacity:1}' +
+  '.tour-btn-arrow.disabled{opacity:0.15;pointer-events:none}' +
+  '.tour-btn-skip{font-size:0.72rem;padding:3px 10px;opacity:0.35;border-color:transparent!important}' +
+  '.tour-btn-skip:hover{opacity:0.6}';
+
+export function ensureTourStyles() {
+  if (document.getElementById('tour-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'tour-styles';
+  style.textContent = TOUR_STYLES;
+  document.head.appendChild(style);
+}
+
+export function clearTourCommandInput() {
+  const msgEl = document.getElementById('message');
+  if (!msgEl) return;
+  msgEl.value = '';
+  msgEl.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+export function createTourSession() {
+  ensureTourStyles();
+  document.body.classList.add('tour-active');
+
+  document.getElementById('tour-tooltip')?.remove();
+  const tooltip = document.createElement('div');
+  tooltip.id = 'tour-tooltip';
+  document.body.appendChild(tooltip);
+
+  let halos = [];
+
+  function makeHalo(target) {
+    const halo = document.createElement('div');
+    halo.className = 'tour-halo';
+    document.body.appendChild(halo);
+
+    const update = () => {
+      const r = target.getBoundingClientRect();
+      halo.style.top = (r.top - 4) + 'px';
+      halo.style.left = (r.left - 4) + 'px';
+      halo.style.width = (r.width + 8) + 'px';
+      halo.style.height = (r.height + 8) + 'px';
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    requestAnimationFrame(() => halo.classList.add('tour-fade-in'));
+
+    return {
+      destroy() {
+        window.removeEventListener('resize', update);
+        window.removeEventListener('scroll', update, true);
+        halo.remove();
+      },
+    };
+  }
+
+  function clearHalos() {
+    halos.forEach(h => h.destroy());
+    halos = [];
+    document.querySelectorAll('.tour-halo').forEach(e => e.remove());
+  }
+
+  function addHalo(target) {
+    const halo = makeHalo(target);
+    halos.push(halo);
+    return halo;
+  }
+
+  function positionTooltip(target, placement) {
+    tooltip.style.visibility = 'hidden';
+    tooltip.style.display = '';
+    const tw = tooltip.offsetWidth || 260;
+    const th = tooltip.offsetHeight || 100;
+
+    if (placement === 'center-above') {
+      const top = Math.max(10, window.innerHeight * 0.32 - th / 2);
+      const left = Math.max(10, window.innerWidth / 2 - tw / 2);
+      tooltip.style.top = top + 'px';
+      tooltip.style.left = left + 'px';
+      tooltip.style.visibility = '';
+      return;
+    }
+
+    const r = target.getBoundingClientRect();
+    const gap = 12;
+    let top;
+    let left;
+
+    if (r.bottom + gap + th < window.innerHeight - 10) {
+      top = r.bottom + gap;
+      left = r.left + r.width / 2 - tw / 2;
+    } else if (r.top - gap - th > 10) {
+      top = r.top - gap - th;
+      left = r.left + r.width / 2 - tw / 2;
+    } else {
+      top = r.top + r.height / 2 - th / 2;
+      left = r.right + gap;
+      if (left + tw > window.innerWidth - 10) left = r.left - tw - gap;
+    }
+
+    if (left + tw > window.innerWidth - 10) left = window.innerWidth - tw - 10;
+    if (left < 10) left = 10;
+    if (top < 10) top = 10;
+    tooltip.style.top = top + 'px';
+    tooltip.style.left = left + 'px';
+    tooltip.style.visibility = '';
+  }
+
+  function clear() {
+    document.querySelectorAll('.odysseus-highlight').forEach(e => e.classList.remove('odysseus-highlight'));
+    clearHalos();
+    tooltip.remove();
+    document.body.classList.remove('tour-active');
+  }
+
+  return { tooltip, addHalo, clearHalos, positionTooltip, clear };
+}
+
+export function showTourStep(session, sel, text, opts = {}) {
+  const isFirst = !!opts.isFirst;
+  const isLast = !!opts.isLast;
+  const before = opts.before;
+  const placement = opts.placement;
+  const extraSel = opts.extraSel;
+  const interactive = !!opts.interactive;
+  const delayMs = opts.delayMs || 0;
+
+  return new Promise(resolve => {
+    session.clearHalos();
+    if (before) {
+      try { before(); } catch (_) {}
+    }
+
+    setTimeout(() => {
+      const target = document.querySelector(sel);
+      if (!target) return resolve('skip');
+      session.addHalo(target);
+      const extra = extraSel ? document.querySelector(extraSel) : null;
+      if (extra) session.addHalo(extra);
+      target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+      session.tooltip.classList.remove('tour-fade-in');
+      session.tooltip.innerHTML =
+        '<div class="tour-text">' + text + '</div>' +
+        '<div class="tour-nav">' +
+          '<button class="tour-btn-arrow' + (isFirst ? ' disabled' : '') + '" data-act="back">←</button>' +
+          '<button class="tour-btn-skip" data-act="skip">' + (isLast ? 'done' : 'skip tour') + '</button>' +
+          '<button class="tour-btn-arrow" data-act="next">' + (isLast ? '✓' : '→') + '</button>' +
+        '</div>';
+
+      requestAnimationFrame(() => {
+        session.positionTooltip(target, placement);
+        session.tooltip.classList.add('tour-fade-in');
+      });
+
+      let onTarget;
+      const cleanup = () => {
+        session.tooltip.removeEventListener('click', onClick);
+        if (onTarget) {
+          target.removeEventListener('click', onTarget, true);
+          if (extra) extra.removeEventListener('click', onTarget, true);
+        }
+      };
+      const onClick = (e) => {
+        const hit = e.target.closest && e.target.closest('[data-act]');
+        const act = hit && hit.dataset.act;
+        if (!act) return;
+        cleanup();
+        resolve(act);
+      };
+
+      session.tooltip.addEventListener('click', onClick);
+      if (interactive) {
+        onTarget = () => { cleanup(); resolve('next'); };
+        target.addEventListener('click', onTarget, true);
+        if (extra) extra.addEventListener('click', onTarget, true);
+      }
+    }, delayMs);
+  });
+}


### PR DESCRIPTION
## Summary

Extracted the duplicated guided-tour scaffolding into `static/js/tourCore.js`, then migrated the Cookbook and Theme tours to use the shared helper. This keeps the first refactor slice small while preserving the existing tour tooltip, halo, navigation, and cleanup behavior.

## Linked Issue

Part of #605; implements the `ROADMAP.md` refactor target for a shared tour core helper.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. Local `uvicorn app:app --host 127.0.0.1 --port 7010` was blocked by a missing local `bcrypt` dependency in this checkout, so I kept this unchecked.

## How to Test

1. Run `node --check static/js/tourCore.js static/js/slashCommands.js` and confirm both files parse.
2. Start the app, run `/tour-cookbook`, and verify the Cookbook walkthrough still opens, highlights each step, supports next/back/skip, and cleans up the tooltip/halo at the end.
3. Run `/tour-theme` and verify the Theme walkthrough still opens, supports the interactive highlighted clicks, supports next/back/skip, and cleans up the tooltip/halo at the end.

## Visual / UI changes — REQUIRED if you touched anything that renders

No intentional visual changes. This PR reuses the existing tour tooltip and halo styles through a shared helper instead of redefining them inside each migrated tour.

### Screenshots / clips

N/A — refactor-only; existing UI should render unchanged.
