### PR TITLE
refactor(tests): finish shared CLI loader adoption

### DIFF
--- a/tests/test_backup_cli_security.py
+++ b/tests/test_backup_cli_security.py
@@ -1,5 +1,3 @@
-import importlib.machinery
-import importlib.util
 import io
 import tarfile
 from pathlib import Path
@@ -7,14 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
+from tests.helpers.cli_loader import load_script
+
 
 def _load_backup_cli():
-    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-backup"
-    loader = importlib.machinery.SourceFileLoader("odysseus_backup_under_test", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-backup")
 
 
 def _patch_repo(module, monkeypatch, root: Path):

--- a/tests/test_contacts_cli_rows.py
+++ b/tests/test_contacts_cli_rows.py
@@ -1,12 +1,8 @@
-import importlib.machinery
-import importlib.util
 import sys
 import types
-from pathlib import Path
 from unittest.mock import MagicMock
 
-
-ROOT = Path(__file__).resolve().parents[1]
+from tests.helpers.cli_loader import load_script
 
 
 def _load_cli(monkeypatch):
@@ -15,12 +11,7 @@ def _load_cli(monkeypatch):
     routes._fetch_contacts = MagicMock()
     routes._create_contact = MagicMock()
     monkeypatch.setitem(sys.modules, "routes.contacts_routes", routes)
-    path = ROOT / "scripts" / "odysseus-contacts"
-    loader = importlib.machinery.SourceFileLoader("odysseus_contacts_cli", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-contacts")
 
 
 def test_contact_rows_skips_invalid_rows(monkeypatch):

--- a/tests/test_mail_cli_read_empty_fetch.py
+++ b/tests/test_mail_cli_read_empty_fetch.py
@@ -1,10 +1,9 @@
-import importlib.machinery
-import importlib.util
 import sys
-from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
+
+from tests.helpers.cli_loader import load_script
 
 
 class _Conn:
@@ -46,12 +45,7 @@ def _load_mail_cli(monkeypatch):
     monkeypatch.setitem(sys.modules, "routes.email_pollers", pollers)
     monkeypatch.setitem(sys.modules, "core", core_mod)
     monkeypatch.setitem(sys.modules, "core.database", database_mod)
-    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-mail"
-    loader = importlib.machinery.SourceFileLoader("odysseus_mail_cli_read_test", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-mail")
 
 
 def test_cmd_read_handles_empty_fetch_payload(monkeypatch):

--- a/tests/test_mail_cli_recipients.py
+++ b/tests/test_mail_cli_recipients.py
@@ -1,8 +1,7 @@
-import importlib.machinery
-import importlib.util
 import sys
-from pathlib import Path
 from types import ModuleType
+
+from tests.helpers.cli_loader import load_script
 
 
 def _load_mail_cli(monkeypatch):
@@ -28,12 +27,7 @@ def _load_mail_cli(monkeypatch):
     monkeypatch.setitem(sys.modules, "core", core_mod)
     monkeypatch.setitem(sys.modules, "core.database", database_mod)
 
-    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-mail"
-    loader = importlib.machinery.SourceFileLoader("odysseus_mail_cli_under_test", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-mail")
 
 
 def test_recipient_list_trims_to_cc_and_bcc(monkeypatch):

--- a/tests/test_preset_cli_set_corrupt_entry.py
+++ b/tests/test_preset_cli_set_corrupt_entry.py
@@ -1,16 +1,10 @@
-import importlib.machinery
-import importlib.util
-from pathlib import Path
 from types import SimpleNamespace
+
+from tests.helpers.cli_loader import load_script
 
 
 def _load_preset_cli():
-    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-preset"
-    loader = importlib.machinery.SourceFileLoader("odysseus_preset_set_corrupt", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-preset")
 
 
 def test_set_replaces_corrupt_existing_entry(monkeypatch):

--- a/tests/test_research_cli_preview.py
+++ b/tests/test_research_cli_preview.py
@@ -3,20 +3,11 @@
 `_summarize` did `(data.get("query") or "")[:200]`. A non-string query from a
 legacy/corrupt research JSON is truthy, so `123[:200]` raised TypeError.
 """
-import importlib.machinery
-import importlib.util
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
+from tests.helpers.cli_loader import load_script
 
 
 def _load_cli():
-    path = ROOT / "scripts" / "odysseus-research"
-    loader = importlib.machinery.SourceFileLoader("odysseus_research_cli", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-research")
 
 
 def test_preview_text_ignores_non_string():

--- a/tests/test_research_cli_store.py
+++ b/tests/test_research_cli_store.py
@@ -1,20 +1,11 @@
-import importlib.machinery
-import importlib.util
 import json
-from pathlib import Path
 from types import SimpleNamespace
 
-
-ROOT = Path(__file__).resolve().parents[1]
+from tests.helpers.cli_loader import load_script
 
 
 def _load_cli():
-    path = ROOT / "scripts" / "odysseus-research"
-    loader = importlib.machinery.SourceFileLoader("odysseus_research_cli", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-research")
 
 
 def test_list_skips_non_object_research_records(tmp_path, monkeypatch):

--- a/tests/test_sessions_cli.py
+++ b/tests/test_sessions_cli.py
@@ -1,9 +1,8 @@
-import importlib.machinery
-import importlib.util
 import sys
-from pathlib import Path
 from types import ModuleType
 from types import SimpleNamespace
+
+from tests.helpers.cli_loader import load_script
 
 
 def _load_sessions_cli(monkeypatch):
@@ -13,13 +12,7 @@ def _load_sessions_cli(monkeypatch):
     database_mod.Session = object
     monkeypatch.setitem(sys.modules, "core", core_mod)
     monkeypatch.setitem(sys.modules, "core.database", database_mod)
-
-    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-sessions"
-    loader = importlib.machinery.SourceFileLoader("odysseus_sessions_cli_under_test", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-sessions")
 
 
 def test_serialize_normalizes_numeric_counters(monkeypatch):

--- a/tests/test_signature_cli_export.py
+++ b/tests/test_signature_cli_export.py
@@ -1,8 +1,7 @@
-import importlib.machinery
-import importlib.util
 import sys
-from pathlib import Path
 from types import ModuleType
+
+from tests.helpers.cli_loader import load_script
 
 
 def _load_signature_cli(monkeypatch):
@@ -14,13 +13,7 @@ def _load_signature_cli(monkeypatch):
     monkeypatch.setitem(sys.modules, "sqlalchemy", sqlalchemy_mod)
     monkeypatch.setitem(sys.modules, "core", core_mod)
     monkeypatch.setitem(sys.modules, "core.database", database_mod)
-
-    path = Path(__file__).resolve().parent.parent / "scripts" / "odysseus-signature"
-    loader = importlib.machinery.SourceFileLoader("odysseus_signature_cli_under_test", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-signature")
 
 
 def test_decode_png_data_accepts_data_url(monkeypatch):

--- a/tests/test_skills_cli_preview.py
+++ b/tests/test_skills_cli_preview.py
@@ -4,26 +4,18 @@
 description (e.g. a number from a hand-edited/legacy skill store) is truthy, so
 `123[:200]` raised TypeError. `_preview_text` coerces non-strings to "".
 """
-import importlib.machinery
-import importlib.util
 import sys
 import types
-from pathlib import Path
 from unittest.mock import MagicMock
 
-ROOT = Path(__file__).resolve().parents[1]
+from tests.helpers.cli_loader import load_script
 
 
 def _load_cli(monkeypatch):
     mod = types.ModuleType("services.memory.skills")
     mod.SkillsManager = MagicMock()
     monkeypatch.setitem(sys.modules, "services.memory.skills", mod)
-    path = ROOT / "scripts" / "odysseus-skills"
-    loader = importlib.machinery.SourceFileLoader("odysseus_skills_cli", str(path))
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
-    return module
+    return load_script("odysseus-skills")
 
 
 def test_preview_text_ignores_non_string(monkeypatch):


### PR DESCRIPTION
## Summary

Part of #2523.

Finishes the remaining obvious shared CLI loader adoption for CLI/script tests.

This PR replaces repeated `SourceFileLoader` / `importlib.util` boilerplate with the existing `tests.helpers.cli_loader.load_script` helper in 10 test files.

The existing test setup is preserved:

- same scripts are loaded;
- existing `sys.modules` stubs stay in place;
- assertions are unchanged;
- no production code is touched;
- no directory moves;
- no root `tests/conftest.py` changes.

Two manual loader patterns were intentionally left alone because they do not load files from `scripts/`:

- `tests/test_mcp_common_truncate.py` loads `mcp_servers/_common.py`.
- `tests/test_search_query_nonstring.py` loads `services/search/query.py` directly to avoid package import side effects.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to replacing duplicated CLI/script loader boilerplate in tests.
- [x] I ran focused validation for the touched tests.
- [x] I did not change production code.
- [x] I did not change test assertions.
- [x] I did not move files or change the test directory structure.

## How to Test

Compile the helper and touched test files:

```bash
python3 -m py_compile \
  tests/helpers/cli_loader.py \
  tests/test_backup_cli_security.py \
  tests/test_contacts_cli_rows.py \
  tests/test_mail_cli_read_empty_fetch.py \
  tests/test_mail_cli_recipients.py \
  tests/test_preset_cli_set_corrupt_entry.py \
  tests/test_research_cli_preview.py \
  tests/test_research_cli_store.py \
  tests/test_sessions_cli.py \
  tests/test_signature_cli_export.py \
  tests/test_skills_cli_preview.py
```

Validated locally:

```text
py_compile passed
```

Run the changed tests:

```bash
python3 -m pytest -q \
  tests/test_backup_cli_security.py \
  tests/test_contacts_cli_rows.py \
  tests/test_mail_cli_read_empty_fetch.py \
  tests/test_mail_cli_recipients.py \
  tests/test_preset_cli_set_corrupt_entry.py \
  tests/test_research_cli_preview.py \
  tests/test_research_cli_store.py \
  tests/test_sessions_cli.py \
  tests/test_signature_cli_export.py \
  tests/test_skills_cli_preview.py
```

Validated locally:

```text
19 passed
```

Run same-script order checks for the mail CLI tests:

```bash
python3 -m pytest -q \
  tests/test_mail_cli_read_empty_fetch.py \
  tests/test_mail_cli_recipients.py
```

Validated locally:

```text
3 passed
```

Run the same mail tests in reverse order:

```bash
python3 -m pytest -q \
  tests/test_mail_cli_recipients.py \
  tests/test_mail_cli_read_empty_fetch.py
```

Validated locally:

```text
3 passed
```

Run same-script order checks for the research CLI tests:

```bash
python3 -m pytest -q \
  tests/test_research_cli_preview.py \
  tests/test_research_cli_store.py
```

Validated locally:

```text
3 passed
```

Run the same research tests in reverse order:

```bash
python3 -m pytest -q \
  tests/test_research_cli_store.py \
  tests/test_research_cli_preview.py
```

Validated locally:

```text
3 passed
```

Check for whitespace / merge artifacts:

```bash
git diff --check
```

Validated locally:

```text
passed
```

Check that the changed files no longer contain manual loader leftovers:

```bash
grep -RInE 'SourceFileLoader|spec_from_file_location|module_from_spec|importlib\.machinery|importlib\.util' \
  tests/test_backup_cli_security.py \
  tests/test_contacts_cli_rows.py \
  tests/test_mail_cli_read_empty_fetch.py \
  tests/test_mail_cli_recipients.py \
  tests/test_preset_cli_set_corrupt_entry.py \
  tests/test_research_cli_preview.py \
  tests/test_research_cli_store.py \
  tests/test_sessions_cli.py \
  tests/test_signature_cli_export.py \
  tests/test_skills_cli_preview.py
```

Validated locally:

```text
no matches found
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only refactor; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This PR is intentionally narrow and behavior-preserving. It only continues the accepted shared helper pattern from the earlier #2523 CLI-loader work.

The next test-suite refactor slice should be separate and should not be stacked on this PR.
