### PR TITLE
Phase 1: consolidate tool output constants into src/constants.py

### DIFF
--- a/src/agent_tools.py
+++ b/src/agent_tools.py
@@ -14,16 +14,17 @@ Sub-modules:
 import logging
 from collections import namedtuple
 
+from src.constants import MAX_OUTPUT_CHARS, MAX_READ_CHARS
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants (kept here — sub-modules import from here)
+# Constants (re-exported for backward compatibility — single source of truth
+# is src.constants; always prefer importing from there for new code)
 # ---------------------------------------------------------------------------
 MAX_AGENT_ROUNDS = 20
 SHELL_TIMEOUT = 60
 PYTHON_TIMEOUT = 30
-MAX_OUTPUT_CHARS = 10_000
-MAX_READ_CHARS = 20_000
 
 # Tool types that trigger execution
 TOOL_TAGS = {"bash", "python", "web_search", "web_fetch", "read_file", "write_file", "edit_file",

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,6 +19,12 @@ UPLOAD_DIR = os.path.join(DATA_DIR, "uploads")
 FEATURES_FILE = os.path.join(DATA_DIR, "features.json")
 SETTINGS_FILE = os.path.join(DATA_DIR, "settings.json")
 
+# Agent tool output limits (single source of truth — imported by tool_execution.py,
+# tool_implementations.py, agent_tools.py, and any other module that needs them)
+MAX_OUTPUT_CHARS = 10_000       # cap for bash/python/web_search/web_fetch output
+MAX_READ_CHARS = 20_000         # cap for read_file / document preview
+MAX_DIFF_LINES = 400            # cap for edit_file unified-diff display
+
 # API Configuration
 MAX_CONTEXT_MESSAGES = 90
 REQUEST_TIMEOUT = 20
@@ -28,7 +34,7 @@ OPENAI_COMPAT_PATH = "/v1/chat/completions"
 DEFAULT_HOST = os.getenv("LLM_HOST", "localhost")
 LLM_HOSTS = [h.strip() for h in os.getenv("LLM_HOSTS", "").split(",") if h.strip()]
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-SEARXNG_INSTANCE = os.getenv('SEARXNG_INSTANCE', 'http://localhost:8080')
+SEARXNG_INSTANCE = os.getenv("SEARXNG_INSTANCE", "http://localhost:8080")
 
 
 # Cleanup configuration

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -18,6 +18,7 @@ import time
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_user
+from src.constants import MAX_OUTPUT_CHARS, MAX_READ_CHARS, MAX_DIFF_LINES
 
 # Persistent working directory for agent subprocesses.
 # Resolves to <repo_root>/data, which is the bind-mounted volume in Docker
@@ -25,10 +26,6 @@ from src.tool_security import is_public_blocked_tool, owner_is_admin_or_single_u
 # Using this as cwd and HOME prevents the agent from silently creating files
 # in ephemeral container layers that are lost on the next rebuild.
 _AGENT_WORKDIR = str(pathlib.Path(__file__).parent.parent / "data")
-
-MAX_OUTPUT_CHARS = 10_000
-MAX_READ_CHARS = 20_000
-MAX_DIFF_LINES = 400  # cap unified-diff size returned to the UI
 
 
 def _unified_diff(old: str, new: str, path: str) -> Optional[Dict[str, Any]]:

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -11,8 +11,7 @@ import os
 import re
 from typing import Any, Dict, List, Optional
 
-MAX_OUTPUT_CHARS = 10_000
-MAX_READ_CHARS = 20_000
+from src.constants import MAX_OUTPUT_CHARS, MAX_READ_CHARS
 
 
 def get_mcp_manager():


### PR DESCRIPTION

## Summary

MAX_OUTPUT_CHARS, MAX_READ_CHARS, and MAX_DIFF_LINES are now defined once in src/constants.py and imported by the three files that previously duplicated them (tool_execution.py, tool_implementations.py, agent_tools.py). agent_tools.py re-exports them for backward compatibility.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Closes #2987

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [X] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Check that src/constants.py now defines MAX_OUTPUT_CHARS, MAX_READ_CHARS, and MAX_DIFF_LINES
2. Verify that src/tool_execution.py, src/tool_implementations.py, and src/agent_tools.py import these constants
   from src.constants instead of defining them locally
3. Run python -m pytest tests/test_agent_tools_truncate_nonstring.py — _truncate tests should pass unchanged
4. Start the app and run a bash/web_search tool — outputs truncated at the same 10K limit as before (behaviour
   identical)