### PR TITLE
fix(tests): accept verify kwarg in endpoint probing and model route mocks

### DIFF
--- a/tests/test_endpoint_probing.py
+++ b/tests/test_endpoint_probing.py
@@ -78,7 +78,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None, **kw: _resp(
+            lambda url, headers=None, timeout=None, verify=None: _resp(
                 200, json={"data": [{"id": "gpt-4o"}, {"id": "gpt-4o-mini"}]}),
         )
         assert _probe_endpoint("https://api.example.com/v1", "key") == ["gpt-4o", "gpt-4o-mini"]
@@ -89,7 +89,7 @@ class TestProbeEndpointParsing:
         # honoring both the "name" and "model" keys.
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None, **kw: _resp(
+            lambda url, headers=None, timeout=None, verify=None: _resp(
                 200, json={"models": [{"name": "llama3:8b"}, {"model": "qwen3:4b"}]}),
         )
         assert _probe_endpoint("https://api.example.com/v1") == ["llama3:8b", "qwen3:4b"]
@@ -98,7 +98,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         seen = []
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             seen.append(url)
             if url.endswith("/api/tags"):
                 return _resp(200, json={"models": [{"name": "llama3:8b"}]})
@@ -114,7 +114,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None, **kw: _resp(200, json={"data": []}),
+            lambda url, headers=None, timeout=None, verify=None: _resp(200, json={"data": []}),
         )
         assert _probe_endpoint("https://api.example.com/v1") == []
 
