### PR TITLE
[codex] fix(cookbook): alias python3 for Windows bash runners

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -270,7 +270,15 @@ def _user_shell_path_bootstrap() -> list[str]:
         '  ODYSSEUS_USER_PATH="$("$ODYSSEUS_USER_SHELL" -ic \'printf "__ODYSSEUS_PATH__%s\\n" "$PATH"\' 2>/dev/null | sed -n \'s/^__ODYSSEUS_PATH__//p\' | tail -n 1 || true)"',
         '  if [ -n "$ODYSSEUS_USER_PATH" ]; then export PATH="$ODYSSEUS_USER_PATH:$PATH"; fi',
         'fi',
-        'command -v python3 >/dev/null 2>&1 || python3() { python "$@"; }',
+        'if ! command -v python3 >/dev/null 2>&1; then',
+        '  if command -v python >/dev/null 2>&1; then',
+        '    python3() { python "$@"; }',
+        '    export -f python3 2>/dev/null || true',
+        '  elif command -v py >/dev/null 2>&1; then',
+        '    python3() { py -3 "$@"; }',
+        '    export -f python3 2>/dev/null || true',
+        '  fi',
+        'fi',
     ]
 
 

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -1,4 +1,7 @@
 import json
+import os
+import shlex
+import shutil
 import subprocess
 import sys
 
@@ -88,6 +91,64 @@ def test_local_tooling_path_export_preserves_spaces_and_expands_path():
     line = _local_tooling_path_export("/Users/John Smith/.venv/bin/python3")
     assert line == 'export PATH="/Users/John Smith/.venv/bin:$PATH"'
     assert line.endswith(':$PATH"')  # $PATH stays expandable in double quotes
+
+
+def _write_executable(path, content):
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_user_shell_path_bootstrap_delegates_to_python_and_exports(tmp_path):
+    bash = shutil.which("bash")
+    assert bash, "bash is required for this regression"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python",
+        '#!/bin/sh\nprintf "python:%s\\n" "$*"\n',
+    )
+    script = "\n".join(
+        _user_shell_path_bootstrap()
+        + [
+            "python3 direct",
+            f"{shlex.quote(bash)} -c 'python3 nested'",
+        ]
+    )
+
+    result = subprocess.run(
+        [bash, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(bin_dir)},
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "python:direct" in result.stdout
+    assert "python:nested" in result.stdout
+
+
+def test_user_shell_path_bootstrap_uses_py_launcher_when_python_is_missing(tmp_path):
+    bash = shutil.which("bash")
+    assert bash, "bash is required for this regression"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "py",
+        '#!/bin/sh\nprintf "py:%s\\n" "$*"\n',
+    )
+    script = "\n".join(_user_shell_path_bootstrap() + ["python3 direct"])
+
+    result = subprocess.run(
+        [bash, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(bin_dir)},
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "py:-3 direct" in result.stdout
 
 
 def test_pip_install_fallback_chain_prefers_venv_safe_install():
@@ -267,7 +328,9 @@ def test_local_tooling_path_export_converts_windows_paths_for_bash():
 
 def test_user_shell_path_bootstrap_falls_back_to_python_on_windows_bash():
     script = "\n".join(_user_shell_path_bootstrap())
-    assert 'command -v python3 >/dev/null 2>&1 || python3() { python "$@"; }' in script
+    assert 'python3() { python "$@"; }' in script
+    assert 'python3() { py -3 "$@"; }' in script
+    assert script.count("export -f python3") == 2
 
 
 def test_serve_preflight_failure_keeps_tmux_pane_visible():


### PR DESCRIPTION
## Summary

Rebases the Windows Cookbook `python3` fallback on top of upstream #676. Upstream now adds a simple `python3() { python "$@"; }` fallback in the shared bash bootstrap; this PR tightens that bootstrap so the fallback is exported into nested `bash -c` pip wrappers and also tries the Windows `py -3` launcher when `python` is missing. That keeps Cookbook download/dependency/serve runners working on native Windows Git Bash without requiring users to create a `python3.exe` symlink.

## Linked Issue

Fixes #2341

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate. Upstream #676 fixed broader Windows background-task handling; this PR is now the smaller remaining nested-bash/`py -3` fallback for #2341.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) for the original branch and verified startup/routing responds. The rebased Windows-specific runner behavior is covered by focused bash regression tests that simulate a PATH with `python`/`py` but no `python3`.

## How to Test

1. `.venv/bin/pytest -q tests/test_cookbook_helpers.py tests/test_platform_compat.py tests/test_cookbook_dependency_completion_regression.py`
2. `.venv/bin/python -m py_compile routes/cookbook_helpers.py routes/cookbook_routes.py tests/test_cookbook_helpers.py`
3. `git diff --check -- routes/cookbook_helpers.py tests/test_cookbook_helpers.py`
4. On native Windows with Git Bash, run a local Cookbook dependency install or serve task where `python3` is absent but `python` or `py` is installed; direct `python3` checks and nested `bash -c` pip fallback wrappers should resolve through the exported fallback.

## Visual / UI changes - REQUIRED if you touched anything that renders

- [x] No UI or visual changes.

### Screenshots / clips

N/A - backend runner bootstrap only.

## Validation

1. `.venv/bin/pytest -q tests/test_cookbook_helpers.py tests/test_platform_compat.py tests/test_cookbook_dependency_completion_regression.py` -> 54 passed
2. `.venv/bin/python -m py_compile routes/cookbook_helpers.py routes/cookbook_routes.py tests/test_cookbook_helpers.py`
3. `git diff --check -- routes/cookbook_helpers.py tests/test_cookbook_helpers.py`