### PR TITLE
[codex] fix(calendar): preserve user timezone date semantics

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -302,6 +302,30 @@ def _parse_dt_pair(s: str):
         return _parse_dt(s), False
 
 
+def _parse_all_day_dt(s: str) -> datetime:
+    """Parse an all-day value as a local calendar date, not a UTC instant."""
+    s = (s or "").strip()
+    if not s:
+        raise ValueError("empty datetime string")
+    try:
+        if len(s) == 10:
+            d = date.fromisoformat(s)
+            return datetime(d.year, d.month, d.day)
+        _s2 = s.replace("Z", "+00:00") if s.endswith("Z") else s
+        parsed = datetime.fromisoformat(_s2)
+        return datetime(parsed.year, parsed.month, parsed.day)
+    except ValueError:
+        parsed = _parse_dt(s)
+        return datetime(parsed.year, parsed.month, parsed.day)
+
+
+def _parse_event_dt_for_storage(s: str, all_day: bool = False):
+    """Parse event datetime storage fields, preserving all-day calendar dates."""
+    if all_day:
+        return _parse_all_day_dt(s), False
+    return _parse_dt_pair(s)
+
+
 def _parse_dt(s: str) -> datetime:
     """Parse a date/datetime string.
 
@@ -804,9 +828,9 @@ def setup_calendar_routes() -> APIRouter:
             # Use the tz-detecting parser so events posted with an offset
             # (e.g. "2026-05-13T10:00:00+09:00" or "...Z") get stored as UTC
             # and flagged for proper Z-suffix on read-back.
-            dtstart, _is_utc = _parse_dt_pair(data.dtstart)
+            dtstart, _is_utc = _parse_event_dt_for_storage(data.dtstart, data.all_day)
             if data.dtend:
-                dtend, _end_utc = _parse_dt_pair(data.dtend)
+                dtend, _end_utc = _parse_event_dt_for_storage(data.dtend, data.all_day)
                 # If start was tz-aware but end was naive (or vice-versa),
                 # trust whichever flag is True — they should match.
                 _is_utc = _is_utc or _end_utc
@@ -866,16 +890,21 @@ def setup_calendar_routes() -> APIRouter:
                 ev.description = data.description
             if data.location is not None:
                 ev.location = data.location
+            _eff_all_day = data.all_day if data.all_day is not None else ev.all_day
             if data.dtstart is not None:
-                ev.dtstart, _s_utc = _parse_dt_pair(data.dtstart)
+                ev.dtstart, _s_utc = _parse_event_dt_for_storage(data.dtstart, _eff_all_day)
                 # When the incoming payload carries tz info, mark the row as
                 # UTC-stored so the serializer adds Z. Don't flip the flag
                 # off if start arrives naive but end was UTC — only escalate.
-                if _s_utc:
+                if _eff_all_day:
+                    ev.is_utc = False
+                elif _s_utc:
                     ev.is_utc = True
             if data.dtend is not None:
-                ev.dtend, _e_utc = _parse_dt_pair(data.dtend)
-                if _e_utc:
+                ev.dtend, _e_utc = _parse_event_dt_for_storage(data.dtend, _eff_all_day)
+                if _eff_all_day:
+                    ev.is_utc = False
+                elif _e_utc:
                     ev.is_utc = True
             if data.all_day is not None:
                 ev.all_day = data.all_day

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -236,6 +236,35 @@ def _digest_windows(now):
     ]
 
 
+def _calendar_window_bounds(start: datetime, end: datetime):
+    """Return local-naive and UTC-naive bounds for a calendar digest window."""
+    if start.tzinfo is not None:
+        local_start = start.replace(tzinfo=None)
+        utc_start = start.astimezone(timezone.utc).replace(tzinfo=None)
+    else:
+        local_start = utc_start = start
+    if end.tzinfo is not None:
+        local_end = end.replace(tzinfo=None)
+        utc_end = end.astimezone(timezone.utc).replace(tzinfo=None)
+    else:
+        local_end = utc_end = end
+    return local_start, local_end, utc_start, utc_end
+
+
+def _calendar_digest_display_dt(ev, tz_name: str | None):
+    """Render UTC-stored event instants in the crew/user timezone for check-ins."""
+    dt = getattr(ev, "dtstart", None)
+    if dt is None:
+        return dt
+    if getattr(ev, "is_utc", False) and tz_name:
+        try:
+            from zoneinfo import ZoneInfo
+            return dt.replace(tzinfo=timezone.utc).astimezone(ZoneInfo(tz_name))
+        except Exception:
+            return dt
+    return dt
+
+
 class TaskScheduler:
     def __init__(self, session_manager):
         self._session_manager = session_manager
@@ -1110,18 +1139,26 @@ class TaskScheduler:
         # Calendar: today+tomorrow, this week, month ahead
         # Pull directly from DB so we can include event_type and importance.
         try:
-            from core.database import SessionLocal as _SL, CalendarEvent as _CE
+            from sqlalchemy import and_ as _and, or_ as _or
+            from core.database import SessionLocal as _SL, CalendarEvent as _CE, CalendarCal as _CC
             _db = _SL()
             try:
                 for label, start, end in _digest_windows(now):
-                    # Strip timezone for naive DB comparison
-                    _s = start.replace(tzinfo=None) if start.tzinfo else start
-                    _e = end.replace(tzinfo=None) if end.tzinfo else end
-                    evs = _db.query(_CE).filter(
-                        _CE.dtstart >= _s,
-                        _CE.dtstart <= _e,
+                    local_s, local_e, utc_s, utc_e = _calendar_window_bounds(start, end)
+                    q = _db.query(_CE).join(_CC).filter(
                         _CE.status != "cancelled",
-                    ).order_by(_CE.dtstart).all()
+                        _or(
+                            _and(_CE.is_utc.is_(True), _CE.dtstart >= utc_s, _CE.dtstart <= utc_e),
+                            _and(
+                                _or(_CE.is_utc.is_(False), _CE.is_utc.is_(None)),
+                                _CE.dtstart >= local_s,
+                                _CE.dtstart <= local_e,
+                            ),
+                        ),
+                    )
+                    if task.owner is not None:
+                        q = q.filter(_CC.owner == task.owner)
+                    evs = q.order_by(_CE.dtstart).all()
                     if not evs:
                         continue
                     # Group by importance for richer output
@@ -1136,7 +1173,12 @@ class TaskScheduler:
                             continue
                         marker = {"critical": "[!!]", "high": "[!]", "normal": "  ", "low": " ·"}[tier]
                         for ev in items:
-                            t = ev.dtstart.strftime("%a %b %d %H:%M")
+                            display_dt = _calendar_digest_display_dt(ev, tz_name) or ev.dtstart
+                            t = (
+                                display_dt.strftime("%a %b %d all day")
+                                if getattr(ev, "all_day", False)
+                                else display_dt.strftime("%a %b %d %H:%M")
+                            )
                             tag = f" ({ev.event_type})" if ev.event_type else ""
                             loc = f" @ {ev.location}" if ev.location else ""
                             lines.append(f"{marker} {t} — {ev.summary}{tag}{loc}")

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2043,7 +2043,10 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
     """Handle manage_calendar tool calls: list/create/update/delete calendar events (local SQLite)."""
     from datetime import datetime, timedelta
     from core.database import SessionLocal, CalendarCal, CalendarEvent, Note
-    from routes.calendar_routes import _ensure_default_calendar, _parse_dt, _parse_dt_pair, parse_due_for_user, _resolve_base_uid
+    from routes.calendar_routes import (
+        _ensure_default_calendar, _parse_dt, _parse_event_dt_for_storage,
+        parse_due_for_user, _resolve_base_uid,
+    )
     import uuid as _uuid
 
     try:
@@ -2120,9 +2123,9 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
         )
         return "" if reminder_only.match(desc) else desc
 
-    def _parse_event_dt(raw: str) -> tuple[datetime, bool]:
+    def _parse_event_dt(raw: str, all_day: bool = False) -> tuple[datetime, bool]:
         """Parse agent event datetimes in the user's timezone when available."""
