### PR TITLE
fix(history): tolerate tool-call turns during compact

### DIFF
--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -544,7 +544,7 @@ def setup_history_routes(session_manager) -> APIRouter:
             # Build text to summarize
             convo_text = "\n".join(
                 f"{(m.role if isinstance(m, ChatMessage) else m.get('role', '')).upper()}: "
-                f"{(m.content if isinstance(m, ChatMessage) else m.get('content', ''))[:2000]}"
+                f"{((m.content if isinstance(m, ChatMessage) else m.get('content')) or '')[:2000]}"
                 for m in older
             )
 

--- a/tests/test_history_compact_tool_calls.py
+++ b/tests/test_history_compact_tool_calls.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.models import ChatMessage
+import routes.history_routes as history_routes
+
+
+class _FakeQuery:
+    def __init__(self, rows=None, first_row=None):
+        self._rows = rows or []
+        self._first_row = first_row
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self._rows
+
+    def first(self):
+        return self._first_row
+
+
+class _FakeDb:
+    def __init__(self):
+        self.added = []
+        self.deleted = []
+        self.session_row = SimpleNamespace(message_count=0, updated_at=None)
+
+    def query(self, model):
+        if model is history_routes.DbSession:
+            return _FakeQuery(first_row=self.session_row)
+        return _FakeQuery(rows=[])
+
+    def add(self, row):
+        self.added.append(row)
+
+    def delete(self, row):
+        self.deleted.append(row)
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _FakeSessionManager:
+    def __init__(self, session):
+        self.session = session
+        self.saved = False
+
+    def get_session(self, session_id):
+        if session_id != self.session.id:
+            raise KeyError(session_id)
+        return self.session
+
+    def save_sessions(self):
+        self.saved = True
+
+
+class _FakeSession:
+    id = "session-1"
+    name = "Tool session"
+    endpoint_url = "http://example.test/v1"
+    model = "test-model"
+    headers = {}
+
+    def __init__(self, history):
+        self.history = history
+        self.message_count = len(history)
+
+    def get_context_messages(self):
+        return [
+            msg.to_dict() if isinstance(msg, ChatMessage) else msg
+            for msg in self.history
+        ]
+
+
+def _compact_prompt_for(monkeypatch, history):
+    captured = {}
+
+    async def fake_llm_call_async(endpoint_url, model, messages, **kwargs):
+        captured["messages"] = messages
+        return "Summary text"
+
+    monkeypatch.setattr(history_routes, "_verify_session_owner", lambda request, session_id: None)
+    monkeypatch.setattr(history_routes, "SessionLocal", lambda: _FakeDb())
+
+    import src.endpoint_resolver as endpoint_resolver
+    import src.llm_core as llm_core
+    import src.model_context as model_context
+
+    monkeypatch.setattr(endpoint_resolver, "resolve_endpoint", lambda kind: (None, None, {}))
+    monkeypatch.setattr(llm_core, "llm_call_async", fake_llm_call_async)
+    monkeypatch.setattr(model_context, "estimate_tokens", lambda messages: 100)
+    monkeypatch.setattr(model_context, "get_context_length", lambda endpoint_url, model: 1000)
+
+    session = _FakeSession(history)
+    manager = _FakeSessionManager(session)
+    app = FastAPI()
+    app.include_router(history_routes.setup_history_routes(manager))
+
+    response = TestClient(app).post("/api/session/session-1/compact")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert manager.saved is True
+    return captured["messages"][1]["content"]
+
+
+def test_manual_compact_tolerates_chatmessage_with_none_content(monkeypatch):
+    compact_prompt = _compact_prompt_for(
+        monkeypatch,
+        [
+            ChatMessage(role="user", content="start"),
+            ChatMessage(role="assistant", content=None),
+            ChatMessage(role="tool", content="tool result"),
+            ChatMessage(role="assistant", content="done"),
+            ChatMessage(role="user", content="next"),
+            ChatMessage(role="assistant", content="final"),
+        ],
+    )
+    assert "ASSISTANT: None" not in compact_prompt
+    assert "ASSISTANT: " in compact_prompt
+
+
+def test_manual_compact_tolerates_dict_message_with_none_content(monkeypatch):
+    compact_prompt = _compact_prompt_for(
+        monkeypatch,
+        [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": None},
+            ChatMessage(role="tool", content="tool result"),
+            ChatMessage(role="assistant", content="done"),
+            ChatMessage(role="user", content="next"),
+            ChatMessage(role="assistant", content="final"),
+        ],
+    )
+    assert "ASSISTANT: None" not in compact_prompt
+    assert "ASSISTANT: " in compact_prompt


### PR DESCRIPTION
## Summary

Manual session compaction builds a text prompt from older messages before calling the utility model. Tool-call assistant turns can have `content=None`, so the existing `m.content[:2000]` slice raised a 500 before compaction could run. This changes the compact prompt builder to treat missing content as an empty string and adds a route regression test for a history containing a tool-call-style assistant message.

Duplicate check note: I searched open issues and open PRs before taking this. I skipped issues that already had PRs or reporters actively taking them, and found no open PR linked to #2303 or directly fixing this `compact_session` `None` content crash. Same-area compaction PRs I found were for different bugs.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2303

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Backend route-only note: I did not claim a manual browser run. I verified the affected compact route path with Docker-based FastAPI regression tests, and this PR does not touch UI, rendering, CSS, HTML, SVG, or `static/js/`.

## How to Test

Run the focused regression set in Docker:

    docker compose run --rm --no-deps --entrypoint python -e PYTHONDONTWRITEBYTECODE=1 --volume "C:\Users\ocean\AntigravityProjects\odysseus:/app" odysseus -m pytest -q -p no:cacheprovider tests/test_history_compact_tool_calls.py tests/test_context_compactor.py tests/test_context_compactor_nonstring.py tests/test_replace_messages_multimodal.py

Expected result: `24 passed`.

The new regression test drives `POST /api/session/{session_id}/compact` with an older assistant message whose `content` is `None`; before this fix that route returned 500 while slicing `None`, and after this fix it completes and sends an empty assistant line into the compact prompt.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - backend history route and tests only. No UI rendering, CSS, HTML, SVG, or `static/js/` files touched.

### Screenshots / clips

N/A - no visual/UI change. Verification is the Docker route regression listed above.