### PR TITLE
fix: live-resume chat stream on session re-entry (#2539)

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -3046,6 +3046,121 @@ import createResearchSynapse from './researchSynapse.js';
   var _insertStreamDoneToast = chatStream.insertStreamDoneToast;
 
   /**
+   * Live-resume a chat run still streaming detached on the server (#2539).
+   *
+   * On session re-entry, GET /api/chat/resume/{id} replays the run's buffer then
+   * streams live. We render reply tokens as they arrive, then reload the session
+   * on completion so the final render matches a normal send. Returns true if it
+   * attached, false to let the caller fall back to spinner+poll.
+   */
+  export async function resumeStream(sessionId) {
+    if (!sessionId) return false;
+    if (hasActiveStream(sessionId)) return false;
+
+    let res;
+    try {
+      res = await fetch(`${API_BASE}/api/chat/resume/${sessionId}`);
+    } catch (e) {
+      return false;
+    }
+    if (!res.ok || !res.body) return false;
+
+    const box = document.getElementById('chat-history');
+    if (!box) return false;
+
+    // Block duplicate re-attach attempts while this reader is live.
+    _backgroundStreams.set(sessionId, { status: 'running', accumulated: '' });
+
+    const holder = document.createElement('div');
+    holder.className = 'msg msg-ai';
+    const meta = sessionModule.getSessions().find(s => s.id === sessionId);
+    const roleLabel = _shortModel(meta && meta.model);
+    const roleTs = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    holder.innerHTML = '<div class="role">' + uiModule.esc(roleLabel) +
+      ' <span class="role-timestamp">' + roleTs + '</span></div>' +
+      '<div class="body"><div class="stream-content"></div></div>';
+    _applyModelColor(holder.querySelector('.role'), meta && meta.model);
+    const contentDiv = holder.querySelector('.stream-content');
+    box.appendChild(holder);
+
+    const spinner = spinnerModule.create('Generating response...', 'right');
+    holder.querySelector('.body').appendChild(spinner.createElement());
+    spinner.start();
+    uiModule.scrollHistory();
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let roundText = '';
+    let gotDelta = false;
+    let leftSession = false;
+
+    const cleanup = () => {
+      try { spinner.destroy(); } catch (_) {}
+      _backgroundStreams.delete(sessionId);
+    };
+
+    const renderDelta = () => {
+      const dt = stripToolBlocks(roundText);
+      contentDiv.innerHTML = markdownModule.mdToHtml(markdownModule.squashOutsideCode(dt));
+      uiModule.scrollHistory();
+    };
+
+    try {
+      readLoop:
+      while (true) {
+        // User left this session: stop rendering, the run continues server-side.
+        if (sessionModule.getCurrentSessionId &&
+            sessionModule.getCurrentSessionId() !== sessionId) {
+          leftSession = true;
+          try { await reader.cancel(); } catch (_) {}
+          break;
+        }
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop();
+        for (const part of parts) {
+          const line = part.split('\n').find(l => l.startsWith('data: '));
+          if (!line) continue;
+          const payload = line.slice(6);
+          if (payload === '[DONE]') {
+            try { await reader.cancel(); } catch (_) {}
+            break readLoop;
+          }
+          let json;
+          try { json = JSON.parse(payload); } catch (_) { continue; }
+          if (json.delta) {
+            roundText += json.delta;
+            if (!gotDelta) { gotDelta = true; try { spinner.destroy(); } catch (_) {} }
+            renderDelta();
+          } else if (json.type === 'doc_stream_open') {
+            if (documentModule) documentModule.streamDocOpen(json.title || '', json.lang || '');
+          } else if (json.type === 'doc_stream_delta') {
+            if (documentModule && json.delta) documentModule.streamDocDelta(json.delta);
+          }
+        }
+      }
+    } catch (e) {
+      // Network drop or parse failure: fall through to the reload below.
+    }
+
+    cleanup();
+    if (holder.parentNode) holder.remove();
+    if (leftSession) return true;
+
+    // Reload from the DB for the canonical final render (tools, sources, metrics).
+    if (sessionModule.getCurrentSessionId &&
+        sessionModule.getCurrentSessionId() === sessionId) {
+      sessionModule.selectSession(sessionId);
+    } else {
+      sessionModule.loadSessions();
+    }
+    return true;
+  }
+
+  /**
    * Check for background streams when switching to a session.
    * Called after history loads on session switch.
    */
@@ -4528,6 +4643,7 @@ import createResearchSynapse from './researchSynapse.js';
     abortCurrentRequest,
     detachCurrentStream,
     checkBackgroundStream,
+    resumeStream,
     hideWelcomeScreen: chatRenderer.hideWelcomeScreen,
     showWelcomeScreen: chatRenderer.showWelcomeScreen,
     checkPendingResearch,

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -3094,6 +3094,11 @@ import createResearchSynapse from './researchSynapse.js';
     let roundText = '';
     let gotDelta = false;
     let leftSession = false;
+    let metricsData = null;
+    // "Rich" responses (tool calls, sources, doc streaming, multi-round) need the
+    // full canonical render, which is rebuilt from the saved DB record on reload.
+    // Plain text replies can be finalized in place without a reload.
+    let rich = false;
 
     const cleanup = () => {
       try { spinner.destroy(); } catch (_) {}
@@ -3136,9 +3141,19 @@ import createResearchSynapse from './researchSynapse.js';
             if (!gotDelta) { gotDelta = true; try { spinner.destroy(); } catch (_) {} }
             renderDelta();
           } else if (json.type === 'doc_stream_open') {
+            rich = true;
             if (documentModule) documentModule.streamDocOpen(json.title || '', json.lang || '');
           } else if (json.type === 'doc_stream_delta') {
+            rich = true;
             if (documentModule && json.delta) documentModule.streamDocDelta(json.delta);
+          } else if (json.type === 'metrics') {
+            metricsData = json.data || metricsData;
+          } else if (json.type === 'tool_start' || json.type === 'tool_output' ||
+                     json.type === 'tool_progress' || json.type === 'agent_step' ||
+                     json.type === 'web_sources' || json.type === 'rag_sources' ||
+                     json.type === 'research_progress' || json.type === 'research_sources' ||
+                     json.type === 'research_findings' || json.type === 'research_done') {
+            rich = true;
           }
         }
       }
