### PR TITLE
feat(model-picker): add remove-from-recent button to Recent section rows

### DIFF
--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -408,27 +408,39 @@ function _initModelPickerDropdown() {
       return;
     }
 
-    // ── Browse mode: Recent (auto) + Favorites (manual). No flat "All" dump. ──
+    // ── Browse mode: sections in order: Favorites → Recent (big catalogs only) → All / Providers ──
+    //   1. Never list the same model twice in the dropdown. Favorites
+    //      win over Recent (if you favorited it, that's where it
+    //      belongs — Recent shouldn't show it again as duplicate).
+    //   2. Small catalogs (≤ BROWSE_ALL_LIMIT total) skip the Recent
+    //      section entirely — when there's only ~10 models, the whole
+    //      list fits below as "All models" and a separate Recent
+    //      section just duplicates rows.
     const shown = new Set();
-    const recentModels = _loadRecent()
-      .map(id => byId.get(id))
-      .filter(Boolean)
-      .slice(0, RECENT_MAX);
     const favModels = favs.map(id => byId.get(id)).filter(Boolean);
-
-    if (recentModels.length) {
-      _addSection('Recent');
-      recentModels.forEach(m => {
-        shown.add(m.mid);
-        _addRow(m, () => {
-          _removeRecent(m.mid);
-          _populate('');
-        });
-      });
-    }
     if (favModels.length) {
       _addSection('Favorites');
       favModels.forEach(m => { shown.add(m.mid); _addRow(m); });
+    }
+    // Recent: only render when the catalog is big enough that surfacing
+    // a recency shortlist is actually useful, AND only models that
+    // aren't already in Favorites (dedupe).
+    if (all.length > BROWSE_ALL_LIMIT) {
+      const recentModels = _loadRecent()
+        .map(id => byId.get(id))
+        .filter(Boolean)
+        .filter(m => !shown.has(m.mid))
+        .slice(0, RECENT_MAX);
+      if (recentModels.length) {
+        _addSection('Recent');
+        recentModels.forEach(m => {
+          shown.add(m.mid);
+          _addRow(m, () => {
+            _removeRecent(m.mid);
+            _populate('');
+          });
+        });
+      }
     }
 
     // Small catalogs: still list everything so users aren't forced to search.

--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -35,6 +35,11 @@ function _pushRecent(mid) {
   next.unshift(mid);
   _saveList(RECENT_KEY, next.slice(0, RECENT_MAX));
 }
+function _removeRecent(mid) {
+  if (!mid) return;
+  const next = _loadRecent().filter(x => x !== mid);
+  _saveList(RECENT_KEY, next);
+}
 function _loadFavorites() { return _loadList(FAVORITES_KEY); }
 function _toggleFavorite(mid) {
   const favs = _loadFavorites();
@@ -304,7 +309,7 @@ function _initModelPickerDropdown() {
       empty.textContent = text;
       listEl.appendChild(empty);
     }
-    function _addRow(m) {
+    function _addRow(m, onRemove) {
       const row = document.createElement('div');
       row.className = 'model-switch-item';
       if (m.stale) {
@@ -373,6 +378,20 @@ function _initModelPickerDropdown() {
       });
       row.appendChild(favDot);
 
+      // Remove-from-recent button (shown only for Recent section items).
+      if (onRemove) {
+        const rmBtn = document.createElement('button');
+        rmBtn.type = 'button';
+        rmBtn.className = 'mp-remove-dot';
+        rmBtn.textContent = '×';
+        rmBtn.title = 'Remove from recent';
+        rmBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          onRemove();
+        });
+        row.appendChild(rmBtn);
+      }
+
       row.addEventListener('click', () => _pick(m));
       listEl.appendChild(row);
     }
@@ -389,34 +408,27 @@ function _initModelPickerDropdown() {
       return;
     }
 
-    // ── Browse mode: Favorites (manual) + Recent (auto), with dedupe. ──
-    // Rules:
-    //   1. Never list the same model twice in the dropdown. Favorites
-    //      win over Recent (if you favorited it, that's where it
-    //      belongs — Recent shouldn't show it again as duplicate).
-    //   2. Small catalogs (≤ BROWSE_ALL_LIMIT total) skip the Recent
-    //      section entirely — when there's only ~10 models, the whole
-    //      list fits below as "All models" and a separate Recent
-    //      section just duplicates rows.
+    // ── Browse mode: Recent (auto) + Favorites (manual). No flat "All" dump. ──
     const shown = new Set();
