### PR TITLE
fix(llm): guard against null arguments in streaming tool-call accumulator

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1690,7 +1690,12 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
                                             if func.get("name"):
                                                 _tc_acc[idx]["name"] = func["name"]
                                             if "arguments" in func:
-                                                _tc_acc[idx]["arguments"] += func["arguments"]
+                                                # Guard against a null arguments delta: `func` can be
+                                                # {"arguments": None} (JSON null), and a raw `+= None`
+                                                # raises TypeError that the broad except swallows,
+                                                # silently dropping the rest of the chunk. Matches the
+                                                # Anthropic accumulator (`partial = ... or ""`) above.
+                                                _tc_acc[idx]["arguments"] += func["arguments"] or ""
                                                 # Stream tool arg deltas for doc tools
                                                 if func["arguments"] and _tc_acc[idx].get("name") in ("create_document", "update_document", "edit_document"):
                                                     yield f'data: {json.dumps({"type": "tool_call_delta", "index": idx, "name": _tc_acc[idx]["name"], "arg_delta": func["arguments"]})}\n\n'

--- a/tests/test_llm_core_streaming.py
+++ b/tests/test_llm_core_streaming.py
@@ -149,3 +149,23 @@ def test_sparse_integer_indices_then_null_do_not_collide(monkeypatch):
     events = _drive(monkeypatch, lines)
     calls = next(e["calls"] for e in events if e.get("type") == "tool_calls")
     assert sorted(c["name"] for c in calls) == ["f0", "f2", "fn"], f"collision: {calls}"
+
+
+def test_null_arguments_delta_does_not_drop_sibling_calls(monkeypatch):
+    # A gateway can emit a tool_call delta whose `arguments` is JSON null. The
+    # accumulator did `"" += None`, raising TypeError caught by the broad except
+    # that wraps the whole chunk — so it abandoned the rest of the tool_calls
+    # loop, silently dropping every LATER call in the same delta. Here the first
+    # call has arguments: null; the second (same delta) must still survive.
+    lines = [
+        _sse({"tool_calls": [
+            {"index": 0, "id": "a", "type": "function",
+             "function": {"name": "first", "arguments": None}},
+            {"index": 1, "id": "b", "type": "function",
+             "function": {"name": "second", "arguments": "{}"}},
+        ]}),
+        "data: [DONE]",
+    ]
+    events = _drive(monkeypatch, lines, model="gpt-4o-test")
+    calls = next(e["calls"] for e in events if e.get("type") == "tool_calls")
+    assert sorted(c["name"] for c in calls) == ["first", "second"], calls


### PR DESCRIPTION
## Summary

In the OpenAI-compatible streaming tool-call accumulator (`src/llm_core.py`), `_tc_acc[idx]["arguments"] += func["arguments"]` had no None-guard. Since `j = json.loads(data)`, a JSON `null` decodes to Python `None`, so a delta with `{"function": {"arguments": null}}` runs `"" += None` → `TypeError`. That's caught by the broad `except Exception` wrapping the whole chunk, which `continue`s — **abandoning the rest of the `tool_calls` loop and silently dropping every later call in the same delta.**

Fix: `+= func["arguments"] or ""` — matching the parallel **Anthropic** accumulator a few lines up (`partial = delta.get("partial_json") or ""`) and the file-wide `arguments ... or {}` / `or '{}'` pattern. Line 1693 was the sole raw `+=`.

Honest scope note: I couldn't name a configured provider that emits literal `arguments: null` on a delta (OpenAI sends `""`), so this is primarily a defensive-consistency fix — but a gateway/proxy that does emit it currently drops sibling tool calls, and the rest of the file already guards this exact shape.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2922

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated changes.
- [ ] I actually ran the app end-to-end. _(Pure streaming-accumulator logic; covered by a behavioral regression test that drives stream_llm with canned SSE — see below.)_

## How to Test

```
DATABASE_URL=sqlite:////tmp/x.db .venv/bin/python -m pytest tests/test_llm_core_streaming.py -q
```

Added `test_null_arguments_delta_does_not_drop_sibling_calls`: a single delta with two tool calls where the first has `arguments: null` — the second must still survive. It **fails without the fix** (only the first call survives; the `+= None` crash drops the loop) and passes with it. Full streaming suite green (5 tests).

## Visual / UI changes
N/A — backend streaming accumulator only.
