### PR TITLE
fix: SSE stream parser crashes with NoneType on providers sending null choice/usage/tc entries

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1395,7 +1395,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                 j = json.loads(data)
                                 # Usage chunk (from stream_options)
                                 _choices = j.get("choices") or []
-                                _delta0 = _choices[0].get("delta") if _choices else None
+                                _delta0 = _choices[0].get("delta") if (_choices and _choices[0] is not None) else None
                                 # Capture usage whenever the chunk carries it and
                                 # the delta has no actual output. Some gateways /
                                 # local servers attach usage to the FINAL delta,
@@ -1409,7 +1409,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                     or _delta0.get("tool_calls")
                                 )
                                 if "usage" in j and not _delta_has_output:
-                                    u = j["usage"]
+                                    u = j["usage"] or {}
                                     _usage_data = {"input_tokens": u.get("prompt_tokens", 0), "output_tokens": u.get("completion_tokens", 0)}
                                     # llama.cpp puts a `timings` block alongside `usage` with the
                                     # TRUE generation speed (predicted_per_second) — pure decode,
@@ -1443,6 +1443,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                             yield f'data: {json.dumps({"delta": content})}\n\n'
                                         # Native tool calls — accumulate across chunks
                                         for tc in delta.get("tool_calls") or []:
+                                            if tc is None:
+                                                continue
                                             func = tc.get("function") or {}
                                             raw_idx = tc.get("index")
                                             if raw_idx is None:

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1424,7 +1424,10 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                             _usage_data["prefill_tps"] = round(_tm["prompt_per_second"], 2)
                                     yield f'data: {json.dumps({"type": "usage", "data": _usage_data})}\n\n'
                                 elif "choices" in j:
-                                    delta = j["choices"][0].get("delta") or {}
+                                    _c0 = (j["choices"] or [None])[0]
+                                    if _c0 is None:
+                                        continue
+                                    delta = _c0.get("delta") or {}
                                     if isinstance(delta, dict):
                                         # Text content
                                         # Reasoning tokens (VLLM --reasoning-parser, e.g. Qwen3/DeepSeek-R1, Nemotron). vLLM 0.20.2 / NIM emit the field as `reasoning`; older builds use `reasoning_content`. Accept either.

--- a/tests/test_llm_core_usage_finish_delta.py
+++ b/tests/test_llm_core_usage_finish_delta.py
@@ -101,3 +101,56 @@ def test_usage_on_empty_choices_chunk_still_captured(monkeypatch):
     ]
     usage = _usage_events(_drive(monkeypatch, lines))
     assert usage and usage[-1] == {"input_tokens": 4, "output_tokens": 2}
+
+
+def test_null_choice_chunk_does_not_crash(monkeypatch):
+    # Some providers emit {"choices": [null]} as a heartbeat/keepalive chunk.
+    # The parser must silently skip it rather than crashing on None.get("delta").
+    lines = [
+        'data: ' + json.dumps({"choices": [{"delta": {"content": "Hello"}}]}),
+        'data: ' + json.dumps({"choices": [None]}),
+        'data: [DONE]',
+    ]
+    result = _drive(monkeypatch, lines)
+    assert "Hello" in result
+
+
+def test_null_choice_with_null_usage_does_not_crash(monkeypatch):
+    # Chunk with both choices:[null] and usage:null — neither field should panic.
+    lines = [
+        'data: ' + json.dumps({"choices": [{"delta": {"content": "Hi"}}]}),
+        'data: ' + json.dumps({"choices": [None], "usage": None}),
+        'data: [DONE]',
+    ]
+    result = _drive(monkeypatch, lines)
+    assert "Hi" in result
+
+
+def test_null_tool_call_in_delta_is_skipped(monkeypatch):
+    # Some providers include null entries in the tool_calls array alongside
+    # valid calls. The null entry must be skipped; the valid call must survive.
+    lines = [
+        'data: ' + json.dumps({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [
+                        None,
+                        {"index": 0, "function": {"name": "get_weather", "arguments": '{"city":'}},
+                    ]
+                }
+            }]
+        }),
+        'data: ' + json.dumps({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [
+                        {"index": 0, "function": {"name": "", "arguments": '"London"}'}},
+                    ]
+                }
+            }]
+        }),
+        'data: [DONE]',
+    ]
+    result = _drive(monkeypatch, lines)
+    # The stream completes without error; the valid tool call was accumulated.
+    assert result is not None


### PR DESCRIPTION
## Summary

Three `NoneType` crash points in `stream_llm` (`src/llm_core.py`) triggered by providers — confirmed on MiniMax-M3, but the guards are safe for all OpenAI-compatible providers:

1. **`choices[0]` null** — some providers include a `None` entry in the `choices` array. The parser assumed every entry is a dict and called `.get("delta")` on it, crashing with `AttributeError: 'NoneType' object has no attribute 'get'`. Fix: add `_choices[0] is not None` guard before calling `.get()`.

2. **`usage` null** — `j["usage"]` can be `None` (not a dict) on some providers. Subsequent `.get()` calls on it crashed. Fix: `j["usage"] or {}`.

3. **`tool_calls` null entry** — individual entries in the `tool_calls` array can be `None`. The `tc.get("function")` call on them crashed. Fix: `if tc is None: continue`.

All three use the `or {}` / null-guard pattern already used elsewhere in the same block. The reporter confirmed zero errors across a 19-round agent session after applying these guards.

## Linked Issue

Fixes #2356

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Configure MiniMax-M3 via `https://api.minimax.io/v1` as a model endpoint.
2. Start an agent session and send any message.
3. Check container logs — `ERROR - Error parsing stream data: 'NoneType' object has no attribute 'get'` should no longer appear.
4. Confirm agent round summaries are non-empty and responses complete correctly.