### PR TITLE
fix: hide Select buttons in Memory/Skills tabs when list is empty

### DIFF
--- a/static/js/memory.js
+++ b/static/js/memory.js
@@ -609,7 +609,7 @@ export function renderMemoryList() {
 
   if (filtered.length === 0) {
     const selectBtn = document.getElementById('memory-select-btn');
-    if (selectBtn) selectBtn.classList.add('hidden');
+    if (selectBtn) selectBtn.disabled = true;
     if (selectMode) exitSelectMode();
     const searchTerm = document.getElementById('memory-search')?.value?.trim() || '';
     const _smiley = '<span style="vertical-align:-3px;margin-left:6px;">' + uiModule.emptyStateIcon('smiley') + '</span>';
@@ -631,7 +631,7 @@ export function renderMemoryList() {
   }
 
   const selectBtn = document.getElementById('memory-select-btn');
-  if (selectBtn) selectBtn.classList.remove('hidden');
+  if (selectBtn) selectBtn.disabled = false;
 
   filtered.forEach(memory => {
     const item = document.createElement('div');

--- a/static/js/memory.js
+++ b/static/js/memory.js
@@ -608,6 +608,9 @@ export function renderMemoryList() {
   memoryList.innerHTML = '';
 
   if (filtered.length === 0) {
+    const selectBtn = document.getElementById('memory-select-btn');
+    if (selectBtn) selectBtn.classList.add('hidden');
+    if (selectMode) exitSelectMode();
     const searchTerm = document.getElementById('memory-search')?.value?.trim() || '';
     const _smiley = '<span style="vertical-align:-3px;margin-left:6px;">' + uiModule.emptyStateIcon('smiley') + '</span>';
     if (searchTerm || activeCategory !== 'all') {
@@ -626,6 +629,9 @@ export function renderMemoryList() {
     }
     return;
   }
+
+  const selectBtn = document.getElementById('memory-select-btn');
+  if (selectBtn) selectBtn.classList.remove('hidden');
 
   filtered.forEach(memory => {
     const item = document.createElement('div');

--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -621,9 +621,15 @@ function renderSkillsList() {
   const showBuiltin = false;
 
   if (!sorted.length && !showBuiltin) {
+    const selectBtn = document.getElementById('skills-select-btn');
+    if (selectBtn) selectBtn.classList.add('hidden');
+    if (_selectMode) _exitSelectMode();
     container.innerHTML = `<div style="text-align:center;opacity:0.4;padding:24px 0;font-size:11px;">${loaded ? 'No skills yet, use agent for it to auto extract them.' : 'Loading…'}</div>`;
     return;
   }
+
+  const selectBtn = document.getElementById('skills-select-btn');
+  if (selectBtn) selectBtn.classList.remove('hidden');
 
   // Library-style cards: a compact bar that expands in-place to show the
   // SKILL.md, with a footer (Delete left; Edit / Run / Approve right).

--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -1073,9 +1073,8 @@ async function _deleteSkill(name, card = null) {
       card.classList.add('doclib-card-deleting');
       card.addEventListener('transitionend', () => card.remove(), { once: true });
       setTimeout(() => { if (card.parentElement) card.remove(); }, 400);
-    } else {
-      await loadSkills();
     }
+    await loadSkills();
     uiModule.showToast('Skill deleted');
   } catch (e) { uiModule.showError('Delete failed: ' + e.message); }
 }

--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -622,14 +622,14 @@ function renderSkillsList() {
 
   if (!sorted.length && !showBuiltin) {
     const selectBtn = document.getElementById('skills-select-btn');
-    if (selectBtn) selectBtn.classList.add('hidden');
+    if (selectBtn) selectBtn.disabled = true;
     if (_selectMode) _exitSelectMode();
     container.innerHTML = `<div style="text-align:center;opacity:0.4;padding:24px 0;font-size:11px;">${loaded ? 'No skills yet, use agent for it to auto extract them.' : 'Loading…'}</div>`;
     return;
   }
 
   const selectBtn = document.getElementById('skills-select-btn');
-  if (selectBtn) selectBtn.classList.remove('hidden');
+  if (selectBtn) selectBtn.disabled = false;
 
   // Library-style cards: a compact bar that expands in-place to show the
   // SKILL.md, with a footer (Delete left; Edit / Run / Approve right).

--- a/static/style.css
+++ b/static/style.css
@@ -842,7 +842,7 @@ body.bg-pattern-sparkles {
       display: flex; gap: 6px; flex-wrap: wrap;
       max-width: calc(100vw - 24px);
       padding: 4px;
-      z-index: 10020;
+      z-index: 100;
       pointer-events: none;
     }
     .minimized-dock-chip {

--- a/static/style.css
+++ b/static/style.css
@@ -10238,8 +10238,9 @@ textarea.memory-add-input {
 }
 
 .memory-toolbar-btn:disabled {
-  opacity: 1;
+  opacity: 0.35;
   cursor: default;
+  outline: none;
 }
 .memory-toolbar-btn.spinning {
   border-color: transparent;

--- a/static/style.css
+++ b/static/style.css
@@ -842,7 +842,7 @@ body.bg-pattern-sparkles {
       display: flex; gap: 6px; flex-wrap: wrap;
       max-width: calc(100vw - 24px);
       padding: 4px;
-      z-index: 100;
+      z-index: 10020;
       pointer-events: none;
     }
     .minimized-dock-chip {


### PR DESCRIPTION
## Summary

The Select button in the Memories and Skills tabs remained clickable even when the list was empty, letting users enter a selection mode with nothing to select. It now disables properly when no items are present and re-enables when items exist. The disabled state is also visually dimmed with reduced opacity and no focus outline. Additionally, deleting a skill individually no longer leaves the count badge and toolbar state stale; previously, the count next to the Skills tab and the Select button's enabled/disabled state would only update after switching tabs.

## Linked Issue

Fixes #2904

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs. This is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated changes mixed in.
- [x] I actually ran the app (docker compose up), no runtime change, only conditional show/hide of a button when the list is empty.

## How to Test

1. Open the Brain modal.
2. Go to the Memories or Skills tab with no memories or skills, the "Select" button should be disabled (dimmed, no focus outline).
3. Add a memory, and the button should become enabled.
4. Go to the Skills tab with no skills, and the "Select" button should be disabled.
5. Have skills loaded, the button should become enabled.
6. Delete a skill individually. The count badge and Select button state should update immediately without needing to switch tabs.

## Visual / UI changes

Disabled Select button (both in the Memories and Skills tabs) now has reduced opacity and no focus outline, so it visually appears disabled.

## Before Fix - Select button clickable

<img width="1070" height="674" alt="image" src="https://github.com/user-attachments/assets/5be54bd6-286c-49bb-9fc7-18c14021e61b" />

## After Fix - Select button disabled and dimmed

<img width="887" height="825" alt="image" src="https://github.com/user-attachments/assets/9fc0d2ab-2f64-4737-ba19-99dc815052b5" />

