### PR TITLE
[codex] fix(calendar): use user-local time context

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -172,6 +172,9 @@ _USER_TZ_OFFSET_MIN: ContextVar = ContextVar("user_tz_offset_min", default=None)
 
 def set_user_tz_offset(offset_min):
     """Set the current user's UTC offset for this async context."""
+    if offset_min in (None, ""):
+        _USER_TZ_OFFSET_MIN.set(None)
+        return
     try:
         v = int(offset_min)
     except (TypeError, ValueError):
@@ -182,6 +185,50 @@ def set_user_tz_offset(offset_min):
 def get_user_tz_offset():
     """Read the current user's UTC offset (minutes east of UTC), or None."""
     return _USER_TZ_OFFSET_MIN.get()
+
+
+def _calendar_user_now(tz_hint: str = "", offset_min=None, now_utc: datetime = None) -> datetime:
+    """Return the browser user's current datetime for prompt anchoring.
+
+    Prefer the IANA timezone name because it carries DST rules. Fall back to
+    the browser's current UTC offset when only an offset is available, and then
+    to server-local time for legacy callers.
+    """
+    from datetime import timezone as _tz, timedelta as _td
+
+    if now_utc is None:
+        now_utc = datetime.now(_tz.utc)
+    elif now_utc.tzinfo is None:
+        now_utc = now_utc.replace(tzinfo=_tz.utc)
+    else:
+        now_utc = now_utc.astimezone(_tz.utc)
+
+    tz_hint = (tz_hint or "").strip()
+    if tz_hint:
+        try:
+            from zoneinfo import ZoneInfo
+            return now_utc.astimezone(ZoneInfo(tz_hint))
+        except Exception:
+            pass
+
+    try:
+        if offset_min not in (None, ""):
+            offset = int(offset_min)
+            return now_utc.astimezone(_tz(_td(minutes=offset)))
+    except (TypeError, ValueError):
+        pass
+
+    return now_utc.astimezone()
+
+
+def _format_utc_offset(dt: datetime) -> str:
+    offset = dt.utcoffset()
+    if offset is None:
+        return "+00:00"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    return f"{sign}{total_minutes // 60:02d}:{total_minutes % 60:02d}"
 
 
 def parse_due_for_user(s: str) -> str:
@@ -1196,7 +1243,7 @@ def setup_calendar_routes() -> APIRouter:
         Output: {"ok": true, "event": {"summary", "dtstart", "dtend",
                   "all_day", "location", "description"}, "confidence": 0.0-1.0}
 
