### PR TITLE
[codex] fix(default-chat): skip non-chat model defaults

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -339,7 +339,8 @@ def _truthy(value: str | None) -> bool:
 _NON_CHAT_PREFIXES = (
     "dall-e", "tts-", "whisper", "text-embedding", "embedding",
     "davinci", "babbage", "moderation", "omni-moderation",
-    "sora", "gpt-image", "chatgpt-image",
+    "sora", "gpt-image", "chatgpt-image", "rerank", "reranker",
+    "clip", "stable-diffusion",
 )
 _NON_CHAT_CONTAINS = (
     "-realtime", "-transcribe", "-tts", "-codex",
@@ -695,6 +696,14 @@ def _visible_models(cached_models, hidden_models, pinned_models=None):
         return merged
     hidden = set(_normalize_model_ids(hidden_models))
     return [m for m in merged if m not in hidden]
+
+
+def _first_visible_chat_model(cached_models, hidden_models, pinned_models=None) -> str:
+    """Return the first visible model that is safe to use as a chat default."""
+    for model_id in _visible_models(cached_models, hidden_models, pinned_models):
+        if _is_chat_model(model_id):
+            return model_id
+    return ""
 
 
 def setup_model_routes(model_discovery):
@@ -1594,11 +1603,15 @@ def setup_model_routes(model_discovery):
                 return {"endpoint_id": "", "endpoint_url": "", "model": ""}
             base = _normalize_base(ep.base_url)
             chat_url = build_chat_url(base)
+            if model and not _is_chat_model(model):
+                model = ""
             if not model and (getattr(ep, "cached_models", None) or getattr(ep, "pinned_models", None)):
                 try:
-                    visible = _visible_models(ep.cached_models, getattr(ep, "hidden_models", None), getattr(ep, "pinned_models", None))
-                    if visible:
-                        model = visible[0]
+                    model = _first_visible_chat_model(
+                        ep.cached_models,
+                        getattr(ep, "hidden_models", None),
+                        getattr(ep, "pinned_models", None),
+                    )
                 except Exception:
                     pass
             return {"endpoint_id": ep.id, "endpoint_url": chat_url, "model": model}

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -261,7 +261,8 @@ class TestIsChatModel:
 
     @pytest.mark.parametrize("model_id", [
         "dall-e-3", "tts-1", "whisper-1", "text-embedding-3-small",
-        "gpt-image-1", "sora-1",
+        "gpt-image-1", "sora-1", "rerank-english-v3.0",
+        "stable-diffusion-xl", "clip-vit-large-patch14",
     ])
     def test_non_chat_models(self, model_id):
         assert _is_chat_model(model_id) is False

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -570,6 +570,105 @@ def test_default_chat_admin_skips_hidden_first_model(monkeypatch):
     assert result["model"] == "visible-model"
 
 
+def test_default_chat_skips_non_chat_cached_models(monkeypatch):
+    """Fallback model selection must not preselect embedding/rerank models."""
+    _install_model_route_import_stubs(monkeypatch)
+    import routes.model_routes as model_routes
+
+    ep = SimpleNamespace(
+        id="ep1",
+        base_url="http://localhost:11434",
+        is_enabled=True,
+        owner=None,
+        cached_models='["text-embedding-3-small", "rerank-english-v3.0", "gpt-4o-mini"]',
+        hidden_models=None,
+    )
+
+    monkeypatch.setattr(model_routes, "ModelEndpoint", _FakeModelEndpoint)
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _FakeDb([ep]))
+    monkeypatch.setattr(model_routes, "_load_settings", lambda: {})
+    monkeypatch.setattr(model_routes, "owner_filter", lambda q, m, u, **kw: q)
+    monkeypatch.setattr(model_routes, "_normalize_base", lambda base: base.rstrip("/"))
+    monkeypatch.setattr(model_routes, "build_chat_url", lambda base: f"{base}/chat/completions")
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(current_user="admin"),
+        app=SimpleNamespace(state=SimpleNamespace(
+            auth_manager=SimpleNamespace(is_admin=lambda user: True)
+        )),
+    )
+
+    result = _default_chat_endpoint()(request)
+    assert result["model"] == "gpt-4o-mini"
+
+
+def test_default_chat_replaces_configured_non_chat_default(monkeypatch):
+    """A stale saved non-chat default should fall forward to a visible chat model."""
+    _install_model_route_import_stubs(monkeypatch)
+    import routes.model_routes as model_routes
+
+    ep = SimpleNamespace(
+        id="ep1",
+        base_url="http://localhost:11434",
+        is_enabled=True,
+        owner=None,
+        cached_models='["text-embedding-3-small", "gpt-4o-mini"]',
+        hidden_models=None,
+    )
+
+    monkeypatch.setattr(model_routes, "ModelEndpoint", _FakeModelEndpoint)
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _FakeDb([ep]))
+    monkeypatch.setattr(model_routes, "_load_settings", lambda: {
+        "default_endpoint_id": "ep1",
+        "default_model": "text-embedding-3-small",
+    })
+    monkeypatch.setattr(model_routes, "owner_filter", lambda q, m, u, **kw: q)
+    monkeypatch.setattr(model_routes, "_normalize_base", lambda base: base.rstrip("/"))
+    monkeypatch.setattr(model_routes, "build_chat_url", lambda base: f"{base}/chat/completions")
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(current_user="admin"),
+        app=SimpleNamespace(state=SimpleNamespace(
+            auth_manager=SimpleNamespace(is_admin=lambda user: True)
+        )),
+    )
+
+    result = _default_chat_endpoint()(request)
+    assert result["model"] == "gpt-4o-mini"
+
+
+def test_default_chat_returns_empty_when_no_visible_chat_model(monkeypatch):
+    """Do not fall back to an embedding-only model list for chat."""
+    _install_model_route_import_stubs(monkeypatch)
+    import routes.model_routes as model_routes
+
+    ep = SimpleNamespace(
+        id="ep1",
+        base_url="http://localhost:11434",
+        is_enabled=True,
+        owner=None,
+        cached_models='["text-embedding-3-small", "rerank-english-v3.0"]',
+        hidden_models=None,
+    )
+
+    monkeypatch.setattr(model_routes, "ModelEndpoint", _FakeModelEndpoint)
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: _FakeDb([ep]))
+    monkeypatch.setattr(model_routes, "_load_settings", lambda: {})
+    monkeypatch.setattr(model_routes, "owner_filter", lambda q, m, u, **kw: q)
+    monkeypatch.setattr(model_routes, "_normalize_base", lambda base: base.rstrip("/"))
+    monkeypatch.setattr(model_routes, "build_chat_url", lambda base: f"{base}/chat/completions")
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(current_user="admin"),
+        app=SimpleNamespace(state=SimpleNamespace(
+            auth_manager=SimpleNamespace(is_admin=lambda user: True)
+        )),
+    )
+
+    result = _default_chat_endpoint()(request)
+    assert result["model"] == ""
+
+
 def test_default_chat_all_models_hidden_returns_empty_model(monkeypatch):
     """When all cached models are hidden, get_default_chat returns model: ''."""
     _install_model_route_import_stubs(monkeypatch)


### PR DESCRIPTION
## Summary

`/api/default-chat` now filters default model selection through the existing chat-capability checks, so embedding, rerank, image, CLIP, and diffusion model IDs are not returned as chat defaults. The route also clears stale saved non-chat defaults and falls forward to the first visible chat-capable cached or pinned model when one exists.

## Linked Issue

Fixes #2137

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `.venv/bin/pytest -q tests/test_review_regressions.py tests/test_model_routes.py tests/test_provider_endpoints.py tests/test_endpoint_resolver.py tests/test_resolve_endpoint_fallbacks.py`
2. `.venv/bin/python -m py_compile routes/model_routes.py`
3. `git diff --check`

## Visual / UI changes -- REQUIRED if you touched anything that renders

No visual or UI rendering changes.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) -- do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first -- bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable; backend route behavior only.
