### PR TITLE
fix: make agent loopback base port env-configurable (#2752)

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2479,7 +2479,21 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
 # Cookbook routes loopback. The agent's tool calls run in-process but
 # need to reach admin-gated cookbook routes; we ride the per-process
 # internal token so require_admin lets us through. See core/middleware.py.
-_COOKBOOK_BASE = "http://localhost:7000"
+#
+# Resolution order:
+#   1. ODYSSEUS_INTERNAL_BASE — explicit override (e.g. behind a TLS proxy).
+#   2. APP_PORT — derive http://127.0.0.1:$APP_PORT (matches docker-compose).
+#   3. Fallback http://127.0.0.1:7000 — preserves legacy default.
+#
+# 127.0.0.1 (not "localhost") avoids IPv6/DNS ambiguity for a strictly-local
+# call. Without this, tools that loop back (app_api, trigger_research,
+# cookbook state read/write) fail with "All connection attempts failed"
+# whenever the running uvicorn isn't on 7000 — which is most non-default
+# deployments and any side-by-side multi-instance setup.
+_COOKBOOK_BASE = os.environ.get(
+    "ODYSSEUS_INTERNAL_BASE",
+    f"http://127.0.0.1:{os.environ.get('APP_PORT', '7000')}",
+)
 
 
 def _internal_headers(owner: Optional[str] = None) -> Dict[str, str]:


### PR DESCRIPTION
## Summary

Fixes #2752. `_COOKBOOK_BASE` was hardcoded to `http://localhost:7000`, so any agent tool that does an HTTP loopback (`app_api`, `trigger_research`, cookbook state read/write) silently fails whenever Odysseus isn't on port 7000.

Now derives the URL in this order:

1. `ODYSSEUS_INTERNAL_BASE` env var — explicit override
2. `APP_PORT` env var — derive `http://127.0.0.1:$APP_PORT` (the docker-compose pattern)
3. Fallback `http://127.0.0.1:7000` — preserves legacy default

Also swaps `localhost` → `127.0.0.1` to avoid IPv6/DNS ambiguity.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## How to Test

This is a backend-only env-var change; no UI to screenshot.

1. Start Odysseus on any port other than 7000, e.g. `APP_PORT=7014 docker compose up` or `uvicorn app:app --port 7014` with `APP_PORT=7014` in env.
2. Open agent mode and ask: \"do a deep research on X\".
3. Before the fix: `trigger_research` returns `\"All connection attempts failed\"` and no research session appears in `data/deep_research/`.
4. After the fix: research kicks off and a session file appears in `data/deep_research/`. `app_api` also works for arbitrary internal endpoints.

Regression check: if `APP_PORT` is unset and `ODYSSEUS_INTERNAL_BASE` is unset, the fallback is still `http://127.0.0.1:7000`, so existing setups on the default port are unaffected.

## Notes

- No schema / API change.
- 15 lines net.