### PR TITLE
fix: search analytics FileHandler crashes on startup writing to read-only image layer

### DIFF
--- a/services/search/analytics.py
+++ b/services/search/analytics.py
@@ -6,14 +6,15 @@ from collections import Counter
 from pathlib import Path
 from typing import Dict, Any
 
+from core.constants import DATA_DIR
+
 from .cache import cache_metrics
 
 logger = logging.getLogger(__name__)
 
-# Dedicated error logger — write to the mounted logs volume, not the image layer.
-# /app/logs is always bind-mounted from the host data directory; /app/services is
-# part of the read-only image layer and cannot be written at runtime.
-_log_dir = Path("/app/logs")
+# Dedicated error logger — write to the data logs directory (writable on both
+# native runs and Docker, where DATA_DIR resolves to the bind-mounted volume).
+_log_dir = Path(DATA_DIR) / "logs"
 _error_log_path = _log_dir / "search_engine_error.log"
 error_logger = logging.getLogger("search_engine_error")
 error_logger.propagate = False

--- a/services/search/analytics.py
+++ b/services/search/analytics.py
@@ -10,17 +10,24 @@ from .cache import cache_metrics
 
 logger = logging.getLogger(__name__)
 
-# Dedicated error logger with file handler
-_error_log_path = Path(__file__).resolve().parent.parent / "search_engine_error.log"
-_error_handler = logging.FileHandler(_error_log_path, encoding="utf-8")
-_error_handler.setLevel(logging.WARNING)
-_error_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+# Dedicated error logger — write to the mounted logs volume, not the image layer.
+# /app/logs is always bind-mounted from the host data directory; /app/services is
+# part of the read-only image layer and cannot be written at runtime.
+_log_dir = Path("/app/logs")
+_error_log_path = _log_dir / "search_engine_error.log"
 error_logger = logging.getLogger("search_engine_error")
-error_logger.addHandler(_error_handler)
 error_logger.propagate = False
+try:
+    _log_dir.mkdir(parents=True, exist_ok=True)
+    _error_handler = logging.FileHandler(_error_log_path, encoding="utf-8")
+    _error_handler.setLevel(logging.WARNING)
+    _error_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    error_logger.addHandler(_error_handler)
+except Exception as _e:
+    logging.getLogger(__name__).warning("search_engine_error log handler unavailable: %s", _e)
 
-# Analytics file
-ANALYTICS_FILE = Path(__file__).resolve().parent.parent / "search_analytics.json"
+# Analytics file — also in the writable logs volume.
+ANALYTICS_FILE = _log_dir / "search_analytics.json"
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`services/search/analytics.py` configures a `logging.FileHandler` pointing at a path inside the application source tree (`/app/services/...`), which is a read-only layer in the container image. The `FileHandler` is instantiated at module import time, so the `PermissionError` crashes Odysseus at startup before any route is registered.

The file is updated to write to `/app/logs/` instead, which is a writable volume mounted by the container. The `_log_dir.mkdir()` call is wrapped in a try/except so a missing logs volume degrades gracefully rather than crashing.

Note: `src/search/analytics.py` is now a compatibility re-export shim that forwards to `services/search/analytics.py` (#2264), so fixing the real implementation here is sufficient — no change needed in the shim.

## Linked Issue

Fixes #2355

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Build the container image and start with `docker compose up` — Odysseus should start without a `PermissionError` from `analytics.py`.
2. Confirm that a log file appears under `/app/logs/` inside the running container.