### PR TITLE
fix: bool('false') string coerces endpoint supports_tools and is_enabled to True

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1525,9 +1525,10 @@ def setup_model_routes(model_discovery):
             if body:
                 if "supports_tools" in body:
                     v = body["supports_tools"]
-                    ep.supports_tools = bool(v) if v in (True, False, "true", "false", 1, 0) else None
+                    ep.supports_tools = {True: True, False: False, 'true': True, 'false': False, 1: True, 0: False}.get(v)
                 if "is_enabled" in body:
-                    ep.is_enabled = bool(body["is_enabled"])
+                    v_ie = body['is_enabled']
+                    ep.is_enabled = v_ie.lower() in ('true', '1', 'yes') if isinstance(v_ie, str) else bool(v_ie)
                 if "name" in body and isinstance(body["name"], str):
                     ep.name = body["name"].strip() or ep.name
                 if "model_type" in body and isinstance(body["model_type"], str):


### PR DESCRIPTION
## Summary

In the `PATCH /api/endpoints/:id` handler, `supports_tools` and `is_enabled` were coerced with `bool(v)`. Python's `bool('false')` returns `True` because the string is non-empty. A JavaScript client that serialises a boolean as the string `'false'` would have the toggle silently flipped — so "disable tool support" would actually enable it.

`supports_tools` now uses an explicit lookup dict that maps `True/False/'true'/'false'/1/0` to the correct boolean, returning `None` for anything else. `is_enabled` uses a case-insensitive string membership check for string inputs and falls back to `bool()` for native booleans/ints.

## Linked Issue

Fixes #2349

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Start Odysseus and add a model endpoint.
2. Send `PATCH /api/endpoints/<id>` with body `{"supports_tools": "false"}` — verify the endpoint's `supports_tools` is now `False`, not `True`.
3. Send `PATCH /api/endpoints/<id>` with body `{"is_enabled": "false"}` — verify the endpoint is now disabled.
4. Send `PATCH /api/endpoints/<id>` with body `{"is_enabled": true}` — verify native boolean still works.