### PR TITLE
feat: add NixOS flake and declarative nixosModules.odysseus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,12 @@ services:
       # Lets the container reach local services on the Docker host, including
       # Ollama at http://host.docker.internal:11434.
       - "host.docker.internal:host-gateway"
+    dns:
+      # systemd-resolved's stub (127.0.0.53) is unreachable from inside a
+      # Podman container — the loopback address resolves to the container,
+      # not the host. Use real upstream resolvers so pip, hf, email, etc. work.
+      - 1.1.1.1
+      - 9.9.9.9
     environment:
       - LLM_HOST=${LLM_HOST:-localhost}
       - LLM_HOSTS=${LLM_HOSTS:-}
@@ -76,6 +82,9 @@ services:
       - chromadb-data:/chroma/chroma
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
+    dns:
+      - 1.1.1.1
+      - 9.9.9.9
     restart: unless-stopped
 
   searxng:
@@ -113,6 +122,9 @@ services:
     # with EACCES and the container fails its healthcheck with permission
     # errors during setup. Mirrors the cap set recommended by the upstream
     # searxng-docker compose file. See issue #721.
+    dns:
+      - 1.1.1.1
+      - 9.9.9.9
     cap_drop:
       - ALL
     cap_add:
@@ -137,6 +149,9 @@ services:
       - ntfy-cache:/var/cache/ntfy
     environment:
       - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+    dns:
+      - 1.1.1.1
+      - 9.9.9.9
     restart: unless-stopped
 
 volumes:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,304 @@
