### PR TITLE
fix: log warnings on silently swallowed agent override loader and endpoint refresh failures

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -993,8 +993,8 @@ def setup_model_routes(model_discovery):
                     db.close()
                 if changed:
                     _invalidate_models_cache()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning('Background endpoint refresh failed: %s', e)
             finally:
                 for st in _refresh_state.values():
                     st["inflight"] = False

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -374,7 +374,8 @@ def get_builtin_overrides() -> dict:
         from src.settings import get_setting
         ov = get_setting("builtin_tool_overrides", {})
         return ov if isinstance(ov, dict) else {}
-    except Exception:
+    except Exception as e:
+        logger.warning('Failed to load builtin tool overrides: %s', e)
         return {}
 
 
@@ -571,8 +572,7 @@ def _build_system_prompt(
         # Skill index is user-editable (name + description), so it must never
         # live in the trusted system role and is NOT cached. Always recompute
         # when the cache hits.
-        from src.agent_loop import _build_base_prompt as _bbp_recompute
-        _, _skill_index_block = _bbp_recompute(
+        _, _skill_index_block = _build_base_prompt(
             disabled_tools, mcp_mgr, needs_admin, relevant_tools,
             mcp_disabled_map=mcp_disabled_map, compact=compact,
         )


### PR DESCRIPTION
## Summary

Two places swallowed all exceptions with a bare `except Exception: pass`:

1. `get_builtin_overrides()` in `src/agent_loop.py` — any failure silently returned `{}`, so misconfigured tool-description overrides produced wrong agent behaviour with no log trace.
2. The background endpoint refresh loop in `routes/model_routes.py` — any probe exception was silently discarded, giving operators no signal that the refresh was broken.

Both are updated to log a `WARNING` with the error detail. Also removes a circular self-import (`from src.agent_loop import _build_base_prompt`) inside `_build_system_prompt`; the function is already in scope and the import created a latent circular reference risk.

## Linked Issue

Fixes #2357

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Temporarily corrupt `builtin_tool_overrides` in settings (e.g. set it to a non-dict value) and restart Odysseus — the server log should contain a `Failed to load builtin tool overrides` warning rather than silently continuing.
2. Force the background endpoint refresh to fail (e.g. temporarily break DB access) — the log should show `Background endpoint refresh failed` rather than being silent.