### PR TITLE
fix(tests): use non-repeating split chunk fixture

### DIFF
--- a/tests/test_split_chunks_no_duplicate_tail.py
+++ b/tests/test_split_chunks_no_duplicate_tail.py
@@ -14,7 +14,10 @@ def test_no_duplicate_tail_chunk():
 
 
 def test_no_chunk_is_contained_in_another():
-    text = "".join(chr(33 + (k % 90)) for k in range(2000))
+    text = "\n".join(
+        f"unique-line-{k:04d}-square-{k * k:08d}-cube-{k * k * k:012d}"
+        for k in range(300)
+    )
     chunks = split_chunks(text, size=1000, overlap=200)
     # The buggy version produced a final 200-char chunk fully inside the prior one.
     for a in range(len(chunks)):


### PR DESCRIPTION
## Summary

Part of #2580.

Updates the split-chunk containment regression test to use deterministic non-repeating records instead of a repeating 90-character fixture. This keeps the test focused on duplicate trailing chunks and avoids false failures caused by accidental substring matches in repetitive input.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to the split_chunks regression test fixture.
- [ ] I ran the app end-to-end.
  - Not applicable: this is a test-only fix. No production code, routes, UI, or runtime behavior changed.

## How to Test

1. Compile the touched test file:

```bash
python3 -m py_compile tests/test_split_chunks_no_duplicate_tail.py
```

2. Run the split_chunks regression tests:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
  python3 -m pytest -q tests/test_split_chunks_no_duplicate_tail.py
```

Validated locally:

```text
4 passed, 1 warning
```

3. Confirm the new fixture does not produce accidental contained chunks:

```text
contained pairs: []
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.
