### PR TITLE
[codex] fix(webhook): emit task trigger URL from CLI

### DIFF
--- a/scripts/odysseus-webhook
+++ b/scripts/odysseus-webhook
@@ -2,7 +2,7 @@
 """odysseus-webhook — shell wrapper for scheduled-task webhook tokens.
 
 Tasks in the scheduled-task system can carry a `webhook_token`. Any
-HTTP POST to `/api/webhook/<token>` fires the task. This CLI lists,
+HTTP POST to `/api/tasks/<task_id>/webhook/<token>` fires the task. This CLI lists,
 rotates, and revokes those tokens.
 
     odysseus-webhook list                       # tasks that have a token
@@ -110,7 +110,7 @@ def cmd_url(args):
         if not t.webhook_token:
             fail(f"task {args.id!r} has no webhook token (rotate one first)")
         base = (args.base or "http://localhost:7000").rstrip("/")
-        url = f"{base}/api/webhook/{t.webhook_token}"
+        url = f"{base}/api/tasks/{t.id}/webhook/{t.webhook_token}"
         emit({
             "task_id": t.id,
             "name": t.name,

--- a/tests/test_webhook_cli_mask.py
+++ b/tests/test_webhook_cli_mask.py
@@ -2,6 +2,7 @@ import importlib.machinery
 import importlib.util
 import sys
 import types
+from types import SimpleNamespace
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -29,3 +30,34 @@ def test_mask_token_handles_short_values(monkeypatch):
     assert cli._mask_token("short") == "***"
     assert cli._mask_token("abcdef1234567890") == "abcdef…7890"
     assert cli._mask_token("short", reveal=True) == "short"
+
+
+def test_url_uses_task_webhook_route(monkeypatch):
+    cli = _load_cli(monkeypatch)
+    task = SimpleNamespace(
+        id="task-123",
+        name="Daily sync",
+        webhook_token="tok_abc",
+    )
+    emitted = []
+
+    class _Db:
+        def get(self, model, ident):
+            assert model is cli.ScheduledTask
+            assert ident == task.id
+            return task
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(cli, "SessionLocal", lambda: _Db())
+    monkeypatch.setattr(cli, "emit", lambda payload, args: emitted.append(payload))
+
+    cli.cmd_url(SimpleNamespace(id=task.id, base="https://app.example.com/"))
+
+    assert emitted == [{
+        "task_id": task.id,
+        "name": task.name,
+        "url": "https://app.example.com/api/tasks/task-123/webhook/tok_abc",
+        "curl": "curl -X POST https://app.example.com/api/tasks/task-123/webhook/tok_abc",
+    }]


### PR DESCRIPTION
## Summary

`odysseus-webhook url` now prints the actual scheduled-task webhook trigger route, including both the task id and token. The CLI docs were updated to match the live route, and the regression test pins the generated URL and curl command.

## Linked Issue

Fixes #2136

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `.venv/bin/pytest -q tests/test_webhook_cli_mask.py tests/test_webhook_trigger_auth_exempt.py`
2. `.venv/bin/python -m py_compile scripts/odysseus-webhook`
3. `git diff --check`

## Visual / UI changes -- REQUIRED if you touched anything that renders

No visual or UI rendering changes.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) -- do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first -- bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable; CLI output only.
