### PR TITLE
fix(tasks): capture caller owner in parse_task endpoint lookup

### DIFF
--- a/routes/task_routes.py
+++ b/routes/task_routes.py
@@ -917,6 +917,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
         import json as _json, re as _re
         from datetime import datetime as _dt
 
+        user = _owner(request)
         body = await request.json()
         desc = (body.get("description") or "").strip()
         if not desc:
@@ -947,9 +948,9 @@ def setup_task_routes(task_scheduler) -> APIRouter:
             "use cron '0 H * * 1-5'. Keep the prompt actionable and self-contained."
         )
         try:
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=user)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=user)
             if not (url and model):
                 return {"success": False, "message": "No model endpoint configured"}
             raw = await llm_call_async(

--- a/tests/test_parse_task_owner_scope.py
+++ b/tests/test_parse_task_owner_scope.py
@@ -1,0 +1,84 @@
+"""Regression: parse_task must scope its LLM endpoint lookup by caller owner.
+
+The POST /api/tasks/parse handler resolves an endpoint to run the
+natural-language task parser. In a multi-user deploy it must pass the caller's
+owner to resolve_endpoint so it cannot pick up another user's private endpoint
+configuration and API key. Every other handler in the file starts with
+`user = _owner(request)` and scopes its lookups; parse_task must do the same.
+"""
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+import routes.task_routes as task_routes
+import src.endpoint_resolver as endpoint_resolver
+import src.llm_core as llm_core
+
+
+def _get_parse_task_handler():
+    """Pull the parse_task closure out of the router built by setup_task_routes."""
+    router = task_routes.setup_task_routes(task_scheduler=object())
+    for route in router.routes:
+        if getattr(route, "path", None) == "/api/tasks/parse":
+            return route.endpoint
+    raise AssertionError("parse_task route not registered")
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def test_parse_task_passes_owner_to_resolve_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_resolve_endpoint(setting_prefix, *args, **kwargs):
+        captured.setdefault("calls", []).append((setting_prefix, kwargs.get("owner")))
+        # Return a usable endpoint so the handler proceeds to the LLM call.
+        return ("http://endpoint", "model-x", {})
+
+    monkeypatch.setattr(endpoint_resolver, "resolve_endpoint", fake_resolve_endpoint)
+    monkeypatch.setattr(
+        llm_core, "llm_call_async", AsyncMock(return_value='{"prompt": "do it"}')
+    )
+    # _owner(request) calls get_current_user; pretend the caller is alice.
+    monkeypatch.setattr(task_routes, "get_current_user", lambda request: "alice")
+
+    handler = _get_parse_task_handler()
+    result = asyncio.run(handler(_FakeRequest({"description": "summarize my email daily at 7am"})))
+
+    assert result.get("success") is True, result
+    assert captured.get("calls"), "resolve_endpoint was never called"
+    # The first (and any) resolve_endpoint call must carry the caller's owner.
+    prefix, owner = captured["calls"][0]
+    assert prefix == "utility"
+    assert owner == "alice", f"resolve_endpoint called without owner scope: {captured['calls']}"
+
+
+def test_parse_task_fallback_default_also_scopes_owner(monkeypatch):
+    """When 'utility' yields no URL, the 'default' fallback must also be owner-scoped."""
+    captured = {}
+
+    def fake_resolve_endpoint(setting_prefix, *args, **kwargs):
+        captured.setdefault("calls", []).append((setting_prefix, kwargs.get("owner")))
+        if setting_prefix == "utility":
+            return (None, None, None)
+        return ("http://endpoint", "model-x", {})
+
+    monkeypatch.setattr(endpoint_resolver, "resolve_endpoint", fake_resolve_endpoint)
+    monkeypatch.setattr(
+        llm_core, "llm_call_async", AsyncMock(return_value='{"prompt": "do it"}')
+    )
+    monkeypatch.setattr(task_routes, "get_current_user", lambda request: "alice")
+
+    handler = _get_parse_task_handler()
+    result = asyncio.run(handler(_FakeRequest({"description": "summarize my email daily at 7am"})))
+
+    assert result.get("success") is True, result
+    calls = dict(captured.get("calls", []))
+    assert calls.get("utility") == "alice", captured["calls"]
+    assert calls.get("default") == "alice", f"default fallback dropped owner scope: {captured['calls']}"


### PR DESCRIPTION
## Summary

`parse_task` (POST `/api/tasks/parse`) turns a free-form description into a structured task draft using an LLM. It resolved the LLM endpoint with `resolve_endpoint("utility")` and the `resolve_endpoint("default")` fallback but never captured the authenticated user, so the lookup ran globally. In a multi-user deployment that can return another user's private endpoint configuration, including its API key, for the parse call. This change captures the user with `user = _owner(request)` and passes `owner=user` to both `resolve_endpoint` calls, matching every other substantive handler in `routes/task_routes.py`.

## Linked Issue

Fixes #2352

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start the app: `docker compose up -d --build`.
2. Add a regression test that drives the `parse_task` closure (built via `setup_task_routes`), patches `get_current_user` to return a user, mocks `resolve_endpoint` and `llm_call_async`, and asserts `resolve_endpoint` is called with `owner=<that user>`. Run `python -m pytest tests/test_parse_task_owner_scope.py -v`. On the current code it fails (called with `owner=None`); with this fix it passes. The included test does exactly this, and also checks the `default` fallback path carries the owner.
3. Confirm the existing task-route tests still pass: `python -m pytest tests/test_task_scheduler_cancel.py tests/test_tasks_cli_preview.py tests/test_task_scheduler_session_delivery.py -q`.

`_owner` returns `None` in single-user mode, which `resolve_endpoint` treats as no filter, so single-user behavior is unchanged.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI changes. This is a backend-only change to one route handler in `routes/task_routes.py`.
