### PR TITLE
[codex] fix(gallery): scope image endpoint keys by owner

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from core.database import SessionLocal, GalleryImage, GalleryAlbum, ModelEndpoint
 from core.database import Session as DbSession
-from src.auth_helpers import get_current_user, require_privilege
+from src.auth_helpers import get_current_user, owner_filter as _endpoint_owner_filter, require_privilege
 from src.upload_limits import read_upload_limited
 
 from routes.gallery_helpers import (
@@ -23,6 +23,37 @@ logger = logging.getLogger(__name__)
 
 GALLERY_UPLOAD_MAX_BYTES = int(os.getenv("ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES", str(100 * 1024 * 1024)))
 GALLERY_TRANSFORM_UPLOAD_MAX_BYTES = int(os.getenv("ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES", str(25 * 1024 * 1024)))
+
+
+def _norm_image_endpoint_url(url: str) -> str:
+    """Normalize image endpoint URLs for stored-row matching."""
+    url = (url or "").rstrip("/")
+    if url.endswith("/v1"):
+        url = url[:-3].rstrip("/")
+    return url
+
+
+def _visible_image_endpoint_query(db, owner):
+    """Enabled image endpoints visible to owner, including legacy shared rows."""
+    q = db.query(ModelEndpoint).filter(
+        ModelEndpoint.is_enabled == True,
+        ModelEndpoint.model_type == "image",
+    )
+    return _endpoint_owner_filter(q, ModelEndpoint, owner)
+
+
+def _first_visible_image_endpoint(db, owner):
+    """First enabled image endpoint visible to owner."""
+    return _visible_image_endpoint_query(db, owner).first()
+
+
+def _visible_image_endpoint_by_url(db, base_url, owner):
+    """Visible image endpoint whose normalized base_url matches base_url."""
+    target = _norm_image_endpoint_url(base_url)
+    for ep in _visible_image_endpoint_query(db, owner).all():
+        if _norm_image_endpoint_url(getattr(ep, "base_url", "")) == target:
+            return ep
+    return None
 
 
 def _sanitize_gallery_filename(filename: str) -> str:
@@ -923,7 +954,7 @@ def setup_gallery_routes() -> APIRouter:
         the request for /v1/images/edits (multipart, inverted mask). Otherwise
         proxy through to a self-hosted diffusion server's /v1/images/inpaint."""
         import httpx
-        require_privilege(request, "can_generate_images")
+        user = require_privilege(request, "can_generate_images")
         body = await request.json()
         # Use endpoint from request body (editor dropdown) or fall back to DB lookup
         base = (body.pop("_endpoint", "") or "").rstrip("/")
@@ -942,34 +973,22 @@ def setup_gallery_routes() -> APIRouter:
         if not base:
             db = SessionLocal()
             try:
-                eps = db.query(ModelEndpoint).filter(
-                    ModelEndpoint.is_enabled == True,
-                    ModelEndpoint.model_type == "image",
-                ).all()
-                if not eps:
+                ep = _first_visible_image_endpoint(db, user)
+                if not ep:
                     raise HTTPException(400, "No image generation endpoint configured. Serve a diffusion model via Cookbook first.")
-                base = eps[0].base_url.rstrip("/")
-                api_key = eps[0].api_key
+                base = ep.base_url.rstrip("/")
+                api_key = ep.api_key
             finally:
                 db.close()
         else:
             # Pull api_key from the matching DB row so OpenAI auth works.
             # Users may have stored base_url with/without /v1 suffix and with/without
             # trailing slash, so compare normalized forms.
-            def _norm_url(u: str) -> str:
-                if not u:
-                    return u
-                u = u.rstrip("/")
-                if u.endswith("/v1"):
-                    u = u[:-3]
-                return u
-            _target = _norm_url(base)
             db = SessionLocal()
             try:
-                for ep in db.query(ModelEndpoint).all():
-                    if _norm_url(ep.base_url) == _target:
-                        api_key = ep.api_key
-                        break
+                ep = _visible_image_endpoint_by_url(db, base, user)
+                if ep:
+                    api_key = ep.api_key
             finally:
                 db.close()
 
@@ -1121,7 +1140,7 @@ def setup_gallery_routes() -> APIRouter:
         you get edge blending + lighting unification while keeping the
         composition recognisable."""
         import httpx, base64 as _b64
-        require_privilege(request, "can_generate_images")
+        user = require_privilege(request, "can_generate_images")
         body = await request.json()
 
         image_b64 = body.get("image")
@@ -1148,23 +1167,19 @@ def setup_gallery_routes() -> APIRouter:
         if not base:
             db = SessionLocal()
             try:
-                eps = db.query(ModelEndpoint).filter(
-                    ModelEndpoint.is_enabled == True,
-                    ModelEndpoint.model_type == "image",
-                ).all()
-                if not eps:
+                ep = _first_visible_image_endpoint(db, user)
+                if not ep:
                     raise HTTPException(400, "No image generation endpoint configured.")
-                base = eps[0].base_url.rstrip("/")
-                api_key = eps[0].api_key
+                base = ep.base_url.rstrip("/")
+                api_key = ep.api_key
             finally:
                 db.close()
         else:
             db = SessionLocal()
             try:
-                for ep in db.query(ModelEndpoint).all():
-                    if ep.base_url.rstrip("/").removesuffix("/v1").rstrip("/") == base.rstrip("/").removesuffix("/v1").rstrip("/"):
-                        api_key = ep.api_key
-                        break
+                ep = _visible_image_endpoint_by_url(db, base, user)
+                if ep:
+                    api_key = ep.api_key
             finally:
                 db.close()
 
@@ -1807,4 +1822,3 @@ def setup_gallery_routes() -> APIRouter:
             db.close()
 
     return router
-

--- a/tests/test_gallery_endpoint_matching.py
+++ b/tests/test_gallery_endpoint_matching.py
@@ -1,41 +1,12 @@
-import ast
-from pathlib import Path
+from routes.gallery_routes import _norm_image_endpoint_url
+
 
 def test_gallery_url_normalization_bug():
-    # Read and parse the actual source file
-    source_path = Path("routes/gallery_routes.py")
-    assert source_path.exists(), "gallery_routes.py could not be found"
-    
-    source = source_path.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    
-    # Locate the comparison node within harmonize_image that references ep.base_url and base
-    compare_node = None
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Compare):
-            segment = ast.get_source_segment(source, node) or ""
-            if "ep.base_url" in segment and "base" in segment and "_norm_url" not in segment:
-                compare_node = node
-                break
-                
-    assert compare_node is not None, "Could not find the ep.base_url vs base comparison inside gallery_routes.py"
-    
-    # Compile the compare node into an expression
-    expr = ast.Expression(body=compare_node)
-    compiled_code = compile(expr, "<string>", "eval")
-    
-    def check_match(ep_url: str, base_url: str) -> bool:
-        class MockEP:
-            def __init__(self, url):
-                self.base_url = url
-        return eval(compiled_code, {}, {"ep": MockEP(ep_url), "base": base_url})
+    # Exact suffix removal must strip only a real trailing /v1 segment, not
+    # arbitrary trailing characters such as rstrip('/v1') would do.
+    assert _norm_image_endpoint_url("http://localhost:8000/v1") == "http://localhost:8000"
+    assert _norm_image_endpoint_url("http://localhost:8000") == "http://localhost:8000"
+    assert _norm_image_endpoint_url("http://localhost:8000/v1/") == "http://localhost:8000"
 
-    # Test cases that SHOULD NOT match under a correct implementation
-    # (Buggy rstrip('/v1') logic incorrectly treats these as equal)
-    assert check_match("http://localhost:8000/v11", "http://localhost:8000") is False
-    assert check_match("http://localhost:8000/dev1", "http://localhost:8000/dev") is False
-
-    # Test cases that SHOULD match under a correct implementation
-    assert check_match("http://localhost:8000/v1", "http://localhost:8000") is True
-    assert check_match("http://localhost:8000", "http://localhost:8000/v1") is True
-    assert check_match("http://localhost:8000/v1/", "http://localhost:8000/v1") is True
+    assert _norm_image_endpoint_url("http://localhost:8000/v11") == "http://localhost:8000/v11"
+    assert _norm_image_endpoint_url("http://localhost:8000/dev1") == "http://localhost:8000/dev1"

--- a/tests/test_gallery_endpoint_owner_scope.py
+++ b/tests/test_gallery_endpoint_owner_scope.py
@@ -1,0 +1,159 @@
+"""Owner-scope regression for gallery image-edit endpoint key resolution.
+
+The inpaint/harmonize routes may attach a stored ModelEndpoint api_key when a
+caller selects an endpoint URL, or when the route falls back to the first image
+endpoint. Both paths must be scoped to endpoints visible to the current user so
+one user cannot spend another user's private image endpoint key.
+"""
+
+from types import SimpleNamespace
+
+import routes.gallery_routes as gallery_routes
+
+
+class _Predicate:
+    def __init__(self, check):
+        self._check = check
+
+    def __call__(self, row):
+        return self._check(row)
+
+    def __or__(self, other):
+        return _Predicate(lambda row: self(row) or other(row))
+
+
+class _Column:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, value):
+        return _Predicate(lambda row: getattr(row, self.name) == value)
+
+
+class _ModelEndpoint:
+    base_url = _Column("base_url")
+    is_enabled = _Column("is_enabled")
+    model_type = _Column("model_type")
+    owner = _Column("owner")
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *predicates):
+        self._rows = [r for r in self._rows if all(p(r) for p in predicates)]
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _DB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, model):
+        assert model is _ModelEndpoint
+        return _Query(self._rows)
+
+
+def _ep(base_url, owner, *, is_enabled=True, model_type="image"):
+    return SimpleNamespace(
+        base_url=base_url,
+        owner=owner,
+        is_enabled=is_enabled,
+        model_type=model_type,
+        api_key=f"key-{owner or 'shared'}",
+    )
+
+
+def _patch_model(monkeypatch):
+    monkeypatch.setattr(gallery_routes, "ModelEndpoint", _ModelEndpoint)
+
+
+URL = "https://img.example.com/v1"
+
+
+def test_image_endpoint_url_match_rejects_another_owners_private_key(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep(URL, "bob")]
+
+    assert gallery_routes._visible_image_endpoint_by_url(_DB(rows), URL, "alice") is None
+
+
+def test_image_endpoint_url_match_returns_callers_own_key(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep(URL, "bob"), _ep(URL, "alice")]
+
+    ep = gallery_routes._visible_image_endpoint_by_url(_DB(rows), URL, "alice")
+
+    assert ep is not None
+    assert ep.owner == "alice"
+    assert ep.api_key == "key-alice"
+
+
+def test_image_endpoint_url_match_allows_legacy_shared_row(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep(URL, None)]
+
+    ep = gallery_routes._visible_image_endpoint_by_url(_DB(rows), URL, "alice")
+
+    assert ep is not None
+    assert ep.owner is None
+
+
+def test_image_endpoint_url_match_requires_enabled_image_endpoint(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [
+        _ep(URL, "alice", is_enabled=False),
+        _ep(URL, "alice", model_type="chat"),
+    ]
+
+    assert gallery_routes._visible_image_endpoint_by_url(_DB(rows), URL, "alice") is None
+
+
+def test_image_endpoint_url_normalization_is_exact(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep("http://localhost:8000/v1", "alice")]
+
+    assert gallery_routes._visible_image_endpoint_by_url(
+        _DB(rows),
+        "http://localhost:8000",
+        "alice",
+    ) is not None
+    assert gallery_routes._visible_image_endpoint_by_url(
+        _DB(rows),
+        "http://localhost:8000/v11",
+        "alice",
+    ) is None
+
+
+def test_image_endpoint_fallback_never_picks_another_owners_endpoint(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep("https://bob.example/v1", "bob"), _ep("https://shared.example/v1", None)]
+
+    ep = gallery_routes._first_visible_image_endpoint(_DB(rows), "alice")
+
+    assert ep is not None
+    assert ep.owner is None
+
+
+def test_image_endpoint_fallback_returns_none_when_only_others_endpoints(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep("https://bob.example/v1", "bob"), _ep("https://carol.example/v1", "carol")]
+
+    assert gallery_routes._first_visible_image_endpoint(_DB(rows), "alice") is None
+
+
+def test_null_owner_is_legacy_single_user_noop(monkeypatch):
+    _patch_model(monkeypatch)
+    rows = [_ep(URL, "bob")]
+
+    ep = gallery_routes._visible_image_endpoint_by_url(_DB(rows), URL, None)
+
+    assert ep is not None
+    assert ep.owner == "bob"

--- a/tests/test_gallery_image_privileges.py
+++ b/tests/test_gallery_image_privileges.py
@@ -37,4 +37,7 @@ def test_image_generation_endpoints_require_image_privilege():
 
 
 def test_gallery_routes_imports_privilege_helper():
-    assert "from src.auth_helpers import get_current_user, require_privilege" in _gallery_source()
+    source = _gallery_source()
+    assert "from src.auth_helpers import" in source
+    assert "get_current_user" in source
+    assert "require_privilege" in source


### PR DESCRIPTION
## Summary

Fixes image inpaint/harmonize endpoint key resolution so stored `ModelEndpoint.api_key` values are only read from image endpoints visible to the current user. Both affected paths are now owner-scoped:

- the no-`_endpoint` fallback chooses the first enabled image endpoint visible to the caller
- the caller-supplied `_endpoint` URL match only attaches a stored API key when the matching image endpoint row is visible to the caller

Explicit self-hosted endpoints can still be used, but they no longer borrow another user's stored key by matching a private `base_url`.

## Linked Issue

Fixes #2256

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure two users with private image `ModelEndpoint` rows. Confirm user A cannot cause `/api/image/inpaint` or `/api/image/harmonize` to attach user B's stored API key by passing user B's endpoint URL.
2. Confirm user A's own enabled image endpoint and legacy null-owner shared image endpoints still resolve.
3. Run `.venv/bin/pytest -q tests/test_gallery_endpoint_owner_scope.py tests/test_gallery_endpoint_ssrf.py tests/test_gallery_endpoint_matching.py tests/test_gallery_image_privileges.py tests/test_gallery_owner_filter_single_user.py tests/test_compare_endpoint_owner_scope.py tests/test_research_endpoint_owner_scope.py tests/test_api_chat_security.py`.
4. Run `git diff --check` and `.venv/bin/python -m py_compile routes/gallery_routes.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**N/A — this PR changes backend endpoint-key resolution only.** It does not change rendering, layout, CSS, colors, or UI component behavior.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** This only scopes backend image endpoint resolution.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable.
