### PR TITLE
Add service health status panel to admin System tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -648,6 +648,10 @@ app.include_router(setup_hwfit_routes())
 from routes.compare_routes import setup_compare_routes
 app.include_router(setup_compare_routes(session_manager))
 
+# System service health probes
+from routes.system_status_routes import setup_system_status_routes
+app.include_router(setup_system_status_routes())
+
 # User Preferences
 from routes.prefs_routes import setup_prefs_routes
 app.include_router(setup_prefs_routes())

--- a/routes/system_status_routes.py
+++ b/routes/system_status_routes.py
@@ -1,0 +1,206 @@
+"""System service health probes — GET /api/system/status (admin only).
+
+Each bundled service gets an independent async probe. _run_probe() wraps
+any probe into a normalised {name, ok, latency_ms, detail} dict:
+  ok=True   — reachable and healthy
+  ok=False  — configured but unreachable / error
+  ok=None   — not configured (raise _Unconfigured from probe); not a failure
+"""
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+from fastapi import APIRouter, Request
+
+from core.middleware import require_admin
+
+logger = logging.getLogger(__name__)
+
+# Per-probe HTTP timeout in seconds. Keeps the endpoint responsive even when
+# a bundled service is completely unreachable (no TCP reset, just silence).
+_PROBE_TIMEOUT = float(os.getenv("SYSTEM_STATUS_TIMEOUT", "3.0"))
+
+
+class _Unconfigured(Exception):
+    """Raised by a probe when the service has no configuration entry.
+    _run_probe treats this as ok=None rather than ok=False."""
+
+
+async def _run_probe(name: str, coro) -> Dict[str, Any]:
+    """Run *coro*, returning a normalised probe result dict.
+
+    Catches _Unconfigured → ok=None, any other exception → ok=False.
+    The coroutine should return a human-readable detail string on success.
+    """
+    t0 = time.monotonic()
+    try:
+        detail = await coro
+        return {
+            "name": name,
+            "ok": True,
+            "latency_ms": round((time.monotonic() - t0) * 1000),
+            "detail": str(detail),
+        }
+    except _Unconfigured as exc:
+        return {
+            "name": name,
+            "ok": None,
+            "latency_ms": 0,
+            "detail": str(exc),
+        }
+    except Exception as exc:
+        return {
+            "name": name,
+            "ok": False,
+            "latency_ms": round((time.monotonic() - t0) * 1000),
+            "detail": str(exc),
+        }
+
+
+async def _chromadb_probe() -> str:
+    """Probe ChromaDB by hitting its heartbeat endpoint."""
+    host = os.getenv("CHROMADB_HOST", "localhost")
+    port = int(os.getenv("CHROMADB_PORT", "8100"))
+    url = f"http://{host}:{port}/api/v2/heartbeat"
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+        r = await client.get(url)
+        r.raise_for_status()
+    return f"Reachable at {host}:{port}"
+
+
+async def _searxng_probe() -> str:
+    """Probe SearXNG by fetching its root page (any 2xx/3xx/4xx = alive)."""
+    from src.constants import SEARXNG_INSTANCE
+    base = SEARXNG_INSTANCE.rstrip("/")
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+        r = await client.get(base + "/")
+        # 5xx = server error (raise); anything below = server is responding
+        if r.status_code >= 500:
+            r.raise_for_status()
+    return f"Reachable at {base}"
+
+
+async def _ntfy_probe() -> str:
+    """Probe the ntfy server configured under Integrations.
+
+    Raises _Unconfigured if no ntfy integration has been added yet so that
+    the frontend shows a neutral 'not configured' indicator rather than a
+    red failure.
+    """
+    from src.integrations import load_integrations
+    integrations = load_integrations()
+    ntfy = next(
+        (i for i in integrations
+         if (i.get("preset") or i.get("name", "")).lower() == "ntfy"),
+        None,
+    )
+    if not ntfy:
+        raise _Unconfigured("Not configured — add ntfy in Settings > Integrations")
+    base_url = (ntfy.get("base_url") or "").strip().rstrip("/")
+    if not base_url:
+        raise _Unconfigured("ntfy base URL is empty — edit the integration in Settings > Integrations")
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+        r = await client.get(base_url + "/")
+        if r.status_code >= 500:
+            r.raise_for_status()
+    return f"Reachable at {base_url}"
+
+
+async def _llm_endpoint_probes() -> List[Dict[str, Any]]:
+    """Probe every enabled LLM endpoint, returning one result dict per endpoint.
+
+    Each dict has the same shape as _run_probe output so the frontend can
+    render them uniformly alongside the bundled-service rows.
+    """
+    from core.database import SessionLocal, ModelEndpoint
+    from src.endpoint_resolver import build_models_url, build_headers
+
+    db = SessionLocal()
+    try:
+        endpoints = (
+            db.query(ModelEndpoint)
+            .filter(ModelEndpoint.is_enabled.is_(True))
+            .all()
+        )
+    finally:
+        db.close()
+
+    if not endpoints:
+        return []
+
+    async def _probe_one(ep) -> Dict[str, Any]:
+        label = ep.name or ep.base_url
+        models_url = build_models_url(ep.base_url)
+        headers = build_headers(ep.api_key, ep.base_url)
+        t0 = time.monotonic()
+        try:
+            async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+                r = await client.get(models_url, headers=headers)
+            ok = r.status_code < 400
+            count = None
+            try:
+                body = r.json()
+                models_list = body.get("models") or body.get("data") or []
+                count = len(models_list)
+            except Exception:
+                pass
+            detail = f"HTTP {r.status_code}"
+            if count is not None:
+                detail += f", {count} model{'s' if count != 1 else ''}"
+            return {
+                "name": label,
+                "ok": ok,
+                "latency_ms": round((time.monotonic() - t0) * 1000),
+                "detail": detail,
+            }
+        except Exception as exc:
+            return {
+                "name": label,
+                "ok": False,
+                "latency_ms": round((time.monotonic() - t0) * 1000),
+                "detail": str(exc),
+            }
+
+    return list(await asyncio.gather(*[_probe_one(ep) for ep in endpoints]))
+
+
+def setup_system_status_routes() -> APIRouter:
+    """Return a router with GET /api/system/status."""
+    router = APIRouter(tags=["system"])
+
+    @router.get("/api/system/status")
+    async def system_status(request: Request) -> Dict[str, Any]:
+        """Return reachability and latency for all configured services.
+
+        Runs all probes concurrently. Response shape:
+          {
+            "services": [
+              {"name": str, "ok": bool|null, "latency_ms": int, "detail": str},
+              ...
+            ],
+            "all_ok": bool   # True only when every *configured* service is up
+          }
+        ok=null means the service is not configured — excluded from all_ok.
+        """
+        require_admin(request)
+
+        bundled = await asyncio.gather(
+            _run_probe("ChromaDB", _chromadb_probe()),
+            _run_probe("SearXNG", _searxng_probe()),
+            _run_probe("ntfy", _ntfy_probe()),
+        )
+
+        llm_results = await _llm_endpoint_probes()
+
+        services: List[Dict[str, Any]] = list(bundled) + llm_results
+
+        # only configured (ok != None) services count toward all_ok
+        configured = [s for s in services if s["ok"] is not None]
+        all_ok = bool(configured) and all(s["ok"] for s in configured)
+
+        return {"services": services, "all_ok": all_ok}
+
+    return router

