### PR TITLE
Add start script

### DIFF
--- a/start_odysseus.sh
+++ b/start_odysseus.sh
@@ -1,0 +1,5 @@
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python setup.py
+python -m uvicorn app:app --host 0.0.0.0 --port 7000


### PR DESCRIPTION
## Summary

Implementation of simple start script for native linux

## Target branch

- [X] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.


## Linked issue

- Request for implementation of native linux start script under the number: #2475 

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [X] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. cd into odysseus folder
2. run the script 
3. check if it opened