### PR TITLE
fix(presets): scope expand-prompt model resolution to owner

### DIFF
--- a/routes/preset_routes.py
+++ b/routes/preset_routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request, Depends
 from pydantic import BaseModel, Field
 
 from src.request_models import PresetUpdateRequest
+from src.auth_helpers import get_current_user
 from core.middleware import require_admin
 
 logger = logging.getLogger(__name__)
@@ -98,9 +99,11 @@ def setup_preset_routes(preset_manager) -> APIRouter:
             {"role": "user", "content": user_input},
         ]
 
+        user = get_current_user(request)
+
         try:
             model_spec = data.get("model") or ""
-            url, model, headers = _resolve_model(model_spec)
+            url, model, headers = _resolve_model(model_spec, owner=user)
             result = await llm_call_async(url, model, messages, temperature=0.8, max_tokens=500, headers=headers)
             return {"success": True, "prompt": result.strip()}
         except Exception as e:

--- a/tests/test_preset_expand_owner_scope.py
+++ b/tests/test_preset_expand_owner_scope.py
@@ -1,0 +1,54 @@
+import json
+import types
+
+import pytest
+
+import src.ai_interaction as ai_interaction
+import src.llm_core as llm_core
+from routes.preset_routes import setup_preset_routes
+
+
+def _expand_handler():
+    """Pull the /api/presets/expand endpoint out of the router for direct calls."""
+    router = setup_preset_routes(preset_manager=None)
+    for route in router.routes:
+        if getattr(route, "path", None) == "/api/presets/expand":
+            return route.endpoint
+    raise AssertionError("expand endpoint not registered")
+
+
+def _request_with_user(user, body):
+    """Minimal Request stand-in: state.current_user plus an awaitable json()."""
+    scope = {"type": "http", "headers": [], "state": {}}
+    request = types.SimpleNamespace()
+    request.state = types.SimpleNamespace(current_user=user)
+
+    async def _json():
+        return body
+
+    request.json = _json
+    return request
+
+
+async def test_expand_passes_owner_to_resolve_model(monkeypatch):
+    seen = {}
+
+    def fake_resolve_model(spec, owner=None):
+        seen["owner"] = owner
+        return ("http://endpoint/v1/chat/completions", "model-x", {})
+
+    async def fake_llm_call_async(url, model, messages, **kwargs):
+        return "expanded prompt"
+
+    # _resolve_model and llm_call_async are imported at call time inside the
+    # handler, so patch them on their source modules, not on routes.preset_routes.
+    monkeypatch.setattr(ai_interaction, "_resolve_model", fake_resolve_model)
+    monkeypatch.setattr(llm_core, "llm_call_async", fake_llm_call_async)
+
+    handler = _expand_handler()
+    request = _request_with_user("alice", {"prompt": "a gruff space pirate", "model": "model-x"})
+
+    result = await handler(request)
+
+    assert result["success"] is True
+    assert seen["owner"] == "alice"


### PR DESCRIPTION
## Summary

`POST /api/presets/expand` resolved its model endpoint without owner scope. The handler `expand_character_prompt` in `routes/preset_routes.py` called `_resolve_model(model_spec)` without passing the calling user, so the `ModelEndpoint` lookup was global: in a multi-user deployment it could match an enabled endpoint owned by another user and use that endpoint's URL and decrypted `api_key`. The same owner-scoping fix was already applied to the tool-dispatch paths in `src/ai_interaction.py` (commit "scope tool model resolution by owner"), but this preset-expansion handler was missed. This change extracts the caller with `get_current_user(request)` and passes `owner=user` to `_resolve_model`, matching the pattern used elsewhere. `owner=None` (single-user mode) keeps the existing no-filter behavior unchanged.

## Linked Issue

Fixes #2283

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Note on the last item: I ran the added test inside the running container so it imports and exercises the real app modules, and I confirmed the handler now passes the owner through to `_resolve_model`. I did not drive a full two-user HTTP request through the live UI, so I left that box unchecked rather than overstate the verification.

## How to Test

1. Add the regression test `tests/test_preset_expand_owner_scope.py` and run `python -m pytest tests/test_preset_expand_owner_scope.py -v`. It builds the router, pulls the `/api/presets/expand` endpoint, sets `request.state.current_user = "alice"`, and asserts `_resolve_model` is called with `owner="alice"`. The test fails before this change (owner is `None`) and passes after.
2. Run the existing owner-scope suite to confirm no regression: `python -m pytest tests/test_ai_interaction_owner_scope.py -v` (7 passed).
3. `python -m py_compile routes/preset_routes.py` is clean.

## Visual / UI changes — REQUIRED if you touched anything that renders

None. Backend only; no UI, CSS, HTML, SVG, or `static/js/` changes.