--- a/routes/system_status_routes.py
+++ b/routes/system_status_routes.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import httpx
 from fastapi import APIRouter, Request
@@ -19,9 +19,9 @@ from core.middleware import require_admin
 
 logger = logging.getLogger(__name__)
 
-# Per-probe HTTP timeout in seconds. Keeps the endpoint responsive even when
-# a bundled service is completely unreachable (no TCP reset, just silence).
-_PROBE_TIMEOUT = float(os.getenv("SYSTEM_STATUS_TIMEOUT", "3.0"))
+def _probe_timeout() -> float:
+    """Read per-call so env-var changes (e.g. in tests) are respected."""
+    return float(os.getenv("SYSTEM_STATUS_TIMEOUT", "3.0"))
 
 
 class _Unconfigured(Exception):
@@ -65,7 +65,7 @@ async def _chromadb_probe() -> str:
     host = os.getenv("CHROMADB_HOST", "localhost")
     port = int(os.getenv("CHROMADB_PORT", "8100"))
     url = f"http://{host}:{port}/api/v2/heartbeat"
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+    async with httpx.AsyncClient(timeout=_probe_timeout()) as client:
         r = await client.get(url)
         r.raise_for_status()
     return f"Reachable at {host}:{port}"
@@ -74,8 +74,10 @@ async def _chromadb_probe() -> str:
 async def _searxng_probe() -> str:
     """Probe SearXNG by fetching its root page (any 2xx/3xx/4xx = alive)."""
     from src.constants import SEARXNG_INSTANCE
