### PR TITLE
fix(docker): opt-in INSTALL_OPTIONAL build arg for AGPL extras

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Install Python deps first (layer cache)
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Python deps first (layer cache). Optional extras (PyMuPDF AGPL, etc.)
+# are opt-in so the default image stays MIT-core; see requirements-optional.txt.
+ARG INSTALL_OPTIONAL=false
+COPY requirements.txt requirements-optional.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && if [ "$INSTALL_OPTIONAL" = "true" ]; then pip install --no-cache-dir -r requirements-optional.txt; fi
 
 # Copy app code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ cd odysseus
 cp .env.example .env       # optional, but recommended for explicit defaults
 docker compose up -d --build
 ```
+To include optional extras in the image (PDF viewer, Office extraction; includes AGPL PyMuPDF), build with `docker compose build --build-arg INSTALL_OPTIONAL=true` before `up`.
+
 Open `http://localhost:7000` when the containers are healthy. Docker Compose
 binds the web UI to `127.0.0.1` by default. If the port is taken, set
 `APP_PORT=7001` in `.env` and recreate the container. Set `APP_BIND=0.0.0.0`


### PR DESCRIPTION
## Summary

Replaces installing `requirements-optional.txt` in every image build with a Docker build arg `INSTALL_OPTIONAL` (default `false`). Keeps the default distributed image MIT-core; users who want PDF/Office extras and accept AGPL implications opt in at build time.

Follow-up to #2577 per maintainer feedback.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #2577

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [ ] This PR targets `main`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Default build (no optional deps):
   ```bash
   docker compose build --no-cache odysseus
   docker compose run --rm odysseus python -c "import importlib.util; print('pymupdf', importlib.util.find_spec('fitz'))"
   ```
   Expect `pymupdf None`.

2. Opt-in build:
   ```bash
   docker compose build --no-cache --build-arg INSTALL_OPTIONAL=true odysseus
   docker compose run --rm odysseus python -c "import importlib.util; print('pymupdf', importlib.util.find_spec('fitz'))"
   ```
   Expect `pymupdf ModuleSpec(...)`.

3. Confirm README Docker section documents the build arg.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — Dockerfile and README only.

Made with [Cursor](https://cursor.com)