### PR TITLE
fix(calendar): keep parsed fallback datetimes naive

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -399,7 +399,17 @@ def _parse_dt(s: str) -> datetime:
     # Last resort: dateutil's fuzzy parser
     try:
         from dateutil import parser as _du
-        return _du.parse(s)
+        parsed = _du.parse(s)
+        # Strip tz like every other return path above — this function's
+        # contract is naive datetimes (CalendarEvent.dtstart is naive). An
+        # offset-bearing non-ISO input (e.g. RFC-2822 "Mon, 05 Jan 2026
+        # 14:00:00 +0900") otherwise leaked tz-aware into the naive column and
+        # crashed read-back comparisons in _expand_rrule with "can't compare
+        # offset-naive and offset-aware datetimes".
+        if parsed.tzinfo is not None:
+            from datetime import timezone as _tz
+            return parsed.astimezone(_tz.utc).replace(tzinfo=None)
+        return parsed
     except Exception:
         raise ValueError(f"could not parse datetime: {s!r}")
 

--- a/tests/test_calendar_parse_dt_naive.py
+++ b/tests/test_calendar_parse_dt_naive.py
@@ -1,0 +1,46 @@
+"""Regression: _parse_dt's dateutil fallback must return naive datetimes.
+
+_parse_dt documents that it returns local-naive datetimes to match the DB
+schema (CalendarEvent.dtstart is naive), and every return path strips tz —
+except the last-resort dateutil branch, which returned dateutil's value
+verbatim. An offset-bearing non-ISO input (e.g. RFC-2822
+"Mon, 05 Jan 2026 14:00:00 +0900", which datetime.fromisoformat rejects but
+dateutil parses) therefore leaked a tz-aware datetime into the naive dtstart
+column. On read-back, _expand_rrule compares ev.dtstart against naive window
+bounds and raises "can't compare offset-naive and offset-aware datetimes".
+
+The fallback now normalizes to UTC and strips tz, exactly like the ISO path.
+"""
+import pytest
+
+from tests.test_null_owner_gates import _import_calendar_helpers
+
+# Inputs datetime.fromisoformat() rejects (so they hit the dateutil fallback)
+# but that carry a numeric UTC offset dateutil resolves to tz-aware.
+_OFFSET_NONISO = [
+    "Mon, 05 Jan 2026 14:00:00 +0900",
+    "January 5, 2026 14:00 +0900",
+]
+
+
+@pytest.mark.parametrize("s", _OFFSET_NONISO)
+def test_parse_dt_dateutil_fallback_returns_naive(s):
+    cal = _import_calendar_helpers()
+    d = cal._parse_dt(s)
+    assert d.tzinfo is None, f"{s!r} leaked tz-aware: {d!r}"
+    # +0900 14:00 -> 05:00 UTC, naive.
+    assert (d.hour, d.minute) == (5, 0)
+
+
+@pytest.mark.parametrize("s", _OFFSET_NONISO)
+def test_parse_dt_pair_fallback_returns_naive(s):
+    cal = _import_calendar_helpers()
+    dt, _is_utc = cal._parse_dt_pair(s)
+    assert dt.tzinfo is None, f"{s!r} leaked tz-aware via _parse_dt_pair: {dt!r}"
+
+
+def test_parse_dt_naive_input_unchanged():
+    cal = _import_calendar_helpers()
+    d = cal._parse_dt("January 5, 2026 14:00")  # no offset -> stays as parsed
+    assert d.tzinfo is None
+    assert (d.hour, d.minute) == (14, 0)


### PR DESCRIPTION
## Summary

Recreates old `main` PR #2011 as a fresh `dev` PR.

`_parse_dt` expects naive datetimes for calendar list comparisons. Its dateutil fallback could return an aware datetime for non-ISO offset strings, which then crashed when compared with naive bounds. This strips timezone info in the fallback path to preserve the helper's naive-datetime contract.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #2010
Supersedes #2011

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs for duplicate or overlapping work.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. Not run: this is calendar date parsing helper logic verified with focused regression tests and compile checks.

## How to Test

1. `venv/bin/python -m pytest -q tests/test_calendar_parse_dt_naive.py` -> 5 passed.
2. `venv/bin/python -m py_compile routes/calendar_routes.py tests/test_calendar_parse_dt_naive.py` -> passed.
3. `git diff --check upstream/dev...HEAD` -> clean.

## Visual / UI changes - REQUIRED if you touched anything that renders

- [x] No UI or visual changes. Backend calendar parsing logic and tests only.

### Screenshots / clips

Not applicable.