### PR TITLE
fix: show backend error detail in context-popup compact button

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -1835,7 +1835,13 @@ export function displayMetrics(messageElement, metrics) {
                 }
               }, 200);
             } else {
-              compactBody.innerHTML = '<span style="color:var(--red);">Compaction failed. Try again later.</span>';
+              let detail = 'Compaction failed. Try again later.';
+              try {
+                const err = await res.json();
+                if (err.detail) detail = err.detail;
+              } catch {}
+              compactBody.textContent = detail;
+              compactBody.style.color = 'var(--red)';
             }
           } catch (err) {
             clearInterval(waveInterval);


### PR DESCRIPTION
## Summary

When the context-popup compact button receives a non-OK response (e.g. 409 for active-run), the backend error detail was being discarded in favor of a generic 'Compaction failed' message. Now parses the JSON response body for non-OK responses and prefers the `detail` field when present, matching the behavior of the `/compact` slash command. Uses `textContent` for safe rendering instead of `innerHTML`.

## Linked Issue

Fixes #2649

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I searched existing issues and PRs and found no duplicates.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## How to Test

1. Open a chat session in Odysseus
2. Start a long-running operation (e.g., model download) to occupy the session
3. Click the context ring to open the context popup
4. Click 'Compact context' while the session has an active run
5. Verify the error message shows the backend detail (e.g., 'Session has an active run; try compacting after it finishes') instead of the generic 'Compaction failed. Try again later.'
6. Also test with no active run to verify the happy path still works correctly
