### PR TITLE
[codex] fix(slash-menu): select command on Enter in autocomplete

### DIFF
--- a/static/js/slashAutocomplete.js
+++ b/static/js/slashAutocomplete.js
@@ -220,14 +220,26 @@ export function initSlashAutocomplete(textarea) {
   textarea.addEventListener('focus', () => { if (textarea.value.startsWith('/')) refresh(); });
   textarea.addEventListener('blur', () => { setTimeout(hide, 120); });  // delay so click works
 
-  textarea.addEventListener('keydown', (e) => {
+  // Listen on `document` in the CAPTURE phase, not on the textarea, so this
+  // runs BEFORE the composer's own bubble-phase Enter handler that submits the
+  // message. The popup wires up via a late async import, so a bubble listener
+  // on the textarea registers after the composer's and loses the Enter — the
+  // command menu can't be chosen with the keyboard (issue #2478). Capturing on
+  // an ancestor wins regardless of registration order; we filter to the
+  // composer and stopImmediatePropagation on the keys we consume so the submit
+  // path doesn't also fire. (Mirrors the capture-phase pattern slashCommands.js
+  // already uses against the same handler.)
+  document.addEventListener('keydown', (e) => {
     if (!visible || !items.length) return;
+    if (e.target !== textarea) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
+      e.stopImmediatePropagation();
       selectedIdx = (selectedIdx + 1) % items.length;
       _render(popup, items, selectedIdx, textarea.value);
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
+      e.stopImmediatePropagation();
       selectedIdx = (selectedIdx - 1 + items.length) % items.length;
       _render(popup, items, selectedIdx, textarea.value);
     } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
@@ -238,16 +250,19 @@ export function initSlashAutocomplete(textarea) {
       const exactHit = items.find(it => it.token === v || it.aliases.includes(v));
       if (e.key === 'Enter' && exactHit) {
         // User typed the whole command — let the normal submit path handle it
+        // (do NOT stop propagation here, so the composer can send it).
         hide();
         return;
       }
       e.preventDefault();
+      e.stopImmediatePropagation();
       insert(items[selectedIdx].token);
     } else if (e.key === 'Escape') {
       e.preventDefault();
+      e.stopImmediatePropagation();
       hide();
     }
-  });
+  }, true);
 
   // Re-position on window resize / scroll
   window.addEventListener('resize', () => { if (visible) _position(popup, textarea); });

