### PR TITLE
Constrain embedding model cache paths

### DIFF
--- a/routes/embedding_routes.py
+++ b/routes/embedding_routes.py
@@ -49,19 +49,35 @@ def _model_cache_name(hf_source: str) -> str:
     return "models--" + hf_source.replace("/", "--")
 
 
+def _model_cache_path(hf_source: str) -> Path:
+    """Return a confined cache path for a fastembed HF source."""
+    root = Path(_cache_dir()).expanduser().resolve()
+    raw_path = root / _model_cache_name(hf_source)
+    if raw_path.is_symlink():
+        raise ValueError("Model cache path must not be a symlink")
+    path = raw_path.resolve(strict=False)
+    try:
+        path.relative_to(root)
+    except ValueError:
+        raise ValueError("Model cache path escapes cache root")
+    return path
+
+
 def _is_downloaded(hf_source: str) -> bool:
     """Check if a model is already cached."""
-    cache = _cache_dir()
-    model_dir = os.path.join(cache, _model_cache_name(hf_source))
-    if not os.path.isdir(model_dir):
+    try:
+        model_dir = _model_cache_path(hf_source)
+    except ValueError:
+        return False
+    if not model_dir.is_dir():
         return False
     # Check for actual model files (not just empty dir)
-    snapshots = os.path.join(model_dir, "snapshots")
-    if os.path.isdir(snapshots):
-        return any(os.listdir(snapshots))
+    snapshots = model_dir / "snapshots"
+    if snapshots.is_dir():
+        return any(snapshots.iterdir())
     # Also check for blobs (older cache format)
-    blobs = os.path.join(model_dir, "blobs")
-    return os.path.isdir(blobs) and any(os.listdir(blobs))
+    blobs = model_dir / "blobs"
+    return blobs.is_dir() and any(blobs.iterdir())
 
 
 def _active_model() -> str:
@@ -119,8 +135,10 @@ def setup_embedding_routes():
 
             cached_size = None
             if downloaded and hf_src:
-                model_path = os.path.join(_cache_dir(), _model_cache_name(hf_src))
-                cached_size = _dir_size_mb(model_path)
+                try:
+                    cached_size = _dir_size_mb(str(_model_cache_path(hf_src)))
+                except ValueError:
+                    cached_size = None
 
             result.append({
                 "model": m["model"],
@@ -217,8 +235,11 @@ def setup_embedding_routes():
         if not hf_src:
             raise HTTPException(400, "No cache source for this model")
 
-        model_path = os.path.join(_cache_dir(), _model_cache_name(hf_src))
-        if not os.path.isdir(model_path):
+        try:
+            model_path = _model_cache_path(hf_src)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        if not model_path.is_dir():
             return {"deleted": False, "message": "Model not cached"}
 
         shutil.rmtree(model_path)

--- a/tests/test_embedding_cache_confinement.py
+++ b/tests/test_embedding_cache_confinement.py
@@ -1,0 +1,75 @@
+import sys
+import types
+
+import pytest
+from fastapi import HTTPException
+
+import routes.embedding_routes as embedding_routes
+
+
+def _install_fastembed_stub(monkeypatch):
+    fastembed = types.ModuleType("fastembed")
+
+    class TextEmbedding:
+        @staticmethod
+        def list_supported_models():
+            return [{"model": "test-model", "sources": {"hf": "org/test-model"}}]
+
+    fastembed.TextEmbedding = TextEmbedding
+    monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+
+
+def _route_endpoint(path: str, method: str):
+    router = embedding_routes.setup_embedding_routes()
+    for route in router.routes:
+        if route.path == path and method in route.methods:
+            return route.endpoint
+    raise AssertionError(f"route not found: {method} {path}")
+
+
+def test_model_cache_path_resolves_under_cache_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(embedding_routes, "_cache_dir", lambda: str(tmp_path / "cache"))
+
+    path = embedding_routes._model_cache_path("org/test-model")
+
+    assert path == (tmp_path / "cache" / "models--org--test-model").resolve()
+
+
+def test_model_cache_path_rejects_top_level_symlink_escape(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    outside = tmp_path / "outside"
+    cache.mkdir()
+    outside.mkdir()
+    monkeypatch.setattr(embedding_routes, "_cache_dir", lambda: str(cache))
+    link = cache / "models--org--test-model"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ValueError):
+        embedding_routes._model_cache_path("org/test-model")
+    assert embedding_routes._is_downloaded("org/test-model") is False
+
+
+def test_delete_model_rejects_symlink_cache_dir(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    outside = tmp_path / "outside"
+    cache.mkdir()
+    outside.mkdir()
+    (outside / "keep.txt").write_text("outside", encoding="utf-8")
+    monkeypatch.setattr(embedding_routes, "_cache_dir", lambda: str(cache))
+    monkeypatch.setattr(embedding_routes, "_active_model", lambda: "other-model")
+    _install_fastembed_stub(monkeypatch)
+    link = cache / "models--org--test-model"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    delete_model = _route_endpoint("/api/embeddings/models/{model_name:path}", "DELETE")
+
+    with pytest.raises(HTTPException) as exc:
+        delete_model("test-model")
+
+    assert exc.value.status_code == 400
+    assert (outside / "keep.txt").exists()


### PR DESCRIPTION
## Summary

Embedding model status/list/delete built FastEmbed cache paths by joining the configured cache root with the catalog-provided model cache directory name. This adds a confined cache-path resolver, rejects top-level model cache symlinks, routes downloaded checks and cached-size reads through it, and makes model deletion fail closed before `shutil.rmtree` if the path is unsafe.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2848

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the focused embedding cache regression set:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_embedding_cache_confinement.py tests/test_embedding_endpoint_config.py tests/test_url_safety.py
```

I ran that command locally and got `13 passed, 1 warning`.

2. Run syntax checks:

```bash
/home/moloch/odysseus/venv/bin/python -m py_compile routes/embedding_routes.py tests/test_embedding_cache_confinement.py
```

That command passed locally.

## Visual / UI changes - REQUIRED if you touched anything that renders

No UI or visual rendering changes.

### Screenshots / clips

Not applicable.
