### PR TITLE
fix(documents): scope endpoint lookup to caller in ai_tidy_documents

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -854,10 +854,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         from src.llm_core import llm_call_async
 
         user = get_current_user(request)
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=user or "")
         if not url or not model:
             # Fall back to default endpoint
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=user)
         if not url or not model:
             raise HTTPException(500, "No endpoint configured for AI tidy")
 

--- a/tests/test_ai_tidy_documents_owner_scope.py
+++ b/tests/test_ai_tidy_documents_owner_scope.py
@@ -1,0 +1,66 @@
+"""Owner-scope regression for POST /api/documents/ai-tidy.
+
+`ai_tidy_documents()` captures the caller via `get_current_user(request)` and
+already scopes the document query with `_owner_session_filter(q, user)`. But the
+LLM endpoint lookup — `resolve_task_endpoint()` then a `resolve_endpoint("default")`
+fallback — was called WITHOUT `owner=user`. In a multi-user deployment those
+global lookups can return ANOTHER user's private endpoint and its decrypted
+api_key, which then drives the tidy LLM call. The endpoint lookup must be scoped
+to the caller the same way the document query already is. Mirrors the session /
+research / compare endpoint owner-scope fixes.
+
+`ai_tidy_documents` is a nested route handler defined inside
+`setup_document_routes`. Building the router pulls in form-upload routes that
+need optional packages not present in every environment, so we assert on the
+function source directly (same approach as test_ai_interaction_owner_scope.py).
+"""
+
+import inspect
+import re
+import sys
+import types
+from unittest.mock import MagicMock
+
+# Stub core.database so importing routes.document_routes is cheap under the
+# conftest sqlalchemy MagicMock stubs (the real package is not installed here).
+if "core.database" not in sys.modules:
+    sys.modules["core.database"] = types.ModuleType("core.database")
+_cd = sys.modules["core.database"]
+for _name in ("SessionLocal", "Document", "DocumentVersion", "Session"):
+    if not hasattr(_cd, _name):
+        setattr(_cd, _name, MagicMock())
+
+import routes.document_routes as document_routes  # noqa: E402
+
+
+def _ai_tidy_source() -> str:
+    """Source of the nested ai_tidy_documents handler."""
+    outer = inspect.getsource(document_routes.setup_document_routes)
+    marker = "async def ai_tidy_documents("
+    start = outer.index(marker)
+    # Slice to the next top-level route decorator after this handler.
+    rest = outer[start + len(marker):]
+    nxt = rest.find("\n    @router.")
+    end = (start + len(marker) + nxt) if nxt != -1 else len(outer)
+    return outer[start:end]
+
+
+def test_task_endpoint_lookup_passes_caller_owner():
+    body = _ai_tidy_source()
+    # The caller is captured as `user`; the task-endpoint lookup must forward it.
+    assert "user = get_current_user(request)" in body
+    assert re.search(r"resolve_task_endpoint\(\s*owner\s*=\s*user", body), \
+        "resolve_task_endpoint must be called with owner=user"
+
+
+def test_default_fallback_lookup_passes_caller_owner():
+    body = _ai_tidy_source()
+    assert re.search(r'resolve_endpoint\(\s*"default"\s*,\s*owner\s*=\s*user', body), \
+        'resolve_endpoint("default", ...) must be called with owner=user'
+
+
+def test_no_unscoped_resolver_call_remains():
+    body = _ai_tidy_source()
+    # Guard against the regressed forms with no owner argument.
+    assert "resolve_task_endpoint()" not in body
+    assert 'resolve_endpoint("default")' not in body


### PR DESCRIPTION
## Summary

`ai_tidy_documents` (POST /api/documents/ai-tidy) captures the caller as `user = get_current_user(request)` and already scopes the document query with `_owner_session_filter(q, user)`, but it resolved the LLM endpoint with `resolve_task_endpoint()` and the `resolve_endpoint("default")` fallback without passing the owner. In a multi-user deployment those global lookups can return another user's private endpoint configuration, including its decrypted API key, for the tidy LLM call. This change passes `owner=user` to both lookups so endpoint resolution is scoped to the caller the same way the document query already is. Both resolvers accept `owner=None` and treat a falsy owner as the global fallback, so single-user and null-owner deployments are unaffected.

## Linked Issue

Fixes #2332

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

This is a backend owner-scoping change with no UI. The regression test asserts the owner is forwarded to both endpoint lookups.

1. Run the new regression test: `python -m pytest tests/test_ai_tidy_documents_owner_scope.py -v` (3 tests, all pass).
2. Confirm the fix in `routes/document_routes.py`: in `ai_tidy_documents`, `resolve_task_endpoint(owner=user or "")` and `resolve_endpoint("default", owner=user)` now pass the caller's owner.
3. Reverting either call to its no-owner form turns the corresponding test red, showing the endpoint lookup is now scoped.

Note: I verified via the targeted regression test and `python -m py_compile routes/document_routes.py`. I did not run a full multi-user docker instance end-to-end, so I left the "ran the app" box unchecked.
