### PR TITLE
docs: point PR checklist at dev

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Fixes #
 ## Checklist
 
 - [ ] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
-- [ ] This PR targets `main`
+- [ ] This PR targets `dev`
 - [ ] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
 - [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
 


### PR DESCRIPTION
## Summary

Updates the PR template checklist so it matches the new contribution flow: PRs should target `dev`, not `main`. The top Target branch section already says this; this fixes the stale checklist line so new contributors do not get contradictory guidance.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #2572

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I verified the change end-to-end for a template-only docs update. Running the app is not applicable because no runtime, UI, CSS, HTML, SVG, or `static/js/` files changed.

## How to Test

1. Open `.github/pull_request_template.md`.
2. Confirm the Target branch section says PRs target `dev`, not `main`.
3. Confirm the Checklist section also says `This PR targets dev`.

Verified locally:

```text
git diff --check
```

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — PR template text only. No UI rendering, CSS, HTML, SVG, or `static/js/` files touched.

### Screenshots / clips

N/A — no visual/UI change.