### PR TITLE
fix(research): honor planning query timeouts

### DIFF
--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -196,6 +196,8 @@ class DeepResearcher:
         max_content_chars: int = 15000,
         max_report_tokens: int = 8192,
         extraction_timeout: int = 90,
+        planning_timeout: int = 90,
+        query_timeout: int = 120,
         extraction_concurrency: int = 3,
         min_rounds: int = 2,
         max_empty_rounds: int = 2,
@@ -215,6 +217,8 @@ class DeepResearcher:
         self.max_content_chars = max_content_chars
         self.max_report_tokens = max_report_tokens
         self.extraction_timeout = min(3600, max(15, int(extraction_timeout or 90)))
+        self.planning_timeout = min(3600, max(15, int(planning_timeout or 90)))
+        self.query_timeout = min(3600, max(15, int(query_timeout or 120)))
         self.extraction_concurrency = min(12, max(1, int(extraction_concurrency or 3)))
         self.min_rounds = min_rounds
         self.max_empty_rounds = max_empty_rounds
@@ -395,7 +399,7 @@ class DeepResearcher:
                 [{"role": "user", "content": prompt}],
                 temperature=0.3,
                 max_tokens=1024,
-                timeout=30,
+                timeout=getattr(self, "planning_timeout", 90),
             )
             # Try to parse as JSON for structured plan
             parsed = self._parse_json_object(response)
@@ -478,6 +482,7 @@ class DeepResearcher:
                 [{"role": "user", "content": prompt}],
                 temperature=0.5,
                 max_tokens=4096,
+                timeout=getattr(self, "query_timeout", 120),
             )
             queries = self._parse_json_array(response)
             # Deduplicate

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -722,6 +722,18 @@ class ResearchHandler:
                 minimum=1,
                 maximum=12,
             )
+            _planning_timeout = _bounded_int(
+                get_setting("research_planning_timeout_seconds", _extraction_timeout),
+                default=_extraction_timeout,
+                minimum=15,
+                maximum=3600,
+            )
+            _query_timeout = _bounded_int(
+                get_setting("research_query_timeout_seconds", _extraction_timeout),
+                default=_extraction_timeout,
+                minimum=15,
+                maximum=3600,
+            )
 
             researcher = DeepResearcher(
                 llm_endpoint=llm_endpoint,
@@ -732,6 +744,8 @@ class ResearchHandler:
                 max_time=max_time,
                 max_report_tokens=_max_report_tokens,
                 extraction_timeout=_extraction_timeout,
+                planning_timeout=_planning_timeout,
+                query_timeout=_query_timeout,
                 extraction_concurrency=_extraction_concurrency,
                 progress_callback=progress_callback,
                 search_provider=search_provider,

--- a/src/settings.py
+++ b/src/settings.py
@@ -85,6 +85,11 @@ DEFAULT_SETTINGS = {
     "research_search_provider": "",
     "research_max_tokens": 16384,
     "research_extraction_timeout_seconds": 90,
+    # Lightweight planning/query LLM calls happen before any search starts.
+    # Keep them separately tunable so slow local backends are not capped by
+    # the old 30s/60s per-call defaults.
+    "research_planning_timeout_seconds": 90,
+    "research_query_timeout_seconds": 90,
     "research_extraction_concurrency": 3,
     # Hard wall-clock cap on a single deep-research run. The previous 600s
     # (10 min) default cut off slow local / edge LLMs mid-synthesis; 1800s

--- a/tests/test_deep_research_extraction_controls.py
+++ b/tests/test_deep_research_extraction_controls.py
@@ -96,3 +96,33 @@ def test_extraction_timeout_allows_long_local_model_runs():
     )
 
     assert researcher.extraction_timeout == 1800
+
+
+@pytest.mark.asyncio
+async def test_planning_and_query_generation_use_configured_timeouts():
+    researcher = DeepResearcher(
+        llm_endpoint="http://local.test/v1/chat/completions",
+        llm_model="local-model",
+        planning_timeout=234,
+        query_timeout=345,
+    )
+    captured = []
+
+    async def fake_llm(messages, temperature=0.3, max_tokens=4096, timeout=60):
+        captured.append(timeout)
+        if max_tokens == 1024:
+            return json.dumps({
+                "sub_questions": ["one"],
+                "key_topics": ["topic"],
+                "success_criteria": "complete",
+            })
+        return json.dumps(["query one", "query two"])
+
+    researcher._llm = fake_llm
+
+    plan = await researcher._create_plan("question")
+    queries = await researcher._generate_queries("question", "", 1)
+
+    assert "Sub-questions: one" in plan
+    assert queries == ["query one", "query two"]
+    assert captured == [234, 345]


### PR DESCRIPTION
## Summary

Deep Research already exposes longer extraction/run timeouts for slow local backends, but the initial planning and query-generation LLM calls still used fixed 30s/60s caps. This threads bounded planning/query timeouts through `DeepResearcher`, defaults them from settings, and adds a regression test that verifies those early calls honor the configured values before any search work starts.

## Linked Issue

Fixes #2621

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `python3 -m pytest tests/test_deep_research_extraction_controls.py` and confirm the planning/query timeout regression test passes.
2. Run `python3 -m py_compile src/deep_research.py src/research_handler.py src/settings.py` to verify the touched Python modules compile.
3. For a manual smoke test, set `research_planning_timeout_seconds` and `research_query_timeout_seconds` in `data/settings.json`, start a Deep Research run against a slow local backend, and confirm the run proceeds past planning/query generation instead of failing at the old 30s/60s caps.

Local verification run:

```text
python3 -m pytest tests/test_deep_research_extraction_controls.py tests/test_deep_research_date_context.py
# 7 passed in 0.36s

python3 -m py_compile src/deep_research.py src/research_handler.py src/settings.py
git diff --check
```

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual/UI changes.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A — no rendering changes.
