### PR TITLE
fix(tests): restore webhook manager after review test import

### DIFF
--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -484,7 +484,25 @@ async def test_webhook_tool_reuses_private_url_validation():
     fake_src_db = types.ModuleType("src.database")
     fake_src_db.SessionLocal = fake_core_db.SessionLocal
     fake_src_db.Webhook = object
+    # Importing do_manage_webhooks below re-executes src.webhook_manager bound to
+    # the faked src.database, whose Webhook is plain `object`. Save BOTH the
+    # sys.modules entry AND the parent-package attribute (src.webhook_manager) so
+    # the real module can be restored afterwards. Without this the polluted
+    # module leaks into the cache and breaks sibling tests that call
+    # WebhookManager._deliver (which evaluates `Webhook.id == webhook_id`).
+    _ABSENT = object()
+    _wm_saved_module = sys.modules.get("src.webhook_manager", _ABSENT)
+    _src_pkg = sys.modules.get("src")
+    _wm_saved_attr = (
+        getattr(_src_pkg, "webhook_manager", _ABSENT) if _src_pkg is not None else _ABSENT
+    )
+
+    # Drop both bindings so the import re-executes against the fake src.database,
+    # still exercising the intended import path.
     sys.modules.pop("src.webhook_manager", None)
+    if _src_pkg is not None and hasattr(_src_pkg, "webhook_manager"):
+        delattr(_src_pkg, "webhook_manager")
+
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setitem(sys.modules, "core.database", fake_core_db)
     monkeypatch.setitem(sys.modules, "src.database", fake_src_db)
@@ -498,6 +516,18 @@ async def test_webhook_tool_reuses_private_url_validation():
         )
     finally:
         monkeypatch.undo()
+        # Restore src.webhook_manager to its exact pre-test state at BOTH the
+        # sys.modules and parent-package attribute level.
+        if _wm_saved_module is _ABSENT:
+            sys.modules.pop("src.webhook_manager", None)
+        else:
+            sys.modules["src.webhook_manager"] = _wm_saved_module
+        if _src_pkg is not None:
+            if _wm_saved_attr is _ABSENT:
+                if hasattr(_src_pkg, "webhook_manager"):
+                    delattr(_src_pkg, "webhook_manager")
+            else:
+                setattr(_src_pkg, "webhook_manager", _wm_saved_attr)
 
     assert result["exit_code"] == 1
     assert "private/internal" in result["error"]


### PR DESCRIPTION
## Summary

Part of #2580.

Fixes an order-dependent webhook test pollution from `tests/test_review_regressions.py`.

`test_webhook_tool_reuses_private_url_validation` temporarily re-imports `src.webhook_manager` while `src.database` is faked with `Webhook = object`. Before this change, the polluted `src.webhook_manager` module could remain cached after the test, so later webhook delivery tests saw `Webhook = object` and failed when `_deliver()` evaluated `Webhook.id == webhook_id`.

This PR saves/restores both:

- `sys.modules["src.webhook_manager"]`
- the parent package attribute `src.webhook_manager`

No production behavior changes.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to review-regression webhook-manager import-state isolation.
- [ ] I ran the app end-to-end.
  - Not applicable: test-only isolation fix. No production code, UI, route, or runtime behavior changed.

## How to Test

1. Compile the touched file:

    python3 -m py_compile tests/test_review_regressions.py

2. Run the polluter test alone:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_review_regressions.py::test_webhook_tool_reuses_private_url_validation

Validated locally:

    1 passed

3. Run the webhook timestamp victim alone:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_webhook_ssrf_resilience.py::test_webhook_delivery_uses_naive_utc_timestamps

Validated locally:

    1 passed

4. Confirm the polluter no longer breaks the victim:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_review_regressions.py::test_webhook_tool_reuses_private_url_validation \
      tests/test_webhook_ssrf_resilience.py::test_webhook_delivery_uses_naive_utc_timestamps

Validated locally:

    2 passed

Additional targeted checks from the investigation:

- full `tests/test_review_regressions.py`: 19 passed
- `-k webhook` over full collection: 6 passed
- explicit restore check confirmed both `sys.modules["src.webhook_manager"]` and `sys.modules["src"].webhook_manager` restore to the real module with real `Webhook`

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only isolation fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.

## Notes

`tests/test_cookbook_helpers.py::test_pip_install_fallback_chain_propagates_failure_in_venv` appears related to existing open PR #2516 and is intentionally not changed here.

`tests/test_edit_file.py::test_edit_file_blocked_at_execution_for_non_admin` was investigated but not changed because the execution-level admin gate currently exists and the test passes in targeted local checks. It should be rechecked after this PR and the cookbook PR are handled.
