### PR TITLE
[codex] fix(skills): preserve SKILL.md version strings

### DIFF
--- a/services/memory/skill_format.py
+++ b/services/memory/skill_format.py
@@ -82,6 +82,7 @@ def slugify(text: str, fallback: str = "skill") -> str:
 
 _FM_KEY_RE = re.compile(r"^([a-z_][a-z0-9_]*):\s*(.*)$", re.IGNORECASE)
 _FM_BLOCK_LIST_RE = re.compile(r"^\s*-\s*(.*)$")
+_STRING_FRONTMATTER_KEYS = {"version"}
 
 
 def _parse_scalar(raw: str) -> Any:
@@ -109,6 +110,17 @@ def _parse_scalar(raw: str) -> Any:
     except ValueError:
         pass
     return raw
+
+
+def _parse_frontmatter_value(key: str, raw: str) -> Any:
+    if key.lower() in _STRING_FRONTMATTER_KEYS:
+        parsed = _parse_scalar(raw)
+        if parsed in (None, ""):
+            return parsed
+        if isinstance(parsed, str):
+            return parsed
+        return raw.strip()
+    return _parse_scalar(raw)
 
 
 def _split_top_level(s: str, sep: str) -> List[str]:
@@ -159,7 +171,7 @@ def parse_frontmatter(text: str) -> tuple[Dict[str, Any], str]:
                 pending_key = key
                 fm[key] = []
             else:
-                fm[key] = _parse_scalar(val)
+                fm[key] = _parse_frontmatter_value(key, val)
                 pending_key = None
             continue
         m2 = _FM_BLOCK_LIST_RE.match(line)

--- a/tests/test_skill_format_version.py
+++ b/tests/test_skill_format_version.py
@@ -1,0 +1,29 @@
+import textwrap
+
+from services.memory.skill_format import Skill
+
+
+def test_skill_version_preserves_trailing_zero_on_round_trip():
+    markdown = textwrap.dedent("""\
+        ---
+        name: versioned-skill
+        description: keeps semver-like versions intact
+        version: 1.10
+        category: general
+        status: draft
+        confidence: 0.8
+        source: learned
+        created: 2026-01-01T00:00:00Z
+        ---
+
+        ## When to Use
+
+        Test skill version parsing.
+        """)
+
+    skill = Skill.from_markdown(markdown)
+    rendered = skill.to_markdown()
+
+    assert skill.version == "1.10"
+    assert "version: 1.10" in rendered
+    assert Skill.from_markdown(rendered).version == "1.10"


### PR DESCRIPTION
## Summary
- treats `version` as a string-valued SKILL.md frontmatter field during parsing
- preserves semver-like values such as `1.10` instead of coercing them through float parsing
- adds a regression test that round-trips `version: 1.10` without corruption

## Linked Issue
Fixes #2131

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work

## How to Test
1. `.venv/bin/pytest -q tests/test_skill_format_version.py tests/test_skill_save_no_rename.py tests/test_skills_routes_owner_update.py tests/test_skills_delete_owner.py tests/test_skills_manager_owner_isolation.py`
2. `.venv/bin/python -m py_compile services/memory/skill_format.py tests/test_skill_format_version.py`
3. `git diff --check upstream/main...HEAD`

## Visual Evidence
No UI changes.