### PR TITLE
fix(chat): route gpt-oss harmony analysis channel to thinking UI (Fixes #2420)

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -587,8 +587,10 @@ def _normalize_thinking(text: str) -> str:
     - Garbled <think> tags (reasoning before the tag, unclosed tags)
     """
     import re
+    from src.text_helpers import normalize_harmony_markup
     if not text:
         return text
+    text = normalize_harmony_markup(text)
     reasoning_prefix_re = re.compile(
         r'^\s*(?:thinking(?:\s+process)?\s*:|the user |i need |i should |i will |they are |the question |i can )',
         re.IGNORECASE,

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1340,6 +1340,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                     _delta0.get("content")
                                     or _delta0.get("reasoning_content")
                                     or _delta0.get("reasoning")
+                                    or _delta0.get("thinking")
                                     or _delta0.get("tool_calls")
                                 )
                                 if "usage" in j and not _delta_has_output:
@@ -1361,8 +1362,14 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                     delta = j["choices"][0].get("delta") or {}
                                     if isinstance(delta, dict):
                                         # Text content
-                                        # Reasoning tokens (VLLM --reasoning-parser, e.g. Qwen3/DeepSeek-R1, Nemotron). vLLM 0.20.2 / NIM emit the field as `reasoning`; older builds use `reasoning_content`. Accept either.
-                                        reasoning = delta.get("reasoning_content") or delta.get("reasoning") or ""
+                                        # Reasoning tokens (VLLM --reasoning-parser, Qwen3/DeepSeek-R1, Nemotron).
+                                        # Ollama OpenAI-compat gpt-oss emits `thinking` for analysis-channel CoT.
+                                        reasoning = (
+                                            delta.get("reasoning_content")
+                                            or delta.get("reasoning")
+                                            or delta.get("thinking")
+                                            or ""
+                                        )
                                         if reasoning:
                                             yield f'data: {json.dumps({"delta": reasoning, "thinking": True})}\n\n'
                                         content = delta.get("content") or ""

--- a/src/text_helpers.py
+++ b/src/text_helpers.py
@@ -42,6 +42,39 @@ _PROMPT_ECHO_RES = (
 # Aggressive heuristic for untagged reasoning prose (models that don't wrap
 # CoT in `<think>` tags). Only applied as opt-in (`prose=True`) because it
 # false-positives on legit user content like "Looking at the attached file…".
+# gpt-oss OpenAI-harmony grammar: <|channel|>analysis<|message|>…<|end|> (double-piped).
+# Distinct from Gemma 4 <|channel>thought (single-piped) handled elsewhere.
+_HARMONY_ANALYSIS_RE = re.compile(
+    r"<\|channel\|>\s*analysis\s*<\|message\|>\s*"
+    r"([\s\S]*?)"
+    r"(?:<\|end\|>|<\|call\|>|<\|return\|>|(?=<\|channel\|>)|$)",
+    re.IGNORECASE,
+)
+_HARMONY_FINAL_RE = re.compile(
+    r"<\|channel\|>\s*final\s*<\|message\|>\s*"
+    r"([\s\S]*?)"
+    r"(?:<\|end\|>|<\|return\|>|(?=<\|channel\|>)|$)",
+    re.IGNORECASE,
+)
+_HARMONY_COMMENTARY_RE = re.compile(
+    r"<\|channel\|>\s*commentary\s*<\|message\|>\s*"
+    r"([\s\S]*?)"
+    r"(?:<\|end\|>|<\|call\|>|<\|return\|>|(?=<\|channel\|>)|$)",
+    re.IGNORECASE,
+)
+_HARMONY_UNCLOSED_ANALYSIS_RE = re.compile(
+    r"<\|channel\|>\s*analysis\s*<\|message\|>\s*([\s\S]+)$",
+    re.IGNORECASE,
+)
+_HARMONY_CONTROL_RE = re.compile(
+    r"<\|(?:start|channel|message|end|return|call|constrain)\|>",
+    re.IGNORECASE,
+)
+_HARMONY_TRAIL_RE = re.compile(
+    r"<\|(?:end|return|call)\|>\s*$",
+    re.IGNORECASE,
+)
+
 _REASONING_PREFIX_RE = re.compile(
     r"^\s*(?:"
     r"the user (?:wants|is|asks|needs|wrote|said|told|messaged|requested)|"
@@ -54,6 +87,39 @@ _REASONING_PREFIX_RE = re.compile(
     r")\b",
     re.IGNORECASE,
 )
+
+
+def normalize_harmony_markup(text: str) -> str:
+    """Convert gpt-oss OpenAI-harmony channel output into Odysseus thinking tags.
+
+    Analysis-channel CoT becomes ``<think>…</think>``;
+    final-channel text is kept as the visible reply. Raw harmony control tokens
+    are stripped so they do not leak into chat bubbles on save or reload.
+    """
+    if not text or "<|channel" not in text:
+        return text
+
+    def _wrap_analysis(m: re.Match) -> str:
+        body = (m.group(1) or "").strip()
+        if not body:
+            return ""
+        return f"<think>{body}</think>\n"
+
+    def _unwrap_channel(m: re.Match) -> str:
+        body = _HARMONY_TRAIL_RE.sub("", (m.group(1) or "")).strip()
+        return f"{body}\n" if body else ""
+
+    out = _HARMONY_ANALYSIS_RE.sub(_wrap_analysis, text)
+    out = _HARMONY_FINAL_RE.sub(_unwrap_channel, out)
+    out = _HARMONY_COMMENTARY_RE.sub(_unwrap_channel, out)
+
+    unc = _HARMONY_UNCLOSED_ANALYSIS_RE.search(out)
+    if unc:
+        body = (unc.group(1) or "").strip()
+        out = out[: unc.start()] + f"<think>{body}</think>"
+
+    out = _HARMONY_CONTROL_RE.sub("", out)
+    return out.strip()
 
 
 def _strip_reasoning_prose(text: str) -> str:
@@ -99,6 +165,7 @@ def strip_think(text: str, *, prose: bool = False, prompt_echo: bool = True) -> 
     """
     if not text:
         return ""
+    text = normalize_harmony_markup(text)
     # Normalize attributes so the closed/open regexes can catch them.
     text = _THINK_ATTR_RE.sub("<think>", text)
     text = _THINK_ATTR_CLOSE_RE.sub("</think>", text)

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1427,6 +1427,9 @@ import createResearchSynapse from './researchSynapse.js';
                 // Detect non-tag thinking patterns: "Thinking:", "Thinking Process:", Gemma-style reasoning
                 // These patterns don't use <think> tags, so we simulate unclosed thinking during streaming
                 const _replyPrefixes = ['Hey', 'Hi ', 'Hi!', 'Hello', 'Sure', 'Yes', 'No ', 'No,', 'Yo', 'OK', 'Here', 'Absolutely', 'Of course', 'Great', 'Alright', 'Thanks', 'Welcome', 'Good ', "I'm happy", "I'd be"];
+                if (!hasUnclosedThink && markdownModule.hasHarmonyAnalysisInProgress(roundText)) {
+                  hasUnclosedThink = true;
+                }
                 if (!hasUnclosedThink && !roundText.includes('<think')) {
                   const _trimmedRT = roundText.trimStart();
                   const _isReasoning = markdownModule.startsWithReasoningPrefix(_trimmedRT);

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -125,8 +125,46 @@ export function startsWithReasoningPrefix(text) {
   return /^\s*(?:thinking(?:\s+process)?\s*:|the user |i need |i should |i will |they are |the question |i can )/i.test(text || '');
 }
 
+/** gpt-oss OpenAI-harmony: <|channel|>analysis<|message|>… → thinking tags. */
+export function normalizeHarmonyMarkup(text) {
+  if (!text || text.indexOf('<|channel') < 0) return text;
+
+  const analysisRe = /<\|channel\|>\s*analysis\s*<\|message\|>\s*([\s\S]*?)(?:<\|end\|>|<\|call\|>|<\|return\|>|(?=<\|channel\|>)|$)/gi;
+  const finalRe = /<\|channel\|>\s*final\s*<\|message\|>\s*([\s\S]*?)(?:<\|end\|>|<\|return\|>|(?=<\|channel\|>)|$)/gi;
+  const commentaryRe = /<\|channel\|>\s*commentary\s*<\|message\|>\s*([\s\S]*?)(?:<\|end\|>|<\|call\|>|<\|return\|>|(?=<\|channel\|>)|$)/gi;
+  const controlRe = /<\|(?:start|channel|message|end|return|call|constrain)\|>/gi;
+  const trailRe = /<\|(?:end|return|call)\|>\s*$/i;
+
+  let out = text.replace(analysisRe, (_m, body) => {
+    const t = (body || '').trim();
+    return t ? `<think>${t}</think>\n` : '';
+  });
+  const unwrap = (_m, body) => {
+    const t = (body || '').replace(trailRe, '').trim();
+    return t ? `${t}\n` : '';
+  };
+  out = out.replace(finalRe, unwrap);
+  out = out.replace(commentaryRe, unwrap);
+
+  const unc = /<\|channel\|>\s*analysis\s*<\|message\|>\s*([\s\S]+)$/i.exec(out);
+  if (unc) {
+    const body = (unc[1] || '').trim();
+    out = out.slice(0, unc.index) + `<think>${body}</think>`;
+  }
+  return out.replace(controlRe, '').trim();
+}
+
+export function hasHarmonyAnalysisInProgress(text) {
+  if (!text || !/<\|channel\|>\s*analysis\s*<\|message\|>/i.test(text)) return false;
+  const finalIdx = text.search(/<\|channel\|>\s*final\s*<\|message\|>/i);
+  const analysisIdx = text.search(/<\|channel\|>\s*analysis\s*<\|message\|>/i);
+  return finalIdx < 0 || finalIdx > analysisIdx;
+}
+
 function normalizePlainThinking(text) {
-  if (!text || /<think/i.test(text)) return text;
+  if (!text) return text;
+  text = normalizeHarmonyMarkup(text);
+  if (/<think/i.test(text)) return text;
 
   const trimmed = text.trimStart();
   if (!startsWithReasoningPrefix(trimmed)) return text;
@@ -687,6 +725,8 @@ const markdownModule = {
   hasUnclosedThinkTag,
   extractThinkingBlocks,
   startsWithReasoningPrefix,
+  normalizeHarmonyMarkup,
+  hasHarmonyAnalysisInProgress,
   renderMermaid
 };
 

--- a/tests/test_harmony_markup.py
+++ b/tests/test_harmony_markup.py
@@ -1,0 +1,46 @@
+"""Regression: gpt-oss OpenAI-harmony analysis-channel tokens must not leak into chat."""
+
+from src.text_helpers import normalize_harmony_markup, strip_think
+from routes.chat_helpers import _normalize_thinking, _extract_thinking_meta
+
+
+def test_analysis_and_final_channels_split():
+    raw = (
+        "<|channel|>analysis<|message|>We are inside Odysseus. We want to list files.<|end|>"
+        "<|channel|>final<|message|>Here are the files in /:<|return|>"
+    )
+    out = normalize_harmony_markup(raw)
+    assert "<|channel|>" not in out
+    assert "We are inside Odysseus" in out
+    assert "Here are the files" in out
+    assert "<think>" in out
+
+
+def test_unclosed_analysis_becomes_thinking():
+    raw = "<|channel|>analysis<|message|>Still reasoning about the request"
+    out = normalize_harmony_markup(raw)
+    assert out.startswith("<think>")
+    assert "Still reasoning" in out
+    assert "<|channel|>" not in out
+
+
+def test_strip_think_removes_harmony_analysis_from_visible():
+    raw = (
+        "<|channel|>analysis<|message|>Internal plan.<|end|>"
+        "<|channel|>final<|message|>The answer.<|return|>"
+    )
+    visible = strip_think(raw)
+    assert "Internal plan" not in visible
+    assert "The answer" in visible
+
+
+def test_chat_helpers_extract_harmony_thinking_meta():
+    raw = (
+        "<|channel|>analysis<|message|>User wants root listing.<|end|>"
+        "<|channel|>final<|message|>bin etc home<|return|>"
+    )
+    normalized = _normalize_thinking(raw)
+    meta = _extract_thinking_meta(normalized)
+    assert meta is not None
+    assert "root listing" in meta["thinking"]
+    assert "bin etc" in meta["reply"]

--- a/tests/test_llm_core_reasoning.py
+++ b/tests/test_llm_core_reasoning.py
@@ -83,6 +83,21 @@ def test_reasoning_field_emits_thinking_chunk(monkeypatch):
     assert any((not d.get("thinking")) and d["delta"] == "Hello" for d in deltas), deltas
 
 
+def test_thinking_field_emits_thinking_chunk(monkeypatch):
+    # Ollama OpenAI-compat gpt-oss streams analysis CoT in `thinking`.
+    deltas = _run_stream(
+        "gpt-oss:20b",
+        [
+            'data: {"choices":[{"delta":{"thinking":"planning shell ls"}}]}',
+            'data: {"choices":[{"delta":{"content":"/bin /etc"}}]}',
+            "data: [DONE]",
+        ],
+        monkeypatch,
+    )
+    assert any(d.get("thinking") and "planning shell" in d["delta"] for d in deltas), deltas
+    assert any((not d.get("thinking")) and "/bin" in d["delta"] for d in deltas), deltas
+
+
 def test_reasoning_content_field_still_supported(monkeypatch):
     # Older builds emit `reasoning_content`; it must still surface as thinking.
     deltas = _run_stream(


### PR DESCRIPTION
## Summary
Normalize OpenAI-harmony `<|channel|>analysis` / `final` tokens so gpt-oss analysis CoT renders in the existing thinking UI instead of the visible assistant reply. Route Ollama `delta.thinking` as thinking chunks alongside `reasoning` / `reasoning_content`.

## Linked Issue
Fixes #2420

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`./start-macos.sh` / uvicorn) and verified the change works end-to-end with `gpt-oss:120b-cloud` on Ollama. Type-checks and unit tests are not enough.

## How to Test
1. Connect Ollama at `http://127.0.0.1:11434/v1` with `gpt-oss:120b-cloud` or local `gpt-oss:20b`.
2. Enable **Agent** mode and **shell**.
3. Send a prompt that triggers analysis (e.g. `what files are in my root directory?`).
4. Confirm analysis appears under **View thinking process**, not as the main reply.

```bash
venv/bin/python -m pytest -q tests/test_harmony_markup.py tests/test_llm_core_reasoning.py
node --check static/js/markdown.js static/js/chat.js
venv/bin/python -m py_compile src/text_helpers.py routes/chat_helpers.py src/llm_core.py
git diff --check
```

## Visual / UI changes
Screenshots attached below: analysis collapsed under "Hide thinking process"; final answer in the main assistant bubble.

- [x] Screenshot or short clip of the change in the running app, attached below.
- [x] Style match: reuses existing thinking-section UI; no new colors, fonts, or components.
- [x] No new component patterns.
- [x] I am not submitting a bulk auto-generated PR.

## Implementation notes
- `src/text_helpers.py`: `normalize_harmony_markup()` for double-piped harmony grammar (distinct from Gemma single-piped `<|channel>thought` in #2224 / #2225).
- `src/llm_core.py`: `delta.thinking` streamed as `{thinking: true}`.
- `static/js/markdown.js` + `static/js/chat.js`: harmony normalization and live-stream detection.
- `routes/chat_helpers.py`: harmony normalization before thinking metadata extraction on save.

## Screenshots
<img width="1147" height="1055" alt="image" src="https://github.com/user-attachments/assets/9a524108-da91-44a1-b5d5-c511b4bcfe9b" />
<img width="1073" height="933" alt="image" src="https://github.com/user-attachments/assets/217e0d3b-ea37-4ea1-bfb2-949fa08d0fd1" />
