### PR TITLE
Add Gemini Enterprise Agent Platform provider

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -10,7 +10,7 @@ import logging
 import httpx
 from datetime import datetime
 from typing import List, Dict, Any, Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlencode, urlparse, urlunparse
 from fastapi import APIRouter, HTTPException, Form, Query, Body, Request, Response
 from pydantic import BaseModel
 from fastapi.responses import StreamingResponse
@@ -261,6 +261,18 @@ _PROVIDER_CURATED = {
         "gemini-3.5", "gemini-3.1", "gemini-3",
         "gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash",
     ],
+    "vertex_express": [
+        "gemini-3.5-flash",
+        "gemini-3.1-pro-preview",
+        "gemini-3.1-pro-preview-customtools",
+        "gemini-3-pro-preview",
+        "gemini-3.1-flash-lite",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-pro",
+        "gemini-2.0-flash-001",
+        "gemini-2.0-flash-lite-001",
+    ],
     "xai": [
         "grok-4.3", "grok-4", "grok-4-fast", "grok-3", "grok-3-fast",
     ],
@@ -280,6 +292,7 @@ _HOST_TO_CURATED = (
     ("together.xyz", "together"),
     ("together.ai", "together"),
     ("fireworks.ai", "fireworks"),
+    ("aiplatform.googleapis.com", "vertex_express"),
     ("googleapis.com", "google"),
     ("x.ai", "xai"),
     ("openrouter.ai", "openrouter"),
@@ -526,6 +539,15 @@ def _probe_single_model(base: str, api_key: str, model_id: str, timeout: int = 1
         h = build_headers(api_key, base)
         h["Content-Type"] = "application/json"
         payload = _build_ollama_payload(model_id, messages, 0.0, 5, stream=False, tools=_test_tools)
+    elif provider == "vertex_express":
+        if not api_key:
+            return {"status": "fail", "error": "Gemini Enterprise Agent Platform API key is required"}
+        from src.llm_core import _build_vertex_payload
+        root = _normalize_base(base).rstrip("/")
+        model_name = model_id if model_id.startswith("publishers/google/models/") else f"publishers/google/models/{model_id}"
+        target_url = f"{root}/{quote(model_name, safe='/')}:generateContent?{urlencode({'key': api_key})}"
+        h = {"Content-Type": "application/json"}
+        payload = _build_vertex_payload(messages, 0.0, 5)
     else:
         target_url = build_chat_url(base)
         h = build_headers(api_key, base)
@@ -618,6 +640,9 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
     For Anthropic, queries their /v1/models API, falling back to hardcoded list."""
     from src.endpoint_resolver import resolve_url
     base = resolve_url(_normalize_base(base_url))
+    if _detect_provider(base) == "vertex_express":
+        models = _probe_vertex_express_models(base, api_key, timeout=timeout)
+        return models or ([] if api_key else list(_PROVIDER_CURATED["vertex_express"]))
     if _detect_provider(base) == "anthropic":
         # Try Anthropic's /v1/models endpoint first
         url = build_models_url(base)
@@ -696,6 +721,82 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
         logger.info(f"Using curated fallback for {curated_key}: {fallback}")
         return list(fallback)
     return []
+
+
+def _vertex_express_models_url(base_url: str, api_key: str) -> str:
+    parsed = urlparse(_normalize_base(base_url))
+    scheme = parsed.scheme or "https"
+    netloc = parsed.netloc or "aiplatform.googleapis.com"
+    root = f"{scheme}://{netloc}/v1beta1"
+    return f"{root}/publishers/google/models?{urlencode({'key': api_key or '', 'pageSize': 100})}"
+
+
+def _parse_vertex_model_ids(data: Dict[str, Any]) -> List[str]:
+    items = data.get("publisherModels") or data.get("models") or data.get("data") or []
+    model_ids: List[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("id") or ""
+        if not isinstance(name, str) or not name:
+            continue
+        model_id = name.rsplit("/", 1)[-1]
+        if model_id.startswith("gemini-") and _is_chat_model(model_id):
+            model_ids.append(model_id)
+    return sorted(set(model_ids), key=lambda mid: (_PROVIDER_CURATED["vertex_express"].index(mid) if mid in _PROVIDER_CURATED["vertex_express"] else 999, mid))
+
+
+def _probe_vertex_express_models(base_url: str, api_key: str = None, timeout: float = 5.0) -> List[str]:
+    if not api_key:
+        return []
+    try:
+        url = _vertex_express_models_url(base_url, api_key)
+        r = httpx.get(url, headers={"Content-Type": "application/json"}, timeout=timeout)
+        r.raise_for_status()
+        return _parse_vertex_model_ids(r.json())
+    except Exception as e:
+        logger.warning(f"Gemini Enterprise Agent Platform model scan failed: {e}")
+        return []
+
+
+def _test_vertex_express(base_url: str, api_key: str = None, timeout: float = 2.0) -> Dict[str, Any]:
+    base = _normalize_base(base_url).rstrip("/")
+    models = list(_PROVIDER_CURATED["vertex_express"])
+    if not api_key:
+        return {
+            "reachable": False,
+            "status_code": 401,
+            "error": "Gemini Enterprise Agent Platform API key is required",
+            "models": models,
+        }
+    model = "gemini-3.1-flash-lite"
+    model_name = f"publishers/google/models/{model}"
+    url = f"{base}/{quote(model_name, safe='/')}:generateContent?{urlencode({'key': api_key})}"
+    payload = {
+        "contents": [{"role": "user", "parts": [{"text": "Say OK"}]}],
+        "generationConfig": {"temperature": 0.0, "maxOutputTokens": 8},
+    }
+    try:
+        r = httpx.post(url, headers={"Content-Type": "application/json"}, json=payload, timeout=timeout)
+        if r.is_success:
+            scanned = _probe_vertex_express_models(base, api_key, timeout=timeout)
+            if scanned:
+                models = scanned
+            return {"reachable": True, "status_code": r.status_code, "error": None, "models": models}
+        error = f"HTTP {r.status_code}"
+        try:
+            body = r.json()
+            err = body.get("error") if isinstance(body, dict) else None
+            if isinstance(err, dict) and err.get("message"):
+                error = err["message"][:160]
+            elif isinstance(err, str):
+                error = err[:160]
+        except Exception:
+            if r.text:
+                error = r.text[:160]
+        return {"reachable": False, "status_code": r.status_code, "error": error, "models": models}
+    except Exception as e:
+        return {"reachable": False, "status_code": None, "error": str(e)[:160], "models": models}
 
 
 def _ping_endpoint(base_url: str, api_key: str = None, timeout: float = 1.5) -> Dict[str, Any]:
@@ -1533,11 +1634,20 @@ def setup_model_routes(model_discovery):
         finally:
             _db_dedup.close()
 
-        model_ids = _probe_endpoint(base_url, api_key.strip() or None, timeout=explicit_timeout) if should_probe else []
+        is_vertex_express = _detect_provider(base_url) == "vertex_express"
+        vertex_ping = None
+        if should_probe and is_vertex_express:
+            vertex_ping = _test_vertex_express(base_url, api_key.strip() or None, timeout=explicit_timeout)
+            model_ids = vertex_ping.get("models", []) if vertex_ping.get("reachable") else []
+        else:
+            model_ids = _probe_endpoint(base_url, api_key.strip() or None, timeout=explicit_timeout) if should_probe else []
         ping = {"reachable": False, "error": None}
         if (should_probe or requested_kind in ("api", "proxy")) and not model_ids:
-            ping = _ping_endpoint(base_url, api_key.strip() or None, timeout=min(explicit_timeout, 2.0))
+            ping = vertex_ping or _ping_endpoint(base_url, api_key.strip() or None, timeout=min(explicit_timeout, 2.0))
         if require_model_list and not model_ids:
+            detail = ping.get("error") if isinstance(ping, dict) else ""
+            if is_vertex_express and detail:
+                raise HTTPException(400, f"Gemini Enterprise Agent Platform test failed: {detail}")
             raise HTTPException(400, _model_endpoint_error_message(base_url, ping))
 
         ep_id = str(uuid.uuid4())[:8]
@@ -1618,6 +1728,19 @@ def setup_model_routes(model_discovery):
         requested_kind = _normalize_endpoint_kind(endpoint_kind)
         configured_timeout = _parse_positive_int(model_refresh_timeout, minimum=1, maximum=60)
         probe_timeout = _explicit_model_list_timeout(base_url, requested_kind, configured_timeout)
+        if _detect_provider(base_url) == "vertex_express":
+            ping = _test_vertex_express(base_url, api_key.strip() or None, timeout=probe_timeout)
+            models = ping.get("models") if ping.get("reachable") else []
+            return {
+                "base_url": base_url,
+                "online": bool(ping.get("reachable")),
+                "status": "online" if ping.get("reachable") else "offline",
+                "ping_error": ping.get("error"),
+                "models": models,
+                "count": len(models),
+                "endpoint_kind": requested_kind,
+                "category": _classify_endpoint(base_url, requested_kind),
+            }
         models = _probe_endpoint(base_url, api_key.strip() or None, timeout=probe_timeout)
         ping = {"reachable": True, "error": None} if models else _ping_endpoint(base_url, api_key.strip() or None, timeout=min(probe_timeout, 2.0))
         return {

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -167,6 +167,8 @@ def build_chat_url(base: str) -> str:
     """Return the correct chat endpoint URL for a given base."""
     base = resolve_url(base)
     provider = _detect_provider(base)
+    if provider == "vertex_express":
+        return base
     if provider == "anthropic":
         return _anthropic_api_root(base) + "/v1/messages"
     if provider == "ollama":
@@ -178,6 +180,8 @@ def build_models_url(base: str) -> str:
     """Return the provider-specific model-list endpoint URL for a base."""
     base = resolve_url(base)
     provider = _detect_provider(base)
+    if provider == "vertex_express":
+        return base
     if provider == "anthropic":
         return _anthropic_api_root(base) + "/v1/models"
     if provider == "ollama":

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -5,13 +5,18 @@ import time
 import json
 import logging
 import hashlib
+import re
 import threading
 from fastapi import HTTPException
 from typing import Optional, Dict, List
 from src.model_context import get_context_length, DEFAULT_CONTEXT
-from urllib.parse import urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 logger = logging.getLogger(__name__)
+
+
+def _redact_url(url: str) -> str:
+    return re.sub(r"([?&]key=)[^&]+", r"\1REDACTED", url or "")
 
 class LLMConfig:
     """Configuration constants for LLM operations."""
@@ -309,6 +314,8 @@ def _detect_provider(url: str) -> str:
     Unknown hosts fall back to the OpenAI-compatible default, which the
     majority of providers implement.
     """
+    if _host_match(url, "aiplatform.googleapis.com"):
+        return "vertex_express"
     if _is_ollama_native_url(url):
         return "ollama"
     if _host_match(url, "anthropic.com"):
@@ -334,6 +341,7 @@ def _provider_label(url: str) -> str:
     """Human-friendly provider name for error messages."""
     if not url:
         return "provider"
+    if _host_match(url, "aiplatform.googleapis.com"): return "Gemini Enterprise Agent Platform"
     if _host_match(url, "anthropic.com"): return "Anthropic"
     if _host_match(url, "ollama.com"): return "Ollama Cloud"
     if _host_match(url, "x.ai"): return "xAI"
@@ -395,6 +403,97 @@ def _format_upstream_error(status: int, body: bytes | str, url: str) -> str:
     if status >= 500:
         return f"{provider} is having an outage (HTTP {status})." + (f" {detail}" if detail else "")
     return f"{provider} returned HTTP {status}" + (f": {detail}" if detail else "")
+
+
+def _extract_bearer_api_key(headers: Optional[Dict]) -> str:
+    if not isinstance(headers, dict):
+        return ""
+    for key in ("Authorization", "authorization"):
+        value = headers.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+            if value.lower().startswith("bearer "):
+                return value[7:].strip()
+            if value:
+                return value
+    for key in ("x-goog-api-key", "X-Goog-Api-Key", "api_key"):
+        value = headers.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _vertex_text_parts(content) -> List[Dict[str, str]]:
+    """MVP text-only Gemini parts builder; non-text parts are ignored."""
+    if isinstance(content, str):
+        return [{"text": content}] if content else []
+    if isinstance(content, list):
+        parts: List[Dict[str, str]] = []
+        for item in content:
+            if isinstance(item, str):
+                if item:
+                    parts.append({"text": item})
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    parts.append({"text": text})
+        return parts
+    if content is None:
+        return []
+    return [{"text": str(content)}]
+
+
+def _build_vertex_payload(messages: List[Dict], temperature: float, max_tokens: int) -> Dict:
+    system_parts: List[Dict[str, str]] = []
+    contents: List[Dict] = []
+    for msg in messages or []:
+        role = msg.get("role")
+        parts = _vertex_text_parts(msg.get("content"))
+        if not parts:
+            continue
+        if role == "system":
+            system_parts.extend(parts)
+        elif role == "assistant":
+            contents.append({"role": "model", "parts": parts})
+        elif role == "tool":
+            # Tool-result mapping is out of scope for the MVP; preserve text as user context.
+            contents.append({"role": "user", "parts": parts})
+        else:
+            contents.append({"role": "user", "parts": parts})
+    payload: Dict = {
+        "contents": contents or [{"role": "user", "parts": [{"text": ""}]}],
+        "generationConfig": {"temperature": temperature},
+    }
+    if system_parts:
+        payload["systemInstruction"] = {"parts": system_parts}
+    if max_tokens and max_tokens > 0:
+        payload["generationConfig"]["maxOutputTokens"] = max_tokens
+    return payload
+
+
+def _vertex_url(base_url: str, model: str, api_key: str, stream: bool = False) -> str:
+    root = (base_url or "https://aiplatform.googleapis.com/v1").rstrip("/")
+    action = "streamGenerateContent" if stream else "generateContent"
+    params = {"key": api_key}
+    if stream:
+        params["alt"] = "sse"
+    model_name = (model or "").strip()
+    if not model_name.startswith("publishers/google/models/"):
+        model_name = f"publishers/google/models/{model_name}"
+    return f"{root}/{quote(model_name, safe='/')}:{action}?{urlencode(params)}"
+
+
+def _parse_vertex_response(data: Dict) -> str:
+    chunks: List[str] = []
+    for cand in data.get("candidates") or []:
+        content = cand.get("content") or {}
+        for part in content.get("parts") or []:
+            text = part.get("text")
+            if text:
+                chunks.append(text)
+    if chunks:
+        return "".join(chunks)
+    raise KeyError("candidates[].content.parts[].text")
 
 # Models that require max_completion_tokens instead of max_tokens
 _MAX_COMPLETION_TOKENS_MODELS = {"o1", "o3", "o4", "gpt-4.5", "gpt-5"}
@@ -909,6 +1008,13 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
             model, messages_copy, temperature, max_tokens,
             stream=False, num_ctx=get_context_length(url, model),
         )
+    elif provider == "vertex_express":
+        api_key = _extract_bearer_api_key(h)
+        if not api_key:
+            raise HTTPException(401, "Gemini Enterprise Agent Platform API key is required")
+        target_url = _vertex_url(url, model, api_key, stream=False)
+        h = {"Content-Type": "application/json"}
+        payload = _build_vertex_payload(messages_copy, temperature, max_tokens)
     else:
         target_url = url
         payload = {
@@ -925,15 +1031,17 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         note_model_activity(target_url, model)
         r = httpx.post(target_url, headers=h, json=payload, timeout=timeout)
     except Exception as e:
-        raise HTTPException(502, f"POST {target_url} failed: {e}")
+        raise HTTPException(502, f"POST {_redact_url(target_url)} failed: {e}")
     if not r.is_success:
-        raise HTTPException(502, f"Upstream {target_url} -> {r.status_code}: {r.text}")
+        raise HTTPException(502, f"Upstream {_redact_url(target_url)} -> {r.status_code}: {r.text}")
     data = r.json()
     try:
         if provider == "anthropic":
             response = _parse_anthropic_response(data)
         elif provider == "ollama":
             response = _parse_ollama_response(data)
+        elif provider == "vertex_express":
+            response = _parse_vertex_response(data)
         else:
             msg = data["choices"][0]["message"]
             response = msg.get("content") or msg.get("reasoning_content") or ""
@@ -1055,6 +1163,13 @@ async def llm_call_async(
             model, messages_copy, temperature, max_tokens,
             stream=False, num_ctx=get_context_length(url, model),
         )
+    elif provider == "vertex_express":
+        api_key = _extract_bearer_api_key(headers)
+        if not api_key:
+            raise HTTPException(401, "Gemini Enterprise Agent Platform API key is required")
+        target_url = _vertex_url(url, model, api_key, stream=False)
+        h = {"Content-Type": "application/json"}
+        payload = _build_vertex_payload(messages_copy, temperature, max_tokens)
     else:
         target_url = url
         h = _provider_headers(provider, headers)
@@ -1085,11 +1200,11 @@ async def llm_call_async(
             if not r.is_success:
                 friendly = _format_upstream_error(r.status_code, r.text, target_url)
                 logger.warning(
-                    f"LLM async call to {target_url} failed in {duration:.2f}s "
+                    f"LLM async call to {_redact_url(target_url)} failed in {duration:.2f}s "
                     f"(attempt {attempt}): HTTP {r.status_code} {friendly}"
                 )
                 raise HTTPException(r.status_code, friendly)
-            logger.info(f"LLM async call to {target_url} succeeded in {duration:.2f}s (attempt {attempt})")
+            logger.info(f"LLM async call to {_redact_url(target_url)} succeeded in {duration:.2f}s (attempt {attempt})")
             _clear_host_dead(target_url)
             data = r.json()
             try:
@@ -1097,6 +1212,8 @@ async def llm_call_async(
                     response = _parse_anthropic_response(data)
                 elif provider == "ollama":
                     response = _parse_ollama_response(data)
+                elif provider == "vertex_express":
+                    response = _parse_vertex_response(data)
                 else:
                     msg = data["choices"][0]["message"]
                     response = msg.get("content") or msg.get("reasoning_content") or ""
@@ -1108,13 +1225,13 @@ async def llm_call_async(
             _cooled = _mark_host_dead(target_url)
             duration = time.time() - start
             _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
-            logger.warning(f"LLM async connect to {target_url} failed after {duration:.2f}s: {e}{_tail}")
+            logger.warning(f"LLM async connect to {_redact_url(target_url)} failed after {duration:.2f}s: {e}{_tail}")
             raise HTTPException(503, f"Cannot reach {_host_key(target_url)}: {e}")
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             duration = time.time() - start
             logger.warning(f"LLM async call attempt {attempt} failed after {duration:.2f}s: {e}")
             if attempt >= max_retries:
-                raise HTTPException(502, f"POST {target_url} failed after {max_retries} attempts: {e}")
+                raise HTTPException(502, f"POST {_redact_url(target_url)} failed after {max_retries} attempts: {e}")
             await asyncio.sleep(LLMConfig.RETRY_DELAY)
 
 async def stream_llm(url: str, model: str, messages: List[Dict], temperature: float = LLMConfig.DEFAULT_TEMPERATURE,
@@ -1159,6 +1276,14 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             model, messages_copy, temperature, max_tokens,
             stream=True, tools=tools, num_ctx=get_context_length(url, model),
         )
+    elif provider == "vertex_express":
+        api_key = _extract_bearer_api_key(headers)
+        if not api_key:
+            yield f'event: error\ndata: {json.dumps({"error": "Gemini Enterprise Agent Platform API key is required", "status": 401})}\n\n'
+            return
+        target_url = _vertex_url(url, model, api_key, stream=True)
+        h = {"Content-Type": "application/json"}
+        payload = _build_vertex_payload(messages_copy, temperature, max_tokens)
     else:
         target_url = url
         payload = {
@@ -1186,6 +1311,44 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         yield f'event: error\ndata: {json.dumps({"error": f"Upstream {_host_key(target_url)} unreachable (cooldown active)", "status": 503})}\n\n'
         return
     note_model_activity(target_url, model)
+
+    # ── Gemini Enterprise Agent Platform / Vertex Express streaming ──
+    if provider == "vertex_express":
+        try:
+            client = _get_http_client()
+            async with client.stream('POST', target_url, json=payload, headers=h, timeout=stream_timeout) as r:
+                _clear_host_dead(target_url)
+                if r.status_code != 200:
+                    raw = (await r.aread()).decode(errors="replace")
+                    friendly = _format_upstream_error(r.status_code, raw, target_url)
+                    yield f'event: error\ndata: {json.dumps({"status": r.status_code, "text": friendly, "raw": raw[:500]})}\n\n'
+                    return
+                async for line in r.aiter_lines():
+                    if not line:
+                        continue
+                    data = line[6:].strip() if line.startswith("data: ") else line.strip()
+                    if not data or data == "[DONE]" or not data.startswith("{"):
+                        continue
+                    try:
+                        text = _parse_vertex_response(json.loads(data))
+                    except Exception:
+                        continue
+                    if text:
+                        yield f'data: {json.dumps({"delta": text})}\n\n'
+                yield "data: [DONE]\n\n"
+        except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+            _cooled = _mark_host_dead(target_url)
+            _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
+            logger.warning(f"Vertex Express stream connect to {_redact_url(target_url)} failed: {e}{_tail}")
+            yield f'event: error\ndata: {json.dumps({"error": f"Cannot reach {_host_key(target_url)}", "status": 503})}\n\n'
+        except httpx.ReadTimeout:
+            yield f'event: error\ndata: {json.dumps({"error": "Read timeout", "status": 504})}\n\n'
+        except httpx.NetworkError:
+            yield f'event: error\ndata: {json.dumps({"error": "Network error", "status": 502})}\n\n'
+        except Exception as e:
+            logger.error(f"Vertex Express stream error: {e}")
+            yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
+        return
 
     # ── Native Ollama streaming ──
     if provider == "ollama":

--- a/static/index.html
+++ b/static/index.html
@@ -2073,6 +2073,7 @@
                   <option value="https://api.together.xyz/v1" data-logo="together">Together AI</option>
                   <option value="https://api.fireworks.ai/inference/v1" data-logo="fireworks">Fireworks AI</option>
                   <option value="https://generativelanguage.googleapis.com/v1beta/openai" data-logo="gemini">Google Gemini</option>
+                  <option value="https://aiplatform.googleapis.com/v1" data-logo="gemini">Gemini Enterprise Agent Platform</option>
                   <option value="https://api.x.ai/v1" data-logo="grok">xAI Grok</option>
                   <option value="https://api.z.ai/api/paas/v4" data-logo="zhipu">Z.AI (Zhipu)</option>
                   <option value="https://api.z.ai/api/coding/paas/v4" data-logo="zhipu">Z.AI Coding Plan</option>

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -53,8 +53,11 @@ const SETUP_PROVIDER_URLS = {
   groq: { name: 'Groq', url: 'https://api.groq.com/openai/v1' },
   gemini: { name: 'Gemini', url: 'https://generativelanguage.googleapis.com/v1beta/openai' },
   google: { name: 'Gemini', url: 'https://generativelanguage.googleapis.com/v1beta/openai' },
+  vertex: { name: 'Gemini Enterprise Agent Platform', url: 'https://aiplatform.googleapis.com/v1' },
+  vertexexpress: { name: 'Gemini Enterprise Agent Platform', url: 'https://aiplatform.googleapis.com/v1' },
+  geminienterprise: { name: 'Gemini Enterprise Agent Platform', url: 'https://aiplatform.googleapis.com/v1' },
 };
-const SETUP_PROVIDER_NAMES = ['deepseek', 'openai', 'openrouter', 'ollama', 'xai', 'anthropic', 'groq', 'gemini'];
+const SETUP_PROVIDER_NAMES = ['deepseek', 'openai', 'openrouter', 'ollama', 'xai', 'anthropic', 'groq', 'gemini', 'vertex'];
 const SETUP_PROVIDER_HINT = SETUP_PROVIDER_NAMES.slice(0, -1).join(', ') + ', or ' + SETUP_PROVIDER_NAMES[SETUP_PROVIDER_NAMES.length - 1];
 const SETUP_LOCAL_ICON = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:5px;"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/></svg>';
 const SETUP_API_ICON = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:5px;"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>';
@@ -75,6 +78,11 @@ function _setupProviderFromInput(input) {
     groq: 'groq',
     gemini: 'gemini',
     google: 'gemini',
+    vertex: 'vertex',
+    vertexexpress: 'vertex',
+    vertexai: 'vertex',
+    geminienterprise: 'vertex',
+    geminienterpriseagentplatform: 'vertex',
     xai: 'xai',
     grok: 'xai',
   };
@@ -91,6 +99,8 @@ function _extractSetupProviderCredential(input) {
     ['open ai', 'openai'], ['openai', 'openai'], ['chatgpt', 'openai'],
     ['anthropic', 'anthropic'], ['claude', 'anthropic'],
     ['groq', 'groq'],
+    ['gemini enterprise agent platform', 'vertex'], ['gemini enterprise', 'vertex'],
+    ['vertex express', 'vertex'], ['vertex ai', 'vertex'], ['vertex', 'vertex'],
     ['google', 'gemini'], ['gemini', 'gemini'],
     ['x ai', 'xai'], ['xai', 'xai'], ['grok', 'xai'],
   ];
@@ -548,6 +558,7 @@ function setupChatUrlForEndpoint(detected) {
   const base = (detected.base_url || '').replace(/\/+$/, '');
   if (detected.name === 'Anthropic') return base.replace(/\/v1$/, '') + '/v1/messages';
   if (base.includes('ollama.com')) return 'https://ollama.com/api/chat';
+  if (base.includes('aiplatform.googleapis.com')) return base;
   return base + '/chat/completions';
 }
 

--- a/tests/test_llm_core_ollama.py
+++ b/tests/test_llm_core_ollama.py
@@ -1,12 +1,19 @@
 """Regression tests for native Ollama Cloud provider handling."""
 import httpx
+import pytest
 
 from src import llm_core
+from src import endpoint_resolver
 
 
 def test_detects_ollama_cloud_native_provider():
     assert llm_core._detect_provider("https://ollama.com/api") == "ollama"
     assert llm_core._detect_provider("https://ollama.com/api/chat") == "ollama"
+
+
+def test_detects_vertex_express_provider():
+    assert llm_core._detect_provider("https://aiplatform.googleapis.com/v1") == "vertex_express"
+    assert endpoint_resolver.build_chat_url("https://aiplatform.googleapis.com/v1") == "https://aiplatform.googleapis.com/v1"
 
 
 def test_llm_call_posts_native_ollama_payload(monkeypatch):
@@ -240,3 +247,94 @@ def test_stream_llm_threads_discovered_num_ctx(monkeypatch):
     assert seen["num_ctx"] == 32768
     assert seen["stream"] is True
     assert out  # we got the SSE error chunk
+
+
+def test_llm_call_posts_vertex_express_payload(monkeypatch):
+    seen = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        seen["url"] = url
+        seen["headers"] = headers
+        seen["json"] = json
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"candidates": [{"content": {"parts": [{"text": "OK"}]}}]},
+        )
+
+    monkeypatch.setattr(llm_core.httpx, "post", fake_post)
+
+    result = llm_core.llm_call(
+        "https://aiplatform.googleapis.com/v1",
+        "gemini-3.5-flash",
+        [
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Say OK"},
+            {"role": "assistant", "content": "Thinking"},
+            {"role": "user", "content": [{"type": "text", "text": "Now answer."}]},
+        ],
+        temperature=0.3,
+        max_tokens=8,
+        headers={"Authorization": "Bearer vertex-key"},
+        timeout=11,
+    )
+
+    assert result == "OK"
+    assert seen["url"] == "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-3.5-flash:generateContent?key=vertex-key"
+    assert seen["headers"] == {"Content-Type": "application/json"}
+    assert seen["json"]["systemInstruction"] == {"parts": [{"text": "Be terse."}]}
+    assert seen["json"]["contents"] == [
+        {"role": "user", "parts": [{"text": "Say OK"}]},
+        {"role": "model", "parts": [{"text": "Thinking"}]},
+        {"role": "user", "parts": [{"text": "Now answer."}]},
+    ]
+    assert seen["json"]["generationConfig"] == {"temperature": 0.3, "maxOutputTokens": 8}
+
+
+@pytest.mark.asyncio
+async def test_stream_llm_parses_vertex_express_sse(monkeypatch):
+    seen = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aiter_lines(self):
+            yield 'data: {"candidates":[{"content":{"parts":[{"text":"O"}]}}]}'
+            yield 'data: {"candidates":[{"content":{"parts":[{"text":"K"}]}}]}'
+
+    class FakeClient:
+        def stream(self, method, url, json=None, headers=None, timeout=None):
+            seen["method"] = method
+            seen["url"] = url
+            seen["json"] = json
+            seen["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.setattr(llm_core, "_get_http_client", lambda: FakeClient())
+
+    chunks = [
+        chunk async for chunk in llm_core.stream_llm(
+            "https://aiplatform.googleapis.com/v1",
+            "publishers/google/models/gemini-3.1-flash-lite",
+            [{"role": "user", "content": "Say OK"}],
+            temperature=0.0,
+            max_tokens=8,
+            headers={"Authorization": "Bearer vertex-key"},
+        )
+    ]
+
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-3.1-flash-lite:streamGenerateContent?key=vertex-key&alt=sse"
+    assert seen["headers"] == {"Content-Type": "application/json"}
+    assert chunks == [
+        'data: {"delta": "O"}\n\n',
+        'data: {"delta": "K"}\n\n',
+        "data: [DONE]\n\n",
+    ]

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -45,6 +45,8 @@ from routes.model_routes import (
     _ping_endpoint,
     _parse_model_list,
     _normalize_refresh_mode,
+    _test_vertex_express,
+    _vertex_express_models_url,
     _truthy,
     _speech_settings_using_endpoint,
     _clear_speech_settings_for_endpoint,
@@ -175,6 +177,9 @@ class TestMatchProviderCurated:
     def test_google_url(self):
         assert _match_provider_curated("https://generativelanguage.googleapis.com/v1beta", "openai") == "google"
 
+    def test_vertex_express_url(self):
+        assert _match_provider_curated("https://aiplatform.googleapis.com/v1", "openai") == "vertex_express"
+
     def test_xai_url(self):
         assert _match_provider_curated("https://api.x.ai/v1", "openai") == "xai"
 
@@ -253,6 +258,14 @@ class TestCurateModels:
     def test_google_current_gemini_curated(self):
         curated, extra = _curate_models(["gemini-3.5-flash", "gemini-3.1-pro"], "google")
         assert curated == ["gemini-3.5-flash", "gemini-3.1-pro"]
+        assert extra == []
+
+    def test_vertex_express_curated(self):
+        curated, extra = _curate_models(
+            ["gemini-2.5-flash", "gemini-3-pro-preview", "gemini-3.1-pro-preview", "gemini-3.5-flash", "gemini-3.1-flash-lite"],
+            "vertex_express",
+        )
+        assert curated == ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3.1-flash-lite", "gemini-2.5-flash"]
         assert extra == []
 
 
@@ -345,7 +358,7 @@ class TestClassifyEndpoint:
         def fake_head(*args, **kwargs):
             raise AssertionError("generic proxy health check should not use HEAD")
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append(("GET", url))
             request = httpx.Request("GET", url)
             return httpx.Response(200, request=request)
@@ -376,7 +389,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             request = httpx.Request("GET", url)
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
@@ -389,18 +402,81 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
 
         assert _probe_endpoint("https://api.groq.com/openai/v1") == _PROVIDER_CURATED["groq"]
 
+    def test_vertex_express_probe_scans_publisher_models(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+        monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
+        seen = {}
+
+        def fake_get(url, headers=None, timeout=None, **kwargs):
+            seen["url"] = url
+            request = httpx.Request("GET", url)
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "publisherModels": [
+                        {"name": "publishers/google/models/text-embedding-005"},
+                        {"name": "publishers/google/models/gemini-3-pro-preview"},
+                        {"name": "publishers/google/models/gemini-3.5-flash"},
+                    ]
+                },
+            )
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+
+        assert _probe_endpoint("https://aiplatform.googleapis.com/v1", "vertex-key") == ["gemini-3.5-flash", "gemini-3-pro-preview"]
+        assert seen["url"] == "https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-key&pageSize=100"
+
+    def test_vertex_express_probe_falls_back_to_curated_without_key(self, monkeypatch):
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+        monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
+        assert _probe_endpoint("https://aiplatform.googleapis.com/v1") == _PROVIDER_CURATED["vertex_express"]
+
+    def test_vertex_express_models_url_uses_v1beta1(self):
+        assert _vertex_express_models_url("https://aiplatform.googleapis.com/v1", "vertex-key") == "https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-key&pageSize=100"
+
+    def test_vertex_express_test_requires_api_key(self):
+        result = _test_vertex_express("https://aiplatform.googleapis.com/v1", "")
+        assert result["reachable"] is False
+        assert result["status_code"] == 401
+        assert "API key is required" in result["error"]
+
+    def test_vertex_express_test_posts_generate_content(self, monkeypatch):
+        seen = {}
+
+        def fake_post(url, headers=None, json=None, timeout=None):
+            seen["url"] = url
+            seen["headers"] = headers
+            seen["json"] = json
+            request = httpx.Request("POST", url)
+            return httpx.Response(
+                200,
+                request=request,
+                json={"candidates": [{"content": {"parts": [{"text": "OK"}]}}]},
+            )
+
+        monkeypatch.setattr(model_routes.httpx, "post", fake_post)
+        monkeypatch.setattr(model_routes, "_probe_vertex_express_models", lambda base_url, api_key=None, timeout=5.0: ["gemini-3.5-flash"])
+
+        result = _test_vertex_express("https://aiplatform.googleapis.com/v1", "vertex-key", timeout=2)
+        assert result["reachable"] is True
+        assert result["models"] == ["gemini-3.5-flash"]
+        assert seen["url"] == "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-3.1-flash-lite:generateContent?key=vertex-key"
+        assert seen["headers"] == {"Content-Type": "application/json"}
+        assert seen["json"]["generationConfig"]["maxOutputTokens"] == 8
+
     def test_keyed_anthropic_probe_does_not_fallback_on_failure(self, monkeypatch):
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)
@@ -412,7 +488,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append(url)
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -432,7 +508,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
         seen = []
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             seen.append((url, headers))
             request = httpx.Request("GET", url)
             response = httpx.Response(
@@ -451,7 +527,7 @@ class TestSetupProbeSafety:
         monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
         monkeypatch.setattr(model_routes, "_normalize_base", lambda url: url.rstrip("/"))
 
-        def fake_get(url, headers=None, timeout=None):
+        def fake_get(url, headers=None, timeout=None, **kwargs):
             raise httpx.ConnectError("offline")
 
         monkeypatch.setattr(model_routes.httpx, "get", fake_get)


### PR DESCRIPTION
## Summary
- add Gemini Enterprise Agent Platform / Vertex AI Express Mode provider detection and endpoint preset
- add native API-key REST generateContent and streamGenerateContent adapter
- scan publisher model list with curated fallback for Gemini Enterprise models
- support slash setup aliases for Vertex/Gemini Enterprise

## Tests
- docker run --rm -v "${PWD}:/app" -w /app odysseus-odysseus python -m pytest tests/test_model_routes.py tests/test_llm_core_ollama.py tests/test_endpoint_resolver.py -q