-        Anchored on the server's current date/time so phrases like
+        Anchored on the browser user's current date/time so phrases like
         "tomorrow", "next Tuesday", "in 30 minutes" resolve correctly.
         Uses the "utility" endpoint (small / fast model) to keep latency low.
         """
@@ -1212,6 +1259,7 @@ def setup_calendar_routes() -> APIRouter:
         if not text:
             raise HTTPException(400, "text is required")
         tz_hint = (body.get("tz") or "").strip()
+        tz_offset = body.get("tz_offset", body.get("tzOffset"))
 
         url, model, headers = resolve_endpoint("utility")
         if not url:
@@ -1219,15 +1267,22 @@ def setup_calendar_routes() -> APIRouter:
         if not url or not model:
             return {"ok": False, "error": "No LLM endpoint configured"}
 
-        now = datetime.now()
+        now = _calendar_user_now(tz_hint, tz_offset)
         now_iso = now.strftime("%Y-%m-%dT%H:%M:%S")
+        offset_label = _format_utc_offset(now)
+        tz_context = (
+            f"User timezone: {tz_hint} (UTC{offset_label}). "
+            if tz_hint
+            else f"User UTC offset: UTC{offset_label}. "
+        )
         # The model gets only the schema it needs to fill out; we re-validate
         # everything client-side too.
         system_prompt = (
             "You are a calendar event parser. Read the user's one-line "
             "description and emit STRICT JSON describing the event. "
             f"Today is {now.strftime('%A, %Y-%m-%d')} ({now_iso}). "
-            + (f"User timezone: {tz_hint}. " if tz_hint else "")
+            f"Local time is {now.strftime('%H:%M')} UTC{offset_label}. "
+            + tz_context
             + "Resolve relative dates (\"tomorrow\", \"friday\", \"next monday\", "
               "\"in 30 minutes\") against today. Default duration is 60 minutes "
               "when no end time is given. If the text mentions a date with no "

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -360,9 +360,8 @@ def setup_chat_routes(
         # times in the USER's tz, not the server's. See calendar_routes.
         try:
             _tz_hdr = request.headers.get("x-tz-offset")
-            if _tz_hdr is not None:
-                from routes.calendar_routes import set_user_tz_offset
-                set_user_tz_offset(_tz_hdr)
+            from routes.calendar_routes import set_user_tz_offset
+            set_user_tz_offset(_tz_hdr)
         except Exception:
             pass
 

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -37,6 +37,43 @@ from src.agent_tools import (
 logger = logging.getLogger(__name__)
 
 
+def _current_date_time_context(now_utc=None) -> str:
+    """Build the per-request date context, preferring the browser UTC offset."""
+    from datetime import datetime as _dt, timezone as _tz
+
+    if now_utc is None:
+        utc_now = _dt.now(_tz.utc)
+    elif now_utc.tzinfo is None:
+        utc_now = now_utc.replace(tzinfo=_tz.utc)
+    else:
+        utc_now = now_utc.astimezone(_tz.utc)
+
+    try:
+        from routes.calendar_routes import (
+            _calendar_user_now,
+            _format_utc_offset,
+            get_user_tz_offset,
+        )
+        _now = _calendar_user_now(offset_min=get_user_tz_offset(), now_utc=utc_now)
+        _off_fmt = _format_utc_offset(_now)
+    except Exception:
+        _now = utc_now.astimezone()
+        _off = _now.strftime('%z')  # e.g. +0900
+        _off_fmt = (f"{_off[:3]}:{_off[3:]}" if _off else "+00:00")
+
+    return (
+        f"## Current date and time\n"
+        f"Today is {_now.strftime('%A, %B %-d, %Y')} ({_now.strftime('%Y-%m-%d')}). "
+        f"Local time is {_now.strftime('%-I:%M %p')} ({_now.strftime('%Z') or 'local'}, UTC{_off_fmt}); "
+        f"current UTC time is {utc_now.strftime('%H:%M')}. "
+        f"Use this for any 'today'/'tomorrow'/'this week' reasoning — do NOT "
+        f"infer the date from training data or from event timestamps.\n"
+        f"When scheduling a task (manage_tasks), scheduled_time is in UTC: "
+        f"subtract the offset above from the user's local time "
+        f"(local {_now.strftime('%H:%M')} = {utc_now.strftime('%H:%M')} UTC right now).\n\n"
+    )
+
+
 def _load_mcp_disabled_map() -> Dict[str, set]:
     """Load per-server disabled tool sets from the database."""
     from core.database import McpServer, SessionLocal
@@ -597,27 +634,11 @@ def _build_system_prompt(
     set_active_model(model)
 
     # Current date/time — every request. Models default to their
-    # training-cutoff date when "today" is asked otherwise (was
-    # rendering April 2026 dates as "today" when the actual date is
-    # May 19, 2026). System TZ-local so calendar/email date math
-    # matches what the user sees.
+    # training-cutoff date when "today" is asked otherwise. Prefer the
+    # browser user's UTC offset when present so calendar/email date math
+    # matches what the user sees, not the server timezone.
     try:
-        from datetime import datetime as _dt, timezone as _tz
-        _now = _dt.now().astimezone()
-        _utc = _dt.now(_tz.utc)
-        _off = _now.strftime('%z')  # e.g. +0900
-        _off_fmt = (f"{_off[:3]}:{_off[3:]}" if _off else "+00:00")
-        agent_prompt = (
-            f"## Current date and time\n"
-            f"Today is {_now.strftime('%A, %B %-d, %Y')} ({_now.strftime('%Y-%m-%d')}). "
-            f"Local time is {_now.strftime('%-I:%M %p')} ({_now.strftime('%Z')}, UTC{_off_fmt}); "
-            f"current UTC time is {_utc.strftime('%H:%M')}. "
-            f"Use this for any 'today'/'tomorrow'/'this week' reasoning — do NOT "
-            f"infer the date from training data or from event timestamps.\n"
-            f"When scheduling a task (manage_tasks), scheduled_time is in UTC: "
-            f"subtract the offset above from the user's local time "
-            f"(local {_now.strftime('%H:%M')} = {_utc.strftime('%H:%M')} UTC right now).\n\n"
-        ) + agent_prompt
+        agent_prompt = _current_date_time_context() + agent_prompt
     except Exception:
         pass
 

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -1876,11 +1876,12 @@ function _wireAll(body) {
       }
       try {
         const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+        const tz_offset = -new Date().getTimezoneOffset();
         const res = await fetch(`${API_BASE}/api/calendar/quick-parse`, {
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ text, tz }),
+          body: JSON.stringify({ text, tz, tz_offset }),
         });
         const data = await res.json().catch(() => ({}));
         if (!res.ok || !data.ok) {

--- a/tests/test_calendar_user_local_time_context.py
+++ b/tests/test_calendar_user_local_time_context.py
@@ -1,0 +1,67 @@
+"""Regression coverage for calendar/chat user-local time anchoring.
+
+Calendar chat requests can cross a date boundary when the server runs in UTC
+but the browser user is west/east of UTC. Relative phrases like "tomorrow"
+must be anchored to the browser user's current date, not the server date.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def test_calendar_quick_parse_uses_timezone_name_for_local_today():
+    from routes.calendar_routes import _calendar_user_now
+
+    fixed_utc = datetime(2026, 6, 4, 2, 30, tzinfo=timezone.utc)
+
+    local_now = _calendar_user_now("America/Los_Angeles", now_utc=fixed_utc)
+
+    assert local_now.strftime("%Y-%m-%d") == "2026-06-03"
+    assert local_now.strftime("%H:%M") == "19:30"
+
+
+def test_calendar_quick_parse_falls_back_to_browser_offset():
+    from routes.calendar_routes import _calendar_user_now
+
+    fixed_utc = datetime(2026, 6, 4, 2, 30, tzinfo=timezone.utc)
+
+    local_now = _calendar_user_now("", offset_min=-420, now_utc=fixed_utc)
+
+    assert local_now.strftime("%Y-%m-%d") == "2026-06-03"
+    assert local_now.strftime("%H:%M") == "19:30"
+
+
+def test_agent_date_context_uses_request_timezone_offset():
+    from routes.calendar_routes import set_user_tz_offset
+    from src.agent_loop import _current_date_time_context
+
+    fixed_utc = datetime(2026, 6, 4, 2, 30, tzinfo=timezone.utc)
+    set_user_tz_offset(-420)
+    try:
+        context = _current_date_time_context(now_utc=fixed_utc)
+    finally:
+        set_user_tz_offset(None)
+
+    assert "Wednesday, June 3, 2026" in context
+    assert "(2026-06-03)" in context
+    assert "UTC-07:00" in context
+    assert "Thursday, June 4, 2026" not in context
+
+
+def test_chat_timezone_context_can_be_cleared():
+    from routes.calendar_routes import get_user_tz_offset, set_user_tz_offset
+
+    set_user_tz_offset(540)
+    assert get_user_tz_offset() == 540
+
+    set_user_tz_offset(None)
+
+    assert get_user_tz_offset() is None
+
+
+def test_quick_parse_frontend_sends_timezone_name_and_offset():
+    calendar_js = Path("static/js/calendar.js").read_text(encoding="utf-8")
+
+    assert "Intl.DateTimeFormat().resolvedOptions().timeZone" in calendar_js
+    assert "-new Date().getTimezoneOffset()" in calendar_js
+    assert "JSON.stringify({ text, tz, tz_offset })" in calendar_js


