### PR TITLE
fix(tests): restore Python CI baseline regressions

### DIFF
--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -56,10 +56,14 @@ def test_session_gone_heuristic_honors_dep_install_success():
     source = _read("static/js/cookbookRunning.js")
 
     assert "const depInstallSucceeded = !!task.payload?._dep && _depInstallSucceeded(lastOutput);" in source
+    # Whitespace-normalized so the check survives line-wrapping/formatting while
+    # still proving the invariant: a finished dependency install short-circuits
+    # looksSuccessful ahead of the download/serve branch.
+    normalized = " ".join(source.split())
     assert (
         "const looksSuccessful = depInstallSucceeded "
-        "|| (task.type === 'download' ? downloadLooksSuccessful : serveLooksReady);"
-    ) in source
+        "|| (task.type === 'download'"
+    ) in normalized
 
 
 def test_background_poll_recovers_done_for_stopped_dependency_install():

--- a/tests/test_tool_index_keyword_boundaries.py
+++ b/tests/test_tool_index_keyword_boundaries.py
@@ -40,8 +40,12 @@ def test_substring_inside_word_does_not_force_document_tools():
 
 def test_substring_inside_word_does_not_force_serve_tools():
     ti = _index()
-    # "observe"/"reserve" contain "serve".
-    tools = ti.get_tools_for_query("please observe the reserve levels")
+    # "observe"/"reserve" contain "serve". serve_model/serve_preset are also in
+    # ALWAYS_AVAILABLE, so pass a non-serve base to isolate the keyword loop (an
+    # empty set falls back to ALWAYS_AVAILABLE). The "serve" hint must NOT fire.
+    tools = ti.get_tools_for_query(
+        "please observe the reserve levels", always_include={"__base__"}
+    )
     assert "serve_model" not in tools
     assert "serve_preset" not in tools
 


### PR DESCRIPTION
## Summary

Part of #2523.

Restores the current Python CI baseline by fixing two stale/brittle regression tests that were failing on clean `dev`:

- `tests/test_cookbook_dependency_completion_regression.py::test_session_gone_heuristic_honors_dep_install_success`
- `tests/test_tool_index_keyword_boundaries.py::test_substring_inside_word_does_not_force_serve_tools`

Root cause:

- The cookbook test still checks the intended invariant, but the source assertion was too formatting-sensitive after `looksSuccessful` was wrapped and extended with the pip-task branch.
- The tool-index test was meant to verify that `"serve"` does not match inside `"observe"` / `"reserve"`, but `serve_model` and related serve tools are now part of `ALWAYS_AVAILABLE`, so the test no longer isolated keyword matching.

Fix:

- Normalize cookbook source whitespace before checking the `depInstallSucceeded ||` invariant.
- Isolate the tool-index keyword loop with a non-serve `always_include` placeholder so `ALWAYS_AVAILABLE` does not pollute the assertion.

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to the two failing CI baseline tests.
- [x] I did not change production code.
- [x] I did not add dependencies.
- [x] I did not skip, xfail, or mark tests flaky.
- [x] I preserved the regression coverage intent for both tests.
- [x] I validated the exact failing tests.
- [x] I validated the related test files.
- [x] I validated in a fresh audit worktree.

## How to Test

Compile the changed test files:

```bash
python3 -m py_compile \
  tests/test_cookbook_dependency_completion_regression.py \
  tests/test_tool_index_keyword_boundaries.py
```

Validated locally:

```text
py_compile passed
```

Check the unchanged JavaScript file still parses:

```bash
node --check static/js/cookbookRunning.js
```

Validated locally:

```text
node --check passed
```

Run the exact tests that were failing in CI:

```bash
python3 -m pytest -q \
  tests/test_cookbook_dependency_completion_regression.py::test_session_gone_heuristic_honors_dep_install_success \
  tests/test_tool_index_keyword_boundaries.py::test_substring_inside_word_does_not_force_serve_tools
```

Validated locally:

```text
2 passed
```

Run both related test files:

```bash
python3 -m pytest -q \
  tests/test_cookbook_dependency_completion_regression.py \
  tests/test_tool_index_keyword_boundaries.py
```

Validated locally:

```text
12 passed
```

Fresh audit worktree validation:

A fresh audit worktree was created from `upstream/dev`, this patch was applied, and the exact failing tests plus related test files were re-run.

Validated in the fresh audit worktree:

```text
2 passed
12 passed
```

Additional note:

A full local `python3 -m pytest -q` was attempted in the audit worktree, but the local environment is missing `nh3`, causing collection errors in visual-report tests before this branch's relevant tests are involved. That is a local dependency/environment issue, not a failure from this patch. CI installs project requirements and should be treated as the full-suite gate for this PR.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only fix; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This PR is intentionally narrow. It only updates stale/brittle test assertions so the current Python CI baseline can recover without weakening the intended regression coverage.
