### PR TITLE
[codex] fix(backup): import disk-backed skills

### DIFF
--- a/routes/backup_routes.py
+++ b/routes/backup_routes.py
@@ -12,6 +12,41 @@ from src.settings import load_settings, save_settings, load_features, save_featu
 logger = logging.getLogger(__name__)
 
 
+def _as_list(value):
+    if isinstance(value, list):
+        return [str(item) for item in value if item not in (None, "")]
+    if value in (None, ""):
+        return []
+    return [str(value)]
+
+
+def _as_float(value, default=0.8):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_text(value):
+    return str(value).strip() if value not in (None, "") else ""
+
+
+def _owner_key(owner):
+    return _as_text(owner)
+
+
+def _skill_id(skill):
+    return _as_text(skill.get("id") or skill.get("name"))
+
+
+def _skill_label(skill):
+    for key in ("title", "description", "name", "id"):
+        value = _as_text(skill.get(key))
+        if value:
+            return value
+    return ""
+
+
 def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRouter:
     router = APIRouter(tags=["backup"])
 
@@ -101,24 +136,80 @@ def setup_backup_routes(memory_manager, preset_manager, skills_manager) -> APIRo
         # ── Skills ──
         if "skills" in body and isinstance(body["skills"], list):
             existing = skills_manager.load_all()
-            existing_ids = {s.get("id") for s in existing}
-            existing_titles = {s.get("title", "").strip().lower() for s in existing}
+            existing_ids = {
+                (_owner_key(s.get("owner")), _skill_id(s))
+                for s in existing
+                if _skill_id(s)
+            }
+            existing_titles = {
+                (_owner_key(s.get("owner")), _skill_label(s).lower())
+                for s in existing
+                if _skill_label(s)
+            }
             added = 0
             for skill in body["skills"]:
-                if not isinstance(skill, dict) or not skill.get("title"):
+                if not isinstance(skill, dict):
                     continue
-                # Skip if same id or same title already exists
-                if skill.get("id") in existing_ids:
+                skill = dict(skill)
+                label = _skill_label(skill)
+                if not label:
                     continue
-                if skill["title"].strip().lower() in existing_titles:
+                target_owner = _as_text(skill.get("owner")) or user
+                owner_key = _owner_key(target_owner)
+                skill_id = _skill_id(skill)
+                title_key = label.lower()
+                # Skip if the importing owner's library already has this skill.
+                if skill_id and (owner_key, skill_id) in existing_ids:
                     continue
-                if user and not skill.get("owner"):
+                if (owner_key, title_key) in existing_titles:
+                    continue
+                if user and not _as_text(skill.get("owner")):
                     skill["owner"] = user
-                existing.append(skill)
-                existing_ids.add(skill.get("id"))
-                existing_titles.add(skill["title"].strip().lower())
-                added += 1
-            skills_manager.save(existing)
+                    target_owner = user
+                    owner_key = _owner_key(target_owner)
+
+                body_extra = skill.get("body_extra")
+                created = _as_text(skill.get("created")) or None
+                result = skills_manager.add_skill(
+                    title=_as_text(skill.get("title") or skill.get("description") or skill.get("name")),
+                    problem=_as_text(skill.get("problem") if skill.get("problem") is not None else skill.get("when_to_use")),
+                    solution=_as_text(skill.get("solution") if skill.get("solution") is not None else skill.get("body_extra")),
+                    steps=_as_list(skill.get("steps") if skill.get("steps") is not None else skill.get("procedure")),
+                    tags=_as_list(skill.get("tags")),
+                    source=_as_text(skill.get("source")) or "imported",
+                    teacher_model=skill.get("teacher_model"),
+                    confidence=_as_float(skill.get("confidence"), 0.8),
+                    owner=target_owner or None,
+                    name=_as_text(skill.get("name") or skill.get("id")) or None,
+                    description=_as_text(skill.get("description") or skill.get("title")),
+                    category=_as_text(skill.get("category")) or "general",
+                    when_to_use=_as_text(skill.get("when_to_use") if skill.get("when_to_use") is not None else skill.get("problem")),
+                    procedure=_as_list(skill.get("procedure") if skill.get("procedure") is not None else skill.get("steps")),
+                    pitfalls=_as_list(skill.get("pitfalls")),
+                    verification=_as_list(skill.get("verification")),
+                    platforms=_as_list(skill.get("platforms")),
+                    requires_toolsets=_as_list(skill.get("requires_toolsets")),
+                    fallback_for_toolsets=_as_list(skill.get("fallback_for_toolsets")),
+                    status=_as_text(skill.get("status")) or "draft",
+                    version=_as_text(skill.get("version")) or "1.0.0",
+                    body_extra=str(body_extra) if body_extra not in (None, "") else None,
+                    created=created,
+                )
+                if isinstance(result, dict):
+                    stored_owner_key = _owner_key(result.get("owner"))
+                    stored_id = _skill_id(result)
+                    stored_label = _skill_label(result)
+                    if stored_id:
+                        existing_ids.add((stored_owner_key, stored_id))
+                    if stored_label:
+                        existing_titles.add((stored_owner_key, stored_label.lower()))
+                    if not result.get("_deduped"):
+                        added += 1
+                else:
+                    added += 1
+                if skill_id:
+                    existing_ids.add((owner_key, skill_id))
+                existing_titles.add((owner_key, title_key))
             imported.append(f"{added} skills")
 
         # ── Presets ──

