### PR TITLE
fix: compact_session crashes with TypeError when history contains tool-call turns

### DIFF
--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -515,7 +515,7 @@ def setup_history_routes(session_manager) -> APIRouter:
             # Build text to summarize
             convo_text = "\n".join(
                 f"{(m.role if isinstance(m, ChatMessage) else m.get('role', '')).upper()}: "
-                f"{(m.content if isinstance(m, ChatMessage) else m.get('content', ''))[:2000]}"
+                f"{(m.content or '' if isinstance(m, ChatMessage) else m.get('content') or '')[:2000]}"
                 for m in older
             )
 


### PR DESCRIPTION
## Summary

The manual compact endpoint (`POST /api/session/{session_id}/compact`) raised `TypeError: 'NoneType' object is not subscriptable` when the session history contained any tool-call turn.

An assistant message that only issues tool calls carries `content=None` (per OpenAI spec — the model produced no text, only `tool_calls`). The `convo_text` builder in `compact_session` sliced `m.content[:2000]` without a None guard, so any session with tool-use history crashed on manual compact with HTTP 500.

Fix: replace `m.content` with `m.content or ''` (and `m.get('content', '')` with `m.get('content') or ''`) so `None` content degrades to an empty string. This is the same pattern applied in PR #1777 to `maybe_compact`; the manual compact endpoint in `history_routes.py` was missed.

## Linked Issue

Fixes #2303

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Start a session in agent mode and use any tool (web search, file read, etc.) to ensure there are tool-call turns in the history.
2. Open the session menu and trigger manual compact.
3. The compact should complete successfully instead of returning HTTP 500.