### PR TITLE
Research: owner-scope the spinoff endpoint fallback chain

### DIFF
--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -572,19 +572,22 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                 ep_headers = dict(r_headers)
 
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("chat"))
+            _merge(*resolve_endpoint("chat", owner=user))
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("research"))
+            _merge(*resolve_endpoint("research", owner=user))
         if not ep_url or not ep_model:
-            _merge(*resolve_endpoint("utility"))
+            _merge(*resolve_endpoint("utility", owner=user))
         if not ep_url or not ep_model:
-            # Last resort: any enabled endpoint
+            # Last resort: any enabled endpoint VISIBLE to the caller. Going
+            # through the unscoped first-enabled query would let a research-
+            # capable user spin off a follow-up chat using another user's
+            # private endpoint (and its decrypted api_key / base_url). See
+            # the docstring on `_owned_enabled_endpoint` above.
             from src.database import SessionLocal
-            from src.database import ModelEndpoint
             from src.endpoint_resolver import normalize_base, build_chat_url, build_headers
             db = SessionLocal()
             try:
-                ep = db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()
+                ep = _owned_enabled_endpoint(db, user)
                 if ep:
                     base = normalize_base(ep.base_url)
                     fallback_url = build_chat_url(base)

--- a/tests/test_research_spinoff_owner_scope.py
+++ b/tests/test_research_spinoff_owner_scope.py
@@ -1,0 +1,98 @@
+"""Owner-scope regression for /api/research/spinoff endpoint resolution.
+
+`research_spinoff()` correctly checks that the caller owns the source research
+report before creating the follow-up chat session, but its endpoint fallback
+chain was not fully owner-scoped: every `resolve_endpoint(...)` call ran
+without an `owner` argument and the last-resort `first()` query against
+`ModelEndpoint` had no owner filter at all. `ModelEndpoint` is a per-user
+private resource that carries a decrypted `api_key`, so an unscoped lookup
+let the spinoff path pick up ANOTHER user's endpoint and silently spend that
+owner's API key / quota (and reach whatever internal `base_url` they had
+configured). Same class as #870 / #1045 / #1099 / #2254 / #2255; #2409
+addresses the spinoff path.
+
+These tests pin the two parts of the fix at the source level:
+
+  1. Every `resolve_endpoint(...)` call inside `research_spinoff` passes
+     `owner=` so the settings-driven fallback chain (chat -> research ->
+     utility) is scoped to the caller.
+  2. The last-resort first-enabled endpoint fallback goes through
+     `_owned_enabled_endpoint(db, user)` instead of a bare
+     `db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()`.
+
+A future change that reintroduces an unscoped lookup on this path will fail
+one of these tests and force the contributor to either re-thread the owner
+or justify the scope change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+RESEARCH_ROUTES = REPO / "routes" / "research_routes.py"
+
+
+def _spinoff_body() -> str:
+    """Return the source of the research_spinoff handler only.
+
+    Slicing from the @router.post for /api/research/spinoff up to the next
+    @router. decorator (or the end of setup_research_routes) keeps the
+    assertions scoped to the handler under test and avoids matching the
+    siblings (`/api/research/start`, the `_resolve_research_endpoint` helper,
+    etc.) that already had their own owner-scope fix.
+    """
+    src = RESEARCH_ROUTES.read_text(encoding="utf-8")
+    start = src.find('@router.post("/api/research/spinoff/{session_id}")')
+    assert start != -1, "research_spinoff route not found"
+    rest = src[start:]
+    # Stop at the next route decorator or the trailing `return router`.
+    end_candidates = [
+        rest.find("\n    @router.", 1),
+        rest.find("\n    return router", 1),
+    ]
+    end_candidates = [c for c in end_candidates if c != -1]
+    assert end_candidates, "could not bound research_spinoff handler"
+    return rest[: min(end_candidates)]
+
+
+def test_research_spinoff_resolve_endpoint_calls_pass_owner():
+    """Every resolve_endpoint(...) call inside research_spinoff must
+    pass `owner=`. Otherwise the settings-driven chat/research/utility
+    fallback can resolve to another tenant's private endpoint and the
+    follow-up chat will silently run against their key (issue #2409).
+    """
+    body = _spinoff_body()
+    calls = re.findall(r"resolve_endpoint\s*\([^)]*\)", body)
+    assert calls, "expected resolve_endpoint(...) calls inside research_spinoff"
+    unscoped = [c for c in calls if "owner=" not in c]
+    assert not unscoped, (
+        "research_spinoff has unscoped resolve_endpoint call(s): "
+        f"{unscoped}. Pass owner=user so the fallback chain only resolves "
+        "to endpoints the caller owns (own rows + legacy null-owner shared)."
+    )
+
+
+def test_research_spinoff_first_enabled_fallback_is_owner_scoped():
+    """The last-resort first-enabled fallback must go through the
+    `_owned_enabled_endpoint(db, owner, ...)` helper, NOT a raw
+    `db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()`.
+
+    A raw query lets a research-capable user spin off a follow-up chat
+    using another user's decrypted api_key + base_url (cross-tenant key
+    spend + SSRF on the configured base). #2409 / class of #870, #1045,
+    #1099, #2254, #2255.
+    """
+    body = _spinoff_body()
+    assert "ModelEndpoint.is_enabled == True" not in body, (
+        "research_spinoff still contains an unscoped first-enabled "
+        "ModelEndpoint query. Use _owned_enabled_endpoint(db, user) so "
+        "the fallback never picks another tenant's private endpoint."
+    )
+    assert "_owned_enabled_endpoint" in body, (
+        "research_spinoff no longer calls _owned_enabled_endpoint. The "
+        "owner-scoped fallback must remain in the resolution chain so a "
+        "panel-launched spinoff with no configured endpoints still has a "
+        "safe last resort."
+    )


### PR DESCRIPTION
 ## Summary

  `research_spinoff` in `routes/research_routes.py` already gates the caller against the source research session via `_owns_in_memory`, but its endpoint fallback chain ran without an owner. The three
  `resolve_endpoint("chat" / "research" / "utility")` calls did not thread the caller through to the settings-driven `endpoint_id` lookup, and the last-resort branch fell through to a bare
  `db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()` that ignored ownership entirely.
  
  `ModelEndpoint` is a per-user private resource that carries a decrypted `api_key`. Without an owner filter on the fallback chain, a research-capable user spinning off a panel-launched report (rp-* IDs, no 
  source chat session to inherit from) could end up driving the follow-up chat against another user's endpoint — silently spending that owner's API key / quota and reaching whatever internal `base_url` they 
  had configured. Same class as #870, #1045, #1099, #2254, #2255 — on the spinoff path.
  
  The fix threads `owner=user` through the three `resolve_endpoint(...)` calls so the configured chat/research/utility resolution is scoped to the caller's `endpoint_id`, and replaces the unscoped 
  `ModelEndpoint.first()` fallback with the existing `_owned_enabled_endpoint(db, user)` helper at the top of the file — the same one `/api/research/start` was switched to in the earlier research-scope work.
   The in-memory ownership guard, the source-session inheritance, and the system primer are untouched.

  ## Linked Issue

  Closes #2409

  ## Type of Change

  - [x] Bug fix (non-breaking — fixes a confirmed issue)
  - [ ] New feature (non-breaking — adds new behaviour)
  - [ ] Breaking change (changes or removes existing behaviour)
  - [ ] Refactor / cleanup (behaviour unchanged)
  - [ ] Documentation only
  - [ ] CI / tooling / configuration

  ## Checklist

  - [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
  - [x] This PR targets `main`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
  - [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

  ## How to Test

  1. Source-level regression test:
     ```
     pytest tests/test_research_spinoff_owner_scope.py -v
     ```
     Both tests pass. The first asserts every `resolve_endpoint(...)` call inside `research_spinoff` carries `owner=`; the second asserts the raw `ModelEndpoint.is_enabled == True` first-enabled query is 
  gone in favour of `_owned_enabled_endpoint`. A future commit that re-introduces an unscoped lookup on this path fails one of those tests.
  2. Sibling existing test still passes — the helper itself is unchanged:
     ```
     pytest tests/test_research_endpoint_owner_scope.py -v
     ```
  3. Manual code check: `git grep -n "resolve_endpoint\|_owned_enabled_endpoint" routes/research_routes.py` — every `resolve_endpoint` call inside the spinoff handler now has `owner=user`, and the previous 
  raw `db.query(ModelEndpoint).filter(ModelEndpoint.is_enabled == True).first()` is replaced by `_owned_enabled_endpoint(db, user)`.

  ## Visual / UI changes — REQUIRED if you touched anything that renders
  
  N/A — this PR is backend-only. Files touched: `routes/research_routes.py` (9 lines diff) and the new `tests/test_research_spinoff_owner_scope.py`. No HTML / CSS / JS / SVG / static asset or any 
  `static/js/` module touched; nothing renders. The visual/style boxes below do not apply.

  - [ ] Screenshot or short clip — N/A, no rendering changed
  - [ ] Style match — N/A
  - [ ] No new component patterns — N/A
  - [x] I am not an LLM agent submitting a bulk PR.

  ### Screenshots / clips

  N/A — backend-only change, nothing renders.
