### PR TITLE
fix(tests): align gallery owner filter null-user expectation

### DIFF
--- a/tests/test_null_owner_gates.py
+++ b/tests/test_null_owner_gates.py
@@ -153,13 +153,13 @@ def test_document_owner_filter_applies_owner_clause():
 # gallery._owner_filter
 # ---------------------------------------------------------------------------
 
-def test_gallery_owner_filter_blocks_anonymous():
+def test_gallery_owner_filter_allows_single_user_mode():
     from routes.gallery_routes import _owner_filter
     fake_q = MagicMock()
     out = _owner_filter(fake_q, user=None)
-    # Anonymous → q.filter(False) → contradiction, empty result set.
-    fake_q.filter.assert_called_once_with(False)
-    assert out is fake_q.filter.return_value
+    # user=None means single-user/auth-disabled mode: return q unchanged, no filter.
+    fake_q.filter.assert_not_called()
+    assert out is fake_q
 
 
 def test_gallery_owner_filter_passes_user():


### PR DESCRIPTION
## Summary

Part of #2580.

Updates the stale gallery owner-filter null-user test to match current single-user/auth-disabled behavior. `_owner_filter(q, user=None)` intentionally returns the original query unchanged instead of filtering to an empty result set.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to the stale gallery null-owner gate test expectation.
- [ ] I ran the app end-to-end.
  - Not applicable: this is a test-only fix. No production code, routes, UI, or runtime behavior changed.

## How to Test

1. Compile the touched and related test files:

```bash
python3 -m py_compile \
  tests/test_null_owner_gates.py \
  tests/test_gallery_owner_filter_single_user.py
```

2. Run the null-owner and gallery single-user owner-filter tests:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
  python3 -m pytest -q \
  tests/test_null_owner_gates.py \
  tests/test_gallery_owner_filter_single_user.py
```

Validated locally:

```text
21 passed, 1 warning
```

3. Confirm the stale expectation is removed:

```bash
rg -n 'test_gallery_owner_filter_blocks_anonymous|assert_called_once_with\(False\)|Anonymous → q\.filter\(False\)' \
  tests/test_null_owner_gates.py
```

Expected: no matches.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.
