### PR TITLE
fix: treat Nix files as readable uploads

### DIFF
--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -20,7 +20,7 @@ def _is_text_file(path: str) -> bool:
     """Check if file has text extension."""
     return any(
         path.lower().endswith(ext)
-        for ext in (".txt", ".py", ".html", ".htm", ".md", ".json", ".csv", ".log", ".js")
+        for ext in (".txt", ".py", ".html", ".htm", ".md", ".json", ".csv", ".log", ".js", ".nix")
     )
 
 
@@ -29,7 +29,8 @@ def _process_text_file(path: str) -> str:
     language_map = {
         ".py": "python", ".js": "javascript", ".html": "html", ".css": "css",
         ".json": "json", ".md": "markdown", ".txt": "text", ".csv": "csv",
-        ".log": "log", ".sh": "bash", ".yml": "yaml", ".yaml": "yaml",
+        ".log": "log", ".sh": "bash", ".bash": "bash", ".nix": "nix",
+        ".yml": "yaml", ".yaml": "yaml",
         ".xml": "xml", ".sql": "sql", ".cpp": "cpp", ".c": "c",
         ".java": "java", ".go": "go", ".rs": "rust", ".php": "php",
         ".rb": "ruby", ".ts": "typescript", ".jsx": "javascript", ".tsx": "typescript",
@@ -91,8 +92,8 @@ def _process_text_file(path: str) -> str:
     header += f"[Type: {language}, Lines: {line_count}, Size: {size_str} bytes]"
 
     code_extensions = {
-        ".py", ".js", ".html", ".css", ".json", ".md", ".sh", ".yml", ".yaml",
-        ".xml", ".sql", ".cpp", ".c", ".java", ".go", ".rs", ".php", ".rb",
+        ".py", ".js", ".html", ".css", ".json", ".md", ".sh", ".bash", ".nix",
+        ".yml", ".yaml", ".xml", ".sql", ".cpp", ".c", ".java", ".go", ".rs", ".php", ".rb",
         ".ts", ".jsx", ".tsx",
     }
     if ext in code_extensions:

--- a/src/upload_handler.py
+++ b/src/upload_handler.py
@@ -175,8 +175,8 @@ class UploadHandler:
         document_extensions = {
             '.pdf', '.docx', '.xlsx', '.pptx', '.xls', '.epub',
             '.txt', '.py', '.js', '.html', '.htm',
-            '.css', '.json', '.md', '.csv', '.log', '.xml', '.yml', 
-            '.yaml', '.sql', '.sh', '.bash', '.c', '.cpp', '.h', 
+            '.css', '.json', '.md', '.csv', '.log', '.xml', '.yml',
+            '.yaml', '.nix', '.sql', '.sh', '.bash', '.c', '.cpp', '.h',
             '.java', '.go', '.rs', '.php', '.rb', '.ts', '.jsx', '.tsx'
         }
         document_mime_types = {

--- a/tests/test_nix_upload_text.py
+++ b/tests/test_nix_upload_text.py
@@ -1,0 +1,20 @@
+from src.document_processor import _is_text_file, _process_text_file
+from src.upload_handler import UploadHandler
+
+
+def test_nix_files_are_treated_as_readable_documents(tmp_path):
+    handler = UploadHandler(str(tmp_path), str(tmp_path / "uploads"))
+
+    assert handler.is_document_file("configuration.nix")
+    assert _is_text_file("configuration.nix")
+
+
+def test_nix_file_processing_includes_content_in_code_block(tmp_path):
+    nix_file = tmp_path / "configuration.nix"
+    nix_file.write_text("{ pkgs, ... }:\n{\n  services.openssh.enable = true;\n}\n", encoding="utf-8")
+
+    rendered = _process_text_file(str(nix_file))
+
+    assert "[Type: nix" in rendered
+    assert "```nix" in rendered
+    assert "services.openssh.enable = true;" in rendered


### PR DESCRIPTION
## Summary
- Treat `.nix` uploads as readable document/text attachments instead of falling through to the non-text attachment stub.
- Render Nix files with a `nix` code fence so configuration contents reach the model with useful file metadata.
- Add focused regression coverage for Nix upload classification and text rendering.

## Linked Issue

Fixes #2241

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## Scope note

This is intentionally limited to `.nix` upload handling for #2241. It does not replace the broader code-attachment extension work in #1910 or the Nix packaging/module work in #1523.

## How to Test

1. Run `python3 -m pytest tests/test_nix_upload_text.py` and confirm both regression tests pass.
2. Run `python3 -m py_compile src/upload_handler.py src/document_processor.py` to confirm the touched modules compile.
3. Upload a small `configuration.nix` file in chat and confirm its text is included as a Nix code block instead of appearing as a generic non-text attachment.

## Visual / UI changes

N/A — no UI rendering, CSS, HTML, or JavaScript was changed.
