### PR TITLE
fix: exclude slash-command/setup messages from LLM context (#2634)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -76,8 +76,20 @@ class Session:
             _session_manager._persist_message(self.id, message)
 
     def get_context_messages(self) -> List[Dict[str, Any]]:
-        """Get messages in format for LLM API."""
-        return [msg.to_dict() for msg in self.history]
+        """Get messages in format for LLM API.
+
+        Slash-command / setup replies are persisted to history so they render
+        in the transcript, but they are UI chatter (e.g. ``/setup ...`` and its
+        status lines) the user never meant as conversation. They carry
+        ``metadata.source == "slash"``; exclude them here so they never reach
+        the model. Display/history-load paths use the raw ``history`` and are
+        unaffected.
+        """
+        return [
+            msg.to_dict()
+            for msg in self.history
+            if (msg.metadata or {}).get("source") != "slash"
+        ]
 
     def get(self, key: str, default=None):
         """Dict-like access for compatibility."""

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -5880,7 +5880,9 @@ async function handleSlashCommand(input) {
   let args = parts.slice(1);
   const ctx = _makeCtx();
   let _userShown = false;
-  function _showUser() { if (!_userShown) { _userShown = true; _addMessage('user', input); _persistMsg('user', input); } }
+  // Tag the echoed command with source:'slash' so it renders in the transcript
+  // but is excluded from LLM context (get_context_messages), like the replies.
+  function _showUser() { if (!_userShown) { _userShown = true; _addMessage('user', input); _persistMsg('user', input, { source: 'slash' }); } }
 
   try {
     // --- Check for --help / -h on any command ---

--- a/tests/test_session_context_excludes_slash.py
+++ b/tests/test_session_context_excludes_slash.py
@@ -1,0 +1,44 @@
+"""Regression: slash-command / setup messages must not reach LLM context.
+
+Slash replies (and the echoed `/setup ...` command) are persisted to history so
+they render in the transcript, tagged ``metadata.source == "slash"``. They are
+UI chatter the user never meant as conversation, so ``get_context_messages``
+(the LLM-API view) must exclude them while the raw history keeps them for
+display. See issue #2634.
+"""
+
+from core.models import Session, ChatMessage
+
+
+def _session_with_slash():
+    s = Session(id="s1", name="t", endpoint_url="http://x/v1", model="m")
+    s.add_message(ChatMessage("user", "hi, give me a recipe"))
+    s.add_message(ChatMessage("user", "/setup copilot", metadata={"source": "slash"}))
+    s.add_message(ChatMessage("assistant", "Starting GitHub Copilot sign-in...", metadata={"source": "slash"}))
+    s.add_message(ChatMessage("assistant", "Here is a recipe", metadata={"model": "m"}))
+    return s
+
+
+def test_context_excludes_slash_messages():
+    ctx = _session_with_slash().get_context_messages()
+    contents = [m["content"] for m in ctx]
+    assert "hi, give me a recipe" in contents
+    assert "Here is a recipe" in contents
+    # Slash command + its status reply are filtered out of LLM context.
+    assert "/setup copilot" not in contents
+    assert all("sign-in" not in c for c in contents)
+    assert len(ctx) == 2
+
+
+def test_history_still_keeps_slash_messages_for_display():
+    s = _session_with_slash()
+    # Raw history (what the UI renders) is untouched.
+    assert len(s.history) == 4
+    assert any(m.content == "/setup copilot" for m in s.history)
+
+
+def test_no_metadata_messages_are_kept():
+    s = Session(id="s2", name="t", endpoint_url="http://x/v1", model="m")
+    s.add_message(ChatMessage("user", "plain"))
+    s.add_message(ChatMessage("assistant", "reply"))
+    assert [m["content"] for m in s.get_context_messages()] == ["plain", "reply"]


### PR DESCRIPTION
## Summary

Slash-command replies and the echoed `/setup ...` command are persisted to session history so they render in the transcript, but they are UI chatter the user never meant as conversation. They were being sent to the model on the next turn, so the model commented on `/setup copilot` and even received transient values like the Copilot device `user_code`. This excludes them at the LLM-context boundary while leaving them visible in the UI. Framework-wide (every `/setup` command), not provider-specific.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2634

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (Filed #2634 first.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified end-to-end: ran `/setup` to persist slash-tagged messages, then confirmed via a fresh DB-hydrated session that `get_context_messages()` excludes them while raw history keeps them (so the message round-trips through persistence and is filtered only at the LLM boundary).

## How to Test

1. Start the app and open a chat. Run `/setup copilot` (or `/setup groq sk-...`); the command and its status replies render.
2. Send a normal message, e.g. `hi, give me a recipe`.
3. Before: the model references the setup command / sign-in messages. After: it does not — they are no longer in context.
4. Automated: `python -m pytest tests/test_session_context_excludes_slash.py` (3 passed) and adjacent session/context tests (24 passed).

What I ran: the pytest above; `python -m py_compile core/models.py`; `node --check static/js/slashCommands.js`; and the DB-roundtrip end-to-end described in the checklist.

## Visual / UI changes — REQUIRED if you touched anything that renders

This touches `static/js/slashCommands.js`, but it does **not** change rendering: the only edit is adding `source: 'slash'` to the metadata of the already-persisted user command (the echo still renders identically via the unchanged `_addMessage`). The other change is backend (`get_context_messages`). No DOM/visual change, so no screenshot applies.

- [x] **Style match** — no new CSS variables/classes/colors/fonts introduced; no styling touched.
- [x] **No Unicode emoji in UI or code.**
- [x] **No new component patterns** — no new widgets; existing persist path reused.

Note on the LLM-agent checkbox: this PR was authored with agent assistance by the repo owner (@vdmkenny), it is a single focused fix (not a bulk submission), and the issue (#2634) was opened first per the guidance.

### Screenshots / clips

Not applicable — no visual change (see above).
