### PR TITLE
fix(notes): scope resolve_endpoint to owner in dispatch_reminder

### DIFF
--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -179,9 +179,9 @@ async def dispatch_reminder(
         try:
             from src.endpoint_resolver import resolve_endpoint
             from src.llm_core import llm_call_async
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=owner)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=owner)
             if url and model:
                 raw = await llm_call_async(
                     url=url, model=model,

--- a/tests/test_dispatch_reminder_owner_scope.py
+++ b/tests/test_dispatch_reminder_owner_scope.py
@@ -1,0 +1,48 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_dispatch_reminder_passes_owner_to_resolve_endpoint(monkeypatch):
+    """dispatch_reminder must scope the LLM endpoint lookup to the note owner.
+
+    With multi-user deployments the endpoint config is per-owner. If
+    resolve_endpoint is called without `owner`, the synthesis LLM (and its
+    API key) can be resolved from another user's private endpoint.
+    """
+    from src import endpoint_resolver
+    from src import settings as settings_mod
+    from routes import note_routes
+
+    # Enable LLM synthesis so the resolve_endpoint branch runs; keep the
+    # browser channel (no SMTP/ntfy needed). _scheduler_ref defaults to None,
+    # so the in-app notification push is skipped.
+    monkeypatch.setattr(
+        settings_mod,
+        "load_settings",
+        lambda: {"reminder_channel": "browser", "reminder_llm_synthesis": True},
+    )
+
+    calls = []
+
+    def fake_resolve_endpoint(setting_prefix, *args, **kwargs):
+        calls.append({"prefix": setting_prefix, "owner": kwargs.get("owner")})
+        # Return empty so both "utility" and "default" are attempted and
+        # llm_call_async is never reached.
+        return ("", "", {})
+
+    monkeypatch.setattr(endpoint_resolver, "resolve_endpoint", fake_resolve_endpoint)
+
+    result = await note_routes.dispatch_reminder(
+        title="Test",
+        note_body="body",
+        note_id="n1",
+        owner="alice",
+    )
+
+    assert calls, "resolve_endpoint was never called"
+    assert all(c["owner"] == "alice" for c in calls), (
+        f"resolve_endpoint called without owner='alice': {calls}"
+    )
+    # Sanity: both endpoint tiers were attempted with the owner.
+    assert {c["prefix"] for c in calls} == {"utility", "default"}
+    assert result["synthesis"] == "[utility model unavailable — no summary generated]"


### PR DESCRIPTION
## Summary

`dispatch_reminder` in `routes/note_routes.py` resolved its LLM endpoint globally instead of for the note's owner. The function takes `owner` and already uses it to scope SMTP config (the docstring says it "scopes SMTP config to their account so we don't cross-leak credentials"), but the synthesis path called `resolve_endpoint("utility")` and `resolve_endpoint("default")` without passing `owner`. In a multi-user deployment, `resolve_endpoint` without an owner runs the global lookup, which can return another user's private endpoint, including its decrypted API key, to synthesize the reminder message. This passes `owner=owner` to both calls. `resolve_endpoint` defaults `owner` to `None` and falls back to global settings when it is empty, so single-user and scheduler-triggered reminders are unchanged.

## Linked Issue

Fixes #2324

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Backend only, no UI. The new regression test patches `resolve_endpoint` at its source module (`src.endpoint_resolver`, since `dispatch_reminder` imports it inside the function body), enables LLM synthesis, records the `(setting_prefix, owner)` pairs, and drives the function far enough to reach both the primary (`"utility"`) and fallback (`"default"`) calls.

1. Check out the branch and run the regression test: `python -m pytest tests/test_dispatch_reminder_owner_scope.py -v`. It passes.
2. Confirm it catches the regression: revert the two `owner=owner` additions in `routes/note_routes.py` and re-run. The test fails, showing both `('utility', None)` and `('default', None)` were recorded instead of `"alice"`.
3. To verify by hand in the running app: patch `src.endpoint_resolver.resolve_endpoint` to capture its `owner` kwarg, call `dispatch_reminder(..., owner="alice")` with `reminder_llm_synthesis` enabled, and confirm the lookup is invoked with `owner="alice"`.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Backend only; no UI, CSS, HTML, SVG, or `static/js/` changes.
