### PR TITLE
fix(skills): scope audit teacher model resolution to owner

### DIFF
--- a/routes/skills_routes.py
+++ b/routes/skills_routes.py
@@ -1014,7 +1014,7 @@ def _resolve_audit_models(owner=None):
             spec = (get_setting("teacher_model", "") or "").strip()
             if spec:
                 from src.ai_interaction import _resolve_model
-                t_url, t_model, t_headers = _resolve_model(spec)
+                t_url, t_model, t_headers = _resolve_model(spec, owner=owner)
                 if t_url and t_model:
                     teacher = (t_url, t_model, t_headers)
     except Exception as e:

--- a/tests/test_skills_audit_owner_scope.py
+++ b/tests/test_skills_audit_owner_scope.py
@@ -1,0 +1,40 @@
+"""Regression test: audit teacher model resolution must be owner-scoped.
+
+`_resolve_audit_models` passes ``owner`` to ``resolve_endpoint`` for the worker
+model but historically called ``_resolve_model(spec)`` without ``owner`` for the
+teacher, letting the teacher step match any enabled ModelEndpoint across users.
+"""
+
+import src.ai_interaction as ai_interaction
+import src.endpoint_resolver as endpoint_resolver
+import src.settings as settings
+from routes.skills_routes import _resolve_audit_models
+
+
+def test_audit_teacher_model_resolution_is_owner_scoped(monkeypatch):
+    captured = {}
+
+    def fake_resolve_model(spec, owner=None):
+        captured["spec"] = spec
+        captured["owner"] = owner
+        return ("http://teacher.local/v1/chat", "gpt-test", {})
+
+    def fake_resolve_endpoint(role, owner=None):
+        return ("http://worker.local/v1/chat", "worker-model", {})
+
+    def fake_get_setting(key, default=None):
+        if key == "teacher_enabled":
+            return True
+        if key == "teacher_model":
+            return "gpt-test"
+        return default
+
+    monkeypatch.setattr(ai_interaction, "_resolve_model", fake_resolve_model)
+    monkeypatch.setattr(endpoint_resolver, "resolve_endpoint", fake_resolve_endpoint)
+    monkeypatch.setattr(settings, "get_setting", fake_get_setting)
+
+    url, model, headers, teacher = _resolve_audit_models(owner="alice")
+
+    assert teacher == ("http://teacher.local/v1/chat", "gpt-test", {})
+    assert captured["spec"] == "gpt-test"
+    assert captured["owner"] == "alice"


### PR DESCRIPTION
## Summary

The skill audit teacher model is resolved without owner scope. `_resolve_audit_models` in `routes/skills_routes.py` already passes `owner` to `resolve_endpoint("utility", owner=owner)` for the worker model, but called `_resolve_model(spec)` without `owner` for the optional teacher model. `_resolve_model` applies `owner_filter` only when `owner` is truthy, so the unscoped call makes every enabled `ModelEndpoint` visible across users, including private rows owned by other users and their decrypted `api_key`. This adds `owner=owner` to that one call so the teacher resolution matches the worker resolution. `owner=None` (single-user / no-auth) keeps the existing no-filter behavior.

## Linked Issue

Fixes #2286

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Note on the last box: verification was done with a regression test executed against the running container (FastAPI app image), not by clicking through the full audit flow in the UI, so I have left it unchecked rather than overstate the testing.

## How to Test

1. In a multi-user deployment, configure two users (A and B), each with their own private `ModelEndpoint`. Make sure B has a private endpoint that A does not own.
2. As user A, set `teacher_enabled = true` and `teacher_model` to a model id that only B's private endpoint serves.
3. Trigger a skill audit as user A (manual `/audit-all` or a scheduled/event audit) and observe which endpoint the teacher step resolves to.
4. Before this fix: the teacher step can resolve to B's private endpoint and use B's decrypted `api_key`. After this fix: the teacher step is scoped to A's own endpoints and does not match B's private rows.

Automated regression test:

1. `tests/test_skills_audit_owner_scope.py` patches `_resolve_model`, `resolve_endpoint`, and `get_setting`, calls `_resolve_audit_models(owner="alice")`, and asserts `_resolve_model` receives `owner="alice"`. Red before the fix (captured `owner=None`), green after.
2. Run: `python3 -m pytest tests/test_skills_audit_owner_scope.py tests/test_ai_interaction_owner_scope.py -v`.

## Visual / UI changes — REQUIRED if you touched anything that renders

None. Backend only; no UI, CSS, HTML, SVG, or `static/js/` changes.
