### PR TITLE
fix: endpoint_resolver ImportError at startup due to wrong module path for ModelEndpoint

### DIFF
--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -11,7 +11,7 @@ import subprocess
 from typing import Optional, Tuple, Dict
 from urllib.parse import urlparse, urlunparse
 
-from src.database import SessionLocal, ModelEndpoint
+from core.database import SessionLocal, ModelEndpoint
 from src.llm_core import _detect_provider, _host_match
 
 logger = logging.getLogger(__name__)
@@ -285,6 +285,8 @@ def resolve_endpoint(
         # If no (usable) model specified, pick the first enabled chat model.
         if not model:
             model = _first_chat_model(_endpoint_enabled_models(ep)) or ""
+        if not model and not fallback_model:
+            logger.warning('[resolve_endpoint] no usable model (all models hidden or list empty)')
 
         return chat_url, model or fallback_model, headers
     except Exception as e:

--- a/tests/test_auth_regressions.py
+++ b/tests/test_auth_regressions.py
@@ -81,12 +81,12 @@ def _auth_regressions_stubs(monkeypatch):
         resolve_endpoint=MagicMock(return_value=("", "", {})),
         normalize_base=MagicMock(),
         build_chat_url=MagicMock(),
+        build_models_url=MagicMock(),
         build_headers=MagicMock(),
     )
     monkeypatch.setitem(sys.modules, "core.database", db)
     monkeypatch.setitem(sys.modules, "core.auth", auth)
     monkeypatch.setitem(sys.modules, "src.endpoint_resolver", ep)
-
 
 from fastapi import HTTPException
 


### PR DESCRIPTION
## Summary

`src/endpoint_resolver.py` imported `ModelEndpoint` from `src.database`, but the class is defined in `core.database`. The wrong import silently prevented the module from loading in deployment configurations without a `src/database.py` shim, resulting in an `ImportError` at startup.

Also adds a `logger.warning` when `resolve_endpoint` finds no usable model (all models hidden or the list is empty), making the previously-silent failure visible in operator logs.

The test stub for `src.endpoint_resolver` in `test_auth_regressions.py` was missing the `build_models_url` attribute, which caused test collection errors.

## Linked Issue

Fixes #2354

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Start Odysseus without any `src/database.py` file present — the server should start without an `ImportError` from `endpoint_resolver`.
2. Run `pytest tests/test_auth_regressions.py -v` — test collection should succeed without `AttributeError: build_models_url`.
3. Configure an endpoint where all models are hidden — the server log should show a `[resolve_endpoint] no usable model` warning rather than silently returning an empty model string.