### PR TITLE
fix(agent): default bash/python subprocess cwd to data/ to prevent ephemeral file loss

### DIFF
--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -12,11 +12,19 @@ import collections
 import json
 import logging
 import os
+import pathlib
 import sys
 import time
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_user
+
+# Persistent working directory for agent subprocesses.
+# Resolves to <repo_root>/data, which is the bind-mounted volume in Docker
+# (/app/data) and the local data directory for manual installs.
+# Using this as cwd and HOME prevents the agent from silently creating files
+# in ephemeral container layers that are lost on the next rebuild.
+_AGENT_WORKDIR = str(pathlib.Path(__file__).parent.parent / "data")
 
 MAX_OUTPUT_CHARS = 10_000
 MAX_READ_CHARS = 20_000
@@ -324,6 +332,7 @@ async def _direct_fallback(
         "TERM": "xterm-256color",
         "COLUMNS": "120",
         "LINES": "40",
+        "HOME": _AGENT_WORKDIR,
     }
 
     try:
@@ -333,6 +342,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
+                cwd=_AGENT_WORKDIR,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,
@@ -359,6 +369,7 @@ async def _direct_fallback(
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=_subproc_env,
+                cwd=_AGENT_WORKDIR,
             )
             stdout, stderr, rc, timed_out = await _run_subprocess_streaming(
                 proc,


### PR DESCRIPTION
## Summary

- Agent `bash` and `python` subprocesses previously inherited `/app` as their working directory, so any file created with a relative path landed in the ephemeral container layer and was permanently lost on the next `docker compose up --build`.
- Set `cwd` and `HOME` to `<repo_root>/data` on both subprocess launchers — the bind-mounted volume in Docker (`/app/data`) and the standard data directory for manual installs.
- Computed via `pathlib.Path(__file__).parent.parent / "data"` at import time: works for both Docker and manual installs without any new env var or compose change.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #2512

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran `python -m py_compile app.py routes/*.py src/*.py` — no errors.
- [ ] I actually ran the app and verified the change works end-to-end.

> Note: I could not run the full Docker stack end-to-end, but the fix is mechanical: `cwd` and `HOME` are passed directly to `asyncio.create_subprocess_shell` / `create_subprocess_exec`. The path resolution (`pathlib.Path(__file__).parent.parent / "data"`) was verified to produce `/app/data` from `/app/src/tool_execution.py`.

## How to Test

1. Start a Docker install (`docker compose up`).
2. Start an agent session, ask: *"create a file called hello.txt with the word hello"*.
3. Confirm the agent creates it under `/app/data/hello.txt` (visible on host at `./data/hello.txt`).
4. Run `docker compose up -d --build` to rebuild the container.
5. Confirm `./data/hello.txt` still exists — the file survived the rebuild.
6. Also verify `pwd` inside a bash tool returns the data directory, and `~` expands to it.

## Visual / UI changes

No visual changes. This fix is entirely in `src/tool_execution.py` — no HTML, CSS, JS, or template modifications.