### PR TITLE
[codex] ci: add advisory pytest smoke workflow

### DIFF
--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -1,0 +1,68 @@
+name: ci / pytest smoke
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pytest-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: Pytest smoke (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run pytest
+        id: pytest
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python -m pytest -q 2>&1 | tee pytest-output.txt
+
+      - name: Publish advisory result
+        if: always()
+        run: |
+          {
+            if [ "${{ steps.pytest.outcome }}" = "success" ]; then
+              echo "### Pytest smoke: passed"
+            else
+              echo "### Pytest smoke: failed (advisory)"
+            fi
+            echo
+            echo "This workflow is intentionally non-blocking while the full test suite is stabilized."
+            echo
+            echo '```text'
+            if [ -f pytest-output.txt ]; then
+              tail -n 120 pytest-output.txt
+            else
+              echo "pytest did not produce an output log."
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a minimal advisory GitHub Actions workflow that runs `python -m pytest -q` on pull requests to `main` and on manual dispatch. The pytest step is `continue-on-error`, and the workflow writes the final test tail to the GitHub step summary so reviewers get a signal without turning the currently-unstable full suite into a merge blocker.

## Linked Issue

Fixes #2335

Part of #2288

## Type of Change

- [ ] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate. #2250 overlaps the general CI area, but it adds ruff + Docker build + multi-version pytest and is currently marked `needs work`; this PR intentionally implements only the non-blocking pytest smoke requested in #2335.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] CI-only change; no app runtime path changed. I validated the workflow syntax locally.

## How to Test

1. `actionlint .github/workflows/pytest-smoke.yml`
2. `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pytest-smoke.yml'); puts 'yaml ok'"`
3. `git diff --cached --check`
4. Open or update this PR and confirm `ci / pytest smoke` runs. If pytest fails, the `Run pytest` step should show the failure, the summary should show an advisory tail, and the job should not fail solely because of pytest.

## Visual / UI changes - REQUIRED if you touched anything that renders

- [x] No UI or visual changes. GitHub Actions workflow only.

### Screenshots / clips

N/A - CI workflow only.

## Validation

1. `actionlint .github/workflows/pytest-smoke.yml`
2. `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pytest-smoke.yml'); puts 'yaml ok'"` -> yaml ok
3. `git diff --cached --check`