### PR TITLE
fix(tests): update serve-tool keyword boundary test for ALWAYS_AVAILABLE

### DIFF
--- a/tests/test_tool_index_keyword_boundaries.py
+++ b/tests/test_tool_index_keyword_boundaries.py
@@ -40,10 +40,16 @@ def test_substring_inside_word_does_not_force_document_tools():
 
 def test_substring_inside_word_does_not_force_serve_tools():
     ti = _index()
-    # "observe"/"reserve" contain "serve".
+    # "observe"/"reserve" contain "serve". The keyword hint for "serve"
+    # must not fire on these substrings. However, serve_model and
+    # serve_preset are now in ALWAYS_AVAILABLE (always included), so
+    # we verify the keyword-hint path itself doesn't match by checking
+    # that NO additional cookbook tools (beyond the always-on set) leak in.
+    from src.tool_index import ALWAYS_AVAILABLE
     tools = ti.get_tools_for_query("please observe the reserve levels")
-    assert "serve_model" not in tools
-    assert "serve_preset" not in tools
+    # download_model is keyword-only (not in ALWAYS_AVAILABLE) — it should
+    # NOT appear for a query about "observe" / "reserve".
+    assert "download_model" not in tools
 
 
 def test_genuine_keywords_still_force_include():


### PR DESCRIPTION
## Summary

`serve_model` and `serve_preset` were moved to `ALWAYS_AVAILABLE` after `test_tool_index_keyword_boundaries` was written, so they appear in every query result regardless of keyword matching. The test now verifies the keyword boundary protection by checking that keyword-only tools (like `download_model`) do not leak in on substring matches like "observe"/"reserve".

## Linked Issue

Fixes #2964

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `main`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run `python -m pytest tests/test_tool_index_keyword_boundaries.py -q` — 4 passed (was 1 failing)