+{
+  description = "Odysseus – local AI workspace (NixOS flake)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [ pkgs.podman-compose ];
+          shellHook = ''
+            echo "Odysseus dev shell. Run 'podman-compose up --build' to start."
+          '';
+        };
+      }
+    )
+    // {
+      nixosModules.odysseus =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.services.odysseus;
+        in
+        {
+          options.services.odysseus = {
+            enable = lib.mkEnableOption "Odysseus AI workspace";
+
+            dataDir = lib.mkOption {
+              type = lib.types.str;
+              default = "/var/lib/odysseus";
+              description = "Directory for persistent Odysseus data (database, uploads, memory, logs).";
+            };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              default = 7000;
+              description = "Host port for the Odysseus web interface.";
+            };
+
+            llamaServerEndpoint = lib.mkOption {
+              type = lib.types.str;
+              default = "http://localhost:11434";
+              description = ''
+                Base URL of the local LLM server (Ollama, llama.cpp, vLLM, etc.).
+                On a Podman bridge network the host is reachable at the gateway
+                address, e.g. http://10.89.0.1:11434.
+              '';
+            };
+
+            searxngSecretKey = lib.mkOption {
+              type = lib.types.str;
+              default = "change-me-before-exposing-to-the-network";
+              description = ''
+                Secret key for SearXNG CSRF/session signing.
+                Override with a random string for any non-local deployment.
+                Can be managed with sops-nix or agenix.
+              '';
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            virtualisation.podman.enable = lib.mkDefault true;
+            virtualisation.podman.dockerCompat = lib.mkDefault true;
+
+            # Fix DNS resolution inside Podman containers.
+            #
+            # Root cause: aardvark-dns (Podman's internal resolver) intercepts all
+            # container DNS queries as the primary nameserver and forwards external
+            # lookups to whatever is in the host's /etc/resolv.conf.  On NixOS with
+            # systemd-resolved the host resolv.conf contains "nameserver 127.0.0.53"
+            # (the stub listener), which is only reachable on the host loopback —
+            # NOT from aardvark running on the Podman bridge.  aardvark therefore
+            # returns SERVFAIL for every external name; glibc does not fall back to
+            # secondary nameservers on SERVFAIL, only on timeout, so adding real IPs
+            # to containers.conf dns_servers has no effect.
+            #
+            # Fix: disable the stub listener so systemd-resolved writes real upstream
+            # IPs into /etc/resolv.conf.  aardvark then picks those up and external
+            # DNS works both on the host and inside every container.
+            networking.nameservers = lib.mkDefault [
+              "1.1.1.1"
+              "9.9.9.9"
+            ];
+
+            # Allow DNS from every Podman bridge network to reach aardvark-dns.
+            # NixOS's nixos-fw INPUT chain has policy drop; the netavark chain
+            # (which already has the right accept rules) never fires because
+            # nixos-fw drops the packet first.  Podman allocates bridge
+            # interfaces named podman0, podman1, … so we open port 53 on the
+            # known range.  podman0 = default network (handled by the Podman
+            # NixOS module), podman1 = odysseus_default.
+            networking.firewall.interfaces."podman1" = lib.mkDefault {
+              allowedUDPPorts = [ 53 ];
+              allowedTCPPorts = [ 53 ];
+            };
+            services.resolved.settings = lib.mkDefault {
+              Resolve = {
+                DNS = "1.1.1.1 9.9.9.9";
+                FallbackDNS = "8.8.8.8 8.8.4.4";
+                DNSStubListener = "no";
+              };
+            };
+
+            virtualisation.containers.containersConf.settings = {
+              containers.dns_servers = [
+                "1.1.1.1"
+                "9.9.9.9"
+              ];
+            };
+
+            assertions = [
+              {
+                assertion = cfg.searxngSecretKey != "change-me-before-exposing-to-the-network";
+                message = "services.odysseus.searxngSecretKey must be changed from its insecure default value before deployment";
+              }
+            ];
+
+            environment.systemPackages = [ pkgs.podman-compose ];
+
+            # Create persistent data directories on first activation.
+            systemd.tmpfiles.rules = [
+              "d ${cfg.dataDir}                       0755 root root -"
+              "d ${cfg.dataDir}/data                  0755 root root -"
+              "d ${cfg.dataDir}/logs                  0755 root root -"
+              "d ${cfg.dataDir}/data/ssh              0700 root root -"
+              "d ${cfg.dataDir}/data/huggingface      0755 root root -"
+              "d ${cfg.dataDir}/data/local            0755 root root -"
+              "d ${cfg.dataDir}/chroma                0755 root root -"
+            ];
+
+            # SearXNG settings template — the entrypoint script sed-substitutes
+            # __SEARXNG_SECRET__ with the NixOS-managed key at container start.
+            environment.etc."odysseus/searxng-settings.yml" = {
+              text = ''
+                use_default_settings: true
+                server:
+                  secret_key: "__SEARXNG_SECRET__"
+                search:
+                  formats:
+                    - html
+                    - json
+              '';
+            };
+
+            environment.etc."odysseus/docker-compose.yml" = {
+              text = ''
+                services:
+                  odysseus:
+                    image: localhost/odysseus_odysseus:latest
+                    build: ${self}
+                    ports:
+                      - "127.0.0.1:${toString cfg.port}:7000"
+                    volumes:
+                      - ${cfg.dataDir}/data:/app/data:z
+                      - ${cfg.dataDir}/logs:/app/logs:z
+                      - ${cfg.dataDir}/data/ssh:/app/.ssh:z
+                      - ${cfg.dataDir}/data/huggingface:/app/.cache/huggingface:z
+                      - ${cfg.dataDir}/data/local:/app/.local:z
+                    extra_hosts:
+                      - "host.docker.internal:host-gateway"
+                    dns:
+                      - 1.1.1.1
+                      - 9.9.9.9
+                    environment:
+                      - PUID=''${PUID:-1000}
+                      - PGID=''${PGID:-1000}
+                      - LLM_HOSTS=''${LLM_HOSTS:-${cfg.llamaServerEndpoint}}
+                      - OLLAMA_BASE_URL=''${OLLAMA_BASE_URL:-${cfg.llamaServerEndpoint}}
+                      - SEARXNG_INSTANCE=http://searxng:8080
+                      - CHROMADB_HOST=chromadb
+                      - CHROMADB_PORT=8000
+                      - DATABASE_URL=sqlite:///./data/app.db
+                      - AUTH_ENABLED=''${AUTH_ENABLED:-true}
+                      - LOCALHOST_BYPASS=''${LOCALHOST_BYPASS:-false}
+                      - SECURE_COOKIES=''${SECURE_COOKIES:-false}
+                    devices:
+                      - nvidia.com/gpu=all
+                    depends_on:
+                      searxng:
+                        condition: service_healthy
+                      chromadb:
+                        condition: service_started
+                    restart: unless-stopped
+
+                  chromadb:
+                    image: docker.io/chromadb/chroma:latest
+                    ports:
+                      - "127.0.0.1:8100:8000"
+                    volumes:
+                      - ${cfg.dataDir}/chroma:/chroma/chroma:z
+                    environment:
+                      - ANONYMIZED_TELEMETRY=FALSE
+                    dns:
+                      - 1.1.1.1
+                      - 9.9.9.9
+                    restart: unless-stopped
+
+                  searxng:
+                    # Pinned — see docker-compose.yml for rationale
+                    image: docker.io/searxng/searxng:2026.5.31-7159b8aed
+                    entrypoint:
+                      - /bin/sh
+                      - -c
+                      - |
+                        set -eu
+                        if [ ! -s /etc/searxng/settings.yml ] || grep -q '__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
+                          secret="${cfg.searxngSecretKey}"
+                          sed "s|__SEARXNG_SECRET__|$$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
+                        fi
+                        exec /usr/local/searxng/entrypoint.sh
+                    ports:
+                      - "127.0.0.1:8080:8080"
+                    volumes:
+                      - searxng-data:/etc/searxng:z
+                      - /etc/odysseus/searxng-settings.yml:/tmp/searxng-settings.yml.template:ro,z
+                    environment:
+                      - SEARXNG_BASE_URL=http://localhost:8080/
+                    dns:
+                      - 1.1.1.1
+                      - 9.9.9.9
+                    cap_drop:
+                      - ALL
+                    cap_add:
+                      - CHOWN
+                      - SETGID
+                      - SETUID
+                      - DAC_OVERRIDE
+                    healthcheck:
+                      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=5).read(1)\""]
+                      interval: 5s
+                      timeout: 6s
+                      retries: 20
+                      start_period: 10s
+                    restart: unless-stopped
+
+                  ntfy:
+                    image: docker.io/binwiederhier/ntfy
+                    command: serve
+                    ports:
+                      - "127.0.0.1:8091:80"
+                    volumes:
+                      - ntfy-cache:/var/cache/ntfy:z
+                    environment:
+                      - NTFY_BASE_URL=''${NTFY_BASE_URL:-http://localhost:8091}
+                    dns:
+                      - 1.1.1.1
+                      - 9.9.9.9
+                    restart: unless-stopped
+
+                volumes:
+                  searxng-data:
+                  ntfy-cache:
+              '';
+            };
+
+            systemd.services.odysseus = {
+              description = "Odysseus AI workspace";
+              after = [
+                "network-online.target"
+                "podman.service"
+              ];
+              wants = [ "network-online.target" ];
+              wantedBy = [ "multi-user.target" ];
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = true;
+                WorkingDirectory = "/etc/odysseus";
+                Environment = "PATH=/run/current-system/sw/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin";
+                ExecStartPre = [
+                  # Always recreate the Podman network so aardvark-dns starts fresh
+                  # and reads the current /etc/resolv.conf (real upstream IPs).
+                  # podman-compose down in pod mode removes the pod but NOT the
+                  # network, so the stale aardvark instance persists across restarts
+                  # with the old forwarding config if we only create-if-missing.
+                  "${pkgs.bash}/bin/bash -c '${pkgs.podman}/bin/podman network rm odysseus_default 2>/dev/null; ${pkgs.podman}/bin/podman network create --dns=1.1.1.1 --dns=9.9.9.9 odysseus_default'"
+                  "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml build"
+                ];
+                ExecStart = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml up -d";
+                ExecStop = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml down";
+                ExecReload = "${pkgs.podman-compose}/bin/podman-compose -f /etc/odysseus/docker-compose.yml restart";
+                Restart = "no";
+                TimeoutStartSec = 600;
+              };
+            };
+          };
+        };
+    };
+}


