### PR TITLE
Isolate HTML popup openers

### DIFF
--- a/static/js/codeRunner.js
+++ b/static/js/codeRunner.js
@@ -362,6 +362,7 @@ export function runHTML(code, panel) {
     addCloseBtn(panel);
     return;
   }
+  try { win.opener = null; } catch (_) {}
   win.document.open();
   win.document.write(code);
   win.document.close();

--- a/static/js/compare/index.js
+++ b/static/js/compare/index.js
@@ -1090,6 +1090,7 @@ function _exportPrint() {
   // the system print dialog — user can pick "Save as PDF" from there.
   const w = window.open('', '_blank');
   if (!w) return;
+  try { w.opener = null; } catch (_) {}
   const escape = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   const html = '<!doctype html><meta charset="utf-8"><title>Compare export</title>' +
     '<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;max-width:780px;margin:32px auto;padding:0 24px;line-height:1.55;color:#222}' +

--- a/tests/test_popup_opener_isolation_js.py
+++ b/tests/test_popup_opener_isolation_js.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_html_code_runner_detaches_opener_before_document_write():
+    src = _source("static/js/codeRunner.js")
+    match = re.search(
+        r"export function runHTML\(code, panel\) \{(?P<body>.*?)showOutput\(panel, 'Opened in new window'",
+        src,
+        re.S,
+    )
+
+    assert match
+    body = match.group("body")
+    assert "win.opener = null" in body
+    assert body.index("win.opener = null") < body.index("win.document.write(code)")
+
+
+def test_compare_print_popup_detaches_opener_before_document_write():
+    src = _source("static/js/compare/index.js")
+    match = re.search(
+        r"function _exportPrint\(\) \{(?P<body>.*?)w\.document\.close\(\);",
+        src,
+        re.S,
+    )
+
+    assert match
+    body = match.group("body")
+    assert "w.opener = null" in body
+    assert body.index("w.opener = null") < body.index("w.document.write(html)")


### PR DESCRIPTION
## Summary

The HTML code-runner (`runHTML` in `codeRunner.js`) and the compare print-export (`_exportPrint` in `compare/index.js`) open a new window and `document.write` user/AI-authored HTML into it without detaching `window.opener`. Because `window.open` is intentionally called without `noopener` (the handle is needed to write the document), the written page kept a live `window.opener` and could navigate the parent tab via `window.opener.location` - reverse tabnabbing. This sets `win.opener = null` before `document.write` in both openers.

## Linked Issue

Fixes #2494

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Focused regression:
   ```bash
   venv/bin/python -m pytest -q tests/test_popup_opener_isolation_js.py
   ```
2. Syntax check: `node --check static/js/codeRunner.js static/js/compare/index.js`
3. Manual: in the HTML code runner, run a page containing `<script>opener && (opener.location='https://example.com')</script>`; confirm the parent tab is not navigated.

## Notes

No visual change - the popup renders identically; only the back-reference to the opener is severed. Rebased onto current `main`.
