### PR TITLE
fix(tool-parsing): don't ship unconvertible <invoke> fence content to the code executor

### DIFF
--- a/src/tool_parsing.py
+++ b/src/tool_parsing.py
@@ -354,14 +354,15 @@ def parse_tool_blocks(text: str) -> List[ToolBlock]:
         # If a code block's content is an <invoke> XML call (some models wrap
         # tool calls in ```python or ```xml fences), parse the invoke instead.
         if '<invoke' in content:
-            invoked = False
             for inv in _XML_INVOKE_RE.finditer(content):
                 block = _parse_xml_invoke(inv)
                 if block:
                     blocks.append(block)
-                    invoked = True
-            if invoked:
-                continue
+            # This fenced block is <invoke> markup, not literal code. Whether or
+            # not any call converted, never fall through to append the raw XML as
+            # a python/bash block — e.g. a hyphenated/namespaced tool name that
+            # _XML_INVOKE_RE's \w+ can't match would otherwise be executed as code.
+            continue
         blocks.append(ToolBlock(tag, content))
 
     # Pattern 2: [TOOL_CALL] blocks (only if no fenced blocks found)

--- a/tests/test_fenced_invoke_no_raw_xml.py
+++ b/tests/test_fenced_invoke_no_raw_xml.py
@@ -1,0 +1,36 @@
+"""Issue #2925 — a fenced ```python/```bash block wrapping an <invoke> call that
+can't be converted (e.g. a hyphenated/namespaced tool name that _XML_INVOKE_RE's
+\\w+ won't match, or an unknown tool) must NOT fall through and ship the raw XML
+to the code executor as if it were python/bash.
+"""
+import sys
+from unittest.mock import MagicMock
+
+for mod in ['src.agent_tools', 'src.tool_parsing', 'src.tool_schemas', 'src.tool_execution']:
+    sys.modules.pop(mod, None)
+for mod in [
+    'sqlalchemy', 'sqlalchemy.orm', 'sqlalchemy.ext', 'sqlalchemy.ext.declarative',
+    'sqlalchemy.ext.hybrid', 'sqlalchemy.sql', 'sqlalchemy.sql.expression',
+    'src.database', 'core.models', 'core.database', 'core.auth'
+]:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+import src.agent_tools  # noqa: E402, F401
+from src.tool_parsing import parse_tool_blocks  # noqa: E402
+
+
+def test_unconvertible_invoke_in_fence_is_not_executed_as_code():
+    text = '```python\n<invoke name="foo-bar">\n<parameter name="x">1</parameter>\n</invoke>\n```'
+    blocks = parse_tool_blocks(text)
+    # the hyphenated name can't match _XML_INVOKE_RE, so nothing converts —
+    # the raw XML must not be appended as a python/bash code block.
+    assert not any(
+        b.tool_type in ("python", "bash") and "<invoke" in b.content for b in blocks
+    ), blocks
+
+
+def test_plain_fenced_python_block_still_parses_as_code():
+    # No regression: an ordinary fenced python block (no <invoke>) still works.
+    blocks = parse_tool_blocks('```python\nprint("hi")\n```')
+    assert any(b.tool_type == "python" and 'print("hi")' in b.content for b in blocks), blocks


### PR DESCRIPTION
## Summary

In `parse_tool_blocks` (`src/tool_parsing.py`), a fenced ```python / ```bash block whose content contains `<invoke` is treated as wrapped tool-call markup, but it only `continue`s if a call **converts**. When none converts, it fell through to `blocks.append(ToolBlock(tag, content))` — shipping the **raw `<invoke ...>` XML to the code executor as python/bash**. This happens for a hyphenated/namespaced tool name (`_XML_INVOKE_RE`'s `\w+` can't match `foo-bar`) or an unknown tool (`_parse_xml_invoke` returns None).

Fix: when the content contains `<invoke`, always `continue` after attempting conversion — never fall through to execute the raw XML as code. ~1 line.

Honest scope: uncommon trigger and the impact is garbled execution / confusing tool errors rather than data loss — but executing raw XML as code is clearly wrong, and the guard is trivial.

## Target branch
- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2925

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and open PRs — this is not a duplicate. (Filed #2925 first.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated changes.
- [ ] I actually ran the app end-to-end. _(Pure parser logic; covered by a behavioral test calling parse_tool_blocks directly — see below.)_

## How to Test

```
DATABASE_URL=sqlite:////tmp/x.db .venv/bin/python -m pytest tests/test_fenced_invoke_no_raw_xml.py -q
```

Added `test_unconvertible_invoke_in_fence_is_not_executed_as_code` (a ```python fence with `<invoke name="foo-bar">` must not yield a python/bash block carrying raw XML) — it **fails without the fix** and passes with it — plus a no-regression test that an ordinary fenced python block still parses as code.

## Visual / UI changes
N/A — tool-call parser only.