@@ -126,7 +126,7 @@ class TestPingEndpoint:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None, **kw: _resp(200),
+            lambda url, headers=None, timeout=None, verify=None: _resp(200),
         )
         assert _ping_endpoint("https://api.example.com/v1", "key") == {
             "reachable": True, "status_code": 200, "error": None,
@@ -137,7 +137,7 @@ class TestPingEndpoint:
         # A 401 means the server answered — surface the status, not "offline".
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None, **kw: _resp(401),
+            lambda url, headers=None, timeout=None, verify=None: _resp(401),
         )
         assert _ping_endpoint("https://api.example.com/v1", "bad") == {
             "reachable": False, "status_code": 401, "error": "HTTP 401",
@@ -146,7 +146,7 @@ class TestPingEndpoint:
     def test_detects_odysseus_login_redirect(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             return _resp(302, headers={"location": "/login?next=/"})
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -158,7 +158,7 @@ class TestPingEndpoint:
     def test_generic_redirect_reported(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             return _resp(301, headers={"location": "https://elsewhere.example/"})
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -169,7 +169,7 @@ class TestPingEndpoint:
     def test_transport_error_is_unreachable(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             raise httpx.ConnectError("Connection refused")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -181,7 +181,7 @@ class TestPingEndpoint:
     def test_ollama_native_version_fallback(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             if url.endswith("/api/version"):
                 return _resp(200)
             # The OpenAI-compatible /v1/models surface is down on this build.
@@ -241,7 +241,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        def fake_post(url, headers=None, json=None, timeout=None, verify=None):
             captured["url"] = url
             return _resp(200, json={"choices": [{"message": {"content": "OK"}}]})
 
@@ -255,7 +255,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "post",
-            lambda url, headers=None, json=None, timeout=None, **kw: _resp(
+            lambda url, headers=None, json=None, timeout=None, verify=None: _resp(
                 400, json={"error": {"message": "model not found"}}),
         )
         result = _probe_single_model("https://api.example.com/v1", "key", "ghost")
@@ -266,7 +266,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "post",
-            lambda url, headers=None, json=None, timeout=None, **kw: _resp(
+            lambda url, headers=None, json=None, timeout=None, verify=None: _resp(
                 403, json={"error": "forbidden"}),
         )
         result = _probe_single_model("https://api.example.com/v1", "key", "m")
@@ -276,7 +276,7 @@ class TestProbeSingleModel:
     def test_timeout(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        def fake_post(url, headers=None, json=None, timeout=None, verify=None):
             raise httpx.TimeoutException("timed out")
 
         monkeypatch.setattr(model_routes.httpx, "post", fake_post)
@@ -287,7 +287,7 @@ class TestProbeSingleModel:
     def test_transport_error_is_fail(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        def fake_post(url, headers=None, json=None, timeout=None, verify=None):
             raise httpx.ConnectError("refused")
 
         monkeypatch.setattr(model_routes.httpx, "post", fake_post)
@@ -299,7 +299,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        def fake_post(url, headers=None, json=None, timeout=None, verify=None):
             captured.update(url=url, headers=headers, payload=json)
             return _resp(200, json={"content": [{"type": "text", "text": "OK"}]})
 
@@ -314,7 +314,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        def fake_post(url, headers=None, json=None, timeout=None, verify=None):
             captured["payload"] = json
             return _resp(200, json={"content": []})
 

--- a/tests/test_endpoint_probing.py
+++ b/tests/test_endpoint_probing.py
@@ -78,7 +78,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(
+            lambda url, headers=None, timeout=None, **kw: _resp(
                 200, json={"data": [{"id": "gpt-4o"}, {"id": "gpt-4o-mini"}]}),
         )
         assert _probe_endpoint("https://api.example.com/v1", "key") == ["gpt-4o", "gpt-4o-mini"]
@@ -89,7 +89,7 @@ class TestProbeEndpointParsing:
         # honoring both the "name" and "model" keys.
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(
+            lambda url, headers=None, timeout=None, **kw: _resp(
                 200, json={"models": [{"name": "llama3:8b"}, {"model": "qwen3:4b"}]}),
         )
         assert _probe_endpoint("https://api.example.com/v1") == ["llama3:8b", "qwen3:4b"]
@@ -98,7 +98,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append(url)
             if url.endswith("/api/tags"):
                 return _resp(200, json={"models": [{"name": "llama3:8b"}]})
@@ -114,7 +114,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(200, json={"data": []}),
+            lambda url, headers=None, timeout=None, **kw: _resp(200, json={"data": []}),
         )
         assert _probe_endpoint("https://api.example.com/v1") == []
 
@@ -126,7 +126,7 @@ class TestPingEndpoint:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(200),
+            lambda url, headers=None, timeout=None, **kw: _resp(200),
         )
         assert _ping_endpoint("https://api.example.com/v1", "key") == {
             "reachable": True, "status_code": 200, "error": None,
@@ -137,7 +137,7 @@ class TestPingEndpoint:
         # A 401 means the server answered — surface the status, not "offline".
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(401),
+            lambda url, headers=None, timeout=None, **kw: _resp(401),
         )
         assert _ping_endpoint("https://api.example.com/v1", "bad") == {
             "reachable": False, "status_code": 401, "error": "HTTP 401",
@@ -146,7 +146,7 @@ class TestPingEndpoint:
     def test_detects_odysseus_login_redirect(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             return _resp(302, headers={"location": "/login?next=/"})
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -158,7 +158,7 @@ class TestPingEndpoint:
     def test_generic_redirect_reported(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             return _resp(301, headers={"location": "https://elsewhere.example/"})
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -169,7 +169,7 @@ class TestPingEndpoint:
     def test_transport_error_is_unreachable(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("Connection refused")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -181,7 +181,7 @@ class TestPingEndpoint:
     def test_ollama_native_version_fallback(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             if url.endswith("/api/version"):
                 return _resp(200)
             # The OpenAI-compatible /v1/models surface is down on this build.
@@ -241,7 +241,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_post(url, headers=None, json=None, timeout=None):
+        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
             captured["url"] = url
             return _resp(200, json={"choices": [{"message": {"content": "OK"}}]})
 
@@ -255,7 +255,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "post",
-            lambda url, headers=None, json=None, timeout=None: _resp(
+            lambda url, headers=None, json=None, timeout=None, **kw: _resp(
                 400, json={"error": {"message": "model not found"}}),
         )
         result = _probe_single_model("https://api.example.com/v1", "key", "ghost")
@@ -266,7 +266,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "post",
-            lambda url, headers=None, json=None, timeout=None: _resp(
+            lambda url, headers=None, json=None, timeout=None, **kw: _resp(
                 403, json={"error": "forbidden"}),
         )
         result = _probe_single_model("https://api.example.com/v1", "key", "m")
@@ -276,7 +276,7 @@ class TestProbeSingleModel:
     def test_timeout(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_post(url, headers=None, json=None, timeout=None):
+        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
             raise httpx.TimeoutException("timed out")
 
         monkeypatch.setattr(model_routes.httpx, "post", fake_post)
@@ -287,7 +287,7 @@ class TestProbeSingleModel:
     def test_transport_error_is_fail(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_post(url, headers=None, json=None, timeout=None):
+        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
             raise httpx.ConnectError("refused")
 
         monkeypatch.setattr(model_routes.httpx, "post", fake_post)
@@ -299,7 +299,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_post(url, headers=None, json=None, timeout=None):
+        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
             captured.update(url=url, headers=headers, payload=json)
             return _resp(200, json={"content": [{"type": "text", "text": "OK"}]})
 
@@ -314,7 +314,7 @@ class TestProbeSingleModel:
         _patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_post(url, headers=None, json=None, timeout=None):
+        def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
             captured["payload"] = json
             return _resp(200, json={"content": []})
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -345,7 +345,7 @@ class TestClassifyEndpoint:
         def fake_head(*args, **kwargs):
             raise AssertionError("generic proxy health check should not use HEAD")
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append(("GET", url))
             request = httpx.Request("GET", url)
             return httpx.Response(200, request=request)
@@ -376,7 +376,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             request = httpx.Request("GET", url)
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
@@ -389,7 +389,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -400,7 +400,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -412,7 +412,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append(url)
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -432,7 +432,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append((url, headers))
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -451,7 +451,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -345,7 +345,7 @@ class TestClassifyEndpoint:
         def fake_head(*args, **kwargs):
             raise AssertionError("generic proxy health check should not use HEAD")
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             seen.append(("GET", url))
             request = httpx.Request("GET", url)
             return httpx.Response(200, request=request)
@@ -376,7 +376,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             request = httpx.Request("GET", url)
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
@@ -389,7 +389,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -400,7 +400,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -412,7 +412,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             seen.append(url)
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -432,7 +432,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             seen.append((url, headers))
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -451,7 +451,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None, **kwargs):
+        def fake_get(url, headers=None, timeout=None, verify=None):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)


### PR DESCRIPTION
## Summary

`_probe_endpoint` and `_ping_endpoint` now pass `verify=` to `httpx.get`/`httpx.post`. The test mocks in `test_endpoint_probing.py` and `test_model_routes.py` used fixed positional signatures without accepting it, so the `verify` kwarg raised `TypeError` and caused 12 test failures.

Adds explicit `verify=None` to all `fake_get`/`fake_post` mock functions and lambdas.

## Linked Issue

Fixes #2625

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run `python -m pytest tests/test_endpoint_probing.py -q` — 28 passed (was 9 failing)
2. Run `python -m pytest tests/test_model_routes.py -q` — 109 passed (was 3 failing)