### PR TITLE
Recall last user message with ArrowUp

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -40,6 +40,7 @@ import groupModule from './js/group.js';
 import * as researchPanelModule from './js/research/panel.js';
 import ttsModule from './js/tts-ai.js';
 import spinnerModule from './js/spinner.js';
+import { recallLastUserMessageFromHistory } from './js/composerRecall.js';
 import { initKeyboardShortcuts } from './js/keyboard-shortcuts.js';
 import { initSidebarLayout, syncRailSide } from './js/sidebar-layout.js';
 import { initSectionCollapse, initSectionDrag } from './js/section-management.js';
@@ -3739,6 +3740,8 @@ function startOdysseusApp() {
   // Enter to send (shift+enter for newline), or new chat when empty
   if (messageInput) {
     messageInput.addEventListener('keydown', (e) => {
+      if (recallLastUserMessageFromHistory(messageInput, el('chat-history'), e)) return;
+
       if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
         e.preventDefault();
         // Flush the debounced icon update so dataset.mode reflects the current

--- a/static/js/composerRecall.js
+++ b/static/js/composerRecall.js
@@ -1,0 +1,38 @@
+export function shouldRecallLastUserMessage(input, event) {
+  if (!input || !event || event.key !== 'ArrowUp') return false;
+  if (input.value !== '') return false;
+  if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return false;
+  if (event.isComposing !== false) return false;
+  return true;
+}
+
+export function getLastUserMessageRaw(chatHistory) {
+  const userMessages = chatHistory?.querySelectorAll?.('.msg-user');
+  if (!userMessages || userMessages.length === 0) return '';
+  const lastUserMessage = userMessages[userMessages.length - 1];
+  const raw = lastUserMessage?.dataset?.raw;
+  return typeof raw === 'string' ? raw : '';
+}
+
+function dispatchInputEvent(input) {
+  if (typeof input?.dispatchEvent !== 'function') return;
+
+  const EventCtor = input.ownerDocument?.defaultView?.Event || globalThis.Event;
+  if (typeof EventCtor !== 'function') return;
+  input.dispatchEvent(new EventCtor('input', { bubbles: true }));
+}
+
+export function recallLastUserMessageFromHistory(input, chatHistory, event) {
+  if (!shouldRecallLastUserMessage(input, event)) return false;
+
+  const raw = getLastUserMessageRaw(chatHistory);
+  if (raw === '') return false;
+
+  if (typeof event.preventDefault === 'function') event.preventDefault();
+  input.value = raw;
+  if (typeof input.setSelectionRange === 'function') {
+    input.setSelectionRange(raw.length, raw.length);
+  }
+  dispatchInputEvent(input);
+  return true;
+}

--- a/tests/test_composer_recall_js.py
+++ b/tests/test_composer_recall_js.py
@@ -1,0 +1,184 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "composerRecall.js"
+_APP = _REPO / "static" / "app.js"
+_HAS_NODE = shutil.which("node") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+
+
+def _run(js: str):
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js,
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_arrowup_empty_composer_recalls_last_user_message():
+    result = _run(
+        f"""
+        import {{ recallLastUserMessageFromHistory }} from '{_HELPER.as_uri()}';
+
+        const dispatched = [];
+        const input = {{
+          value: '',
+          selection: null,
+          setSelectionRange(start, end) {{ this.selection = [start, end]; }},
+          dispatchEvent(event) {{ dispatched.push({{ type: event.type, bubbles: event.bubbles }}); }},
+        }};
+        const history = {{
+          querySelectorAll(selector) {{
+            if (selector !== '.msg-user') throw new Error('unexpected selector: ' + selector);
+            return [
+              {{ dataset: {{ raw: 'first prompt' }} }},
+              {{ dataset: {{ raw: 'last prompt\\nwith newline' }} }},
+            ];
+          }},
+        }};
+        let prevented = false;
+        const handled = recallLastUserMessageFromHistory(input, history, {{
+          key: 'ArrowUp',
+          isComposing: false,
+          preventDefault() {{ prevented = true; }},
+        }});
+
+        console.log(JSON.stringify({{
+          handled,
+          prevented,
+          value: input.value,
+          selection: input.selection,
+          dispatched,
+        }}));
+        """
+    )
+
+    assert result == {
+        "handled": True,
+        "prevented": True,
+        "value": "last prompt\nwith newline",
+        "selection": [24, 24],
+        "dispatched": [{"type": "input", "bubbles": True}],
+    }
+
+
+def test_arrowup_recall_leaves_non_empty_composer_alone():
+    result = _run(
+        f"""
+        import {{ recallLastUserMessageFromHistory }} from '{_HELPER.as_uri()}';
+
+        const input = {{
+          value: 'already typing',
+          selection: null,
+          setSelectionRange(start, end) {{ this.selection = [start, end]; }},
+        }};
+        let prevented = false;
+        const handled = recallLastUserMessageFromHistory(
+          input,
+          {{ querySelectorAll() {{ return [{{ dataset: {{ raw: 'last prompt' }} }}]; }} }},
+          {{
+            key: 'ArrowUp',
+            isComposing: false,
+            preventDefault() {{ prevented = true; }},
+          }}
+        );
+
+        console.log(JSON.stringify({{
+          handled,
+          prevented,
+          value: input.value,
+          selection: input.selection,
+        }}));
+        """
+    )
+
+    assert result == {
+        "handled": False,
+        "prevented": False,
+        "value": "already typing",
+        "selection": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "event_patch",
+    [
+        {"key": "Enter", "isComposing": False},
+        {"key": "ArrowUp", "isComposing": True},
+        {"key": "ArrowUp", "isComposing": False, "shiftKey": True},
+        {"key": "ArrowUp", "isComposing": False, "altKey": True},
+        {"key": "ArrowUp", "isComposing": False, "ctrlKey": True},
+        {"key": "ArrowUp", "isComposing": False, "metaKey": True},
+    ],
+)
+def test_arrowup_recall_ignores_wrong_key_composition_and_modifiers(event_patch):
+    result = _run(
+        f"""
+        import {{ recallLastUserMessageFromHistory }} from '{_HELPER.as_uri()}';
+
+        const input = {{ value: '' }};
+        let prevented = false;
+        const event = {{
+          ...{json.dumps(event_patch)},
+          preventDefault() {{ prevented = true; }},
+        }};
+        const handled = recallLastUserMessageFromHistory(
+          input,
+          {{ querySelectorAll() {{ return [{{ dataset: {{ raw: 'last prompt' }} }}]; }} }},
+          event
+        );
+
+        console.log(JSON.stringify({{
+          handled,
+          prevented,
+          value: input.value,
+        }}));
+        """
+    )
+
+    assert result == {"handled": False, "prevented": False, "value": ""}
+
+
+def test_arrowup_recall_requires_last_user_dataset_raw():
+    result = _run(
+        f"""
+        import {{ recallLastUserMessageFromHistory }} from '{_HELPER.as_uri()}';
+
+        const input = {{ value: '' }};
+        let prevented = false;
+        const handled = recallLastUserMessageFromHistory(
+          input,
+          {{ querySelectorAll() {{ return [{{ dataset: {{ raw: 'first prompt' }} }}, {{ dataset: {{ raw: '' }} }}]; }} }},
+          {{
+            key: 'ArrowUp',
+            isComposing: false,
+            preventDefault() {{ prevented = true; }},
+          }}
+        );
+
+        console.log(JSON.stringify({{
+          handled,
+          prevented,
+          value: input.value,
+        }}));
+        """
+    )
+
+    assert result == {"handled": False, "prevented": False, "value": ""}
+
+
+def test_app_wires_recall_into_message_keydown():
+    body = _APP.read_text(encoding="utf-8")
+    assert "import { recallLastUserMessageFromHistory } from './js/composerRecall.js';" in body
+    assert "recallLastUserMessageFromHistory(messageInput, el('chat-history'), e)" in body


### PR DESCRIPTION
## Summary

Adds ArrowUp recall for the chat composer when the input is literally empty. The handler pulls `dataset.raw` from the latest `.msg-user`, restores it into `#message`, places the caret at the end, and leaves normal textarea navigation alone for non-empty input, modifier keys, and IME composition.

## Linked Issue

Fixes #2144

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Send a chat message, focus an empty `#message` composer, and press ArrowUp.
2. Confirm the last user message text is restored and the caret is placed at the end.
3. Confirm ArrowUp is left alone when the composer is non-empty, when a modifier key is held, or during IME composition.
4. Run `.venv/bin/pytest -q tests/test_composer_recall_js.py tests/test_keybind_altgr_js.py tests/test_new_chat_clears_input.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable: this changes keyboard behavior only and does not change rendered UI.
