### PR TITLE
feat(model-picker): add stable data-testid automation selectors

### DIFF
--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -254,6 +254,13 @@ function _initModelPickerDropdown() {
     let slug = slash > 0 ? mid.substring(0, slash) : 'other';
     return _PROVIDER_ALIAS[slug] || slug;
   }
+  function _selectorKey(value) {
+    return String(value || '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'unknown';
+  }
   const _collapsedProviders = new Set(_loadList('odysseus-model-collapsed'));
   let _justExpandedProvider = null;
 
@@ -283,18 +290,25 @@ function _initModelPickerDropdown() {
     function _addSection(label) {
       const el = document.createElement('div');
       el.className = 'mp-section-label';
+      el.dataset.testid = 'model-picker-section';
+      el.dataset.section = _selectorKey(label);
       el.textContent = label;
       listEl.appendChild(el);
     }
     function _addEmpty(text) {
       const empty = document.createElement('div');
       empty.className = 'model-switch-empty';
+      empty.dataset.testid = 'model-picker-empty';
       empty.textContent = text;
       listEl.appendChild(empty);
     }
     function _addRow(m) {
       const row = document.createElement('div');
       row.className = 'model-switch-item';
+      row.dataset.testid = 'model-picker-option';
+      row.dataset.modelId = m.mid || '';
+      row.dataset.stale = m.stale ? 'true' : 'false';
+      if (m.endpointId) row.dataset.endpointId = m.endpointId;
       if (m.stale) {
         row.classList.add('model-switch-stale');
         row.style.opacity = '0.45';
@@ -330,8 +344,11 @@ function _initModelPickerDropdown() {
       const favDot = document.createElement('button');
       favDot.type = 'button';
       favDot.className = 'mp-fav-dot' + (favs.includes(m.mid) ? ' active' : '');
+      favDot.dataset.testid = 'model-picker-favorite';
+      favDot.dataset.modelId = m.mid || '';
       favDot.textContent = '●';
       const _setFavState = (on) => {
+        favDot.dataset.favorited = on ? 'true' : 'false';
         favDot.classList.toggle('active', on);
         favDot.title = on ? 'Remove from favorites' : 'Add to favorites';
         favDot.setAttribute('aria-label', on ? 'Remove from favorites' : 'Add to favorites');
@@ -418,6 +435,9 @@ function _initModelPickerDropdown() {
         const isCollapsed = _collapsedProviders.has(provider);
         const header = document.createElement('div');
         header.className = 'mp-provider-header';
+        header.dataset.testid = 'model-picker-provider-header';
+        header.dataset.provider = provider;
+        header.dataset.collapsed = isCollapsed ? 'true' : 'false';
         header.innerHTML =
           `<svg class="mp-provider-chevron${isCollapsed ? ' collapsed' : ''}" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>`
           + `<span class="mp-provider-name">${_providerDisplayName(provider)}</span>`
@@ -440,6 +460,8 @@ function _initModelPickerDropdown() {
         if (!isCollapsed) {
           const group = document.createElement('div');
           group.className = 'mp-provider-group' + (_justExpandedProvider === provider ? ' mp-just-expanded' : '');
+          group.dataset.testid = 'model-picker-provider-group';
+          group.dataset.provider = provider;
           models.forEach(m => {
             _addRow(m);
             // Move the just-appended row into the group container

--- a/tests/test_model_picker_stable_selectors.py
+++ b/tests/test_model_picker_stable_selectors.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+SOURCE = (Path(__file__).resolve().parents[1] / "static/js/modelPicker.js").read_text(
+    encoding="utf-8"
+)
+
+
+def test_model_picker_options_expose_stable_automation_selectors():
+    assert "row.dataset.testid = 'model-picker-option';" in SOURCE
+    assert "row.dataset.modelId = m.mid || '';" in SOURCE
+    assert "row.dataset.endpointId = m.endpointId;" in SOURCE
+    assert "row.dataset.stale = m.stale ? 'true' : 'false';" in SOURCE
+
+
+def test_model_picker_favorites_expose_model_and_state_selectors():
+    assert "favDot.dataset.testid = 'model-picker-favorite';" in SOURCE
+    assert "favDot.dataset.modelId = m.mid || '';" in SOURCE
+    assert "favDot.dataset.favorited = on ? 'true' : 'false';" in SOURCE
+
+
+def test_model_picker_sections_and_provider_groups_are_targetable():
+    assert "el.dataset.testid = 'model-picker-section';" in SOURCE
+    assert "el.dataset.section = _selectorKey(label);" in SOURCE
+    assert "empty.dataset.testid = 'model-picker-empty';" in SOURCE
+    assert "header.dataset.testid = 'model-picker-provider-header';" in SOURCE
+    assert "header.dataset.provider = provider;" in SOURCE
+    assert "header.dataset.collapsed = isCollapsed ? 'true' : 'false';" in SOURCE
+    assert "group.dataset.testid = 'model-picker-provider-group';" in SOURCE
+    assert "group.dataset.provider = provider;" in SOURCE


### PR DESCRIPTION
## Summary
- adds stable data-testid selectors to dynamically rendered model picker rows, favorites, sections, empty states, provider headers, and provider groups
- adds entity/state data attributes such as data-model-id, data-endpoint-id, data-stale, data-favorited, data-provider, and data-collapsed
- uses DOM dataset assignments instead of HTML string interpolation, and adds source-level regression coverage for the selector contract

## Linked Issue
Part of #2089

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I searched existing issues and PRs for duplicate or overlapping work
- [x] This PR targets main
- [x] My changes are limited to the model picker selector surface
- [x] I ran the relevant source and syntax checks for this metadata-only frontend change

## How to Test
1. .venv/bin/pytest -q tests/test_model_picker_stable_selectors.py tests/test_new_chat_model_preference.py tests/test_group_chat_storage.py
2. node --check static/js/modelPicker.js
3. .venv/bin/python -m py_compile tests/test_model_picker_stable_selectors.py
4. git diff --check upstream/main...HEAD

## Visual Evidence
No visual rendering change. This only adds invisible data-* attributes to existing DOM elements; no CSS, text, layout, or interaction behavior changed.