### PR TITLE
fix(tests): update search service mock to match current API signature

### DIFF
--- a/tests/test_search_service_nondict_rows.py
+++ b/tests/test_search_service_nondict_rows.py
@@ -3,18 +3,18 @@ import asyncio
 import services.search.service as svc_mod
 from services.search.service import SearchService
 
-
 def test_search_skips_non_dict_results(monkeypatch):
     # comprehensive_web_search aggregates external provider + cache results;
     # a malformed row (string/None) made the old loop call r.get and crash,
     # losing the whole search.
-    async def fake_search(query, max_results=10, fetch_content=False):
-        return [
-            {"url": "https://a.com", "title": "A", "snippet": "x"},
+    def fake_search(query, max_pages=10, return_sources=False):
+        results = [
+            {"url": "https://a.com", "title": "A"},
             "junk-row",
             None,
-            {"url": "https://b.com", "title": "B", "snippet": "y"},
+            {"url": "https://b.com", "title": "B"},
         ]
+        return ("", results)
 
     monkeypatch.setattr(svc_mod, "comprehensive_web_search", fake_search)
     svc = SearchService()


### PR DESCRIPTION
comprehensive_web_search now called with (query, max_pages, return_sources) and returns a tuple (_context, results). The test mock still used the old async signature with max_results/fetch_content and returned a plain list, causing TypeError on every run.

Fixes #2331

## Summary

comprehensive_web_search is now called with (query, max_pages=N, return_sources=True) and returns a (_context, raw_results) tuple (see services/search/service.py line 75). 
The test mock still had the old signature (query, max_results=10, fetch_content=False) returning a plain list, so every run raised:
TypeError: fake_search() got an unexpected keyword argument 'max_pages'

Updated mock to match the current call signature and return a tuple, the test still verifies non-dict rows are skipped.


<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

## Linked Issue

Fixes #2331 

Fixes #
tests/test_search_service_nondict_rows.py

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.python -m pytest tests/test_search_service_nondict_rows.py -v

Same fix pattern as merged commit 2efebcc and be8f1fa.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
