### PR TITLE
Fix Agent mode on Ollama v1 endpoints

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -13,6 +13,7 @@ import re
 import time
 import logging
 from typing import AsyncGenerator, List, Dict, Optional, Set
+from urllib.parse import urlparse
 
 from src.llm_core import stream_llm, stream_llm_with_fallback, _is_ollama_native_url
 from src.model_context import estimate_tokens
@@ -465,6 +466,64 @@ _API_HOSTS = frozenset([
     # schemas and the agent silently degrades to fenced-block parsing.
     "localhost", "127.0.0.1", "host.docker.internal",
 ])
+
+_TOOL_SCHEMA_MODEL_HINTS = (
+    "gpt-4", "gpt-5", "gpt-o", "claude", "gemini", "gemma",
+    "qwen3", "qwen2.5", "mixtral", "mistral", "llama-3.1", "llama-3.2",
+    "llama-3.3", "llama-4",
+    # Local-served models that follow OpenAI-style function calling via
+    # vLLM's `--enable-auto-tool-choice`. Belt-and-suspenders with the
+    # per-endpoint flag below.
+    "minimax", "kimi", "yi-", "phi-3", "phi-4", "command-r",
+    "glm-4", "internlm", "hermes",
+    # deepseek-v2/v3/chat support tools via the cloud API; deepseek-r1
+    # (reasoning model) does not — handled by the blocklist below.
+    "deepseek-v", "deepseek-chat",
+)
+_NO_TOOL_SCHEMA_MODEL_HINTS = (
+    "deepseek-r1",
+)
+
+
+def _is_ollama_openai_compat_url(endpoint_url: str) -> bool:
+    """Return True for Ollama's local/LAN OpenAI-compatible `/v1` endpoint."""
+    try:
+        parsed = urlparse(endpoint_url or "")
+        port = parsed.port
+    except Exception:
+        return False
+
+    host = (parsed.hostname or "").lower()
+    path = (parsed.path or "").rstrip("/")
+    is_ollama_host = port == 11434 or host == "ollama"
+    return is_ollama_host and (path == "/v1" or path.startswith("/v1/"))
+
+
+def _agent_uses_native_tool_schemas(
+    model: str,
+    endpoint_url: str,
+    endpoint_supports: Optional[bool] = None,
+) -> bool:
+    """Decide whether agent mode should send native function/tool schemas."""
+    if endpoint_supports is True:
+        return True
+    if endpoint_supports is False:
+        return False
+
+    model_lc = (model or "").lower()
+    if any(kw in model_lc for kw in _NO_TOOL_SCHEMA_MODEL_HINTS):
+        return False
+
+    # Ollama native `/api/chat` and local Ollama's OpenAI-compatible `/v1`
+    # endpoint can accept the request shape but many models respond to schemas
+    # with a single tool-call token and no prose. Default these to the text
+    # fenced-block path unless the endpoint is explicitly opted in.
+    if _is_ollama_native_url(endpoint_url or "") or _is_ollama_openai_compat_url(endpoint_url or ""):
+        return False
+
+    model_supports_tools = any(kw in model_lc for kw in _TOOL_SCHEMA_MODEL_HINTS)
+    return any(h in (endpoint_url or "") for h in _API_HOSTS) or model_supports_tools
+
 _MCP_KEYWORDS = frozenset(["browse", "browser", "website", "calendar", "event", "email",
                            "gmail", "screenshot", "navigate", "click", "miniflux", "rss", "feed"])
 _ADMIN_SCHEMA_NAMES = frozenset([
@@ -1449,11 +1508,6 @@ async def stream_agent_loop(
     prep_timings["tool_selection"] = time.time() - _t1
 
     _t2 = time.time()
-    # Hosted-API match by URL, OR the model name looks like a recent model
-    # known to follow OpenAI-style function calling (DeepSeek, GPT*, Claude,
-    # Gemini, Qwen3+, Mixtral, Llama 3.1+). Caught the DeepSeek-via-local-
-    # vLLM case where endpoint_url doesn't include a vendor host.
-    _model_lc = (model or "").lower()
     # Step 1: per-endpoint override (set at registration time from the
     # serve command — `--enable-auto-tool-choice` flips it on. UI can
     # also toggle per endpoint). NULL = unknown, fall through to the
@@ -1474,41 +1528,7 @@ async def stream_agent_loop(
             _db.close()
     except Exception as _e:
         logger.debug(f"endpoint supports_tools lookup failed: {_e}")
-    _model_supports_tools = any(kw in _model_lc for kw in (
-        "gpt-4", "gpt-5", "gpt-o", "claude", "gemini", "gemma",
-        "qwen3", "qwen2.5", "mixtral", "mistral", "llama-3.1", "llama-3.2",
-        "llama-3.3", "llama-4",
-        # Local-served models that follow OpenAI-style function calling
-        # via vLLM's `--enable-auto-tool-choice`. Belt-and-suspenders
-        # with the per-endpoint flag above.
-        "minimax", "kimi", "yi-", "phi-3", "phi-4", "command-r",
-        "glm-4", "internlm", "hermes",
-        # deepseek-v2/v3/chat support tools via the cloud API; deepseek-r1
-        # (reasoning model) does not — handled by the blocklist below.
-        "deepseek-v", "deepseek-chat",
-    ))
-    # Models known to reject tool schemas at the Ollama/local level even when
-    # the endpoint URL would otherwise enable native function calling.
-    # The per-endpoint supports_tools flag (True/False) always takes priority
-    # and can override this list for users who know their setup.
-    _model_no_tools = any(kw in _model_lc for kw in (
-        "deepseek-r1",
-    ))
-    # Native Ollama endpoints (/api/chat) handle tool schemas differently from
-    # the OpenAI-compat path. Models like gemma4, qwen3.5, ministral respond to
-    # tool schemas by emitting a single native tool_call token then stopping,
-    # rather than writing a fenced block — the agent loop sees 1 token and no
-    # recognised tool, so the round terminates immediately (issue #1567).
-    # Unless the endpoint is explicitly marked supports_tools=True by the user
-    # (via the endpoint settings toggle), treat Ollama-native as text-only so
-    # the fenced-block path is used instead of native function calling.
-    _is_ollama_native = _is_ollama_native_url(endpoint_url or "")
-    if _endpoint_supports is True:
-        _is_api_model = True
-    elif _endpoint_supports is False or _model_no_tools or _is_ollama_native:
-        _is_api_model = False
-    else:
-        _is_api_model = any(h in endpoint_url for h in _API_HOSTS) or _model_supports_tools
+    _is_api_model = _agent_uses_native_tool_schemas(model, endpoint_url or "", _endpoint_supports)
     messages, mcp_schemas = _build_system_prompt(
         messages, model, active_document, mcp_mgr, disabled_tools,
         needs_admin=_needs_admin, relevant_tools=_relevant_tools,

--- a/tests/test_tool_support_heuristic.py
+++ b/tests/test_tool_support_heuristic.py
@@ -1,39 +1,25 @@
 """Regression tests for the tool-support heuristic in stream_agent_loop.
 
 Verifies two critical cases:
-  1. deepseek-r1 on a local Ollama endpoint must NOT enable native tool schemas
-     (Ollama returns HTTP 400 for these models when tools are sent).
+  1. Ollama's local OpenAI-compatible `/v1` endpoint must NOT enable native
+     tool schemas by default. Some models return a single tool-call token and
+     no prose when schemas are sent.
   2. api.deepseek.com must still be treated as tool-capable via the host
      allow-list (_API_HOSTS), so cloud deepseek users keep working.
 """
-import pytest
-from src.agent_loop import _API_HOSTS
+from src.agent_loop import (
+    _API_HOSTS,
+    _agent_uses_native_tool_schemas,
+    _is_ollama_openai_compat_url,
+)
 
 
 def _compute_is_api_model(model: str, endpoint_url: str, endpoint_supports=None) -> bool:
-    """Replicate the heuristic from stream_agent_loop without side effects."""
-    model_lc = model.lower()
-
-    model_supports_tools = any(kw in model_lc for kw in (
-        "gpt-4", "gpt-5", "gpt-o", "claude", "gemini", "gemma",
-        "qwen3", "qwen2.5", "mixtral", "mistral", "llama-3.1", "llama-3.2",
-        "llama-3.3", "llama-4",
-        "minimax", "kimi", "yi-", "phi-3", "phi-4", "command-r",
-        "glm-4", "internlm", "hermes",
-        "deepseek-v", "deepseek-chat",
-    ))
-    model_no_tools = any(kw in model_lc for kw in (
-        "deepseek-r1",
-    ))
-
-    if endpoint_supports is True:
-        return True
-    if endpoint_supports is False or model_no_tools:
-        return False
-    return any(h in endpoint_url for h in _API_HOSTS) or model_supports_tools
+    """Wrap the production heuristic used by stream_agent_loop."""
+    return _agent_uses_native_tool_schemas(model, endpoint_url, endpoint_supports)
 
 
-class TestDeepSeekToolSupport:
+class TestLocalOllamaToolSupport:
     # --- local Ollama cases (must NOT get tool schemas) ---
 
     def test_deepseek_r1_7b_local_ollama_no_tools(self):
@@ -55,6 +41,20 @@ class TestDeepSeekToolSupport:
         assert _compute_is_api_model(
             "deepseek-r1:7b", "http://host.docker.internal:11434/v1"
         ) is False
+
+    def test_gemma4_local_ollama_v1_no_tools(self):
+        assert _compute_is_api_model("gemma4:e2b", "http://localhost:11434/v1") is False
+
+    def test_qwen_local_ollama_v1_no_tools(self):
+        assert _compute_is_api_model("qwen2.5:14b", "http://localhost:11434/v1") is False
+
+    def test_lan_ollama_v1_no_tools_by_port(self):
+        assert _compute_is_api_model("gemma4:e2b", "http://192.168.1.50:11434/v1") is False
+
+    def test_ollama_openai_compat_url_detector(self):
+        assert _is_ollama_openai_compat_url("http://localhost:11434/v1") is True
+        assert _is_ollama_openai_compat_url("http://localhost:11434/v1/chat/completions") is True
+        assert _is_ollama_openai_compat_url("http://localhost:8000/v1") is False
 
     # --- cloud API cases (must still get tool schemas) ---
 
@@ -82,6 +82,12 @@ class TestDeepSeekToolSupport:
         )
         assert result is True
 
+    def test_endpoint_supports_true_overrides_local_ollama_v1_default(self):
+        result = _compute_is_api_model(
+            "gemma4:e2b", "http://localhost:11434/v1", endpoint_supports=True
+        )
+        assert result is True
+
     def test_endpoint_supports_false_overrides_cloud(self):
         """supports_tools=False on an endpoint gates even cloud APIs."""
         result = _compute_is_api_model(
@@ -89,13 +95,13 @@ class TestDeepSeekToolSupport:
         )
         assert result is False
 
-    # --- other local models unaffected ---
+    # --- other local OpenAI-compatible servers unaffected ---
 
-    def test_qwen_local_still_gets_tools(self):
-        assert _compute_is_api_model("qwen2.5:14b", "http://localhost:11434/v1") is True
+    def test_qwen_local_non_ollama_still_gets_tools(self):
+        assert _compute_is_api_model("qwen2.5:14b", "http://localhost:8000/v1") is True
 
-    def test_llama_local_gets_tools_via_host(self):
-        assert _compute_is_api_model("llama3.2:3b", "http://localhost:11434/v1") is True
+    def test_llama_local_non_ollama_gets_tools_via_host(self):
+        assert _compute_is_api_model("llama3.2:3b", "http://localhost:8000/v1") is True
 
 
 class TestApiHostsContainsDeepSeek:


### PR DESCRIPTION
## Summary

Fixes agent mode for local Ollama OpenAI-compatible endpoints such as `http://localhost:11434/v1` by defaulting them to the fenced-block tool path instead of sending native tool schemas. Some Ollama-served models, including the reported `gemma4:e2b`, can stop after a single tool-call token with no prose when schemas are sent. Explicit `supports_tools=True` endpoint overrides still opt a server back into native tool schemas, while non-Ollama local OpenAI-compatible servers remain tool-capable.

## Linked Issue

Fixes #2261

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure an Ollama endpoint at `http://localhost:11434/v1`, select a model such as `gemma4:e2b`, and use Agent mode.
2. Confirm the agent no longer sends native function schemas by default for that Ollama `/v1` endpoint, so the model uses the fenced-block tool path instead of stopping after one tool-call token.
3. Confirm setting the endpoint's `supports_tools=True` override still enables native tool schemas.
4. Run `.venv/bin/pytest -q tests/test_tool_support_heuristic.py tests/test_ollama_port_detection.py tests/test_agent_loop.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**N/A — this PR changes no rendering.** No CSS, HTML, SVG, or DOM-rendering `static/js` code is touched.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** This only adjusts backend agent tool-schema selection.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable.
