### PR TITLE
Stabilize full test suite ordering

### DIFF
--- a/tests/test_companion_readonly.py
+++ b/tests/test_companion_readonly.py
@@ -15,16 +15,6 @@ from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# core.database instantiates SQLAlchemy declarative classes at import time, which
-# blows up under conftest's sqlalchemy MagicMock stubs. companion.routes only
-# imports it lazily inside the /models handler, but stub it defensively so the
-# import is robust regardless of collection order.
-if "core.database" not in sys.modules:
-    _db = types.ModuleType("core.database")
-    _db.SessionLocal = MagicMock()
-    _db.ModelEndpoint = MagicMock()
-    sys.modules["core.database"] = _db
-
 import companion.routes as companion_routes
 from companion.routes import setup_companion_routes, token_owner, owner_can_see
 


### PR DESCRIPTION
## Summary

This fixes the full pytest run on current main by isolating database and route stubs that leaked across test modules, tightening stale regression assertions, and keeping a couple of small service regressions covered.

## Linked Issue

Follow-up to #1491.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Check out this branch and install the normal test dependencies.
2. Run the full suite from the repo root:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS="-p no:cacheprovider" venv/bin/python -m pytest -q
```

I ran that command locally and got `1941 passed, 1 skipped`.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI or visual rendering changes.

### Screenshots / clips

Not applicable.