### PR TITLE
fix(tests): make cookbook venv fallback test deterministic

### DIFF
--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -125,15 +125,15 @@ def test_pip_install_fallback_chain_propagates_failure_in_venv():
     reported success even though nothing was installed.  The negated
     `{ ! venv_check && user }` shape propagates the failure correctly.
     """
-    import shlex
-    py = shlex.quote(sys.executable)
-    # Use the venv python so venv_check detects we're in a venv.
+    # Simulate "inside a venv" deterministically: the venv check exits 0.
     # Base install fails, venv_check exits 0, negated to 1,
-    # && skips user, group exits 1.
+    # && skips user, group exits 1.  This avoids depending on whether the
+    # test runner's own interpreter happens to be inside a venv (which
+    # differs between local and CI environments).
     script = (
-        f"{py} -c 'import sys; sys.exit(1)' || "
-        f"{{ ! {py} -c \"import sys; sys.exit(0 if sys.prefix != sys.base_prefix else 1)\" "
-        f"&& echo user_attempt; }}"
+        "false || "
+        "{ ! true "  # venv_check=0 (in venv) → negated to 1 → user skipped
+        "&& echo user_attempt; }"
     )
     result = subprocess.run(
         ["bash", "-c", script],


### PR DESCRIPTION
## Summary

Part of #2580.

Fixes the remaining CI-environment-dependent cookbook test:

`tests/test_cookbook_helpers.py::test_pip_install_fallback_chain_propagates_failure_in_venv`

The test intended to prove that when the base install fails inside a venv, the generated fallback chain does not attempt the `--user` fallback and exits non-zero.

Before this change, the test used the actual test runner Python environment to detect whether it was inside a venv. That passed locally but failed in GitHub CI when the runner interpreter was not inside a venv, causing the simulated `user_attempt` path to run.

This PR makes the test deterministic by simulating the shell states directly:

- `false` = base install fails
- `true` = venv check reports “inside venv”
- `! true` = false, so `&& echo user_attempt` is skipped

No production behavior changes.

## Target branch

- [x] `dev`

## Linked Issue

Part of #2580

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2580.
- [x] This PR targets `dev`.
- [x] Scope is limited to making one cookbook fallback-chain test deterministic.
- [ ] I ran the app end-to-end.
  - Not applicable: test-only CI determinism fix. No production code, UI, route, or runtime behavior changed.

## How to Test

1. Compile the touched file:

    python3 -m py_compile tests/test_cookbook_helpers.py

2. Run the target failing test:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_cookbook_helpers.py::test_pip_install_fallback_chain_propagates_failure_in_venv

Validated locally:

    1 passed

3. Run the full cookbook helper test file:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q tests/test_cookbook_helpers.py

Validated locally:

    44 passed

4. Run the final targeted baseline check:

    PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' \
      python3 -m pytest -q \
      tests/test_cookbook_helpers.py::test_pip_install_fallback_chain_propagates_failure_in_venv \
      tests/test_edit_file.py::test_edit_file_blocked_at_execution_for_non_admin

Validated locally:

    2 passed

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI/rendering files touched.

### Screenshots / clips

Not applicable.

## Notes

PR #2516 was reviewed as related context but not used for this slice because it targets `main` and changes production cookbook helper behavior. This PR is intentionally test-only and scoped to the current `dev` CI baseline failure.
