### PR TITLE
[codex] fix(research): sanitize visual report markdown

### DIFF
--- a/src/visual_report.py
+++ b/src/visual_report.py
@@ -32,6 +32,76 @@ logger = logging.getLogger(__name__)
 # Helpers
 # ---------------------------------------------------------------------------
 
+_REPORT_ALLOWED_TAGS = {
+    "a", "abbr", "b", "blockquote", "br", "code", "del", "details", "div",
+    "em", "figcaption", "figure", "h1", "h2", "h3", "h4", "h5", "h6", "hr",
+    "i", "img", "kbd", "li", "ol", "p", "pre", "s", "span", "strong",
+    "sub", "summary", "sup", "table", "tbody", "td", "th", "thead", "tr",
+    "ul",
+}
+_REPORT_DROP_TAGS = {
+    "base", "button", "canvas", "embed", "form", "iframe", "input", "link",
+    "meta", "object", "script", "select", "source", "style", "svg", "textarea",
+    "video", "audio",
+}
+_REPORT_ALLOWED_ATTRS = {
+    "*": {"class", "id", "title"},
+    "a": {"href", "target", "rel", "title"},
+    "img": {"src", "alt", "title", "loading"},
+    "ol": {"start"},
+    "td": {"colspan", "rowspan", "align"},
+    "th": {"colspan", "rowspan", "align"},
+}
+_SAFE_LINK_SCHEMES = {"http", "https", "mailto", "tel"}
+_SAFE_MEDIA_SCHEMES = {"http", "https"}
+
+
+def _safe_url_attr(value: str, *, media: bool = False) -> bool:
+    """Return True only for URL attributes safe in untrusted report HTML."""
+    if not isinstance(value, str):
+        return False
+    value = html.unescape(value).strip()
+    if not value:
+        return False
+    if value.startswith("#") and not media:
+        return True
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        return False
+    allowed = _SAFE_MEDIA_SCHEMES if media else _SAFE_LINK_SCHEMES
+    return parsed.scheme.lower() in allowed
+
+
+def _sanitize_report_html(report_html: str) -> str:
+    """Allowlist-sanitize LLM-generated visual-report HTML fragments."""
+    soup = BeautifulSoup(report_html or "", "html.parser")
+
+    for element in list(soup.find_all(True)):
+        if element.parent is None:
+            continue
+        name = (element.name or "").lower()
+        if name in _REPORT_DROP_TAGS:
+            element.decompose()
+            continue
+        if name not in _REPORT_ALLOWED_TAGS:
+            element.unwrap()
+            continue
+
+        allowed_attrs = set(_REPORT_ALLOWED_ATTRS.get("*", set()))
+        allowed_attrs.update(_REPORT_ALLOWED_ATTRS.get(name, set()))
+        for attr in list(element.attrs):
+            attr_l = attr.lower()
+            if attr_l.startswith("on") or attr_l == "style" or attr_l not in allowed_attrs:
+                del element.attrs[attr]
+                continue
+            if attr_l == "href" and not _safe_url_attr(element.attrs.get(attr)):
+                del element.attrs[attr]
+                continue
+            if attr_l == "src" and not _safe_url_attr(element.attrs.get(attr), media=True):
+                del element.attrs[attr]
+
+    return str(soup)
+
 def _autolink_urls(md_text: str) -> str:
     """Convert bare URLs to markdown links before processing.
 
@@ -64,7 +134,7 @@ def _md_to_html(md_text: str) -> str:
         r'<a target="_blank" rel="noopener noreferrer" href="\1',
         result,
     )
-    return result
+    return _sanitize_report_html(result)
 
 
 def _extract_headings(md_text: str) -> List[Dict[str, str]]:

--- a/tests/test_visual_report.py
+++ b/tests/test_visual_report.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 
-from src.visual_report import generate_visual_report
+from src.visual_report import _md_to_html, _sanitize_report_html, generate_visual_report
 
 
 def test_visual_report_toc_links_match_rendered_heading_ids():
@@ -36,3 +36,75 @@ Configuration body.
         target = soup.find(id=target_id)
         assert target is not None
         assert target.name in {"h2", "h3"}
+
+
+def test_visual_report_markdown_sanitizes_active_html():
+    html = _md_to_html(
+        """
+## Safe Heading
+
+<script>alert(1)</script>
+<iframe src="https://evil.example/embed"></iframe>
+<svg><script>alert(2)</script></svg>
+
+<p onclick="alert(3)" style="position:fixed" data-x="1">Body</p>
+<a href="javascript:alert(5)" onclick="alert(6)">bad link</a>
+"""
+    )
+    soup = BeautifulSoup(html, "html.parser")
+
+    assert soup.find("script") is None
+    assert soup.find("iframe") is None
+    assert soup.find("svg") is None
+
+    paragraph = soup.find("p", string="Body")
+    assert paragraph.get_text(strip=True) == "Body"
+    assert "onclick" not in paragraph.attrs
+    assert "style" not in paragraph.attrs
+    assert "data-x" not in paragraph.attrs
+
+    link = soup.find("a", string="bad link")
+    assert link is not None
+    assert "href" not in link.attrs
+    assert "onclick" not in link.attrs
+
+
+def test_visual_report_sanitizer_strips_image_event_handlers():
+    soup = BeautifulSoup(
+        _sanitize_report_html(
+            '<img src="https://example.com/a.png" onerror="alert(1)" '
+            'style="width:1px" data-x="1" alt="ok">'
+        ),
+        "html.parser",
+    )
+
+    image = soup.find("img")
+    assert image["src"] == "https://example.com/a.png"
+    assert image["alt"] == "ok"
+    assert "onerror" not in image.attrs
+    assert "style" not in image.attrs
+    assert "data-x" not in image.attrs
+
+
+def test_visual_report_markdown_preserves_safe_markdown_features():
+    html = _md_to_html(
+        """
+See https://example.com/path.
+
+```python
+print("ok")
+```
+
+| A | B |
+|---|---|
+| 1 | 2 |
+"""
+    )
+    soup = BeautifulSoup(html, "html.parser")
+
+    link = soup.find("a", href="https://example.com/path.")
+    assert link is not None
+    assert link["target"] == "_blank"
+    assert "noopener" in link["rel"]
+    assert soup.find("table") is not None
+    assert soup.find("code") is not None


### PR DESCRIPTION
## Summary

Fixes stored-XSS risk in deep-research visual reports by allowlist-sanitizing the HTML fragment produced from LLM-generated report markdown at `_md_to_html`. Raw active/embedding tags such as `script`, `iframe`, and `svg` are removed; event-handler, style, and unknown attributes are stripped; and unsafe `href`/`src` URL schemes are rejected before the fragment is interpolated into the report page.

The sanitizer is applied only to untrusted report markdown output, so Odysseus' own report template scripts and generated image controls remain unchanged.

## Linked Issue

Fixes #2257

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Generate or load a deep-research report whose markdown includes raw active HTML such as `<script>`, `<iframe>`, event-handler attributes, `style`, and a `javascript:` link.
2. Open `/api/research/report/{id}` and confirm those active tags/attributes/unsafe URLs are absent from the rendered report fragment while normal markdown headings, links, code blocks, and tables still render.
3. Run `.venv/bin/pytest -q tests/test_visual_report.py tests/test_visual_report_nonstring.py tests/test_visual_report_icon_url.py tests/test_research_report_read.py tests/test_research_owner_scope_routes.py tests/test_security_regressions.py`.
4. Run `git diff --check` and `.venv/bin/python -m py_compile src/visual_report.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**N/A — this PR changes sanitization of untrusted generated report content, not report layout, styling, colors, or component behavior.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** This only sanitizes untrusted report markdown before it enters the existing report template.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable.
