### PR TITLE
Expose pip CUDA runtime libs on LD_LIBRARY_PATH so llama.cpp serve uses the GPU

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -625,6 +625,29 @@ def _append_llama_cpp_linux_accel_build_lines(runner_lines: list[str]) -> None:
     runner_lines.append('    fi')
 
 
+def _append_llama_cpp_serve_cuda_env_lines(runner_lines: list[str]) -> None:
+    """Put pip-installed CUDA runtime libraries on LD_LIBRARY_PATH before serving.
+
+    The Linux build (``_append_llama_cpp_linux_accel_build_lines``) compiles
+    ``llama-server`` with ``-DGGML_CUDA=ON`` when a CUDA toolchain is present,
+    which dynamically links the wheel's ``libcudart`` / ``libcublas``. Those
+    wheels install their ``.so`` files under
+    ``~/.local/lib/python*/site-packages/nvidia/*/lib``, which is not on the
+    dynamic loader's default search path, and the build never runs ``ldconfig``.
+    Without this, the GPU-built binary cannot load the CUDA runtime at serve
+    time and llama.cpp falls back to CPU with ``warning: no usable GPU found``
+    (#2239). This is the runtime mirror of the build-time PATH/CUDA_HOME export.
+
+    It is a no-op when no such wheels are installed (the ``[ -d ]`` guard) and is
+    skipped on macOS, which serves via Metal rather than CUDA.
+    """
+    runner_lines.append('if [ "$(uname -s)" != "Darwin" ]; then')
+    runner_lines.append('  for _culib in ~/.local/lib/python*/site-packages/nvidia/*/lib; do')
+    runner_lines.append('    [ -d "$_culib" ] && export LD_LIBRARY_PATH="$_culib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"')
+    runner_lines.append('  done')
+    runner_lines.append('fi')
+
+
 def _llama_cpp_rebuild_cmd() -> str:
     """Shell command that clears the Cookbook-managed llama.cpp build.
 

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -37,7 +37,8 @@ from routes.cookbook_helpers import (
     _validate_local_dir, _validate_ssh_port, _validate_gpus, _shell_path,
     _ps_squote, _bash_squote, _validate_serve_cmd, _parse_serve_phase,
     _safe_env_prefix, _local_tooling_path_export, _append_serve_preflight_exit_lines,
-    _append_serve_exit_code_lines, _append_llama_cpp_linux_accel_build_lines, _cached_model_scan_script,
+    _append_serve_exit_code_lines, _append_llama_cpp_linux_accel_build_lines,
+    _append_llama_cpp_serve_cuda_env_lines, _cached_model_scan_script,
     _ollama_bind_from_cmd, _pip_install_fallback_chain, _pip_install_no_cache,
     _user_shell_path_bootstrap, _venv_safe_local_pip_install_cmd,
     ModelDownloadRequest, ServeRequest,
@@ -144,6 +145,14 @@ def setup_cookbook_routes() -> APIRouter:
                 r"Address already in use|bind.*address.*in use",
                 "Port is already in use.",
                 [{"label": "retry on port 8001", "op": "replace", "flag": "--port", "value": "8001"}],
+            ),
+            (
+                r"no usable GPU found|--gpu-layers option will be ignored|ggml_cuda_init.*failed|libcu(dart|blas)[^ ]*\.so[^ ]*: cannot open",
+                "llama.cpp was built with CUDA but the CUDA runtime libraries are not loadable at serve time, so it fell back to CPU.",
+                [
+                    {"label": "rebuild llama.cpp so it recompiles against the current CUDA toolchain", "op": "manual"},
+                    {"label": "install the CUDA runtime wheels (pip install nvidia-cuda-runtime-cu12 nvidia-cublas-cu12) and re-serve", "op": "manual"},
+                ],
             ),
             (
                 r"No CUDA GPUs are available|no GPU.*found|CUDA_VISIBLE_DEVICES.*invalid",
@@ -1028,6 +1037,10 @@ def setup_cookbook_routes() -> APIRouter:
                 # ollama is found (otherwise macOS falls back to a slow source build).
                 # /opt/homebrew = Apple Silicon, /usr/local = Intel; harmless on Linux.
                 runner_lines.append('export PATH="$HOME/.local/bin:$HOME/bin:$HOME/llama.cpp/build/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"')
+                # A CUDA-built llama-server links the pip wheel's libcudart/libcublas,
+                # which live off the loader's default path. Expose them at serve time
+                # (not just during the build) or it silently falls back to CPU (#2239).
+                _append_llama_cpp_serve_cuda_env_lines(runner_lines)
                 runner_lines.append('if [ -d /data/data/com.termux ]; then')
                 runner_lines.append('  # Termux: no native build — use the Python bindings (CPU).')
                 runner_lines.append('  if ! python3 -c "import llama_cpp" 2>/dev/null; then')

--- a/tests/test_cookbook_cuda_serve_ldpath.py
+++ b/tests/test_cookbook_cuda_serve_ldpath.py
@@ -1,0 +1,49 @@
+"""Regression: llama.cpp serve must expose the pip CUDA runtime libs at runtime.
+
+A Linux CUDA build links the wheel's libcudart/libcublas, which install under
+site-packages/nvidia/*/lib and are not on the dynamic loader's default path. The
+serve flow only exported PATH (bin dirs), never LD_LIBRARY_PATH, so a GPU-built
+llama-server could not load the CUDA runtime and fell back to CPU with
+"warning: no usable GPU found, --gpu-layers option will be ignored" (#2239).
+
+The serve branch now prepends those wheel lib dirs to LD_LIBRARY_PATH (the
+runtime mirror of the build-time PATH/CUDA_HOME export), and the serve-output
+diagnosis recognizes the runtime warning (build-time CMake errors were already
+covered by #559).
+"""
+import pathlib
+
+from routes.cookbook_helpers import _append_llama_cpp_serve_cuda_env_lines
+
+_ROUTES = (
+    pathlib.Path(__file__).resolve().parent.parent / "routes" / "cookbook_routes.py"
+).read_text(encoding="utf-8")
+
+
+def test_serve_cuda_env_lines_put_wheel_libs_on_ld_library_path():
+    lines = []
+    _append_llama_cpp_serve_cuda_env_lines(lines)
+    script = "\n".join(lines)
+    # Globs the pip CUDA wheel lib dirs (covers cudart/cublas, cu12/cu13 layouts).
+    assert "site-packages/nvidia/*/lib" in script
+    # Prepends each existing dir to the runtime loader path.
+    assert "export LD_LIBRARY_PATH=" in script
+    # Only acts when the dir exists, so it is a no-op without the wheels.
+    assert '[ -d "$_culib" ]' in script
+    # No leading/trailing colon when LD_LIBRARY_PATH was previously unset.
+    assert "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" in script
+    # Skipped on macOS, which serves via Metal rather than CUDA.
+    assert '[ "$(uname -s)" != "Darwin" ]' in script
+
+
+def test_serve_branch_exports_cuda_runtime_path():
+    # The llama.cpp serve branch must call the helper so the export is in scope
+    # when llama-server launches, not only during the one-time source build.
+    assert "_append_llama_cpp_serve_cuda_env_lines(runner_lines)" in _ROUTES
+
+
+def test_serve_diagnosis_recognizes_runtime_gpu_fallback():
+    # The serve-time "no usable GPU found" warning must be diagnosed; this is the
+    # runtime half that #559 (build-time CMake errors) did not cover.
+    assert "no usable GPU found" in _ROUTES
+    assert "--gpu-layers option will be ignored" in _ROUTES


