### PR TITLE
fix(security): block Odysseus secret files from agent tools and fail-close auth gate

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1151,8 +1151,9 @@ def setup_model_routes(model_discovery):
                 raise HTTPException(401, "Not authenticated")
         except HTTPException:
             raise
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error('Auth gate error in GET /api/models, failing closed: %s', e)
+            raise HTTPException(status_code=500, detail='Internal error')
         # Admins see every endpoint (they manage the global pool); regular
         # users get the owner-scoped view.
         _is_admin = False

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -162,6 +162,10 @@ _SENSITIVE_BASENAMES: set[str] = {
 _SENSITIVE_FILE_PATTERNS: tuple[str, ...] = (
     "authorized_keys", "id_rsa", "id_ed25519", "id_ecdsa",
     "known_hosts",
+    # Odysseus secrets — always block even though they live inside DATA_DIR.
+    # auth.json: bcrypt hashes + usernames. .app_key: Fernet master key.
+    # sessions.json: live session tokens. These three together = full compromise.
+    "auth.json", "sessions.json", ".app_key",
 )
 
 
@@ -251,7 +255,11 @@ def _resolve_tool_path(raw_path: str) -> str:
     expanded = os.path.expanduser(str(raw_path).strip())
     resolved = os.path.realpath(expanded)
 
-    if _is_sensitive_path(resolved):
+    # Check both the pre-symlink path and the resolved path. On NixOS,
+    # home-manager symlinks (e.g. ~/.ssh/config → /nix/store/…) resolve to
+    # a store path that strips .ssh from the components, so checking only
+    # the resolved path would miss the deny-list entry.
+    if _is_sensitive_path(expanded) or _is_sensitive_path(resolved):
         raise ValueError(
             f"path '{raw_path}' is inside a sensitive directory "
             f"(e.g. .ssh, .gnupg) or matches a sensitive filename"

--- a/tests/test_tool_path_confinement.py
+++ b/tests/test_tool_path_confinement.py
@@ -196,6 +196,47 @@ def test_extra_root_still_blocks_sensitive(tmp_path):
             _resolve_tool_path("~/.ssh/authorized_keys")
 
 
+# ── Odysseus-specific secret file tests ───────────────────────────────
+
+def test_blocks_odysseus_auth_json(tmp_path, monkeypatch):
+    """auth.json inside DATA_DIR must be blocked — it holds bcrypt hashes."""
+    from src.tool_execution import _resolve_tool_path
+    from src.constants import DATA_DIR
+    os.makedirs(DATA_DIR, exist_ok=True)
+    target = os.path.join(DATA_DIR, "auth.json")
+    with pytest.raises(ValueError, match="sensitive"):
+        _resolve_tool_path(target)
+
+
+def test_blocks_odysseus_sessions_json(tmp_path):
+    """sessions.json inside DATA_DIR must be blocked — it holds live tokens."""
+    from src.tool_execution import _resolve_tool_path
+    from src.constants import DATA_DIR
+    os.makedirs(DATA_DIR, exist_ok=True)
+    target = os.path.join(DATA_DIR, "sessions.json")
+    with pytest.raises(ValueError, match="sensitive"):
+        _resolve_tool_path(target)
+
+
+def test_blocks_odysseus_app_key(tmp_path):
+    """.app_key inside DATA_DIR must be blocked — it is the Fernet master key."""
+    from src.tool_execution import _resolve_tool_path
+    from src.constants import DATA_DIR
+    os.makedirs(DATA_DIR, exist_ok=True)
+    target = os.path.join(DATA_DIR, ".app_key")
+    with pytest.raises(ValueError, match="sensitive"):
+        _resolve_tool_path(target)
+
+
+def test_blocks_odysseus_secrets_via_is_sensitive():
+    """_is_sensitive_path must flag the three Odysseus secrets regardless of dir."""
+    from src.tool_execution import _is_sensitive_path
+    assert _is_sensitive_path("/app/data/auth.json")
+    assert _is_sensitive_path("/app/data/sessions.json")
+    assert _is_sensitive_path("/app/data/.app_key")
+    assert _is_sensitive_path("/tmp/auth.json")
+
+
 # ── Integration: dispatch-level tests ────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds `auth.json`, `sessions.json`, and `.app_key` to the sensitive-file deny-list in `_resolve_tool_path` so the `read_file`/`write_file` agent tools cannot access Odysseus's own credential files even though they live inside `DATA_DIR` (which is on the allowlist). Those three files together represent a full account compromise.

Also checks `_is_sensitive_path` against the pre-symlink expanded path in addition to the `realpath`, so NixOS/home-manager symlinks (which strip `.ssh` from the resolved components) no longer bypass the deny-list.

In `GET /api/models`, replaces a bare `except Exception: pass` auth gate with explicit fail-closed behaviour: any unexpected exception from the auth check now returns HTTP 500 instead of silently granting full model-list access.

## Linked Issue

Fixes #2348

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `pytest tests/test_tool_path_confinement.py -v` — all four new secret-file tests (`test_blocks_odysseus_*`) should pass.
2. In a running Odysseus instance, ask the agent to `read_file <DATA_DIR>/auth.json` — it should return a "sensitive" error, not file contents.
3. Simulate a broken auth manager (e.g. raise in `is_configured`) and call `GET /api/models` — the response should be HTTP 500, not 200 with the model list.