### PR TITLE
fix(tests): call live tool_execution module in edit-file gate test

### DIFF
--- a/tests/test_edit_file.py
+++ b/tests/test_edit_file.py
@@ -11,7 +11,7 @@ from src.tool_security import (
     is_public_blocked_tool,
     blocked_tools_for_owner,
 )
-from src.tool_execution import _do_edit_file, execute_tool_block
+from src.tool_execution import _do_edit_file
 from src.agent_tools import ToolBlock
 
 
@@ -34,13 +34,20 @@ def test_blocked_tools_for_owner_includes_edit_file_for_non_admin(monkeypatch):
 @pytest.mark.asyncio
 async def test_edit_file_blocked_at_execution_for_non_admin(monkeypatch):
     # Execution-level gate: a non-admin owner must be refused even if the tool
-    # reaches execute_tool_block.
+    # reaches execute_tool_block. edit_file stays admin-gated by tool_security
+    # after #2684 (ALWAYS_AVAILABLE only changed advertisement, not execution).
+    #
+    # Resolve execute_tool_block from the live module object (te) rather than a
+    # top-level import: other test modules pop src.tool_execution from
+    # sys.modules and re-import it, so a stale top-level reference would call a
+    # different module's function than the one monkeypatch targets — silently
+    # bypassing the admin gate.
     import src.tool_execution as te
     monkeypatch.setattr(te, "_owner_is_admin", lambda owner: False)
     ws = tempfile.mkdtemp()
     p = os.path.join("/tmp", "ef_block.txt")
     open(p, "w").write("a\n")
-    _desc, result = await execute_tool_block(
+    _desc, result = await te.execute_tool_block(
         ToolBlock("edit_file", json.dumps({"path": p, "old_string": "a", "new_string": "b"})),
         owner="bob",
     )


### PR DESCRIPTION
## Summary

Part of #2580.

Fixes the final CI-order-dependent failure:

`tests/test_edit_file.py::test_edit_file_blocked_at_execution_for_non_admin`

The intended policy is unchanged: `edit_file` remains admin-gated at execution level. Commit `7b4365f` made `write_file` / `edit_file` always available for tool discovery, but explicitly kept the `tool_security` execution gate.

The failure was a test-isolation issue. Some tests remove and re-import `src.tool_execution`, which can leave the test's top-level imported `execute_tool_block` bound to a stale module object. The test then monkeypatches the current `src.tool_execution._owner_is_admin`, but calls the stale function object, so the monkeypatch is bypassed and the edit succeeds.

This PR updates the test to call `te.execute_tool_block(...)` from the same live module object that is monkeypatched.

No production behavior changes.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to edit-file admin-gate test isolation.
- [ ] I ran the app end-to-end.
  - Not applicable: test-only isolation fix. No production code, UI, route, or runtime behavior changed.

## How to Test

1. Compile the touched file:

    python3 -m py_compile tests/test_edit_file.py

2. Run the target failing test:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_edit_file.py::test_edit_file_blocked_at_execution_for_non_admin

Validated locally:

    1 passed

3. Run the full edit-file test file:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q tests/test_edit_file.py

Validated locally:

    7 passed

4. Run the known polluter-order check:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_unknown_tool_calls.py \
      tests/test_function_call_non_object_args.py \
      tests/test_edit_file.py::test_edit_file_blocked_at_execution_for_non_admin

Validated locally:

    11 passed

5. Run the final targeted baseline check:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_cookbook_helpers.py::test_pip_install_fallback_chain_propagates_failure_in_venv \
      tests/test_edit_file.py

Validated locally:

    8 passed

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only isolation fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.
