### PR TITLE
fix(notes): track + remove the select-mode Esc keydown listener so it doesn't leak per open

### DIFF
--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -31,6 +31,9 @@ let _reminderTimer = null;
 // (previously leaked one per openPanel; on multi-open sessions this
 // stacked dozens of identical handlers).
 let _notesKeydownHandler = null;
+// Capture-phase "Esc cancels select mode" listener on document — tracked so it
+// is removed on close instead of leaking +1 per panel open/close cycle.
+let _notesSelectEscHandler = null;
 const REMINDER_FIRED_KEY = 'odysseus-notes-reminder-fired';
 // Note IDs already shown with the entry-glow once. Re-set when the user
 // reschedules the reminder so the new firing glows again on next open.
@@ -53,6 +56,10 @@ function _forceCloseNotesPanel() {
   if (_notesKeydownHandler) {
     document.removeEventListener('keydown', _notesKeydownHandler);
     _notesKeydownHandler = null;
+  }
+  if (_notesSelectEscHandler) {
+    document.removeEventListener('keydown', _notesSelectEscHandler, true);
+    _notesSelectEscHandler = null;
   }
   if (_reminderTimer) {
     clearInterval(_reminderTimer);
@@ -1270,13 +1277,17 @@ export function openPanel() {
   // than a *-bulk-cancel button, so the global Esc-cancel handler in
   // keyboard-shortcuts.js can't reach it — handle it here. Capture phase
   // + stopPropagation so Esc cancels select instead of closing the panel.
-  document.addEventListener('keydown', (e) => {
+  if (_notesSelectEscHandler) {
+    document.removeEventListener('keydown', _notesSelectEscHandler, true);
+  }
+  _notesSelectEscHandler = (e) => {
     if (e.key === 'Escape' && _selectMode) {
       e.preventDefault();
       e.stopPropagation();
       _exitSelectMode();
     }
-  }, true);
+  };
+  document.addEventListener('keydown', _notesSelectEscHandler, true);
   document.getElementById('notes-select-all').addEventListener('change', (e) => {
     if (e.target.checked) _notes.forEach(n => _selectedIds.add(n.id));
     else _selectedIds.clear();
@@ -1579,6 +1590,10 @@ export function closePanel(direction) {
   if (_notesKeydownHandler) {
     document.removeEventListener('keydown', _notesKeydownHandler);
     _notesKeydownHandler = null;
+  }
+  if (_notesSelectEscHandler) {
+    document.removeEventListener('keydown', _notesSelectEscHandler, true);
+    _notesSelectEscHandler = null;
   }
   if (_reminderTimer) {
     clearInterval(_reminderTimer);

--- a/tests/test_notes_select_esc_listener_js.py
+++ b/tests/test_notes_select_esc_listener_js.py
@@ -1,0 +1,30 @@
+"""Issue #2791 — the Notes panel's capture-phase "Esc cancels select mode"
+keydown listener must be tracked and removed on close, not leaked anonymously on
+every open/close cycle.
+
+notes.js is a browser ES module with a heavy import chain (can't be node-imported
+in isolation), so — per the repo's convention for DOM-coupled guards (cf. the
+document.js diff-discard and memory.js filter-guard tests) — this asserts the
+tracked-handler pattern in source.
+"""
+from pathlib import Path
+
+SRC = Path("static/js/notes.js").read_text(encoding="utf-8")
+
+
+def test_select_esc_listener_is_tracked_not_anonymous():
+    assert "let _notesSelectEscHandler = null;" in SRC
+    # added via the tracked module-level var in capture phase
+    assert "document.addEventListener('keydown', _notesSelectEscHandler, true);" in SRC
+
+
+def test_select_esc_listener_removed_with_matching_capture_flag():
+    # remove-before-add in openPanel + removal in both close paths => >= 3,
+    # each with the `true` capture flag (a removal without it would not match).
+    removals = SRC.count("document.removeEventListener('keydown', _notesSelectEscHandler, true);")
+    assert removals >= 3, removals
+
+
+def test_old_anonymous_capture_listener_is_gone():
+    # the leak was an inline anonymous capture listener; it must no longer exist.
+    assert "addEventListener('keydown', (e) => {\n    if (e.key === 'Escape' && _selectMode)" not in SRC


### PR DESCRIPTION
## Summary

`openPanel()` in `static/js/notes.js` adds a capture-phase `document` keydown listener (Esc cancels select mode) as an **anonymous** closure on every open, but both close paths only remove the *named* `_notesKeydownHandler` (the three `removeEventListener('keydown', ...)` calls all target it). So this anonymous capture listener accumulated +1 per open/close cycle for the page lifetime, keeping `_exitSelectMode`/`_selectMode` closures alive.

Fix mirrors the existing tracked `_notesKeydownHandler` pattern: hoist it into a module-level `_notesSelectEscHandler`, remove-before-add in `openPanel`, and remove it (with the matching `true` capture flag) in both `closePanel` and `_forceCloseNotesPanel`. ~10 lines; no behavior change beyond not leaking.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2791

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and open PRs — this is not a duplicate. (Filed #2791 first.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated changes.
- [ ] I actually ran the app end-to-end. _(Honest note: notes.js is a browser ES module with a heavy import chain, so it can't be node-imported in isolation; following the repo's convention for DOM-coupled guards — static source assertion (cf. the document.js diff-discard / memory.js filter-guard tests) — plus `node --check`. See How to Test.)_

## How to Test

```
node --check static/js/notes.js
DATABASE_URL=sqlite:////tmp/x.db .venv/bin/python -m pytest tests/test_notes_select_esc_listener_js.py -q
```

3 source-assertion tests pin: the listener is tracked (module var + capture-phase add), it's removed with the matching `true` capture flag in remove-before-add + both close paths (≥3 removals), and the old anonymous inline listener is gone. Manual: open/close the Notes panel repeatedly and check `getEventListeners(document).keydown` no longer grows. `node --check` passes.

## Visual / UI changes
N/A — listener-lifecycle fix; no UI/behavior change (Esc-cancels-select still works, it just stops leaking).
