### PR TITLE
test(rag): cover owner-scoped document ids

### DIFF
--- a/tests/test_rag_vector_owner_doc_ids.py
+++ b/tests/test_rag_vector_owner_doc_ids.py
@@ -1,0 +1,85 @@
+from src.rag_vector import VectorRAG, _generate_doc_id
+
+
+class FakeEmbeddingModel:
+    url = "fake://embeddings"
+    model = "fake"
+
+    def encode(self, texts, normalize_embeddings=True):
+        return [[1.0, 0.0] for _ in texts]
+
+
+class FakeCollection:
+    def __init__(self):
+        self.rows = {}
+
+    def get(self, ids=None, include=None):
+        found_ids = [doc_id for doc_id in (ids or []) if doc_id in self.rows]
+        result = {"ids": found_ids}
+        if include and "documents" in include:
+            result["documents"] = [self.rows[doc_id]["document"] for doc_id in found_ids]
+        if include and "metadatas" in include:
+            result["metadatas"] = [self.rows[doc_id]["metadata"] for doc_id in found_ids]
+        return result
+
+    def add(self, ids, embeddings, documents, metadatas):
+        for doc_id, embedding, document, metadata in zip(ids, embeddings, documents, metadatas):
+            if doc_id in self.rows:
+                raise ValueError(f"duplicate id: {doc_id}")
+            self.rows[doc_id] = {
+                "embedding": embedding,
+                "document": document,
+                "metadata": metadata,
+            }
+
+
+def _fake_rag():
+    rag = object.__new__(VectorRAG)
+    rag.persist_directory = "fake"
+    rag._collection = FakeCollection()
+    rag._model = FakeEmbeddingModel()
+    rag._healthy = True
+    return rag
+
+
+def test_generate_doc_id_is_namespaced_by_owner_without_churning_unowned_ids():
+    text = "shared boilerplate chunk"
+
+    assert _generate_doc_id(text) == _generate_doc_id(text, "")
+    assert _generate_doc_id(text, "alice") != _generate_doc_id(text, "bob")
+    assert _generate_doc_id(text, "alice") != _generate_doc_id(text)
+
+
+def test_add_document_keeps_identical_chunks_for_different_owners():
+    rag = _fake_rag()
+    text = "byte-identical chunk that both users uploaded"
+
+    assert rag.add_document(text, {"owner": "alice", "source": "alice.txt"})
+    assert rag.add_document(text, {"owner": "bob", "source": "bob.txt"})
+
+    assert set(rag.collection.rows) == {
+        _generate_doc_id(text, "alice"),
+        _generate_doc_id(text, "bob"),
+    }
+    assert {row["metadata"]["owner"] for row in rag.collection.rows.values()} == {
+        "alice",
+        "bob",
+    }
+
+
+def test_add_documents_batch_keeps_identical_chunks_for_different_owners():
+    rag = _fake_rag()
+    text = "same shared license header"
+
+    result = rag.add_documents_batch([
+        (text, {"owner": "alice", "source": "alice.md"}),
+        (text, {"owner": "bob", "source": "bob.md"}),
+    ])
+
+    assert result["success"] is True
+    assert result["added_count"] == 2
+    assert result["failed_count"] == 0
+    assert set(rag.collection.rows) == {
+        _generate_doc_id(text, "alice"),
+        _generate_doc_id(text, "bob"),
+    }


### PR DESCRIPTION
## Summary

Test-only: adds regression coverage for owner-scoped RAG document IDs. Current `main` already namespaces document IDs by owner, but issue #1662 is still open and the behavior was only indirectly covered. These tests pin the single-document and batch add paths so byte-identical chunks from different owners are stored under separate IDs while unowned IDs stay stable. No production code changes.

## Linked Issue

Part of #1662

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified startup/routing responds. This is test-only coverage, so there is no UI flow to exercise.

## How to Test

1. `.venv/bin/pytest -q tests/test_rag_vector_id_stability.py tests/test_rag_vector_owner_doc_ids.py`
2. `.venv/bin/python -m py_compile src/rag_vector.py tests/test_rag_vector_owner_doc_ids.py`
3. `.venv/bin/uvicorn app:app --host 127.0.0.1 --port 8123`, then `curl -fsS -I http://127.0.0.1:8123/` returns `302 /login`.

## Visual / UI changes - REQUIRED if you touched anything that renders

- [x] No UI or visual changes.

### Screenshots / clips

N/A - test-only RAG coverage.
