### PR TITLE
fix(routes): honor pinned endpoint model IDs outside model picker

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -28,7 +28,7 @@ from core.database import SessionLocal, get_session_mode, set_session_mode
 from core.database import Session as DBSession, ChatMessage as DBChatMessage
 from core.database import Document as DBDocument, ModelEndpoint
 from routes.research_routes import _resolve_research_endpoint
-from routes.model_routes import _visible_models
+from routes.model_routes import _visible_models, _normalize_model_ids
 from routes.chat_helpers import (
     resolve_session_auth,
     build_chat_context,
@@ -195,10 +195,15 @@ def _recover_empty_session_model(sess, session_id: str, owner: str | None = None
             cached = json.loads(ep.cached_models) if isinstance(ep.cached_models, str) else (ep.cached_models or [])
         except Exception:
             cached = []
-        if not cached:
+        pinned = getattr(ep, "pinned_models", None)
+        # An endpoint may expose only admin-pinned IDs (cloud deployment IDs
+        # that never appear in /v1/models), in which case cached_models is
+        # empty but the picker still offered the pinned model. Recover from
+        # pinned too, mirroring the dropdown the user actually saw.
+        if not cached and not _normalize_model_ids(pinned):
             return False
         try:
-            visible = _visible_models(cached, getattr(ep, "hidden_models", None))
+            visible = _visible_models(cached, getattr(ep, "hidden_models", None), pinned)
         except Exception:
             visible = cached
         if not visible:

--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -37,6 +37,27 @@ def _first_chat_model(models) -> str:
     return (models[0] if models else "")
 
 
+def _endpoint_default_model(ep) -> str:
+    """First chat model an endpoint offers, honoring admin-pinned model IDs.
+
+    Pinned model IDs (cloud deployment IDs) live in pinned_models and never
+    appear in cached_models, so picking from cached alone yields no model for a
+    pinned-only endpoint. Merge cached + pinned, then pick the first chat model.
+    """
+    out = []
+    for raw in (getattr(ep, "cached_models", None), getattr(ep, "pinned_models", None)):
+        if not raw:
+            continue
+        try:
+            vals = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception:
+            vals = []
+        for v in (vals or []):
+            if v not in out:
+                out.append(v)
+    return _first_chat_model(out)
+
+
 def _resolve_research_endpoint(sess) -> tuple:
     """Return (endpoint_url, model, headers) for Deep Research, checking admin overrides."""
     url, model, headers = resolve_endpoint(
@@ -382,13 +403,10 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
                 ep_headers = build_headers(ep.api_key, base)
                 ep_model = body.model or ""
                 if not ep_model:
-                    try:
-                        import json as _json
-                        models = _json.loads(ep.cached_models) if ep.cached_models else []
-                        if models:
-                            ep_model = _first_chat_model(models)
-                    except Exception:
-                        pass
+                    # Honor admin-pinned model IDs: a pinned-only endpoint has
+                    # empty cached_models, so picking from cached alone left the
+                    # research model empty and the run failed with model="".
+                    ep_model = _endpoint_default_model(ep)
             finally:
                 db.close()
         else:

--- a/routes/task_routes.py
+++ b/routes/task_routes.py
@@ -165,7 +165,17 @@ def _resolve_run_endpoint(db, task: ScheduledTask, run: TaskRun) -> str:
                     cached = json.loads(ep.cached_models) or []
                 except Exception:
                     cached = []
-            if model in cached:
+            # Admin-pinned model IDs (cloud deployment IDs) live in
+            # pinned_models and intentionally never appear in cached_models, so
+            # matching cached alone fails to resolve the endpoint for a task
+            # pinned to such a model. Match pinned too.
+            pinned = []
+            if getattr(ep, "pinned_models", None):
+                try:
+                    pinned = json.loads(ep.pinned_models) or []
+                except Exception:
+                    pinned = []
+            if model in cached or model in pinned:
                 return ep.base_url or ""
     except Exception:
         pass

--- a/tests/test_recover_empty_session_pinned.py
+++ b/tests/test_recover_empty_session_pinned.py
@@ -1,0 +1,83 @@
+"""Regression test for _recover_empty_session_model honoring pinned models.
+
+Producer side (routes/model_routes.py): the model-list / endpoint-save
+endpoints build the picker dropdown with
+    _visible_models(cached_models, hidden_models, pinned_models)
+so an admin-pinned model ID (one that does NOT appear in /v1/models, e.g. a
+cloud deployment ID) shows up in the dropdown and is selectable.
+
+Consumer side (routes/chat_routes._recover_empty_session_model): when a
+session's model was never persisted (Issue #587 window), it tries to recover
+the model from the matching endpoint. The bug: it only looks at
+`cached_models` (bails with `if not cached: return False`) and calls
+`_visible_models(cached, hidden)` WITHOUT the pinned list — so a pinned-only
+endpoint can never recover, and the chat POSTs upstream with model="".
+"""
+
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import MagicMock
+
+# Stub optional deps pulled in by `core` package __init__ but not installed
+# in the test venv.
+for _m in ["pyotp"]:
+    if _m not in sys.modules:
+        try:
+            __import__(_m)
+        except Exception:
+            sys.modules[_m] = MagicMock()
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Point the DB at a throwaway sqlite file BEFORE importing core.database.
+_DB_PATH = tempfile.mktemp(suffix=".db")
+os.environ["DATABASE_URL"] = "sqlite:///" + _DB_PATH
+
+
+def _setup():
+    import core.database as db
+    db.init_db()
+    return db
+
+
+def test_recover_empty_session_uses_pinned_only_endpoint():
+    db = _setup()
+    import routes.chat_routes as cr
+
+    # Endpoint with NO cached models but a single admin-pinned deployment ID
+    # — exactly the documented cloud-deploy-ID case the picker supports.
+    s = db.SessionLocal()
+    try:
+        ep = db.ModelEndpoint(
+            id="ep-pinned",
+            name="Pinned Cloud",
+            base_url="https://cloud.example.com/v1",
+            is_enabled=True,
+            cached_models=None,
+            hidden_models=None,
+            pinned_models='["my-cloud-deploy-id"]',
+            model_type="llm",
+        )
+        s.add(ep)
+        sess_row = db.Session(
+            id="sess-1",
+            name="t",
+            model="",  # never persisted
+            endpoint_url="https://cloud.example.com/v1",
+        )
+        s.add(sess_row)
+        s.commit()
+    finally:
+        s.close()
+
+    class _Sess:
+        model = ""
+        endpoint_url = "https://cloud.example.com/v1"
+
+    sess = _Sess()
+    recovered = cr._recover_empty_session_model(sess, "sess-1", owner=None)
+
+    assert recovered is True, "should recover the pinned model"
+    assert sess.model == "my-cloud-deploy-id", f"got {sess.model!r}"

--- a/tests/test_research_endpoint_default_model.py
+++ b/tests/test_research_endpoint_default_model.py
@@ -1,0 +1,52 @@
+"""Regression: research endpoint model selection must honor pinned model IDs.
+
+When research is started against an explicitly chosen endpoint with no model
+specified, the handler picked the endpoint's default model from cached_models
+only. Admin-pinned model IDs (cloud deployment IDs) live in pinned_models and
+never appear in cached_models, so a pinned-only endpoint yielded an empty model
+and the research run failed with model="". `_endpoint_default_model` merges
+cached + pinned before picking the first chat model.
+"""
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# research_routes pulls a few app modules at import; stub the heavy/optional
+# ones so the pure helper is importable in the test venv.
+for _name in ["pyotp"]:
+    if _name not in sys.modules:
+        try:
+            __import__(_name)
+        except Exception:
+            sys.modules[_name] = MagicMock()
+
+from routes.research_routes import _endpoint_default_model
+
+
+def test_pinned_only_endpoint_yields_pinned_model():
+    ep = SimpleNamespace(cached_models=None, pinned_models='["my-cloud-deploy-id"]')
+    assert _endpoint_default_model(ep) == "my-cloud-deploy-id"
+
+
+def test_cached_first_chat_model_still_used():
+    ep = SimpleNamespace(
+        cached_models='["text-embedding-3-large", "gpt-4o"]',
+        pinned_models=None,
+    )
+    # skips the embedding model, picks the chat model
+    assert _endpoint_default_model(ep) == "gpt-4o"
+
+
+def test_cached_and_pinned_merge():
+    ep = SimpleNamespace(
+        cached_models='["text-embedding-3-large"]',
+        pinned_models='["my-cloud-deploy-id"]',
+    )
+    # cached has only a non-chat model; pinned chat id wins
+    assert _endpoint_default_model(ep) == "my-cloud-deploy-id"
+
+
+def test_no_models_returns_empty():
+    ep = SimpleNamespace(cached_models=None, pinned_models=None)
+    assert _endpoint_default_model(ep) == ""

--- a/tests/test_task_run_endpoint_pinned.py
+++ b/tests/test_task_run_endpoint_pinned.py
@@ -1,0 +1,56 @@
+"""Regression: _resolve_run_endpoint must match admin-pinned model IDs.
+
+The recent-runs listing (GET /api/tasks/{id}/runs) exposes an `endpoint_url`
+for reopening a task run in chat, computed by `_resolve_run_endpoint`. It
+matched the task/run model only against each endpoint's `cached_models`. Admin
+pinned model IDs (cloud deployment IDs) live in `pinned_models` and never
+appear in `cached_models`, so a task pinned to such a model resolved to an
+empty endpoint URL and could not be reopened against its real endpoint.
+"""
+import os
+import sys
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+for _m in ["pyotp"]:
+    if _m not in sys.modules:
+        try:
+            __import__(_m)
+        except Exception:
+            sys.modules[_m] = MagicMock()
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_DB_PATH = tempfile.mktemp(suffix=".db")
+os.environ["DATABASE_URL"] = "sqlite:///" + _DB_PATH
+
+
+def test_resolve_run_endpoint_matches_pinned_model():
+    import core.database as db
+    db.init_db()
+    import routes.task_routes as tr
+
+    s = db.SessionLocal()
+    try:
+        s.add(db.ModelEndpoint(
+            id="ep-pin", name="Cloud", base_url="https://cloud.example.com/v1",
+            is_enabled=True, cached_models=None,
+            pinned_models='["my-cloud-deploy-id"]', model_type="llm",
+        ))
+        s.commit()
+    finally:
+        s.close()
+
+    task = SimpleNamespace(endpoint_url=None, session_id=None, model="my-cloud-deploy-id")
+    run = SimpleNamespace(model=None)
+
+    s2 = db.SessionLocal()
+    try:
+        url = tr._resolve_run_endpoint(s2, task, run)
+    finally:
+        s2.close()
+
+    # Old code matched cached_models only (empty here) → "". With pinned
+    # matching, the endpoint resolves.
+    assert url == "https://cloud.example.com/v1", repr(url)


### PR DESCRIPTION
## Summary

Repackages the focused pinned-model route fixes from the old `main` queue as a fresh `dev` PR. `dev` already has model endpoint support for admin-pinned model IDs, but several downstream routes still treated `cached_models` as the only source of selectable models.

This fixes those remaining route holes:

- Deep Research endpoint default-model selection now considers `pinned_models` for pinned-only endpoints.
- Task run endpoint resolution matches the task's model against both cached and pinned model IDs.
- Empty-session chat model recovery can recover a model from pinned-only endpoints.

Supersedes old `main` PRs #2084, #2081, and #2078. The original commits are cherry-picked with attribution.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #2116

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs for duplicate or overlapping work.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. Not run for this fresh `dev` branch: this is backend route resolution logic verified with focused regression tests and compile checks. The original `main` PR validation also booted the app and confirmed `/api/health`.

## How to Test

1. `venv/bin/python -m pytest -q tests/test_research_endpoint_default_model.py tests/test_task_run_endpoint_pinned.py tests/test_recover_empty_session_pinned.py` -> 6 passed.
2. `venv/bin/python -m py_compile routes/research_routes.py routes/task_routes.py routes/chat_routes.py` -> passed.
3. `git diff --check upstream/dev...HEAD` -> clean.

## Visual / UI changes - REQUIRED if you touched anything that renders

- [x] No UI or visual changes. Backend route logic and tests only.

### Screenshots / clips

Not applicable.
