### PR TITLE
ci: add CI workflow with ruff lint, pytest, and docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          uv pip install --system ruff
+      - name: Lint with ruff
+        run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install core dependencies
+        run: |
+          uv pip install --system -r requirements.txt
+      - name: Run tests
+        run: python -m pytest tests/ -v --tb=short -x
+      - name: Test app import smoke
+        run: python -c "import sys; sys.path.insert(0, '.'); from app import app; print('App loaded OK')"
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t odysseus --build-arg BUILDKIT_INLINE_CACHE=1 .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
Creates `.github/workflows/ci.yml` with three job groups:

- **lint** — ruff check (E, F, I, W) on Python 3.11 + 3.12
- **test** — pytest on Python 3.11 + 3.12, plus a quick `app:app` import smoke test
- **docker-build** — verify the Dockerfile builds cleanly

Also adds `[tool.ruff]` config to `pyproject.toml` (120 char line-length, standard pycodestyle + import rules).

Closes the issue: no workflows directory existed before this PR.