--- a/services/memory/skill_format.py
+++ b/services/memory/skill_format.py
@@ -307,7 +307,7 @@ def emit_body(sections: Dict[str, Any]) -> str:
         parts.append(f"## {heading}\n\n{body}")
     extra = (sections.get("body_extra") or "").strip()
     if extra:
-        parts.append(extra)
+        parts.append(f"## Notes\n\n{extra}" if parts else extra)
     return "\n\n".join(parts) + ("\n" if parts else "")
 
 

--- a/services/memory/skills.py
+++ b/services/memory/skills.py
@@ -315,6 +315,8 @@ class SkillsManager:
         fallback_for_toolsets: Optional[List[str]] = None,
         status: str = "draft",
         version: str = "1.0.0",
+        body_extra: Optional[str] = None,
+        created: Optional[str] = None,
     ) -> Dict:
         # Normalize name
         nm = slugify(name or title or description or "skill")
@@ -371,11 +373,12 @@ class SkillsManager:
             source=source,
             teacher_model=teacher_model,
             owner=owner,
+            created=str(created or ""),
             when_to_use=(when_to_use if when_to_use is not None else (problem or "")),
             procedure=list(procedure if procedure is not None else (steps or [])),
             pitfalls=list(pitfalls or []),
             verification=list(verification or []),
-            body_extra=(solution if solution and not procedure else ""),
+            body_extra=(body_extra if body_extra is not None else (solution if solution and not procedure else "")),
         )
         self._write_skill(sk)
 