### PR DESCRIPTION
## Summary

A Linux llama.cpp build compiles `llama-server` with `-DGGML_CUDA=ON` when a CUDA toolchain is present, which dynamically links the pip wheel's `libcudart` / `libcublas`. Those wheels install their `.so` files under `~/.local/lib/python*/site-packages/nvidia/*/lib`, which is not on the dynamic loader's default search path, and the build never runs `ldconfig`.

The serve flow (`routes/cookbook_routes.py`) only exported `PATH` (bin dirs) and `CUDA_VISIBLE_DEVICES`; it never set `LD_LIBRARY_PATH`. So a GPU-built `llama-server` could not load the CUDA runtime at serve time, the CUDA backend failed to initialize, and llama.cpp fell back to CPU with `warning: no usable GPU found, --gpu-layers option will be ignored`. Because the build branch is skipped once `llama-server` exists, every subsequent serve was affected too. This is the bug several users on modern GPUs (RTX 4070 / 5080 / 4090 Laptop) report in #831 after installing the CUDA wheels and rebuilding.

**Fix:**
- Add `_append_llama_cpp_serve_cuda_env_lines()` in `routes/cookbook_helpers.py`, which prepends any pip CUDA wheel `lib` dirs to `LD_LIBRARY_PATH`. This is the runtime mirror of the existing build-time `PATH`/`CUDA_HOME` export. It is a no-op when no such wheels are installed (a `[ -d ]` guard) and is skipped on macOS (Metal, not CUDA).
- Call it at the top of the llama.cpp serve branch so the export is in scope both for the one-time source build and for the eventual `llama-server` launch.
- Add a `_diagnose_serve_output` pattern for the runtime `no usable GPU found` / `--gpu-layers option will be ignored` warning. This complements #559, which only catches build-time CMake errors.