-        return _parse_dt_pair(parse_due_for_user(raw))
+        return _parse_event_dt_for_storage(parse_due_for_user(raw), all_day=all_day)
 
     def _create_calendar_reminder(summary: str, location: str, dtstart: datetime,
                                   all_day: bool, minutes_before: int,
@@ -2278,13 +2281,13 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
 
             all_day = bool(args.get("all_day", False))
             try:
-                dtstart, dtstart_is_utc = _parse_event_dt(dtstart_str)
+                dtstart, dtstart_is_utc = _parse_event_dt(dtstart_str, all_day=all_day)
             except ValueError as e:
                 return {"error": f"Could not parse dtstart {dtstart_str!r}: {e}", "exit_code": 1}
             dtend_raw = args.get("dtend") or args.get("end") or args.get("end_time")
             if dtend_raw:
                 try:
-                    dtend, dtend_is_utc = _parse_event_dt(dtend_raw)
+                    dtend, dtend_is_utc = _parse_event_dt(dtend_raw, all_day=all_day)
                     dtstart_is_utc = dtstart_is_utc or dtend_is_utc
                 except ValueError as e:
                     return {"error": f"Could not parse dtend {dtend_raw!r}: {e}", "exit_code": 1}
@@ -2429,12 +2432,21 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
                 _eff_all_day = (
                     args["all_day"] if args.get("all_day") is not None else ev.all_day
                 )
-                ev.dtstart, _su = _parse_event_dt(args["dtstart"])
+                ev.dtstart, _su = _parse_event_dt(args["dtstart"], all_day=_eff_all_day)
                 ev.is_utc = bool(_su and not _eff_all_day)
             if args.get("dtend") is not None:
-                ev.dtend, _eu = _parse_event_dt(args["dtend"])
+                _eff_all_day = (
+                    args["all_day"] if args.get("all_day") is not None else ev.all_day
+                )
+                ev.dtend, _eu = _parse_event_dt(args["dtend"], all_day=_eff_all_day)
+                if _eff_all_day:
+                    ev.is_utc = False
+                elif _eu:
+                    ev.is_utc = True
             if args.get("all_day") is not None:
                 ev.all_day = args["all_day"]
+                if ev.all_day:
+                    ev.is_utc = False
             # Tag/category + importance updates (any of these aliases).
             _tag = (args.get("event_type") or args.get("tag")
                     or args.get("category") or args.get("type"))

--- a/tests/test_calendar_update_event_tz.py
+++ b/tests/test_calendar_update_event_tz.py
@@ -11,6 +11,7 @@ was already fixed for the analogous issue.
 import json
 import tempfile
 import uuid
+from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine
@@ -86,5 +87,49 @@ async def test_update_event_dtstart_anchored_to_user_tz(tokyo_offset):
         # And concretely: 14:00 Tokyo is 05:00 UTC, stored naive-UTC.
         assert ev.dtstart.hour == 5
         assert bool(ev.is_utc) is True
+    finally:
+        db.close()
+
+
+async def test_all_day_event_keeps_user_calendar_date(tokyo_offset):
+    from src.tool_implementations import do_manage_calendar
+
+    owner = "allday-" + uuid.uuid4().hex[:6]
+
+    created = await do_manage_calendar(json.dumps({
+        "action": "create_event",
+        "summary": "Tokyo holiday",
+        "dtstart": "2026-06-10",
+        "all_day": True,
+    }), owner=owner)
+    assert created.get("exit_code", 0) == 0, created
+    uid = created["uid"]
+
+    db = _TS()
+    try:
+        ev = db.query(CalendarEvent).filter(CalendarEvent.uid == uid).first()
+        assert ev.dtstart == datetime(2026, 6, 10)
+        assert ev.dtend == datetime(2026, 6, 11)
+        assert bool(ev.all_day) is True
+        assert bool(ev.is_utc) is False
+    finally:
+        db.close()
+
+    updated = await do_manage_calendar(json.dumps({
+        "action": "update_event",
+        "uid": uid,
+        "dtstart": "2026-06-12",
+        "dtend": "2026-06-13",
+        "all_day": True,
+    }), owner=owner)
+    assert updated.get("exit_code", 0) == 0, updated
+
+    db = _TS()
+    try:
+        ev = db.query(CalendarEvent).filter(CalendarEvent.uid == uid).first()
+        assert ev.dtstart == datetime(2026, 6, 12)
+        assert ev.dtend == datetime(2026, 6, 13)
+        assert bool(ev.all_day) is True
+        assert bool(ev.is_utc) is False
     finally:
         db.close()

--- a/tests/test_digest_windows.py
+++ b/tests/test_digest_windows.py
@@ -1,7 +1,13 @@
 """Tests for the calendar check-in digest windows (src/task_scheduler.py)."""
 from datetime import datetime, timedelta
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
 
-from src.task_scheduler import _digest_windows
+from src.task_scheduler import (
+    _calendar_digest_display_dt,
+    _calendar_window_bounds,
+    _digest_windows,
+)
 
 
 def test_windows_are_contiguous_with_no_gap():
@@ -20,3 +26,27 @@ def test_event_seven_and_a_half_days_out_is_covered():
     event = now + timedelta(days=7, hours=12)  # fell in the old 7-8 day gap
     buckets = [label for label, start, end in _digest_windows(now) if start <= event <= end]
     assert buckets, "event ~7.5 days out should land in a digest window"
+
+
+def test_calendar_window_bounds_keep_local_and_utc_forms():
+    start = datetime(2026, 6, 10, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+    end = start + timedelta(days=1)
+
+    assert _calendar_window_bounds(start, end) == (
+        datetime(2026, 6, 10, 0, 0),
+        datetime(2026, 6, 11, 0, 0),
+        datetime(2026, 6, 9, 15, 0),
+        datetime(2026, 6, 10, 15, 0),
+    )
+
+
+def test_calendar_digest_display_dt_converts_utc_stored_events():
+    ev = SimpleNamespace(dtstart=datetime(2026, 6, 9, 15, 30), is_utc=True)
+
+    got = _calendar_digest_display_dt(ev, "Asia/Tokyo")
+
+    assert got.year == 2026
+    assert got.month == 6
+    assert got.day == 10
+    assert got.hour == 0
+    assert got.minute == 30

--- a/tests/test_scheduler_scheduled_time_validation.py
+++ b/tests/test_scheduler_scheduled_time_validation.py
@@ -24,3 +24,11 @@ def test_malformed_scheduled_time_returns_none():
 def test_valid_scheduled_time_still_computes():
     now = datetime(2026, 6, 2, 8, 0)
     assert compute_next_run("daily", "09:00", after=now) == datetime(2026, 6, 2, 9, 0)
+
+
+def test_valid_scheduled_time_with_timezone_stores_naive_utc():
+    now_utc = datetime(2026, 6, 2, 12, 0)  # 21:00 on June 2 in Tokyo.
+    assert (
+        compute_next_run("daily", "09:00", after=now_utc, tz_name="Asia/Tokyo")
+        == datetime(2026, 6, 3, 0, 0)
+    )


### PR DESCRIPTION
## Summary

Preserve user-local calendar semantics in the remaining timezone-sensitive paths. All-day event create/update now stores date-only values as local calendar dates instead of converting midnight through UTC, check-in digest calendar windows compare UTC-stored timed events against UTC bounds while keeping all-day/legacy rows on local bounds, and scheduler timezone next-run behavior is covered with a regression test.

## Linked Issue

Fixes #2117

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. I verified the calendar storage/window behavior with focused DB-backed/unit regressions.

## How to Test

1. `.venv/bin/pytest -q tests/test_calendar_update_event_tz.py tests/test_digest_windows.py tests/test_scheduler_scheduled_time_validation.py tests/test_compute_next_run_monthly_clamp.py tests/test_calendar_recurrence.py tests/test_caldav_writeback.py`
2. `.venv/bin/python -m py_compile routes/calendar_routes.py src/tool_implementations.py src/task_scheduler.py tests/test_calendar_update_event_tz.py tests/test_digest_windows.py tests/test_scheduler_scheduled_time_validation.py`
3. `git diff --check upstream/main..HEAD`

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — this PR changes calendar datetime parsing, scheduler digest queries, and tests only. It does not change rendering, CSS, layout, or UI component patterns.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** This only changes backend datetime handling and tests.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable.
