### PR TITLE
fix(tests): provide required endpoint_url in archived sessions model filter test

### DIFF
--- a/tests/test_archived_sessions_model_filter.py
+++ b/tests/test_archived_sessions_model_filter.py
@@ -51,7 +51,7 @@ def _seed(owner, *models):
         db.query(DbSession).delete()
         for m in models:
             db.add(DbSession(id=str(uuid.uuid4()), owner=owner, name=f"chat {m}",
-                             model=m, archived=True))
+                             endpoint_url="http://localhost", model=m, archived=True))
         db.commit()
     finally:
         db.close()


### PR DESCRIPTION
## Summary

The sessions table now enforces NOT NULL on `endpoint_url`, but the test fixture in `test_archived_sessions_model_filter.py` omitted it when seeding archived sessions, causing `sqlite3.IntegrityError` on all three test cases. Adds `endpoint_url="http://localhost"` to the seed.

## Linked Issue

Fixes #2274

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run `python -m pytest tests/test_archived_sessions_model_filter.py -q` — 3 passed (was 3 failing)