### PR TITLE
macOS: skip pip install when requirements.txt is unchanged

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -134,10 +134,17 @@ if [ ! -d venv ]; then
   "$PY" -m venv venv
 fi
 VENV_PY="./venv/bin/python3"
-echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
-"$VENV_PY" -m pip install --quiet --upgrade pip
-# Not --quiet: this is the slow step, so show progress (and any real errors).
-"$VENV_PY" -m pip install -r requirements.txt
+HASH_FILE="venv/.requirements_hash"
+REQ_HASH="$(md5 -q requirements.txt 2>/dev/null || md5sum requirements.txt 2>/dev/null | awk '{print $1}')"
+if [ "$(cat "$HASH_FILE" 2>/dev/null)" != "$REQ_HASH" ]; then
+  echo "▶ Installing Python packages (first run downloads a few — can take a few minutes)…"
+  "$VENV_PY" -m pip install --quiet --upgrade pip
+  # Not --quiet: this is the slow step, so show progress (and any real errors).
+  "$VENV_PY" -m pip install -r requirements.txt
+  echo "$REQ_HASH" > "$HASH_FILE"
+else
+  echo "▶ Python packages up to date — skipping install."
+fi
 
 # chromadb-client (HTTP-only) conflicts with the full chromadb package. If
 # it got installed (e.g., from an older requirements-optional.txt), remove


### PR DESCRIPTION
## Summary

\`start-macos.sh\` ran \`pip install -r requirements.txt\` unconditionally on every launch, even when nothing had changed. On a warm machine with a fully-populated venv this adds 10–20 seconds of unnecessary startup delay.

**Fix:** compute an md5 hash of \`requirements.txt\` on each launch and store it in \`venv/.requirements_hash\`. Skip install when the hash matches; run a full install (and update the hash) when it doesn't. The hash file lives inside \`venv/\` which is already gitignored, so it never touches the repo.

A changed \`requirements.txt\` still triggers a full install automatically — behaviour is identical to before for first runs and after dependency changes.

## Linked issues

Fixes #2502

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this fixes #2502 which is confirmed and unaddressed.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `./start-macos.sh` on a machine with a populated venv — it should complete the pip step normally and write `venv/.requirements_hash`.
2. Run `./start-macos.sh` again without touching `requirements.txt` — the output should show `Python packages up to date — skipping install.` and the pip step should be skipped entirely (completes in under 1 s).
3. Run `touch requirements.txt` to invalidate the hash, then `./start-macos.sh` again — pip install should run as normal.

Syntax checked with: `bash -n start-macos.sh`