### PR TITLE
fix: raise imaplib line limit for large mailboxes

### DIFF
--- a/routes/email_helpers.py
+++ b/routes/email_helpers.py
@@ -714,6 +714,10 @@ def _open_imap_connection(host: str, port: int, *, starttls: bool, timeout: int 
         conn.sock.settimeout(timeout)
     except Exception:
         pass
+    # Raise the IMAP line-length limit from the default 1 MB to 50 MB so that
+    # large mailboxes (tens of thousands of messages) don't crash with
+    # "got more than 1000000 bytes" on UID SEARCH ALL.  (#2883)
+    imaplib._MAXLINE = 50_000_000
     return conn
 
 def _imap_connect(account_id: str | None = None, owner: str = ""):


### PR DESCRIPTION
## Linked Issue

Fixes #2883

## Summary

Python's `imaplib` defaults to a 1 MB line limit. Mailboxes with tens of thousands of messages exceed this on `FETCH` responses, crashing with `imaplib.IMAP4.abort: socket error: line too long`.

## Fix

Set `_maxline` to 50 MB after opening the IMAP connection in the IMAP email source. This is a well-known fix for this Python limitation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test

1. Connect to an IMAP mailbox with 10,000+ messages
2. Run `list` or `read` operations that fetch message metadata
3. Verify no `line too long` errors occur
4. Run existing email tests: all should pass
5. The fix is a single line with no behavioral change for normal-sized mailboxes

## Checklist

- [x] I searched existing issues and PRs for duplicates