### PR TITLE
[codex] fix(research): scope spinoff endpoint fallback

### DIFF
--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -37,13 +37,15 @@ def _first_chat_model(models) -> str:
     return (models[0] if models else "")
 
 
-def _resolve_research_endpoint(sess) -> tuple:
+def _resolve_research_endpoint(sess, owner: Optional[str] = None) -> tuple:
     """Return (endpoint_url, model, headers) for Deep Research, checking admin overrides."""
+    endpoint_owner = owner if owner is not None else getattr(sess, "owner", None)
     url, model, headers = resolve_endpoint(
         "research",
         fallback_url=sess.endpoint_url,
         fallback_model=sess.model,
         fallback_headers=sess.headers,
+        owner=endpoint_owner,
     )
     return url, model, headers
 
@@ -392,17 +394,17 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
             finally:
                 db.close()
         else:
-            ep_url, ep_model, ep_headers = resolve_endpoint("research")
+            ep_url, ep_model, ep_headers = resolve_endpoint("research", owner=user)
             if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("utility")
+                ep_url, ep_model, ep_headers = resolve_endpoint("utility", owner=user)
             # When neither research nor utility is configured, use the user's
             # configured DEFAULT model (default_endpoint_id/default_model) rather
             # than arbitrarily grabbing the first enabled endpoint's first model
             # (which surfaced gpt-3.5). "Default" should mean the default model.
             if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("default")
+                ep_url, ep_model, ep_headers = resolve_endpoint("default", owner=user)
             if not ep_url:
-                ep_url, ep_model, ep_headers = resolve_endpoint("chat")
+                ep_url, ep_model, ep_headers = resolve_endpoint("chat", owner=user)
             if not ep_url:
                 from src.database import SessionLocal
                 from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
@@ -551,8 +553,8 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
 
         # Inherit endpoint/model/headers from the source session when possible.
         # For panel-launched research (rp-* IDs), there is no chat session, so
-        # fall back through the same chain as /api/research/start: research →
-        # utility → first enabled endpoint in the DB.
+        # fall back through the same owner-scoped chain as /api/research/start:
+        # chat → research → utility → first enabled endpoint visible to user.
         ep_url, ep_model, ep_headers = "", "", {}
         try:
             src_sess = session_manager.get_session(session_id)
@@ -572,19 +574,18 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                 ep_headers = dict(r_headers)
 
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("chat"))
+            _merge(*resolve_endpoint("chat", owner=user))
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("research"))
+            _merge(*resolve_endpoint("research", owner=user))
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("utility"))
+            _merge(*resolve_endpoint("utility", owner=user))
         if not ep_url or not ep_model:
-            # Last resort: any enabled endpoint
+            # Last resort: caller-owned + legacy shared endpoints only.
             from src.database import SessionLocal
-            from src.database import ModelEndpoint
             from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
             db = SessionLocal()
             try:
-                ep = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()
+                ep = _owned_enabled_endpoint(db, user)
                 if ep:
                     base = normalize_base(ep.base_url)
                     fallback_url = build_chat_url(base)
@@ -594,7 +595,7 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                         try:
                             models = json.loads(ep.cached_models)
                             if models:
-                                fallback_model = models[0]
+                                fallback_model = _first_chat_model(models)
                         except Exception:
                             pass
                     _merge(fallback_url, fallback_model, fallback_headers)

--- a/tests/test_research_owner_scope_routes.py
+++ b/tests/test_research_owner_scope_routes.py
@@ -2,13 +2,15 @@
 
 import asyncio
 import json
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
 
-from routes.research_routes import setup_research_routes
+import routes.research_routes as research_routes
+from routes.research_routes import _resolve_research_endpoint, setup_research_routes
 
 
 def _request(user: str):
@@ -35,6 +37,69 @@ def _research_handler():
     handler = MagicMock()
     handler._active_tasks = {}
     return handler
+
+
+class _Predicate:
+    def __init__(self, check):
+        self._check = check
+
+    def __call__(self, row):
+        return self._check(row)
+
+    def __or__(self, other):
+        return _Predicate(lambda row: self(row) or other(row))
+
+
+class _Column:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, value):
+        return _Predicate(lambda row: getattr(row, self.name) == value)
+
+
+class _ModelEndpoint:
+    id = _Column("id")
+    is_enabled = _Column("is_enabled")
+    owner = _Column("owner")
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *predicates):
+        self._rows = [
+            row for row in self._rows
+            if all(predicate(row) for predicate in predicates)
+        ]
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+class _DB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def query(self, model):
+        assert model is _ModelEndpoint
+        return _Query(self._rows)
+
+    def close(self):
+        pass
+
+
+def _endpoint(eid, owner, *, base_url=None, model=None, api_key=None, is_enabled=True):
+    return SimpleNamespace(
+        id=eid,
+        owner=owner,
+        is_enabled=is_enabled,
+        base_url=base_url or f"https://{eid}.example/v1",
+        api_key=api_key or f"key-{eid}",
+        cached_models=json.dumps([model or f"{eid}-chat"]),
+    )
 
 
 def test_library_returns_only_caller_owned_unarchived_reports(tmp_path, monkeypatch):
