### PR TITLE
fix: Add WSL paths to hardware detection fallback for remote hosts

### DIFF
--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -82,14 +82,14 @@ def _detect_nvidia():
     # Retry through a login shell with the common CUDA bin dirs on PATH.
     if not out and _remote_host:
         out = _run(
-            "bash -lc 'export PATH=\"$PATH:/usr/bin:/usr/local/bin:/usr/local/cuda/bin\"; "
+            "bash -lc 'export PATH=\"$PATH:/usr/bin:/usr/local/bin:/usr/local/cuda/bin:/usr/lib/wsl/lib\"; "
             "nvidia-smi --query-gpu=memory.total,name --format=csv,noheader,nounits'"
         )
     # Last resort: call nvidia-smi by absolute path. Some hosts have a login
     # shell that isn't bash (or a profile that errors), so the bash -lc retry
     # above still comes back empty even though the binary is right there.
     if not out and _remote_host:
-        for _p in ("/usr/bin/nvidia-smi", "/usr/local/bin/nvidia-smi", "/usr/local/cuda/bin/nvidia-smi"):
+        for _p in ("/usr/bin/nvidia-smi", "/usr/local/bin/nvidia-smi", "/usr/local/cuda/bin/nvidia-smi", "/usr/lib/wsl/lib/nvidia-smi"):
             out = _run(f"{_p} --query-gpu=memory.total,name --format=csv,noheader,nounits")
             if out:
                 break


### PR DESCRIPTION
## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->
This PR extends the fallbacks used to locate `nvidia-smi` on remote hosts when running `services/hwfit/hardware.py` by adding the path `"/usr/lib/wsl/lib/nvidia-smi"`. This path seems to be the default location of the executable for WSL-environments (at the very least, it was for mine.)
With this addition, remote servers running in WSL environments should be able to correctly identify their GPU hardware.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #2932

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Follow steps to reproduce in https://github.com/pewdiepie-archdaemon/odysseus/issues/2932 with `main` branch
2. Switch to PR branch & rebuild odysseus
3. Open cookbook and rescan hardware - GPU should be detected now

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
See https://github.com/pewdiepie-archdaemon/odysseus/issues/2932 for screenshots before & after