### PR TITLE
Fix/token cache invalidate

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,8 +203,19 @@ if AUTH_ENABLED:
     _token_cache_dirty = True
 
     def _token_cache_invalidate():
-        nonlocal_dict = app.state.__dict__
-        nonlocal_dict["_token_cache_dirty"] = True
+        """Mark the in-memory API-token cache as dirty so the next request
+        rebuilds it. Set both the app.state flag and the module-level flag to
+        avoid mismatches when callers touch either namespace.
+        """
+        try:
+            # Preferred: set attribute on app.state
+            app.state._token_cache_dirty = True
+        except Exception:
+            # Fallback: directly set the underlying dict entry
+            app.state.__dict__["_token_cache_dirty"] = True
+        # Keep module-level flag in sync for any legacy references
+        global _token_cache_dirty
+        _token_cache_dirty = True
     app.state.invalidate_token_cache = _token_cache_invalidate
     app.state._token_cache = _token_cache
     app.state._token_cache_dirty = True

--- a/tests/test_token_cache_invalidate.py
+++ b/tests/test_token_cache_invalidate.py
@@ -1,0 +1,16 @@
+def test_invalidate_token_cache_sets_both_flags():
+    """Ensure the API-token cache invalidator sets both the app.state flag
+    and the module-level flag to avoid mismatches across contexts.
+    """
+    import app as ody_app
+
+    # Start from a known state
+    ody_app._token_cache_dirty = False
+    ody_app.app.state._token_cache_dirty = False
+
+    # Call the exposed invalidator
+    ody_app.app.state.invalidate_token_cache()
+
+    # Both flags should be True after invalidation
+    assert ody_app._token_cache_dirty is True
+    assert ody_app.app.state._token_cache_dirty is True


### PR DESCRIPTION
## Summary
Ensure API-token cache invalidation reliably marks the in-memory cache dirty across codepaths. `_token_cache_invalidate` now sets both `app.state._token_cache_dirty` and the module-level `_token_cache_dirty` (with a small fallback), so callers that read either flag observe the same state. This prevents missed DB refreshes or redundant bcrypt scans.

## Linked Issue
Fixes #2402

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets main
- [x] Changes limited to the scope described (small backend change + test)
- [x] I ran the focused unit tests locally

## How to Test
1. Run unit test: `pytest -q tests/test_token_cache_invalidate.py`
2. Run companion pairing tests: `pytest -q tests/test_companion_pairing.py`
3. Optional: start the app, create an API token, call an endpoint with that token and confirm the request succeeds and `last_used_at` is updated.

## Files Changed
- app.py — sync flags in `_token_cache_invalidate`
- tests/test_token_cache_invalidate.py — new unit test