+    if not SEARXNG_INSTANCE or not SEARXNG_INSTANCE.strip():
+        raise _Unconfigured("SEARXNG_INSTANCE is not set — configure the SearXNG URL in .env")
     base = SEARXNG_INSTANCE.rstrip("/")
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+    async with httpx.AsyncClient(timeout=_probe_timeout()) as client:
         r = await client.get(base + "/")
         # 5xx = server error (raise); anything below = server is responding
         if r.status_code >= 500:
@@ -102,7 +104,7 @@ async def _ntfy_probe() -> str:
     base_url = (ntfy.get("base_url") or "").strip().rstrip("/")
     if not base_url:
         raise _Unconfigured("ntfy base URL is empty — edit the integration in Settings > Integrations")
-    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+    async with httpx.AsyncClient(timeout=_probe_timeout()) as client:
         r = await client.get(base_url + "/")
         if r.status_code >= 500:
             r.raise_for_status()
@@ -137,7 +139,7 @@ async def _llm_endpoint_probes() -> List[Dict[str, Any]]:
         headers = build_headers(ep.api_key, ep.base_url)
         t0 = time.monotonic()
         try:
-            async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+            async with httpx.AsyncClient(timeout=_probe_timeout()) as client:
                 r = await client.get(models_url, headers=headers)
             ok = r.status_code < 400
             count = None
@@ -187,14 +189,14 @@ def setup_system_status_routes() -> APIRouter:
         """
         require_admin(request)
 
-        bundled = await asyncio.gather(
+        all_results = await asyncio.gather(
             _run_probe("ChromaDB", _chromadb_probe()),
             _run_probe("SearXNG", _searxng_probe()),
             _run_probe("ntfy", _ntfy_probe()),
+            _llm_endpoint_probes(),
         )
-
-        llm_results = await _llm_endpoint_probes()
-
+        bundled = all_results[:3]
+        llm_results = all_results[3]
         services: List[Dict[str, Any]] = list(bundled) + llm_results
 
         # only configured (ok != None) services count toward all_ok

--- a/routes/system_status_routes.py
+++ b/routes/system_status_routes.py
@@ -52,6 +52,7 @@ async def _run_probe(name: str, coro) -> Dict[str, Any]:
             "detail": str(exc),
         }
     except Exception as exc:
+        logger.warning("Probe %r failed: %s", name, exc)
         return {
             "name": name,
             "ok": False,
@@ -93,7 +94,7 @@ async def _ntfy_probe() -> str:
     red failure.
     """
     from src.integrations import load_integrations
