### PR TITLE
fix: respect user round count in deep research

### DIFF
--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -107,13 +107,16 @@ You are deciding whether a research report is comprehensive enough.
 **Current report:**
 {report}
 
-**Rounds completed:** {round_num}
+**Rounds completed:** {round_num} of {max_rounds}
 
 Based on the report so far, do we have enough information to answer the question \
 comprehensively?  Consider:
 - Are the key aspects of the question addressed?
 - Are there obvious gaps or unanswered sub-questions?
 - Is the evidence sufficient and from multiple sources?
+
+If rounds completed is well below the target, prefer continuing unless the \
+report is already exhaustive.
 
 Reply with ONLY "YES" or "NO" followed by a brief one-sentence reason.
 Example: "YES — The report covers all major aspects with evidence from multiple sources."
@@ -698,6 +701,7 @@ class DeepResearcher:
             question=question,
             report=report,
             round_num=round_num,
+            max_rounds=self.max_rounds,
         )
 
         try:

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -777,7 +777,7 @@ class ResearchHandler:
                 llm_model=llm_model,
                 llm_headers=llm_headers,
                 max_rounds=max_rounds,
-                min_rounds=min(3, max_rounds),
+                min_rounds=max(2, max_rounds - 2),
                 max_time=max_time,
                 max_report_tokens=_max_report_tokens,
                 extraction_timeout=_extraction_timeout,


### PR DESCRIPTION
## Linked Issue

Fixes #2863

## Summary

When a user sets 4+ rounds in deep research, only 2-3 rounds execute because:
1. The STOP_PROMPT did not include the target round count — the LLM had no way to know the user wanted more rounds
2. min_rounds was capped at 3 via min(3, max_rounds), so the LLM could stop after round 3 regardless

## Fix

1. Added max_rounds to STOP_PROMPT as 'Rounds completed: X of Y' with guidance to prefer continuing when well below target
2. Changed min_rounds from min(3, max_rounds) to max(2, max_rounds - 2), giving the LLM 2 rounds to make an informed stop decision while respecting the user's setting

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test

1. Start deep research with `rounds=6` on any topic
2. Observe the research runs through all 6 rounds instead of stopping at 2-3
3. Verify Auto mode still works correctly (max_rounds=20, min_rounds=18)
4. Run existing deep research tests: all should pass

## Checklist

- [x] I searched existing issues and PRs for duplicates