### PR TITLE
Sanitize calendar export filenames

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -1,6 +1,7 @@
 """Calendar routes — local SQLite-backed calendar CRUD."""
 
 import logging
+import re
 import uuid
 from datetime import datetime, date, timedelta
 from typing import Optional, List
@@ -98,6 +99,15 @@ def _ics_escape(text: str) -> str:
         .replace("\n", "\\n")
         .replace("\r", "\\n")
     )
+
+
+def _safe_ics_filename(name: str) -> str:
+    """Return a conservative .ics filename safe for Content-Disposition."""
+    stem = name if isinstance(name, str) else ""
+    stem = re.sub(r"[^A-Za-z0-9._-]", "_", stem).strip("._-")
+    if not stem:
+        stem = "calendar"
+    return f"{stem[:128]}.ics"
 
 
 def _resolve_base_uid(uid: str) -> str:
@@ -1168,11 +1178,14 @@ def setup_calendar_routes() -> APIRouter:
             lines.append("END:VCALENDAR")
 
             ics_data = "\r\n".join(lines)
-            safe_name = cal.name.replace(" ", "_").replace("/", "_")
+            download_name = _safe_ics_filename(cal.name)
             return Response(
                 content=ics_data,
                 media_type="text/calendar",
-                headers={"Content-Disposition": f'attachment; filename="{safe_name}.ics"'},
+                headers={
+                    "Content-Disposition": f'attachment; filename="{download_name}"',
+                    "X-Content-Type-Options": "nosniff",
+                },
             )
         except HTTPException:
             raise

--- a/tests/test_calendar_owner_scope.py
+++ b/tests/test_calendar_owner_scope.py
@@ -324,3 +324,21 @@ def test_export_ics_rejects_cross_owner_calendar_at_route_boundary(monkeypatch):
     assert exc.value.status_code == 404
     assert not session.event_query.all_called
     session.close.assert_called_once()
+
+
+def test_export_ics_sanitizes_calendar_name_for_download_header(monkeypatch):
+    calendar_routes = _import_calendar_routes(monkeypatch)
+    cal = _calendar("alice")
+    cal.name = 'Work\r\nX-Injected: yes";/..\\evil'
+    session = _FakeSession(calendars=[cal])
+    monkeypatch.setattr(calendar_routes, "SessionLocal", lambda: session)
+    export_ics = _route_endpoint(calendar_routes, "/export/{cal_id}", "GET")
+
+    response = asyncio.run(export_ics(_request(), cal_id="cal-target"))
+
+    assert (
+        response.headers["content-disposition"]
+        == 'attachment; filename="Work__X-Injected__yes___.._evil.ics"'
+    )
+    assert response.headers["x-content-type-options"] == "nosniff"
+    session.close.assert_called_once()

--- a/tests/test_ics_escape.py
+++ b/tests/test_ics_escape.py
@@ -23,3 +23,19 @@ def test_newlines_become_literal_backslash_n():
 def test_empty_and_none_safe():
     assert _esc()("") == ""
     assert _esc()(None) == ""
+
+
+def test_safe_ics_filename_strips_header_metacharacters():
+    safe_filename = _import_calendar_helpers()._safe_ics_filename
+
+    assert (
+        safe_filename('Work\r\nX-Injected: yes";/..\\evil')
+        == "Work__X-Injected__yes___.._evil.ics"
+    )
+
+
+def test_safe_ics_filename_falls_back_for_empty_names():
+    safe_filename = _import_calendar_helpers()._safe_ics_filename
+
+    assert safe_filename("////") == "calendar.ics"
+    assert safe_filename(None) == "calendar.ics"


### PR DESCRIPTION
## Summary

Calendar export used the user-controlled calendar name directly in the quoted `Content-Disposition` filename after only replacing spaces and forward slashes. This adds a conservative `.ics` filename sanitizer for calendar exports, uses it before building the download header, and adds `X-Content-Type-Options: nosniff` to the ICS response.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2838

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the focused calendar export regression set:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_ics_escape.py tests/test_calendar_owner_scope.py tests/test_ics_export_escaping.py
```

I ran that command locally and got `20 passed, 1 warning`.

2. Focus `tests/test_calendar_owner_scope.py::test_export_ics_sanitizes_calendar_name_for_download_header` to verify a calendar name containing CR/LF, quotes, semicolons, slash, and backslash cannot flow into the response header unchanged.

## Visual / UI changes - REQUIRED if you touched anything that renders

No UI or visual rendering changes.

### Screenshots / clips

Not applicable.
