### PR TITLE
fix(tool_index): add manage_memory to ALWAYS_AVAILABLE

### DIFF
--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -34,6 +34,10 @@ ALWAYS_AVAILABLE = frozenset({
     "list_served_models", "stop_served_model",
     # Generic API loopback — the catch-all when no named tool fits.
     "app_api",
+    # Memory is ambient — "remember this" can follow any message regardless
+    # of topic. Without this, RAG drops it and the agent falls back to
+    # app_api /api/memory/add which fails with 422 on first attempt.
+    "manage_memory",
 })
 
 # Tools that the Personal Assistant always has access to during scheduled


### PR DESCRIPTION
## Summary

`manage_memory` is an ambient tool — a user can ask the agent to remember something after any message, regardless of topic. When the current message contains no memory-related keywords, semantic tool RAG does not select `manage_memory` for that round. The agent then falls back to `app_api POST /api/memory/add`, which fails 422 on the first attempt before retrying to 200. Adding `manage_memory` to `ALWAYS_AVAILABLE` fixes this, consistent with how `app_api` is already handled.

## Linked Issue

Fixes #2385

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Configure an agent with memory enabled. Send a message with no memory-related keywords (e.g. "What is the capital of France?").
2. Before fix: observe `manage_memory` absent from the tool list for that round; agent calls `app_api POST /api/memory/add` → 422, then retries → 200.
3. After fix: `manage_memory` is present in every round's tool list regardless of message content. No 422 errors.

Tested on MiniMax-M3 via https://api.minimax.io/v1 (OpenAI-compatible) across a 19-round agent session with mixed memory and non-memory messages — zero 422 errors after fix.
