### PR TITLE
docs: add agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Agent Guide
+
+This file gives coding agents a compact map of the repository and the rules that keep changes reviewable. It complements, but does not replace, `README.md`, `CONTRIBUTING.md`, and `SECURITY.md`.
+
+## Contribution Rules
+
+- Read `CONTRIBUTING.md`, this file, and the pull request template before changing code.
+- Keep one issue, one focused branch, and one focused pull request. Avoid broad rewrites, formatting-only churn, and unrelated cleanup.
+- Search open issues and pull requests before starting. If the change is large, speculative, or product-facing, open or use an issue first.
+- For UI work, reuse the existing visual language: CSS variables, existing component patterns, dark-theme defaults, and inline SVG/plain text instead of emoji.
+- Do not commit secrets, tokens, private logs, database contents, or user data. Follow `SECURITY.md` for vulnerabilities.
+- When a change affects setup, ports, environment variables, provider support, or documented behavior, update `README.md` and this guide in the same pull request.
+
+## Repository Map
+
+- `app.py` wires the FastAPI app, route modules, middleware, startup work, and static assets.
+- `routes/` contains HTTP route modules for chat, documents, email, calendar, research, settings, uploads, and related UI/API surfaces.
+- `services/` contains domain services such as search, memory, speech, research, email, calendar, and background helpers.
+- `src/` contains compatibility modules and lower-level utilities used by services, routes, and command-line helpers.
+- `mcp_servers/` contains MCP server integrations exposed to agents and external tools.
+- `static/` contains browser assets; `static/js/` modules should stay narrow and reuse existing DOM/CSS patterns.
+- `docs/` contains user-facing guides, screenshots, and the landing page assets.
+- `tests/` contains the regression suite. Add the smallest focused test that covers a bug when practical.
+- `docker/`, `Dockerfile`, and `docker-compose*.yml` define the containerized deployment path.
+- `scripts/`, `setup.py`, `launch-windows.ps1`, and `start-macos.sh` cover setup, maintenance, and platform launch flows.
+
+## Code Change Guidelines
+
+- Prefer surgical fixes over new abstractions. If a helper already exists, reuse it instead of creating a parallel implementation.
+- Preserve owner/user scoping when resolving model endpoints, files, sessions, memories, settings, email accounts, calendars, and background jobs.
+- Treat file paths from users, tools, MCP servers, and archives as untrusted; normalize and confine them before reading or writing.
+- Keep persisted data migrations explicit and backward-compatible. If a schema or settings shape changes, add the matching migration/default handling.
+- For provider/model changes, handle unavailable backends and malformed provider responses gracefully instead of crashing the request path.
+- For background work, avoid silent failures: log actionable errors and keep user-visible status consistent with the actual state.
+
+## Verification Expectations
+
+Run the smallest relevant checks for the touched surface and include the exact commands in the pull request body. Common examples:
+
+```bash
+python -m pytest
+python -m py_compile app.py routes/*.py src/*.py
+node --check static/js/<file-you-changed>.js
+```
+
+For docs-only changes, inspect the rendered Markdown when practical and at least run `git diff --check` to catch whitespace problems.
+
+## Pull Request Notes
+
+Use the repository pull request template. Include a linked issue, the type of change, focused reviewer steps under `How to Test`, and screenshots/clips for anything visual. Be explicit about what the pull request does not change when the surrounding subsystem is larger than the fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Guidance
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

Adds a small repository-root `AGENTS.md` with contribution guardrails, a concise codebase map, verification expectations, and PR guidance for agent-assisted contributors. Adds `CLAUDE.md` as a thin pointer to the canonical guide so Claude-oriented tooling finds the same instructions without duplicating content.

## Linked Issue

Fixes #1928

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  - Not run: documentation-only change; no application behavior or rendered UI changed.

## How to Test

1. Open `AGENTS.md` and confirm it gives focused contributor guardrails, a repository map, and verification expectations without replacing `README.md` or `CONTRIBUTING.md`.
2. Open `CLAUDE.md` and confirm it points readers to `AGENTS.md` instead of duplicating the guide.
3. Run `git diff --check` to confirm the Markdown additions do not introduce whitespace errors.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes. This is a documentation-only PR and does not touch HTML, CSS, SVG, frontend JavaScript, or rendered app components.

- [x] No rendering changed — visual checklist N/A.

### Screenshots / clips

N/A — documentation-only change.
