### PR TITLE
fix(modals): stop tool windows drifting from the cursor when dragged

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2694,6 +2694,9 @@ function initializeEventListeners() {
 
       // Reset to flex-centered position each time modal opens
       new MutationObserver(() => {
+        // windowDrag-managed modals position themselves; this reset would fire
+        // mid-drag (on the modal-dragging class) and yank them off the cursor.
+        if (m.dataset.sharedDrag) return;
         if (!m.classList.contains('hidden')) {
           content.style.position = '';
           content.style.left = '';
@@ -2717,6 +2720,7 @@ function initializeEventListeners() {
       }
 
       header.addEventListener('mousedown', (e) => {
+        if (m.dataset.sharedDrag) return;  // handled by windowDrag.js
         if (e.target.closest('.close-btn')) return;
         e.preventDefault();
         startDrag(e.clientX, e.clientY);
@@ -2739,6 +2743,7 @@ function initializeEventListeners() {
       // the swipe-dismiss gesture.
       if (window.innerWidth > 768) {
         header.addEventListener('touchstart', (e) => {
+          if (m.dataset.sharedDrag) return;  // handled by windowDrag.js
           if (e.target.closest('.close-btn')) return;
           const t = e.touches[0];
           startDrag(t.clientX, t.clientY);

--- a/static/js/windowDrag.js
+++ b/static/js/windowDrag.js
@@ -58,6 +58,9 @@ export function makeWindowDraggable(modal, options = {}) {
   const content = options.content;
   const header = options.header;
   if (!content || !header) return;
+  // Flag so the legacy generic modal-drag in app.js leaves this one alone —
+  // double-wiring fights over the inline position and the window drifts.
+  if (modal) modal.dataset.sharedDrag = '1';
   const fsClass = options.fsClass || null;
   const onEnterFullscreen = options.onEnterFullscreen || null;
   const onExitFullscreen = options.onExitFullscreen || null;

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v326';
+const CACHE_NAME = 'odysseus-v327';
 
 // Core shell precached on install so repeat opens are instant without any
 // network wait. Keep this list in sync with the <script type="module"> tags


### PR DESCRIPTION
## Summary
Tool windows that use the shared `windowDrag` helper (Brain, Gallery, Tasks, Calendar,
Cookbook, Email, Library, Theme) were drag-wired twice: the legacy generic modal-drag in
`static/app.js` also picked them up. That legacy code's MutationObserver resets the
content's inline position on any class change while the modal is visible, so the moment
`windowDrag` added its `modal-dragging` class at drag start, the just-set `position:fixed`
was wiped — and subsequent `left`/`top` updates landed as relative offsets, throwing the
window away from the cursor. `settings-modal` was already excluded; this marks every
windowDrag-managed modal (`dataset.sharedDrag`) and has the legacy drag + reset observer
skip them. JS-only; no styling changes.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue
Fixes #2540

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
[before-drag-jumps.webm](https://github.com/user-attachments/assets/d92a2f2d-af98-4e5a-8f3c-5ff1d16d2d5e)
[after-drag-tracks.webm](https://github.com/user-attachments/assets/ebbb84b3-2f96-41da-bb63-10b15e286691)
[after-drag-tracks.webm](https://github.com/user-attachments/assets/0a59382a-92cf-40f8-a508-2b073b048835)
[before-drag-jumps.webm](https://github.com/user-attachments/assets/7944152f-9eb7-46ec-8cfe-6bf1c4e368d0)

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] My changes are limited to the scope described — no unrelated refactors or whitespace.
- [x] I actually ran the app (Docker container on :7000) and verified the fix end-to-end.

## How to Test
1. On desktop (viewport wider than 768px), open the Brain (Memory) modal from the icon rail.
2. Drag it by the title bar — it now stays under the cursor instead of jumping away.
3. Same check for Gallery / Tasks / Calendar / Cookbook.

## Visual / UI changes
- [x] Before/after clips attached below.
- [x] Style match: no new CSS, colors, fonts, or components — behavior-only JS fix.
- [x] No new component patterns.

### Screenshots / clips
[before-drag-jumps.webm](https://github.com/user-attachments/assets/8565682c-16f7-4e36-a37a-69acce681a99)
[after-drag-tracks.webm](https://github.com/user-attachments/assets/c6c93fb2-ba87-4f97-a678-0fcfef551a0b)
