### PR TITLE
fix(tests): add endpoint URLs to remaining session fixtures

### DIFF
--- a/tests/test_replace_messages_multimodal.py
+++ b/tests/test_replace_messages_multimodal.py
@@ -45,6 +45,7 @@ def _make_session(sid, owner="alice"):
     db = _TS()
     try:
         db.add(DbSession(id=sid, owner=owner, name="chat", model="gpt-4o",
+                         endpoint_url="http://localhost:11434",
                          archived=False, message_count=1))
         db.commit()
     finally:

--- a/tests/test_rewrite_persist_column.py
+++ b/tests/test_rewrite_persist_column.py
@@ -36,7 +36,14 @@ def test_rewrite_query_selects_and_updates_latest_assistant_message():
     base = datetime(2026, 6, 3, 12, 0, 0)
     db = TS()
     try:
-        db.add(DbSession(id=sid, owner="alice", name="c", model="m", archived=False))
+        db.add(DbSession(
+            id=sid,
+            owner="alice",
+            name="c",
+            model="m",
+            endpoint_url="http://localhost:11434",
+            archived=False,
+        ))
         db.add(DBChatMessage(id="m1", session_id=sid, role="assistant", content="old first", timestamp=base))
         db.add(DBChatMessage(id="m2", session_id=sid, role="assistant", content="old latest", timestamp=base + timedelta(minutes=1)))
         db.commit()


### PR DESCRIPTION
## Summary

Adds required `endpoint_url` values to the remaining test `Session` fixtures that still failed after `Session.endpoint_url` became non-nullable. This is a test-only fixture/schema drift fix for replace-message and rewrite-persistence tests; it does not change product behavior.

## Linked Issue

Fixes #2308

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the relevant path and verified the change works end-to-end. For this test-only fixture fix, the relevant path is the failing pytest group.

## How to Test

1. `python -m py_compile tests/test_replace_messages_multimodal.py tests/test_rewrite_persist_column.py`
2. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' python -m pytest -q tests/test_replace_messages_multimodal.py tests/test_rewrite_persist_column.py`
3. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' python -m pytest -q tests/test_archived_sessions_model_filter.py tests/test_replace_messages_multimodal.py tests/test_rewrite_persist_column.py`

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — test-only change. No UI, CSS, HTML, SVG, or `static/js/` rendering files were touched.
