### PR TITLE
fix: keep email paperclip attachments after file input reset

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -2676,7 +2676,7 @@ import * as Modals from './modalManager.js';
   }
 
   async function _handleAttachUpload(e) {
-    const files = e.target.files;
+    const files = Array.from(e.target.files || []);
     e.target.value = ''; // reset for next upload
     await _uploadComposeFiles(files);
   }

--- a/tests/test_email_compose_attachments_js.py
+++ b/tests/test_email_compose_attachments_js.py
@@ -1,0 +1,39 @@
+"""Regression guard for email compose paperclip attachments (#2227)."""
+
+import re
+from pathlib import Path
+
+
+SRC = Path(__file__).resolve().parent.parent / "static/js/document.js"
+
+
+def _function_body(name: str) -> str:
+    text = SRC.read_text(encoding="utf-8")
+    match = re.search(rf"\n\s*(?:async\s+)?function\s+{name}\([^)]*\)\s*\{{", text)
+    assert match, f"{name} not found"
+
+    start = match.end()
+    depth = 1
+    i = start
+    while i < len(text) and depth:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} body did not close"
+    return text[start : i - 1]
+
+
+def test_file_picker_snapshots_files_before_resetting_input():
+    body = _function_body("_handleAttachUpload")
+
+    snapshot = "const files = Array.from(e.target.files || []);"
+    reset = "e.target.value = '';"
+    upload = "await _uploadComposeFiles(files);"
+
+    assert snapshot in body
+    assert reset in body
+    assert upload in body
+    assert body.index(snapshot) < body.index(reset) < body.index(upload)
+    assert "const files = e.target.files;" not in body


### PR DESCRIPTION
## Summary

The email compose paperclip handler kept a live `input.files` reference, cleared the file input, then passed that same `FileList` to the upload helper. In browsers where clearing the input empties the live `FileList`, the picker path uploaded nothing even though drag-and-drop worked.

This snapshots selected files into a normal array before resetting the input, so the existing compose upload helper receives the chosen files reliably.

## Linked Issue

Fixes #2227

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## How to Test

1. `.venv/bin/pytest -q tests/test_email_compose_attachments_js.py`
2. `.venv/bin/pytest -q tests/test_upload_error_surfaced.py tests/test_modal_dock_composer_clearance.py tests/test_email_compose_attachments_js.py`
3. `git diff --check`

## Checklist

- [x] I searched existing issues and PRs for duplicates.
- [x] I added or updated tests for this change.
