### PR TITLE
fix(memory): let manual add specify memory category

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -307,6 +307,7 @@
                 <input type="text" id="new-memory-input" placeholder=" " class="memory-add-input skill-hint-input" aria-label="New memory text" />
                 <span class="skill-rich-ph"><span class="k">Add a memory</span> &mdash; e.g. 'I prefer concise replies' <svg class="k" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-left:4px;" aria-hidden="true"><polyline points="9 10 4 15 9 20"/><path d="M20 4v7a4 4 0 0 1-4 4H4"/></svg></span>
               </div>
+              <select id="new-memory-category" class="memory-edit-cat-select" aria-label="Memory category"></select>
             </div>
           </div>
           <div class="admin-card">

--- a/static/js/memory.js
+++ b/static/js/memory.js
@@ -18,6 +18,26 @@ let selectedIds = new Set();
 
 const MEMORY_CATEGORIES = ['fact', 'identity', 'preference', 'contact', 'project', 'goal', 'task'];
 
+function _ensureNewMemoryCategorySelect() {
+  const sel = document.getElementById('new-memory-category');
+  if (!sel || sel.dataset.wired === '1') return;
+  sel.dataset.wired = '1';
+  MEMORY_CATEGORIES.forEach(cat => {
+    const opt = document.createElement('option');
+    opt.value = cat;
+    opt.textContent = cat;
+    if (cat === 'fact') opt.selected = true;
+    sel.appendChild(opt);
+  });
+}
+
+function _readNewMemoryCategory() {
+  _ensureNewMemoryCategorySelect();
+  const sel = document.getElementById('new-memory-category');
+  const cat = sel?.value || 'fact';
+  return MEMORY_CATEGORIES.includes(cat) ? cat : 'fact';
+}
+
 let _memoryDragWired = false;
 function _wireMemoryDrag() {
   if (_memoryDragWired) return;
@@ -274,6 +294,7 @@ async function syncPrefToggle(elementId, prefKey, onMsg, offMsg, dimBelow = true
 }
 
 export async function loadMemories() {
+  _ensureNewMemoryCategorySelect();
   try {
     const response = await fetch(`${window.location.origin}/api/memory`);
 
@@ -977,6 +998,7 @@ export function updateMemoryCount() {
 export async function addNewMemory() {
   const input = document.getElementById('new-memory-input');
   const text = input.value.trim();
+  const category = _readNewMemoryCategory();
 
   if (!text) {
     showError('Memory text cannot be empty');
@@ -991,6 +1013,7 @@ export async function addNewMemory() {
       },
       body: JSON.stringify({
         text: text,
+        category: category,
       })
     });
 


### PR DESCRIPTION
## Summary

Manual memory add on the Brain Add tab always saved as category `fact` because
the UI only sent `{ text }` and the API defaulted the category.

Add a category selector (same options as inline edit) and include `category` in
the `/api/memory/add` JSON payload.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #2788

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above
- [x] I actually ran the app and verified the change end-to-end

## How to Test

1. Open Brain → Add tab
2. Enter text, choose **preference** (or another category) from the dropdown
3. Add the memory
4. Memories tab → entry shows the selected category, not always `fact`

Also run: `node --check static/js/memory.js`

## Visual / UI changes

- [x] Screenshot attached (Add tab with category dropdown + Memories tab showing category)

### Screenshots / clips

<!-- attach before/after -->
<img width="731" height="610" alt="Screenshot 2026-06-05 at 13 25 27" src="https://github.com/user-attachments/assets/1af4e04e-ef5d-484d-9aa0-56033ff1a296" />


<img width="692" height="586" alt="Screenshot 2026-06-05 at 13 15 54" src="https://github.com/user-attachments/assets/277bda21-d222-4da9-bcfd-9534c13081e0" />

