### PR TITLE
feat: add responsive hamburger menu for mobile navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,6 +101,50 @@
   .nav-links { display: flex; align-items: center; gap: 22px; }
   .nav-links a { color: var(--muted); font-size: 14px; font-weight: 500; }
   .nav-links a:hover { color: var(--fg); }
+  .nav-links-hamburger {
+    display: none;
+    position: relative;
+  }
+  .hamburger-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--panel);
+    color: var(--fg);
+    cursor: pointer;
+  }
+  .hamburger-btn:hover {
+    border-color: var(--accent);
+  }
+  .hamburger-menu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    min-width: 220px;
+    display: none;
+    flex-direction: column;
+    padding: 12px;
+    background: rgba(17,17,17,0.98);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+  }
+  .hamburger-menu a {
+    color: var(--muted);
+    padding: 8px 10px;
+    border-radius: 6px;
+  }
+  .hamburger-menu a:hover {
+    color: var(--fg);
+  }
+  .nav-links-hamburger.open .hamburger-menu {
+    display: flex;
+  }
   .btn {
     display: inline-flex; align-items: center; gap: 8px;
     padding: 9px 16px; border-radius: 10px; font-weight: 600; font-size: 14px;
@@ -376,7 +420,8 @@
   @media (max-width: 820px) {
     .grid { grid-template-columns: repeat(2, 1fr); }
     .shotrow { grid-template-columns: 1fr; }
-    .nav-links a:not(.btn) { display: none; }
+    .nav-links { display: none; }
+    .nav-links-hamburger { display: block; }
     .codeblock { display: flex; flex-wrap: wrap; gap: 8px; align-items: flex-start; overflow-wrap: anywhere; }
     .codeblock > span { flex: 1 1 auto; min-width: 0; }
     .codeblock .copy-btn { margin-left: auto; }
@@ -406,6 +451,28 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
           GitHub
         </a>
+      </div>
+      
+      <div class="nav-links-hamburger">
+        <button class="hamburger-btn" aria-label="Open menu">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M3.5,7 C3.22385763,7 3,6.77614237 3,6.5 C3,6.22385763 3.22385763,6 3.5,6 L20.5,6 C20.7761424,6 21,6.22385763 21,6.5 C21,6.77614237 20.7761424,7 20.5,7 L3.5,7 Z M3.5,12 C3.22385763,12 3,11.7761424 3,11.5 C3,11.2238576 3.22385763,11 3.5,11 L20.5,11 C20.7761424,11 21,11.2238576 21,11.5 C21,11.7761424 20.7761424,12 20.5,12 L3.5,12 Z M3.5,17 C3.22385763,17 3,16.7761424 3,16.5 C3,16.2238576 3.22385763,16 3.5,16 L20.5,16 C20.7761424,16 21,16.2238576 21,16.5 C21,16.7761424 20.7761424,17 20.5,17 L3.5,17 Z"/>
+          </svg>
+        </button>
+
+        <div class="hamburger-menu">
+          <a href="#features">Features</a>
+          <a href="#testimonials">Testimonials</a>
+          <a href="#how">How it started</a>
+          <a href="#start">Get started</a>
+
+          <a class="btn" href="https://github.com/pewdiepie-archdaemon/odysseus" target="_blank">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/>
+            </svg>
+            GitHub
+          </a>
+        </div>
       </div>
     </div>
   </nav>
@@ -946,6 +1013,22 @@
           btn.textContent = 'Copied!'; btn.classList.add('copied');
           setTimeout(function () { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
         });
+      });
+    })();
+    
+    (function () {
+      var container = document.querySelector('.nav-links-hamburger');
+      if (!container) return;
+
+      var button = container.querySelector('.hamburger-btn');
+
+      button.addEventListener('click', function (e) {
+        e.stopPropagation();
+        container.classList.toggle('open');
+      });
+
+      document.addEventListener('click', function () {
+        container.classList.remove('open');
       });
     })();
   </script>


### PR DESCRIPTION
## Summary

This commit adds a fully functional mobile hamburger menu.

Previously, the navbar links would simply disappear at smaller screen sizes with no way to access them. They’re now available through a hamburger dropdown instead. The dropdown contains the same navigation links as the desktop navbar, including the GitHub button.

Note: I previously committed the mobile navigation change to the wrong file `static/landing.html` (#480). The real live GitHub Pages source is `docs/index.html`, so this update applies the change to the correct page.

## Linked Issue

#2245

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Open the site on a mobile or narrow viewport.
2. Verify navbar links are hidden behind a hamburger menu.
3. Open the hamburger menu and confirm all links are present, including the GitHub button.
4. Click links and verify navigation works correctly.

## Visual / UI Changes — REQUIRED if you touched anything that renders

Adds a mobile hamburger menu for small-screen layouts. Desktop navigation is unchanged.

## Screenshot

<img width="565" height="364" alt="image" src="https://github.com/user-attachments/assets/4be2527d-d78e-44e0-8ade-3bcaff099e3b" />
