### PR TITLE
fix(calendar): cap RRULE expansion

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -460,6 +460,9 @@ def _event_to_dict(ev: CalendarEvent) -> dict:
 
 # ── Recurrence expansion ──
 
+_RRULE_EXPANSION_LIMIT = 1000
+
+
 def _expand_rrule(
     ev: CalendarEvent, start: datetime, end: datetime
 ) -> List[dict]:
@@ -482,6 +485,7 @@ def _expand_rrule(
         d = _event_to_dict(ev)
         d["is_recurrence"] = False
         d["series_uid"] = ev.uid
+        d["truncated"] = False
         return [d]
 
     # Parse the rrule, applying it to the base dtstart.
@@ -507,6 +511,7 @@ def _expand_rrule(
         d = _event_to_dict(ev)
         d["is_recurrence"] = False
         d["series_uid"] = ev.uid
+        d["truncated"] = False
         # Malformed RRULE rows are fetched by the recurring SQL branch
         # with only dtstart < end_dt — the base event may not actually
         # overlap the window. Only return if it does.
@@ -519,21 +524,25 @@ def _expand_rrule(
     # (matching non-recurring overlap semantics: dtstart < end AND
     # dtend > start).
     expand_start = start - duration
-    occurrences = rule.between(expand_start, end, inc=True)
-    if not occurrences:
-        return []
-
     results = []
+    truncated = False
     base = _event_to_dict(ev)
 
-    for occ_start in occurrences:
+    for occ_start in rule.xafter(expand_start, inc=True):
+        if occ_start >= end:
+            break
+
         occ_end = occ_start + duration
 
         # Overlap filter: occurrence must intersect [start, end).
         # This enforces exclusive-end semantics (occ_start >= end is
         # excluded) and includes multi-day crossings (occ_end > start).
-        if occ_start >= end or occ_end <= start:
+        if occ_end <= start:
             continue
+
+        if len(results) >= _RRULE_EXPANSION_LIMIT:
+            truncated = True
+            break
 
         # Build the compound uid: {base_uid}::{date} or ::{datetime}
         if ev.all_day:
@@ -545,6 +554,7 @@ def _expand_rrule(
         d["uid"] = occ_uid
         d["series_uid"] = ev.uid
         d["is_recurrence"] = True
+        d["truncated"] = False
 
         if ev.all_day:
             d["dtstart"] = occ_start.strftime("%Y-%m-%d")
@@ -556,6 +566,10 @@ def _expand_rrule(
             d["is_utc"] = bool(getattr(ev, "is_utc", False))
 
         results.append(d)
+
+    if truncated:
+        for d in results:
+            d["truncated"] = True
 
     return results
 
@@ -786,8 +800,12 @@ def setup_calendar_routes() -> APIRouter:
                 expanded.extend(_expand_rrule(e, start_dt, end_dt))
 
             # Sort by occurrence start time for consistent frontend ordering.
+            truncated = any(e.get("truncated") for e in expanded)
             expanded.sort(key=lambda d: d["dtstart"])
-            return {"events": expanded}
+            response: dict = {"events": expanded}
+            if truncated:
+                response["truncated"] = True
+            return response
         except HTTPException:
             raise
         except Exception as e:

--- a/tests/test_calendar_recurrence.py
+++ b/tests/test_calendar_recurrence.py
@@ -319,3 +319,20 @@ def test_expand_metadata_inheritance():
         assert r["importance"] == "critical"
         assert r["event_type"] == "work"
         assert r["location"] == "Room 42"
+
+
+def test_expand_daily_rrule_large_window_is_capped_and_marked_truncated():
+    """Wide recurring windows must not materialize unbounded occurrence lists."""
+    cal = _import_calendar_helpers()
+    ev = _make_event(
+        uid="evt-daily-cap",
+        dtstart=datetime(2020, 1, 1, 9, 0),
+        dtend=datetime(2020, 1, 1, 10, 0),
+        rrule="FREQ=DAILY",
+    )
+
+    results = cal._expand_rrule(ev, datetime(2020, 1, 1), datetime(2030, 1, 1))
+
+    assert len(results) == cal._RRULE_EXPANSION_LIMIT
+    assert results[-1]["uid"] == "evt-daily-cap::2022-09-26T09:00"
+    assert all(r["truncated"] is True for r in results)


### PR DESCRIPTION
## Summary

Caps recurring calendar expansion so wide RRULE queries do not materialize unbounded occurrence lists. The recurrence path now streams occurrences up to a 1000-occurrence limit and marks capped results as truncated so callers can detect partial output.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2890

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `python3 -m py_compile routes/calendar_routes.py`.
2. Run `python3 -m pytest tests/test_calendar_recurrence.py tests/test_calendar_rrule_until_utc.py tests/test_calendar_rrule.py tests/test_calendar_owner_scope.py tests/test_calendar_parse_dt_naive.py -q`.
3. For the regression specifically, inspect `tests/test_calendar_recurrence.py::test_expand_daily_rrule_large_window_is_capped_and_marked_truncated`: before the fix this failed because `_expand_rrule` had no expansion limit/truncation marker; after the fix it returns exactly 1000 daily occurrences and marks them truncated.

Local result:

```text
34 passed, 1 warning
```

I did not run the full app because this is a backend recurrence-expansion guard with focused regression coverage and no UI rendering changes.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual/UI changes. This PR only touches calendar recurrence expansion logic and a regression test.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styles or components changed.
- [x] **No new component patterns.** No UI components changed.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused fix for an existing issue.

### Screenshots / clips

N/A — no visual/UI changes.
