### PR TITLE
[codex] fix(hwfit): keep selected GGUF no-fit rows

### DIFF
--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -374,10 +374,15 @@ def analyze_model(model, system, target_quant=None, scoring_use_case=None, targe
         # and RAM modes where llama.cpp serving is the natural path.
         quant_to_try = "Q4_K_M"
 
-    # Multi-GPU filter: skip the row if the resolved quant is a GGUF tier
-    # (Q*/IQ-prefixed) — vLLM/SGLang can't serve those, so showing them on
-    # a 2+ GPU rig just clutters the list with unservable candidates.
-    if gpu_count >= 2 and quant_to_try and quant_to_try.upper().startswith(("Q2", "Q3", "Q4", "Q5", "Q6", "Q8", "IQ")):
+    # Multi-GPU filter: skip auto-resolved GGUF tiers (Q*/IQ-prefixed) because
+    # vLLM/SGLang can't serve them. If the user explicitly selected a quant,
+    # let it fall through so the existing no_fit row explains the mismatch.
+    if (
+        gpu_count >= 2
+        and not target_quant
+        and quant_to_try
+        and quant_to_try.upper().startswith(("Q2", "Q3", "Q4", "Q5", "Q6", "Q8", "IQ"))
+    ):
         return None
 
     result = _try_quant_at(model, quant_to_try, ctx, effective_vram, 0 if native_gpu_only else eff_ram)


### PR DESCRIPTION
## Summary

- Preserve explicitly selected GGUF quant rows on multi-GPU hardware so oversized selections produce the existing no_fit result instead of disappearing.
- Keep the auto-resolved multi-GPU GGUF filter intact for unselected Q*/IQ rows.
- Fix the current regression where the selected Q8_0 test returned None.

## Linked Issue

Fixes #2248

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets main.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run .venv/bin/pytest -q tests/test_hwfit_quant_formats.py::test_selected_gguf_quant_is_strict_not_lower_quant_fallback and confirm the selected Q8_0 case returns a no_fit row.
2. Run .venv/bin/pytest -q tests/test_hwfit_quant_formats.py tests/test_hwfit_amd.py tests/test_hwfit_macos.py tests/test_hwfit_manual_backend.py tests/test_hwfit_params_b_malformed.py and confirm the surrounding hwfit GGUF filtering behavior still passes.
3. Run git diff --check and confirm there are no whitespace errors.

## Visual / UI Changes

N/A - no visual UI changes.