### PR TITLE
fix(ui): restore all-edge modal snap zones for docking

### DIFF
--- a/static/js/tileManager.js
+++ b/static/js/tileManager.js
@@ -6,16 +6,13 @@
  * when the cursor is near a snap zone. On release, snaps the modal-content
  * to fill that zone with a springy animation.
  *
- * Snap zones (9):
- *   - top edge (10% strip)        → maximize
- *   - top-left corner             → top-left quarter
- *   - top-right corner            → top-right quarter
+ * Snap zones:
+ *   - over top edge               → fullscreen
+ *   - top strip                   → maximize
+ *   - top edge                    → top half
  *   - left edge                   → left half
  *   - right edge                  → right half
- *   - bottom-left corner          → bottom-left quarter
- *   - bottom-right corner         → bottom-right quarter
  *   - bottom edge                 → bottom half
- *   - sidebar edge (if present)   → snap next to the sidebar
  *
  * Mobile (≤768px) is excluded — the swipe-dismiss UX takes precedence.
  *
@@ -24,7 +21,6 @@
  */
 
 const EDGE_THRESHOLD_PX = 24;     // how close to an edge counts as "near"
-const CORNER_THRESHOLD_PX = 64;   // corner box size
 const TOP_FULL_STRIP_PX = 8;      // top strip → maximize
 
 let _ghost = null;
@@ -111,9 +107,13 @@ function _zoneForPointer(x, y) {
     return { name: 'maximize', rect: { left: safe.left, top: safe.top, width: W, height: H } };
   }
 
-  // Corner quarter-snaps DISABLED (user request) — only the top strip
-  // (maximize) and the right/bottom half-snaps remain. The LEFT-half snap
-  // is also disabled (the sidebar lives there; docking over it is awkward).
+  // Symmetric edge half-snaps. The safe rect already starts to the right of
+  // the sidebar/rail, so left-half fills the left side of the workspace
+  // without covering navigation.
+  if (y <= safe.top + EDGE_THRESHOLD_PX)
+    return { name: 'top-half', rect: { left: safe.left, top: safe.top, width: W, height: H / 2 } };
+  if (x <= safe.left + EDGE_THRESHOLD_PX)
+    return { name: 'left-half', rect: { left: safe.left, top: safe.top, width: W / 2, height: H } };
   if (x >= safe.right - EDGE_THRESHOLD_PX)
     return { name: 'right-half', rect: { left: safe.left + W / 2, top: safe.top, width: W / 2, height: H } };
   if (y >= safe.bottom - EDGE_THRESHOLD_PX)
@@ -131,8 +131,7 @@ function _zoneForContent(content, x, y) {
   // flip to top tabs via CSS when the window gets narrow.
   if (modal && modal.id === 'settings-modal' && zone.name !== 'right-half') return null;
   if (modal && (modal.id === 'cookbook-modal'
-      || modal.id === 'theme-modal'
-      || modal.id === 'memory-modal')
+      || modal.id === 'theme-modal')
       && zone.name !== 'fullscreen') return null;
   return zone;
 }
