### PR TITLE
fix: re-export _SPORTS_HINT_RE from search ranking compatibility shim

### DIFF
--- a/src/search/ranking.py
+++ b/src/search/ranking.py
@@ -7,6 +7,7 @@ parallel copy; it now re-exports so the two cannot drift out of sync again.
 
 from services.search.ranking import (  # noqa: F401
     _AGE_FORMATS,
+    _SPORTS_HINT_RE,
     _utcnow_naive,
     rank_search_results,
     recency_score,


### PR DESCRIPTION
## Summary

The compatibility re-export shim at `src/search/ranking.py` forgot `_SPORTS_HINT_RE`, so tests importing `src.search.ranking` raised `AttributeError` on the `[src]` parametrize variant of `test_search_ranking_sports_substring`.

Scoped per review feedback on #2080 — dropped the PDF and nondict changes that duplicate #2004 and #1919.

## Linked Issue

Fixes #1995

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run `python -m pytest tests/test_search_ranking_sports_substring.py -q` — 6 passed (was 2 failing on [src])

🤖 Generated with [Claude Code](https://claude.com/claude-code)