### PR TITLE
fix(start-macos): skip pip install when requirements.txt is unchanged

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -134,10 +134,17 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 VENV_PY="./venv/bin/python3"
-echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$VENV_PY" -m pip install --quiet --upgrade pip
-# Not --quiet: this is the slow step, so show progress (and any real errors).
-"$VENV_PY" -m pip install -r requirements.txt
+REQ_HASH="$(md5 -q requirements.txt 2>/dev/null || md5sum requirements.txt | cut -d' ' -f1)"
+REQ_HASH_FILE="venv/.requirements_hash"
+if [ ! -f "$REQ_HASH_FILE" ] || [ "$REQ_HASH" != "$(cat "$REQ_HASH_FILE" 2>/dev/null)" ]; then
+  echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
+  "$VENV_PY" -m pip install --quiet --upgrade pip
+  # Not --quiet: this is the slow step, so show progress (and any real errors).
+  "$VENV_PY" -m pip install -r requirements.txt
+  echo "$REQ_HASH" > "$REQ_HASH_FILE"
+else
+  echo "▶ Python packages up to date — skipping install"
+fi
 
 # chromadb-client (HTTP-only) conflicts with the full chromadb package. If
 # it got installed (e.g., from an older requirements-optional.txt), remove


### PR DESCRIPTION
## Summary

`start-macos.sh` runs `pip install -r requirements.txt` unconditionally on every launch, even when nothing has changed. On a warm machine with a fully-populated venv this adds ~15 seconds of unnecessary delay. This PR hashes `requirements.txt` on each launch and skips the install step when the hash matches the last recorded value. A full install still runs on first launch, after `requirements.txt` changes, or after deleting `venv/`. The hash file lives in `venv/.requirements_hash`, which is already gitignored.

## Linked Issue

Fixes #2502

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `./start-macos.sh` — full install runs, `venv/.requirements_hash` is written.
2. Run `./start-macos.sh` again — should print `▶ Python packages up to date — skipping install` and reach the uvicorn start ~15 seconds faster.
3. Edit `requirements.txt` (e.g. add a comment), run again — install step re-runs and hash updates.
4. Delete `venv/` and re-run — full install from scratch as before.