### PR TITLE
fix(tests): make webhook SSRF test clean-worktree deterministic

### DIFF
--- a/tests/test_webhook_ssrf_resilience.py
+++ b/tests/test_webhook_ssrf_resilience.py
@@ -1,15 +1,27 @@
+import os
 import sys
 import json
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
 from tests.helpers.import_state import clear_module, preserve_import_state
 
 # conftest.py stubs src.database; drop the stub so webhook_manager imports the
-# real module. preserve_import_state restores both sys.modules and the parent
-# src.database attribute after the block, preventing stub leakage into siblings.
-with preserve_import_state("src.database"):
+# real module. preserve_import_state restores sys.modules and parent-package
+# attributes for both src.database and core.database after the block, preventing
+# stub/engine leakage into siblings.
+#
+# Importing the real core.database runs init_db() -> create_all() against
+# DATABASE_URL (default sqlite:///./data/app.db); in a clean worktree with no
+# ./data directory that raises sqlite3.OperationalError during collection. Pin
+# DATABASE_URL to in-memory SQLite for the import: it needs no filesystem path
+# and leaves no artifact, and these tests never touch the real engine
+# (validate_webhook_url is pure; the delivery test monkeypatches SessionLocal).
+# patch.dict restores the prior DATABASE_URL after the block.
+with patch.dict(os.environ, {"DATABASE_URL": "sqlite:///:memory:"}), \
+        preserve_import_state("src.database", "core.database"):
     clear_module("src.database")
     _core_database = sys.modules.get("core.database")
     _core_database_all = (


### PR DESCRIPTION
## Summary

Part of #2523.

Makes `tests/test_webhook_ssrf_resilience.py` deterministic in a clean worktree where `./data` does not exist.

The test intentionally imports the real `src.webhook_manager`, which imports `src.database` and then `core.database`. `core.database` defaults to `sqlite:///./data/app.db` and runs DB initialization at import time. In a fresh checkout without `./data`, that import can fail during test collection with:

```text
sqlite3.OperationalError: unable to open database file
```

This PR keeps the fix test-only by pinning `DATABASE_URL` to `sqlite:///:memory:` only around the real webhook-manager import. It also preserves both `src.database` and `core.database` import state so the temporary in-memory DB binding does not leak into sibling tests.

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to one test file.
- [x] I ran focused validation in the current branch.
- [x] I ran clean-worktree validation with no `./data` directory.
- [x] I verified the test does not create `./data` or repo-local DB artifacts.
- [x] I did not change production code.
- [x] I did not change test assertions.
- [x] I did not modify root `tests/conftest.py`.
- [x] I did not move files or change the test directory structure.

## How to Test

Compile the touched file:

```bash
python3 -m py_compile tests/test_webhook_ssrf_resilience.py
```

Validated locally:

```text
py_compile passed
```

Run the focused webhook SSRF test:

```bash
python3 -m pytest -q tests/test_webhook_ssrf_resilience.py
```

Validated locally:

```text
2 passed, 1 warning
```

Run order-sensitive sibling checks:

```bash
python3 -m pytest -q \
  tests/test_webhook_ssrf_resilience.py \
  tests/test_review_regressions.py

python3 -m pytest -q \
  tests/test_review_regressions.py \
  tests/test_webhook_ssrf_resilience.py
```

Validated locally:

```text
21 passed, 1 warning
21 passed, 1 warning
```

Run session/import-state sibling checks:

```bash
python3 -m pytest -q \
  tests/test_webhook_ssrf_resilience.py \
  tests/test_blind_compare_redaction.py \
  tests/test_session_ghost_delete.py \
  tests/test_session_owner_attribution.py

python3 -m pytest -q \
  tests/test_blind_compare_redaction.py \
  tests/test_session_ghost_delete.py \
  tests/test_session_owner_attribution.py \
  tests/test_webhook_ssrf_resilience.py
```

Validated locally:

```text
22 passed, 1 warning
22 passed, 1 warning
```

Clean-worktree validation:

A fresh audit worktree was created from `upstream/dev`, `./data` was removed/confirmed absent, and this PR's patch was applied.

Before pytest:

```text
data exists=False is_dir=False
```

Then the focused and order-sensitive pytest commands above passed in that fresh audit worktree.

After pytest:

```text
data exists=False is_dir=False
```

So this PR does not create `./data`, `./data/app.db`, or other repo-local DB artifacts.

Check for whitespace / merge artifacts:

```bash
git diff --check
```

Validated locally:

```text
passed
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This intentionally does not modify `tests/conftest.py` or production database initialization. The goal is limited to making this specific test file's real import path deterministic in clean worktrees.

Broader DB test setup can be handled separately if needed.
