### PR TITLE
[codex] fix(research): ignore fenced headings in visual reports

### DIFF
--- a/src/visual_report.py
+++ b/src/visual_report.py
@@ -27,10 +27,35 @@ from urllib.parse import urlparse
 import markdown
 
 logger = logging.getLogger(__name__)
+_FENCE_LINE_RE = re.compile(r'^[ \t]{0,3}(`{3,}|~{3,})')
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _iter_markdown_content_lines(md_text: str):
+    """Yield markdown lines that are outside fenced code blocks."""
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+    offset = 0
+    for line in md_text.splitlines(keepends=True):
+        m = _FENCE_LINE_RE.match(line)
+        if m:
+            marker = m.group(1)
+            marker_char = marker[0]
+            after_marker = line[m.end():].strip()
+            if not in_fence:
+                in_fence = True
+                fence_char = marker_char
+                fence_len = len(marker)
+            elif marker_char == fence_char and len(marker) >= fence_len and not after_marker:
+                in_fence = False
+            offset += len(line)
+            continue
+        if not in_fence:
+            yield line, offset
+        offset += len(line)
 
 def _autolink_urls(md_text: str) -> str:
     """Convert bare URLs to markdown links before processing.
@@ -95,14 +120,20 @@ def _extract_headings(md_text: str) -> List[Dict[str, str]]:
             seen_slugs[slug] = 0
         return slug
 
-    for m in re.finditer(r'^(#{2,3})\s+(.+)$', md_text, re.MULTILINE):
+    for line, _offset in _iter_markdown_content_lines(md_text):
+        m = re.match(r'^(#{2,3})\s+(.+)$', line)
+        if not m:
+            continue
         level = len(m.group(1))
         text = _plain_heading_text(m.group(2))
         if not text:
             continue
         headings.append({"level": level, "text": text, "slug": _make_slug(text)})
     if not headings:
-        for m in re.finditer(r'^\*\*([^*]+)\*\*\s*$', md_text, re.MULTILINE):
+        for line, _offset in _iter_markdown_content_lines(md_text):
+            m = re.match(r'^\*\*([^*]+)\*\*\s*$', line)
+            if not m:
+                continue
             text = _plain_heading_text(m.group(1)).rstrip(':')
             if 3 < len(text) < 80:
                 headings.append({"level": 2, "text": text, "slug": _make_slug(text)})
@@ -1646,19 +1677,22 @@ def _extract_report_title(markdown_text: str, fallback: str):
         return fallback, markdown_text
 
     # Walk through headings (h1 first, then h2 anywhere) and use the first
-    # non-generic one. Track the chosen match so we can strip it from the body.
+    # non-generic one. Track the chosen line so we can strip it from the body.
     candidates = []
     for level, pattern in ((1, r'^# +(.+?)\s*$'), (2, r'^## +(.+?)\s*$')):
-        for m in re.finditer(pattern, markdown_text, re.MULTILINE):
+        for line, offset in _iter_markdown_content_lines(markdown_text):
+            m = re.match(pattern, line)
+            if not m:
+                continue
             cand = m.group(1).strip().rstrip('#').strip()
             if cand and cand.lower() not in _GENERIC_HEADINGS:
-                candidates.append((level, m, cand))
+                candidates.append((level, offset, offset + len(line), cand))
 
     # Prefer h1 over h2; among same-level, prefer the earliest.
-    candidates.sort(key=lambda t: (t[0], t[1].start()))
+    candidates.sort(key=lambda t: (t[0], t[1]))
     if candidates:
-        _level, match, title = candidates[0]
-        stripped = markdown_text[:match.start()] + markdown_text[match.end():]
+        _level, start, end, title = candidates[0]
+        stripped = markdown_text[:start] + markdown_text[end:]
         return title, stripped.lstrip()
     return fallback, markdown_text
 

--- a/tests/test_visual_report.py
+++ b/tests/test_visual_report.py
@@ -36,3 +36,62 @@ Configuration body.
         target = soup.find(id=target_id)
         assert target is not None
         assert target.name in {"h2", "h3"}
+
+
+def test_visual_report_toc_ignores_headings_inside_fenced_code():
+    report = """
+# Report Title
+
+## Real Section
+
+```markdown
+## Fake Code Section
+### Fake Code Detail
+```
+
+### Real Detail
+"""
+
+    html = generate_visual_report(
+        "visual report anchors",
+        report,
+        sources=[],
+        stats={},
+        session_id="rp-fenced-heading-test",
+    )
+    soup = BeautifulSoup(html, "html.parser")
+
+    links = soup.select(".toc-sidebar nav a")
+    assert [link.get_text(strip=True) for link in links] == [
+        "Real Section",
+        "Real Detail",
+    ]
+
+    for link in links:
+        target_id = link["href"].removeprefix("#")
+        target = soup.find(id=target_id)
+        assert target is not None
+        assert target.get_text(" ", strip=True) == link.get_text(strip=True)
+
+
+def test_visual_report_title_ignores_heading_inside_fenced_code():
+    report = """
+```python
+# Not The Report Title
+```
+
+# Real Report Title
+
+## Real Section
+"""
+
+    html = generate_visual_report(
+        "fallback title",
+        report,
+        sources=[],
+        stats={},
+        session_id="rp-fenced-title-test",
+    )
+    soup = BeautifulSoup(html, "html.parser")
+
+    assert soup.select_one(".hero h1").get_text(strip=True) == "Real Report Title"


### PR DESCRIPTION
## Summary

Ignore Markdown headings inside fenced code blocks when building visual report TOC entries and when selecting the generated report title. This prevents code samples containing `##` or `###` lines from shifting TOC anchors away from the rendered headings, while preserving existing heading slug behavior for real report sections.

## Linked Issue

Fixes #2132

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. I verified the generated HTML with BeautifulSoup regression tests rather than launching the full app.

## How to Test

1. `.venv/bin/pytest -q tests/test_visual_report.py tests/test_visual_report_nonstring.py tests/test_visual_report_icon_url.py`
2. `.venv/bin/python -m py_compile src/visual_report.py tests/test_visual_report.py`
3. `git diff --check HEAD~1..HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

No layout, spacing, color, or component styling changed. The generated report HTML now assigns TOC links and heading IDs from real Markdown headings only; headings shown inside code blocks remain code content.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not attached: this is an anchor/TOC generation fix with no visual style or layout delta.
