### PR TITLE
fix(auth): distinguish empty model allowlists

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -30,10 +30,12 @@ DEFAULT_PRIVILEGES = {
     "can_manage_memory": True,
     "max_messages_per_day": 0,
     "allowed_models": [],
+    "allowed_models_restricted": False,
 }
 
 # Admins get everything
 ADMIN_PRIVILEGES = {k: (True if isinstance(v, bool) else (0 if isinstance(v, int) else [])) for k, v in DEFAULT_PRIVILEGES.items()}
+ADMIN_PRIVILEGES["allowed_models_restricted"] = False
 
 DEFAULT_AUTH_PATH = os.path.join(
     Path(__file__).parent.parent, "data", "auth.json"

--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -75,7 +75,7 @@ def _enforce_chat_privileges(request, sess) -> None:
     allowlist, or HTTPException(429) if the user has hit their daily message
     cap. No-op for unauthenticated callers or when auth_manager is absent
     (single-user mode). Admins receive ADMIN_PRIVILEGES from get_privileges,
-    which means empty allowed_models / zero cap → no-op for them.
+    which means unrestricted allowed_models / zero cap -> no-op for them.
     """
     try:
         user = get_current_user(request)
@@ -88,8 +88,10 @@ def _enforce_chat_privileges(request, sess) -> None:
         return
 
     privs = auth_manager.get_privileges(user) or {}
-    allowed = privs.get("allowed_models") or []
-    if allowed and sess.model and sess.model not in allowed:
+    allowed_raw = privs.get("allowed_models")
+    allowed = allowed_raw if isinstance(allowed_raw, list) else []
+    restricted = bool(privs.get("allowed_models_restricted")) or bool(allowed)
+    if restricted and sess.model and sess.model not in allowed:
         raise HTTPException(403, f"Your account is not allowed to use model '{sess.model}'.")
 
     cap = int(privs.get("max_messages_per_day") or 0)

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -87,8 +87,11 @@ async function loadUsers() {
           <input type="number" min="0" value="${maxMsg}" data-priv="max_messages_per_day" data-user="${esc(u.username)}" style="width:70px;padding:4px 6px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--fg);font-size:12px;text-align:center;">
         </div>`;
         // Allowed models — checkbox list
-        const allowedSet = new Set((u.privileges && u.privileges.allowed_models) || []);
-        const allEmpty = allowedSet.size === 0;
+        const allowedModels = Array.isArray(u.privileges && u.privileges.allowed_models)
+          ? u.privileges.allowed_models
+          : [];
+        const allowedSet = new Set(allowedModels);
+        const modelsRestricted = !!(u.privileges && u.privileges.allowed_models_restricted);
         html += `<div style="padding:4px 0;">
           <div style="display:flex;align-items:center;justify-content:space-between;">
             <span style="font-size:12px;">Allowed models</span>
@@ -97,7 +100,7 @@ async function loadUsers() {
               <a href="#" class="priv-models-none" data-user="${esc(u.username)}" style="font-size:10px;opacity:0.5;">None</a>
             </div>
           </div>
-          <div style="font-size:10px;opacity:0.4;margin-bottom:4px;">${allEmpty ? 'All models allowed (no restrictions)' : allowedSet.size + ' model(s) allowed'}</div>
+          <div style="font-size:10px;opacity:0.4;margin-bottom:4px;">${!modelsRestricted ? 'All models allowed (no restrictions)' : (allowedSet.size === 0 ? 'No models allowed' : allowedSet.size + ' model(s) allowed')}</div>
           <div class="priv-models-list" data-user="${esc(u.username)}">
             <span style="opacity:0.4;font-size:11px;">Loading models...</span>
           </div>
@@ -119,7 +122,7 @@ async function loadUsers() {
           // Load models list on first expand
           if (!_modelsLoaded && !privPanel.classList.contains('hidden')) {
             _modelsLoaded = true;
-            _loadModelsForUser(u.username, allowedSet, privPanel);
+            _loadModelsForUser(u.username, allowedSet, modelsRestricted, privPanel);
           }
         });
 
@@ -199,7 +202,7 @@ async function loadUsers() {
   } catch (e) { list.innerHTML = '<div class="admin-error">Failed to load users</div>'; }
 }
 
-async function _loadModelsForUser(username, allowedSet, privPanel) {
+async function _loadModelsForUser(username, allowedSet, modelsRestricted, privPanel) {
   const listEl = privPanel.querySelector(`.priv-models-list[data-user="${username}"]`);
   if (!listEl) return;
   try {
@@ -216,9 +219,9 @@ async function _loadModelsForUser(username, allowedSet, privPanel) {
       listEl.innerHTML = '<span style="opacity:0.4;font-size:11px;">No models available</span>';
       return;
     }
-    const allEmpty = allowedSet.size === 0;
+    let restricted = modelsRestricted;
     listEl.innerHTML = sortModelObjects(allModels).map(m => {
-      const checked = allEmpty || allowedSet.has(m.mid) ? 'checked' : '';
+      const checked = !restricted || allowedSet.has(m.mid) ? 'checked' : '';
       return `<label>
         <input type="checkbox" class="priv-model-cb" data-mid="${esc(m.mid)}" ${checked}>
         <span>${esc(m.display)}</span>
@@ -232,14 +235,15 @@ async function _loadModelsForUser(username, allowedSet, privPanel) {
       listEl.querySelectorAll('.priv-model-cb').forEach(cb => {
         if (cb.checked) checked.push(cb.dataset.mid);
       });
-      // If all are checked, send empty array (= no restrictions)
-      const value = checked.length === allModels.length ? [] : checked;
+      // All checked means unrestricted; zero checked means explicitly no models.
+      restricted = checked.length !== allModels.length;
+      const value = restricted ? checked : [];
       const hint = privPanel.querySelector('.priv-models-list[data-user]')?.previousElementSibling?.querySelector('div[style*="opacity"]');
-      if (hint) hint.textContent = value.length === 0 ? 'All models allowed (no restrictions)' : value.length + ' model(s) allowed';
+      if (hint) hint.textContent = !restricted ? 'All models allowed (no restrictions)' : (value.length === 0 ? 'No models allowed' : value.length + ' model(s) allowed');
       fetch(`/api/auth/users/${encodeURIComponent(username)}/privileges`, {
         method: 'PUT', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ allowed_models: value }),
+        body: JSON.stringify({ allowed_models: value, allowed_models_restricted: restricted }),
       }).catch(() => {});
     }
     listEl.querySelectorAll('.priv-model-cb').forEach(cb => cb.addEventListener('change', _saveModels));

--- a/tests/test_chat_helpers.py
+++ b/tests/test_chat_helpers.py
@@ -1,5 +1,67 @@
 import pytest
-from routes.chat_helpers import clean_thinking_for_save, needs_auto_name
+from fastapi import HTTPException
+
+from routes.chat_helpers import _enforce_chat_privileges, clean_thinking_for_save, needs_auto_name
+
+
+class _AuthManager:
+    def __init__(self, privileges):
+        self._privileges = privileges
+
+    def get_privileges(self, username):
+        assert username == "alice"
+        return self._privileges
+
+
+class _Request:
+    def __init__(self, privileges):
+        self.app = type("App", (), {})()
+        self.app.state = type("State", (), {"auth_manager": _AuthManager(privileges)})()
+
+
+class _Session:
+    def __init__(self, model):
+        self.model = model
+
+
+def test_allowed_models_legacy_empty_list_remains_unrestricted(monkeypatch):
+    monkeypatch.setattr("routes.chat_helpers.get_current_user", lambda request: "alice")
+
+    _enforce_chat_privileges(
+        _Request({"allowed_models": [], "max_messages_per_day": 0}),
+        _Session("provider/model-a"),
+    )
+
+
+def test_allowed_models_explicit_empty_restricted_list_blocks_all_models(monkeypatch):
+    monkeypatch.setattr("routes.chat_helpers.get_current_user", lambda request: "alice")
+
+    with pytest.raises(HTTPException) as exc:
+        _enforce_chat_privileges(
+            _Request({
+                "allowed_models": [],
+                "allowed_models_restricted": True,
+                "max_messages_per_day": 0,
+            }),
+            _Session("provider/model-a"),
+        )
+
+    assert exc.value.status_code == 403
+    assert "provider/model-a" in exc.value.detail
+
+
+def test_allowed_models_nonempty_list_still_restricts_without_new_flag(monkeypatch):
+    monkeypatch.setattr("routes.chat_helpers.get_current_user", lambda request: "alice")
+
+    _enforce_chat_privileges(
+        _Request({"allowed_models": ["provider/model-a"], "max_messages_per_day": 0}),
+        _Session("provider/model-a"),
+    )
+    with pytest.raises(HTTPException):
+        _enforce_chat_privileges(
+            _Request({"allowed_models": ["provider/model-a"], "max_messages_per_day": 0}),
+            _Session("provider/model-b"),
+        )
 
 
 @pytest.mark.parametrize("name,expected", [


### PR DESCRIPTION
## Summary

Distinguishes unrestricted model access from an explicitly empty allowed-model list so admins can set a user to no allowed models without that state being interpreted as all models allowed. The admin UI now saves an `allowed_models_restricted` flag, while legacy empty allowlists remain unrestricted for existing users.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2934

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. As an admin, create or open a non-admin user with at least one configured model endpoint.
2. In Settings -> Admin -> Users, expand that user, click `None` under Allowed models, then reload the page.
3. Confirm the user still shows no models allowed and cannot send chat requests with any model; selecting `All` should restore unrestricted access.

Verified locally:
- `venv/bin/python -m pytest -q tests/test_chat_helpers.py` (21 passed)
- `venv/bin/python -m py_compile core/auth.py routes/chat_helpers.py tests/test_chat_helpers.py`
- `node --check static/js/admin.js`
- `git diff --check`
- `venv/bin/python -m uvicorn app:app --host 127.0.0.1 --port 7000`, then fetched `/` and `/static/js/admin.js` from the running app

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

No screenshot attached: this only changes the existing Allowed models state text/save payload (`No models allowed` vs unrestricted), with no new layout/component/styling. I did run the app and verified the changed admin JS was served by the live uvicorn process.