### PR TITLE
refactor(tests): reuse import-state helper in auth tests

### DIFF
--- a/tests/test_auth_session_revocation.py
+++ b/tests/test_auth_session_revocation.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException
 
+from tests.helpers.import_state import clear_module
+
 
 def _real_core_package():
     root = Path(__file__).resolve().parent.parent
@@ -20,9 +22,7 @@ def _real_core_package():
         core = types.ModuleType("core")
         sys.modules["core"] = core
     core.__path__ = [core_path]
-    if hasattr(core, "auth"):
-        delattr(core, "auth")
-    sys.modules.pop("core.auth", None)
+    clear_module("core.auth")
     return core
 
 

--- a/tests/test_delete_user_revokes_api_tokens.py
+++ b/tests/test_delete_user_revokes_api_tokens.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers.import_state import clear_module
+
 
 def _real_core_package():
     root = Path(__file__).resolve().parent.parent
@@ -22,9 +24,7 @@ def _real_core_package():
         core = types.ModuleType("core")
         sys.modules["core"] = core
     core.__path__ = [core_path]
-    if hasattr(core, "auth"):
-        delattr(core, "auth")
-    sys.modules.pop("core.auth", None)
+    clear_module("core.auth")
     return core
 
 

--- a/tests/test_rename_user_case_insensitive.py
+++ b/tests/test_rename_user_case_insensitive.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.helpers.import_state import clear_module
+
 
 def _real_core_package():
     root = Path(__file__).resolve().parent.parent
@@ -23,9 +25,7 @@ def _real_core_package():
         core = types.ModuleType("core")
         sys.modules["core"] = core
     core.__path__ = [core_path]
-    if hasattr(core, "auth"):
-        delattr(core, "auth")
-    sys.modules.pop("core.auth", None)
+    clear_module("core.auth")
     return core
 
 


### PR DESCRIPTION
## Summary

Part of #2523.

Continues the shared import-state helper adoption by replacing duplicated `core.auth` cache eviction boilerplate in a small, homogeneous auth-test batch.

Changed files:

- `tests/test_auth_session_revocation.py`
- `tests/test_delete_user_revokes_api_tokens.py`
- `tests/test_rename_user_case_insensitive.py`

Each file had the same `_real_core_package()` pattern:

```python
if hasattr(core, "auth"):
    delattr(core, "auth")
sys.modules.pop("core.auth", None)
```

This PR replaces that repeated tail with:

```python
clear_module("core.auth")
```

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to one repeated import-state cleanup pattern.
- [x] I did not modify `tests/helpers/import_state.py`.
- [x] I did not modify `tests/conftest.py`.
- [x] I did not change production code.
- [x] I did not move files.
- [x] I did not rewrite unrelated assertions.
- [x] I did not add dependencies.
- [x] I validated the changed files.
- [x] I validated neighboring auth/security import-sensitive groups.
- [x] I classified the slower auth concurrency group as pre-existing/expected test cost.

## How to Test

Check whitespace / conflict markers:

```bash
git diff --check
```

Validated locally:

```text
passed
```

Compile the changed files:

```bash
python3 -m py_compile \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
py_compile passed
```

Run focused tests for the changed files:

```bash
python3 -m pytest -q \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
10 passed, 1 warning
```

Run import-state helper plus changed auth tests:

```bash
python3 -m pytest -q \
  tests/test_helpers_import_state.py \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
20 passed, 1 warning
```

Run neighboring auth import-sensitive tests:

```bash
python3 -m pytest -q \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
28 passed, 1 warning
```

Timing note:

This group takes about 36 seconds because `tests/test_auth_config_lock_concurrency.py` contains several intentionally concurrent disk/file consistency tests. `--durations=15` showed the slow tests are all from that file, not from this refactor.

Run broader auth/security order-sensitive groups:

```bash
python3 -m pytest -q \
  tests/test_auth_regressions.py \
  tests/test_security_regressions.py \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py

python3 -m pytest -q \
  tests/test_rename_user_case_insensitive.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_auth_session_revocation.py \
  tests/test_auth_regressions.py \
  tests/test_security_regressions.py
```

Validated locally:

```text
113 passed, 1 warning
113 passed, 1 warning
```

Fresh audit worktree validation:

A fresh audit worktree was created from `upstream/dev`, this patch was applied, and the same focused/order-sensitive validation was repeated.

Validated in the fresh audit worktree:

```text
10 passed, 1 warning
20 passed, 1 warning
28 passed, 1 warning
113 passed, 1 warning
113 passed, 1 warning
```

Check old boilerplate is removed from the changed files:

```bash
grep -RInE 'delattr\(core, "auth"\)|sys\.modules\.pop\("core\.auth"' \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
no matches
```

Check shared helper usage exists:

```bash
grep -RInE 'from tests\.helpers\.import_state import clear_module|clear_module\("core\.auth"\)' \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
shared helper import and clear_module("core.auth") found in all three files
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only refactor; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This PR intentionally skips larger mixed-risk files such as `tests/test_security_regressions.py` and `tests/test_review_regressions.py`. Those files contain heterogeneous import/module manipulation patterns and should be handled separately, if at all.

This slice is limited to one byte-identical `core.auth` eviction pattern across three auth tests.
