### PR TITLE
Detect pip CUDA nvcc in system install locations, not just ~/.local

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -580,8 +580,17 @@ def _append_llama_cpp_linux_accel_build_lines(runner_lines: list[str]) -> None:
     # so cmake's CUDA configure can find it. We keep this after the ROCm/HIP
     # check — a machine with both stacks should honor the native HIP toolchain on
     # AMD hosts instead of accidentally preferring a stray nvcc wheel.
-    runner_lines.append('    for _cudir in ~/.local/lib/python*/site-packages/nvidia/cu13 ~/.local/lib/python*/site-packages/nvidia/cu12 ~/.local/lib/python*/site-packages/nvidia/cuda_nvcc; do')
-    runner_lines.append('      [ -x "$_cudir/bin/nvcc" ] && export CUDA_HOME="$_cudir" && export PATH="$_cudir/bin:$PATH" && break')
+    #
+    # The wheels can land in the per-user tree (~/.local, `pip install --user`) or
+    # a system tree — e.g. `pip install` as root inside a Docker image puts them
+    # under /usr/local/lib or /usr/lib, and Debian/Ubuntu use dist-packages while
+    # other distros use site-packages. Searching only ~/.local missed all of those,
+    # so a GPU host that installed the CUDA wheels as root still fell back to a CPU
+    # build with "no HIP/CUDA toolchain found". Search every base/layout. (#2377)
+    runner_lines.append('    for _cubase in ~/.local /usr/local /usr; do')
+    runner_lines.append('      for _cudir in "$_cubase"/lib/python*/site-packages/nvidia/cu13 "$_cubase"/lib/python*/site-packages/nvidia/cu12 "$_cubase"/lib/python*/site-packages/nvidia/cuda_nvcc "$_cubase"/lib/python*/dist-packages/nvidia/cu13 "$_cubase"/lib/python*/dist-packages/nvidia/cu12 "$_cubase"/lib/python*/dist-packages/nvidia/cuda_nvcc "$_cubase"/lib/python3/dist-packages/nvidia/cu13 "$_cubase"/lib/python3/dist-packages/nvidia/cu12 "$_cubase"/lib/python3/dist-packages/nvidia/cuda_nvcc; do')
+    runner_lines.append('        [ -x "$_cudir/bin/nvcc" ] && export CUDA_HOME="$_cudir" && export PATH="$_cudir/bin:$PATH" && break 2')
+    runner_lines.append('      done')
     runner_lines.append('    done')
     # rm -rf build so a prior poisoned CMakeCache.txt (e.g. from a failed CUDA
     # or HIP attempt) doesn't cause the next configure to reuse stale settings.

--- a/tests/test_cookbook_cuda_build_nvcc_detect.py
+++ b/tests/test_cookbook_cuda_build_nvcc_detect.py
@@ -1,0 +1,89 @@
+"""Regression for #2377: the llama.cpp build must detect a pip-installed nvcc
+no matter where pip put the CUDA wheels.
+
+The build-time detector used to glob only ~/.local/lib/python*/site-packages.
+A GPU host that installed the CUDA wheels as root inside a Docker image (so the
+wheels land in /usr/local/lib/.../dist-packages, not ~/.local) was therefore
+told "no HIP/CUDA toolchain found" and got a CPU-only build. The fix searches
+the per-user and system trees, and both the site-packages and dist-packages
+layouts.
+"""
+import shlex
+import subprocess
+import textwrap
+from pathlib import Path
+
+from routes.cookbook_helpers import _append_llama_cpp_linux_accel_build_lines
+
+
+def _detection_block() -> str:
+    """The generated `for _cubase ... done` nvcc-detection shell, as one string."""
+    lines: list[str] = []
+    _append_llama_cpp_linux_accel_build_lines(lines)
+    start = next(i for i, ln in enumerate(lines) if "for _cubase in" in ln)
+    done_seen = 0
+    end = start
+    for i in range(start, len(lines)):
+        end = i
+        if lines[i].strip() == "done":
+            done_seen += 1
+            if done_seen == 2:  # the outer `done` closes the detection block
+                break
+    return "\n".join(lines[start : end + 1])
+
+
+def test_build_nvcc_detection_searches_user_and_system_layouts():
+    block = _detection_block()
+    # per-user tree preserved (no regression) ...
+    assert "~/.local" in block
+    assert "site-packages/nvidia/cuda_nvcc" in block
+    # ... plus the system trees a root/Docker install uses ...
+    assert "/usr/local" in block
+    assert " /usr;" in block or " /usr " in block
+    # ... and the Debian/Ubuntu dist-packages layout.
+    assert "dist-packages/nvidia/cuda_nvcc" in block
+    assert "lib/python3/dist-packages/nvidia/cu12" in block
+    # still keys off an executable nvcc and exports the same vars.
+    assert '[ -x "$_cudir/bin/nvcc" ]' in block
+    assert 'export CUDA_HOME="$_cudir"' in block
+    assert "break 2" in block
+
+
+def _run_detection(bases: list[str], block: str) -> str:
+    """Run the real detection block with its base list swapped for a sandbox."""
+    rebased = block.replace("~/.local /usr/local /usr", " ".join(shlex.quote(b) for b in bases))
+    script = rebased + '\necho "CUDA_HOME=$CUDA_HOME"'
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True).stdout
+    line = next((l for l in out.splitlines() if l.startswith("CUDA_HOME=")), "CUDA_HOME=")
+    return line[len("CUDA_HOME=") :]
+
+
+def test_build_nvcc_detection_finds_dist_packages_nvcc(tmp_path: Path):
+    # Mirror the #2377 repro: empty per-user tree, real nvcc in a *system*
+    # dist-packages tree (where `pip install` as root drops the wheels).
+    user = tmp_path / "user"
+    (user / "lib/python3.12/site-packages/nvidia").mkdir(parents=True)
+    system = tmp_path / "system"
+    nvcc_dir = system / "lib/python3.12/dist-packages/nvidia/cuda_nvcc/bin"
+    nvcc_dir.mkdir(parents=True)
+    nvcc = nvcc_dir / "nvcc"
+    nvcc.write_text("#!/bin/sh\necho nvcc\n")
+    nvcc.chmod(0o755)
+
+    block = _detection_block()
+    found = _run_detection([str(user), str(system)], block)
+    assert found == str(system / "lib/python3.12/dist-packages/nvidia/cuda_nvcc"), found
+
+    # Negative control: the old user-only / site-packages-only form misses it.
+    old = textwrap.dedent(
+        f"""
+        for _cudir in {shlex.quote(str(user))}/lib/python*/site-packages/nvidia/cu13 \
+                      {shlex.quote(str(user))}/lib/python*/site-packages/nvidia/cu12 \
+                      {shlex.quote(str(user))}/lib/python*/site-packages/nvidia/cuda_nvcc; do
+          [ -x "$_cudir/bin/nvcc" ] && export CUDA_HOME="$_cudir" && break
+        done
+        echo "CUDA_HOME=$CUDA_HOME"
+        """
+    )
+    out = subprocess.run(["bash", "-c", old], capture_output=True, text=True).stdout
+    assert "CUDA_HOME=\n" in out + "\n", "old detector should have found nothing"


