### PR TITLE
Harden markdown raw HTML sanitization

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -60,8 +60,20 @@ const _ALLOWED_HTML_BAD_TAGS = new Set([
   'SVG', 'MATH',
 ]);
 const _ALLOWED_HTML_URL_ATTRS = new Set([
-  'href', 'src', 'xlink:href', 'action', 'formaction', 'background', 'poster',
+  'href', 'src', 'srcset', 'xlink:href', 'action', 'formaction', 'background', 'poster',
 ]);
+
+function _compactUrlSchemeValue(value) {
+  return String(value || '').replace(/[\u0000-\u0020\u007f-\u009f]+/g, '').toLowerCase();
+}
+
+function _isDangerousUrl(value) {
+  return /^(javascript|vbscript|data):/.test(_compactUrlSchemeValue(value));
+}
+
+function _isDangerousSrcset(value) {
+  return String(value || '').split(',').some(candidate => _isDangerousUrl(candidate));
+}
 
 function _cleanAllowedHtmlOnce(htmlString) {
   const tpl = document.createElement('template');
@@ -82,11 +94,17 @@ function _cleanAllowedHtmlOnce(htmlString) {
         el.removeAttribute(attr.name);
         continue;
       }
+      if (name === 'style') {
+        const value = _compactUrlSchemeValue(attr.value);
+        if (/javascript:|vbscript:|data:|expression\(/.test(value)) {
+          el.removeAttribute(attr.name);
+        }
+        continue;
+      }
       // Neutralize javascript:/vbscript:/data: in URL-bearing attributes.
       // Strip control/space chars first so e.g. "java\tscript:" can't slip by.
       if (_ALLOWED_HTML_URL_ATTRS.has(name)) {
-        const value = (attr.value || '').replace(/[\x00-\x20]+/g, '').toLowerCase();
-        if (/^(javascript|vbscript|data):/.test(value)) {
+        if (name === 'srcset' ? _isDangerousSrcset(attr.value) : _isDangerousUrl(attr.value)) {
           el.removeAttribute(attr.name);
         }
       }

--- a/tests/test_markdown_dom_xss_helpers.py
+++ b/tests/test_markdown_dom_xss_helpers.py
@@ -1,0 +1,25 @@
+"""Regression guards for markdown raw-HTML sanitizer helpers."""
+
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def test_markdown_raw_html_sanitizer_checks_url_attr_edge_cases():
+    src = (_REPO / "static" / "js" / "markdown.js").read_text(encoding="utf-8")
+
+    assert "function _compactUrlSchemeValue(value)" in src
+    assert "function _isDangerousUrl(value)" in src
+    assert "function _isDangerousSrcset(value)" in src
+    assert "'srcset'" in src
+    assert "candidate => _isDangerousUrl(candidate)" in src
+    assert "name === 'srcset' ? _isDangerousSrcset(attr.value) : _isDangerousUrl(attr.value)" in src
+
+
+def test_markdown_raw_html_sanitizer_strips_scriptable_css():
+    src = (_REPO / "static" / "js" / "markdown.js").read_text(encoding="utf-8")
+
+    assert "if (name === 'style')" in src
+    assert r"javascript:|vbscript:|data:|expression\(" in src
+    assert "el.removeAttribute(attr.name);" in src


### PR DESCRIPTION
## Summary

The raw-inline-HTML sanitizer (`_cleanAllowedHtmlOnce`) guarded a fixed URL-attribute set but missed `srcset`, never scrubbed scriptable `style`, and only stripped U+0000-U+0020 control chars before the scheme check. This adds `srcset` (validated per candidate), drops `style` attributes carrying `javascript:`/`vbscript:`/`data:`/`expression(`, and widens control-char stripping to U+007F-U+009F so an obfuscated scheme can't slip through model/tool-supplied markdown rendered in chat.

## Linked Issue

Fixes #2490

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Focused regression:
   ```bash
   venv/bin/python -m pytest -q tests/test_markdown_dom_xss_helpers.py
   ```
2. Syntax check: `node --check static/js/markdown.js`
3. Manual: render markdown containing `<img srcset="x,javascript:alert(1)">` and `<b style="background:url(javascript:alert(1))">`; confirm both attributes are dropped.

## Notes

No visual change - security hardening only. Extends the existing allowed-HTML sanitizer; legitimate markdown renders identically. Rebased onto current `main`.
