### PR TITLE
fix(chat): flag and cancel stalled agent runs on reachable endpoints

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -23,6 +23,11 @@ import slashCommands, { initSlashCommands, isCommand, handleSlashCommand, handle
 import createResearchSynapse from './researchSynapse.js';
   const RESEARCH_TIMEOUT_MS = 360000;
   const DEFAULT_TIMEOUT_MS = 120000;
+  // Agent mode only: once the endpoint probe confirms the model is reachable
+  // but no token has arrived, wait this many seconds before auto-cancelling.
+  // Without it the user sits on the full agent timeout while the model
+  // silently stalls on the tool-definition prompt (see issue #280).
+  const AGENT_STALL_GRACE_S = 50;
   const RESEARCH_SVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>';
 
   let API_BASE = '';
@@ -527,6 +532,7 @@ import createResearchSynapse from './researchSynapse.js';
     let timedOut = false;
     let processingProbeTimer = null;
     let processingProbeAbort = null;
+    let agentStallTimer = null;
     let _renderStream = () => {};
     let _cancelThinkingTimer = () => {};
     let _removeThinkingSpinner = () => {};
@@ -538,6 +544,10 @@ import createResearchSynapse from './researchSynapse.js';
       if (processingProbeAbort) {
         try { processingProbeAbort.abort(); } catch (_) {}
         processingProbeAbort = null;
+      }
+      if (agentStallTimer) {
+        clearInterval(agentStallTimer);
+        agentStallTimer = null;
       }
     };
 
