### PR TITLE
fix(images): valid, fully-qualified generated-image links

### DIFF
--- a/mcp_servers/image_gen_server.py
+++ b/mcp_servers/image_gen_server.py
@@ -115,6 +115,10 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 
             img = images[0]
             image_url = None
+            # Prefix the instance's public base URL (existing app_public_url setting) so the
+            # link is fully-qualified and clickable when the model echoes it. Empty = relative
+            # same-origin path (unchanged default).
+            _pub_base = (get_setting("app_public_url", "") or "").rstrip("/")
 
             if img.get("b64_json"):
                 img_dir = Path("data/generated_images")
@@ -122,7 +126,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 filename = f"{uuid.uuid4().hex[:12]}.png"
                 img_path = img_dir / filename
                 img_path.write_bytes(base64.b64decode(img["b64_json"]))
-                image_url = f"/api/generated-image/{filename}"
+                image_url = f"{_pub_base}/api/generated-image/{filename}"
 
                 # Save to gallery
                 try:
@@ -146,7 +150,13 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             else:
                 return [TextContent(type="text", text="Error: Unexpected image API response format")]
 
-            result = f"Generated image for: {prompt[:100]}\nimage_url: {image_url}\nmodel: {model_id}\nsize: {size}"
+            # "Direct link:" rather than an "image_url:" label — small models copied the
+            # label token ("image_url") into the link href, producing a broken link.
+            result = (
+                f"Generated image for: {prompt[:100]}\n"
+                f"Direct link: {image_url}\n"
+                f"model: {model_id}\nsize: {size}"
+            )
             return [TextContent(type="text", text=result)]
 
     except httpx.TimeoutException:


### PR DESCRIPTION
## Summary

When a chat model calls `generate_image`, the image URL it echoes into its reply is a relative same-origin path (`/api/generated-image/…`), which the chat doesn't turn into a clickable link. This PR reuses the **existing `app_public_url` setting** to prepend the instance's public base URL, so the model echoes a fully-qualified `https://…` link that the frontend auto-links — a valid, clickable link to the generated image. When `app_public_url` is empty (the default) the path stays relative, so behavior is unchanged. It also labels the URL as a clean `Direct link:` so the model echoes it verbatim. One backend file; no new settings, no frontend changes.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2824

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — one file, no unrelated changes.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Set **app_public_url** in Settings to your instance URL (e.g. `https://odysseus.example.com`).
2. In **agent** mode, ask the model to generate an image.
3. Confirm the image link in the model's reply is now a valid, clickable absolute URL (`https://…/api/generated-image/…`).
4. With `app_public_url` empty, confirm behavior is unchanged (relative same-origin path).

## Visual / UI changes

No new UI — backend-only (`mcp_servers/image_gen_server.py`); no `static/js`, CSS, or DOM changes.

- [x] No visual change introduced by this PR.