-    integrations = load_integrations()
+    integrations = await asyncio.to_thread(load_integrations)
     ntfy = next(
         (i for i in integrations
          if (i.get("preset") or i.get("name", "")).lower() == "ntfy"),
@@ -143,14 +144,17 @@ async def _llm_endpoint_probes() -> List[Dict[str, Any]]:
                 r = await client.get(models_url, headers=headers)
             ok = r.status_code < 400
             count = None
-            try:
-                body = r.json()
-                models_list = body.get("models") or body.get("data") or []
-                count = len(models_list)
-            except Exception:
-                pass
+            if ok:
+                try:
+                    body = r.json()
+                    models_list = body.get("models") or body.get("data") or []
+                    count = len(models_list)
+                except Exception:
+                    pass
             detail = f"HTTP {r.status_code}"
-            if count is not None:
+            if r.status_code in (401, 403):
+                detail += " — check API key"
+            elif count is not None:
                 detail += f", {count} model{'s' if count != 1 else ''}"
             return {
                 "name": label,
@@ -159,11 +163,12 @@ async def _llm_endpoint_probes() -> List[Dict[str, Any]]:
                 "detail": detail,
             }
         except Exception as exc:
+            logger.warning("Probe failed for endpoint %r: %s", label, exc)
             return {
                 "name": label,
                 "ok": False,
                 "latency_ms": round((time.monotonic() - t0) * 1000),
-                "detail": str(exc),
+                "detail": "Connection failed",
             }
 
     return list(await asyncio.gather(*[_probe_one(ep) for ep in endpoints]))
@@ -201,7 +206,8 @@ def setup_system_status_routes() -> APIRouter:
 
         # only configured (ok != None) services count toward all_ok
         configured = [s for s in services if s["ok"] is not None]
-        all_ok = bool(configured) and all(s["ok"] for s in configured)
+        # Vacuous truth: no configured services means nothing is broken yet
+        all_ok = not configured or all(s["ok"] for s in configured)
 
         return {"services": services, "all_ok": all_ok}
 

--- a/static/index.html
+++ b/static/index.html
@@ -2142,6 +2142,12 @@
         <div data-settings-panel="system" class="hidden">
 
           <div class="admin-card">
+            <h2 style="display:flex;align-items:center;justify-content:space-between;"><span><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>Service Status</span><button class="admin-btn-sm" id="adm-svc-refresh" style="font-size:11px;margin-left:auto;">Refresh</button></h2>
+            <div class="admin-toggle-sub" style="margin-bottom:8px">Connectivity check for bundled services and configured model endpoints.</div>
+            <div id="adm-service-status-list"><div class="admin-empty">Loading...</div></div>
+          </div>
+
+          <div class="admin-card">
             <h2><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:5px;opacity:0.6"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>Data Backup</h2>
             <div class="admin-toggle-sub" style="margin-bottom:8px">Export or import your user data (memories, presets, settings, skills, preferences) as a JSON file.</div>
             <div style="display:flex;gap:8px;flex-wrap:wrap;">

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1960,10 +1960,10 @@ async function loadServiceStatus() {
         ? 'var(--green)'
         : svc.ok === false
           ? 'var(--red)'
-          : 'color-mix(in srgb, var(--fg) 40%, transparent)';
+          : 'color-mix(in srgb, var(--fg) 50%, transparent)';
       const dot = `<svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true" style="flex-shrink:0;margin-top:3px"><circle cx="4" cy="4" r="4" fill="${color}"/></svg>`;
-      const latency = (svc.ok === true && svc.latency_ms != null)
-        ? `<span style="font-size:10px;opacity:0.4;margin-left:6px;">${svc.latency_ms}ms</span>`
+      const latency = (svc.ok === true && Number.isFinite(+svc.latency_ms))
+        ? `<span style="font-size:10px;opacity:0.4;margin-left:6px;">${+svc.latency_ms}ms</span>`
         : '';
       const detail = svc.detail
         ? `<div style="font-size:11px;opacity:0.45;margin-top:2px;">${esc(svc.detail)}</div>`

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1939,6 +1939,48 @@ const featureLabels = {
   gallery: 'Gallery'
 };
 
+/* ── Service Status ── */
+async function loadServiceStatus() {
+  const list = el('adm-service-status-list');
+  if (!list) return;
+  list.innerHTML = '<div class="admin-empty">Checking services…</div>';
+  try {
+    const res = await fetch('/api/system/status', { credentials: 'same-origin' });
+    if (!res.ok) {
+      list.innerHTML = '<div class="admin-error">Failed to load service status</div>';
+      return;
+    }
+    const data = await res.json();
+    if (!data.services || !data.services.length) {
+      list.innerHTML = '<div class="admin-empty">No services found</div>';
+      return;
+    }
+    list.innerHTML = data.services.map(svc => {
+      const color = svc.ok === true
+        ? 'var(--green)'
+        : svc.ok === false
+          ? 'var(--red)'
+          : 'color-mix(in srgb, var(--fg) 40%, transparent)';
+      const dot = `<svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true" style="flex-shrink:0;margin-top:3px"><circle cx="4" cy="4" r="4" fill="${color}"/></svg>`;
+      const latency = (svc.ok === true && svc.latency_ms != null)
+        ? `<span style="font-size:10px;opacity:0.4;margin-left:6px;">${svc.latency_ms}ms</span>`
+        : '';
+      const detail = svc.detail
+        ? `<div style="font-size:11px;opacity:0.45;margin-top:2px;">${esc(svc.detail)}</div>`
+        : '';
+      return `<div class="admin-toggle-row" style="padding:6px 0;border-bottom:1px solid var(--border);align-items:flex-start;gap:8px;">
+        ${dot}
+        <div style="flex:1;min-width:0;">
+          <span style="font-size:12px;">${esc(svc.name)}</span>${latency}
+          ${detail}
+        </div>
+      </div>`;
+    }).join('');
+  } catch (e) {
+    list.innerHTML = `<div class="admin-error">Error: ${esc(e.message)}</div>`;
+  }
+}
+
 async function loadFeatures() {
   const container = el('adm-featureToggles');
   try {
@@ -2097,9 +2139,22 @@ function initDangerZone() {
 /* ═══════════════════════════════════════════
    INIT & REFRESH
    ═══════════════════════════════════════════ */
+function initServiceStatusRefresh() {
+  const btn = el('adm-svc-refresh');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    btn.disabled = true;
+    btn.textContent = 'Checking…';
+    loadServiceStatus().finally(() => {
+      btn.disabled = false;
+      btn.textContent = 'Refresh';
+    });
+  });
+}
+
 function initAll() {
   modalEl = el('settings-modal');
-  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations()];
+  const inits = [initSignupToggle, initAddUser, initEndpointForm, initMcpForm, initCalDAV, initBackup, initDangerZone, () => settingsModule.initIntegrations(), initServiceStatusRefresh];
   for (const fn of inits) {
     try { fn(); } catch (e) { console.error('Admin init error in', fn.name || 'anonymous', e); }
   }
@@ -2112,6 +2167,7 @@ function refreshAll() {
   loadEndpoints();
   loadBuiltinTools();
   loadMcpServers();
+  loadServiceStatus();
 }
 
 /* ═══════════════════════════════════════════

--- a/tests/test_system_status_routes.py
+++ b/tests/test_system_status_routes.py
@@ -1,0 +1,262 @@
+"""Unit tests for routes/system_status_routes.py."""
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_dependencies(monkeypatch):
+    mw = types.ModuleType("core.middleware")
+    mw.require_admin = lambda request: None
+    monkeypatch.setitem(sys.modules, "core.middleware", mw)
+
+    db_mod = types.ModuleType("core.database")
+    db_mod.SessionLocal = MagicMock()
+    db_mod.ModelEndpoint = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.database", db_mod)
+
+    const_mod = types.ModuleType("src.constants")
+    const_mod.SEARXNG_INSTANCE = "http://searxng-test:8080"
+    monkeypatch.setitem(sys.modules, "src.constants", const_mod)
+
+    intg_mod = types.ModuleType("src.integrations")
+    intg_mod.load_integrations = lambda: []
+    monkeypatch.setitem(sys.modules, "src.integrations", intg_mod)
+
+    ep_mod = types.ModuleType("src.endpoint_resolver")
+    ep_mod.build_models_url = lambda base: base.rstrip("/") + "/models"
+    ep_mod.build_headers = lambda api_key, base: {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    monkeypatch.setitem(sys.modules, "src.endpoint_resolver", ep_mod)
+
+    yield
+
+
+def _import_module():
+    if "routes.system_status_routes" in sys.modules:
+        del sys.modules["routes.system_status_routes"]
+    import importlib
+    return importlib.import_module("routes.system_status_routes")
+
+
+class TestRunProbe:
+    def test_success(self):
+        mod = _import_module()
+        async def _ok():
+            return "all good"
+        result = asyncio.run(mod._run_probe("Svc", _ok()))
+        assert result["ok"] is True
+        assert result["detail"] == "all good"
+        assert isinstance(result["latency_ms"], int)
+
+    def test_exception_ok_false(self):
+        mod = _import_module()
+        async def _fail():
+            raise ConnectionError("refused")
+        result = asyncio.run(mod._run_probe("Svc", _fail()))
+        assert result["ok"] is False
+        assert "refused" in result["detail"]
+
+    def test_unconfigured_ok_none(self):
+        mod = _import_module()
+        async def _unc():
+            raise mod._Unconfigured("no url")
+        result = asyncio.run(mod._run_probe("ntfy", _unc()))
+        assert result["ok"] is None
+        assert "no url" in result["detail"]
+
+
+class TestChromadbProbe:
+    def test_success(self, monkeypatch):
+        mod = _import_module()
+        monkeypatch.setenv("CHROMADB_HOST", "chroma-host")
+        monkeypatch.setenv("CHROMADB_PORT", "8200")
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        async def mock_get(url, **kwargs):
+            assert "chroma-host" in url and "8200" in url
+            return mock_resp
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            detail = asyncio.run(mod._chromadb_probe())
+        assert "chroma-host" in detail and "8200" in detail
+
+    def test_connection_error_propagates(self, monkeypatch):
+        mod = _import_module()
+        async def mock_get(url, **kwargs):
+            raise ConnectionError("down")
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(ConnectionError):
+                asyncio.run(mod._chromadb_probe())
+
+
+class TestSearxngProbe:
+    def test_success(self):
+        mod = _import_module()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        async def mock_get(url, **kwargs):
+            return mock_resp
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            detail = asyncio.run(mod._searxng_probe())
+        assert "searxng-test" in detail
+
+    def test_5xx_raises(self):
+        mod = _import_module()
+        import httpx as real_httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.raise_for_status.side_effect = real_httpx.HTTPStatusError("503", request=MagicMock(), response=mock_resp)
+        async def mock_get(url, **kwargs):
+            return mock_resp
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(real_httpx.HTTPStatusError):
+                asyncio.run(mod._searxng_probe())
+
+
+class TestNtfyProbe:
+    def test_unconfigured_when_no_integration(self):
+        mod = _import_module()
+        with pytest.raises(mod._Unconfigured):
+            asyncio.run(mod._ntfy_probe())
+
+    def test_unconfigured_when_base_url_empty(self):
+        mod = _import_module()
+        sys.modules["src.integrations"].load_integrations = lambda: [{"preset": "ntfy", "base_url": ""}]
+        try:
+            with pytest.raises(mod._Unconfigured):
+                asyncio.run(mod._ntfy_probe())
+        finally:
+            sys.modules["src.integrations"].load_integrations = lambda: []
+
+    def test_success(self):
+        mod = _import_module()
+        sys.modules["src.integrations"].load_integrations = lambda: [{"preset": "ntfy", "base_url": "http://ntfy-host:8091"}]
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        async def mock_get(url, **kwargs):
+            return mock_resp
+        try:
+            with patch("httpx.AsyncClient") as mock_cls:
+                mock_client = AsyncMock()
+                mock_client.get = mock_get
+                mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+                detail = asyncio.run(mod._ntfy_probe())
+            assert "ntfy-host" in detail
+        finally:
+            sys.modules["src.integrations"].load_integrations = lambda: []
+
+
+class TestLlmEndpointProbes:
+    def test_empty_when_no_endpoints(self):
+        mod = _import_module()
+        db_mod = sys.modules["core.database"]
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+        db_mod.SessionLocal.return_value = mock_db
+        results = asyncio.run(mod._llm_endpoint_probes())
+        assert results == []
+
+    def test_ok_endpoint(self):
+        mod = _import_module()
+        db_mod = sys.modules["core.database"]
+        ep = MagicMock()
+        ep.name = "Local Ollama"
+        ep.base_url = "http://localhost:11434/v1"
+        ep.api_key = None
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = [ep]
+        db_mod.SessionLocal.return_value = mock_db
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"models": ["llama3"]}
+        async def mock_get(url, **kwargs):
+            return mock_resp
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            results = asyncio.run(mod._llm_endpoint_probes())
+        assert len(results) == 1
+        assert results[0]["ok"] is True
+        assert results[0]["name"] == "Local Ollama"
+
+    def test_unreachable_endpoint(self):
+        mod = _import_module()
+        db_mod = sys.modules["core.database"]
+        ep = MagicMock()
+        ep.name = "Bad EP"
+        ep.base_url = "http://dead:9999/v1"
+        ep.api_key = None
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = [ep]
+        db_mod.SessionLocal.return_value = mock_db
+        async def mock_get(url, **kwargs):
+            raise ConnectionError("refused")
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            results = asyncio.run(mod._llm_endpoint_probes())
+        assert results[0]["ok"] is False
+
+
+class TestSystemStatusRoute:
+    def test_all_ok_false_when_service_fails(self):
+        mod = _import_module()
+        router = mod.setup_system_status_routes()
+        handler = next(r.endpoint for r in router.routes if r.path == "/api/system/status")
+        async def patched_chromadb(): raise ConnectionError("down")
+        async def patched_searxng(): return "ok"
+        async def patched_ntfy(): raise mod._Unconfigured("not set")
+        async def patched_llm(): return []
+        with (
+            patch.object(mod, "_chromadb_probe", patched_chromadb),
+            patch.object(mod, "_searxng_probe", patched_searxng),
+            patch.object(mod, "_ntfy_probe", patched_ntfy),
+            patch.object(mod, "_llm_endpoint_probes", patched_llm),
+        ):
+            result = asyncio.run(handler(request=MagicMock()))
+        assert result["all_ok"] is False
+        names = [s["name"] for s in result["services"]]
+        assert "ChromaDB" in names and "SearXNG" in names and "ntfy" in names
+
+    def test_all_ok_true_ignores_unconfigured(self):
+        mod = _import_module()
+        router = mod.setup_system_status_routes()
+        handler = next(r.endpoint for r in router.routes if r.path == "/api/system/status")
+        async def patched_chromadb(): return "Reachable at localhost:8100"
+        async def patched_searxng(): return "Reachable at http://localhost:8080"
+        async def patched_ntfy(): raise mod._Unconfigured("not set")
+        async def patched_llm(): return [{"name": "Ollama", "ok": True, "latency_ms": 10, "detail": "HTTP 200, 2 models"}]
+        with (
+            patch.object(mod, "_chromadb_probe", patched_chromadb),
+            patch.object(mod, "_searxng_probe", patched_searxng),
+            patch.object(mod, "_ntfy_probe", patched_ntfy),
+            patch.object(mod, "_llm_endpoint_probes", patched_llm),
+        ):
+            result = asyncio.run(handler(request=MagicMock()))
+        ntfy_entry = next(s for s in result["services"] if s["name"] == "ntfy")
+        assert ntfy_entry["ok"] is None
+        assert result["all_ok"] is True

--- a/tests/test_system_status_routes.py
+++ b/tests/test_system_status_routes.py
@@ -133,12 +133,9 @@ class TestSearxngProbe:
 
     def test_unconfigured_when_instance_empty(self, monkeypatch):
         mod = _import_module()
-        sys.modules["src.constants"].SEARXNG_INSTANCE = ""
-        try:
-            with pytest.raises(mod._Unconfigured):
-                asyncio.run(mod._searxng_probe())
-        finally:
-            sys.modules["src.constants"].SEARXNG_INSTANCE = "http://searxng-test:8080"
+        monkeypatch.setattr(sys.modules["src.constants"], "SEARXNG_INSTANCE", "")
+        with pytest.raises(mod._Unconfigured):
+            asyncio.run(mod._searxng_probe())
 
 
 class TestNtfyProbe:
@@ -147,32 +144,26 @@ class TestNtfyProbe:
         with pytest.raises(mod._Unconfigured):
             asyncio.run(mod._ntfy_probe())
 
-    def test_unconfigured_when_base_url_empty(self):
+    def test_unconfigured_when_base_url_empty(self, monkeypatch):
         mod = _import_module()
-        sys.modules["src.integrations"].load_integrations = lambda: [{"preset": "ntfy", "base_url": ""}]
-        try:
-            with pytest.raises(mod._Unconfigured):
-                asyncio.run(mod._ntfy_probe())
-        finally:
-            sys.modules["src.integrations"].load_integrations = lambda: []
+        monkeypatch.setattr(sys.modules["src.integrations"], "load_integrations", lambda: [{"preset": "ntfy", "base_url": ""}])
+        with pytest.raises(mod._Unconfigured):
+            asyncio.run(mod._ntfy_probe())
 
-    def test_success(self):
+    def test_success(self, monkeypatch):
         mod = _import_module()
-        sys.modules["src.integrations"].load_integrations = lambda: [{"preset": "ntfy", "base_url": "http://ntfy-host:8091"}]
+        monkeypatch.setattr(sys.modules["src.integrations"], "load_integrations", lambda: [{"preset": "ntfy", "base_url": "http://ntfy-host:8091"}])
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         async def mock_get(url, **kwargs):
             return mock_resp
-        try:
-            with patch("httpx.AsyncClient") as mock_cls:
-                mock_client = AsyncMock()
-                mock_client.get = mock_get
-                mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-                mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-                detail = asyncio.run(mod._ntfy_probe())
-            assert "ntfy-host" in detail
-        finally:
-            sys.modules["src.integrations"].load_integrations = lambda: []
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            detail = asyncio.run(mod._ntfy_probe())
+        assert "ntfy-host" in detail
 
 
 class TestLlmEndpointProbes:

--- a/tests/test_system_status_routes.py
+++ b/tests/test_system_status_routes.py
@@ -131,6 +131,15 @@ class TestSearxngProbe:
             with pytest.raises(real_httpx.HTTPStatusError):
                 asyncio.run(mod._searxng_probe())
 
+    def test_unconfigured_when_instance_empty(self, monkeypatch):
+        mod = _import_module()
+        sys.modules["src.constants"].SEARXNG_INSTANCE = ""
+        try:
+            with pytest.raises(mod._Unconfigured):
+                asyncio.run(mod._searxng_probe())
+        finally:
+            sys.modules["src.constants"].SEARXNG_INSTANCE = "http://searxng-test:8080"
+
 
 class TestNtfyProbe:
     def test_unconfigured_when_no_integration(self):


### PR DESCRIPTION
## Summary

The admin System tab had no way to check whether ChromaDB, SearXNG, ntfy, or any of the configured model endpoints were actually reachable. You'd only find out something was broken when a feature silently stopped working. This adds a Service Status card that runs concurrent probes in the background and shows each service as a colored dot — green for ok, red for failing, gray for not configured — with latency and a short message explaining failures.

Backend is a single `/api/system/status` endpoint in a new `routes/system_status_routes.py` module. Each service has its own async probe function; they all run in one `asyncio.gather` call so the whole panel loads in one round trip. Unconfigured services return `ok=null` rather than an error so a fresh install doesn't show everything as broken. LLM endpoint errors are logged server-side and a generic message returned to the client to avoid leaking API keys.

Frontend is a small addition to `admin.js` — a `loadServiceStatus()` function and a Refresh button wired to it. Styles use only existing CSS variables and admin card classes.

## Linked Issue

Fixes #2463

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Start the app: `uvicorn app:app --host 0.0.0.0 --port 7000`
2. Log in as admin, open Settings → System tab.
3. The Service Status card shows up. Each configured service gets a dot — green if reachable, red with an error message if not, gray if unconfigured.
4. Click Refresh — dots and latency update live.
5. To test failure state: stop ChromaDB or point `CHROMADB_HOST` at a bad address and refresh — it turns red with a connection error.
6. Leave `SEARXNG_INSTANCE` blank — SearXNG shows gray (not configured), not red.
7. `pytest tests/test_system_status_routes.py -v` — 16 tests, all pass.

## Visual / UI changes

- [x] **Screenshot** attached below.
- [x] **Style match** — only existing variables (`--green`, `--red`, `--fg`, `--border`) and existing classes (`admin-card`, `admin-toggle-row`, `admin-btn-sm`, `admin-empty`, `admin-error`). No new color values, font sizes, or spacing units.
- [x] **No new component patterns** — extends the existing admin settings card.
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots

<img width="1725" height="999" alt="Screenshot 2026-06-04 at 2 31 15 PM" src="https://github.com/user-attachments/assets/908c4e43-11bd-4e61-aafc-bcbbe66094e8" />
