### PR TITLE
fix: llm_call_async raises immediately on HTTP 429/502/503/504 instead of retrying

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -988,6 +988,9 @@ async def llm_call_async(
                     f"LLM async call to {target_url} failed in {duration:.2f}s "
                     f"(attempt {attempt}): HTTP {r.status_code} {friendly}"
                 )
+                if r.status_code in (429, 502, 503, 504) and attempt < max_retries:
+                    await asyncio.sleep(LLMConfig.RETRY_DELAY)
+                    continue
                 raise HTTPException(r.status_code, friendly)
             logger.info(f"LLM async call to {target_url} succeeded in {duration:.2f}s (attempt {attempt})")
             _clear_host_dead(target_url)
@@ -1009,7 +1012,9 @@ async def llm_call_async(
             duration = time.time() - start
             _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
             logger.warning(f"LLM async connect to {target_url} failed after {duration:.2f}s: {e}{_tail}")
-            raise HTTPException(503, f"Cannot reach {_host_key(target_url)}: {e}")
+            if _cooled or attempt >= max_retries:
+                raise HTTPException(503, f"Cannot reach {_host_key(target_url)}: {e}")
+            await asyncio.sleep(LLMConfig.RETRY_DELAY)
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             duration = time.time() - start
             logger.warning(f"LLM async call attempt {attempt} failed after {duration:.2f}s: {e}")


### PR DESCRIPTION
## Summary

The retry loop in `llm_call_async` called `raise HTTPException(r.status_code, ...)` immediately for every non-success HTTP response regardless of how many attempts remained. For transient upstream errors (rate-limit 429, bad-gateway 502, gateway-timeout 504) the call should back off and retry within the existing attempt budget instead of failing the first time.

`ConnectError`/`ConnectTimeout` had the same problem: always raised immediately even when the host had not been cooled and retries remained.

Changes:
- After a 429/502/503/504 response and `attempt < max_retries`, sleep `RETRY_DELAY` and continue the loop instead of raising immediately.
- `ConnectError`/`ConnectTimeout`: only raise if the host is cooled or we've exhausted retries; otherwise sleep and retry.

## Linked Issue

Fixes #2351

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Point Odysseus at a mock server that returns 429 on the first request and 200 on the second — the call should succeed rather than raise immediately.
2. Point Odysseus at an unreachable host with `max_retries > 1` — the error should appear only after the expected number of attempts.
3. Run `pytest tests/test_llm_core_*.py -v` — all existing tests pass.