### PR TITLE
fix(memory): record dislikes as dislikes, not preferences

### DIFF
--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -192,11 +192,19 @@ def _fallback_memory_candidates(messages) -> list[dict]:
             if place:
                 add(f"User lives in {place}.", "identity")
 
-        m = re.search(r"\bi (?:prefer|like|love|hate|do not like|don't like)\s+([^.!?\n]{4,100})", text, re.I)
+        m = re.search(r"\bi (prefer|like|love|hate|do not like|don't like)\s+([^.!?\n]{4,100})", text, re.I)
         if m:
-            preference = _clean_memory_value(m.group(1), 100)
+            preference = _clean_memory_value(m.group(2), 100)
             if preference:
-                add(f"User prefers {preference}.", "preference")
+                # The same pattern catches likes and dislikes; keep the stored
+                # sentiment faithful instead of recording every match as a
+                # preference ("I hate cilantro" must not become "User prefers
+                # cilantro").
+                verb = m.group(1).lower()
+                if verb in ("hate", "do not like", "don't like"):
+                    add(f"User dislikes {preference}.", "preference")
+                else:
+                    add(f"User prefers {preference}.", "preference")
 
         m = re.search(
             r"\bi (?:(?:want|would like|plan|hope) to|wanna) "

--- a/tests/test_memory_fallback_dislike.py
+++ b/tests/test_memory_fallback_dislike.py
@@ -1,0 +1,31 @@
+"""The fallback memory extractor must not invert dislikes into preferences.
+
+_fallback_memory_candidates matched both positive (prefer/like/love) and
+negative (hate/do not like/don't like) sentiment verbs in one alternation but
+formatted every hit as "User prefers X.", so "I hate cilantro" was stored as
+"User prefers cilantro" -- the opposite of what the user said, then persisted
+to memory and re-injected into context. These pin the sentiment.
+"""
+from services.memory.memory_extractor import _fallback_memory_candidates
+
+
+def _texts(content):
+    cands = _fallback_memory_candidates([{"role": "user", "content": content}])
+    return [c["text"].lower() for c in cands]
+
+
+def test_dislike_is_not_stored_as_preference():
+    texts = _texts("I hate cilantro in my food")
+    assert not any("prefers cilantro" in t for t in texts)
+    assert any("dislikes cilantro" in t for t in texts)
+
+
+def test_negated_like_is_not_stored_as_preference():
+    texts = _texts("I don't like crowded trains")
+    assert not any("prefers crowded" in t for t in texts)
+    assert any("dislikes crowded" in t for t in texts)
+
+
+def test_genuine_preference_still_stored():
+    texts = _texts("I love spicy ramen noodles")
+    assert any("prefers spicy ramen" in t for t in texts)


### PR DESCRIPTION
## Summary

`services/memory/memory_extractor.py::_fallback_memory_candidates` (the regex fallback used when LLM memory extraction is unavailable or fails) matched positive and negative sentiment verbs in one alternation (`prefer|like|love|hate|do not like|don't like`) but formatted every match as `"User prefers {X}."`. So `"I hate cilantro"` was stored as `"User prefers cilantro."` — the inverse of what the user said. These fallback facts are persisted to memory and later re-injected into the model's context, so the inverted preference actively misleads the assistant.

The fix captures the matched verb and branches on it: negatives become `"User dislikes {X}."`, positives stay `"User prefers {X}."` (still filed under the existing `preference` category).

## Linked Issue

Fixes #2429

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. _Not done — pure extraction logic; verified via unit tests rather than a full app boot. Flagging honestly per CONTRIBUTING._

## How to Test

1. `python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt`
2. Check out `fix/memory-fallback-dislike-inversion`.
3. `PYTHONPATH=. python -m pytest tests/test_memory_fallback_dislike.py -q` → 3 passed (a dislike and a negated "like" are no longer stored as preferences; a genuine "love"/"like" still is).
4. (Optional) `python -c "from services.memory.memory_extractor import _fallback_memory_candidates as f; print(f([{'role':'user','content':'I hate cilantro in my food'}]))"` → `User dislikes cilantro in my food.`

## Visual / UI changes — REQUIRED if you touched anything that renders

None — backend logic only.

---

Prepared with assistance from Claude Opus 4.8 (Claude Code); issue filed first per CONTRIBUTING.