--- a/tests/test_slash_autocomplete_enter_capture_js.py
+++ b/tests/test_slash_autocomplete_enter_capture_js.py
@@ -1,0 +1,63 @@
+"""Regression guard for issue #2478 — Enter must select a slash-command from the menu.
+
+The slash-command autocomplete popup (static/js/slashAutocomplete.js) wires its
+keydown handling up through a late async ``import()`` from chat.js, so a
+bubble-phase listener on the ``#message`` textarea registers *after* the
+composer's own Enter-to-send handler on the same element. Same element + same
+phase ⇒ registration order wins ⇒ the composer submits the half-typed ``/command``
+text and the menu's selection never runs, so the menu can't be chosen with the
+keyboard.
+
+The fix listens on ``document`` in the CAPTURE phase (so it runs before the
+composer's bubble handler regardless of registration order), filters to the
+composer element, and calls ``stopImmediatePropagation()`` on the keys it
+consumes so the submit path does not also fire. A fully-typed exact command
+(``exactHit``) is deliberately left to propagate so it still submits.
+
+Kept as a static source check because slashAutocomplete.js is browser-coupled
+and not importable in pytest (matches tests/test_document_editor_scroll.py).
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AC_JS = (ROOT / "static/js/slashAutocomplete.js").read_text()
+
+
+def _keydown_listener_block() -> str:
+    """The document keydown listener body, sliced from its registration to ``}, true);``."""
+    start = AC_JS.index("document.addEventListener('keydown'")
+    end = AC_JS.index("}, true);", start) + len("}, true);")
+    return AC_JS[start:end]
+
+
+def test_keydown_is_captured_on_document_not_bubbled_on_textarea():
+    block = _keydown_listener_block()
+    # Capture phase on an ancestor — wins the Enter race against the composer.
+    assert block.endswith("}, true);")
+    # The old bubble-phase textarea listener must be gone, or the bug returns.
+    assert "textarea.addEventListener('keydown'" not in AC_JS
+
+
+def test_handler_filters_to_the_composer():
+    # Listening on document means the handler sees every keydown; it must only
+    # act on the composer textarea.
+    assert "if (e.target !== textarea) return;" in _keydown_listener_block()
+
+
+def test_consumed_keys_stop_propagation_to_suppress_submit():
+    block = _keydown_listener_block()
+    # ArrowDown / ArrowUp / insert / Escape each suppress the composer's handler.
+    assert block.count("e.stopImmediatePropagation();") >= 4
+
+
+def test_fully_typed_command_still_submits():
+    # The exactHit branch must NOT stop propagation — a fully-typed command
+    # should still reach the composer's submit path (hide + return, no stop).
+    block = _keydown_listener_block()
+    exact_idx = block.index("exactHit")
+    # Between the exactHit match and its early `return;`, there must be no
+    # stopImmediatePropagation (otherwise typed commands would stop submitting).
+    return_idx = block.index("return;", exact_idx)
+    assert "stopImmediatePropagation" not in block[exact_idx:return_idx]
+    assert "let the normal submit path handle it" in block


### PR DESCRIPTION
## Summary

Typing `/` in the chat composer opens the slash-command menu, which can be scrolled — but pressing **Enter** on a highlighted command didn't select it (issue #2478). Root cause is an event-ordering race: `slashAutocomplete.js` wires its keydown handling through a **late async `import()`** from `chat.js`, so its bubble-phase listener on the `#message` textarea registers *after* the composer's own Enter-to-send handler on the same element. Same element + same phase ⇒ registration order wins ⇒ Enter submitted the half-typed `/command` text before the menu could insert it.

The fix listens on `document` in the **capture phase** (so it runs before the composer's bubble handler regardless of registration order), filters to the composer textarea, and calls `stopImmediatePropagation()` on the keys the menu consumes (Arrow/Tab/Enter/Escape) so the submit path doesn't also fire. This mirrors the capture-phase pattern `slashCommands.js` already uses against the very same composer handler (see its `messageInputListener` comment). A fully-typed exact command is deliberately left to propagate, so it still submits normally.

## Linked Issue

Fixes #2478

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (Verified: #2478's cross-reference timeline is empty and no open/closed PR references it.)
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified end-to-end. **Honest note:** I verified the fix behaviourally with a jsdom DOM-event-model test (below) plus a static regression test and a full code trace — but not a live in-browser session. A reviewer running the app can confirm the repro in seconds.

## How to Test

Static regression guard (matches the repo's convention for browser-coupled JS, e.g. `tests/test_document_editor_scroll.py`):

```
python -m pytest tests/test_slash_autocomplete_enter_capture_js.py -q
```

→ 4 passed. Confirmed it's a real guard: with the one-file fix reverted, all 4 fail.

Behavioural verification of the event-ordering mechanism (jsdom faithfully implements DOM capture/bubble + `stopImmediatePropagation`). This reproduces the bug and proves the fix:

```js
import { JSDOM } from 'jsdom';
function scenario(applyFix) {
  const { window } = new JSDOM('<textarea id="message"></textarea>');
  const ta = window.document.getElementById('message');
  const log = { send:false, insert:false };
  ta.addEventListener('keydown', e => { if (e.key==='Enter'&&!e.shiftKey) log.send=true; }); // composer (bubble), registered first
  const h = e => { if (e.target!==ta) return; if (e.key==='Enter'){ e.preventDefault(); if(applyFix) e.stopImmediatePropagation(); log.insert=true; } };
  if (applyFix) window.document.addEventListener('keydown', h, true); // FIX: capture on ancestor
  else ta.addEventListener('keydown', h);                            // current: late bubble on textarea
  ta.dispatchEvent(new window.KeyboardEvent('keydown', { key:'Enter', bubbles:true, cancelable:true }));
  return log;
}
// current  -> { send:true,  insert:true }  (composer submits the half-typed command)
// with fix -> { send:false, insert:true }  (Enter selects the command, submit suppressed)
```

Manual (reproduces #2478): type `/` in chat, arrow to a command, press **Enter** — it now inserts the selected command instead of submitting the raw text. Typing a full command (e.g. `/help`) and pressing Enter still submits, unchanged.

## Visual / UI changes

**No visual change.** This is a keyboard-behaviour fix in `static/js/slashAutocomplete.js` — no rendering, CSS, HTML, SVG, or styling is touched, and no new component/styles are introduced. A before/after screenshot would look identical; the behaviour difference is "Enter selects the highlighted command" vs "Enter submits raw text". Single, individually root-caused fix for one reported bug (AI-assisted, verified as above).
