### PR TITLE
fix(tests): pre-import real modules in conftest to prevent stub contamination

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,18 @@ from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Pre-import real heavy modules BEFORE any test file's module-level stubs can
+# replace them with MagicMock. Some test files (e.g. test_llm_core_sanitize_*)
+# stub sqlalchemy/core.database at module scope with `if mod not in sys.modules`,
+# which fires during collection. If the real module hasn't been imported yet,
+# the stub wins and contaminates every subsequent test that needs the real ORM.
+try:
+    import sqlalchemy  # noqa: F401
+    import sqlalchemy.orm  # noqa: F401
+    import core.database  # noqa: F401
+except ImportError:
+    pass  # not installed — the stubs below will handle it
+
 def _has_module(mod_name: str) -> bool:
     try:
         return importlib.util.find_spec(mod_name) is not None


### PR DESCRIPTION
## Summary

Some test files (e.g. `test_llm_core_sanitize_tool_calls`) stub `sqlalchemy` and `core.database` at module level with \`if mod not in sys.modules\`. During pytest collection these stubs fire before the real modules are imported, contaminating every subsequent test that needs real ORM objects — causing ~10+ cascading failures that only appear in the full suite (all pass individually).

Pre-imports the real \`sqlalchemy\`, \`sqlalchemy.orm\`, and \`core.database\` in \`conftest.py\` so the module-level guards find them already loaded and skip the stubs.

## Linked Issue

Fixes #2395

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets \`main\`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run \`python -m pytest tests/test_llm_core_sanitize_tool_calls.py tests/test_gallery_owner_filter_single_user.py tests/test_document_close_clears_active_route.py tests/test_rename_user_case_insensitive.py tests/test_topic_analyzer.py -q\` — all 15 pass (previously some failed due to stub contamination)
2. Run full suite: \`python -m pytest tests/ -q\` — ~1887 passed (up from ~1815 before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)