### PR TITLE
Add triage automation + issue-source guardrail

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,17 +21,27 @@ body:
       options:
         - label: I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues?q=is%3Aissue+is%3Aopen) and [discussions](https://github.com/pewdiepie-archdaemon/odysseus/discussions) and did not find an existing report of this bug.
           required: true
+        - label: This is a bug in **Odysseus itself** — not an error returned by my model backend (Ollama, vLLM, OpenAI, Anthropic, etc.), my API provider, or my local configuration. (If an AI agent is filing this on your behalf, confirm this before submitting.)
+          required: true
         - label: This is **not** a security vulnerability. (Vulnerabilities go to [GitHub Security Advisories](https://github.com/pewdiepie-archdaemon/odysseus/security/advisories/new) — see [SECURITY.md](https://github.com/pewdiepie-archdaemon/odysseus/blob/main/SECURITY.md).)
           required: true
-        - label: I am running the latest code from `main`.
+        - label: I am running the latest release, or the latest code from `main`.
           required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Odysseus Version / Commit
+      description: Release tag, or the commit SHA from `git rev-parse --short HEAD`. "Latest" is not specific enough to deduplicate against fixes already merged.
+      placeholder: "v1.4.2  or  a1b2c3d"
+    validations:
+      required: true
 
   - type: dropdown
     id: install-method
     attributes:
       label: Install Method
       options:
-        - "-- Please Select --"
         - Docker (docker compose up)
         - Manual Python install (pip / venv)
         - Windows native (launch-windows.ps1)
@@ -45,7 +55,6 @@ body:
     attributes:
       label: Operating System
       options:
-        - "-- Please Select --"
         - Linux
         - macOS
         - Windows

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -1,0 +1,71 @@
+name: Require Issue Link
+
+# Nudges every PR to reference an issue. The PR template already asks for this;
+# this makes it visible to the maintainer instead of relying on the honour system.
+#
+# Uses pull_request_target so it can label/comment on PRs from forks, but it ONLY
+# reads the event payload (PR title/body) and never checks out or runs head code,
+# so the elevated token is not exposed to untrusted contributions.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: require-issue-link-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-issue-link:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check for a linked issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const title = pr.title || "";
+
+            // Matches: Fixes #12, Closes #12, Resolves #12, Part of #12,
+            // and cross-repo refs like Fixes owner/repo#12, plus full issue URLs.
+            const linkPattern =
+              /\b(close[sd]?|fixe?[sd]?|resolve[sd]?|part of|relate[sd]? to)\b[:\s]+(#\d+|[\w.-]+\/[\w.-]+#\d+|https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
+
+            const hasLink = linkPattern.test(body) || linkPattern.test(title);
+
+            const label = "needs-issue-link";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = pr.number;
+
+            const current = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number });
+            const hasLabel = current.data.some(l => l.name === label);
+
+            if (hasLink) {
+              if (hasLabel) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label })
+                  .catch(() => {});
+              }
+              core.info("Linked issue found — OK.");
+              return;
+            }
+
+            if (!hasLabel) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+              const marker = "<!-- require-issue-link -->";
+              await github.rest.issues.createComment({
+                owner, repo, issue_number,
+                body: `${marker}\nThanks for the PR! It doesn't reference an issue yet.\n\n` +
+                  `Please link the issue this addresses by adding one of the following to the PR description:\n\n` +
+                  "```\nFixes #123\nCloses #123\nPart of #123\n```\n\n" +
+                  `If there is no issue yet, please [open one](https://github.com/${owner}/${repo}/issues/new/choose) first so the change can be discussed and de-duplicated. ` +
+                  `This label will clear automatically once a link is added.`
+              });
+            }
+            core.warning("No linked issue found — labelled needs-issue-link.");

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+name: Close Stale Issues and PRs
+
+# Gently drains the backlog. Inactive issues/PRs get a warning label first,
+# then close after a further grace period. Anything still being discussed,
+# pinned, security-related, or accepted is exempt.
+
+on:
+  schedule:
+    - cron: "30 1 * * *"  # daily, 01:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "pinned,security,roadmap,keep,in-progress,help wanted,good first issue"
+          exempt-pr-labels: "pinned,security,keep,in-progress"
+          exempt-all-milestones: true
+          stale-issue-message: >
+            This issue has had no activity for 60 days and is now marked `stale`.
+            If it is still relevant, leave a comment or add new information and the
+            label will be removed. Otherwise it will be closed in 14 days. This keeps
+            the tracker focused — it is not a judgement on the report.
+          close-issue-message: >
+            Closing as stale after no further activity. If this is still happening on
+            the latest version, please reopen with updated reproduction steps. Thanks
+            for helping keep the tracker clean.
+          stale-pr-message: >
+            This pull request has had no activity for 30 days and is now marked `stale`.
+            Rebase, push an update, or leave a comment to keep it open. It will be closed
+            in 14 days otherwise — you can always reopen when you are ready to continue.
+          close-pr-message: >
+            Closing as stale after no further activity. Reopen any time you would like to
+            pick this back up. Thanks for the contribution.
+          ascending: true  # process oldest first
+          operations-per-run: 200

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -1,0 +1,28 @@
+name: Triage New Issues
+
+# Stamps every newly opened issue with `needs-triage` so the maintainer can see
+# at a glance what has not been looked at yet. Removing the label (or adding any
+# other label) is the signal that triage has happened.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Add needs-triage label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ["needs-triage"]
+            });