@@ -120,3 +185,107 @@ def test_delete_rejects_cross_owner_without_unlinking_report(tmp_path, monkeypat
     assert exc.value.status_code == 404
     assert path.exists()
     assert json.loads(path.read_text(encoding="utf-8"))["result"] == "bob secret"
+
+
+def test_resolve_research_endpoint_uses_session_owner(monkeypatch):
+    calls = []
+
+    def fake_resolve(setting_prefix, **kwargs):
+        calls.append((setting_prefix, kwargs))
+        return (
+            "https://research.example/v1/chat/completions",
+            "research-chat",
+            {"Authorization": "Bearer key"},
+        )
+
+    monkeypatch.setattr(research_routes, "resolve_endpoint", fake_resolve)
+
+    sess = SimpleNamespace(
+        endpoint_url="https://fallback.example/v1/chat/completions",
+        model="fallback-chat",
+        headers={"X-Fallback": "1"},
+        owner="alice",
+    )
+
+    assert _resolve_research_endpoint(sess) == (
+        "https://research.example/v1/chat/completions",
+        "research-chat",
+        {"Authorization": "Bearer key"},
+    )
+    assert calls == [(
+        "research",
+        {
+            "fallback_url": "https://fallback.example/v1/chat/completions",
+            "fallback_model": "fallback-chat",
+            "fallback_headers": {"X-Fallback": "1"},
+            "owner": "alice",
+        },
+    )]
+
+
+def test_spinoff_endpoint_fallback_is_owner_scoped(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    session_id = "alice-report"
+    _write_research(
+        tmp_path / "data" / "deep_research",
+        session_id,
+        owner="alice",
+        query="Alice research",
+        result="Alice report body",
+        sources=[],
+    )
+
+    resolve_calls = []
+
+    def fake_resolve(setting_prefix, **kwargs):
+        resolve_calls.append((setting_prefix, kwargs.get("owner")))
+        return "", "", {}
+
+    endpoints = [
+        _endpoint(
+            "bob", "bob",
+            base_url="https://bob.example/v1",
+            model="bob-chat",
+            api_key="bob-key",
+        ),
+        _endpoint(
+            "alice", "alice",
+            base_url="https://alice.example/v1",
+            model="alice-chat",
+            api_key="alice-key",
+        ),
+    ]
+
+    db_mod = sys.modules["src.database"]
+    monkeypatch.setattr(db_mod, "ModelEndpoint", _ModelEndpoint, raising=False)
+    monkeypatch.setattr(db_mod, "SessionLocal", lambda: _DB(endpoints), raising=False)
+    monkeypatch.setattr(research_routes, "resolve_endpoint", fake_resolve)
+
+    handler = _research_handler()
+    handler.get_result.return_value = None
+    handler.get_sources.return_value = []
+    handler.get_raw_findings.return_value = []
+
+    session_manager = MagicMock()
+    session_manager.get_session.side_effect = KeyError(session_id)
+    session_manager.create_session.return_value = SimpleNamespace(
+        headers={},
+        add_message=MagicMock(),
+    )
+
+    router = setup_research_routes(handler, session_manager=session_manager)
+    target = _route(router, "/api/research/spinoff/{session_id}", "POST")
+
+    out = asyncio.run(target(session_id=session_id, request=_request("alice")))
+
+    assert out["session_id"]
+    assert resolve_calls == [
+        ("chat", "alice"),
+        ("research", "alice"),
+        ("utility", "alice"),
+    ]
+    kwargs = session_manager.create_session.call_args.kwargs
+    assert kwargs["owner"] == "alice"
+    assert kwargs["endpoint_url"] == "https://alice.example/v1/chat/completions"
+    assert kwargs["model"] == "alice-chat"
+    assert session_manager.create_session.return_value.headers == {"Authorization": "Bearer alice-key"}


### PR DESCRIPTION
## Summary

- pass the current owner into Deep Research endpoint resolution paths
- scope research spinoff configured endpoint fallbacks with `owner=user`
- use the existing `_owned_enabled_endpoint(...)` helper for the spinoff last-resort endpoint fallback
- add route-level regressions proving spinoff does not borrow another user's private endpoint/API key

## Linked Issue

Fixes #2409

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the owner-scope regression suite:

   ```bash
   .venv/bin/pytest -q tests/test_research_owner_scope_routes.py tests/test_research_endpoint_owner_scope.py tests/test_compare_endpoint_owner_scope.py tests/test_research_chat_stream_owner.py tests/test_auth_regressions.py
   ```

2. Run adjacent endpoint/research fallback tests:

   ```bash
   .venv/bin/pytest -q tests/test_endpoint_resolver.py tests/test_resolve_endpoint_fallbacks.py tests/test_research_query_fallback.py tests/test_research_service.py
   ```

3. Compile the edited Python modules:

   ```bash
   .venv/bin/python -m py_compile routes/research_routes.py tests/test_research_owner_scope_routes.py
   ```

4. Check the diff for whitespace errors:

   ```bash
   git diff --check
   ```

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend route/security fix only. No UI, CSS, HTML, SVG, or `static/js/` changes.

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A.
