### PR TITLE
fix(routes): owner-scope helper endpoint resolution across authenticated routes

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -1368,7 +1368,7 @@ def setup_calendar_routes() -> APIRouter:
         "tomorrow", "next Tuesday", "in 30 minutes" resolve correctly.
         Uses the "utility" endpoint (small / fast model) to keep latency low.
         """
-        _require_user(request)
+        owner = _require_user(request)
         from src.endpoint_resolver import resolve_endpoint
         from src.llm_core import llm_call_async
         from src.text_helpers import strip_think
@@ -1394,9 +1394,9 @@ def setup_calendar_routes() -> APIRouter:
         if tz_hint:
             set_user_tz_name(tz_hint)
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=owner)
         if not url:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=owner)
         if not url or not model:
             return {"ok": False, "error": "No LLM endpoint configured"}
 

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -853,10 +853,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         from src.llm_core import llm_call_async
 
         user = get_current_user(request)
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=user)
         if not url or not model:
             # Fall back to default endpoint
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=user)
         if not url or not model:
             raise HTTPException(500, "No endpoint configured for AI tidy")
 

--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -527,6 +527,8 @@ def setup_history_routes(session_manager) -> APIRouter:
         except KeyError:
             raise HTTPException(404, "Session not found")
         _reject_compact_during_active_run(session_id)
+        from src.auth_helpers import effective_user
+        owner = getattr(session, "owner", None) or effective_user(request)
 
         try:
             from src.model_context import estimate_tokens, get_context_length
@@ -555,7 +557,7 @@ def setup_history_routes(session_manager) -> APIRouter:
             )
 
             # Use utility model if available
-            util_url, util_model, util_headers = resolve_endpoint("utility")
+            util_url, util_model, util_headers = resolve_endpoint("utility", owner=owner)
             compact_url = util_url or session.endpoint_url
             compact_model = util_model or session.model
             compact_headers = util_headers if util_url else session.headers

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -181,9 +181,9 @@ async def dispatch_reminder(
         try:
             from src.endpoint_resolver import resolve_endpoint
             from src.llm_core import llm_call_async
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=owner)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=owner)
             if url and model:
                 raw = await llm_call_async(
                     url=url, model=model,

--- a/routes/task_routes.py
+++ b/routes/task_routes.py
@@ -1047,6 +1047,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
         desc = (body.get("description") or "").strip()
         if not desc:
             return {"success": False, "message": "Nothing to parse"}
+        owner = _owner(request)
 
         now = _dt.now()
         # Give the model the current date/time + weekday so relative phrasing
@@ -1073,9 +1074,9 @@ def setup_task_routes(task_scheduler) -> APIRouter:
             "use cron '0 H * * 1-5'. Keep the prompt actionable and self-contained."
         )
         try:
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=owner)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=owner)
             if not (url and model):
                 return {"success": False, "message": "No model endpoint configured"}
             raw = await llm_call_async(

--- a/tests/test_route_endpoint_owner_resolution.py
+++ b/tests/test_route_endpoint_owner_resolution.py
@@ -1,0 +1,80 @@
+"""Regression guards for owner-scoped route helper endpoint resolution.
+
+These routes already know the request/session owner before dispatching LLM
+helper calls. Their endpoint resolution must preserve that owner so a
+multi-user install cannot select another user's private ModelEndpoint/API key.
+"""
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _function_calls(path: str, function_name: str, call_name: str) -> list[ast.Call]:
+    tree = ast.parse((ROOT / path).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            return [
+                child for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Name)
+                and child.func.id == call_name
+            ]
+    raise AssertionError(f"{function_name} not found in {path}")
+
+
+def _assert_calls_are_owner_scoped(path: str, function_name: str, call_name: str) -> None:
+    calls = _function_calls(path, function_name, call_name)
+    assert calls, f"{function_name} has no {call_name} calls"
+    missing = [
+        call.lineno for call in calls
+        if not any(keyword.arg == "owner" for keyword in call.keywords)
+    ]
+    assert not missing, f"{path}:{function_name} has unscoped {call_name} calls at {missing}"
+
+
+def test_document_ai_tidy_resolves_endpoints_with_owner():
+    _assert_calls_are_owner_scoped(
+        "routes/document_routes.py",
+        "ai_tidy_documents",
+        "resolve_task_endpoint",
+    )
+    _assert_calls_are_owner_scoped(
+        "routes/document_routes.py",
+        "ai_tidy_documents",
+        "resolve_endpoint",
+    )
+
+
+def test_note_reminder_synthesis_resolves_endpoints_with_owner():
+    _assert_calls_are_owner_scoped(
+        "routes/note_routes.py",
+        "dispatch_reminder",
+        "resolve_endpoint",
+    )
+
+
+def test_calendar_quick_parse_resolves_endpoints_with_owner():
+    _assert_calls_are_owner_scoped(
+        "routes/calendar_routes.py",
+        "quick_parse",
+        "resolve_endpoint",
+    )
+
+
+def test_task_parse_resolves_endpoints_with_owner():
+    _assert_calls_are_owner_scoped(
+        "routes/task_routes.py",
+        "parse_task",
+        "resolve_endpoint",
+    )
+
+
+def test_history_compact_resolves_endpoints_with_owner():
+    _assert_calls_are_owner_scoped(
+        "routes/history_routes.py",
+        "compact_session",
+        "resolve_endpoint",
+    )


### PR DESCRIPTION
## Summary

- pass the existing request/session owner into model endpoint resolution for route helper LLM calls
- cover document AI tidy, note reminder synthesis, calendar quick-parse, task parse, and manual history compaction
- add an AST regression guard that fails if these helper routes call endpoint resolution without `owner=`

## Linked Issue

Fixes #2413

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the owner-resolution and nearby route regression tests:

   ```bash
   .venv/bin/pytest -q tests/test_route_endpoint_owner_resolution.py tests/test_calendar_owner_scope.py tests/test_calendar_update_event_tz.py tests/test_calendar_parse_dt_tonight.py tests/test_ics_import_dedup_tz.py tests/test_caldav_writeback.py tests/test_caldav_writeback_route.py tests/test_document_tidy_null_timestamp.py tests/test_document_tool_owner_scope.py tests/test_owned_document_query.py tests/test_notes_update_due_date.py tests/test_notes_cli_items.py tests/test_tasks_cli_preview.py tests/test_task_scheduler_session_delivery.py tests/test_history_topics_owner_scope.py tests/test_history_order_by_timestamp_regression.py tests/test_history_db_fallback_hidden.py tests/test_session_endpoint_owner_scope.py
   ```

2. Compile the edited Python modules:

   ```bash
   .venv/bin/python -m py_compile routes/document_routes.py routes/note_routes.py routes/calendar_routes.py routes/task_routes.py routes/history_routes.py tests/test_route_endpoint_owner_resolution.py
   ```

3. Check the diff for whitespace errors:

   ```bash
   git diff --check
   ```

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend route/security fix only. No UI, CSS, HTML, SVG, or `static/js` changes.

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A.
