### PR TITLE
fix(notes): reset search filter on panel reopen so stale query doesn't hide notes

### DIFF
--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -1099,6 +1099,9 @@ export function openPanel() {
   if (_open) return;
   _open = true;
   _editingId = null;
+  // Reset the search filter — the rebuilt pane's search input renders empty, so a
+  // stale _searchQuery would silently hide non-matching notes after a reopen.
+  _searchQuery = '';
   _clearViewedReminderGlows();
   _firedDotDismissedAt = Date.now();
   try { localStorage.setItem(REMINDER_DISMISSED_AT_KEY, String(_firedDotDismissedAt)); } catch {}

--- a/tests/test_notes_search_reset_on_reopen_js.py
+++ b/tests/test_notes_search_reset_on_reopen_js.py
@@ -1,0 +1,29 @@
+"""Issue #2919 — openPanel must reset _searchQuery so a reopened Notes panel
+doesn't keep filtering by a stale query (the rebuilt search box renders empty).
+
+notes.js is a browser ES module with a heavy import chain (can't node-import in
+isolation), so — per the repo's DOM-coupled-guard convention — this asserts the
+reset is present in openPanel, beside the existing _editingId reset.
+"""
+import re
+from pathlib import Path
+
+SRC = Path("static/js/notes.js").read_text(encoding="utf-8")
+
+
+def _open_panel_body():
+    start = SRC.index("export function openPanel()")
+    rest = SRC[start + len("export function openPanel()"):]
+    m = re.search(r"\n(?:export\s+)?(?:async\s+)?function ", rest)
+    return rest[: m.start()] if m else rest
+
+
+def test_open_panel_resets_search_query():
+    body = _open_panel_body()
+    assert "_searchQuery = ''" in body, body[:400]
+    # reset must sit with the other open-time state resets, before render
+    assert body.index("_searchQuery = ''") < body.index("_renderNotes") if "_renderNotes" in body else True
+
+
+def test_module_still_declares_search_query():
+    assert "let _searchQuery = ''" in SRC


### PR DESCRIPTION
## Summary

The Notes panel kept filtering by a stale search query after close/reopen: `closePanel` removes the search input DOM, `openPanel` rebuilds an empty one and resets `_editingId` but never `_searchQuery` (`static/js/notes.js:25`, set at :1212, read by the filter at :1705). So the rebuilt empty search box and the still-applied filter desync, silently hiding non-matching notes. Fix: reset `_searchQuery = ''` in `openPanel` beside the existing `_editingId` reset. One line.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2919

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and open PRs — this is not a duplicate. (Filed #2919 first.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated changes.
- [] I actually ran the app end-to-end. _(Honest note: notes.js is a browser ES module with a heavy import chain; per the repo's DOM-coupled-guard convention this is source-asserted + `node --check`. Manual repro below.)_

## How to Test

```
node --check static/js/notes.js
DATABASE_URL=sqlite:////tmp/x.db .venv/bin/python -m pytest tests/test_notes_search_reset_on_reopen_js.py -q
```

Manual: open Notes → search `groceries` → close → reopen ⇒ before, search box empty but list still filtered (notes hidden); after, all notes show. 2 source-assertion tests pin the reset is in `openPanel`; `node --check` passes.

## Visual / UI changes
N/A — fixes a stale-state desync; the search box and list behave as before, just consistently.
