### PR TITLE
[codex] fix(documents): keep export zip language extensions

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -506,10 +506,15 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                     ext = _ext.get(doc.language or "text", ".txt")
                     base = (doc.title or "document").strip() or "document"
                     base = re.sub(r"[^\w\-. ]+", "", base)[:60].strip() or doc.id
-                    name = base if "." in base else base + ext
+                    if base.lower().endswith(ext.lower()):
+                        name = base
+                        stem = base[: -len(ext)] or base
+                    else:
+                        name = base + ext
+                        stem = base
                     i = 1
                     while name in used:
-                        name = f"{base}-{i}" + ("" if "." in base else ext)
+                        name = f"{stem}-{i}{ext}"
                         i += 1
                     used.add(name)
                     zf.writestr(name, doc.current_content or "")

--- a/tests/test_document_export_zip.py
+++ b/tests/test_document_export_zip.py
@@ -1,0 +1,103 @@
+import io
+import sys
+import tempfile
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+
+def _drop_fake_core_database():
+    parent = sys.modules.get("core")
+    attr = getattr(parent, "database", None) if parent is not None else None
+    mod = sys.modules.get("core.database") or attr
+    if mod is None or isinstance(getattr(mod, "__file__", None), str):
+        return
+    sys.modules.pop("core.database", None)
+    sys.modules.pop("src.database", None)
+    if parent is not None and attr is mod:
+        delattr(parent, "database")
+
+
+_drop_fake_core_database()
+
+import core.database as cdb
+import routes.document_routes as droutes
+from core.database import Document
+
+
+def _endpoint(method, path):
+    router = droutes.setup_document_routes(MagicMock(), None)
+    for route in router.routes:
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set()):
+            return route.endpoint
+    raise RuntimeError(f"{method} {path} not found")
+
+
+class _Request:
+    state = SimpleNamespace(current_user="alice")
+
+    def __init__(self, ids):
+        self._ids = ids
+
+    async def json(self):
+        return {"ids": self._ids}
+
+
+async def test_export_zip_appends_language_extension_for_dotted_titles(monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    engine = create_engine(
+        f"sqlite:///{tmp.name}",
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    cdb.Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(droutes, "SessionLocal", session_factory)
+
+    docs = [
+        Document(
+            id="doc-dotted",
+            owner="alice",
+            title="analysis.v1",
+            language="python",
+            current_content="print('one')\n",
+            version_count=1,
+        ),
+        Document(
+            id="doc-with-ext",
+            owner="alice",
+            title="script.py",
+            language="python",
+            current_content="print('two')\n",
+            version_count=1,
+        ),
+        Document(
+            id="doc-duplicate",
+            owner="alice",
+            title="analysis.v1",
+            language="python",
+            current_content="print('three')\n",
+            version_count=1,
+        ),
+    ]
+    doc_ids = [doc.id for doc in docs]
+    db = session_factory()
+    try:
+        db.add_all(docs)
+        db.commit()
+    finally:
+        db.close()
+
+    export_zip = _endpoint("POST", "/api/documents/export-zip")
+    response = await export_zip(_Request(doc_ids))
+
+    with zipfile.ZipFile(io.BytesIO(response.body)) as zf:
+        assert set(zf.namelist()) == {
+            "analysis.v1.py",
+            "analysis.v1-1.py",
+            "script.py",
+        }


### PR DESCRIPTION
## Summary

Document export ZIP filenames now derive their extension from the document language instead of treating any dot in the title as an existing extension. A dotted Python title like `analysis.v1` exports as `analysis.v1.py`, existing `script.py` titles are left alone, and duplicate names keep the extension at the end.

## Linked Issue

Fixes #2134

## Type of Change

- [x] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `.venv/bin/pytest -q tests/test_document_export_zip.py tests/test_document_close_clears_active_route.py tests/test_document_library_language_facet.py`
2. `.venv/bin/python -m py_compile routes/document_routes.py tests/test_document_export_zip.py`
3. `git diff --check`

## Visual / UI changes -- REQUIRED if you touched anything that renders

No visual or UI rendering changes.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) -- do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first -- bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable; backend ZIP filename behavior only.
