### PR TITLE
fix(docs): add mobile landing nav menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,6 +101,21 @@
   .nav-links { display: flex; align-items: center; gap: 22px; }
   .nav-links a { color: var(--muted); font-size: 14px; font-weight: 500; }
   .nav-links a:hover { color: var(--fg); }
+  .menu-toggle {
+    display: none; align-items: center; justify-content: center; flex-direction: column; gap: 4px;
+    width: 40px; height: 40px; border-radius: 10px; border: 1px solid var(--border);
+    background: var(--panel); color: var(--fg); cursor: pointer;
+  }
+  .menu-toggle span { display: block; width: 18px; height: 2px; border-radius: 999px; background: currentColor; }
+  .menu-toggle:hover { border-color: var(--accent); color: var(--accent); }
+  .mobile-menu {
+    display: none; border-top: 1px solid var(--border); background: rgba(17,17,17,0.96);
+    padding: 10px 0 14px;
+  }
+  .mobile-menu .wrap { display: flex; flex-direction: column; align-items: stretch; gap: 8px; height: auto; }
+  .mobile-menu a { color: var(--muted); font-size: 15px; font-weight: 600; padding: 10px 2px; }
+  .mobile-menu a:hover { color: var(--fg); }
+  .mobile-menu .btn { justify-content: center; margin-top: 4px; }
   .btn {
     display: inline-flex; align-items: center; gap: 8px;
     padding: 9px 16px; border-radius: 10px; font-weight: 600; font-size: 14px;
@@ -376,7 +391,9 @@
   @media (max-width: 820px) {
     .grid { grid-template-columns: repeat(2, 1fr); }
     .shotrow { grid-template-columns: 1fr; }
-    .nav-links a:not(.btn) { display: none; }
+    .nav-links { display: none; }
+    .menu-toggle { display: inline-flex; }
+    .mobile-menu.open { display: block; }
     .codeblock { display: flex; flex-wrap: wrap; gap: 8px; align-items: flex-start; overflow-wrap: anywhere; }
     .codeblock > span { flex: 1 1 auto; min-width: 0; }
     .codeblock .copy-btn { margin-left: auto; }
@@ -398,6 +415,23 @@
         Odysseus
       </div>
       <div class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#testimonials">Testimonials</a>
+        <a href="#how">How it started</a>
+        <a href="#start">Get started</a>
+        <a class="btn" href="https://github.com/pewdiepie-archdaemon/odysseus" target="_blank">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .4.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
+          GitHub
+        </a>
+      </div>
+      <button class="menu-toggle" type="button" aria-label="Open navigation menu" aria-controls="mobile-menu" aria-expanded="false">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </button>
+    </div>
+    <div class="mobile-menu" id="mobile-menu">
+      <div class="wrap">
         <a href="#features">Features</a>
         <a href="#testimonials">Testimonials</a>
         <a href="#how">How it started</a>
@@ -694,6 +728,29 @@
   </footer>
 
   <script>
+    // Mobile navigation: expose hidden desktop links behind a hamburger menu.
+    (function () {
+      var toggle = document.querySelector('.menu-toggle');
+      var menu = document.getElementById('mobile-menu');
+      if (!toggle || !menu) return;
+
+      function setOpen(open) {
+        menu.classList.toggle('open', open);
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        toggle.setAttribute('aria-label', open ? 'Close navigation menu' : 'Open navigation menu');
+      }
+
+      toggle.addEventListener('click', function () {
+        setOpen(!menu.classList.contains('open'));
+      });
+      menu.querySelectorAll('a').forEach(function (link) {
+        link.addEventListener('click', function () { setOpen(false); });
+      });
+      window.addEventListener('resize', function () {
+        if (window.matchMedia('(min-width: 821px)').matches) setOpen(false);
+      });
+    })();
+
     // Hero background: Perlin flow field — colored particle streams (ported from
     // the app's own background effect, scoped to the hero and brand-colored).
     (function () {


### PR DESCRIPTION
## Summary
- Adds a mobile-only hamburger button to the landing page navbar.
- Provides the same navigation links and GitHub button in the mobile dropdown.
- Keeps the desktop navbar unchanged while restoring access to links under 820px widths.

## Linked Issue
Fixes #2245

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup

## How to Test
1. Run `node --check /tmp/odysseus-docs-index-scripts.js` after extracting the inline scripts from `docs/index.html`.
2. Run `git diff --check`.
3. Open `docs/index.html` in a browser, narrow the viewport below 820px, and verify the hamburger opens/closes the mobile menu and each menu link is available.

## Checks Run
- `node --check /tmp/odysseus-docs-index-scripts.js`
- `git diff --check`

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the checks listed above.

## Scope
- Only changes the landing page navigation in `docs/index.html`.
- Does not change app routes, backend behavior, or the desktop navbar layout.