I verified `_odysseus_has_cudart` already handles both the consolidated `cu12`/`cu13` (`$CUDA_HOME/lib`) and the separate-component (`cuda_runtime/lib`) wheel layouts, so no detection change was needed there.

## Linked Issue

Fixes #2239
Part of #831

## Type of Change

- [x] Bug fix (non-breaking; fixes a confirmed issue)
- [ ] New feature (non-breaking; adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs; this is not a duplicate. (Searched open PRs for `LD_LIBRARY_PATH`, `no usable GPU`, `cudart`; the only related PR is my own diagnosis PR #559, which is build-time only and does not export runtime libraries.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above; no unrelated refactors or whitespace changes mixed in.
- [ ] I ran the full app end-to-end. I cannot end-to-end verify a CUDA path without a GPU on the build host; see the caveat below.

## How to Test

1. Run the new regression test: `./venv/bin/python -m pytest -q tests/test_cookbook_cuda_serve_ldpath.py` -> 3 passed. It asserts the helper globs `site-packages/nvidia/*/lib` and prepends each existing dir to `LD_LIBRARY_PATH` (guarded, no-op without wheels, skipped on macOS), that the serve branch calls the helper, and that the serve diagnosis recognizes the runtime warning.
2. Confirm red-before / green-after: `git stash push routes/cookbook_helpers.py routes/cookbook_routes.py` and re-run the test; it fails (the helper import is gone and the route assertions miss). `git stash pop` and it passes.
3. Regression sweep: `./venv/bin/python -m pytest -q tests/test_cookbook_helpers.py tests/test_cookbook_cuda_serve_ldpath.py` -> 43 passed.
4. `./venv/bin/python -m py_compile routes/cookbook_helpers.py routes/cookbook_routes.py tests/test_cookbook_cuda_serve_ldpath.py` -> passes.

## Caveat

I do not have a CUDA GPU on this machine, so I validated the generated serve script and the diagnosis rather than a live GPU offload. Final confirmation that a previously CPU-bound serve now offloads to the GPU would benefit from one of the affected #831 reporters testing it. The change is additive and guarded (no-op without the pip CUDA wheels, skipped on macOS), so it should not affect CPU-only or Metal serves.
