### PR TITLE
fix: KeyError on missing 'content' key in system messages crashes LLM hot path

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -67,7 +67,7 @@ _host_health_lock = threading.Lock()
 _model_activity: Dict[str, float] = {}
 
 def _model_activity_key(url: str, model: str) -> str:
-    return f"{(url or '').strip().rstrip()}|{(model or '').strip()}"
+    return f"{(url or '').strip()}|{(model or '').strip()}"
 
 def note_model_activity(url: str, model: str):
     """Record that a real upstream request used this endpoint/model."""
@@ -809,7 +809,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
     non_sys = []
     for m in messages_copy:
         if m.get("role") == "system":
-            sys_parts.append(m["content"])
+            sys_parts.append(m.get('content') or '')
         else:
             non_sys.append(m)
     if sys_parts:
@@ -928,7 +928,7 @@ async def llm_call_async(
     non_sys = []
     for m in messages_copy:
         if m.get("role") == "system":
-            sys_parts.append(m["content"])
+            sys_parts.append(m.get('content') or '')
         else:
             non_sys.append(m)
     if sys_parts:
@@ -1038,7 +1038,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     non_sys = []
     for m in messages_copy:
         if m.get("role") == "system":
-            sys_parts.append(m["content"])
+            sys_parts.append(m.get('content') or '')
         else:
             non_sys.append(m)
     if sys_parts:


### PR DESCRIPTION
## Summary

In `llm_call`, `llm_call_async`, and `stream_llm`, system messages were accessed with `m['content']`. A system message without a `'content'` key — possible via malformed tool results — raised a `KeyError` in the hot path and crashed the in-progress LLM call.

Replaces `m["content"]` with `m.get("content") or ""` in all three functions so a missing key degrades gracefully to an empty string. Also removes a redundant `.rstrip()` after `.strip()` in `_model_activity_key`.

## Linked Issue

Fixes #2350

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `pytest tests/test_llm_core_*.py -v` — all existing LLM core tests should pass.
2. In a test or REPL, call `llm_call` (or its async variant) with a message list that includes `{"role": "system"}` (no `"content"` key) — the call should proceed rather than raise `KeyError`.