@@ -304,6 +303,7 @@ function _reclampAll(animate = false) {
     switch (name) {
       case 'fullscreen':     r = { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight }; break;
       case 'maximize':       r = { left: safe.left, top: safe.top, width: W, height: H }; break;
+      case 'top-half':       r = { left: safe.left, top: safe.top, width: W, height: H/2 }; break;
       case 'left-half':      r = { left: safe.left, top: safe.top, width: W/2, height: H }; break;
       case 'right-half':     r = { left: safe.left + W/2, top: safe.top, width: W/2, height: H }; break;
       case 'bottom-half':    r = { left: safe.left, top: safe.top + H/2, width: W, height: H/2 }; break;
@@ -372,6 +372,14 @@ export function previewZoneAt(x, y, target = null) {
 export function clearPreview() {
   _hideGhost();
   _activeZone = null;
+}
+
+export function _zoneForPointerForTests(x, y) {
+  return _zoneForPointer(x, y);
+}
+
+export function _zoneForContentForTests(content, x, y) {
+  return _zoneForContent(content, x, y);
 }
 
 // Snap a modal (its .modal-content) into a previously-detected zone.

--- a/tests/test_tile_manager_snap_zones_js.py
+++ b/tests/test_tile_manager_snap_zones_js.py
@@ -1,0 +1,117 @@
+"""Regression coverage for desktop modal tile snap edge zones."""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "tileManager.js"
+_HAS_NODE = shutil.which("node") is not None
+
+
+def _run_tile_case():
+    script = textwrap.dedent(
+        f"""
+        globalThis.window = {{
+          innerWidth: 1200,
+          innerHeight: 800,
+          addEventListener() {{}},
+        }};
+        globalThis.document = {{
+          readyState: 'loading',
+          body: {{ appendChild() {{}} }},
+          documentElement: {{ style: {{ setProperty() {{}}, removeProperty() {{}} }} }},
+          addEventListener() {{}},
+          getElementById() {{ return null; }},
+          querySelector() {{ return null; }},
+          querySelectorAll() {{ return []; }},
+          createElement() {{
+            return {{
+              style: {{}},
+              classList: {{ add() {{}}, remove() {{}} }},
+              remove() {{}},
+            }};
+          }},
+        }};
+        globalThis.requestAnimationFrame = (fn) => fn();
+        globalThis.MutationObserver = class {{
+          observe() {{}}
+          disconnect() {{}}
+        }};
+
+        const mod = await import('{_HELPER.as_posix()}');
+        const pick = (zone) => zone ? {{
+          name: zone.name,
+          rect: {{
+            left: zone.rect.left,
+            top: zone.rect.top,
+            width: zone.rect.width,
+            height: zone.rect.height,
+          }},
+        }} : null;
+
+        const memoryModal = {{ id: 'memory-modal' }};
+        const memoryContent = {{ closest() {{ return memoryModal; }} }};
+        const settingsModal = {{ id: 'settings-modal' }};
+        const settingsContent = {{ closest() {{ return settingsModal; }} }};
+
+        console.log(JSON.stringify({{
+          fullscreen: pick(mod._zoneForPointerForTests(500, 0)),
+          maximize: pick(mod._zoneForPointerForTests(500, 8)),
+          top: pick(mod._zoneForPointerForTests(500, 20)),
+          left: pick(mod._zoneForPointerForTests(20, 300)),
+          right: pick(mod._zoneForPointerForTests(1190, 300)),
+          bottom: pick(mod._zoneForPointerForTests(500, 790)),
+          memoryBottom: pick(mod._zoneForContentForTests(memoryContent, 500, 790)),
+          settingsTop: pick(mod._zoneForContentForTests(settingsContent, 500, 20)),
+          settingsRight: pick(mod._zoneForContentForTests(settingsContent, 1190, 300)),
+        }}));
+        """
+    )
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=script,
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_tile_manager_detects_all_four_workspace_edges():
+    zones = _run_tile_case()
+
+    assert zones["fullscreen"]["name"] == "fullscreen"
+    assert zones["maximize"]["name"] == "maximize"
+    assert zones["top"] == {
+        "name": "top-half",
+        "rect": {"left": 4, "top": 4, "width": 1192, "height": 396},
+    }
+    assert zones["left"] == {
+        "name": "left-half",
+        "rect": {"left": 4, "top": 4, "width": 596, "height": 792},
+    }
+    assert zones["right"] == {
+        "name": "right-half",
+        "rect": {"left": 600, "top": 4, "width": 596, "height": 792},
+    }
+    assert zones["bottom"] == {
+        "name": "bottom-half",
+        "rect": {"left": 4, "top": 400, "width": 1192, "height": 396},
+    }
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_regular_tool_modals_are_not_limited_to_fullscreen_only():
+    zones = _run_tile_case()
+
+    assert zones["memoryBottom"]["name"] == "bottom-half"
+    assert zones["settingsTop"] is None
+    assert zones["settingsRight"]["name"] == "right-half"


### PR DESCRIPTION

## Summary

Restores symmetric desktop tile snap zones for draggable tool panels so the shared modal tiling path can preview and snap to the top, left, right, and bottom workspace edges. The top fullscreen/maximize behavior is preserved, Settings keeps its right-half-only guard, and the Brain modal is no longer incorrectly limited to fullscreen-only snaps.

## Linked Issue

Fixes #1074

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

I smoke-started the app with `uvicorn app:app` and confirmed `/` responds with the expected auth redirect. I did not attach a manual drag recording; the interaction logic is covered by the focused browser-module regression below.

## How to Test

1. Run `.venv/bin/pytest -q tests/test_tile_manager_snap_zones_js.py tests/test_modal_dock_composer_clearance.py tests/test_snap_other_layers_nonarray_js.py`.
2. Start Odysseus and open a draggable desktop tool panel such as Library, Email, or Brain.
3. Drag the panel header near the top, left, right, and bottom workspace edges and confirm the snap preview appears and the panel tiles to that half of the workspace on release.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus existing visual language. It reuses the existing `#tile-ghost` preview and does not add colors, spacing, typography, icons, or component classes.
- [x] **No new component patterns.** This extends the existing shared `tileManager.js` snap behavior instead of adding a parallel docking UI.
- [ ] **I am not an LLM agent submitting a bulk PR.** This is a single issue-linked fix, not a bulk PR.

### Screenshots / clips

Not attached. This changes snap-zone behavior and reuses the existing snap preview styling; no new visual style was introduced.