### PR DESCRIPTION
## Summary

The repo already has strong issue/PR templates and a clear CONTRIBUTING.md, but nothing **enforces** them — and at ~187 issues / ~338 PRs that honour-system gap is the bottleneck. This adds a small, in-repo enforcement layer (no new language dependencies) plus one guardrail tailored to the fact that Odysseus *is* the AI workspace users run, so their agents tend to auto-file backend/API errors here as Odysseus bugs.

| File | What it does |
|---|---|
| `.github/workflows/require-issue-link.yml` | Labels (`needs-issue-link`) + comments PRs with no `Fixes/Closes/Part of #NNN`; the label clears itself once a link is added. |
| `.github/workflows/stale.yml` | `actions/stale@v9`: inactive issues 60d→warn→14d→close, PRs 30d→14d, with exemptions for `security`, `pinned`, `roadmap`, `in-progress`, `help wanted`, `good first issue`. |
| `.github/workflows/triage-label.yml` | Stamps `needs-triage` on every newly opened issue. |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Adds a required "this is an Odysseus bug, not a model-backend / API / config error" checkbox; adds a required version/commit field; softens "latest `main`" → "latest release or `main`" so Docker-pinned and macOS-app users aren't blocked. |

**Why it's safe:** `require-issue-link.yml` uses `pull_request_target` (needed to label/comment fork PRs) but only reads the event payload (PR title/body) — it never checks out or runs head code, and the body/title are read via the `github-script` JS context, never interpolated into a shell `run:` step, so there is no workflow-injection surface. The three labels are auto-created on first use; happy to add a bootstrap step if you'd prefer fixed colours. Stale timings are conservative starting points and easy to tune.

## Linked Issue

Fixes #2297

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  - **Not applicable / disclosed honestly:** this PR only touches `.github` GitHub Actions workflows and the issue-form schema — there is no app runtime to exercise. Validation is via the Actions tab and YAML parsing (see *How to Test*). Flagging per CONTRIBUTING.md ("if you could not run a check, say so") rather than ticking a box that doesn't apply.

## How to Test

1. **require-issue-link** — open a test PR with no `Fixes #` in the body → it gets the `needs-issue-link` label + a comment. Edit the body to add `Fixes #2297` → on the next run the label is removed.
2. **triage-label** — open a test issue → it gets `needs-triage`.
3. **stale** — trigger manually from the Actions tab (`workflow_dispatch`) to dry-run against the current backlog before letting the schedule run.
4. **bug_report.yml** — open a new bug report and confirm the new required checkbox + version field render correctly in the form.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Not applicable.** This PR touches only `.github/workflows/*.yml` and `.github/ISSUE_TEMPLATE/bug_report.yml`. No buttons, icons, CSS, HTML, SVG, fonts, spacing, or `static/js/` modules are changed — nothing in the running app renders differently.

---

Filed #2297 first and kept this PR focused per CONTRIBUTING.md. Timings, label colours, and message wording are all yours to adjust — tell me what you'd change and I'll update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)