### PR TITLE
fix(markdown): avoid autolinking dotted import paths

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -488,9 +488,11 @@ export function mdToHtml(src) {
   // allowlist keeps it from matching file names / versions ("package.json",
   // "node.js", "v1.2.3"); the required start/[\s(<] prefix means domains
   // already inside an http link (preceded by "//") or an email ("@") are
-  // skipped. Trailing sentence punctuation is kept outside the link.
+  // skipped. Require the TLD to end at a real domain boundary so dotted code
+  // identifiers like `sklearn.metrics` do not link `sklearn.me` and leave
+  // placeholder fragments in the remaining text.
   s = s.replace(
-    /(^|[\s(<])((?:www\.)?[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9-]+)*\.(?:com|org|net|io|ai|co|dev|app|gov|edu|news|info|tech|xyz|me)(?:\/[^\s<>"'`\])]*)?)/gi,
+    /(^|[\s(<])((?:www\.)?[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9-]+)*\.(?:com|org|net|io|ai|co|dev|app|gov|edu|news|info|tech|xyz|me)(?=$|[\/\s<>"'`\]).,;:!?])(?:\/[^\s<>"'`\])]*)?)/gi,
     (match, prefix, domain) => {
       const trail = (domain.match(/[.,;:!?)]+$/) || [''])[0];
       const core = trail ? domain.slice(0, -trail.length) : domain;

--- a/tests/test_markdown_rendering_js.py
+++ b/tests/test_markdown_rendering_js.py
@@ -27,6 +27,15 @@ def _run_markdown_case(markdown: str, render_expr: str = "mod.mdToHtml(input)"):
         globalThis.document = {
           readyState: 'loading',
           addEventListener() {},
+          createElement(tag) {
+            if (tag !== 'template') throw new Error(`unsupported element: ${tag}`);
+            return {
+              _html: '',
+              content: { querySelectorAll() { return []; } },
+              set innerHTML(value) { this._html = value; },
+              get innerHTML() { return this._html; },
+            };
+          },
         };
         globalThis.MutationObserver = class { observe() {} };
 
@@ -147,3 +156,20 @@ def test_extract_thinking_blocks_handles_thought_tag(node_available):
 
     assert result["thinkingBlocks"] == ["internal reasoning"]
     assert result["content"] == "Final answer."
+
+
+def test_dotted_python_import_paths_are_not_autolinked(node_available):
+    html = _run_markdown_case(
+        "from imblearn.combine import SMOTETomek\n"
+        "from sklearn.metrics import f1_score\n"
+        "from sklearn.compose import ColumnTransformer\n\n"
+        "See example.com/docs for normal domain autolinking."
+    )
+
+    assert "___ALLOWED_HTML_" not in html
+    assert "imblearn.combine" in html
+    assert "sklearn.metrics" in html
+    assert "sklearn.compose" in html
+    assert 'href="https://imblearn.com' not in html
+    assert 'href="https://sklearn.me' not in html
+    assert 'href="https://example.com/docs"' in html


### PR DESCRIPTION
## Summary

The scheme-less domain autolinker now requires a real domain boundary after an allowed TLD. This prevents dotted Python import paths such as `imblearn.combine`, `sklearn.metrics`, and `sklearn.compose` from being partially linked as `imblearn.com` / `sklearn.me`, which could leave `___ALLOWED_HTML_*___` placeholder fragments in rendered code-ish output.

## Linked Issue

Fixes #2208

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Render text containing `from imblearn.combine import SMOTETomek`, `from sklearn.metrics import f1_score`, and `from sklearn.compose import ColumnTransformer`; confirm none of those dotted import paths become links or placeholder fragments.
2. Render normal prose containing `example.com/docs`; confirm scheme-less domain autolinking still creates a link.
3. Run `.venv/bin/pytest -q tests/test_markdown_rendering_js.py`.
4. Run `node tests/markdown_codefence_placeholder_regression.mjs`.
5. Run `node --check static/js/markdown.js` and `git diff --check`.

## Visual / UI changes — REQUIRED if you touched anything that renders

This changes markdown autolink rendering behavior only; it does not change layout, styling, colors, spacing, or component structure.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no visual style primitives were changed; existing markdown/link styling is reused.
- [x] **No new component patterns.** This only narrows the existing scheme-less domain matcher.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not attached; this is a text-rendering parser fix covered by the renderer regression above.