+    const recentModels = _loadRecent()
+      .map(id => byId.get(id))
+      .filter(Boolean)
+      .slice(0, RECENT_MAX);
     const favModels = favs.map(id => byId.get(id)).filter(Boolean);
+
+    if (recentModels.length) {
+      _addSection('Recent');
+      recentModels.forEach(m => {
+        shown.add(m.mid);
+        _addRow(m, () => {
+          _removeRecent(m.mid);
+          _populate('');
+        });
+      });
+    }
     if (favModels.length) {
       _addSection('Favorites');
       favModels.forEach(m => { shown.add(m.mid); _addRow(m); });
-    }
-    // Recent: only render when the catalog is big enough that surfacing
-    // a recency shortlist is actually useful, AND only models that
-    // aren't already in Favorites (dedupe).
-    if (all.length > BROWSE_ALL_LIMIT) {
-      const recentModels = _loadRecent()
-        .map(id => byId.get(id))
-        .filter(Boolean)
-        .filter(m => !shown.has(m.mid))
-        .slice(0, RECENT_MAX);
-      if (recentModels.length) {
-        _addSection('Recent');
-        recentModels.forEach(m => { shown.add(m.mid); _addRow(m); });
-      }
     }
 
     // Small catalogs: still list everything so users aren't forced to search.

--- a/static/style.css
+++ b/static/style.css
@@ -2840,6 +2840,34 @@ body.bg-pattern-sparkles {
       45% { text-shadow: 0 0 10px color-mix(in srgb, var(--accent, var(--red)) 60%, transparent); }
       100% { text-shadow: 0 0 0 color-mix(in srgb, var(--accent, var(--red)) 0%, transparent); }
     }
+    /* Inline remove-from-recent button — only shown on Recent rows. */
+    .model-picker-list .mp-remove-dot {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      margin: -4px -4px -4px 2px;
+      padding: 0;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      color: color-mix(in srgb, var(--fg) 28%, transparent);
+      font-family: inherit;
+      font-size: 15px;
+      line-height: 1;
+      transition: color 0.15s ease, opacity 0.15s ease, transform 0.12s ease;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .model-picker-list .mp-remove-dot:hover {
+      color: var(--red, #ff5555);
+      transform: scale(1.1);
+    }
+    .model-picker-list .mp-remove-dot:focus-visible {
+      outline: none;
+      color: var(--red, #ff5555);
+    }
     /* First-run hint when a large catalog has no Recent/Favorites yet. */
     .model-picker-list .mp-empty-hint {
       flex-direction: column;


### PR DESCRIPTION
## Summary

Adds a small `×` remove button to each model in the **Recent** section of the model picker dropdown. Clicking it removes the model from the Recent list without affecting favorites or the underlying endpoint.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

#2898

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Open the model picker (click the model name in the chat header).
2. Use a few different models to populate the **Recent** section.
3. Hover over a Recent row — a `×` button appears on the right.
4. Click the `×` — the model is removed from Recent.
5. Re-open the picker — the removed model no longer appears in Recent.

## Visual / UI changes — REQUIRED

- [x] Style match: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (--red, --fg, --bg, --card, --border, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - No Unicode emoji in UI or code. Use inline SVG (matching the monochrome icon style already in static/index.html) or plain text.
  - Monospaced font (Fira Code) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
  - No new component patterns. If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] I am not an LLM agent submitting a bulk PR. If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

**Before:** Recent models appear with no way to remove individual entries. Users must wait for the list to roll off naturally or clear all localStorage.

**After:** Each Recent row shows a subtle `×` button on hover/focus. Clicking it immediately removes that specific model from Recent and refreshes the list.

Screenshots:
*(add your before/after screenshots here)*

**Before (No X):**

<img width="529" height="73" alt="BeforeRecents" src="https://github.com/user-attachments/assets/d45abcb9-13c2-4c0b-b7c0-5e2629d909e1" />

**After:**

<img width="485" height="110" alt="AfterRecents" src="https://github.com/user-attachments/assets/33729e69-1e74-422f-8ce0-d6dd9db2765e" />

