### PR TITLE
fix(hwfit): filter non-GGUF models on Windows

### DIFF
--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -576,6 +576,7 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
     system_backend = (system.get("backend") or "").lower()
     apple_silicon = system_backend in ("mps", "metal", "apple")
     rocm = system_backend == "rocm"
+    is_windows = system.get("platform") == "windows"
 
     # Consumer AMD Radeon (RDNA, gfx10/11/12): the practical local serving path
     # is GGUF via llama.cpp. vLLM/SGLang on ROCm are validated for datacenter
@@ -615,7 +616,11 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
         # servable path, so a model needs a real GGUF to be recommended.
         # Otherwise the Cookbook rates vLLM-only AWQ/GPTQ builds "GOOD" on a
         # Radeon that can't actually serve them.
-        if (apple_silicon or consumer_amd) and not (m.get("is_gguf") or m.get("gguf_sources")):
+        #
+        # Windows is the same: Odysseus only supports llama.cpp on Windows,
+        # which requires GGUF. vLLM/SGLang are explicitly blocked, so AWQ/GPTQ
+        # models without a GGUF source are unservable there.
+        if (apple_silicon or consumer_amd or is_windows) and not (m.get("is_gguf") or m.get("gguf_sources")):
             continue
 
         # Format filter: AWQ tab -> only AWQ models, FP4 tab -> FP4-family models, etc.

--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -539,6 +539,7 @@ def _detect_windows():
             "backend": d.get("gpu_backend", "cpu_x86"),
             "homogeneous": True,
             "gpu_error": None,
+            "platform": "windows",
         }
         # PowerShell only reports aggregate GPU info, not per-card detail, so we
         # can't tell a mixed box from a uniform one here — assume one homogeneous

--- a/tests/test_hwfit_windows.py
+++ b/tests/test_hwfit_windows.py
@@ -1,0 +1,74 @@
+"""Windows support for Cookbook hardware-fit.
+
+Odysseus only supports llama.cpp on Windows (vLLM/SGLang are explicitly
+blocked). llama.cpp requires GGUF, so non-GGUF models — including AWQ/GPTQ/
+FP8 safetensors repos — must be filtered out on Windows so the Cookbook does
+not recommend models the user cannot actually serve.
+"""
+
+from services.hwfit.fit import rank_models
+from services.hwfit.models import get_models
+
+
+def _windows_system(ram_gb=32.0, vram_gb=16.0):
+    return {
+        "has_gpu": True,
+        "backend": "cuda",
+        "gpu_name": "NVIDIA RTX 4060",
+        "gpu_vram_gb": vram_gb,
+        "gpu_count": 1,
+        "available_ram_gb": ram_gb * 0.7,
+        "total_ram_gb": ram_gb,
+        "platform": "windows",
+    }
+
+
+def _cuda_system():
+    return {
+        "has_gpu": True,
+        "backend": "cuda",
+        "gpu_name": "NVIDIA RTX 4090",
+        "gpu_vram_gb": 24.0,
+        "gpu_count": 1,
+        "available_ram_gb": 32.0,
+        "total_ram_gb": 64.0,
+    }
+
+
+def test_only_gguf_models_recommended_on_windows():
+    """llama.cpp (GGUF) is the only servable path on Windows, so every model
+    recommended there must ship a real GGUF — no vLLM-only AWQ/GPTQ/FP8."""
+    catalog = {m["name"]: m for m in get_models()}
+    unservable = [
+        r["name"] for r in rank_models(_windows_system(), limit=900)
+        if not (catalog.get(r["name"], {}).get("is_gguf")
+                or catalog.get(r["name"], {}).get("gguf_sources"))
+    ]
+    assert unservable == [], f"{len(unservable)} non-GGUF models on Windows, e.g. {unservable[:3]}"
+
+
+def test_safetensors_models_still_recommended_on_cuda():
+    """Regression guard: the GGUF-only rule must not leak onto CUDA."""
+    names = {r["name"] for r in rank_models(_cuda_system(), limit=900)}
+    assert "microsoft/Phi-mini-MoE-instruct" in names
+
+
+def test_awq_model_hidden_on_windows():
+    """The user's reported issue: Qwen2.5-3B-Instruct-AWQ is AWQ-only and must
+    not be recommended on Windows where it cannot be served."""
+    names = {r["name"] for r in rank_models(_windows_system(), limit=900)}
+    assert "Qwen/Qwen2.5-3B-Instruct-AWQ" not in names
+
+
+def test_awq_model_visible_on_cuda():
+    """The same AWQ model should still be visible on CUDA where vLLM can
+    serve it."""
+    names = {r["name"] for r in rank_models(_cuda_system(), limit=900)}
+    assert "Qwen/Qwen2.5-3B-Instruct-AWQ" in names
+
+
+def test_gguf_alternate_still_recommended_on_windows():
+    """Qwen2.5-3B-Instruct (the base model) has a GGUF source, so it should
+    still appear on Windows even though the AWQ variant is hidden."""
+    names = {r["name"] for r in rank_models(_windows_system(), limit=900)}
+    assert "Qwen/Qwen2.5-3B-Instruct" in names


### PR DESCRIPTION
```markdown
## Summary

Odysseus only supports llama.cpp on Windows (vLLM and SGLang are explicitly blocked). llama.cpp requires GGUF files, but the Cookbook hardware-fit scan was still recommending AWQ/GPTQ/FP8 safetensors models to Windows users — models they cannot actually serve. This fix adds a "platform": "windows" flag to hardware detection and extends the existing GGUF-only filter (used for Apple Silicon and consumer AMD RDNA) to also apply to Windows hosts.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2526

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [ ] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. On a Windows machine with an NVIDIA GPU, run Odysseus
2. Open the Cookbook and click "Rescan" to refresh hardware detection
3. Search for "Qwen/Qwen2.5-3B-Instruct-AWQ" — it should NOT appear in recommendations
4. Search for "Qwen/Qwen2.5-3B-Instruct" (the base model) — it SHOULD appear (has GGUF source)
5. On a Linux/CUDA machine, verify that the AWQ model still appears in recommendations (regression guard)

Or run the automated tests:


python -m pytest tests/test_hwfit_windows.py tests/test_hwfit_amd.py tests/test_hwfit_macos.py tests/test_hwfit_manual_backend.py -v


Expected: 32 passed (1 pre-existing unrelated failure on Windows: `test_detect_system_propagates_unified_memory` asserts `backend == "metal"` but on a Windows host `detect_system()` returns `"cuda"` — this is unrelated to this change).

## Visual / UI changes — REQUIRED if you touched anything that renders

This change does not affect the UI. It only affects which models are recommended by the hardware-fit backend.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no UI changes
```