### PR TITLE
fix(document): render Mermaid diagrams in markdown preview

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -8554,6 +8554,9 @@ import * as Modals from './modalManager.js';
       if (window.hljs) {
         preview.querySelectorAll('pre code').forEach(b => window.hljs.highlightElement(b));
       }
+      if (markdownModule && markdownModule.renderMermaid) {
+        markdownModule.renderMermaid(preview);
+      }
       preview.style.display = '';
       wrap.style.display = 'none';
     } else {


### PR DESCRIPTION
## Summary

- Render Mermaid diagrams after the document markdown preview converts fenced `mermaid` blocks to preview DOM nodes.
- Keeps the change limited to the markdown document preview path; chat rendering is unchanged.

## Linked Issue

Fixes #2412

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`.
- [x] My changes are limited to the scope described above.
- [ ] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Open a markdown document containing a Mermaid fenced block, for example:
   ```mermaid
   graph TD
     A[Chat Mermaid] --> B[Document preview]
   ```
2. Switch the document to Preview and verify the graph renders instead of remaining an unprocessed code block.
3. Run `node --check static/js/document.js`.
4. Run `git diff --check`.

## Verification

- `node --check static/js/document.js`
- `git diff --check`

I did not run a full browser smoke test in this environment.
