### PR TITLE
fix(security): add double-checked locking to singleton initializers

### DIFF
--- a/notes/Agent.md
+++ b/notes/Agent.md
@@ -1,0 +1,36 @@
+# Agentic Mode
+
+Odysseus has a built-in Agent mode that gives the model access to tools like `read_file`, `write_file`, `bash`, web search, and more. The challenge with local models is that tool-use support has to be explicitly enabled.
+
+## Why local models often don't work in agent mode
+
+By default, Odysseus assumes local models **don't support native function calling** (`src/agent_loop.py:1539-1549`). Specifically:
+
+- Ollama native endpoints (`/api/chat`) are treated as text-only by default, even for capable models, because of a known issue where they emit one tool token then stop (issue #1567).
+- Ollama's OpenAI-compat path (`/v1/chat/completions`) is also text-only by default.
+
+## How to enable it
+
+1. Go to **Settings → Model Endpoints** in the Odysseus UI.
+2. Find your local model endpoint (Ollama, LM Studio, vLLM, etc.).
+3. Toggle **"Supports Tools"** to **ON** for that endpoint.
+
+This sets `supports_tools = True` in the database, which overrides all default heuristics and forces native function calling on.
+
+## Using Agent mode
+
+- In the chat UI, switch the mode selector from **Chat** to **Agent**.
+- Set a **Workspace** folder path — this confines `read_file` / `write_file` / `bash` to that directory and tells the model "this folder IS the project, start exploring it."
+
+## Local models known to work well
+
+The following models are explicitly recognized as tool-capable in `src/agent_loop.py:1511-1523`:
+
+- `qwen2.5`, `qwen3`
+- `llama-3.1`, `llama-3.2`, `llama-3.3`, `llama-4`
+- `mistral`, `mixtral`
+- `gemma` (via API path)
+- `hermes` variants
+- `phi-3`, `phi-4`
+
+For best results, serve your model via **vLLM with `--enable-auto-tool-choice`**, or use Ollama's OpenAI-compat endpoint (`/v1/`) and enable the "Supports Tools" toggle in endpoint settings.

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -222,15 +222,18 @@ def _clear_host_dead(url: str) -> None:
 # 100-500ms TCP+TLS handshake. Lazy init so we bind to the running event loop.
 _http_client: Optional[httpx.AsyncClient] = None
 _http_limits = httpx.Limits(max_connections=100, max_keepalive_connections=30, keepalive_expiry=30.0)
+_http_client_lock = threading.Lock()
 
 def _get_http_client() -> httpx.AsyncClient:
     """Return process-wide AsyncClient. Per-request timeout is passed at call time."""
     global _http_client
     if _http_client is None or _http_client.is_closed:
-        from src.tls_overrides import llm_verify
-        _http_client = httpx.AsyncClient(
-            limits=_http_limits, http2=False, verify=llm_verify(),
-        )
+        with _http_client_lock:
+            if _http_client is None or _http_client.is_closed:
+                from src.tls_overrides import llm_verify
+                _http_client = httpx.AsyncClient(
+                    limits=_http_limits, http2=False, verify=llm_verify(),
+                )
     return _http_client
 
 def _get_cached_response(cache_key: str) -> Optional[str]:

--- a/src/secret_storage.py
+++ b/src/secret_storage.py
@@ -20,6 +20,7 @@ single migration pass rewrites them.
 
 import os
 import logging
+import threading
 from pathlib import Path
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 _KEY_PATH = Path(__file__).resolve().parent.parent / "data" / ".app_key"
 _PREFIX = "enc:"
 _fernet: Fernet | None = None
+_fernet_lock = threading.Lock()
 
 
 def _load_or_create_key() -> bytes:
@@ -49,7 +51,9 @@ def _load_or_create_key() -> bytes:
 def _get_fernet() -> Fernet:
     global _fernet
     if _fernet is None:
-        _fernet = Fernet(_load_or_create_key())
+        with _fernet_lock:
+            if _fernet is None:
+                _fernet = Fernet(_load_or_create_key())
     return _fernet
 
 


### PR DESCRIPTION
## Summary

- `_get_fernet()` in `src/secret_storage.py` had a TOCTOU race: two concurrent requests could both see `_fernet is None`, both call `Fernet.generate_key()`, and the second write would silently overwrite the first key — permanently invalidating any secrets encrypted with the original key
- `_get_http_client()` in `src/llm_core.py` had the same pattern: concurrent threads could both see `is_closed=True` and race to create a new client, leaking the old one
- Also adds `notes/Agent.md` documenting how to enable and use agentic mode with local models

## Fix

Both functions now use double-checked locking with `threading.Lock` — fast path reads without the lock, slow path (initialization) holds the lock and re-checks before writing.

## Test plan

- [ ] Verify encrypted secrets (IMAP/SMTP passwords) still decrypt correctly after restart
- [ ] Confirm no regressions in LLM request handling under concurrent load
- [ ] Check `notes/Agent.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)