### PR TITLE
fix(tests): restore core module attrs in session owner test

### DIFF
--- a/tests/test_session_owner_attribution.py
+++ b/tests/test_session_owner_attribution.py
@@ -62,26 +62,44 @@ def _restore_module_and_parent_attr(dotted_name, saved_module, saved_attr):
         setattr(pkg, attr, saved_attr)
 
 
+def _set_module_and_parent_attr(dotted_name, module):
+    """Install a module at both sys.modules *and* the parent-package attribute.
+
+    Setting only sys.modules[...] leaves the parent `core` package attribute
+    pointing at the previous (real) module, so a later import resolving through
+    the parent would bypass the stub — and, symmetrically, a stub left on the
+    parent attribute would poison later tests. Controlling both keeps the two
+    views consistent so the finally block can fully undo them.
+    """
+    sys.modules[dotted_name] = module
+    pkg_name, _, attr = dotted_name.rpartition(".")
+    pkg = sys.modules.get(pkg_name)
+    if pkg is not None:
+        setattr(pkg, attr, module)
+
+
+# Modules whose import-time effects leak through both sys.modules and the parent
+# `core`/`routes` package attributes. core.database/core.models are stubbed so
+# routes.session_routes imports under conftest's MagicMock sqlalchemy shim;
+# core.session_manager and routes.session_routes are (re)imported fresh. Each is
+# captured at both levels and restored in the finally block so this file cannot
+# poison later tests via `import core.<...>` / `import routes.session_routes`.
 _TEMP_STUBS = ("core.database", "core.models")
-_saved = {name: sys.modules.get(name, _ABSENT) for name in _TEMP_STUBS}
-_saved["core.session_manager"] = sys.modules.get("core.session_manager", _ABSENT)
-_sr_saved = _save_module_and_parent_attr("routes.session_routes")
+_MANAGED = _TEMP_STUBS + ("core.session_manager", "routes.session_routes")
+_saved = {name: _save_module_and_parent_attr(name) for name in _MANAGED}
 try:
     for _name in _TEMP_STUBS:
-        sys.modules[_name] = MagicMock(name=_name)
-    sys.modules.pop("core.session_manager", None)
-    # Clear the sys.modules entry AND the parent `routes` attribute so the
-    # stubbed import below produces a fresh module with no stale binding behind it.
+        _set_module_and_parent_attr(_name, MagicMock(name=_name))
+    # Clear sys.modules AND the parent package attribute for the modules we
+    # re-import so the stubbed import below yields fresh modules with no stale
+    # binding reachable behind them.
+    _restore_module_and_parent_attr("core.session_manager", _ABSENT, _ABSENT)
     _restore_module_and_parent_attr("routes.session_routes", _ABSENT, _ABSENT)
     importlib.import_module("core.session_manager")
     import routes.session_routes as SR  # noqa: E402
 finally:
-    for _name, _val in _saved.items():
-        if _val is _ABSENT:
-            sys.modules.pop(_name, None)
-        else:
-            sys.modules[_name] = _val
-    _restore_module_and_parent_attr("routes.session_routes", *_sr_saved)
+    for _name, _save in _saved.items():
+        _restore_module_and_parent_attr(_name, *_save)
 
 from fastapi import HTTPException  # noqa: E402
 from src.auth_helpers import effective_user  # noqa: E402


### PR DESCRIPTION
## Summary

Part of #2580.

Fixes import-time pollution from `tests/test_session_owner_attribution.py`.

The test temporarily stubs `core.database` and `core.models`, then imports `core.session_manager` and `routes.session_routes` under those stubs. Before this change, cleanup restored only `sys.modules` for the `core.*` modules, but not the parent package attributes such as `core.database`, `core.models`, and `core.session_manager`.

This left stubbed modules reachable through the parent `core` package and caused later session-manager tests to see `MagicMock name='core.database.Session'`.

This PR saves/restores both:

- `sys.modules[...]`
- the parent package attribute

for:

- `core.database`
- `core.models`
- `core.session_manager`
- `routes.session_routes`

No production behavior changes.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to session-owner test import-state isolation.
- [ ] I ran the app end-to-end.
  - Not applicable: test-only isolation fix. No production code, UI, route, or runtime behavior changed.

## How to Test

1. Compile the touched file:

    python3 -m py_compile tests/test_session_owner_attribution.py

2. Run the target test alone:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q tests/test_session_owner_attribution.py

Validated locally:

    8 passed, 1 warning

3. Run the victim tests alone:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_replace_messages_multimodal.py \
      tests/test_topic_analyzer.py \
      tests/test_truncate_message_count_regression.py

Validated locally:

    7 passed, 8 warnings

4. Confirm session owner attribution no longer pollutes the victims:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      -k 'test_multimodal_content_round_trips_through_replace_messages or test_plain_string_content_still_round_trips or test_topic_analyzer_hydrates_sessions or test_truncate_keep_count_exceeds_total_does_not_inflate_count' \
      tests/test_session_owner_attribution.py \
      tests/test_replace_messages_multimodal.py \
      tests/test_topic_analyzer.py \
      tests/test_truncate_message_count_regression.py

Validated locally:

    4 passed, 11 deselected, 8 warnings

5. Confirm the boundary-window reproducer no longer pollutes victims:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      -k 'test_multimodal_content_round_trips_through_replace_messages or test_plain_string_content_still_round_trips or test_topic_analyzer_hydrates_sessions or test_truncate_keep_count_exceeds_total_does_not_inflate_count' \
      tests/test_session_endpoint_owner_scope.py \
      tests/test_session_export_filename.py \
      tests/test_session_export_nonstring_content.py \
      tests/test_session_ghost_delete.py \
      tests/test_session_manager_persist_guard.py \
      tests/test_session_mode_helpers.py \
      tests/test_session_owner_attribution.py \
      tests/test_replace_messages_multimodal.py \
      tests/test_topic_analyzer.py \
      tests/test_truncate_message_count_regression.py

Validated locally:

    4 passed, 34 deselected, 8 warnings

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only isolation fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.
