### PR TITLE
fix: prevent path traversal in IMAP attachment path (3 occurrences)

### DIFF
--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -51,6 +51,7 @@ from routes.email_helpers import (
     attachment_extract_dir,
 )
 from routes.email_pollers import _start_poller
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Sanitize the folder query parameter by extracting only the basename via Path(folder).name. Prevents directory escape attacks like folder=../../etc/passwd.

Fixes 3 occurrences at lines 1294, 1329, 1537.