### PR TITLE
[codex] fix(chat): accept common code attachments

### DIFF
--- a/src/chat_helpers.py
+++ b/src/chat_helpers.py
@@ -15,6 +15,18 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
+CHAT_TEXT_EXTENSIONS = {
+    ".txt", ".md", ".markdown", ".rst", ".csv", ".json", ".jsonl", ".log",
+    ".html", ".htm", ".css", ".xml", ".yml", ".yaml", ".toml", ".ini",
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".sh", ".bash", ".sql",
+    ".c", ".h", ".cpp", ".hpp", ".java", ".go", ".rs", ".php", ".rb",
+}
+CHAT_MEDIA_EXTENSIONS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".pdf",
+    ".webm", ".wav", ".mp3", ".m4a", ".ogg",
+}
+CHAT_ALLOWED_UPLOAD_EXTENSIONS = CHAT_TEXT_EXTENSIONS | CHAT_MEDIA_EXTENSIONS
+
 
 def extract_urls(text: str) -> List[str]:
     """Extract URLs from text using regex pattern."""
@@ -219,19 +231,15 @@ def validate_file_upload(file: UploadFile) -> UploadFile:
             }
         )
 
-    allowed_extensions = {'.txt', '.py', '.html', '.md', '.json', '.csv', '.js',
-                         '.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.pdf',
-                         '.webm', '.wav', '.mp3', '.m4a', '.ogg'}
-
     _, ext = os.path.splitext(file.filename.lower())
 
-    if ext not in allowed_extensions:
+    if ext not in CHAT_ALLOWED_UPLOAD_EXTENSIONS:
         raise HTTPException(
             status_code=400,
             detail={
                 "error": "UNSUPPORTED_FILE_TYPE",
                 "message": f"File type '{ext}' not allowed",
-                "allowed_types": sorted(allowed_extensions)
+                "allowed_types": sorted(CHAT_ALLOWED_UPLOAD_EXTENSIONS)
             }
         )
 

--- a/src/document_processor.py
+++ b/src/document_processor.py
@@ -15,24 +15,31 @@ logger = logging.getLogger(__name__)
 MAX_INLINE_ATTACHMENT_CHARS = 24000
 MIN_INLINE_ATTACHMENT_SLICE = 500
 
+TEXT_ATTACHMENT_EXTENSIONS = (
+    ".txt", ".md", ".markdown", ".rst", ".csv", ".json", ".jsonl", ".log",
+    ".html", ".htm", ".css", ".xml", ".yml", ".yaml", ".toml", ".ini",
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".sh", ".bash", ".sql",
+    ".c", ".h", ".cpp", ".hpp", ".java", ".go", ".rs", ".php", ".rb",
+)
+
 
 def _is_text_file(path: str) -> bool:
     """Check if file has text extension."""
-    return any(
-        path.lower().endswith(ext)
-        for ext in (".txt", ".py", ".html", ".htm", ".md", ".json", ".csv", ".log", ".js")
-    )
+    return path.lower().endswith(TEXT_ATTACHMENT_EXTENSIONS)
 
 
 def _process_text_file(path: str) -> str:
     """Process text file with enhanced formatting and metadata."""
     language_map = {
         ".py": "python", ".js": "javascript", ".html": "html", ".css": "css",
+        ".htm": "html",
         ".json": "json", ".md": "markdown", ".txt": "text", ".csv": "csv",
-        ".log": "log", ".sh": "bash", ".yml": "yaml", ".yaml": "yaml",
+        ".log": "log", ".sh": "bash", ".bash": "bash", ".yml": "yaml", ".yaml": "yaml",
         ".xml": "xml", ".sql": "sql", ".cpp": "cpp", ".c": "c",
-        ".java": "java", ".go": "go", ".rs": "rust", ".php": "php",
+        ".h": "c", ".hpp": "cpp", ".java": "java", ".go": "go",
+        ".rs": "rust", ".php": "php",
         ".rb": "ruby", ".ts": "typescript", ".jsx": "javascript", ".tsx": "typescript",
+        ".toml": "toml", ".ini": "ini", ".rst": "rst", ".jsonl": "json",
     }
 
     filename = os.path.basename(path)