### PR DESCRIPTION
## Summary

Adds a `flake.nix` with a `nixosModules.odysseus` output so NixOS users can deploy the full Odysseus container stack declaratively. Also fixes a DNS resolution failure that affects every Docker/Podman deployment on systemd-resolved hosts.

**DNS fix (all users):** All compose services were silently broken on hosts using systemd-resolved because the stub resolver `127.0.0.53` is unreachable from inside containers. This breaks Cookbook dependency installs, Hugging Face downloads, SearXNG/Deep Research, and email DNS. Added explicit `dns: [1.1.1.1, 9.9.9.9]` to every service in `docker-compose.yml`.

**NixOS module:** `services.odysseus.enable = true` in `configuration.nix` spins up the whole stack. The module handles Podman setup, data directory creation, the systemd-resolved stub problem at the OS level, and generates the compose file from NixOS options.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2517

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

> **Note on the last checklist item:** The NixOS module was developed and iteratively debugged on a live NixOS system via `nixos-rebuild switch`. The DNS fix in `docker-compose.yml` was verified by confirming `dig pypi.org` from inside the container resolved correctly after adding the entries. Full `docker compose up` on the host was not re-run after the final cleanup to `upstream/dev` base — flagging this honestly per the contribution guidelines.

## How to Test

**DNS fix (docker-compose.yml):**
```bash
docker compose up -d --build
docker compose exec odysseus python -c "import urllib.request; print(urllib.request.urlopen('https://pypi.org').status)"
# Should print 200, not hang or error
```

**NixOS module:**
```nix
# In your NixOS configuration.nix:
{
  inputs.odysseus.url = "github:clochard04/odysseus/feat/nixos-flake";

  imports = [ inputs.odysseus.nixosModules.odysseus ];

  services.odysseus = {
    enable = true;
    searxngSecretKey = "your-random-secret-here";
    # llamaServerEndpoint = "http://10.89.0.1:11434"; # if using Podman bridge
  };
}
```
```bash
sudo nixos-rebuild switch
sudo systemctl start odysseus
curl http://localhost:7000   # should return Odysseus HTML
```

**Verify DNS inside containers works after NixOS module is active:**
```bash
podman exec odysseus_odysseus_1 python -c "import socket; print(socket.gethostbyname('pypi.org'))"
```

## Visual / UI changes

N/A — this PR adds only `flake.nix`, `flake.lock`, and DNS entries to `docker-compose.yml`. No UI, frontend, CSS, or HTML is changed.