### PR TITLE
feat(notes): per-item Agent: solve button on todo hover

### DIFF
--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -1783,6 +1783,9 @@ function _renderNotes() {
         contentHtml += `<div class="note-checkbox${doneClass}" data-note-id="${note.id}" data-idx="${i}" style="padding-left:${indent * 16}px">
           <span class="note-check-dot" title="Mark done"></span>
           <span class="note-check-text">${_linkify(item.text)}</span>
+          <button class="note-checkbox-agent" data-note-id="${note.id}" data-idx="${i}" title="Solve this todo with the agent">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect x="4" y="8" width="16" height="12" rx="2"/><path d="M2 14h2M20 14h2M15 13v2M9 13v2"/></svg>
+          </button>
           <button class="note-checkbox-rm" data-note-id="${note.id}" data-idx="${i}" title="Delete item">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
@@ -2134,7 +2137,7 @@ function _bindCardEvents(body) {
   // Click empty area of checklist preview (not on checkbox/X) — edit
   body.querySelectorAll('.note-checklist-preview').forEach(el => {
     el.addEventListener('click', (e) => {
-      if (e.target.closest('.note-checkbox, .note-checkbox-rm, .note-cl-quickadd, input')) return;
+      if (e.target.closest('.note-checkbox, .note-checkbox-rm, .note-checkbox-agent, .note-cl-quickadd, input')) return;
       e.stopPropagation();
       tapToEditOrSelect(el.closest('.note-card'));
     });
@@ -2160,7 +2163,7 @@ function _bindCardEvents(body) {
   // title / content preview triggered edit, so padding + empty gutters were
   // dead zones that felt broken on mobile.
   if (_isNotesMobileMode() && !_selectMode) {
-    const _INTERACTIVE = 'button, a, input, label, .note-card-color-dot, .note-checkbox, .note-checkbox-rm, .note-cl-quickadd, .note-agent-tag, .note-card-pin, .note-card-corner-trash, .note-card-corner-menu, .note-card-corner-unarchive, .note-card-edit-corner, .note-card-reminder, .note-card-cb';
+    const _INTERACTIVE = 'button, a, input, label, .note-card-color-dot, .note-checkbox, .note-checkbox-rm, .note-checkbox-agent, .note-cl-quickadd, .note-agent-tag, .note-card-pin, .note-card-corner-trash, .note-card-corner-menu, .note-card-corner-unarchive, .note-card-edit-corner, .note-card-reminder, .note-card-cb';
     body.querySelectorAll('.note-card').forEach(card => {
       card.addEventListener('click', (e) => {
         if (e.target.closest(_INTERACTIVE)) return;
@@ -2477,6 +2480,19 @@ function _bindCardEvents(body) {
         _renderNotes();
         uiModule.showError('Failed to remove item');
       });
+    });
+  });
+
+  // Per-item agent solve (hover button next to the X). Scoped to one todo
+  // item — uses the note title as context if present, but only the single
+  // item's text as the work. Mirrors the per-note _agentSolveNote pattern.
+  body.querySelectorAll('.note-checkbox-agent').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (_selectMode) return;
+      const noteId = btn.dataset.noteId;
+      const idx = parseInt(btn.dataset.idx);
+      _agentSolveTodoItem(noteId, idx);
     });
   });
 
@@ -4365,6 +4381,66 @@ async function _agentSolveNote(id) {
       .catch(() => {});
 
     uiModule.showToast('Agent working in background — tap the Agent tag when ready');
+  } catch (e) {
+    uiModule.showError('Agent failed: ' + (e.message || e));
+  }
+}
+
+// Per-item version of _agentSolveNote. Scoped to a single checklist item;
+// the note title (if any) is included as context, but only this one item's
+// text is the work the agent is asked to do. agent_session_id is set on the
+// PARENT note (latest-wins) so the Agent tag still surfaces the most recent
+// run from this note — same UX as a per-note solve.
+async function _agentSolveTodoItem(noteId, idx) {
+  const note = _notes.find(n => n.id === noteId);
+  if (!note || !Array.isArray(note.items)) return;
+  const item = note.items[idx];
+  const itemText = (item && (item.text || '').trim()) || '';
+  if (!itemText) {
+    uiModule.showToast('Nothing to solve — item is empty');
+    return;
+  }
+  const titleCtx = (note.title || '').trim();
+  const prompt = titleCtx
+    ? `Context (from note "${titleCtx}").\n\nHelp me with this todo: ${itemText}`
+    : `Help me with this todo: ${itemText}`;
+  try {
+    const dc = await (await fetch(`${API_BASE}/api/default-chat`, { credentials: 'same-origin' })).json();
+    if (!dc.endpoint_url || !dc.model) { uiModule.showError('No default chat model configured'); return; }
+
+    const label = itemText.slice(0, 40);
+    const csFd = new FormData();
+    csFd.append('name', 'Agent: ' + label);
+    csFd.append('endpoint_url', dc.endpoint_url);
+    csFd.append('model', dc.model);
+    if (dc.endpoint_id) csFd.append('endpoint_id', dc.endpoint_id);
+    csFd.append('skip_validation', 'true');
+    const csRes = await fetch(`${API_BASE}/api/session`, { method: 'POST', credentials: 'same-origin', body: csFd });
+    if (!csRes.ok) { uiModule.showError('Could not create agent session'); return; }
+    const sess = await csRes.json();
+    const sid = sess.id;
+
+    const n = _notes.find(x => x.id === noteId);
+    if (n) n.agent_session_id = sid;
+    _renderNotes();
+    _patchNote(noteId, { agent_session_id: sid }).catch(() => {});
+
+    const fd = new FormData();
+    fd.append('message', prompt);
+    fd.append('session', sid);
+    fd.append('mode', 'agent');
+    fetch(`${API_BASE}/api/chat_stream`, { method: 'POST', credentials: 'same-origin', body: fd })
+      .then(async (res) => {
+        if (!res.ok || !res.body) return;
+        const reader = res.body.getReader();
+        while (true) { const { done } = await reader.read(); if (done) break; }
+        if (window.sessionModule && window.sessionModule.markStreamComplete) {
+          try { window.sessionModule.markStreamComplete(sid); } catch {}
+        }
+      })
+      .catch(() => {});
+
+    uiModule.showToast('Agent working on this item — tap the Agent tag when ready');
   } catch (e) {
     uiModule.showError('Agent failed: ' + (e.message || e));
   }

--- a/static/style.css
+++ b/static/style.css
@@ -32126,6 +32126,30 @@ body.notes-mobile-mode.notes-drag-mode .note-card-pin.active {
 .note-checkbox:hover .note-checkbox-rm { opacity: 0.55; }
 .note-checkbox-rm:hover { opacity: 1 !important; color: var(--red); background: color-mix(in srgb, var(--red) 12%, transparent); }
 .note-card-selectmode .note-checkbox-rm { display: none; }
+
+/* Per-item "solve with agent" button — mirrors .note-checkbox-rm visually
+   so the two hover-actions on a todo item read as a pair. Sits to the left
+   of the X (DOM order = agent then X), both pushed to the right via the
+   shared margin-left:auto pattern. */
+.note-checkbox-agent {
+  flex: 0 0 auto;
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  opacity: 0;
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  margin-right: 0;
+  transition: opacity 0.12s, background 0.12s, color 0.12s;
+}
+.note-checkbox:hover .note-checkbox-agent { opacity: 0.55; }
+.note-checkbox-agent:hover { opacity: 1 !important; color: var(--red); background: color-mix(in srgb, var(--red) 12%, transparent); }
+.note-card-selectmode .note-checkbox-agent { display: none; }
 .note-check-dot {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
## Summary

Adds a hover-revealed agent button next to each todo item's X button, scoped to **one checklist item**. Mirrors the existing per-note \"Agent: solve this\" affordance but lets you delegate a single todo without sending the whole note.

Drafted because it's visual — needs an in-browser test before promoting.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## How to Test

1. Open the Notes panel.
2. Open or create a checklist note with at least 2 todo items, e.g. \"Buy groceries\" / \"Book flight\" / \"Email Sam\".
3. Hover any item — confirm two buttons appear at the right edge: the agent (robot) icon then the X. Both should fade in on hover, same animation as the X today.
4. Click the agent icon on one item. Expect:
   - Toast: \"Agent working on this item — tap the Agent tag when ready\"
   - New chat session created server-side named `Agent: {item text}`
   - The note card sprouts the existing Agent tag (clicking it opens the chat with the agent's work)
5. Click the X on a different item — confirm the delete-item flow still works exactly as before (no regression).
6. Click neither — confirm clicking the rest of the card still opens the editor like before.
7. Repeat on mobile if you can — hover-only patterns can be tricky there; the agent button reuses the same hover/visibility CSS rules as the existing X.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] Screenshot or short clip of the change in the running app — **maintainer to attach after browser test**
- [x] **Style match**: reused existing CSS variables (`--fg`, `--red`), mirrored `.note-checkbox-rm` styling exactly, reused the existing robot SVG icon (same one used in the per-note Agent menu), monospaced font / dark theme unchanged.
- [x] **No new component patterns** — the new button is a sibling of the existing X, same classes shape, same hover lifecycle.
- [x] **No Unicode emoji.** Inline SVG only.
- [x] Not a bulk auto-generated PR — focused change, single feature.

## Implementation notes

- New element: `<button class=\"note-checkbox-agent\">` placed before the X in the item template. DOM order = text → agent → X.
- Both buttons use `margin-left: auto` (same flexbox pattern as the existing X), so they end up grouped at the right.
- Reuses the robot SVG already used in the per-note corner-menu Agent item at line 4267 (now drawn at 10x10 to match X size).
- New helper `_agentSolveTodoItem(noteId, idx)` is the per-item analog of `_agentSolveNote(id)`. Same session-creation + background-stream-drain pattern. Sets `note.agent_session_id` latest-wins so the existing Agent tag surfaces the most recent run from this note — the existing review path (#2561's live-resume chat reattach) works unchanged.
- Prompt format: `\"Help me with this todo: {item text}\"` (plus `Context (from note \"{title}\")` line when the note has a title). Keeps the agent focused on the single item without burying it in the rest of the note.
- Hidden in select-mode and in the same `_INTERACTIVE` / skip-click lists as the X so card-clicks don't fire on the new button.

## What this doesn't do (intentionally)

- No per-item `agent_session_id` field. The latest run wins on the parent note. Adding per-item tracking would change the data model; skip for v1.
- No \"agent done — mark this todo complete\" auto-tick. The agent's run is opaque; the user marks the todo done manually after reviewing.
- No new backend endpoints or DB changes.

## Related

- Builds on #2561 (vdmkenny's live-resume chat-stream fix on `dev`) — the per-item review flow is much better because of it.
- Per-note version of this same affordance has been in the repo since the original notes panel work.