### PR TITLE
[codex] fix(tests): clean agent loop import stubs

### DIFF
--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,22 +4,57 @@ and _append_tool_results. Uses mock imports to avoid loading the full app stack.
 import sys
 from unittest.mock import MagicMock
 
-# Mock heavy dependencies before importing
-for mod in [
+_MOCKED_IMPORTS = [
     'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
     'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
     'src.database',
     'src.agent_tools',
     'core.models', 'core.database',
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+]
+_INJECTED_IMPORT_STUBS = {}
+_PREEXISTING_AGENT_LOOP = sys.modules.get("src.agent_loop")
 
-from src.agent_loop import (
-    _detect_admin_intent,
-    _compute_final_metrics,
-    _append_tool_results,
-)
+
+def _drop_module_if_same(name, expected):
+    if sys.modules.get(name) is expected:
+        sys.modules.pop(name, None)
+    parent_name, _, attr = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, "__dict__", {}).get(attr) is expected:
+        delattr(parent, attr)
+
+
+# Mock heavy dependencies before importing. Only clean up stubs this file
+# created so pre-existing conftest/pytest modules keep their intended state.
+for mod in _MOCKED_IMPORTS:
+    if mod not in sys.modules:
+        stub = MagicMock()
+        sys.modules[mod] = stub
+        _INJECTED_IMPORT_STUBS[mod] = stub
+
+_IMPORTED_AGENT_LOOP = None
+try:
+    from src.agent_loop import (
+        _detect_admin_intent,
+        _compute_final_metrics,
+        _append_tool_results,
+    )
+    _IMPORTED_AGENT_LOOP = sys.modules.get("src.agent_loop")
+finally:
+    if _PREEXISTING_AGENT_LOOP is None and _IMPORTED_AGENT_LOOP is not None:
+        _drop_module_if_same("src.agent_loop", _IMPORTED_AGENT_LOOP)
+    for _mod, _stub in _INJECTED_IMPORT_STUBS.items():
+        _drop_module_if_same(_mod, _stub)
+
+
+def test_import_stubs_do_not_leak_into_later_tests():
+    leaked = [
+        mod for mod, stub in _INJECTED_IMPORT_STUBS.items()
+        if sys.modules.get(mod) is stub
+    ]
+    assert leaked == []
+    if _PREEXISTING_AGENT_LOOP is None:
+        assert sys.modules.get("src.agent_loop") is not _IMPORTED_AGENT_LOOP
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- tracks the MagicMock modules that tests/test_agent_loop.py injects for its isolated src.agent_loop import
- removes only those injected stubs after the helper import, and drops the src.agent_loop cache entry created under the mocked dependencies
- adds a regression assertion so injected import stubs cannot leak into later tests silently

## Linked Issue
Fixes #2321

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] CI / tooling / configuration
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work
- [x] This PR targets main
- [x] My changes are limited to the scope described above with no unrelated refactors
- [x] I ran the relevant test path for this test-isolation change

## How to Test
1. .venv/bin/pytest -q tests/test_agent_loop.py tests/test_agent_tools_truncate_nonstring.py tests/test_research_report_read.py
2. .venv/bin/python -m py_compile tests/test_agent_loop.py
3. git diff --check upstream/main...HEAD

## Visual Evidence
No UI changes; this only changes test import cleanup.