### PR TITLE
fix: always offer write_file/edit_file (not RAG-only) like read_file

### DIFF
--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -22,7 +22,12 @@ logger = logging.getLogger(__name__)
 # Tools that are ALWAYS included regardless of retrieval results.
 # These are the most commonly needed and should never be missing.
 ALWAYS_AVAILABLE = frozenset({
-    "bash", "python", "web_search", "web_fetch", "read_file",
+    "bash", "python", "web_search", "web_fetch",
+    # File tools: read AND write/edit. An agent with disk access should always
+    # be able to change files, not just read them — otherwise a bare "edit X"
+    # request can miss write_file/edit_file (RAG-only) and the model wrongly
+    # falls back to edit_document (editor panel). All admin-gated by tool_security.
+    "read_file", "write_file", "edit_file",
     "grep", "glob", "ls",  # code-navigation tools (admin-gated by tool_security)
     "api_call",  # For configured integrations (Miniflux, Gitea, Linkding, etc.)
     # The two genuinely AMBIENT cookbook tools — "what's running" and


### PR DESCRIPTION
## Summary

The on-disk write tools `write_file` and `edit_file` were only offered to the model via the per-query tool-RAG retriever, while `read_file`/`grep`/`glob`/`ls` are in `ALWAYS_AVAILABLE` (`src/tool_index.py`) and always sent. On a bare editing request ("make a small edit to allego.py") the retriever could miss the write tools, so the model was never offered `edit_file`/`write_file` and wrongly fell back to `edit_document` (the editor panel) or improvised with `bash sed`. This adds `write_file` and `edit_file` to `ALWAYS_AVAILABLE` next to `read_file` — an agent with disk access should always be able to write as well as read. Both stay admin-gated by `tool_security`, so non-admin exposure is unchanged.

Files changed: `src/tool_index.py` (two tool names added to `ALWAYS_AVAILABLE`).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2683

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start a fresh conversation in Agent mode, no workspace set.
2. Ask a bare editing request, e.g. "edit the file /tmp/foo.txt".
3. Check the server log line `agent-debug ... tool_names=[...]` for that turn.

Before: `tool_names` omits `write_file`/`edit_file`; the model claims it lacks `edit_file` and falls back to `edit_document`/`bash`.
After: `tool_names` includes both, e.g.:

    tool_names=['bash', 'python', 'web_search', 'web_fetch', 'read_file', 'grep', 'glob', 'ls', 'write_file', 'edit_file', 'create_document', 'edit_document', 'suggest_document', 'update_document', 'manage_memory']

Checks run:
- Verified live (`uvicorn app:app`, Anthropic API + claude-haiku-4.5): fresh no-workspace chat now offers `write_file`/`edit_file` (log above).
- `py_compile src/tool_index.py` — pass.
- `python -c "from src.tool_index import ALWAYS_AVAILABLE as A; print('write_file' in A, 'edit_file' in A)"` -> `True True`.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI changes — backend tool-selection only (`src/tool_index.py`).
