### PR TITLE
fix(context): preserve history when compaction summary fails

### DIFF
--- a/src/context_compactor.py
+++ b/src/context_compactor.py
@@ -339,7 +339,7 @@ async def maybe_compact(
         )
     except Exception as e:
         logger.error(f"Compaction summary failed: {e}")
-        return system_msgs + recent, context_length, False
+        return messages, context_length, False
 
     summary_msg = {
         "role": "system",

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -192,3 +192,53 @@ class TestMaybeCompactFourthMessage:
         ]}
         result = self._run(messages)
         assert len(result) == 3 and result[2] is True
+
+
+class TestMaybeCompactFailure:
+    def test_summary_failure_preserves_original_messages(self):
+        messages = [
+            {"role": "system", "content": "You are helpful. " * 200},
+            {"role": "user", "content": "OLDER-1"},
+            {"role": "assistant", "content": "OLDER-2"},
+            {"role": "user", "content": "OLDER-3"},
+            {"role": "assistant", "content": "RECENT-1"},
+            {"role": "user", "content": "RECENT-2"},
+            {"role": "assistant", "content": "RECENT-3"},
+        ]
+
+        orig_ctx = cc.get_context_length
+        orig_call = cc.llm_call_async
+        orig_resolve = cc.resolve_endpoint
+
+        async def _boom(*a, **k):
+            raise RuntimeError("summary model down")
+
+        cc.get_context_length = lambda url, model: 500
+        cc.llm_call_async = _boom
+        cc.resolve_endpoint = lambda which: (None, None, None)
+        try:
+            compacted_messages, context_length, was_compacted = asyncio.run(
+                maybe_compact(
+                    session=None,
+                    endpoint_url="http://local/v1/chat/completions",
+                    model="local-model",
+                    messages=list(messages),
+                    headers={},
+                )
+            )
+        finally:
+            cc.get_context_length = orig_ctx
+            cc.llm_call_async = orig_call
+            cc.resolve_endpoint = orig_resolve
+
+        assert compacted_messages == messages
+        assert context_length == 500
+        assert was_compacted is False
+        assert [m["content"] for m in compacted_messages if m["role"] != "system"] == [
+            "OLDER-1",
+            "OLDER-2",
+            "OLDER-3",
+            "RECENT-1",
+            "RECENT-2",
+            "RECENT-3",
+        ]


### PR DESCRIPTION
## Summary

When automatic context compaction crosses the threshold but the summary LLM call fails, keep the original message list unchanged instead of returning only the system preface plus recent messages. This prevents a transient utility-model failure from silently dropping the older half of the conversation while reporting `was_compacted=False`.

## Linked Issue

Fixes #2160

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `.venv/bin/python -m pytest -q tests/test_context_compactor.py tests/test_context_compactor_nonstring.py` and confirm the context compactor regression suite passes.
2. Run `.venv/bin/python -m py_compile src/context_compactor.py` to verify the touched backend module compiles.
3. Optional manual check: force `maybe_compact()` over the compaction threshold and make `llm_call_async` raise; the returned messages should equal the original input and `was_compacted` should be `False`.

Local results:

```text
.venv/bin/python -m pytest -q tests/test_context_compactor.py tests/test_context_compactor_nonstring.py
22 passed in 0.29s

.venv/bin/python -m py_compile src/context_compactor.py
passed
```

I also attempted a local `uvicorn app:app` smoke run, but this fresh manual checkout has not been initialized with a writable SQLite data path yet, so startup failed before serving with `sqlite3.OperationalError: unable to open database file`. The change itself is covered by the focused unit regression above.

Prepared with assistance from OpenAI Codex.

## Visual / UI changes — REQUIRED if you touched anything that renders

Backend-only change; no visual/UI rendering files were touched.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Not applicable; backend-only context compaction change.
