### PR TITLE
fix(tests): add missing endpoint_url to DbSession fixtures

### DIFF
--- a/tests/test_replace_messages_multimodal.py
+++ b/tests/test_replace_messages_multimodal.py
@@ -44,7 +44,9 @@ def manager(monkeypatch):
 def _make_session(sid, owner="alice"):
     db = _TS()
     try:
-        db.add(DbSession(id=sid, owner=owner, name="chat", model="gpt-4o",
+        db.add(DbSession(id=sid, owner=owner, name="chat", 
+                         model="gpt-4o",
+                         endpoint_url="http://localhost:11434",
                          archived=False, message_count=1))
         db.commit()
     finally:

--- a/tests/test_rewrite_persist_column.py
+++ b/tests/test_rewrite_persist_column.py
@@ -36,7 +36,9 @@ def test_rewrite_query_selects_and_updates_latest_assistant_message():
     base = datetime(2026, 6, 3, 12, 0, 0)
     db = TS()
     try:
-        db.add(DbSession(id=sid, owner="alice", name="c", model="m", archived=False))
+        db.add(DbSession(id=sid, owner="alice", name="c", model="m",
+                         endpoint_url="http://localhost:11434",
+                         archived=False))
         db.add(DBChatMessage(id="m1", session_id=sid, role="assistant", content="old first", timestamp=base))
         db.add(DBChatMessage(id="m2", session_id=sid, role="assistant", content="old latest", timestamp=base + timedelta(minutes=1)))
         db.commit()


### PR DESCRIPTION
sessions.endpoint_url is NOT NULL but test_replace_messages_multimodal and test_rewrite_persist_column were not updated. Same fix as 6e66e69 which covered test_archived_sessions_model_filter.

Fixes #2315

## Summary

Two test fixtures were missed when sessions.endpoint_url became NOT NULL. Same fix as 6e66e69, add endpoint_url="http://localhost:11434" to DbSession constructors in 
test_replace_messages_multimodal.py 
and 
test_rewrite_persist_column.py.

## Linked Issue

#2315 

Fixes;
tests/test_replace_messages_multimodal.py 
tests/test_rewrite_persist_column.py

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. python -m pytest tests/test_replace_messages_multimodal.py tests/test_rewrite_persist_column.py -v

Test-only fix, no source behavior change. Same pattern as merged commit 6e66e69. Verified with git stash to confirm the error and git stash pop to confirm the fix.


## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