@@ -860,7 +870,38 @@ import createResearchSynapse from './researchSynapse.js';
                 spinner.updateMessage('Still waiting for model');
               } else if (status.alive) {
                 const latency = status.latency_ms ? ` (${status.latency_ms}ms)` : '';
-                spinner.updateMessage(`Endpoint online${latency}; waiting for first token`);
+                if (_isAgent) {
+                  // The endpoint is reachable but the agent run produced no
+                  // token. The usual cause is the model choking on the
+                  // tool-definition prompt — context too small (common with
+                  // LM Studio defaults) or no tool-calling support — and some
+                  // backends stall silently instead of erroring, leaving the
+                  // user on the full agent timeout. Flag the likely fix and,
+                  // if nothing arrives within a generous window, auto-cancel
+                  // with reason='agent-stall'. See issue #280.
+                  let _agentWait = AGENT_STALL_GRACE_S;
+                  spinner.updateMessage(`Model online${latency} — no agent response; cancelling in ${_agentWait}s`);
+                  agentStallTimer = setInterval(() => {
+                    if (!spinner || !spinner.element || (currentAbort && currentAbort.signal.aborted) || accumulated) {
+                      clearInterval(agentStallTimer);
+                      agentStallTimer = null;
+                      return;
+                    }
+                    _agentWait--;
+                    if (_agentWait > 0) {
+                      spinner.updateMessage(`Model online${latency} — no agent response; cancelling in ${_agentWait}s`);
+                    } else {
+                      clearInterval(agentStallTimer);
+                      agentStallTimer = null;
+                      if (currentAbort && !currentAbort.signal.aborted) {
+                        currentAbort._reason = 'agent-stall';
+                        currentAbort.abort();
+                      }
+                    }
+                  }, 1000);
+                } else {
+                  spinner.updateMessage(`Endpoint online${latency}; waiting for first token`);
+                }
               } else {
                 // Probe confirms the endpoint isn't responding. Don't
                 // sit on a hung fetch — give the user 5s to read the
@@ -2600,6 +2641,22 @@ import createResearchSynapse from './researchSynapse.js';
               offlineNote.innerHTML =
                 `<span style="color: var(--color-error);">[${offlineMsg}]</span>`;
               holder.querySelector('.body').appendChild(offlineNote);
+            }
+            currentAbort = null;
+            return;
+          }
+
+          if (abortReason === 'agent-stall') {
+            const stallMsg = "No response in agent mode. The model is reachable but produced nothing — usually it needs a larger context window for the tool definitions, or a model that supports tool calling. Increase the model's context length (e.g. 8192+ in LM Studio) or switch models, then try again.";
+            if (holder && !accumulated) {
+              holder.querySelector('.body').innerHTML =
+                `<div style="color: var(--color-error); font-style: italic; padding: 4px 0;">[${stallMsg}]</div>`;
+            } else if (holder && accumulated) {
+              const stallNote = document.createElement('div');
+              stallNote.className = 'stopped-indicator';
+              stallNote.innerHTML =
+                `<span style="color: var(--color-error);">[${stallMsg}]</span>`;
+              holder.querySelector('.body').appendChild(stallNote);
             }
             currentAbort = null;
             return;

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -533,6 +533,11 @@ import createResearchSynapse from './researchSynapse.js';
     let processingProbeTimer = null;
     let processingProbeAbort = null;
     let agentStallTimer = null;
+    // Hoisted so the catch block can stop streaming TTS on abort/error. The
+    // value is assigned inside the try below; a try-scoped `const` would be out
+    // of scope in catch and throw a ReferenceError there, which swallowed every
+    // abort message (timeout / offline / agent-stall) before it could render.
+    let streamingTTS = false;
     let _renderStream = () => {};
     let _cancelThinkingTimer = () => {};
     let _removeThinkingSpinner = () => {};
@@ -1021,7 +1026,7 @@ import createResearchSynapse from './researchSynapse.js';
       let isThinking = false;
       let thinkingStartTime = null;
       // Streaming TTS: synthesize sentence-by-sentence during streaming
-      const streamingTTS = !!(window.aiTTSManager && window.aiTTSManager.autoPlay && window.aiTTSManager.available);
+      streamingTTS = !!(window.aiTTSManager && window.aiTTSManager.autoPlay && window.aiTTSManager.available);
       if (streamingTTS) window.aiTTSManager.streamingStart();
       // Multi-bubble agent tracking
       let roundHolder = holder;       // Current AI text bubble (changes per round)

--- a/tests/test_agent_stall_cancel.py
+++ b/tests/test_agent_stall_cancel.py
@@ -1,0 +1,45 @@
+"""Agent-mode stall detection (issue #280).
+
+When the model endpoint is reachable but an agent run produces no token —
+typically the model choking on the tool-definition prompt (context too small,
+common with LM Studio defaults, or no tool-calling support) — older builds left
+the user on the full agent timeout with no explanation. The endpoint probe's
+"alive" branch must instead, *in agent mode only*, flag the likely fix and
+auto-cancel after a generous grace window with an actionable error.
+
+These pin the chat.js wiring in source (mirrors test_chat_stream_scope.py).
+"""
+from pathlib import Path
+
+SRC = Path("static/js/chat.js").read_text(encoding="utf-8")
+
+
+def test_agent_stall_watchdog_is_agent_gated_and_cancels():
+    assert "const AGENT_STALL_GRACE_S = 50;" in SRC
+    alive_idx = SRC.index("} else if (status.alive) {")
+    branch = SRC[alive_idx:alive_idx + 2000]
+    # Only agent mode arms the watchdog...
+    assert "if (_isAgent) {" in branch
+    assert "agentStallTimer = setInterval(" in branch
+    assert "currentAbort._reason = 'agent-stall';" in branch
+    assert "currentAbort.abort();" in branch
+    # ...plain chat keeps the old, non-cancelling wait message.
+    assert "waiting for first token" in branch
+
+
+def test_agent_stall_timer_is_declared_and_cleared():
+    # Declared in the outer scope and torn down in clearProcessingProbe so the
+    # interval never outlives the request (e.g. once the first token arrives).
+    assert "let agentStallTimer = null;" in SRC
+    clear_idx = SRC.index("const clearProcessingProbe = () => {")
+    clear_body = SRC[clear_idx:clear_idx + 400]
+    assert "clearInterval(agentStallTimer)" in clear_body
+    assert "agentStallTimer = null;" in clear_body
+
+
+def test_agent_stall_error_message_is_actionable():
+    assert "if (abortReason === 'agent-stall') {" in SRC
+    msg_idx = SRC.index("if (abortReason === 'agent-stall') {")
+    msg_body = SRC[msg_idx:msg_idx + 800]
+    assert "context" in msg_body.lower()
+    assert "tool calling" in msg_body.lower()

--- a/tests/test_chat_stream_scope.py
+++ b/tests/test_chat_stream_scope.py
@@ -17,3 +17,20 @@ def test_stream_render_helpers_are_visible_to_catch_block():
     assert "_cancelThinkingTimer = () => {" in try_body
     assert "_removeThinkingSpinner = () => {" in try_body
     assert "function _renderStream()" not in try_body
+
+
+def test_streaming_tts_is_visible_to_catch_block():
+    # The catch block stops streaming TTS on abort/error. streamingTTS must be
+    # declared in the outer scope, not as a try-scoped `const`, or the catch
+    # throws a ReferenceError that swallows every abort message (timeout /
+    # offline / agent-stall) before it can render. See issue #280.
+    source = Path("static/js/chat.js").read_text(encoding="utf-8")
+    try_start = source.index("    try {\n      // Re-enable auto-scroll")
+    catch_start = source.index("    } catch (err) {", try_start)
+
+    outer_scope = source[:try_start]
+    try_body = source[try_start:catch_start]
+
+    assert "let streamingTTS = false;" in outer_scope
+    assert "const streamingTTS =" not in try_body
+    assert "streamingTTS = !!(" in try_body


### PR DESCRIPTION
## Summary

In agent mode, when the model endpoint is reachable but the run produces no token, the model has usually choked on the tool-definition prompt — context too small (common with LM Studio defaults) or no tool-calling support — and some backends stall silently instead of erroring. Today the endpoint probe sees the endpoint is alive, shows *"Endpoint online; waiting for first token"*, and the user sits on the **full agent timeout** with no explanation (issue #280).

This PR has two commits:

1. **Agent-stall watchdog** (`static/js/chat.js`): once the probe confirms the model is alive but no token has arrived, agent mode flags the likely cause and, if nothing arrives within a generous grace window (`AGENT_STALL_GRACE_S = 50`), auto-cancels with a new `'agent-stall'` reason and an actionable message — raise the model's context length (e.g. 8192+ in LM Studio) or switch to a tool-capable model. Plain chat is unchanged. The watchdog is torn down in `clearProcessingProbe()`, mirroring the existing *offline* countdown beside it.
2. **Prerequisite fix — hoist `streamingTTS`**: it was a `try`-scoped `const` referenced in the `catch` block, so *any* abort/error threw a `ReferenceError` there before the message could render. That silently swallowed **every** abort message (timeout / offline / agent-stall) — leaving an empty bubble. Hoisting it to the outer scope (the pattern the stream-render helpers already follow) restores all of them. The agent-stall message only appears once this is fixed.

## Linked Issue

Part of #280

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end (see Verification below — driven against a stub endpoint that reproduces the #280 stall; screenshots attached).

## How to Test

1. Point Odysseus at a model that's reachable but stalls in agent mode — e.g. LM Studio with a small context window, or a model without tool-calling (the #280 setup). *(For a deterministic repro, a tiny OpenAI-compatible server that returns 200 on `GET /v1/models` but hangs on `POST /v1/chat/completions` works — that's what the capture below uses.)*
2. Switch to **Agent** mode and send a short message.
   - **Before:** spinner shows "Endpoint online; waiting for first token" and hangs until the full agent timeout with no explanation.
   - **After:** the probe confirms the model is online, the spinner counts down `Model online — no agent response; cancelling in Ns`, then shows the actionable error.
3. Sanity-check chat mode is unaffected.
4. `python -m pytest tests/test_agent_stall_cancel.py tests/test_chat_stream_scope.py` → passes.

## Verification (ran end-to-end against the real app)

Started `uvicorn app:app`, logged in, registered a stub endpoint that answers `GET` 200 (so `probe-local` reports it **alive**) but hangs on the completion `POST` (no token ever), then sent a message in **agent mode**. Observed timeline (grace temporarily shortened for the capture):

```
t=1–2s: Processing request
t=3s:   Checking model endpoint
t=4s:   Model online (274ms) — no agent response; cancelling in 5s
t=5–8s: …cancelling in 4s / 3s / 2s / 1s
t=9s+:  [No response in agent mode. The model is reachable but produced nothing —
        usually it needs a larger context window for the tool definitions, or a
        model that supports tool calling. Increase the model's context length
        (e.g. 8192+ in LM Studio) or switch models, then try again.]
```
No JS console/page errors. Also covered by `node --check` and the unit tests above.

| Countdown (watchdog armed) | Final actionable message |
|---|---|
| ![countdown](https://raw.githubusercontent.com/sanjulaonline/odysseus/pr2062-assets/pr280/countdown.png) | ![final message](https://raw.githubusercontent.com/sanjulaonline/odysseus/pr2062-assets/pr280/final.png) |

## Visual / UI changes

No new styling, layout, components, colors, or icons — only status/error **text**. The countdown reuses the spinner status line; the final error reuses the existing `var(--color-error)` message style already used by the adjacent "Endpoint offline" / timeout handlers in the same catch block (see screenshots above).
