### PR TITLE
refactor(tests): reuse import-state helper in auth manager tests

### DIFF
--- a/tests/test_auth_config_lock_concurrency.py
+++ b/tests/test_auth_config_lock_concurrency.py
@@ -6,18 +6,17 @@ with missing users or assertion errors.
 """
 
 import json
-import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 
+from tests.helpers.import_state import clear_module
+
 
 def _fresh_auth_manager(tmp_path):
-    sys.modules.pop("core.auth", None)
-    if "core" in sys.modules and hasattr(sys.modules["core"], "auth"):
-        delattr(sys.modules["core"], "auth")
+    clear_module("core.auth")
     from core.auth import AuthManager
 
     return AuthManager(str(tmp_path / "auth.json"))

--- a/tests/test_reserved_username_admin_escalation.py
+++ b/tests/test_reserved_username_admin_escalation.py
@@ -11,17 +11,15 @@ is reserved for the same reason (bearer-token owner attribution collision).
 See the privilege-escalation finding from the 2026-06 code review.
 """
 
-import sys
-
 import pytest
+
+from tests.helpers.import_state import clear_module
 
 
 def _fresh_auth_manager(tmp_path):
     # Same import dance as test_security_regressions: drop any cached stub so
     # we exercise the real module from disk rather than a conftest mock.
-    sys.modules.pop("core.auth", None)
-    if "core" in sys.modules and hasattr(sys.modules["core"], "auth"):
-        delattr(sys.modules["core"], "auth")
+    clear_module("core.auth")
     from core.auth import AuthManager
 
     return AuthManager(str(tmp_path / "auth.json"))


### PR DESCRIPTION
## Summary

Part of #2523.

Continues shared import-state helper adoption by replacing duplicated inline `core.auth` cache eviction in `_fresh_auth_manager()` tests.

Changed files:

- `tests/test_auth_config_lock_concurrency.py`
- `tests/test_reserved_username_admin_escalation.py`

Both files previously used:

```python
sys.modules.pop("core.auth", None)
if "core" in sys.modules and hasattr(sys.modules["core"], "auth"):
    delattr(sys.modules["core"], "auth")
```

This PR replaces that repeated logic with:

```python
clear_module("core.auth")
```

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to one repeated import-state cleanup pattern.
- [x] I did not modify `tests/helpers/import_state.py`.
- [x] I did not modify `tests/conftest.py`.
- [x] I did not change production code.
- [x] I did not move files.
- [x] I did not rewrite unrelated assertions.
- [x] I did not add dependencies.
- [x] I did not touch the auth concurrency test logic.
- [x] I validated the changed files.
- [x] I validated neighboring auth/security import-sensitive groups.
- [x] I classified the slow auth concurrency runtime as pre-existing test cost.

## How to Test

Check whitespace / conflict markers:

```bash
git diff --check
```

Validated locally:

```text
passed
```

Compile the changed files:

```bash
python3 -m py_compile \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py
```

Validated locally:

```text
py_compile passed
```

Run focused tests:

```bash
python3 -m pytest -q --durations=10 \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py
```

Validated locally:

```text
18 passed, 1 warning
```

Run neighboring import-state/auth tests:

```bash
python3 -m pytest -q --durations=10 \
  tests/test_helpers_import_state.py \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py \
  tests/test_auth_session_revocation.py \
  tests/test_delete_user_revokes_api_tokens.py \
  tests/test_rename_user_case_insensitive.py
```

Validated locally:

```text
38 passed, 1 warning
```

Run broader auth/security order-sensitive groups:

```bash
python3 -m pytest -q --durations=10 \
  tests/test_auth_regressions.py \
  tests/test_security_regressions.py \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py

python3 -m pytest -q --durations=10 \
  tests/test_reserved_username_admin_escalation.py \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_auth_regressions.py \
  tests/test_security_regressions.py
```

Validated locally:

```text
121 passed, 1 warning
121 passed, 1 warning
```

Timing note:

The auth groups take about 35–36 seconds because `tests/test_auth_config_lock_concurrency.py` contains intentional concurrent disk/file consistency tests. `--durations=10` confirmed the slow cases are from that file, not this refactor.

Fresh audit worktree validation:

A fresh audit worktree was created from `upstream/dev`, this patch was applied, and the same validation was repeated.

Validated in the fresh audit worktree:

```text
18 passed, 1 warning
38 passed, 1 warning
121 passed, 1 warning
121 passed, 1 warning
```

Check old inline boilerplate is gone:

```bash
grep -RInE 'delattr\(sys\.modules\["core"\], "auth"\)|sys\.modules\.pop\("core\.auth"|delattr\(core, "auth"\)' \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py
```

Validated locally:

```text
no matches
```

Check shared helper usage exists:

```bash
grep -RInE 'from tests\.helpers\.import_state import clear_module|clear_module\("core\.auth"\)' \
  tests/test_auth_config_lock_concurrency.py \
  tests/test_reserved_username_admin_escalation.py
```

Validated locally:

```text
shared helper import and clear_module("core.auth") found in both files
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only refactor; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This PR intentionally does not optimize the auth concurrency tests. Their runtime is pre-existing and was only measured to confirm this refactor did not introduce new slowness.

This is a narrow follow-up to #2864, limited to the `_fresh_auth_manager()` `core.auth` eviction pair.
