### PR TITLE
fix(notes): bring panel to front on focus

### DIFF
--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -10,6 +10,7 @@ import { attachColorPicker } from './colorPicker.js';
 import { makeWindowDraggable } from './windowDrag.js';
 import { snapModalToZone } from './tileManager.js';
 import { applyEdgeDock, clearDockSide } from './modalSnap.js';
+import { nextNotesPaneZIndex } from './notesStacking.js';
 
 const API_BASE = window.location.origin;
 let _open = false;
@@ -1187,6 +1188,8 @@ export function openPanel() {
   });
   backdrop.appendChild(pane);
   document.body.appendChild(backdrop);
+  pane.addEventListener('pointerdown', _bringNotesPaneToFront, { capture: true });
+  _bringNotesPaneToFront();
   _wireNotesWindow(pane);
   _restoreNotesSidebarDock(pane);
 
@@ -1568,6 +1571,12 @@ function _ensureNotesChipRegistered() {
     restoreFn: () => { openPanel(); },
     closeFn: () => { _forceCloseNotesPanel(); },
   });
+}
+
+function _bringNotesPaneToFront() {
+  const backdrop = document.getElementById('notes-pane-backdrop');
+  if (!backdrop) return;
+  backdrop.style.zIndex = String(nextNotesPaneZIndex(document));
 }
 
 // `direction === 'down'` (mobile swipe-down) MINIMIZES the panel to a

--- a/static/js/notesStacking.js
+++ b/static/js/notesStacking.js
@@ -1,0 +1,34 @@
+export const NOTES_PANE_MIN_Z = 1000;
+
+
+function _computedStyle(doc, el) {
+  const view = doc?.defaultView || globalThis;
+  if (view && typeof view.getComputedStyle === 'function') {
+    return view.getComputedStyle(el);
+  }
+  if (typeof globalThis.getComputedStyle === 'function') {
+    return globalThis.getComputedStyle(el);
+  }
+  return el?.style || {};
+}
+
+
+function _isHiddenWindow(doc, el) {
+  if (!el) return true;
+  if (el.classList?.contains('hidden') || el.classList?.contains('modal-minimized')) return true;
+  const style = _computedStyle(doc, el);
+  return style?.display === 'none' || style?.visibility === 'hidden';
+}
+
+
+export function nextNotesPaneZIndex(doc = document) {
+  let top = 0;
+  const nodes = doc?.querySelectorAll?.('.modal, #notes-pane-backdrop') || [];
+  for (const node of nodes) {
+    if (_isHiddenWindow(doc, node)) continue;
+    const style = _computedStyle(doc, node);
+    const z = parseInt(style?.zIndex ?? node?.style?.zIndex, 10);
+    if (Number.isFinite(z)) top = Math.max(top, z);
+  }
+  return Math.max(NOTES_PANE_MIN_Z, top + 1);
+}

--- a/tests/test_notes_panel_stacking_js.py
+++ b/tests/test_notes_panel_stacking_js.py
@@ -1,0 +1,92 @@
+"""Regression coverage for Notes panel click-to-front stacking."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "notesStacking.js"
+_HAS_NODE = shutil.which("node") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+
+
+def _run(js: str):
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js,
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_notes_panel_zindex_uses_minimum_without_modals():
+    js = f"""
+    import {{ nextNotesPaneZIndex }} from '{_HELPER.as_uri()}';
+    const doc = {{
+      defaultView: {{ getComputedStyle: () => ({{ display: 'block', visibility: 'visible', zIndex: 'auto' }}) }},
+      querySelectorAll: () => [],
+    }};
+    console.log(JSON.stringify(nextNotesPaneZIndex(doc)));
+    """
+
+    assert _run(js) == 1000
+
+
+def test_notes_panel_zindex_clears_current_top_modal():
+    js = f"""
+    import {{ nextNotesPaneZIndex }} from '{_HELPER.as_uri()}';
+    const visible = (z) => ({{
+      classList: {{ contains: () => false }},
+      z,
+    }});
+    const doc = {{
+      defaultView: {{
+        getComputedStyle: (node) => ({{
+          display: 'block',
+          visibility: 'visible',
+          zIndex: String(node.z),
+        }}),
+      }},
+      querySelectorAll: () => [visible(260), visible(1007), visible(300)],
+    }};
+    console.log(JSON.stringify(nextNotesPaneZIndex(doc)));
+    """
+
+    assert _run(js) == 1008
+
+
+def test_notes_panel_zindex_ignores_hidden_or_minimized_windows():
+    js = f"""
+    import {{ nextNotesPaneZIndex }} from '{_HELPER.as_uri()}';
+    const windowNode = (z, hiddenClass, display) => ({{
+      classList: {{ contains: (name) => name === hiddenClass }},
+      z,
+      display,
+    }});
+    const doc = {{
+      defaultView: {{
+        getComputedStyle: (node) => ({{
+          display: node.display || 'block',
+          visibility: 'visible',
+          zIndex: String(node.z),
+        }}),
+      }},
+      querySelectorAll: () => [
+        windowNode(5000, 'hidden'),
+        windowNode(4000, 'modal-minimized'),
+        windowNode(3000, null, 'none'),
+        windowNode(1200, null),
+      ],
+    }};
+    console.log(JSON.stringify(nextNotesPaneZIndex(doc)));
+    """
+
+    assert _run(js) == 1201


### PR DESCRIPTION
## Summary

- promotes the Notes pane backdrop when the panel opens so it does not start behind already-open panels
- promotes the Notes pane again on pointer focus so clicking a visible part of Notes brings it above Gallery, Calendar, Tasks, and other tool windows
- adds a small DOM-free z-index helper with node-driven regression tests

## Linked Issue

Fixes #2344

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs for duplicate or overlapping work.
- [x] This PR targets `main`.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the full app end-to-end. Not run: verified with focused JS tests plus a headless Chrome visual fixture instead of a full server session.

## How to Test

Run the focused frontend regression checks:

```bash
.venv/bin/python -m pytest -q tests/test_notes_panel_stacking_js.py tests/test_keybind_altgr_js.py tests/test_esc_menu_stack_js.py
node --check static/js/notes.js
node --check static/js/notesStacking.js
git diff --check
```

Visual verification run locally with headless Chrome: a fixture rendered a modal at `z-index: 1200`, applied the real `notesStacking.js` helper to the Notes backdrop, and the resulting screenshot showed the Notes panel above that modal. Screenshot path in the local workspace was `/tmp/odysseus-notes-front-stack.png`.

## Visual / UI changes

- [x] Visual verification performed with headless Chrome against the real CSS/helper path.
- [x] Style match: existing Notes panel styles are reused; only stacking behavior changes.
- [x] No new component pattern; this keeps the existing Notes panel.
- [x] No Unicode emoji in UI or code.
