### PR TITLE
fix(teacher): pass owner through teacher model resolution

### DIFF
--- a/src/teacher_escalation.py
+++ b/src/teacher_escalation.py
@@ -229,12 +229,12 @@ portable across users / hosts.
 """
 
 
-async def _call_teacher(teacher_model_spec: str, prompt: str) -> Optional[str]:
+async def _call_teacher(teacher_model_spec: str, prompt: str, owner: Optional[str] = None) -> Optional[str]:
     """Call the configured teacher endpoint with the escalation prompt."""
     from src.llm_core import llm_call_async
     from src.ai_interaction import _resolve_model, _TEACHER_SYSTEM_PROMPT
     try:
-        url, model, headers = _resolve_model(teacher_model_spec)
+        url, model, headers = _resolve_model(teacher_model_spec, owner=owner)
     except Exception as e:
         logger.warning(f"teacher endpoint not resolvable ({teacher_model_spec!r}): {e}")
         return None
@@ -388,7 +388,7 @@ async def escalate_and_learn(
         untrusted_trace_guard=_UNTRUSTED_TRACE_GUARD,
         trace=_format_trace(tool_results, agent_reply),
     )
-    response = await _call_teacher(teacher_spec, prompt)
+    response = await _call_teacher(teacher_spec, prompt, owner=owner)
     if not response:
         return None
 
@@ -523,7 +523,7 @@ async def run_teacher_inline(
     # Resolve teacher endpoint
     try:
         from src.ai_interaction import _resolve_model
-        teacher_url, teacher_model, teacher_headers = _resolve_model(teacher_spec)
+        teacher_url, teacher_model, teacher_headers = _resolve_model(teacher_spec, owner=owner)
     except Exception as e:
         logger.warning(f"teacher endpoint not resolvable ({teacher_spec!r}): {e}")
         yield (
@@ -617,7 +617,7 @@ async def run_teacher_inline(
         untrusted_trace_guard=_UNTRUSTED_TRACE_GUARD,
         trace=_format_trace(captured_tool_events, teacher_text),
     )
-    skill_response = await _call_teacher(teacher_spec, prompt)
+    skill_response = await _call_teacher(teacher_spec, prompt, owner=owner)
     if skill_response and "NO_SKILL" in skill_response and not _extract_skill_json(skill_response):
         logger.info("teacher declined to write a skill (NO_SKILL)")
         yield (

--- a/tests/test_teacher_escalation_owner_scope.py
+++ b/tests/test_teacher_escalation_owner_scope.py
@@ -1,0 +1,94 @@
+"""Owner-scope regression tests for src/teacher_escalation.py.
+
+The teacher escalation path resolves a model endpoint via
+`_resolve_model`, which only applies the owner filter when an `owner`
+argument is supplied. If owner is not threaded through, the teacher
+lookup can match any user's private endpoint (and its decrypted
+api_key) in a multi-user deployment. These tests assert that owner is
+passed at every relevant call site.
+"""
+
+import pytest
+
+from src import teacher_escalation
+
+
+async def test_call_teacher_passes_owner_to_resolve_model(monkeypatch):
+    """_call_teacher must forward owner to _resolve_model."""
+    seen = {}
+
+    def fake_resolve_model(spec, owner=None):
+        seen["owner"] = owner
+        return ("http://endpoint", "model-id", {})
+
+    async def fake_llm_call_async(*args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr("src.ai_interaction._resolve_model", fake_resolve_model)
+    monkeypatch.setattr("src.llm_core.llm_call_async", fake_llm_call_async)
+
+    result = await teacher_escalation._call_teacher("gpt-test", "prompt", owner="alice")
+
+    assert result == "ok"
+    assert seen["owner"] == "alice"
+
+
+async def test_escalate_and_learn_threads_owner(monkeypatch):
+    """escalate_and_learn must pass owner when calling _call_teacher."""
+    seen = {}
+
+    async def fake_call_teacher(spec, prompt, owner=None):
+        seen["owner"] = owner
+        return None  # no skill -> early return, keeps the test focused
+
+    monkeypatch.setattr(teacher_escalation, "_call_teacher", fake_call_teacher)
+    monkeypatch.setattr("src.settings.get_setting", lambda key, default=None: "gpt-teacher")
+
+    await teacher_escalation.escalate_and_learn(
+        "request", [], "reply", "reason", owner="alice"
+    )
+
+    assert seen["owner"] == "alice"
+
+
+async def test_run_teacher_inline_threads_owner(monkeypatch):
+    """run_teacher_inline must pass owner to _resolve_model (place A)."""
+    seen = {}
+
+    def fake_resolve_model(spec, owner=None):
+        seen["owner"] = owner
+        return ("http://endpoint", "model-id", {})
+
+    # Gates: teacher enabled + a teacher_model configured.
+    monkeypatch.setattr(
+        "src.settings.get_setting",
+        lambda key, default=None: True if key == "teacher_enabled" else "gpt-teacher",
+    )
+    # Force the Tier 1 regex eval to report failure so escalation proceeds.
+    monkeypatch.setattr(
+        teacher_escalation,
+        "evaluate_turn_regex",
+        lambda events, reply: ("failure", "stubbed failure"),
+    )
+    monkeypatch.setattr("src.ai_interaction._resolve_model", fake_resolve_model)
+
+    # stream_agent_loop is invoked after _resolve_model; stub it to a
+    # no-op async generator so we exercise place A without a live model.
+    async def fake_stream_agent_loop(*args, **kwargs):
+        if False:
+            yield ""  # make this an async generator
+        return
+
+    monkeypatch.setattr("src.agent_loop.stream_agent_loop", fake_stream_agent_loop)
+
+    gen = teacher_escalation.run_teacher_inline(
+        student_endpoint_url="http://student",
+        student_messages=[{"role": "user", "content": "do a thing"}],
+        student_tool_events=[],
+        student_reply="i can't",
+        owner="alice",
+    )
+    async for _ in gen:
+        pass
+
+    assert seen["owner"] == "alice"


### PR DESCRIPTION
## Summary

The teacher escalation path resolves its model endpoint without owner scope, so in a multi-user deployment it can match another user's private `ModelEndpoint` and use that endpoint's decrypted `api_key`. `escalate_and_learn` and `run_teacher_inline` already accept an `owner` argument and thread it to `resolve_endpoint`, but the teacher model lookup goes through `_resolve_model`, which only applies the owner filter when `owner` is passed, and it was never passed. `_call_teacher` had no `owner` parameter at all, so callers had no way to forward it. This change adds `owner: Optional[str] = None` to `_call_teacher` and threads `owner=owner` through the four relevant call sites. `owner=None` is the default everywhere, so single-user behavior is unchanged. This is the same class of issue already fixed in `ai_interaction.py` and `routes/skills_routes.py`; `src/teacher_escalation.py` was missed.

## Linked Issue

Fixes #2290

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

This is a backend-only change with no UI surface. It is covered by a new regression test that asserts `owner` is threaded to `_resolve_model` at every teacher resolution call site.

1. Run the new test, which fails before the fix and passes after:
   `python3 -m pytest tests/test_teacher_escalation_owner_scope.py -v`
   Expected: 3 passed.
2. Confirm no regression in the sibling owner-scope test:
   `python3 -m pytest tests/test_ai_interaction_owner_scope.py -v`
   Expected: 7 passed.
3. Code-level check: in `src/teacher_escalation.py`, both `_resolve_model(...)` calls and both `_call_teacher(...)` calls now pass `owner=owner`, and `_call_teacher` accepts `owner: Optional[str] = None`.

## Visual / UI changes — REQUIRED if you touched anything that renders

None — backend only. No UI, CSS, HTML, SVG, or `static/js/` changes.
