### PR TITLE
fix(cookbook): shim python3 when it's a Windows Store alias stub

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -362,7 +362,12 @@ def _user_shell_path_bootstrap() -> list[str]:
         '  ODYSSEUS_USER_PATH="$("$ODYSSEUS_USER_SHELL" -ic \'printf "__ODYSSEUS_PATH__%s\\n" "$PATH"\' 2>/dev/null | sed -n \'s/^__ODYSSEUS_PATH__//p\' | tail -n 1 || true)"',
         '  if [ -n "$ODYSSEUS_USER_PATH" ]; then export PATH="$ODYSSEUS_USER_PATH:$PATH"; fi',
         'fi',
-        'command -v python3 >/dev/null 2>&1 || python3() { python "$@"; }',
+        # Windows can expose python3 as a Microsoft Store App Execution Alias
+        # under WindowsApps. Git Bash sees that stub as present, but it exits
+        # before running Python. A Windows venv usually has python.exe, not
+        # python3.exe, so treat a missing or WindowsApps python3 as absent.
+        '_odys_py3="$(command -v python3 2>/dev/null || true)"',
+        'case "$_odys_py3" in ""|*[Ww]indows[Aa]pps*) python3() { python "$@"; } ;; esac',
         'command -v python >/dev/null 2>&1 || python() { python3 "$@"; }',
     ]
 

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -466,7 +466,13 @@ def test_local_tooling_path_export_converts_windows_paths_for_bash():
 
 def test_user_shell_path_bootstrap_falls_back_to_python_on_windows_bash():
     script = "\n".join(_user_shell_path_bootstrap())
-    assert 'command -v python3 >/dev/null 2>&1 || python3() { python "$@"; }' in script
+    # A missing python3 OR a Microsoft Store App Execution Alias stub under
+    # WindowsApps must shim python3 -> python so the venv interpreter is used.
+    assert '_odys_py3="$(command -v python3 2>/dev/null || true)"' in script
+    assert (
+        'case "$_odys_py3" in ""|*[Ww]indows[Aa]pps*) python3() { python "$@"; } ;; esac'
+        in script
+    )
     assert 'command -v python >/dev/null 2>&1 || python() { python3 "$@"; }' in script
 
 


### PR DESCRIPTION
## Summary

On native-Windows installs, every Cookbook action that shells out to `python3` — dependency installs and model serves — fails immediately with `Python was not found … exit 49`. Cause: the Microsoft Store **App execution alias** makes `python3` resolve to a 0-byte stub in `%LOCALAPPDATA%\Microsoft\WindowsApps`, and since a standard Windows venv ships `python.exe` but **no `python3.exe`**, the existing guard `command -v python3 || python3() { python "$@"; }` finds the stub, assumes python3 is real, and never installs the fallback. This makes the guard treat a missing **or** WindowsApps-stub `python3` as absent and shim it to `python` (which the venv/Scripts PATH prepend resolves to the real interpreter). No behaviour change on Linux/macOS, where `python3` is a real binary outside `WindowsApps`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2636

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [ ] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app` via `launch-windows.ps1`) and verified the change works end-to-end.

## How to Test

1. On Windows with the default Microsoft Store `python3` alias enabled, in Git Bash, simulate the wrapper (venv has `python.exe`, no `python3.exe`):
   ```bash
   export PATH="/c/path/to/venv/Scripts:$PATH"; hash -r
   command -v python3          # -> .../WindowsApps/python3   (the dead stub)
   python3 -c "print(1)"       # -> "Python was not found..."  exit 9009/49
   ```
2. With this change, the emitted bootstrap is:
   ```bash
   _odys_py3="$(command -v python3 2>/dev/null || true)"
   case "$_odys_py3" in ""|*[Ww]indows[Aa]pps*) python3() { python "$@"; } ;; esac
   ```
   Re-run after prepending the venv: `python3 -c "import sys; print(sys.executable)"` now prints the venv `python.exe`.
3. End-to-end: `launch-windows.ps1` → Cookbook → Dependencies → install any package (e.g. `hf_transfer`) → succeeds (previously exited 49). Serving a GGUF model likewise gets past the `python3` step.
4. Unit test: `python -m pytest tests/test_cookbook_helpers.py -k user_shell_path_bootstrap` (added/updated, passes).

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes — this only touches the bash bootstrap emitted for Cookbook shell wrappers (`routes/cookbook_helpers.py`).
