### PR TITLE
fix(gallery): add auth check to /api/image/sharpen

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -1316,6 +1316,7 @@ def setup_gallery_routes() -> APIRouter:
     @router.post("/api/image/sharpen")
     async def sharpen_image(request: Request):
         """Apply unsharp-mask sharpening to an image."""
+        require_privilege(request, "can_generate_images")
         body = await request.json()
         image_b64 = body.get("image")
         amount = body.get("amount", 50) / 100.0


### PR DESCRIPTION
## Summary

Missing authentication on `/api/image/sharpen` endpoint.

## Pain Before

Every image-processing endpoint (denoise, upscale, remove-bg, enhance-face, inpaint, harmonize) calls `require_privilege(request, "can_generate_images")` as its first action. The sharpen endpoint was missing this check, allowing unauthenticated users to trigger CPU-intensive PIL UnsharpMask processing on arbitrary base64 payloads with no rate limiting.

## What Was Fixed

Added `require_privilege(request, "can_generate_images")` to the `sharpen_image` handler, matching every sibling endpoint.

## Target branch

- [x] This PR targets `main` (security fix landed directly on the stable branch per the maintainer's standing exception for auth/permission fixes).

## Linked Issue

Fixes #2879

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the relevant tests and the change works end-to-end. See "How to Test" below.

## How to Test

1. `git checkout fix/b3.1-sharpen-auth`
2. `./venv/bin/python -m py_compile routes/gallery_routes.py` — passes.
3. With the app running, hit `POST /api/image/sharpen` with a valid base64 payload **without** an authenticated session — expect `403` from `require_privilege` (previously: 200 + sharpened image).
4. Authenticate, repeat — expect `200` with the sharpened image bytes.

## Changes

- **File**: `routes/gallery_routes.py`
- **Lines**: `sharpen_image()` (~line 1317)
- **Net change**: +1 line

## Visual / UI changes

Not applicable — backend endpoint, no rendering touched.
