### PR TITLE
fix(tests): make archived session filter test multipart-independent

### DIFF
--- a/tests/test_archived_sessions_model_filter.py
+++ b/tests/test_archived_sessions_model_filter.py
@@ -6,7 +6,9 @@ silently DROPPED "gpt-4o" (contains but does not end with the value), and
 over-matched models that merely share the suffix. The sibling name filter
 already uses a wildcard-escaped contains match.
 """
+import sys
 import tempfile
+import types
 import uuid
 
 import pytest
@@ -34,11 +36,32 @@ def _route(router, path, method="GET"):
     raise AssertionError(f"route not found: {path}")
 
 
+def _stub_multipart_if_missing(monkeypatch):
+    """Satisfy FastAPI's optional python-multipart probe.
+
+    setup_session_routes() registers form-based routes we don't exercise here.
+    When FastAPI analyzes their Form() params at registration time it calls
+    ensure_multipart_is_installed(), which raises RuntimeError if neither
+    python-multipart nor multipart is importable. This archived-session model
+    filter test must not depend on that optional package, so inject a minimal
+    stub (only when it's genuinely absent) to let route setup proceed.
+    """
+    try:
+        import python_multipart  # noqa: F401
+        return
+    except ImportError:
+        pass
+    stub = types.ModuleType("python_multipart")
+    stub.__version__ = "0.0.20"  # FastAPI asserts __version__ > "0.0.12"
+    monkeypatch.setitem(sys.modules, "python_multipart", stub)
+
+
 @pytest.fixture
 def archived_endpoint(monkeypatch):
     import routes.session_routes as sr
     from unittest.mock import MagicMock
 
+    _stub_multipart_if_missing(monkeypatch)
     monkeypatch.setattr(sr, "SessionLocal", _TS)
     monkeypatch.setattr(sr, "effective_user", lambda request: "alice")
     router = sr.setup_session_routes(MagicMock(), {})


### PR DESCRIPTION
## Summary

Part of #2523.

Makes `tests/test_archived_sessions_model_filter.py` deterministic in environments where optional multipart packages are not installed.

The test calls `routes.session_routes.setup_session_routes(...)` to exercise the real archived-session route setup. That registers all session routes, including unrelated form-based routes. During FastAPI route registration, form parameters trigger `ensure_multipart_is_installed()`, which fails if neither `python-multipart` nor `multipart` is available.

This PR keeps the fix test-only by adding a small file-local helper that stubs `python_multipart` only when it is genuinely absent. The stub is minimal and scoped through `monkeypatch`, so it is restored after each test.

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to `tests/test_archived_sessions_model_filter.py`.
- [x] I preserved the archived-session model-filter assertions.
- [x] I did not change production code.
- [x] I did not change dependency files.
- [x] I did not modify `tests/conftest.py`.
- [x] I did not move files or change the test directory structure.
- [x] I validated the focused test.
- [x] I validated related DB-sensitive and session/import-sensitive groups.
- [x] I validated in a fresh audit worktree with no `./data`.

## How to Test

Confirm optional multipart packages are absent in the validation environment:

```bash
python3 - <<'PY2'
import importlib.util

for name in ["python_multipart", "multipart", "multipart.multipart"]:
    try:
        spec = importlib.util.find_spec(name)
    except ModuleNotFoundError as exc:
        spec = f"ModuleNotFoundError: {exc}"
    print(f"{name}: {spec}")
PY2
```

Validated locally:

```text
python_multipart: None
multipart: None
multipart.multipart: ModuleNotFoundError: No module named 'multipart'
```

Compile the touched file:

```bash
python3 -m py_compile tests/test_archived_sessions_model_filter.py
```

Validated locally:

```text
py_compile passed
```

Run the focused archived-session model-filter test:

```bash
python3 -m pytest -q tests/test_archived_sessions_model_filter.py
```

Validated locally:

```text
3 passed, 1 warning
```

Run the related DB-sensitive group:

```bash
python3 -m pytest -q \
  tests/test_sqlite_foreign_keys.py \
  tests/test_rewrite_persist_column.py \
  tests/test_replace_messages_multimodal.py \
  tests/test_topic_analyzer.py \
  tests/test_archived_sessions_model_filter.py
```

Validated locally:

```text
12 passed, 6 warnings
```

Run session/import-sensitive groups:

```bash
python3 -m pytest -q \
  tests/test_session_ghost_delete.py \
  tests/test_session_owner_attribution.py \
  tests/test_webhook_ssrf_resilience.py \
  tests/test_archived_sessions_model_filter.py

python3 -m pytest -q \
  tests/test_archived_sessions_model_filter.py \
  tests/test_webhook_ssrf_resilience.py \
  tests/test_session_owner_attribution.py \
  tests/test_session_ghost_delete.py
```

Validated locally:

```text
20 passed, 2 warnings
20 passed, 1 warning
```

Fresh audit worktree validation:

A fresh audit worktree was created from `upstream/dev`, this patch was applied, and `./data` was removed/confirmed absent before pytest.

Before pytest:

```text
data exists=False is_dir=False
```

The focused test, DB-sensitive group, and session/import-sensitive groups all passed in that fresh audit worktree.

After pytest:

```text
data exists=False is_dir=False
```

Check for whitespace / merge artifacts:

```bash
git diff --check
```

Validated locally:

```text
passed
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

The helper intentionally stubs only `python_multipart`, and only when the real package is absent. It does not patch FastAPI internals or route setup behavior.

This keeps the archived-session model-filter coverage intact while removing an unrelated optional dependency trap from the test environment.
