### PR TITLE
test: make split chunk regression deterministic

### DIFF
--- a/tests/test_split_chunks_no_duplicate_tail.py
+++ b/tests/test_split_chunks_no_duplicate_tail.py
@@ -14,7 +14,9 @@ def test_no_duplicate_tail_chunk():
 
 
 def test_no_chunk_is_contained_in_another():
-    text = "".join(chr(33 + (k % 90)) for k in range(2000))
+    # Use non-repeating tokens so this checks chunk boundaries rather than
+    # accidentally matching repeated source text inside another chunk.
+    text = "".join(f"{k:04x}|" for k in range(400))
     chunks = split_chunks(text, size=1000, overlap=200)
     # The buggy version produced a final 200-char chunk fully inside the prior one.
     for a in range(len(chunks)):


### PR DESCRIPTION
## Summary

The split chunk duplicate-tail regression test used a 90-character repeating fixture, so the containment assertion could fail even when `split_chunks()` emitted the correct chunk boundaries. This changes that fixture to non-repeating fixed-width tokens so the test checks only whether a whole emitted chunk is contained in another emitted chunk.

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`, not `main`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. Not applicable: this is a test-only CI baseline fix.

## How to Test

1. Run `uv run pytest tests/test_split_chunks_no_duplicate_tail.py -q` and confirm the four split chunk regression tests pass.
2. Run `python3 -m py_compile src/personal_docs.py tests/test_split_chunks_no_duplicate_tail.py` to confirm the touched test and imported helper compile.
3. Run `git diff --check` to confirm the patch has no whitespace errors.

Local results:

```text
uv run pytest tests/test_split_chunks_no_duplicate_tail.py -q
....                                                                     [100%]
4 passed in 0.15s

python3 -m py_compile src/personal_docs.py tests/test_split_chunks_no_duplicate_tail.py
# passed

git diff --check
# passed
```

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] Screenshot or short clip of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] Style match: not applicable; no UI/rendering files changed.
- [x] No new component patterns.

### Screenshots / clips

Not applicable; this PR only changes a Python regression test.
