### PR TITLE
fix(documents): prevent cross-document overwrite from stale AI diff

### DIFF
--- a/static/js/document.js
+++ b/static/js/document.js
@@ -8978,6 +8978,14 @@ import * as Modals from './modalManager.js';
 
   /** Open the document panel immediately for a doc being streamed in */
   export function streamDocOpen(title, language) {
+    // Discard any pending AI-edit diff before this stream changes the active
+    // document. When the AI streams a NEW document while an unapproved diff is
+    // open on the current one, streamDocOpen reassigns activeDocId below; if the
+    // stale diff isn't cleared first, a later exitDiffMode applies the old doc's
+    // content to the new one and overwrites it (issue #2467). activeDocId still
+    // points at the previously-active doc here, so exitDiffMode(true) restores
+    // and saves THAT doc — same guard handleDocUpdate/switchToDoc use.
+    if (_diffModeActive) exitDiffMode(true);
     // If already streaming a doc, reuse it (don't create a second temp doc)
     if (_streamDocId && docs.has(_streamDocId)) {
       const existing = docs.get(_streamDocId);
@@ -9199,6 +9207,16 @@ import * as Modals from './modalManager.js';
   /** Handle SSE doc_update event from AI */
   export function handleDocUpdate(data) {
     const streamingId = streamDocFinalize();
+    // Discard any pending AI-edit diff before this update changes the active
+    // document. The diff state (_diffModeActive/_diffOldContent/...) is a
+    // module-global singleton bound to whatever doc was active when the diff
+    // opened; if we switch documents without clearing it, a later tab switch or
+    // Accept/Reject-All flushes the stale diff's content into the now-active
+    // doc and silently overwrites it (issue #2467). activeDocId still points at
+    // the previously-active doc here, so exitDiffMode(true) restores and saves
+    // THAT doc before we reassign activeDocId below — mirroring switchToDoc()
+    // and enterDiffMode().
+    if (_diffModeActive) exitDiffMode(true);
     let docId = data.doc_id;
     const newContent = data.content || '';
 

--- a/tests/test_document_diff_discard_on_update_js.py
+++ b/tests/test_document_diff_discard_on_update_js.py
@@ -1,0 +1,77 @@
+"""Regression guard for issue #2467 — cross-document overwrite via a stale AI-edit diff.
+
+document.js keeps the AI-edit diff state (``_diffModeActive`` / ``_diffOldContent`` /
+``_diffNewContent`` / ``_diffChunks``) as a module-global singleton bound to whatever
+document was active when the diff opened. ``handleDocUpdate()`` switches the active
+document (``activeDocId``) whenever an AI update targets a different doc. If a pending
+diff is not discarded first, a later tab switch (``switchToDoc`` → ``exitDiffMode(true)``)
+or Accept/Reject-All flushes the stale diff's content into the now-active document and
+silently overwrites it.
+
+The fix discards any pending diff while ``activeDocId`` still points at the
+previously-active doc, mirroring the guard ``switchToDoc()`` and ``enterDiffMode()``
+already use. It must run in BOTH places that switch the active document for an AI
+update: ``handleDocUpdate()`` and ``streamDocOpen()``. The streamed path matters most —
+when the AI creates a NEW document (the issue's own repro), ``streamDocOpen`` reassigns
+``activeDocId`` first, so a guard only in ``handleDocUpdate`` would fire too late and
+still overwrite the new doc. Kept as a static source check because document.js is
+browser-coupled and not importable in pytest.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_JS = (ROOT / "static/js/document.js").read_text()
+
+GUARD = "if (_diffModeActive) exitDiffMode(true);"
+
+
+def _function_body(src: str, signature: str) -> str:
+    """Return the full text of a JS function, brace-matched from its signature."""
+    start = src.index(signature)
+    depth = 0
+    i = src.index("{", start)
+    while i < len(src):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+    raise AssertionError(f"unbalanced braces after {signature!r}")
+
+
+HANDLE_DOC_UPDATE = _function_body(DOC_JS, "export function handleDocUpdate(data)")
+STREAM_DOC_OPEN = _function_body(DOC_JS, "export function streamDocOpen(title, language)")
+
+
+def test_handle_doc_update_discards_pending_diff():
+    # A new AI update on a different document must not leave a stale diff bound
+    # to the old doc, or a later tab switch / Accept-All overwrites the wrong doc.
+    assert GUARD in HANDLE_DOC_UPDATE
+
+
+def test_diff_discard_runs_before_active_doc_is_switched():
+    # The discard must run while activeDocId still points at the previously
+    # active doc, so exitDiffMode(true) restores and saves THAT doc — not the new
+    # one. Any activeDocId reassignment inside handleDocUpdate must come after it.
+    guard_at = HANDLE_DOC_UPDATE.index(GUARD)
+    reassign_at = HANDLE_DOC_UPDATE.index("activeDocId = docId;")
+    assert guard_at < reassign_at
+
+
+def test_stream_doc_open_discards_pending_diff_before_switching():
+    # The AI-creates-a-new-document path switches activeDocId inside
+    # streamDocOpen (before any doc_update reaches handleDocUpdate), so the guard
+    # must be here too — and before streamDocOpen reassigns activeDocId, or the
+    # streamed new doc gets overwritten by the stale diff (the issue's own repro).
+    assert GUARD in STREAM_DOC_OPEN
+    assert STREAM_DOC_OPEN.index(GUARD) < STREAM_DOC_OPEN.index("activeDocId = docId;")
+
+
+def test_diff_discard_reuses_the_existing_idiom():
+    # Sanity: this exact guard is the established pattern (switchToDoc,
+    # enterDiffMode, handleDocUpdate, streamDocOpen, …) — the fix reuses it
+    # rather than inventing a new mechanism.
+    assert DOC_JS.count(GUARD) >= 5


### PR DESCRIPTION
## Summary

The document editor keeps the AI-edit diff state (`_diffModeActive`, `_diffOldContent`, `_diffNewContent`, `_diffChunks`) as a module-global singleton bound to whatever document was active when the diff opened, and every document shares one `#doc-editor-textarea`. When the active document is switched while an unapproved diff is open, the stale diff must be discarded first — otherwise a later `exitDiffMode` (a tab switch via `switchToDoc`, or Accept/Reject-All) flushes the old document's content into the now-active document and silently overwrites it (issue #2467).

The active document is switched in **two** places for an AI update, and both now discard a pending diff first — while `activeDocId` still points at the previously-active doc, so `exitDiffMode(true)` restores and saves *that* doc:
- `handleDocUpdate()` — a `doc_update` targeting a different document.
- `streamDocOpen()` — the AI streaming a **new** document. This runs first on that path (before any `doc_update` reaches `handleDocUpdate`), so it's the one that matters for the issue's own repro: pending diff on doc A → AI creates doc B → B overwritten. A guard only in `handleDocUpdate` fires too late on this path.

Both reuse the exact `if (_diffModeActive) exitDiffMode(true);` guard that `switchToDoc()` and `enterDiffMode()` already use.

## Linked Issue

Fixes #2467

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (Verified: #2467's timeline is empty, no other PR references it, and the guard is not on `main`.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified end-to-end. **Honest note:** verified via the static regression test below plus a code trace of the SSE/diff lifecycle (`doc_stream_start → streamDocOpen → deltas → doc_update → handleDocUpdate`); not a live browser session.

## How to Test

```
python -m pytest tests/test_document_diff_discard_on_update_js.py -q
```

→ 4 passed. The test asserts the discard guard exists in **both** `handleDocUpdate` and `streamDocOpen`, and runs **before** each reassigns `activeDocId`. Confirmed it's a real guard: reverting the `streamDocOpen` guard fails the streamed-path test; reverting the `handleDocUpdate` guard fails its test.

Manual (reproduces #2467):
1. Ask the AI to create document A with text.
2. Ask it to edit A so the "approve changes" diff appears — do **not** approve.
3. Ask it to create a new document B.
4. Switch to A's tab and back.

Before: B's content is overwritten by A's. After: A's pending diff is discarded (A saved unchanged) when B starts streaming, so the two documents no longer affect each other.

## Visual / UI changes

None — this is a behavioral data-safety guard in `static/js/document.js`; it changes only *which* document's content is persisted, not any rendering, CSS, HTML, or styling. No new component patterns or styles.
