### PR TITLE
[codex] fix(tools): expose manage_research schema

### DIFF
--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -877,6 +877,23 @@ FUNCTION_TOOL_SCHEMAS = [
     {
         "type": "function",
         "function": {
+            "name": "manage_research",
+            "description": "List, read/open, or delete saved deep-research reports from the Library. Use this to read an existing completed report; use trigger_research only to start new research.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["list", "read", "open", "view", "get", "delete"],
+                               "description": "list = show saved reports; read/open/view/get = return report text by id; delete = remove a saved report"},
+                    "id": {"type": "string", "description": "Research id from action='list' or a #research-<id> link"},
+                    "search": {"type": "string", "description": "Optional query filter for action='list'"}
+                },
+                "required": ["action"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "resolve_contact",
             "description": "Look up a contact's email address by name. Searches CardDAV address book and sent email history. Use when the user says 'message [name]' or 'email [name]' without an email address.",
             "parameters": {

--- a/tests/test_manage_research_tool_schema.py
+++ b/tests/test_manage_research_tool_schema.py
@@ -1,0 +1,30 @@
+import json
+
+import src.agent_tools  # noqa: F401
+from src.tool_schemas import FUNCTION_TOOL_SCHEMAS, function_call_to_tool_block
+
+
+def _schema_for(name: str) -> dict:
+    return next(s for s in FUNCTION_TOOL_SCHEMAS if s["function"]["name"] == name)
+
+
+def test_manage_research_is_exposed_to_native_function_calling():
+    schema = _schema_for("manage_research")
+    params = schema["function"]["parameters"]
+
+    assert params["required"] == ["action"]
+    assert {"list", "read", "open", "view", "get", "delete"}.issubset(
+        set(params["properties"]["action"]["enum"])
+    )
+    assert "id" in params["properties"]
+    assert "search" in params["properties"]
+
+
+def test_manage_research_native_call_converts_to_tool_block():
+    args = {"action": "read", "id": "abc123"}
+
+    block = function_call_to_tool_block("manage_research", json.dumps(args))
+
+    assert block is not None
+    assert block.tool_type == "manage_research"
+    assert json.loads(block.content) == args


### PR DESCRIPTION
## Summary
- registers `manage_research` in the native OpenAI-compatible function tool schemas
- exposes list/read/open/view/get/delete actions plus id/search parameters for saved research reports
- adds regression coverage for schema exposure and native-call conversion into the existing tool block pipeline

## Linked Issue
Fixes #2130

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work

## How to Test
1. `.venv/bin/pytest -q tests/test_manage_research_tool_schema.py tests/test_unknown_tool_calls.py tests/test_function_call_non_object_args.py tests/test_research_report_read.py`
2. `.venv/bin/python -m py_compile src/tool_schemas.py tests/test_manage_research_tool_schema.py`
3. `git diff --check upstream/main...HEAD`

## Visual Evidence
No UI changes.