### PR TITLE
[codex] fix(email): parse comma display-name recipients

### DIFF
--- a/mcp_servers/email_server.py
+++ b/mcp_servers/email_server.py
@@ -57,6 +57,31 @@ def _clean_header_value(value) -> str:
     return re.sub(r"[\r\n]+[ \t]*", " ", str(value)).strip()
 
 
+def _address_field_values(*fields) -> list[str]:
+    values: list[str] = []
+    for field in fields:
+        if not field:
+            continue
+        if isinstance(field, str):
+            values.append(field)
+            continue
+        try:
+            values.extend(str(item) for item in field if item)
+        except TypeError:
+            values.append(str(field))
+    return values
+
+
+def _envelope_recipients(*fields) -> list[str]:
+    """Extract SMTP envelope addresses without splitting quoted display names."""
+    out: list[str] = []
+    for _name, addr in email.utils.getaddresses(_address_field_values(*fields)):
+        addr = (addr or "").strip()
+        if addr:
+            out.append(addr)
+    return out
+
+
 def _db_path() -> Path:
     return DATA_DIR / "app.db"
 
@@ -805,15 +830,7 @@ def _send_email(to, subject, body, in_reply_to=None, references=None, cc=None, b
         msg["Message-ID"] = email.utils.make_msgid()
     msg.set_content(body)
 
-    recipients = []
-    if isinstance(to, str):
-        recipients.extend([a.strip() for a in to.split(",") if a.strip()])
-    else:
-        recipients.extend(to)
-    if cc:
-        recipients.extend([a.strip() for a in cc.split(",")] if isinstance(cc, str) else cc)
-    if bcc:
-        recipients.extend([a.strip() for a in bcc.split(",")] if isinstance(bcc, str) else bcc)
+    recipients = _envelope_recipients(to, cc, bcc)
 
     conn = _smtp_connect(send_account, cfg=cfg)
     try:

--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -71,6 +71,21 @@ def _send_smtp_message(cfg: dict, from_addr: str, recipients: list[str], message
         smtp.sendmail(from_addr, recipients, message)
 
 
+def _envelope_recipients(*fields: str) -> list[str]:
+    """Extract bare SMTP envelope addresses from To/Cc/Bcc header strings.
+
+    Splitting on commas corrupts quoted display names such as
+    ``"Smith, John" <john@corp.com>``. ``email.utils.getaddresses`` understands
+    the address grammar and returns the underlying mailbox safely.
+    """
+    out: list[str] = []
+    for _name, addr in email.utils.getaddresses([f for f in fields if f]):
+        addr = (addr or "").strip()
+        if addr:
+            out.append(addr)
+    return out
+
+
 def _strip_think(text: str) -> str:
     """Email-flavored think strip — thin wrapper over the central helper.
 

--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -33,7 +33,7 @@ from src.llm_core import llm_call_async
 
 from routes.email_helpers import (
     _strip_think, _extract_reply, _apply_email_style_mechanics, _load_settings, _save_settings, _get_email_config,
-    _send_smtp_message,
+    _send_smtp_message, _envelope_recipients,
     _imap_connect, _imap, _decode_header,
     _detect_sent_folder, _detect_spam_folder, _imap_move,
     _extract_attachment_text, _extract_text,
@@ -1021,11 +1021,7 @@ def _scheduled_poll_once() -> dict:
                 if has_atts:
                     outer.attach(body_container)
                     _attach_compose_uploads(outer, attachments)
-                recipients = [a.strip() for a in (r[1] or "").split(",") if a.strip()]
-                if r[2]:
-                    recipients.extend([a.strip() for a in r[2].split(",") if a.strip()])
-                if r[3]:
-                    recipients.extend([a.strip() for a in r[3].split(",") if a.strip()])
+                recipients = _envelope_recipients(r[1], r[2], r[3])
 
                 _send_smtp_message(cfg, cfg["from_address"], recipients, outer.as_string())
 

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -40,7 +40,7 @@ from routes.email_helpers import (
     _strip_think, _extract_reply, _apply_email_style_mechanics, require_owner, require_user, _assert_owns_account,
     _q, _attach_compose_uploads, _cleanup_compose_uploads,
     _load_settings, _save_settings, _get_email_config,
-    _send_smtp_message, _smtp_security_mode,
+    _send_smtp_message, _smtp_security_mode, _envelope_recipients,
     _IMAP_TIMEOUT_SECONDS, _open_imap_connection,
     _imap_connect, _imap, _decode_header, _detect_sent_folder, _detect_drafts_folder,
     _extract_attachment_text, _list_attachments_from_msg,
@@ -322,20 +322,6 @@ def _apply_odysseus_headers(msg, kind: str | None = None, ref_id: str | None = N
         msg["X-Odysseus-Kind"] = re.sub(r"[^A-Za-z0-9_.-]", "-", kind)[:64]
     if ref_id:
         msg["X-Odysseus-Ref"] = re.sub(r"[^A-Za-z0-9_.:-]", "-", ref_id)[:128]
-
-
-def _envelope_recipients(*fields: str) -> list:
-    """Extract bare SMTP envelope addresses from one or more To/Cc/Bcc header
-    strings. A naive `field.split(",")` corrupts display names that contain a
-    comma (e.g. `"Smith, John" <john@corp.com>`, the canonical Outlook form):
-    it splits into `"Smith` and `John" <john@corp.com>`, breaking delivery.
-    email.utils.getaddresses parses the address grammar correctly."""
-    out = []
-    for _name, addr in email.utils.getaddresses([f for f in fields if f]):
-        addr = (addr or "").strip()
-        if addr:
-            out.append(addr)
-    return out
 
 
 def _md_to_email_html(text: str) -> str:

--- a/static/js/emailLibrary/utils.js
+++ b/static/js/emailLibrary/utils.js
@@ -88,9 +88,46 @@ export function _formatBubbleDate(iso) {
 // Format a raw "to" address string ("Foo <foo@x.com>, bar@y.com") into a
 // short, readable list — display names when present, just the local part
 // of the email otherwise, and ", +N" once there are more than 2 recipients.
+function _splitAddressList(raw) {
+  const out = [];
+  let cur = '';
+  let quoted = false;
+  let angleDepth = 0;
+  let escaped = false;
+  for (const ch of String(raw || '')) {
+    if (escaped) {
+      cur += ch;
+      escaped = false;
+      continue;
+    }
+    if (quoted && ch === '\\') {
+      cur += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      quoted = !quoted;
+      cur += ch;
+      continue;
+    }
+    if (!quoted && ch === '<') angleDepth++;
+    else if (!quoted && ch === '>' && angleDepth > 0) angleDepth--;
+    if (!quoted && angleDepth === 0 && ch === ',') {
+      const part = cur.trim();
+      if (part) out.push(part);
+      cur = '';
+      continue;
+    }
+    cur += ch;
+  }
+  const part = cur.trim();
+  if (part) out.push(part);
+  return out;
+}
+
 export function _formatRecipients(raw) {
   if (!raw) return '';
-  const addrs = String(raw).split(',').map(s => s.trim()).filter(Boolean);
+  const addrs = _splitAddressList(raw);
   if (!addrs.length) return '';
   const friendly = addrs.map(a => {
     const m = a.match(/^\s*"?([^"<]+?)"?\s*<[^>]+>\s*$/);

--- a/tests/test_email_envelope_recipients.py
+++ b/tests/test_email_envelope_recipients.py
@@ -7,6 +7,8 @@ Outlook / corporate address-book form): it splits into `"Smith` and
 delivery fails. `_envelope_recipients` uses email.utils.getaddresses instead.
 """
 import routes.email_routes as email_routes
+import routes.email_pollers as email_pollers
+import mcp_servers.email_server as mcp_email_server
 
 
 def test_display_name_with_comma_yields_one_address():
@@ -24,3 +26,54 @@ def test_to_cc_bcc_combined_and_none_safe():
 
 def test_empty_and_none_fields():
     assert email_routes._envelope_recipients("", None) == []
+
+
+def test_scheduled_email_envelope_uses_comma_aware_parser():
+    got = email_pollers._envelope_recipients('"Doe, Jane" <jane@x.com>, bob@y.com', None, "carol@z.com")
+    assert got == ["jane@x.com", "bob@y.com", "carol@z.com"]
+
+
+def test_mcp_send_email_uses_comma_aware_envelope_parser(monkeypatch):
+    sent = {}
+
+    class FakeSMTP:
+        def send_message(self, msg, from_addr=None, to_addrs=None):
+            sent["from_addr"] = from_addr
+            sent["to_addrs"] = list(to_addrs)
+
+        def quit(self):
+            sent["quit"] = True
+
+    monkeypatch.setattr(
+        mcp_email_server,
+        "_resolve_send_config",
+        lambda account: (
+            "acct",
+            {
+                "from_address": "sender@example.com",
+                "account_name": "Work",
+                "account_id": "acct1",
+            },
+        ),
+    )
+    monkeypatch.setattr(mcp_email_server, "_smtp_connect", lambda send_account, cfg=None: FakeSMTP())
+    monkeypatch.setattr(
+        mcp_email_server,
+        "_imap_connect",
+        lambda account: (_ for _ in ()).throw(RuntimeError("no imap")),
+    )
+
+    result = mcp_email_server._send_email(
+        to='"Doe, Jane" <jane@x.com>, bob@y.com',
+        cc='"Boss, Bob" <boss@z.com>',
+        bcc="hidden@z.com",
+        subject="Hello",
+        body="Body",
+    )
+
+    assert sent == {
+        "from_addr": "sender@example.com",
+        "to_addrs": ["jane@x.com", "bob@y.com", "boss@z.com", "hidden@z.com"],
+        "quit": True,
+    }
+    assert result["to"] == sent["to_addrs"]

--- a/tests/test_email_format_recipients_js.py
+++ b/tests/test_email_format_recipients_js.py
@@ -1,0 +1,41 @@
+"""Pin email recipient display formatting around quoted commas."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_format_recipients_keeps_quoted_comma_display_name_together():
+    values = _node_eval(
+        """
+        const { _formatRecipients } = await import('./static/js/emailLibrary/utils.js');
+        console.log(JSON.stringify({
+          one: _formatRecipients('"Doe, Jane" <jane@x.com>'),
+          two: _formatRecipients('"Doe, Jane" <jane@x.com>, Bob <bob@y.com>'),
+          three: _formatRecipients('"Doe, Jane" <jane@x.com>, Bob <bob@y.com>, carol@z.com')
+        }));
+        """
+    )
+
+    assert values == {
+        "one": "Doe, Jane",
+        "two": "Doe, Jane, Bob",
+        "three": "Doe, Jane, Bob +1",
+    }


### PR DESCRIPTION
## Summary

Parse email recipient lists with address-grammar-aware handling so quoted display names containing commas are not split into broken SMTP envelope recipients or UI recipient labels. The route send path keeps using the parser, scheduled delivery now uses it too, the MCP email server no longer uses bare comma splits, and the email library formatter respects quoted and angle-address commas.

## Linked Issue

Fixes #2119

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. SMTP end-to-end delivery was not run because that requires real mail credentials; the SMTP call is covered with a stub that asserts the exact envelope recipients passed to `send_message`.

## How to Test

1. `.venv/bin/pytest -q tests/test_email_envelope_recipients.py tests/test_email_format_recipients_js.py tests/test_mail_cli_recipients.py tests/test_reply_recipients_js.py tests/test_mcp_email_decode_header_spaces.py`
2. `node --check static/js/emailLibrary/utils.js`
3. `.venv/bin/python -m py_compile routes/email_helpers.py routes/email_routes.py routes/email_pollers.py mcp_servers/email_server.py tests/test_email_envelope_recipients.py tests/test_email_format_recipients_js.py`
4. `git diff --check`

## Visual / UI changes — REQUIRED if you touched anything that renders

No layout, styling, spacing, color, or component behavior changes. The `static/js/` change is limited to recipient text formatting, and the Node regression test verifies the displayed summary strings for quoted comma display names.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not attached: this is a parser/text-formatting fix with no visual layout or style delta.
