### PR TITLE
fix(tests): accept verify in endpoint HTTP mocks

### DIFF
--- a/tests/test_endpoint_probing.py
+++ b/tests/test_endpoint_probing.py
@@ -78,7 +78,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(
+            lambda url, headers=None, timeout=None, verify=None, **kwargs: _resp(
                 200, json={"data": [{"id": "gpt-4o"}, {"id": "gpt-4o-mini"}]}),
         )
         assert _probe_endpoint("https://api.example.com/v1", "key") == ["gpt-4o", "gpt-4o-mini"]
@@ -89,7 +89,7 @@ class TestProbeEndpointParsing:
         # honoring both the "name" and "model" keys.
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(
+            lambda url, headers=None, timeout=None, verify=None, **kwargs: _resp(
                 200, json={"models": [{"name": "llama3:8b"}, {"model": "qwen3:4b"}]}),
         )
         assert _probe_endpoint("https://api.example.com/v1") == ["llama3:8b", "qwen3:4b"]
@@ -98,7 +98,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             seen.append(url)
             if url.endswith("/api/tags"):
                 return _resp(200, json={"models": [{"name": "llama3:8b"}]})
@@ -114,7 +114,7 @@ class TestProbeEndpointParsing:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(200, json={"data": []}),
+            lambda url, headers=None, timeout=None, verify=None, **kwargs: _resp(200, json={"data": []}),
         )
         assert _probe_endpoint("https://api.example.com/v1") == []
 
@@ -126,7 +126,7 @@ class TestPingEndpoint:
         _patch_resolve(monkeypatch)
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(200),
+            lambda url, headers=None, timeout=None, verify=None, **kwargs: _resp(200),
         )
         assert _ping_endpoint("https://api.example.com/v1", "key") == {
             "reachable": True, "status_code": 200, "error": None,
@@ -137,7 +137,7 @@ class TestPingEndpoint:
         # A 401 means the server answered — surface the status, not "offline".
         monkeypatch.setattr(
             model_routes.httpx, "get",
-            lambda url, headers=None, timeout=None: _resp(401),
+            lambda url, headers=None, timeout=None, verify=None, **kwargs: _resp(401),
         )
         assert _ping_endpoint("https://api.example.com/v1", "bad") == {
             "reachable": False, "status_code": 401, "error": "HTTP 401",
@@ -146,7 +146,7 @@ class TestPingEndpoint:
     def test_detects_odysseus_login_redirect(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             return _resp(302, headers={"location": "/login?next=/"})
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -158,7 +158,7 @@ class TestPingEndpoint:
     def test_generic_redirect_reported(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             return _resp(301, headers={"location": "https://elsewhere.example/"})
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -169,7 +169,7 @@ class TestPingEndpoint:
     def test_transport_error_is_unreachable(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             raise httpx.ConnectError("Connection refused")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -181,7 +181,7 @@ class TestPingEndpoint:
     def test_ollama_native_version_fallback(self, monkeypatch):
         _patch_resolve(monkeypatch)
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             if url.endswith("/api/version"):
                 return _resp(200)
             # The OpenAI-compatible /v1/models surface is down on this build.

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -345,7 +345,7 @@ class TestClassifyEndpoint:
         def fake_head(*args, **kwargs):
             raise AssertionError("generic proxy health check should not use HEAD")
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             seen.append(("GET", url))
             request = httpx.Request("GET", url)
             return httpx.Response(200, request=request)
@@ -376,7 +376,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             request = httpx.Request("GET", url)
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
@@ -389,7 +389,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -400,7 +400,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -412,7 +412,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             seen.append(url)
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -432,7 +432,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             seen.append((url, headers))
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -451,7 +451,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)


### PR DESCRIPTION
## Summary

Part of #2580.

Updates endpoint/model-route test HTTP mocks to accept the `verify` keyword argument now passed by production endpoint probing code. This fixes isolated endpoint probing test failures without changing production code or test assertions.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to endpoint/model-route test HTTP mock signatures.
- [ ] I ran the app end-to-end.
  - Not applicable: this is a test-only fix. No production code, routes, UI, or runtime behavior changed.

## How to Test

1. Compile the touched test files:

```bash
python3 -m py_compile \
  tests/test_endpoint_probing.py \
  tests/test_model_routes.py
```

2. Confirm no stale fake `httpx.get()` signatures remain in the touched files:

```bash
python3 - <<'PY'
from pathlib import Path
import re

bad = []

for path in [
    Path("tests/test_endpoint_probing.py"),
    Path("tests/test_model_routes.py"),
]:
    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
        if "lambda url, headers=None, timeout=None" in line and "**kwargs" not in line:
            bad.append(f"{path}:{lineno}: {line.strip()}")
        if re.search(r"def fake_get\(url, headers=None, timeout=None", line) and "**kwargs" not in line:
            bad.append(f"{path}:{lineno}: {line.strip()}")

if bad:
    print("\n".join(bad))
    raise SystemExit(1)

print("ok")
PY
```

3. Run the targeted verify-related tests:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
  python3 -m pytest -q \
  tests/test_endpoint_probing.py \
  tests/test_model_routes.py \
  -k 'probe or ping or list_model_ids'
```

Validated locally:

```text
40 passed, 97 deselected, 1 warning
```

4. Run the full touched test files:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
  python3 -m pytest -q \
  tests/test_endpoint_probing.py \
  tests/test_model_routes.py
```

Validated locally:

```text
137 passed, 1 warning
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.