@@ -91,9 +98,10 @@ def _process_text_file(path: str) -> str:
     header += f"[Type: {language}, Lines: {line_count}, Size: {size_str} bytes]"
 
     code_extensions = {
-        ".py", ".js", ".html", ".css", ".json", ".md", ".sh", ".yml", ".yaml",
+        ".py", ".js", ".html", ".htm", ".css", ".json", ".jsonl", ".md", ".markdown",
+        ".sh", ".bash", ".yml", ".yaml",
         ".xml", ".sql", ".cpp", ".c", ".java", ".go", ".rs", ".php", ".rb",
-        ".ts", ".jsx", ".tsx",
+        ".ts", ".jsx", ".tsx", ".h", ".hpp", ".toml", ".ini", ".rst",
     }
     if ext in code_extensions:
         code_block = f"```{language}\n{content}"

--- a/tests/test_chat_code_attachment_extensions.py
+++ b/tests/test_chat_code_attachment_extensions.py
@@ -1,0 +1,68 @@
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from src.chat_helpers import validate_file_upload
+from src.document_processor import _is_text_file, _process_text_file
+
+
+def _upload(name: str, data: bytes = b"content") -> UploadFile:
+    return UploadFile(filename=name, file=io.BytesIO(data))
+
+
+@pytest.mark.parametrize("filename", [
+    "component.tsx",
+    "view.jsx",
+    "styles.css",
+    "schema.yml",
+    "script.sh",
+    "query.sql",
+    "main.rs",
+    "server.go",
+    "Widget.java",
+    "native.hpp",
+    "pyproject.toml",
+    "settings.ini",
+])
+def test_validate_file_upload_accepts_common_code_files(filename):
+    upload = _upload(filename)
+
+    assert validate_file_upload(upload) is upload
+
+
+def test_validate_file_upload_keeps_rejecting_executables():
+    with pytest.raises(HTTPException) as exc:
+        validate_file_upload(_upload("run.exe"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"] == "UNSUPPORTED_FILE_TYPE"
+
+
+@pytest.mark.parametrize("filename", [
+    "component.tsx",
+    "view.jsx",
+    "styles.css",
+    "schema.yml",
+    "script.sh",
+    "query.sql",
+    "main.rs",
+    "server.go",
+    "Widget.java",
+    "native.hpp",
+    "pyproject.toml",
+    "settings.ini",
+])
+def test_document_processor_treats_common_code_files_as_text(filename):
+    assert _is_text_file(filename)
+
+
+def test_process_text_file_formats_typescript_attachment(tmp_path):
+    path = tmp_path / "component.tsx"
+    path.write_text("export const value: number = 1;\n", encoding="utf-8")
+
+    rendered = _process_text_file(str(path))
+
+    assert "[Type: typescript" in rendered
+    assert "```typescript" in rendered
+    assert "export const value" in rendered


### PR DESCRIPTION
## Summary
- expands chat upload validation to accept common source and config text extensions
- teaches the document processor to inline those same code/config attachments with language-aware fences
- leaves `.nix` out of scope because #2249 already covers that extension

## Linked Issue
Fixes #2133

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work
- [x] I reviewed #2249 and avoided duplicating its `.nix` change

## How to Test
1. `.venv/bin/pytest -q tests/test_chat_code_attachment_extensions.py tests/test_direct_upload_limits.py tests/test_chat_helpers.py`
2. `.venv/bin/python -m py_compile src/chat_helpers.py src/document_processor.py tests/test_chat_code_attachment_extensions.py`
3. `git diff --check upstream/main...HEAD`

## Visual Evidence
No UI changes.