### PR TITLE
fix(windows): detect installed CUDA toolkit on launch

### DIFF
--- a/launch-windows.ps1
+++ b/launch-windows.ps1
@@ -141,7 +141,20 @@ if (-not (Find-GitBash)) {
     Write-Host "      https://git-scm.com/download/win" -ForegroundColor Yellow
 }
 
-# 6. Start the server (use `python -m uvicorn` - bare `uvicorn` may not be on PATH)
+# 6. Point CUDA_PATH at a real CUDA toolkit so GPU llama-cpp-python can import.
+$cudaBase = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
+if (Test-Path $cudaBase) {
+    $cudaBest = Get-ChildItem $cudaBase -Directory -ErrorAction SilentlyContinue |
+        Where-Object { Test-Path (Join-Path $_.FullName "bin") } |
+        Sort-Object { try { [version]($_.Name -replace "^v", "") } catch { [version]"0.0" } } -Descending |
+        Select-Object -First 1
+    if ($cudaBest) {
+        $env:CUDA_PATH = $cudaBest.FullName
+        Write-Host ("Using CUDA_PATH = " + $cudaBest.FullName) -ForegroundColor Cyan
+    }
+}
+
+# 7. Start the server (use `python -m uvicorn` - bare `uvicorn` may not be on PATH)
 Write-Step ("Starting Odysseus at http://{0}:{1}" -f $BindHost, $Port)
 Write-Host "Press Ctrl+C to stop."
 Write-Host ""


### PR DESCRIPTION
## Summary

On native Windows, a stale user or system `CUDA_PATH` can point at an uninstalled CUDA toolkit directory. GPU Python packages such as `llama-cpp-python` may try to load DLLs from `$CUDA_PATH\bin`; if that folder no longer exists, import or server startup can fail even though a newer CUDA toolkit is installed.

This PR keeps the launcher fix narrow:

- during `launch-windows.ps1`, scan `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA`;
- ignore stale version folders that do not contain `bin`;
- set the process-local `CUDA_PATH` to the newest installed toolkit that does contain `bin`;
- print the selected CUDA path for troubleshooting.

This does not change persistent user/system environment variables and does not modify the Cookbook serve command builder.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Related to #2638

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I ran focused validation for the changed behavior.

## How to Test

PowerShell syntax validation:

```powershell
$errors=$null
[System.Management.Automation.Language.Parser]::ParseFile('launch-windows.ps1',[ref]$null,[ref]$errors) | Out-Null
if ($errors -and $errors.Count) { $errors; exit 1 } else { 'parse ok' }
```

Result: `parse ok`.

Whitespace check:

```powershell
git diff --check
```

Result: passed.

Manual native Windows validation:

1. Install CUDA toolkit under `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA`.
2. Leave an older/stale CUDA version folder present without `bin`.
3. Start Odysseus with `launch-windows.ps1`.
4. Confirm startup prints `Using CUDA_PATH = ...\CUDA\<newest-valid-version>`.

## Visual / UI changes

No visual layout change. This only changes the Windows launcher process environment.
