### PR TITLE
[codex] fix(checkin): use half-open digest windows

### DIFF
--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -225,9 +225,10 @@ RETIRED_HOUSEKEEPING_ACTIONS = frozenset({
 def _digest_windows(now):
     """(label, start, end) buckets for the calendar check-in digest.
 
-    The windows are contiguous so no event is dropped between buckets — an
-    earlier version started the 30-day window at now+8d while the week window
-    ended at now+7d, so events ~7-8 days out fell into no bucket.
+    The windows are contiguous and consumed as half-open [start, end) ranges,
+    so no event is dropped between buckets and a boundary event is not listed
+    twice. An earlier version started the 30-day window at now+8d while the
+    week window ended at now+7d, so events ~7-8 days out fell into no bucket.
     """
     return [
         ("today_tomorrow", now, now + timedelta(days=2)),
@@ -1119,7 +1120,7 @@ class TaskScheduler:
                     _e = end.replace(tzinfo=None) if end.tzinfo else end
                     evs = _db.query(_CE).filter(
                         _CE.dtstart >= _s,
-                        _CE.dtstart <= _e,
+                        _CE.dtstart < _e,
                         _CE.status != "cancelled",
                     ).order_by(_CE.dtstart).all()
                     if not evs:

--- a/tests/test_digest_windows.py
+++ b/tests/test_digest_windows.py
@@ -1,7 +1,8 @@
 """Tests for the calendar check-in digest windows (src/task_scheduler.py)."""
+import inspect
 from datetime import datetime, timedelta
 
-from src.task_scheduler import _digest_windows
+from src.task_scheduler import TaskScheduler, _digest_windows
 
 
 def test_windows_are_contiguous_with_no_gap():
@@ -18,5 +19,26 @@ def test_windows_are_contiguous_with_no_gap():
 def test_event_seven_and_a_half_days_out_is_covered():
     now = datetime(2026, 6, 2, 9, 0, 0)
     event = now + timedelta(days=7, hours=12)  # fell in the old 7-8 day gap
-    buckets = [label for label, start, end in _digest_windows(now) if start <= event <= end]
+    buckets = [label for label, start, end in _digest_windows(now) if start <= event < end]
     assert buckets, "event ~7.5 days out should land in a digest window"
+
+
+def test_boundary_event_belongs_to_later_window_only():
+    now = datetime(2026, 6, 2, 9, 0, 0)
+    windows = _digest_windows(now)
+
+    first_boundary = windows[1][1]
+    second_boundary = windows[2][1]
+
+    first_buckets = [label for label, start, end in windows if start <= first_boundary < end]
+    second_buckets = [label for label, start, end in windows if start <= second_boundary < end]
+
+    assert first_buckets == ["this_week"]
+    assert second_buckets == ["next_30_days"]
+
+
+def test_checkin_calendar_query_uses_exclusive_window_end():
+    body = inspect.getsource(TaskScheduler._execute_checkin)
+
+    assert "_CE.dtstart < _e" in body
+    assert "_CE.dtstart <= _e" not in body


### PR DESCRIPTION
## Summary
- treats check-in digest calendar windows as half-open `[start, end)` ranges
- changes the calendar query end bound from inclusive to exclusive so boundary events only land in the later bucket
- adds regression coverage for no-gap windows, boundary assignment, and the exclusive query condition

## Linked Issue
Fixes #2128

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work

## How to Test
1. `.venv/bin/pytest -q tests/test_digest_windows.py tests/test_calendar_recurrence.py tests/test_calendar_rrule.py tests/test_calendar_rrule_until_utc.py`
2. `.venv/bin/python -m py_compile src/task_scheduler.py tests/test_digest_windows.py`
3. `git diff --check upstream/main...HEAD`

## Visual Evidence
No UI changes.