### PR TITLE
[codex] fix(cookbook): preserve background serve diagnosis

### DIFF
--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -8,6 +8,7 @@ import uiModule from './ui.js';
 import { _diagnose, _showDiagnosis, _clearDiagnosis } from './cookbook-diagnosis.js';
 import { registerMenuDismiss } from './escMenuStack.js';
 import { computeProgressSignal } from './cookbookProgressSignal.js';
+import { applyLiveTaskStatus, normalizeLiveDiagnosis } from './cookbookTaskStatusMerge.js';
 
 // Human-friendly badge label for a task's internal status. Avoids surfacing
 // the word "error" in the sidebar — a server the user stopped or one that
@@ -153,6 +154,11 @@ function _terminalServeDiagnosis(task, outputText) {
       : 'Suggested action: copy the troubleshooting bundle, then edit serve settings or relaunch with a CPU/backend fallback.',
     fixes: [{ label: 'Edit serve', action: (panel) => _openServeEditForTask(task) }],
   };
+}
+
+function _serveDiagnosisForTask(task, outputText) {
+  if (task?.type !== 'serve' || !['stopped', 'error', 'crashed', 'failed'].includes(task.status)) return null;
+  return normalizeLiveDiagnosis(task.diagnosis) || _terminalServeDiagnosis(task, outputText);
 }
 
 function _redactCrashReportText(text) {
@@ -1816,8 +1822,9 @@ export function _renderRunningTab() {
       }
       const startNow = el.querySelector('.cookbook-task-start-now');
       if (startNow) startNow.style.display = (task.type === 'download' && task.status === 'queued') ? '' : 'none';
-      const terminalDiag = _terminalServeDiagnosis(task, el.querySelector('.cookbook-output-pre')?.textContent || task.output || '');
-      if (terminalDiag) _showDiagnosis(el, terminalDiag, el.querySelector('.cookbook-output-pre')?.textContent || task.output || '');
+      const outputText = el.querySelector('.cookbook-output-pre')?.textContent || task.output || '';
+      const terminalDiag = _serveDiagnosisForTask(task, outputText);
+      if (terminalDiag) _showDiagnosis(el, terminalDiag, outputText);
     }
     if (!task) {
       if (el._uptimeInterval) { clearInterval(el._uptimeInterval); el._uptimeInterval = null; }
@@ -1853,7 +1860,7 @@ export function _renderRunningTab() {
     const _waveEl = el.querySelector('.cookbook-task-wave');
     if (_waveEl && task.status === 'running') _registerWaveEl(_waveEl);
 
-    const terminalDiag = _terminalServeDiagnosis(task, task.output || '');
+    const terminalDiag = _serveDiagnosisForTask(task, task.output || '');
     if (terminalDiag) _showDiagnosis(el, terminalDiag, task.output || '');
 
     const _uptimeEl = el.querySelector('.cookbook-task-uptime');
@@ -3304,30 +3311,10 @@ async function _pollBackgroundStatus() {
       for (const task of localTasks) {
         const live = statusById.get(task.sessionId);
         if (!live) continue;
-        const updates = {};
-        const nextStatus = live.status === 'completed'
-          ? 'done'
-          : (live.status === 'error'
-            ? 'error'
-            : (live.status === 'stopped' ? (task.type === 'download' ? 'crashed' : 'stopped') : null));
-        if (nextStatus && task.status !== nextStatus) {
-          updates.status = nextStatus;
-          if (nextStatus === 'done' && task.payload?._dep) completedDeps.push(task);
-        }
-        if ((live.status === 'running' || live.status === 'ready') && task.status !== live.status) {
-          updates.status = live.status === 'ready' ? 'ready' : 'running';
-        }
-        if (live.progress && live.progress !== task.progress) updates.progress = live.progress;
-        if (live.output_tail) {
-          const previous = String(task.output || '');
-          const tail = String(live.output_tail || '');
-          if (tail && !previous.endsWith(tail)) {
-            updates.output = `${previous ? `${previous}\n` : ''}${tail}`.slice(-5000);
-          }
-        }
-        if (Object.keys(updates).length) {
-          Object.assign(task, updates);
+        const previousStatus = task.status;
+        if (applyLiveTaskStatus(task, live)) {
           changed = true;
+          if (previousStatus !== 'done' && task.status === 'done' && task.payload?._dep) completedDeps.push(task);
         }
       }
       if (changed) {

--- a/static/js/cookbookTaskStatusMerge.js
+++ b/static/js/cookbookTaskStatusMerge.js
@@ -1,0 +1,66 @@
+// Pure helpers for merging /api/cookbook/tasks/status records into saved
+// Cookbook task state. Kept browser-free so regressions can run under Node.
+
+function _cleanString(value) {
+  return String(value || '').trim();
+}
+
+export function normalizeLiveDiagnosis(diagnosis) {
+  if (!diagnosis || typeof diagnosis !== 'object') return null;
+  const message = _cleanString(diagnosis.message);
+  const suggestion = _cleanString(diagnosis.suggestion);
+  if (!message) return null;
+  return {
+    ...diagnosis,
+    message,
+    ...(suggestion ? { suggestion } : {}),
+  };
+}
+
+function _nextStatus(task, live) {
+  if (live.status === 'completed') return 'done';
+  if (live.status === 'error') return 'error';
+  if (live.status === 'stopped') return task.type === 'download' ? 'crashed' : 'stopped';
+  if (live.status === 'ready') return 'ready';
+  if (live.status === 'running') return 'running';
+  return null;
+}
+
+export function liveTaskStatusUpdates(task, live) {
+  if (!task || !live) return {};
+  const updates = {};
+  const nextStatus = _nextStatus(task, live);
+  if (nextStatus && task.status !== nextStatus) updates.status = nextStatus;
+
+  if (live.progress && live.progress !== task.progress) updates.progress = live.progress;
+
+  if (live.output_tail) {
+    const previous = String(task.output || '');
+    const tail = String(live.output_tail || '');
+    if (tail && !previous.endsWith(tail)) {
+      updates.output = `${previous ? `${previous}\n` : ''}${tail}`.slice(-5000);
+    }
+  }
+
+  const taskType = live.type || task.type;
+  const diagnosis = normalizeLiveDiagnosis(live.diagnosis);
+  if (taskType === 'serve' && diagnosis) {
+    updates.diagnosis = diagnosis;
+  } else if (task.diagnosis && (live.status === 'running' || live.status === 'ready' || live.status === 'completed')) {
+    updates.diagnosis = null;
+  }
+
+  const cmd = _cleanString(live.cmd);
+  if (taskType === 'serve' && cmd && !task.payload?._cmd) {
+    updates.payload = { ...(task.payload || {}), _cmd: cmd };
+  }
+
+  return updates;
+}
+
+export function applyLiveTaskStatus(task, live) {
+  const updates = liveTaskStatusUpdates(task, live);
+  if (!Object.keys(updates).length) return false;
+  Object.assign(task, updates);
+  return true;
+}

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -18,14 +18,17 @@ def test_backend_status_treats_download_exit_zero_as_completed():
 
 def test_background_status_poll_reconciles_into_local_tasks():
     source = _read("static/js/cookbookRunning.js")
+    merge = _read("static/js/cookbookTaskStatusMerge.js")
 
+    assert "import { applyLiveTaskStatus" in source
     assert "const statusById = new Map(tasks.map(t => [t.session_id, t]));" in source
-    assert "const nextStatus = live.status === 'completed'" in source
-    assert "? 'done'" in source
-    assert ": (live.status === 'error'" in source
-    assert "? 'error'" in source
+    assert "if (applyLiveTaskStatus(task, live))" in source
+    assert "previousStatus !== 'done' && task.status === 'done'" in source
     assert "_saveTasks(localTasks);" in source
     assert "completedDeps.forEach(t => _refreshDepsAfterInstall(t));" in source
+    assert "if (live.status === 'completed') return 'done';" in merge
+    assert "if (live.status === 'error') return 'error';" in merge
+    assert "task.type === 'download' ? 'crashed' : 'stopped'" in merge
 
 
 def test_local_windows_session_commands_use_local_powershell_log_dir():

--- a/tests/test_cookbook_task_status_merge_js.py
+++ b/tests/test_cookbook_task_status_merge_js.py
@@ -1,0 +1,133 @@
+"""Regression tests for Cookbook background task status merging.
+
+The Running tab is browser-heavy, so these tests exercise the pure merge helper
+under Node. The #2193 bug was that background status polling kept the red error
+badge but discarded backend-provided serve diagnosis and launch command details.
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HAS_NODE = shutil.which("node") is not None
+
+
+@pytest.fixture(scope="module")
+def node_available():
+    if not _HAS_NODE:
+        pytest.skip("node binary not on PATH")
+
+
+def _run_node(script: str) -> dict:
+    res = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_REPO,
+        capture_output=True,
+        timeout=15,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise AssertionError(f"node failed:\n{res.stderr}")
+    lines = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    if not lines:
+        raise AssertionError("node produced no stdout")
+    return json.loads(lines[-1])
+
+
+def test_background_status_persists_serve_diagnosis_and_command(node_available):
+    script = textwrap.dedent("""
+        const { applyLiveTaskStatus } = await import('./static/js/cookbookTaskStatusMerge.js');
+        const task = {
+          sessionId: 'serve-1',
+          type: 'serve',
+          status: 'running',
+          output: '',
+          payload: { repo_id: 'org/model' },
+        };
+        const changed = applyLiveTaskStatus(task, {
+          session_id: 'serve-1',
+          type: 'serve',
+          status: 'error',
+          output_tail: 'Traceback\\nCUDA runtime library not found',
+          diagnosis: {
+            message: 'CUDA runtime is missing.',
+            suggestion: 'Suggested action: install CUDA runtime or use CPU fallback.',
+          },
+          cmd: 'vllm serve org/model --port 8000',
+        });
+        console.log(JSON.stringify({
+          changed,
+          status: task.status,
+          output: task.output,
+          diagnosis: task.diagnosis,
+          cmd: task.payload._cmd,
+        }));
+    """)
+    out = _run_node(script)
+    assert out["changed"] is True
+    assert out["status"] == "error"
+    assert "CUDA runtime library not found" in out["output"]
+    assert out["diagnosis"]["message"] == "CUDA runtime is missing."
+    assert out["cmd"] == "vllm serve org/model --port 8000"
+
+
+def test_background_status_clears_stale_diagnosis_when_serve_recovers(node_available):
+    script = textwrap.dedent("""
+        const { applyLiveTaskStatus } = await import('./static/js/cookbookTaskStatusMerge.js');
+        const task = {
+          sessionId: 'serve-2',
+          type: 'serve',
+          status: 'error',
+          progress: '',
+          diagnosis: { message: 'old failure' },
+          payload: { _cmd: 'keep this command' },
+        };
+        const changed = applyLiveTaskStatus(task, {
+          session_id: 'serve-2',
+          type: 'serve',
+          status: 'running',
+          progress: 'loading 42%',
+          cmd: 'do not overwrite existing command',
+        });
+        console.log(JSON.stringify({
+          changed,
+          status: task.status,
+          progress: task.progress,
+          diagnosis: task.diagnosis,
+          cmd: task.payload._cmd,
+        }));
+    """)
+    out = _run_node(script)
+    assert out["changed"] is True
+    assert out["status"] == "running"
+    assert out["progress"] == "loading 42%"
+    assert out["diagnosis"] is None
+    assert out["cmd"] == "keep this command"
+
+
+def test_background_status_does_not_duplicate_output_tail(node_available):
+    script = textwrap.dedent("""
+        const { applyLiveTaskStatus } = await import('./static/js/cookbookTaskStatusMerge.js');
+        const task = {
+          sessionId: 'download-1',
+          type: 'download',
+          status: 'running',
+          output: 'line 1\\nline 2',
+          payload: {},
+        };
+        const changed = applyLiveTaskStatus(task, {
+          session_id: 'download-1',
+          type: 'download',
+          status: 'running',
+          output_tail: 'line 2',
+        });
+        console.log(JSON.stringify({ changed, output: task.output }));
+    """)
+    out = _run_node(script)
+    assert out["changed"] is False
+    assert out["output"] == "line 1\nline 2"


### PR DESCRIPTION
## Summary
- Fix the Cookbook background status merge so failed serve tasks keep backend-provided `diagnosis`, `output_tail`, and `cmd` data.
- Render stored backend diagnoses when the Running tab is rebuilt after the modal was closed.
- Extract the status merge into a browser-free helper with Node regression coverage for failed serve tasks, recovery, and output-tail deduping.

## Linked Issue
Fixes #2193.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Tests

## How to Test
1. Run `.venv/bin/pytest -q tests/test_cookbook_task_status_merge_js.py tests/test_cookbook_dependency_completion_regression.py tests/test_cookbook_progress_signal_js.py`.
2. Run `node --check static/js/cookbookTaskStatusMerge.js`.
3. Run `node --check static/js/cookbookRunning.js`.
4. Run `git diff --check main`.

## Notes
Playwright is not installed in this checkout, so browser smoke coverage was not run; the new Node tests exercise the background-poll state path directly.

## Checklist
- [x] I searched existing issues and PRs for duplicate coverage before opening this.
- [x] I tested this locally.