### PR TITLE
[codex] fix(cookbook): narrow qwen moe optimization gate

### DIFF
--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -9,6 +9,7 @@ import { providerLogo } from './providers.js';
 import { makeWindowDraggable } from './windowDrag.js';
 import { _diagnose, _showDiagnosis, _clearDiagnosis, _runQuickCmd, ERROR_PATTERNS } from './cookbook-diagnosis.js';
 import { _hwfitCache, _hwfitDebounce, _hwfitFetch, _hwfitInit, _hwfitRenderList, _hwfitRenderHw, _renderGpuToggles, _expandModelRow, _fitColors, _hwfitColumns, _cachedModelIds, _gpuToggleTotal, _resetGpuToggleState } from './cookbook-hwfit.js';
+import { _detectModelOptimizations } from './cookbookModelOptimizations.js';
 
 // Sub-modules
 import {
@@ -177,51 +178,6 @@ export function _isWindows(hostOrTask) {
  *  reports no platform but does report backend: "metal". */
 export function _isMetal() {
   return ['metal', 'mps', 'apple'].includes(String(_hwfitCache?.system?.backend || '').toLowerCase());
-}
-
-/** Detect model-specific vLLM optimizations */
-function _detectModelOptimizations(modelName) {
-  const n = (modelName || '').toLowerCase();
-  const opts = { envVars: [], flags: [], tips: [] };
-
-  // Qwen3.5 MoE models
-  if (n.includes('qwen3.5') || n.includes('qwen3-') && (n.includes('a10b') || n.includes('a22b') || n.includes('a3b'))) {
-    opts.envVars.push('VLLM_USE_DEEP_GEMM=0', 'VLLM_USE_FLASHINFER_MOE_FP16=1', 'VLLM_USE_FLASHINFER_SAMPLER=0', 'OMP_NUM_THREADS=4');
-    opts.flags.push('--enable-expert-parallel', '--reasoning-parser qwen3');
-    opts.tips.push('MoE optimizations: expert parallel + flashinfer MoE kernels');
-  }
-  // Qwen3 MoE (non-3.5)
-  else if (n.includes('qwen3') && (n.includes('a10b') || n.includes('a22b') || n.includes('a3b'))) {
-    opts.envVars.push('VLLM_USE_DEEP_GEMM=0', 'VLLM_USE_FLASHINFER_MOE_FP16=1');
-    opts.flags.push('--enable-expert-parallel', '--reasoning-parser qwen3');
-    opts.tips.push('MoE optimizations: expert parallel');
-  }
-  // DeepSeek MoE
-  else if (n.includes('deepseek') && (n.includes('v3') || n.includes('r1'))) {
-    opts.flags.push('--enable-expert-parallel');
-    opts.tips.push('MoE expert parallel for DeepSeek');
-  }
-  // Speculative decoding — pick the right MTP method per model family.
-  // opts.spec.{method,tokens} seed the UI dropdown/input; the actual flag is
-  // assembled by the command builder so the user can edit before launching.
-  let specDefault = null;
-  if (n.includes('qwen3-next') || (n.includes('qwen3.5') && (n.includes('a10b') || n.includes('a22b')))) {
-    specDefault = { method: 'qwen3_next_mtp', tokens: 2 };
-  } else if (
-    (n.includes('deepseek') && (n.includes('v3') || n.includes('v3.1') || n.includes('r1'))) ||
-    n.includes('kimi-k2') || n.includes('kimi_k2') ||
-    n.includes('glm-4.5') || n.includes('glm4.5') ||
-    n.includes('minimax-m1') || n.includes('minimax_m1')
-  ) {
-    specDefault = { method: 'mtp', tokens: 3 };
-  }
-  if (specDefault) {
-    opts.spec = specDefault;
-    opts.flags.push(`--speculative-config '{"method":"${specDefault.method}","num_speculative_tokens":${specDefault.tokens}}'`);
-    opts.tips.push(`Speculative decoding (${specDefault.method}, ${specDefault.tokens} tokens): ~1.5-2x faster generation`);
-  }
-
-  return opts;
 }
 
 /** Detect the right vLLM tool-call-parser based on model name.

--- a/static/js/cookbookModelOptimizations.js
+++ b/static/js/cookbookModelOptimizations.js
@@ -1,0 +1,49 @@
+function _hasMoeActiveParamSuffix(name) {
+  return /(?:^|[-_/])a\d+(?:\.\d+)?b(?:$|[-_/])/.test(name);
+}
+
+/** Detect model-specific vLLM optimizations. */
+export function _detectModelOptimizations(modelName) {
+  const n = (modelName || '').toLowerCase();
+  const opts = { envVars: [], flags: [], tips: [] };
+  const hasMoeActiveParams = _hasMoeActiveParamSuffix(n);
+
+  // Qwen3.5 MoE models. Dense Qwen3.5 names like Qwen/Qwen3.5-4B do not have
+  // an A*B active-expert suffix and must not receive expert-parallel flags.
+  if (n.includes('qwen3.5') && hasMoeActiveParams) {
+    opts.envVars.push('VLLM_USE_DEEP_GEMM=0', 'VLLM_USE_FLASHINFER_MOE_FP16=1', 'VLLM_USE_FLASHINFER_SAMPLER=0', 'OMP_NUM_THREADS=4');
+    opts.flags.push('--enable-expert-parallel', '--reasoning-parser qwen3');
+    opts.tips.push('MoE optimizations: expert parallel + flashinfer MoE kernels');
+  }
+  // Qwen3 MoE (non-3.5)
+  else if (n.includes('qwen3') && hasMoeActiveParams) {
+    opts.envVars.push('VLLM_USE_DEEP_GEMM=0', 'VLLM_USE_FLASHINFER_MOE_FP16=1');
+    opts.flags.push('--enable-expert-parallel', '--reasoning-parser qwen3');
+    opts.tips.push('MoE optimizations: expert parallel');
+  }
+  // DeepSeek MoE
+  else if (n.includes('deepseek') && (n.includes('v3') || n.includes('r1'))) {
+    opts.flags.push('--enable-expert-parallel');
+    opts.tips.push('MoE expert parallel for DeepSeek');
+  }
+  // Speculative decoding - pick the right MTP method per model family.
+  // opts.spec.{method,tokens} seed the UI dropdown/input; the actual flag is
+  // assembled by the command builder so the user can edit before launching.
+  let specDefault = null;
+  if (n.includes('qwen3-next') || (n.includes('qwen3.5') && (n.includes('a10b') || n.includes('a22b')))) {
+    specDefault = { method: 'qwen3_next_mtp', tokens: 2 };
+  } else if (
+    (n.includes('deepseek') && (n.includes('v3') || n.includes('v3.1') || n.includes('r1'))) ||
+    n.includes('kimi-k2') || n.includes('kimi_k2') ||
+    n.includes('glm-4.5') || n.includes('glm4.5') ||
+    n.includes('minimax-m1') || n.includes('minimax_m1')
+  ) {
+    specDefault = { method: 'mtp', tokens: 3 };
+  }
+  if (specDefault) {
+    opts.spec = specDefault;
+    opts.flags.push(`--speculative-config '{"method":"${specDefault.method}","num_speculative_tokens":${specDefault.tokens}}'`);
+    opts.tips.push(`Speculative decoding (${specDefault.method}, ${specDefault.tokens} tokens): ~1.5-2x faster generation`);
+  }
+  return opts;
+}

--- a/tests/test_cookbook_model_optimizations_js.py
+++ b/tests/test_cookbook_model_optimizations_js.py
@@ -1,0 +1,63 @@
+"""Regression tests for Cookbook vLLM model optimization detection."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _detect(model_name: str) -> dict:
+    source = f"""
+        import {{ _detectModelOptimizations }} from './static/js/cookbookModelOptimizations.js';
+        console.log(JSON.stringify(_detectModelOptimizations({json.dumps(model_name)})));
+    """
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_dense_qwen35_does_not_get_moe_expert_parallel_flags():
+    opts = _detect("Qwen/Qwen3.5-4B")
+
+    assert "--enable-expert-parallel" not in opts["flags"]
+    assert "--reasoning-parser qwen3" not in opts["flags"]
+    assert opts["envVars"] == []
+
+
+def test_qwen35_moe_gets_expert_parallel_flags():
+    opts = _detect("Qwen/Qwen3.5-35B-A3B")
+
+    assert "--enable-expert-parallel" in opts["flags"]
+    assert "--reasoning-parser qwen3" in opts["flags"]
+    assert "VLLM_USE_FLASHINFER_MOE_FP16=1" in opts["envVars"]
+
+
+def test_qwen35_a17b_moe_suffix_is_detected():
+    opts = _detect("Qwen/Qwen3.5-397B-A17B")
+
+    assert "--enable-expert-parallel" in opts["flags"]
+    assert "--reasoning-parser qwen3" in opts["flags"]
+
+
+def test_qwen3_moe_still_gets_expert_parallel_flags():
+    opts = _detect("Qwen/Qwen3-235B-A22B")
+
+    assert "--enable-expert-parallel" in opts["flags"]
+    assert "--reasoning-parser qwen3" in opts["flags"]
+
+
+def test_qwen35_a10b_keeps_speculative_default():
+    opts = _detect("Qwen/Qwen3.5-122B-A10B")
+
+    assert opts["spec"] == {"method": "qwen3_next_mtp", "tokens": 2}
+    assert any("--speculative-config" in flag for flag in opts["flags"])


### PR DESCRIPTION
## Summary

Narrow the Cookbook vLLM MoE optimization detector so dense Qwen3.5 models like `Qwen/Qwen3.5-4B` no longer receive expert-parallel or MoE env flags. The detector is now a pure tested module, and Qwen MoE handling keys off active-expert suffixes such as `-A3B`, `-A10B`, or `-A17B` while preserving the existing Qwen3/Qwen3.5 MoE and speculative defaults.

## Linked Issue

Fixes #2127

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. This change is covered with focused Node-backed regression tests for the detector; I did not launch a vLLM server.

## How to Test

1. `.venv/bin/pytest -q tests/test_cookbook_model_optimizations_js.py tests/test_cookbook_cpu_only_serve.py tests/test_cookbook_dependency_completion_regression.py`
2. `node --check static/js/cookbookModelOptimizations.js && node --check static/js/cookbook.js`
3. `git diff --check HEAD~1..HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No layout, spacing, color, or component styling changed. The only UI-visible effect is that dense Qwen3.5 models no longer get MoE-only serve options from the model optimization detector.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not attached: this is a model-detection logic fix with no visual layout or style delta.
