### PR TITLE
fix(documents): attach images/files to non-email documents

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -2647,32 +2647,74 @@ import * as Modals from './modalManager.js';
     if (list.length === 0) return;
     const doc = docs.get(activeDocId);
     if (!doc) return;
-    if (doc.language !== 'email') return;
-    if (!doc._composeAtts) doc._composeAtts = [];
 
-    for (const file of list) {
-      try {
-        const fd = new FormData();
-        fd.append('file', file);
-        const res = await fetch(`${API_BASE}/api/email/compose-upload`, {
-          method: 'POST',
-          body: fd,
-        });
-        const data = await res.json();
-        if (data.success) {
-          doc._composeAtts.push({
-            token: data.token,
-            filename: data.filename,
-            size: data.size,
+    // Email compose — upload to email compose endpoint, store as attachment tokens
+    if (doc.language === 'email') {
+      if (!doc._composeAtts) doc._composeAtts = [];
+      for (const file of list) {
+        try {
+          const fd = new FormData();
+          fd.append('file', file);
+          const res = await fetch(`${API_BASE}/api/email/compose-upload`, {
+            method: 'POST',
+            body: fd,
           });
-        } else {
-          if (uiModule) uiModule.showError(`Failed to upload ${file.name}: ${data.error || ''}`);
+          const data = await res.json();
+          if (data.success) {
+            doc._composeAtts.push({
+              token: data.token,
+              filename: data.filename,
+              size: data.size,
+            });
+          } else {
+            if (uiModule) uiModule.showError(`Failed to upload ${file.name}: ${data.error || ''}`);
+          }
+        } catch (err) {
+          if (uiModule) uiModule.showError(`Failed to upload ${file.name}`);
         }
-      } catch (err) {
-        if (uiModule) uiModule.showError(`Failed to upload ${file.name}`);
       }
+      _renderComposeAttachments();
+      return;
     }
-    _renderComposeAttachments();
+
+    // Regular document — upload via general upload endpoint, insert as markdown
+    const ta = document.getElementById('doc-editor-textarea');
+    if (!ta) return;
+    try {
+      const fd = new FormData();
+      for (const file of list) {
+        fd.append('files', file);
+      }
+      const res = await fetch(`${API_BASE}/api/upload`, {
+        method: 'POST',
+        body: fd,
+      });
+      if (!res.ok) {
+        const errText = await res.text().catch(() => 'Unknown error');
+        if (uiModule) uiModule.showError(`Upload failed: ${errText}`);
+        return;
+      }
+      const data = await res.json();
+      const uploaded = data.files || [];
+      let insert = '';
+      for (const f of uploaded) {
+        const url = `${API_BASE}/api/upload/${f.id}`;
+        if (f.mime && f.mime.startsWith('image/')) {
+          insert += `![](${url})\n`;
+        } else {
+          insert += `[${f.name}](${url})\n`;
+        }
+      }
+      const cursor = ta.selectionStart;
+      const before = ta.value.slice(0, cursor);
+      const after = ta.value.slice(cursor);
+      ta.value = before + insert + after;
+      ta.selectionStart = ta.selectionEnd = cursor + insert.length;
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      ta.focus();
+    } catch (err) {
+      if (uiModule) uiModule.showError(`Failed to upload ${list.map(f => f.name).join(', ')}`);
+    }
   }
 
   async function _handleAttachUpload(e) {


### PR DESCRIPTION
Summary
The paperclip "Attach files" button in the document editor was visible for all document types but only functional for email compose documents. Clicking it on a markdown/text document silently did nothing because _uploadComposeFiles had a if (doc.language !== 'email') return; guard with no fallback path. The fix routes non-email uploads through the general /api/upload endpoint and inserts the result as markdown (![](/api/upload/{id}) for images, [{name}](/api/upload/{id}) for other files) at the cursor position.

Linked Issue

Fixes #2271

Type of Change

- Bug fix (non-breaking — fixes a confirmed issue)

How to Test
1. Open Odysseus, create a new markdown document
2. Click the paperclip icon in the toolbar
3. Select an image file — it should insert ![](/api/upload/{id}) into the editor at cursor
4. Select a non-image file (e.g. PDF) — it should insert [filename](/api/upload/{id})
5. Repeat with an email compose document — attach bar should work as before

Visual / UI changes
No visual changes — the button and behavior are identical; it just now works for non-email documents. The image/file link appears as plain markdown in the editor (matching the existing editing experience).