### PR TITLE
fix(tests): make conftest DB import clean-worktree safe

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,16 @@ from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Importing core.database below runs init_db() at import time, and its default
+# (sqlite:///./data/app.db) can't be opened in a clean worktree because SQLite
+# won't create the missing ./data parent dir — pytest then dies during
+# collection, before any test module loads. Default to an in-memory DB for the
+# test session so collection is deterministic and writes no repo-local
+# artifacts. An explicit DATABASE_URL (a real test/CI database) is preserved.
+# This only unblocks collection/import-time init; it does not provide a shared
+# file-backed DB across processes — tests needing that must set DATABASE_URL.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
 # Pre-import real heavy modules BEFORE any test file's module-level stubs can
 # replace them with MagicMock. Some test files (e.g. test_llm_core_sanitize_*)
 # stub sqlalchemy/core.database at module scope with `if mod not in sys.modules`,


### PR DESCRIPTION
## Summary

Part of #2523.

Makes pytest collection deterministic in clean worktrees where `./data` does not exist.

`tests/conftest.py` imports `core.database` during collection. Importing `core.database` runs `init_db()` at import time, and the production default database URL is `sqlite:///./data/app.db`. In a fresh worktree with no `./data`, SQLite cannot create the missing parent directory, so pytest can fail before any test module has a chance to apply scoped import isolation.

This PR sets a test-only default before importing `core.database`:

```python
os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
```

This preserves any explicit `DATABASE_URL` from CI or local test runs, avoids creating repo-local runtime artifacts, and only affects pytest through `tests/conftest.py`.

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to `tests/conftest.py`.
- [x] I preserved explicit `DATABASE_URL` values with `setdefault`.
- [x] I verified the fix works in a fresh audit worktree with no `./data`.
- [x] I verified the targeted tests do not create `./data` or `./data/app.db`.
- [x] I did not change production code.
- [x] I did not change test assertions.
- [x] I did not move files or change the test directory structure.
- [x] I did not touch the paused #2833 session-test PR files.

## How to Test

Compile the touched file:

```bash
python3 -m py_compile tests/conftest.py
```

Validated locally:

```text
py_compile passed
```

Fresh clean-worktree validation:

A fresh audit worktree was created from `upstream/dev`, this patch was applied, and `./data` was removed/confirmed absent before pytest.

Before pytest:

```text
before: data exists=False is_dir=False
```

Run the session tests that previously exposed the conftest collection trap:

```bash
python3 -m pytest -q \
  tests/test_session_ghost_delete.py \
  tests/test_session_owner_attribution.py
```

Validated locally in the fresh audit worktree:

```text
15 passed
```

Run the webhook SSRF test:

```bash
python3 -m pytest -q tests/test_webhook_ssrf_resilience.py
```

Validated locally in the fresh audit worktree:

```text
2 passed, 1 warning
```

Run broader import/order-sensitive groups:

```bash
python3 -m pytest -q \
  tests/test_blind_compare_redaction.py \
  tests/test_session_ghost_delete.py \
  tests/test_session_owner_attribution.py \
  tests/test_webhook_ssrf_resilience.py \
  tests/test_review_regressions.py

python3 -m pytest -q \
  tests/test_webhook_ssrf_resilience.py \
  tests/test_review_regressions.py \
  tests/test_session_owner_attribution.py \
  tests/test_session_ghost_delete.py \
  tests/test_blind_compare_redaction.py
```

Validated locally in the fresh audit worktree:

```text
41 passed, 1 warning
41 passed, 1 warning
```

Run DB-sensitive tests excluding the known unrelated `python-multipart` environment failure:

```bash
python3 -m pytest -q \
  tests/test_sqlite_foreign_keys.py \
  tests/test_rewrite_persist_column.py \
  tests/test_replace_messages_multimodal.py \
  tests/test_topic_analyzer.py
```

Validated locally in the fresh audit worktree:

```text
9 passed, 6 warnings
```

Classification note:

```bash
python3 -m pytest -q tests/test_archived_sessions_model_filter.py
```

This still fails in the audit environment because `python-multipart` is not installed. That failure is unrelated to this DB clean-worktree fix and occurs during FastAPI route setup, not SQLite/database initialization.

After pytest:

```text
after classify: data exists=False is_dir=False
```

Check for whitespace / merge artifacts:

```bash
git diff --check
```

Validated locally:

```text
passed
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only conftest fix; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This PR intentionally does not fix the separate `python-multipart` test-environment issue in `tests/test_archived_sessions_model_filter.py`.

The purpose here is only to remove the clean-worktree pytest collection trap caused by `core.database` import-time initialization when `./data` is absent.
