### PR TITLE
refactor(tests): add temp sqlite helper

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -72,6 +72,16 @@ Use only for the guarded fake/stub `src.endpoint_resolver` cleanup pattern.
   cached against them.
 - Accepts explicit extra dependent module names to evict alongside the defaults.
 
+### `tests.helpers.sqlite_db.make_temp_sqlite`
+
+Use for the repeated file-backed temp sqlite setup in tests.
+
+- Only constructs `(SessionLocal, engine, tmpfile)` from the repeated block.
+- Does not patch modules and does not clean up the temp file.
+- The caller must bind `SessionLocal` explicitly onto whatever module the code
+  under test reads, and must keep the returned objects alive.
+- Do not use it as a general DB fixture framework.
+
 ## What not to abstract yet
 
 Some remaining patterns should stay as-is for now rather than being forced into

--- a/tests/helpers/sqlite_db.py
+++ b/tests/helpers/sqlite_db.py
@@ -1,0 +1,29 @@
+"""Construct a file-backed temp sqlite DB for tests.
+
+Only builds the SQLAlchemy objects from the repeated temp-sqlite block. It
+does not patch modules, manage cleanup, or own any global state — the caller
+keeps the returned objects alive and binds ``SessionLocal`` where needed.
+"""
+import tempfile
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+
+def make_temp_sqlite(metadata):
+    """Build a file-backed temp sqlite database and create its tables.
+
+    Returns ``(SessionLocal, engine, tmpfile)``. The caller must keep these
+    references alive (temp file and engine GC are the caller's concern) and
+    bind ``SessionLocal`` onto whatever module the code under test reads.
+    """
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    engine = create_engine(
+        f"sqlite:///{tmpfile.name}",
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    return SessionLocal, engine, tmpfile

--- a/tests/test_calendar_rrule.py
+++ b/tests/test_calendar_rrule.py
@@ -7,29 +7,19 @@ calling do_manage_calendar with an rrule stores a single event carrying that RRU
 
 import json
 import sys
-import tempfile
 import uuid
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 
 from tests.helpers.import_state import clear_fake_database_modules
+from tests.helpers.sqlite_db import make_temp_sqlite
 
 clear_fake_database_modules()
 
 import core.database as cdb
 from core.database import CalendarEvent
 
-_TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
-_ENGINE = create_engine(
-    f"sqlite:///{_TMPDB.name}",
-    connect_args={"check_same_thread": False},
-    poolclass=NullPool,
-)
-cdb.Base.metadata.create_all(_ENGINE)
-_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+_TS, _ENGINE, _TMPDB = make_temp_sqlite(cdb.Base.metadata)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_calendar_update_event_tz.py
+++ b/tests/test_calendar_update_event_tz.py
@@ -9,25 +9,15 @@ Tokyo user) and left is_utc inconsistent. The do_manage_notes update path
 was already fixed for the analogous issue.
 """
 import json
-import tempfile
 import uuid
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 
 import core.database as cdb
 from core.database import CalendarEvent
+from tests.helpers.sqlite_db import make_temp_sqlite
 
-_TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
-_ENGINE = create_engine(
-    f"sqlite:///{_TMPDB.name}",
-    connect_args={"check_same_thread": False},
-    poolclass=NullPool,
-)
-cdb.Base.metadata.create_all(_ENGINE)
-_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+_TS, _ENGINE, _TMPDB = make_temp_sqlite(cdb.Base.metadata)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_replace_messages_multimodal.py
+++ b/tests/test_replace_messages_multimodal.py
@@ -10,26 +10,16 @@ back as a corrupted string blob - the attachment was destroyed. The
 sibling _persist_message json.dumps-es list content; replace_messages did
 not.
 """
-import tempfile
 import uuid
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 
 import core.database as cdb
 from core.database import Session as DbSession
 from core.models import ChatMessage
+from tests.helpers.sqlite_db import make_temp_sqlite
 
-_TMPDB = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
-_ENGINE = create_engine(
-    f"sqlite:///{_TMPDB.name}",
-    connect_args={"check_same_thread": False},
-    poolclass=NullPool,
-)
-cdb.Base.metadata.create_all(_ENGINE)
-_TS = sessionmaker(bind=_ENGINE, autoflush=False, autocommit=False)
+_TS, _ENGINE, _TMPDB = make_temp_sqlite(cdb.Base.metadata)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Part of #2523.

Adds a small test helper for the repeated file-backed temp sqlite construction pattern:

```python
tests.helpers.sqlite_db.make_temp_sqlite(metadata)
```

The helper only constructs and returns:

