### PR TITLE
fix(models): make pinned models visible in chat UI model selector

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1028,12 +1028,13 @@ def setup_model_routes(model_discovery):
         for ep in endpoints:
             base = _normalize_base(ep.base_url)
             provider = _detect_provider(base)
-            # Use cached models — background refresh keeps them updated
-            model_ids = _cached_model_ids(ep)
+            # Merge cached + pinned models, then filter out hidden ones
             ep_model_type = getattr(ep, "model_type", None) or "llm"
-            # Filter out hidden (probe-failed) models
-            hidden = _hidden_model_ids(ep)
-            model_ids = [m for m in model_ids if m not in hidden]
+            model_ids = _visible_models(
+                _cached_model_ids(ep),
+                ep.hidden_models,
+                getattr(ep, "pinned_models", None),
+            )
             # Build correct URL based on provider
             chat_url = build_chat_url(base)
             kind = _effective_endpoint_kind(ep, base)
@@ -1042,6 +1043,13 @@ def setup_model_routes(model_discovery):
             if model_ids:
                 curated_key = _match_provider_curated(base, None)
                 curated, extra = _curate_models(model_ids, curated_key)
+                # Pinned models are admin-selected — they always belong in the
+                # primary curated list, not buried in extras.
+                pinned = _normalize_model_ids(getattr(ep, "pinned_models", None))
+                for m in pinned:
+                    if m not in curated:
+                        curated.append(m)
+                extra = [m for m in extra if m not in pinned]
                 items.append({
                     "host": "custom",
                     "port": 0,


### PR DESCRIPTION
Two bugs prevented pinned models from appearing in the chat model picker:

1. _fetch_models() only used _cached_model_ids(), ignoring pinned_models. Since a provider may not list a pinned model in its `/v1/models` response, the cached list was empty, so the endpoint showed as offline with no models.

2. _curate_models() filtered unknown pinned IDs into models_extra, but the chat UI only reads models (primary list). Pinned models stayed invisible.

Fix: use _visible_models() to merge cached + pinned, then promote pinned IDs from models_extra to models so they appear in the dropdown.

## Summary

This PR fixes the model picker so that admin-pinned models (added via #1521) actually appear in the chat UI and are selectable. Before this fix, `_fetch_models()` only read cached models from the provider's `/v1/models` list, ignoring any pinned model IDs. For providers that do not expose every model ID in their model list, or providers that don't expose `/v1/models` at all, the cached set was empty, causing the endpoint to show as "offline" with no models. Additionally, `_curate_models()` sorted unknown pinned IDs into the `models_extra` secondary list, which the chat UI does not read. The fix merges cached and pinned models via `_visible_models()` and then promotes pinned IDs into the primary `models` list, making them visible and selectable.

## Linked Issue

Part of #1521, related PR #2550

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Add an endpoint for any provider that does not list a specific model ID in its `/v1/models` response.
2. Pin a model that the provider does not auto-list (e.g. a model ID the provider does not expose in its model list) via PATCH `/api/model-endpoints/{id}/models`.
3. Set the pinned model as your default chat model.
4. Open the chat page and click the model selector. The pinned model should appear and be selectable.
5. Send a message. The chat should successfully route to the pinned model instead of showing "No models connected".

## Visual / UI changes — REQUIRED if you touched anything that renders

**No visual changes.** 

### Screenshots / clips

<img width="601" height="286" alt="image" src="https://github.com/user-attachments/assets/3623caa0-d53b-47e1-9a53-c7cab3f73b0e" />
