### PR TITLE
fix(calendar): cap RRULE expansion and sanitize export filename

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -1,6 +1,7 @@
 """Calendar routes — local SQLite-backed calendar CRUD."""
 
 import logging
+import re
 import uuid
 from datetime import datetime, date, timedelta
 from typing import Optional, List
@@ -506,6 +507,7 @@ def _expand_rrule(
     results = []
     base = _event_to_dict(ev)
 
+    _MAX_OCCURRENCES = 1000
     for occ_start in occurrences:
         occ_end = occ_start + duration
 
@@ -536,6 +538,8 @@ def _expand_rrule(
             d["is_utc"] = bool(getattr(ev, "is_utc", False))
 
         results.append(d)
+        if len(results) >= _MAX_OCCURRENCES:
+            break
 
     return results
 
@@ -1168,7 +1172,7 @@ def setup_calendar_routes() -> APIRouter:
             lines.append("END:VCALENDAR")
 
             ics_data = "\r\n".join(lines)
-            safe_name = cal.name.replace(" ", "_").replace("/", "_")
+            safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", cal.name or "calendar")
             return Response(
                 content=ics_data,
                 media_type="text/calendar",


### PR DESCRIPTION
## Summary

RRULE expansion had no upper bound on generated occurrences, and calendar export had a header injection vulnerability.

## Pain Before

`_expand_rrule` in calendar_routes.py expanded recurring events with no cap on the number of occurrences. Combined with unbounded `start`/`end` query parameters in `list_events`, a pathological RRULE (e.g. `FREQ=DAILY` over a 100-year window) could generate ~36K dicts in memory per event. Multiple such events in a single query would OOM the server.

The export endpoint built `Content-Disposition` headers from calendar names by only replacing space and slash. Quotes, backslashes, and CRLF characters passed through, enabling header injection when a calendar name contains `" ; filename="evil.html"` or `\r\n`.

## What Was Fixed

Added `_MAX_OCCURRENCES = 1000` cap to `_expand_rrule` — covers any realistic calendar view (daily events over ~3 years) while preventing memory exhaustion. Changed `safe_name` to strip all non-alphanumeric characters via `re.sub(r"[^A-Za-z0-9._-]", "_", ...)`.

## Changes

- **File**: `routes/calendar_routes.py`
- **Lines**: `_expand_rrule()` (~line 509), export handler (~line 1172)
- **Net change**: +5 / -1 lines
