### PR TITLE
fix(document): add 404 guard to version list/get endpoints

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -664,8 +664,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         try:
             # Verify ownership before listing versions
             doc = db.query(Document).filter(Document.id == doc_id).first()
-            if doc:
-                _verify_doc_owner(db, doc, user)
+            if not doc:
+                raise HTTPException(404, "Document not found")
+            _verify_doc_owner(db, doc, user)
             versions = db.query(DocumentVersion).filter(
                 DocumentVersion.document_id == doc_id
             ).order_by(DocumentVersion.version_number.desc()).all()
@@ -688,8 +689,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         try:
             # Verify ownership
             doc = db.query(Document).filter(Document.id == doc_id).first()
-            if doc:
-                _verify_doc_owner(db, doc, user)
+            if not doc:
+                raise HTTPException(404, "Document not found")
+            _verify_doc_owner(db, doc, user)
             ver = db.query(DocumentVersion).filter(
                 DocumentVersion.document_id == doc_id,
                 DocumentVersion.version_number == num,


### PR DESCRIPTION
## Summary

Version list/get endpoints returned data without authentication when the parent Document row was missing.

## Pain Before

`list_versions` and `get_version` used a soft `if doc:` guard before calling `_verify_doc_owner`. When the Document row was deleted (e.g. by `/api/documents/tidy`) but orphaned `DocumentVersion` rows remained, the ownership check was skipped entirely and version content was returned to any caller. The `restore_version` endpoint correctly raises 404 when the parent is gone.

## What Was Fixed

Changed both endpoints to match `restore_version`'s pattern: raise `HTTPException(404)` when the parent document doesn't exist, then always verify ownership.

## Target branch

- [x] This PR targets `main` (security fix landed directly on the stable branch per the maintainer's standing exception for auth/permission fixes).

## Linked Issue

Fixes #2880

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the relevant tests and the change works end-to-end. See "How to Test" below.

## How to Test

1. `git checkout fix/b4.1-version-auth`
2. `./venv/bin/python -m py_compile routes/document_routes.py` — passes.
3. With the app running, create a Document and at least one version, then `db.delete()` the Document row directly (or call `/api/documents/tidy`).
4. Hit `GET /api/documents/{id}/versions` **as a different authenticated user** — expect `404` (previously: 200 with the orphaned version rows).
5. Hit `GET /api/documents/{id}/versions/{n}` with the same setup — expect `404` for any `n` (previously: 200 with the version content).
6. Hit either endpoint as the original owner against a non-deleted document — expect normal `200` response.

## Changes

- **File**: `routes/document_routes.py`
- **Lines**: `list_versions()`, `get_version()` (~lines 664-699)
- **Net change**: +6 / -4 lines

## Visual / UI changes

Not applicable — backend endpoint, no rendering touched.