### PR DESCRIPTION
## Summary

Calendar chat and quick-add parsing now anchor relative dates to the browser user's local time instead of the server timezone. The chat stream timezone offset is reused when building the agent's `Current date and time` prompt, and calendar quick-add sends both the IANA timezone name and current browser offset so prompt anchoring stays correct across UTC date boundaries.

## Linked Issue

Fixes #2253

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. From a browser timezone west of UTC, send a chat request near a UTC date boundary such as "add lunch to my calendar tomorrow at noon" and confirm the agent prompt's current date matches the browser-local date.
2. Use calendar quick-add with a relative phrase such as "dinner tomorrow 7pm" and confirm the quick-add parser anchors "tomorrow" to the browser-local date, not the server date.
3. Run `.venv/bin/pytest -q tests/test_calendar_user_local_time_context.py tests/test_calendar_update_event_tz.py tests/test_calendar_parse_dt_tonight.py tests/test_calendar_rrule.py tests/test_calendar_rrule_until_utc.py`.
4. Run `.venv/bin/pytest -q tests/test_action_intents.py tests/test_notes_update_due_date.py tests/test_calendar_owner_scope.py`.
5. Run `git diff --check` and `.venv/bin/python -m py_compile routes/calendar_routes.py routes/chat_routes.py src/agent_loop.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**N/A — this PR changes request payload/time-context wiring only.** It does not change rendering, layout, CSS, colors, or UI component behavior.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** This only threads browser timezone context into existing calendar/chat requests and prompts.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable.
