### PR TITLE
👷 Enable automated Claude code review on PRs

### DIFF
--- a/.claude/rules/CLAUDE_CODE_REVIEW.md
+++ b/.claude/rules/CLAUDE_CODE_REVIEW.md
@@ -1,0 +1,184 @@
+# Claude Code Review — Maintainer Setup
+
+This repo ships an automated code-review workflow at
+[`.github/workflows/claude-code-review.yml`](../../.github/workflows/claude-code-review.yml).
+When a pull request is marked **Ready for review**, Claude reads the diff,
+posts inline comments on specific issues, and leaves one summary comment.
+If it finds issues, it flips the PR back to **draft** so the author can fix
+everything in one pass instead of triggering a re-review on every push.
+
+It will not run until a maintainer completes the two one-time setup steps
+below. Both require **admin** access to the repository (or the org).
+
+---
+
+## What you need
+
+1. The **Claude GitHub App** installed on this repository — gives the
+   workflow a bot identity to post reviews as and grants the GitHub API
+   access the action needs.
+2. An **`ANTHROPIC_API_KEY`** repository secret — pays for the model calls
+   that actually do the review.
+
+You need both. The app handles *GitHub* auth; the API key handles
+*Anthropic* (model) billing.
+
+---
+
+## Step 1 — Install the Claude GitHub App
+
+1. Go to **https://github.com/apps/claude** and click **Install** (or
+   **Configure** if it is already installed on your account/org).
+2. Choose the account or organization that owns this repo
+   (`pewdiepie-archdaemon`).
+3. Under **Repository access**, either select **All repositories** or pick
+   **Only select repositories** and add **odysseus**.
+4. Confirm. The app requests read/write on pull requests, issues, and
+   contents — that is what lets it post review comments.
+
+> Shortcut: if you have the Claude Code CLI installed locally, running
+> `/install-github-app` from inside the repo walks you through both this
+> step and Step 2 interactively.
+
+---
+
+## Step 2 — Add the `ANTHROPIC_API_KEY` secret
+
+1. Create an API key at the **Anthropic Console**:
+   **https://console.anthropic.com/settings/keys** → *Create Key*.
+   Use a key from a workspace/project you are comfortable billing PR
+   reviews against — you can set a monthly spend limit on that workspace.
+2. In GitHub: **odysseus → Settings → Secrets and variables → Actions →
+   New repository secret**.
+3. Name it exactly **`ANTHROPIC_API_KEY`** and paste the key as the value.
+4. Save.
+
+> The name must match exactly — the workflow reads
+> `secrets.ANTHROPIC_API_KEY`. A typo here is the #1 cause of "the action
+> ran but did nothing."
+
+That is it. The next PR marked *Ready for review* triggers a review.
+
+---
+
+## How it triggers
+
+| Event | Reviewed? |
+|-------|-----------|
+| PR opened as **draft** | No |
+| PR opened as **ready** (non-draft) | Yes |
+| Draft → **Ready for review** | Yes |
+| New push to an already-ready PR | **No** — does not re-run on every push |
+| PR with only doc/media/etc. changes (no matched paths) | No |
+
+The workflow only watches code-ish paths (`*.py`, `*.js`, `*.css`,
+`*.html`, `*.sh`, `*.yml`/`*.yaml`, `Dockerfile`, `docker-compose.yml`,
+`requirements*.txt`) and skips itself. To get a fresh review after pushing
+fixes: keep the PR in draft while you work, then click **Ready for review**
+again.
+
+If you would rather review on *every* push too, add `synchronize` to the
+`on.pull_request.types` list in the workflow.
+
+---
+
+## Extending the review rules
+
+The workflow itself is thin — it routes to a rules folder, so you tune the
+review by editing Markdown, not YAML:
+
+```
+.claude/rules/
+  review-prompt.md          # the review prompt itself — the workflow loads this verbatim
+  INDEX.md                  # routing table: changed-path glob → reviewer file
+  review-guidelines.md      # how a review is conducted (always loaded)
+  review-checks-common.md   # cross-cutting checks + false-positive gate (always loaded)
+  reviewers/
+    backend-python.md       # routes/**, src/**, *.py (incl. tests)
+    frontend-web.md         # static/js, *.html, *.css
+    infra.md                # Dockerfile, compose, *.sh, CI
+    docs.md                 # *.md, docs/**
+```
+
+The workflow loads `review-prompt.md` verbatim and hands it to Claude, so
+the prompt lives in Markdown — not in the GitHub Action. On each run that
+prompt tells Claude to read `INDEX.md`, classify the changed files, and
+load only the reviewer file(s) for the domains that actually changed.
+
+- **Change how the review runs / what it does overall** → edit
+  `review-prompt.md`. No workflow edit needed.
+- **Tweak a domain's checks** → edit the matching `reviewers/*.md`.
+- **Add a new domain** → create `reviewers/<domain>.md` and add a row to
+  the routing table in `INDEX.md`. No workflow edit needed.
+- **A rule that applies to every file** → put it in
+  `review-checks-common.md`, not a single domain file.
+
+> The prompt is read as literal Markdown, so GitHub Actions `${{ ... }}`
+> expressions do **not** work inside `review-prompt.md`. Use the
+> `PR_NUMBER` and `REPO` environment variables (the workflow sets them) in
+> any `gh` commands instead. The only things that stay in the workflow are
+> the trigger, the model (`claude_args`), and the tool allowlist.
+
+See [`INDEX.md`](INDEX.md) for the
+authoritative routing table and the "How to extend" notes.
+
+## Cost & model
+
+The workflow runs on **`--model haiku`** (`claude-haiku-4-5`) — fast and
+cheap, sized for routine review passes. To trade cost for depth, edit the
+single `claude_args` line in the workflow:
+
+```yaml
+claude_args: '--model sonnet ...'   # deeper reasoning, moderate cost
+claude_args: '--model opus ...'     # most thorough, highest cost
+```
+
+Set a spend cap on the Anthropic workspace tied to the key so a busy PR day
+cannot surprise you.
+
+---
+
+## What the review can and cannot touch
+
+The action runs with a tightly scoped tool allowlist (see `claude_args`):
+read-only file access (`Read`, `Grep`, `Glob`), the GitHub inline-comment
+tools, and read-only `gh` commands plus `gh pr review` / `gh pr ready`. It
+**cannot** push code, merge, change settings, or run arbitrary shell. The
+GitHub token is scoped to this PR via the `permissions:` block in the
+workflow (`contents: read`, `pull-requests: write`, `issues: write`).
+
+Code in the diff is sent to the Anthropic API to perform the review.
+Anthropic does not train on API traffic, but treat it like any third-party
+service: do not put real secrets in code (use the `ANTHROPIC_API_KEY`
+secret and `.env`, which is git-ignored). This matches
+[`SECURITY.md`](../../SECURITY.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+---
+
+## These reviews are AI-generated — verify before acting
+
+Claude's review is a helpful first pass, **not** a substitute for human
+judgment. It is biased toward the patterns in its training data and only
+sees the diff plus the few files it reads — it does not know the full
+runtime behavior, your roadmap, or context outside the PR. It can be
+confidently wrong, miss real bugs, and flag non-issues.
+
+- Authors: treat each comment as a suggestion to evaluate, not a command.
+  Push back in the thread when it is wrong.
+- Reviewers: a clean Claude pass does **not** mean the PR is approved. A
+  human still owns the merge decision.
+- Never merge solely because the bot was happy.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| Workflow never starts | PR is a draft, or the diff touched no matched `paths`. Mark it Ready, or push a code file. |
+| Run starts then fails at the Claude step | `ANTHROPIC_API_KEY` missing/misnamed/expired, or the workspace hit its spend limit. Re-check Step 2 and the Anthropic Console. |
+| "Resource not accessible by integration" | Claude GitHub App not installed on this repo, or its permissions were declined. Redo Step 1. |
+| Forked-PR runs have no secret access | GitHub does not expose secrets to workflows triggered from forks by default. Reviews run for branches in this repo; decide your policy for fork PRs (e.g. a maintainer pushes the branch, or use `pull_request_target` with appropriate caution). |
+| Duplicate reviews on one commit | The workflow already de-dupes by SHA; if you still see dupes, check for a second copy of this workflow file. |
+
+Logs live under the repo's **Actions** tab → **Claude Code Review**.

--- a/.claude/rules/INDEX.md
+++ b/.claude/rules/INDEX.md
@@ -1,0 +1,48 @@
+# Reviewer Routing Index
+
+This is the routing table for automated code review. The
+[`Claude Code Review` workflow](../../.github/workflows/claude-code-review.yml)
+reads this file, classifies the files changed in a PR, and loads the
+matching reviewer rule file(s) below — so each review only pulls in the
+rules relevant to what actually changed.
+
+For one-time setup (installing the Claude GitHub App and the
+`ANTHROPIC_API_KEY` secret), see
+[`CLAUDE_CODE_REVIEW.md`](CLAUDE_CODE_REVIEW.md).
+
+**Always loaded** (every review, regardless of domain):
+
+- [`review-guidelines.md`](review-guidelines.md) — how to conduct the
+  review: threads, summaries, scope, draft handling.
+- [`review-checks-common.md`](review-checks-common.md) — cross-cutting
+  checks and the false-positive gate that applies to all files.
+
+## Routing table
+
+Match each changed file against the patterns top-to-bottom; load the
+reviewer file for every domain with at least one matched file. Skip
+domains with no changed files to conserve context.
+
+| Changed path matches | Reviewer rules |
+|----------------------|----------------|
+| `app.py`, `routes/**/*.py`, `src/**/*.py`, `services/**/*.py`, `mcp_servers/**/*.py`, `tests/**/*.py`, any other `**/*.py` | [`reviewers/backend-python.md`](reviewers/backend-python.md) |
+| `static/**/*.js`, `static/**/*.css`, `static/**/*.html`, `**/*.html`, `**/*.svelte` | [`reviewers/frontend-web.md`](reviewers/frontend-web.md) |
+| `Dockerfile`, `docker-compose.yml`, `docker/**`, `**/*.sh`, `*.service`, `*.ps1`, `.github/workflows/**`, `requirements*.txt` | [`reviewers/infra.md`](reviewers/infra.md) |
+| `**/*.md`, `docs/**`, `LICENSE`, `licenses/**` | [`reviewers/docs.md`](reviewers/docs.md) |
+
+A file may match more than one domain (e.g. a `.github/workflows/*.yml`
+and a `.md` in the same PR) — load every matching reviewer.
+
+## How to extend
+
+To add a new reviewer domain:
+
+1. Create `reviewers/<domain>.md` (copy an existing one as a template).
+   Keep it to a focused checklist of what to check **and** common
+   false-positives to avoid.
+2. Add a row to the routing table above mapping the file patterns to it.
+
+To tighten or relax an existing domain, edit its `reviewers/*.md` file —
+no workflow YAML change needed. Cross-cutting rules that apply to *every*
+file belong in [`review-checks-common.md`](review-checks-common.md), not
+in a single domain file.

--- a/.claude/rules/review-checks-common.md
+++ b/.claude/rules/review-checks-common.md
@@ -1,0 +1,74 @@
+# Cross-Cutting Review Checks
+
+Universal checks applied to **every** changed file, regardless of domain.
+For workflow rules see [`review-guidelines.md`](review-guidelines.md); for
+domain specifics see [`reviewers/`](reviewers/).
+
+## Severity levels
+
+- **REQUIRED** — a real bug, security hole, or correctness/logic error.
+  Should be addressed (or justified) before merge.
+- **RECOMMENDED** — an improvement: clarity, naming, structure,
+  performance that is not a bug. Advisory; never blocks.
+
+Do not label something REQUIRED unless it is genuinely a defect. When in
+doubt, RECOMMENDED.
+
+## False-positive gate (before EVERY inline comment)
+
+Do not post unless ALL of these hold:
+
+0. **In scope** — the file is part of this PR's diff
+   (`gh pr diff --name-only`). If not, it is pre-existing — skip.
+1. **Real issue** — a bug / security / architecture / performance /
+   logic / naming problem, not a style preference a linter owns.
+2. **Verified** — you read the actual file at HEAD and the issue still
+   applies at the latest commit.
+3. **Adds value** — the fix is materially better, not a restatement of
+   the original.
+
+If any fails, do NOT post. When in doubt, skip it.
+
+## Code verification protocol
+
+1. Read the actual file — never raise an issue from a diff snippet alone.
+2. Confirm exact line numbers and values.
+3. Check whether a later commit in the PR already fixes it.
+4. Quote the exact code when making a claim.
+
+## Cross-cutting checks
+
+- **Secrets** — no API keys, passwords, or tokens committed to code.
+  Odysseus is privacy-first: flag anything that logs, stores, or
+  transmits user data, credentials, or PII unexpectedly.
+- **Dead code** — for a new function/class/constant, grep for references
+  outside its definition. No references → flag as possibly unused
+  (exclude tests, exports, and framework entrypoints).
+- **Parameter changes** — if a signature changed, grep ALL call sites
+  (not just the diff) before claiming a break or suggesting a new
+  required argument.
+- **Input validation** — validate user/request input early; fail loud
+  with context. Flag silent exception swallowing (`except: pass`,
+  discarded errors that drive later branching).
+- **Naming** — only flag genuinely misleading names. An established
+  pattern (5+ existing uses) is a convention, not a smell.
+
+## Known false-positive traps
+
+Verify the real code before raising any of these:
+
+1. Formatting that is already correct (read current code, not diff
+   context).
+2. Code that no longer exists after a force-push (verify the line is
+   still there).
+3. A return type / annotation that is already present (read the actual
+   signature).
+4. YAGNI — accept the author's "defer" judgment.
+5. `except E: side_effect(); raise` is NOT swallowing — the caller still
+   receives the error.
+6. Shell scripts may target different shells — check the shebang before
+   flagging syntax.
+7. Intentional behavior removal that the PR title/body explains — not a
+   bug.
+8. f-strings without placeholders (`f"static"`) are ruff F541 — flag the
+   missing `{}`, not the string.

--- a/.claude/rules/review-guidelines.md
+++ b/.claude/rules/review-guidelines.md
@@ -1,0 +1,72 @@
+# Review Guidelines
+
+How to *conduct* a review — workflow, threads, summaries, and author
+interaction. For *what to check*, see the domain reviewers in
+[`reviewers/`](reviewers/) and the cross-cutting
+[`review-checks-common.md`](review-checks-common.md).
+
+## Workflow
+
+1. Read the PR intent: `gh pr view <N> --json title,body`. Note any
+   stated test steps and any "POC / WIP / experimental" framing.
+2. Read the diff: `gh pr diff <N> --stat`, then `gh pr diff <N>`.
+3. Check existing review comments first
+   (`mcp__github__get_pull_request_review_comments`) so you never repeat
+   feedback from a previous round.
+4. Post inline comments only for NEW issues in changed lines.
+5. Post exactly ONE summary comment per review cycle (see below).
+
+## Scope & noise
+
+- Review the lines this PR changes. Issues in **unchanged** code are
+  "pre-existing, out of scope" — mention at most informationally, never
+  block on them.
+- Group related issues; keep the summary brief.
+- Every inline comment references a file path and line.
+- Never re-raise feedback the author has already addressed or consciously
+  declined in an earlier round.
+
+## Context-aware depth
+
+| Context | Focus | Avoid |
+|---------|-------|-------|
+| Normal change | All standards below | Bikeshedding |
+| POC / experimental / WIP | Does it work? Security. Broken logic. | YAGNI, edge cases, style |
+| Refactor (no behavior change) | Behavior preservation | New-feature requests, scope creep |
+| Infra / config | Behavioral changes, correctness | Questioning stated design intent |
+
+Detect POC from the PR title/body ("POC", "demo", "prototype",
+"experimental", "WIP"). If POC, open the summary with "Reviewing as
+POC with relaxed standards" and review only bugs, security, and broken
+logic.
+
+## Summary comment
+
+- ONE summary per cycle, **COMMENT status** — never `APPROVE` or
+  `REQUEST_CHANGES` (a human owns the merge decision).
+- High-level observations and cross-cutting notes only. Do NOT repeat
+  inline-comment content.
+- If the PR is clean, post a short positive summary and stop. An empty
+  nitpick wall is noise.
+- Do NOT comment on PR title/body/commit-message *formatting* — that is
+  out of scope for code review.
+- After the author pushes fixes: acknowledge what was addressed in one
+  brief note; only flag genuinely new or still-unfixed issues.
+
+## Code suggestions
+
+Use GitHub ```suggestion blocks for straightforward, committable fixes
+(single-line: comment on the line; multi-line: set start_line/line). Add
+a one-line explanation before the block. Use prose for complex changes.
+Never use a suggestion block for non-code changes (renames, file moves).
+
+## Draft handoff
+
+If the review posted any inline comments, convert the PR back to draft
+(`gh pr ready --undo <N>`) so the author can fix everything in one pass
+without triggering a re-review on each push. The author marks "Ready for
+review" again when done. Do NOT convert a clean PR to draft.
+
+> Verify the real inline-comment count from the API before deciding —
+> `gh pr view <N> --json reviewComments --jq '.reviewComments | length'`
+> — do not rely on recollection of whether you posted comments.

--- a/.claude/rules/review-prompt.md
+++ b/.claude/rules/review-prompt.md
@@ -1,0 +1,82 @@
+<!--
+  Orchestration prompt for the Claude Code Review workflow.
+
+  This file IS the review prompt. The workflow
+  (.github/workflows/claude-code-review.yml) loads it verbatim and hands
+  it to Claude, so you can tune the review here WITHOUT editing the GitHub
+  Action. Keep it as plain instructions.
+
+  Note: GitHub Actions `${{ ... }}` expressions do NOT work in this file —
+  it is read as literal text. Use the PR_NUMBER and REPO environment
+  variables (available to gh/Bash at runtime) instead.
+
+  The leading HTML comment (this block) is fine — Claude reads past it.
+-->
+You are performing an automated code review for Odysseus, a self-hosted
+Python (Flask/uvicorn) AI workspace with a vanilla JS + HTML/CSS frontend.
+Be brief but thorough, and constructive.
+
+The pull request number is in the `PR_NUMBER` environment variable and the
+repository in `REPO`. Use them in gh commands, e.g.
+`gh pr diff "$PR_NUMBER"`.
+
+STEP 1 — LOAD REVIEW RULES & PROJECT CONTEXT
+Read these first (skip any that do not exist). The rules files are the
+source of truth — follow them; the steps below only summarize the flow:
+- .claude/rules/INDEX.md                (reviewer routing table)
+- .claude/rules/review-guidelines.md    (how to run the review)
+- .claude/rules/review-checks-common.md (cross-cutting + false-positive gate)
+- CONTRIBUTING.md, SECURITY.md, README.md (project context)
+
+STEP 2 — UNDERSTAND THE CHANGE
+- `gh pr view "$PR_NUMBER" --json title,body` to read the author's intent
+  and stated test steps.
+- `gh pr diff "$PR_NUMBER" --stat` then `gh pr diff "$PR_NUMBER"` for the
+  actual changes.
+- If the title/body marks this POC / experimental / WIP, relax standards:
+  review only for bugs, security, and broken logic.
+
+STEP 3 — ROUTE TO DOMAIN REVIEWERS
+Using the routing table in .claude/rules/INDEX.md, classify the changed
+files and load every matching .claude/rules/reviewers/*.md file. Apply
+each loaded reviewer's checklist to the files in its domain. Skip domains
+with no changed files to conserve context. (If the rules folder is absent,
+fall back to general review: correctness, security, error handling,
+performance, naming.)
+
+STEP 4 — CROSS-CUTTING CHECKS (apply to all changed files)
+Apply every check in .claude/rules/review-checks-common.md — secrets/PII,
+dead code, parameter call-site analysis, input validation, naming, and the
+code-verification protocol. Issues in UNCHANGED code are "pre-existing,
+out of scope".
+
+STEP 5 — FALSE-POSITIVE GATE (before EVERY inline comment)
+Apply the gate in .claude/rules/review-checks-common.md: post only if the
+file is in THIS PR's diff, it is a real
+bug/security/architecture/performance/logic/naming issue (not a
+linter-owned style preference), and you have read the actual code at the
+latest commit. When in doubt, skip it.
+
+STEP 6 — PRODUCE OUTPUT
+- Check existing review comments first
+  (mcp__github__get_pull_request_review_comments) to avoid duplicating
+  feedback.
+- Post inline comments for specific issues. Use GitHub ```suggestion
+  blocks for straightforward, committable fixes; describe the approach in
+  prose for complex ones.
+- Post exactly ONE summary review comment (COMMENT status, never APPROVE
+  or REQUEST_CHANGES) with high-level observations and cross-cutting notes.
+  Do not repeat inline content.
+- Do not comment on PR title/body/commit-message formatting.
+- If the PR is clean, post a short positive summary and stop — an empty
+  nitpick list is not worth a wall of text.
+
+STEP 7 — CONVERT TO DRAFT IF ISSUES WERE FOUND
+Check the REAL inline-comment count from the API (do not trust your own
+recollection):
+  `gh pr view "$PR_NUMBER" --json reviewComments --jq '.reviewComments | length'`
+If the count is greater than 0, convert the PR back to draft so the author
+can fix everything without triggering re-reviews on each push:
+  `gh pr ready --undo "$PR_NUMBER"`
+The author marks "Ready for review" again when done. If the count is 0, do
+NOT convert to draft.

--- a/.claude/rules/reviewers/backend-python.md
+++ b/.claude/rules/reviewers/backend-python.md
@@ -1,0 +1,48 @@
+# Reviewer — Backend (Python)
+
+**Scope:** `app.py`, `routes/**/*.py`, `src/**/*.py`, `services/**/*.py`,
+`mcp_servers/**/*.py`, `tests/**/*.py`, and any other `**/*.py`.
+
+Odysseus is a Flask/uvicorn app: HTTP routes in `routes/`, business logic
+and integrations in `src/`. Apply [`../review-checks-common.md`](../review-checks-common.md)
+first, then the domain checks below.
+
+## Check
+
+- **Route safety** — new/changed routes validate input before use,
+  enforce auth where the sibling routes do, and never trust client data
+  for file paths, shell commands, or model/endpoint selection.
+- **Injection** — SQL built by string concatenation, shell commands from
+  user input, prompt injection into model calls, unsafe deserialization
+  (`pickle`, `yaml.load` without `SafeLoader`), path traversal in file
+  handlers/uploads.
+- **Secrets & data** — credentials read from config/env, not literals.
+  No logging of secrets, tokens, full prompts containing user data, or
+  PII. Honour the privacy-first posture in [`SECURITY.md`](../../../SECURITY.md).
+- **Error handling** — fail loud with context; no bare `except:` or
+  `except Exception: pass` that hides failures; DB writes are wrapped in
+  a transaction where partial writes would corrupt state.
+- **Blocking I/O** — long/network/subprocess calls on the request path
+  should be async or offloaded; flag obvious blocking in hot routes.
+- **Resource hygiene** — files/connections/clients closed (context
+  managers); no obvious leaks in loops over user input.
+- **Style** — type hints on new defs; clear names over comments; no
+  f-strings without placeholders (F541); no unused imports.
+
+## Tests (`tests/**`)
+
+- New behavior has a test; bug fixes add a regression test.
+- Tests assert on real outcomes, not just "did not raise".
+- No live network/model calls in unit tests — they should be stubbed.
+
+## Common false-positives — do NOT flag
+
+- A bare `raise` after a side effect (the caller still gets the error).
+- Patterns already used 5+ times elsewhere (established convention).
+- Missing async on a genuinely cheap, non-blocking call.
+- Test-only helpers that look "unused" but are referenced by fixtures.
+
+## Extend
+
+Add checks here as backend conventions emerge. Cross-cutting rules go in
+[`../review-checks-common.md`](../review-checks-common.md) instead.

--- a/.claude/rules/reviewers/docs.md
+++ b/.claude/rules/reviewers/docs.md
@@ -1,0 +1,38 @@
+# Reviewer — Documentation
+
+**Scope:** `**/*.md`, `docs/**`, `LICENSE`, `licenses/**`.
+
+Apply [`../review-checks-common.md`](../review-checks-common.md) first.
+Documentation review is light-touch — prefer RECOMMENDED over REQUIRED
+unless a doc actively misleads users.
+
+## Check
+
+- **Accuracy** — commands, flags, file paths, and env vars in docs match
+  the real code. Verify a referenced file/dir exists (Glob) and a
+  referenced command is real before trusting it. Unverified references in
+  user-facing docs are REQUIRED to fix.
+- **Setup steps** — install/run instructions in `README.md` /
+  `CONTRIBUTING.md` actually work with the current code (e.g. the right
+  Python version, the right `docker compose` invocation).
+- **Planned vs shipped** — features not yet implemented are marked
+  `[PLANNED]` so users don't try to use them.
+- **Secrets & PII** — no real keys, tokens, private logs, personal data,
+  or public IPs in examples (per [`CONTRIBUTING.md`](../../../CONTRIBUTING.md)
+  and [`SECURITY.md`](../../../SECURITY.md)). Use obvious placeholders.
+- **Links** — internal links resolve; no dead relative paths after a file
+  move.
+- **Clarity (RECOMMENDED)** — headings, code fences with a language, and
+  consistent terminology ("TireTutor", project names spelled correctly).
+
+## Common false-positives — do NOT flag
+
+- Prose style, tone, or wording preferences.
+- Line length / formatting a Markdown linter would own.
+- Intentional brevity in a stub or placeholder doc.
+
+## Extend
+
+Add checks here as doc conventions emerge (e.g. a required section in
+release notes). Cross-cutting rules go in
+[`../review-checks-common.md`](../review-checks-common.md).

--- a/.claude/rules/reviewers/frontend-web.md
+++ b/.claude/rules/reviewers/frontend-web.md
@@ -1,0 +1,40 @@
+# Reviewer — Frontend (Web)
+
+**Scope:** `static/**/*.js`, `static/**/*.css`, `static/**/*.html`,
+`**/*.html`, `**/*.svelte`.
+
+Odysseus ships a vanilla-JS frontend (`static/js`, `static/app.js`) with
+server-rendered HTML and a service worker (`static/sw.js`). Apply
+[`../review-checks-common.md`](../review-checks-common.md) first, then the
+domain checks below.
+
+## Check
+
+- **XSS** — no `innerHTML` / `insertAdjacentHTML` / template injection of
+  unescaped user or model output. Prefer `textContent`, or escape
+  explicitly. Flag `eval`, `new Function`, and `document.write`.
+- **Token / data leakage** — auth tokens, API keys, and session data
+  must not be written to the DOM, `localStorage` in plaintext where
+  avoidable, console logs, or query strings.
+- **Fetch & endpoints** — requests go to same-origin / configured
+  endpoints; no hardcoded third-party URLs that exfiltrate data; handle
+  non-200 responses (don't assume success).
+- **Service worker / caching** — `sw.js` changes must not cache
+  authenticated or user-specific responses indefinitely; bump the cache
+  version when cached assets change.
+- **Accessibility (RECOMMENDED)** — interactive elements are reachable
+  and labelled; images have `alt`; color is not the only signal.
+- **Correctness** — no unhandled promise rejections; event listeners
+  cleaned up where elements are removed; no obvious layout-breaking CSS.
+
+## Common false-positives — do NOT flag
+
+- `innerHTML` with a static, developer-authored constant (no user data).
+- Inline styles or class patterns already used widely in the codebase.
+- Missing framework conventions — this is intentionally vanilla JS.
+
+## Extend
+
+Add checks here as frontend conventions emerge (e.g. a component pattern,
+a sanitizer helper). Cross-cutting rules go in
+[`../review-checks-common.md`](../review-checks-common.md).

--- a/.claude/rules/reviewers/infra.md
+++ b/.claude/rules/reviewers/infra.md
@@ -1,0 +1,42 @@
+# Reviewer — Infrastructure
+
+**Scope:** `Dockerfile`, `docker-compose.yml`, `docker/**`, `**/*.sh`,
+`*.service`, `*.ps1`, `.github/workflows/**`, `requirements*.txt`.
+
+Apply [`../review-checks-common.md`](../review-checks-common.md) first.
+Trust stated design intent in the PR — frame concerns as "consider
+whether", not "this is wrong".
+
+## Check
+
+- **Docker** — no secrets baked into image layers or `ENV`; pin base
+  images to a tag (not a moving `latest` where reproducibility matters);
+  minimize layers and copied context (`.dockerignore`); run as non-root
+  where practical; `docker compose config` would still parse.
+- **Shell scripts** — check the shebang before flagging syntax (bash vs
+  sh vs fish differ); quote variable expansions (`"$VAR"`); `set -euo
+  pipefail` for bash where failure should abort; no `curl | sh` of
+  untrusted sources; no silent error swallowing (`|| true`, `2>/dev/null`)
+  on steps whose result drives later logic.
+- **GitHub Actions** — least-privilege `permissions:` block; pin actions
+  to a major version or SHA; do not echo secrets into logs; secrets are
+  unavailable to fork PRs by default (don't assume they exist);
+  `concurrency` set for PR-triggered workflows to avoid pile-ups.
+- **Dependencies** (`requirements*.txt`) — new deps are justified, not
+  obviously abandoned, and reasonably pinned; flag a dependency added for
+  a one-line utility.
+- **Systemd / service units** — correct `ExecStart`, restart policy, and
+  no plaintext secrets in the unit.
+
+## Common false-positives — do NOT flag
+
+- A deliberately unpinned base image in a dev-only file.
+- `|| true` on a genuinely optional cleanup step.
+- Different scripts using different shells — that is allowed.
+- Questioning a design choice the PR body already explains.
+
+## Extend
+
+Add checks here as deployment conventions firm up (e.g. a required CI
+gate, an image-scanning step). Cross-cutting rules go in
+[`../review-checks-common.md`](../review-checks-common.md).

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,115 @@
+name: Claude Code Review
+
+# Automated PR review powered by Claude.
+# Setup guide: .claude/rules/CLAUDE_CODE_REVIEW.md
+#
+# Runs only when a PR is marked "Ready for review" (or opened as a
+# non-draft). Draft PRs are skipped, and the review does NOT re-run on
+# every push — keep iterating in draft, then click "Ready for review"
+# again when you want a fresh pass.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    paths:
+      - "**/*.py"
+      - "**/*.js"
+      - "**/*.ts"
+      - "**/*.css"
+      - "**/*.html"
+      - "**/*.sh"
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "requirements*.txt"
+      - "!.github/workflows/claude*.yml"
+
+jobs:
+  claude-review:
+    # Never review drafts. A PR opened directly as a draft still fires
+    # the "opened" event, so this guard is what enforces ready-only.
+    if: >-
+      !github.event.pull_request.draft
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Skip if a run for this commit already exists
+        id: dedup
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PEER_RUN=$(gh api \
+            "repos/${{ github.repository }}/actions/runs?head_sha=${{ github.sha }}&per_page=10" \
+            --jq "[.workflow_runs[] | select(.name == \"${{ github.workflow }}\" and .id != ${{ github.run_id }} and .conclusion != \"cancelled\" and .conclusion != \"skipped\" and .status != \"queued\")] | first | .id // empty" \
+            2>/dev/null || true)
+          if [ -n "$PEER_RUN" ]; then
+            echo "::notice::Skipping duplicate run — SHA ${{ github.sha }} already handled by run $PEER_RUN"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if PR already merged or closed
+        if: steps.dedup.outputs.skip != 'true'
+        id: pr-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          STATE=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} --json state -q '.state')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "::notice::Skipping — PR #${{ github.event.pull_request.number }} is $STATE"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.dedup.outputs.skip != 'true' && steps.pr-state.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Load review prompt
+        if: steps.dedup.outputs.skip != 'true' && steps.pr-state.outputs.skip != 'true'
+        id: prompt
+        run: |
+          PROMPT_FILE=".claude/rules/review-prompt.md"
+          if [ ! -f "$PROMPT_FILE" ]; then
+            echo "::error::Missing $PROMPT_FILE — cannot run review."
+            exit 1
+          fi
+          # Stream the prompt file verbatim into the step env so the prompt
+          # lives in Markdown, not in this workflow. Random delimiter avoids
+          # any clash with the file's own contents.
+          DELIM="REVIEW_PROMPT_EOF_$(openssl rand -hex 8)"
+          {
+            echo "REVIEW_PROMPT<<$DELIM"
+            cat "$PROMPT_FILE"
+            echo "$DELIM"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Claude Code Review
+        if: steps.dedup.outputs.skip != 'true' && steps.pr-state.outputs.skip != 'true'
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Consumed by gh/Bash inside the prompt (see review-prompt.md).
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Prompt body lives in .claude/rules/review-prompt.md — edit it
+          # there; no need to touch this workflow.
+          prompt: ${{ env.REVIEW_PROMPT }}
+
+          # https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # Swap --model haiku for sonnet or opus here for deeper (pricier) reviews.
+          claude_args: '--model haiku --allowed-tools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_review_comments,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr ready:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*)"'

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ services/data/
 
 # IDE / Editor
 .aider*
-.claude/
+.claude/*
+!.claude/rules/
 .vscode/
 .idea/
 *.swp


### PR DESCRIPTION
## Summary

Adds an opt-in, self-hosted **Claude code-review** GitHub Action. When a PR is marked **Ready for review**, it reviews the diff, posts inline comments plus one summary, and flips the PR back to draft if it finds issues so the author can fix them in a single pass (it does **not** re-run on every push). Review behaviour lives in editable Markdown under `.claude/rules/` — a routing `INDEX.md`, shared guidelines/checks, per-domain reviewers, and the prompt itself — so maintainers tune reviews without editing the workflow YAML. The workflow is inert until a maintainer installs the Claude GitHub App and adds an `ANTHROPIC_API_KEY` secret.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2673

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

> On the last box: this PR adds a GitHub Actions workflow + Markdown config — there is no in-app code path to exercise. The workflow YAML was validated with `yq`, and the action cannot run until a maintainer installs the Claude GitHub App and adds an `ANTHROPIC_API_KEY` secret (see `.claude/rules/CLAUDE_CODE_REVIEW.md`). Honest disclosure: this PR was prepared with AI assistance, and #2673 was opened first per the repo's LLM-contribution guidance.

## How to Test

1. Install the **Claude GitHub App** on the repo and add an `ANTHROPIC_API_KEY` repository secret (steps in `.claude/rules/CLAUDE_CODE_REVIEW.md`).
2. Open a draft PR that changes a matched path (e.g. any `*.py`), then click **Ready for review**.
3. Confirm the **Claude Code Review** workflow runs (Actions tab) and posts inline comments + a summary; if it raises issues, confirm the PR is flipped back to draft.
4. Static check without the app: `yq '.on.pull_request.types' .github/workflows/claude-code-review.yml` → `[opened, ready_for_review]`.

## Visual / UI changes

Not applicable — this PR adds only a GitHub Actions workflow and Markdown rules under `.claude/`. No buttons, icons, CSS, HTML, SVG, or `static/js/` rendering code is touched.

---

[`f7a7707`](https://github.com/wooyek/odysseus/commit/f7a7707ef07e45ba9fa5d8cd58987ad6e6f86728) 👷 Enable automated Claude code review on PRs

> Reviews are AI-generated — a first pass, not a substitute for human review. Verify findings before acting; a clean pass is not an approval.