@@ -3147,16 +3162,28 @@ import createResearchSynapse from './researchSynapse.js';
     }
 
     cleanup();
-    if (holder.parentNode) holder.remove();
-    if (leftSession) return true;
+    if (leftSession) { if (holder.parentNode) holder.remove(); return true; }
 
-    // Reload from the DB for the canonical final render (tools, sources, metrics).
-    if (sessionModule.getCurrentSessionId &&
-        sessionModule.getCurrentSessionId() === sessionId) {
-      sessionModule.selectSession(sessionId);
-    } else {
-      sessionModule.loadSessions();
+    const onThisSession = sessionModule.getCurrentSessionId &&
+                          sessionModule.getCurrentSessionId() === sessionId;
+
+    // Plain text reply: finalize in place. Replace the live bubble with a
+    // canonical single message (markdown + footer actions + metrics) using the
+    // same renderer history does. No history refetch, no end-of-stream flicker.
+    if (onThisSession && !rich && roundText.trim()) {
+      if (holder.parentNode) holder.remove();
+      const model = meta && meta.model;
+      const meta_ = metricsData ? Object.assign({ model }, metricsData) : { model };
+      chatRenderer.addMessage('assistant', roundText, model, meta_);
+      uiModule.scrollHistory();
+      return true;
     }
+
+    // Rich response (tools, sources, docs, multi-round) or user moved on:
+    // reload from the DB for the full canonical render.
+    if (holder.parentNode) holder.remove();
+    if (onThisSession) sessionModule.selectSession(sessionId);
+    else sessionModule.loadSessions();
     return true;
   }
 

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -82,13 +82,15 @@ import createResearchSynapse from './researchSynapse.js';
 
   // Background streaming support
   const _backgroundStreams = new Map(); // sessionId -> { status, accumulated, sourcesHtml, abortCtrl, query, metrics }
+  const _resumingStreams = new Set();   // sessionId -> a resumeStream() reader is live (re-attach lock)
   let _streamSessionId = null; // Session ID for the currently active reader loop
   let _lastReaderActivity = 0; // Timestamp of last reader.read() success — used to detect frozen streams
   let _webLockRelease = null;  // Function to release the Web Lock held during streaming
 
   /** Check if an SSE reader is still actively connected for a session. */
   function hasActiveStream(sessionId) {
-    return _streamSessionId === sessionId || _backgroundStreams.has(sessionId);
+    return _streamSessionId === sessionId || _backgroundStreams.has(sessionId) ||
+           _resumingStreams.has(sessionId);
   }
 
   // Sources box builder and toggleSources are now in chatRenderer.js