```python
(SessionLocal, engine, tmpfile)
```

It does not patch modules, bind `SessionLocal`, manage cleanup, or own global state.

Migrated the first low-risk proving slice:

- `tests/test_calendar_rrule.py`
- `tests/test_calendar_update_event_tz.py`
- `tests/test_replace_messages_multimodal.py`

Each migrated file now keeps the same module-level lifetime bindings:

```python
_TS, _ENGINE, _TMPDB = make_temp_sqlite(cdb.Base.metadata)
```

The file-specific binding fixtures and assertions are unchanged.

Also updates `tests/README.md` to document the new helper.

No production code is changed.

## Target branch

`dev`

## Linked Issue

Part of #2523.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is part of #2523.
- [x] This PR targets `dev`.
- [x] Scope is limited to the temp-sqlite construction helper proving slice.
- [x] I did not modify production code.
- [x] I did not modify `tests/conftest.py`.
- [x] I did not move files.
- [x] I did not rewrite assertions.
- [x] I did not alter DB binding fixtures beyond replacing construction.
- [x] I did not add dependencies.
- [x] I updated `tests/README.md`.
- [x] I validated the migrated files.
- [x] I validated a neighboring DB/import-sensitive group.
- [x] I validated in a fresh audit worktree.

## How to Test

Check whitespace / conflict markers:

```bash
git diff --check
```

Validated locally:

```text
passed
```

Compile changed Python files:

```bash
python3 -m py_compile \
  tests/helpers/sqlite_db.py \
  tests/test_calendar_rrule.py \
  tests/test_calendar_update_event_tz.py \
  tests/test_replace_messages_multimodal.py
```

Validated locally:

```text
py_compile passed
```

Run migrated tests:

```bash
python3 -m pytest -q \
  tests/test_calendar_rrule.py \
  tests/test_calendar_update_event_tz.py \
  tests/test_replace_messages_multimodal.py
```

Validated locally:

```text
5 passed, 1 warning
```

Run neighboring DB/import-sensitive group:

```bash
python3 -m pytest -q \
  tests/test_calendar_rrule.py \
  tests/test_calendar_update_event_tz.py \
  tests/test_replace_messages_multimodal.py \
  tests/test_document_close_clears_active_route.py \
  tests/test_task_scheduler_session_delivery.py
```

Validated locally:

```text
9 passed, 1 warning
```

Run reverse-order migrated tests:

```bash
python3 -m pytest -q \
  tests/test_replace_messages_multimodal.py \
  tests/test_calendar_update_event_tz.py \
  tests/test_calendar_rrule.py
```

Validated locally:

```text
5 passed, 1 warning
```

Fresh audit worktree validation:

A fresh audit worktree was created from `upstream/dev`, this patch was applied, and the same validation was repeated.

Validated in the fresh audit worktree:

```text
5 passed, 1 warning
9 passed, 1 warning
5 passed, 1 warning
after: data exists=False is_dir=False
```

Check old local temp-sqlite construction is gone from migrated files:

```bash
grep -RInE '_TMPDB = tempfile\.NamedTemporaryFile|create_engine\(|sessionmaker\(|poolclass=NullPool' \
  tests/test_calendar_rrule.py \
  tests/test_calendar_update_event_tz.py \
  tests/test_replace_messages_multimodal.py
```

Validated locally:

```text
no matches
```

Check new helper usage exists:

```bash
grep -RIn 'make_temp_sqlite' \
  tests/helpers/sqlite_db.py \
  tests/README.md \
  tests/test_calendar_rrule.py \
  tests/test_calendar_update_event_tz.py \
  tests/test_replace_messages_multimodal.py
```

Validated locally:

```text
helper definition, README entry, and all three migrated call sites found
```

Confirm remaining deferred temp-sqlite users still exist for follow-up slices:

```bash
git grep -nE '_TMPDB = tempfile.NamedTemporaryFile|poolclass=NullPool' -- tests \
  | grep -v 'test_calendar_rrule.py' \
  | grep -v 'test_calendar_update_event_tz.py' \
  | grep -v 'test_replace_messages_multimodal.py' \
  || true
```

Validated locally:

```text
remaining deferred users found in archived/caldav/document/gallery follow-up candidates
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable. Test-only refactor plus README update; no UI, route, template, frontend, or rendered output changed.

## Screenshots / clips

Not applicable.

## Notes

This is the proving slice for the temp-sqlite helper. It intentionally migrates only the first three low-risk users.

Deferred follow-up groups should stay separate:

- caldav temp-sqlite group;
- route-test temp-sqlite group;
- near-variant inline temp-sqlite helpers.
