### PR TITLE
fix: resolve copy/edit/run buttons flickering during markdown text streaming

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3824,12 +3824,39 @@ body.bg-pattern-sparkles {
     pre.pre-compact .edit-code.bottom,
     pre.pre-compact .run-code.bottom { top: auto; bottom: 3px; }
 
-    /* Touch devices: no hover, so always show copy/run/edit buttons */
-    @media (hover: none) {
-      pre .copy-code { opacity:0.7; }
-      pre .edit-code { opacity:0.7; }
-      pre .run-code { opacity:0.7; }
+ /* ============================================================
+   FIX: Prevent copy/edit/run buttons from flickering apna work 
+   ============================================================ */
+
+/* 1. Desktop standard state: hide buttons safely without breaking DOM layout */
+pre .copy-code, 
+pre .edit-code, 
+pre .run-code {
+    opacity: 0 !important;
+    visibility: hidden !important;
+    pointer-events: none;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+}
+
+/* 2. Desktop hover state: show smoothly when mouse enters the pre block */
+pre:hover .copy-code, 
+pre:hover .edit-code, 
+pre:hover .run-code {
+    opacity: 1 !important;
+    visibility: visible !important;
+    pointer-events: auto;
+}
+
+/* 3. Touch devices: retain original behavior (always visible) */
+@media (hover: none) {
+    pre .copy-code, 
+    pre .edit-code, 
+    pre .run-code { 
+        opacity: 0.7 !important; 
+        visibility: visible !important;
+        pointer-events: auto;
     }
+}
 
     /* Code runner output panel */
     .code-runner-output {

--- a/static/style.css
+++ b/static/style.css
@@ -3824,38 +3824,29 @@ body.bg-pattern-sparkles {
     pre.pre-compact .edit-code.bottom,
     pre.pre-compact .run-code.bottom { top: auto; bottom: 3px; }
 
- /* ============================================================
-   FIX: Prevent copy/edit/run buttons from flickering apna work 
-   ============================================================ */
-
-/* 1. Desktop standard state: hide buttons safely without breaking DOM layout */
-pre .copy-code, 
-pre .edit-code, 
-pre .run-code {
-    opacity: 0 !important;
-    visibility: hidden !important;
-    pointer-events: none;
-    transition: opacity 0.15s ease, visibility 0.15s ease;
+/* Touch devices: no hover, so always show copy/run/edit buttons */
+@media (hover: none) {
+    pre .copy-code, pre .edit-code, pre .run-code {
+        opacity: 0.7;
+    }
 }
 
-/* 2. Desktop hover state: show smoothly when mouse enters the pre block */
-pre:hover .copy-code, 
-pre:hover .edit-code, 
-pre:hover .run-code {
-    opacity: 1 !important;
-    visibility: visible !important;
+/* Ensure action buttons don't break layout or flicker during re-renders */
+pre .copy-code, pre .edit-code, pre .run-code {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+pre:hover .copy-code, pre:hover .edit-code, pre:hover .run-code {
+    visibility: visible;
+    opacity: 0.7;
     pointer-events: auto;
 }
 
-/* 3. Touch devices: retain original behavior (always visible) */
-@media (hover: none) {
-    pre .copy-code, 
-    pre .edit-code, 
-    pre .run-code { 
-        opacity: 0.7 !important; 
-        visibility: visible !important;
-        pointer-events: auto;
-    }
+pre .copy-code:hover, pre .edit-code:hover, pre .run-code:hover {
+    opacity: 1;
 }
 
     /* Code runner output panel */


### PR DESCRIPTION
# fix: resolve copy/edit/run buttons flickering during markdown text streaming

## Summary

Fixed a frontend layout-shifting bug where copy, edit, and run buttons would flicker aggressively during dynamic markdown text streaming. This was caused by DOM manipulation destroying the hover target, which has now been stabilized using safe CSS properties (`visibility`, `opacity`, and `pointer-events`).

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2916

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open Odysseus and start any chat session that generates code blocks.
2. Ensure you are on a desktop/laptop browser where hover effects are active.
3. While a response containing code blocks is actively streaming, place your mouse cursor over the bottom-right action buttons (copy, edit, run) inside the code block.
4. Verify that the buttons stay visible and do not flicker or jump layout positions while text continues to output.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips
<img width="1920" height="1160" alt="image" src="https://github.com/user-attachments/assets/a88fec9d-ca35-4a26-a4f6-98c8c3098c26" />