### PR DESCRIPTION
## Summary

The Linux llama.cpp build detects a pip-installed `nvcc` (from vLLM / NVIDIA CUDA wheels) and puts it on `PATH` so cmake's CUDA configure can find it. The detector globbed only `~/.local/lib/python*/site-packages/nvidia/{cu13,cu12,cuda_nvcc}`.

That misses every install location other than a per-user `pip install --user`. In particular, installing the CUDA wheels as root inside a Docker image (`pip install ...` with no `--user`) lands them in the system tree: `/usr/local/lib/python3.x/dist-packages/nvidia/...` on Debian/Ubuntu, or `/usr/lib/python3/dist-packages/...`. The glob never checks those, so `nvcc` is invisible, the build hits the `else` branch, prints `no HIP/CUDA toolchain found - building llama-server for CPU only`, and produces a CPU-only binary on a perfectly capable GPU host. This is the build-time blocker behind the GPU reports in #831, one step before the serve-time `LD_LIBRARY_PATH` gap (#2239 / #2242): the build never produces a CUDA binary at all.

**Fix:** search the per-user and system bases (`~/.local`, `/usr/local`, `/usr`) and both the `site-packages` and `dist-packages` layouts, keying off an executable `nvcc` exactly as before. The first match wins and exports the same `CUDA_HOME` / `PATH`. ROCm/HIP is still detected first, so AMD hosts are unaffected, and the no-toolchain CPU fallback is unchanged.

## Linked Issue

Fixes #2377
Part of #831

## Type of Change

- [x] Bug fix (non-breaking; fixes a confirmed issue)
- [ ] New feature (non-breaking; adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs; this is not a duplicate. (The sibling PR #2242 fixes the serve-time `LD_LIBRARY_PATH`; this is the build-time `nvcc` detection, a different function and failure.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above; no unrelated refactors or whitespace changes mixed in.
- [x] Verified with a red/green regression test (see How to Test).

## How to Test

1. Run the new test: `./venv/bin/python -m pytest -q tests/test_cookbook_cuda_build_nvcc_detect.py` -> 2 passed. It asserts the generated detection searches the user and system bases plus both layouts, and behaviourally runs the real generated shell against a sandbox where `nvcc` exists only in a system `dist-packages` tree, confirming it is found (with a negative control showing the old user-only / site-packages-only form misses it).
2. Confirm red-before / green-after: `git stash push routes/cookbook_helpers.py` and re-run the test; it fails (the broadened detection is gone). `git stash pop` and it passes.
3. Regression sweep: `./venv/bin/python -m pytest -q tests/test_cookbook_helpers.py tests/test_cookbook_cuda_build_nvcc_detect.py` -> 46 passed.
4. `./venv/bin/python -m py_compile routes/cookbook_helpers.py` -> passes.
