### PR TITLE
fix(cookbook): don't 500 the packages panel when an optional package crashes on import

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -1014,6 +1014,12 @@ def setup_shell_routes() -> APIRouter:
                     pkg["installed"] = False
                 except importlib_metadata.PackageNotFoundError:
                     pkg["installed"] = False
+                except Exception:
+                    # Installed but crashes on import — e.g. a CUDA build of
+                    # llama-cpp-python raising FileNotFoundError when the CUDA
+                    # toolkit dir is absent. One broken optional package must not
+                    # 500 the entire packages panel; report it as not usable.
+                    pkg["installed"] = False
 
             if pkg.get("installed"):
                 update_status = _package_pip_update_status(pkg, probe)


### PR DESCRIPTION
## Summary

`GET /api/cookbook/packages` (`list_packages()` in `routes/shell_routes.py`) probes each optional package with `importlib.import_module()` but only catches `ImportError` / `PackageNotFoundError`. If any one optional package is installed but raises a *different* exception on import, it propagates and 500s the whole endpoint — the UI shows `Error loading packages: Unexpected token 'I', "Internal S"... is not valid JSON` and the entire Dependencies panel is unusable. This catches any exception from the per-package import probe and reports that single package as not-installed, so one broken optional package can't take down the panel.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2637

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [ ] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app` via `launch-windows.ps1`) and verified the change works end-to-end.

## How to Test

1. Make one optional package crash on import (non-ImportError). Real example on Windows: a CUDA build of `llama-cpp-python` whose toolkit dir is absent raises `FileNotFoundError` at import. Verify the throw:
   ```
   python -c "import importlib; importlib.import_module('llama_cpp')"
   # FileNotFoundError: ...\CUDA\vXX\bin   (NOT an ImportError)
   ```
2. Open Cookbook → Dependencies.
   - Before: whole panel fails — `Error loading packages: Unexpected token 'I' …` (endpoint returns 500).
   - After: panel loads normally; the broken package shows as not-installed.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI/visual changes — backend only (`list_packages` exception handling in `routes/shell_routes.py`).