@@ -3049,8 +3051,10 @@ import createResearchSynapse from './researchSynapse.js';
    * Live-resume a chat run still streaming detached on the server (#2539).
    *
    * On session re-entry, GET /api/chat/resume/{id} replays the run's buffer then
-   * streams live. We render reply tokens as they arrive, then reload the session
-   * on completion so the final render matches a normal send. Returns true if it
+   * streams live; reply tokens render as they arrive. On completion a plain text
+   * reply is finalized in place (canonical bubble via chatRenderer.addMessage, no
+   * reload); a "rich" reply (tool calls, sources, doc streaming, multi-round) is
+   * reloaded from the DB so its full render stays faithful. Returns true if it
    * attached, false to let the caller fall back to spinner+poll.
    */
   export async function resumeStream(sessionId) {
@@ -3068,8 +3072,10 @@ import createResearchSynapse from './researchSynapse.js';
     const box = document.getElementById('chat-history');
     if (!box) return false;
 
-    // Block duplicate re-attach attempts while this reader is live.
-    _backgroundStreams.set(sessionId, { status: 'running', accumulated: '' });
+    // Block duplicate re-attach attempts while this reader is live. A dedicated
+    // set (not _backgroundStreams) so checkBackgroundStream doesn't mistake this
+    // for a same-tab POST stream and spawn its own spinner+poll on re-entry.
+    _resumingStreams.add(sessionId);
 
     const holder = document.createElement('div');
     holder.className = 'msg msg-ai';
@@ -3102,7 +3108,7 @@ import createResearchSynapse from './researchSynapse.js';
 
     const cleanup = () => {
       try { spinner.destroy(); } catch (_) {}
-      _backgroundStreams.delete(sessionId);
+      _resumingStreams.delete(sessionId);
     };
 
     const renderDelta = () => {

--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -2157,7 +2157,14 @@ async function _checkServerStream(sessionId) {
     // Skip if this is a research stream — research has its own progress UI
     if (info.mode === 'research' || info.is_research) return;
 
-    // Server is still streaming — show spinner and poll
+    // Live-resume the detached run: replay its buffer then stream live tokens
+    // (#2539). Falls back to the spinner+poll path below if unavailable.
+    if (window.chatModule && window.chatModule.resumeStream) {
+      const attached = await window.chatModule.resumeStream(sessionId);
+      if (attached) return;
+    }
+
+    // Fallback: server is still streaming, show spinner and poll.
     const box = document.getElementById('chat-history');
     if (!box) return;
 


### PR DESCRIPTION
## Summary

When a chat session was re-entered while its agent run was still streaming on the server (page refresh, or reopening the tab), the UI only showed a frozen "Generating response..." spinner. It polled `stream_status` until the run finished and then did a full reload, so the live tokens were never displayed. This wires the existing detached-run resume endpoint into the re-entry path so the response streams in live.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2539

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Start the app and open a chat with a model. Send a prompt that takes a while to generate (e.g. "write a very long, detailed document").
2. While the response is still streaming, refresh the page (or close and reopen the tab).
3. **Before:** the session shows a frozen "Generating response..." spinner until the run finishes, then reloads.
4. **After:** the session re-attaches to the running stream and renders the reply live (replays what was already generated, then continues token by token). On completion it settles into the normal final render with metrics.

Backend was already in place: `GET /api/chat/resume/{id}` (`agent_runs.subscribe`) replays the run's buffer then streams live. The gap was purely on the frontend, which never consumed it.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] Screenshot or short clip of the change in the running app, attached below.
- [x] **Style match**: reuses the existing AI message markup (`msg msg-ai`, `role`, `body`, `stream-content`), the existing `spinner.js` module, and `chatRenderer`/`markdown` helpers. No new CSS variables, classes, fonts, or colors. No Unicode emoji.
- [x] **No new component patterns.** The live bubble mirrors the existing send-path rendering; on completion it reuses `selectSession` for the canonical render.

### Screenshots / clips

Hard reloaded the page while this essay was rendering, and it resumed fine.
<img width="1485" height="828" alt="image" src="https://github.com/user-attachments/assets/16e1facf-c53f-4f75-8950-7d6b792b9a66" />