### PR TITLE
fix(tests): use line-level PDF marker assertion

### DIFF
--- a/tests/test_build_user_content_pdf_marker.py
+++ b/tests/test_build_user_content_pdf_marker.py
@@ -50,8 +50,9 @@ def test_pdf_body_marker_stripped_without_eating_text(monkeypatch, tmp_path):
     )
 
     body = content[0]["text"] if isinstance(content, list) else content
-    # The leading page text must survive intact.
-    assert "[Page 1 text]:" in body
-    assert "to the board, the agenda is set" in body
-    # The old lstrip(chars) corruption ate "[P" then "to" -> "age 1 text]: the board".
-    assert "age 1 text" not in body
+    body_lines = body.splitlines()
+    # The leading page marker and page text must survive intact.
+    assert "[Page 1 text]:" in body_lines
+    assert "to the board, the agenda is set" in body_lines
+    # The old lstrip(chars) corruption produced a line like "age 1 text]:" (missing "[P").
+    assert "age 1 text]:" not in body_lines


### PR DESCRIPTION
## Summary

Part of #2580.

Updates the PDF marker regression test to check the corrupted marker at line level instead of using a broad substring assertion. This preserves the test intent while avoiding a false failure because `age 1 text` is naturally contained inside the valid `[Page 1 text]:` marker.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to the PDF marker regression test assertion.
- [ ] I ran the app end-to-end.
  - Not applicable: this is a test-only fix. No production code, routes, UI, or runtime behavior changed.

## How to Test

1. Compile the touched test file:

```bash
python3 -m py_compile tests/test_build_user_content_pdf_marker.py
```

2. Run the PDF marker regression test:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
  python3 -m pytest -q tests/test_build_user_content_pdf_marker.py
```

Validated locally:

```text
1 passed, 1 warning
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.
