### PR TITLE
[codex] fix(gallery): record requested image quality

### DIFF
--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -1582,6 +1582,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
         model_spec = _settings.get("image_model", "")
     if quality == "medium" and _settings.get("image_quality"):
         quality = _settings["image_quality"]
+    requested_quality = quality if quality in ("low", "medium", "high", "auto") else "medium"
 
     # Auto-detect best available image model if still not set
     if not model_spec:
@@ -1658,14 +1659,15 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
         "size": size,
     }
 
-    # GPT image models and local diffusion support quality; DALL-E does not
+    # GPT image models and local diffusion support quality; DALL-E does not.
+    # Keep requested_quality for gallery/chat metadata even when it cannot be
+    # sent in the DALL-E API payload.
     if is_gpt_image or is_local_diffusion:
-        if quality in ("low", "medium", "high", "auto"):
-            payload["quality"] = quality
-        else:
-            payload["quality"] = "medium"
+        payload["quality"] = requested_quality
 
-    logger.info(f"Image generation: model={model_id}, size={size}, quality={quality}, prompt={prompt[:80]}")
+    metadata_quality = payload.get("quality", requested_quality)
+
+    logger.info(f"Image generation: model={model_id}, size={size}, quality={metadata_quality}, prompt={prompt[:80]}")
 
     try:
         # GPT image models can take 30-120s+ depending on quality
@@ -1702,7 +1704,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                         prompt=prompt,
                         model=model_id,
                         size=size,
-                        quality=payload.get("quality", "medium"),
+                        quality=metadata_quality,
                         session_id=session_id,
                         owner=owner,
                     ))
@@ -1750,7 +1752,7 @@ async def do_generate_image(content: str, session_id: Optional[str] = None, owne
                 "image_prompt": prompt,
                 "image_model": model_id,
                 "image_size": size,
-                "image_quality": payload.get("quality", "medium"),
+                "image_quality": metadata_quality,
             }
 
     except httpx.TimeoutException:

--- a/tests/test_generate_image_quality_metadata.py
+++ b/tests/test_generate_image_quality_metadata.py
@@ -1,0 +1,79 @@
+import pytest
+import httpx
+
+from src import ai_interaction
+import src.database as database
+import src.settings as settings
+
+
+class _ImageResponse:
+    status_code = 200
+    text = ""
+
+    def json(self):
+        return {"data": [{"url": "https://cdn.example/generated.png"}]}
+
+
+class _DownloadResponse:
+    status_code = 200
+    content = b"png-bytes"
+
+
+@pytest.mark.asyncio
+async def test_dalle_gallery_metadata_records_requested_quality(monkeypatch, tmp_path):
+    captured = {}
+    saved = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, json, headers):
+            captured["url"] = url
+            captured["payload"] = dict(json)
+            return _ImageResponse()
+
+    class FakeGalleryImage:
+        def __init__(self, **kwargs):
+            saved.update(kwargs)
+
+    class FakeDb:
+        def add(self, image):
+            captured["added"] = image
+
+        def commit(self):
+            captured["committed"] = True
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(settings, "load_settings", lambda: {})
+    monkeypatch.setattr(ai_interaction, "_resolve_model", lambda spec, owner=None: (
+        "https://api.example/v1/chat/completions",
+        "dall-e-3",
+        {},
+    ))
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: _DownloadResponse())
+    monkeypatch.setattr(database, "SessionLocal", lambda: FakeDb())
+    monkeypatch.setattr(database, "GalleryImage", FakeGalleryImage, raising=False)
+
+    result = await ai_interaction.do_generate_image(
+        "a bright robot\ndall-e-3\n1024x1024\nhigh",
+        session_id="session-1",
+        owner="alice",
+    )
+
+    assert "quality" not in captured["payload"]
+    assert saved["quality"] == "high"
+    assert result["image_quality"] == "high"
+    assert saved["model"] == "dall-e-3"
+    assert saved["session_id"] == "session-1"
+    assert saved["owner"] == "alice"


### PR DESCRIPTION
## Summary
- records a sanitized requested image quality separately from the image-generation API payload
- keeps DALL-E requests from sending unsupported `quality` while preserving the requested quality in gallery records and chat events
- adds a no-network regression test covering DALL-E `high` quality metadata

## Linked Issue
Fixes #2129

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work

## How to Test
1. `.venv/bin/pytest -q tests/test_generate_image_quality_metadata.py tests/test_chat_image_routing.py tests/test_ai_interaction_owner_scope.py tests/test_gallery_cli_preview.py tests/test_gallery_cli_album_count.py`
2. `.venv/bin/python -m py_compile src/ai_interaction.py tests/test_generate_image_quality_metadata.py`
3. `git diff --check upstream/main...HEAD`

## Visual Evidence
No UI changes.