--- a/tests/test_backup_import_cross_user_dedup.py
+++ b/tests/test_backup_import_cross_user_dedup.py
@@ -7,10 +7,10 @@ dedup must be scoped to the caller\'s own memories. The full multi-tenant
 store is still saved back.
 """
 import asyncio
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import routes.backup_routes as br
+from services.memory.skills import SkillsManager
 
 
 class _Req:
@@ -41,6 +41,21 @@ def _setup(monkeypatch, store, user="alice"):
     return endpoint, saved
 
 
+def _import_endpoint(monkeypatch, skills_manager, user="alice"):
+    monkeypatch.setattr(br, "require_admin", lambda request: None)
+    monkeypatch.setattr(br, "get_current_user", lambda request: user)
+
+    mem = MagicMock()
+    mem.load_all.return_value = []
+    router = br.setup_backup_routes(mem, MagicMock(), skills_manager)
+    endpoint = None
+    for r in router.routes:
+        if r.path == "/api/import" and "POST" in getattr(r, "methods", set()):
+            endpoint = r.endpoint
+    assert endpoint is not None
+    return endpoint
+
+
 def test_user_can_import_memory_matching_another_users_text(monkeypatch):
     # bob already has "buy milk"; alice imports her own "Buy Milk".
     endpoint, saved = _setup(monkeypatch, [{"text": "buy milk", "owner": "bob"}])
@@ -58,3 +73,104 @@ def test_users_own_duplicate_is_still_skipped(monkeypatch):
     alice_milk = [e for e in saved["entries"]
                   if e.get("owner") == "alice" and e.get("text", "").lower() == "buy milk"]
     assert len(alice_milk) == 1  # the real duplicate is still deduped
+
+
+def test_skill_import_writes_disk_backed_skill(monkeypatch, tmp_path):
+    sm = SkillsManager(str(tmp_path))
+    endpoint = _import_endpoint(monkeypatch, sm)
+
+    body = {
+        "skills": [{
+            "id": "debug-flow",
+            "name": "debug-flow",
+            "description": "Debug flow",
+            "title": "Debug flow",
+            "category": "ops",
+            "tags": ["debug"],
+            "status": "published",
+            "confidence": 0.7,
+            "source": "imported",
+            "owner": "alice",
+            "created": "2026-01-01T00:00:00Z",
+            "when_to_use": "When debugging failures",
+            "procedure": ["Check logs"],
+            "pitfalls": ["Do not skip reproduction"],
+            "verification": ["Failure is reproduced"],
+            "body_extra": "Extra backup context",
+        }]
+    }
+
+    result = asyncio.run(endpoint(_Req(body)))
+
+    assert result["imported"] == ["1 skills"]
+    skills = sm.load(owner="alice")
+    assert len(skills) == 1
+    skill = skills[0]
+    assert skill["name"] == "debug-flow"
+    assert skill["description"] == "Debug flow"
+    assert skill["category"] == "ops"
+    assert skill["procedure"] == ["Check logs"]
+    assert skill["verification"] == ["Failure is reproduced"]
+    assert skill["body_extra"] == "Extra backup context"
+    assert skill["created"] == "2026-01-01T00:00:00Z"
+
+
+def test_user_can_import_skill_matching_another_users_title(monkeypatch, tmp_path):
+    sm = SkillsManager(str(tmp_path))
+    sm.add_skill(
+        name="shared-flow",
+        description="Shared Flow",
+        when_to_use="Bob's workflow",
+        procedure=["Bob step"],
+        owner="bob",
+        source="user",
+    )
+    endpoint = _import_endpoint(monkeypatch, sm, user="alice")
+
+    body = {
+        "skills": [{
+            "name": "shared-flow",
+            "description": "Shared Flow",
+            "when_to_use": "Alice's workflow",
+            "procedure": ["Alice step"],
+            "owner": "alice",
+            "source": "imported",
+        }]
+    }
+
+    result = asyncio.run(endpoint(_Req(body)))
+
+    assert result["imported"] == ["1 skills"]
+    assert len(sm.load(owner="bob")) == 1
+    alice_skills = sm.load(owner="alice")
+    assert len(alice_skills) == 1
+    assert alice_skills[0]["description"] == "Shared Flow"
+
+
+def test_import_skips_current_users_existing_skill(monkeypatch, tmp_path):
+    sm = SkillsManager(str(tmp_path))
+    sm.add_skill(
+        name="shared-flow",
+        description="Shared Flow",
+        when_to_use="Alice's workflow",
+        procedure=["Alice step"],
+        owner="alice",
+        source="user",
+    )
+    endpoint = _import_endpoint(monkeypatch, sm, user="alice")
+
+    body = {
+        "skills": [{
+            "name": "shared-flow",
+            "description": "Shared Flow",
+            "when_to_use": "Alice's workflow",
+            "procedure": ["Alice step"],
+            "owner": "alice",
+            "source": "imported",
+        }]
+    }
+
+    result = asyncio.run(endpoint(_Req(body)))
+
+    assert result["imported"] == ["0 skills"]
+    assert len(sm.load(owner="alice")) == 1


### PR DESCRIPTION
## Summary

Importing a backup JSON that contains skills now writes each skill through the disk-backed `SkillsManager.add_skill(...)` API instead of calling the removed `save(...)` method. Exact duplicate detection is scoped to the target owner, and imported skills keep exported metadata that the backup format already emits, including `created` and `body_extra`.

## Linked Issue

Fixes #2416

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `.venv/bin/python -m pytest tests/test_backup_import_cross_user_dedup.py`.
2. Run `.venv/bin/python -m pytest tests/test_backup_import_cross_user_dedup.py tests/test_skill_save_no_rename.py tests/test_skills_manager_owner_isolation.py tests/test_skills_routes_owner_update.py tests/test_skills_delete_owner.py tests/test_skills_tag_token_match.py`.
3. Run `.venv/bin/python -m compileall routes/backup_routes.py services/memory/skills.py services/memory/skill_format.py tests/test_backup_import_cross_user_dedup.py`.
4. Run `git diff --check`.

## Visual / UI changes - REQUIRED if you touched anything that renders

Not applicable; no UI or rendering changes.

### Screenshots / clips

Not applicable.