### PR TITLE
fix(docker): install requirements-optional in default image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install Python deps first (layer cache)
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt requirements-optional.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir -r requirements-optional.txt
 
 # Copy app code
 COPY . .


### PR DESCRIPTION
## Summary
Docker image now installs `requirements-optional.txt` (PyMuPDF for PDF viewer, markitdown for Office attachments) so those features work without a manual pip step inside the container.

Note: PyMuPDF is AGPL — aligns with existing optional-deps documentation in the repo.

## Test plan
- [ ] `docker compose build` succeeds
- [ ] PDF preview in Documents works without "install PyMuPDF" error

Made with [Cursor](https://cursor.com)