### PR TITLE
Fix session cleanup cutoff timezone

### DIFF
--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -14,7 +14,7 @@ import logging
 from datetime import datetime, timezone, timedelta
 from typing import Dict, Optional
 
-from .database import Session as DbSession, ChatMessage as DbChatMessage, Document as DbDocument, SessionLocal
+from .database import Session as DbSession, ChatMessage as DbChatMessage, Document as DbDocument, SessionLocal, utcnow_naive
 from .models import Session, ChatMessage
 
 logger = logging.getLogger(__name__)
@@ -616,7 +616,7 @@ class SessionManager:
 
         try:
             all_sessions = db.query(DbSession).all()
-            cutoff_date = datetime.now(timezone.utc) - timedelta(days=auto_archive_days)
+            cutoff_date = utcnow_naive() - timedelta(days=auto_archive_days)
 
             for db_session in all_sessions:
                 stats['total_checked'] += 1

--- a/tests/test_session_manager_cleanup.py
+++ b/tests/test_session_manager_cleanup.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.session_manager import SessionManager
+import core.session_manager as SM
+
+
+def _manager_with(sessions=None):
+    manager = SessionManager.__new__(SessionManager)
+    manager.sessions = dict(sessions or {})
+    return manager
+
+
+def test_cleanup_empty_sessions_archives_old_naive_last_accessed(monkeypatch):
+    old_session = SimpleNamespace(
+        id="old-chat",
+        archived=False,
+        last_accessed=datetime(2026, 5, 1, 12, 0, 0),
+        message_count=3,
+        is_important=False,
+    )
+    db = MagicMock()
+    db.query.return_value.all.return_value = [old_session]
+
+    monkeypatch.setattr(SM, "SessionLocal", lambda: db)
+    monkeypatch.setattr(SM, "utcnow_naive", lambda: datetime(2026, 6, 4, 12, 0, 0))
+
+    stats = _manager_with().cleanup_empty_sessions(auto_archive_days=30)
+
+    assert old_session.archived is True
+    assert stats == {"deleted_empty": 0, "archived_old": 1, "total_checked": 1}
+    db.commit.assert_called_once()
+    db.rollback.assert_not_called()


### PR DESCRIPTION
## Summary

`SessionManager.cleanup_empty_sessions()` now uses the repository's naive UTC helper when computing the auto-archive cutoff. This keeps the cutoff comparable with the existing naive `Session.last_accessed` database values and prevents cleanup from failing with an offset-naive/offset-aware datetime comparison error.

## Linked Issue

Fixes #2039

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Create or identify a non-empty session whose `last_accessed` value is stored as a naive UTC `datetime`.
2. Run `SessionManager.cleanup_empty_sessions(auto_archive_days=30)`.
3. Confirm the cleanup does not raise a naive/aware datetime comparison `TypeError` and archives old, non-important sessions as expected.

Additional local checks run:

```bash
git diff --check HEAD~1..HEAD
DATABASE_URL=sqlite:////tmp/odysseus-session-cleanup-test.db /tmp/odysseus-pr-venv/bin/python -m pytest tests/test_session_manager_cleanup.py tests/test_database_utcnow.py tests/test_cleanup_service_utcnow.py
```

Result: 5 passed.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. This PR only changes backend session cleanup datetime handling and adds a regression test.

### Screenshots / clips

Not applicable.
