### PR TITLE
fix(memory): match query-type keywords on whole words, not substrings

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -302,17 +302,21 @@ class MemoryManager:
         
         query_lower = query.lower()
         
-        # Determine query type based on keywords
+        # Determine query type based on keywords. Match whole words, not raw
+        # substrings: otherwise short tokens like "i"/"am"/"me"/"my" match
+        # inside ordinary words ("bitcoin", "name", "time", ...) and force
+        # almost every query to be classified "identity".
+        query_tokens = set(tokenize(query_lower))
         query_type = None
-        if any(word in query_lower for word in identity_words):
+        if query_tokens & set(identity_words):
             query_type = "identity"
-        elif any(word in query_lower for word in contact_words):
+        elif query_tokens & set(contact_words):
             query_type = "contact"
-        elif any(word in query_lower for word in preference_words):
+        elif query_tokens & set(preference_words):
             query_type = "preference"
-        elif any(word in query_lower for word in task_words):
+        elif query_tokens & set(task_words):
             query_type = "task"
-        elif any(word in query_lower for word in fact_words):
+        elif query_tokens & set(fact_words):
             query_type = "fact"
         
         relevant = []
@@ -342,7 +346,6 @@ class MemoryManager:
         for memory in other_memories:
             memory_text = memory["text"].lower()
             memory_tokens = set(tokenize(memory_text))
-            query_tokens = set(tokenize(query_lower))
             
             # Calculate base Jaccard similarity
             if not query_tokens or not memory_tokens:

--- a/tests/test_memory_query_type_word_match.py
+++ b/tests/test_memory_query_type_word_match.py
@@ -1,0 +1,53 @@
+"""MemoryManager.get_relevant_memories must classify the query type by whole
+words, not raw substrings.
+
+The classifier keyed off single-letter/short tokens like "i", "am", "me", "my"
+using `word in query_lower`, a substring test. Because "i" is a substring of a
+huge fraction of English words ("bitcoin", "price", "list", "find", ...),
+almost every query was forced to query_type == "identity", which then
+force-promotes every identity/name memory to score 0.9 and suppresses the
+contact/preference/task boosts.
+
+get_relevant_memories lives in the canonical src/memory.py; services.memory
+re-exports it (#50). Pin the behaviour via both import paths so a future
+divergent copy -- or a broken re-export -- is caught.
+"""
+import tempfile
+
+import pytest
+
+from src.memory import MemoryManager as SrcMemoryManager
+from services.memory import MemoryManager as ServicesMemoryManager
+
+_MANAGERS = [SrcMemoryManager, ServicesMemoryManager]
+
+_NAME_MEM = {"text": "User's name is Sam Carter", "id": "name"}
+_BTC_MEM = {"text": "The bitcoin price is tracked on the exchange", "id": "btc"}
+
+
+def _mm(cls):
+    return cls(tempfile.mkdtemp(prefix="odysseus_mem_qtype_"))
+
+
+@pytest.mark.parametrize("cls", _MANAGERS)
+def test_non_identity_query_does_not_force_promote_identity_memory(cls):
+    # "bitcoin" and "is" merely *contain* the letter "i"; that must not be read
+    # as the standalone identity keyword "i" and shove the name memory to the
+    # top of an unrelated factual query.
+    result = _mm(cls).get_relevant_memories(
+        "what is the bitcoin price", [_NAME_MEM, _BTC_MEM]
+    )
+    ids = [m["id"] for m in result]
+    assert ids, "expected at least one relevant memory"
+    assert ids[0] == "btc"
+
+
+@pytest.mark.parametrize("cls", _MANAGERS)
+def test_identity_query_still_surfaces_identity_memory(cls):
+    # A genuine identity query (whole word "my"/"name") must still surface it.
+    result = _mm(cls).get_relevant_memories(
+        "what is my name", [_NAME_MEM, _BTC_MEM]
+    )
+    ids = [m["id"] for m in result]
+    assert "name" in ids
+    assert ids[0] == "name"


### PR DESCRIPTION
## Summary

`MemoryManager.get_relevant_memories` classified the query type with `word in query_lower`, a substring test, against keyword lists that include single-letter/short tokens (`"i"`, `"am"`, `"me"`, `"my"`). Because `"i"` is a substring of a large fraction of English words (`"bitcoin"`, `"list"`, `"find"`, `"time"`, …), nearly every query matched the first branch and was classified `"identity"`. That force-promoted every identity/name memory to score `0.9` at the top of unrelated queries and prevented the contact/preference/task boosts from running at all (the `elif` chain stopped at `"identity"`).

This is the "memory relevance classifies nearly every query as identity (substring match on 'i')" item from #2120. The fix lands in the canonical `src/memory.py`; after the #50 import-canonicalization `services/memory` re-exports that class, so the `/memory` HTTP routes, `src/ai_interaction.py`, and the MCP memory server all pick it up. The classifier now matches against the tokenized query — the function already tokenizes for its Jaccard scoring — so keywords match whole words; the query token set is also hoisted out of the per-candidate loop.

## Linked Issue

Part of #2120

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. _Not done — pure relevance-ranking logic; verified via a regression test asserted over both `MemoryManager` import paths + `py_compile`, rather than a full app boot. Flagging honestly per CONTRIBUTING._

## How to Test

1. `python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt`
2. Check out `fix/memory-query-type-word-match`.
3. `PYTHONPATH=. python -m pytest tests/test_memory_query_type_word_match.py -q` → 4 passed (asserted via both the `src.memory` and `services.memory` import paths; the non-identity case fails on `main` before the fix).
4. (Optional) Confirm a query like `"what is the bitcoin price"` no longer force-ranks a name/identity memory first.

## Visual / UI changes — REQUIRED if you touched anything that renders

None — backend logic only.

---

Scope note: #2120 also lists two other substring-match sites (model cost label, gallery tag pill); this PR fixes only the memory-relevance one, hence "Part of" rather than "Fixes". Rebased onto `main` after the #50 memory-canonicalization refactor, so the change is now a single edit to the canonical `src/memory.py`. Prepared with assistance from Claude Opus 4.8 (Claude Code); issue filed first per CONTRIBUTING.
