### PR TITLE
Require document privilege for personal RAG uploads

### DIFF
--- a/routes/personal_routes.py
+++ b/routes/personal_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, UploadFile, File, 
 from src.request_models import DirectoryRequest
 from core.constants import BASE_DIR, PERSONAL_DIR
 from src.rag_singleton import get_rag_manager
-from src.auth_helpers import get_current_user, require_user
+from src.auth_helpers import require_privilege, require_user
 from core.middleware import require_admin
 from src.upload_handler import secure_filename
 
@@ -194,7 +194,7 @@ def setup_personal_routes(personal_docs_manager, rag_manager, rag_available):
     @router.post("/upload")
     async def upload_files_to_rag(request: Request, files: List[UploadFile] = File(...)):
         """Upload files directly into RAG. Supports text and PDF."""
-        user = get_current_user(request)
+        user = require_privilege(request, "can_use_documents")
         rag = _rag()
         if not rag:
             raise HTTPException(503, "RAG system is not available — is the embedding service running?")

--- a/tests/test_personal_upload_privilege.py
+++ b/tests/test_personal_upload_privilege.py
@@ -1,0 +1,98 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from routes import personal_routes
+
+
+def _upload_endpoint():
+    router = personal_routes.setup_personal_routes(_FakePersonalDocs(), None, True)
+    for route in router.routes:
+        if getattr(route, "path", "") == "/api/personal/upload" and "POST" in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError("upload endpoint not found")
+
+
+def _request(privileges):
+    class _AuthManager:
+        def get_privileges(self, user):
+            assert user == "alice"
+            return privileges
+
+    return SimpleNamespace(
+        state=SimpleNamespace(current_user="alice"),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=_AuthManager(),
+            ),
+        ),
+        client=SimpleNamespace(host="203.0.113.10"),
+    )
+
+
+class _FakePersonalDocs:
+    def __init__(self):
+        self.added = []
+
+    def add_directory(self, directory, index=False):
+        self.added.append((directory, index))
+
+
+class _FakeRAG:
+    def __init__(self):
+        self.docs = []
+
+    def _split_into_chunks(self, text, chunk_size=500):
+        return [text]
+
+    def add_document(self, chunk, metadata):
+        self.docs.append((chunk, metadata))
+        return True
+
+
+class _Upload:
+    filename = "notes.txt"
+
+    async def read(self, limit):
+        return b"hello from upload"
+
+
+def test_personal_upload_requires_document_privilege(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setattr(
+        personal_routes,
+        "get_rag_manager",
+        lambda: pytest.fail("RAG must not be touched before privilege passes"),
+    )
+
+    endpoint = _upload_endpoint()
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(endpoint(request=_request({"can_use_documents": False}), files=[]))
+
+    assert exc.value.status_code == 403
+
+
+def test_personal_upload_indexes_with_privileged_owner(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    monkeypatch.setattr(personal_routes, "UPLOADS_DIR", str(tmp_path))
+    rag = _FakeRAG()
+    monkeypatch.setattr(personal_routes, "get_rag_manager", lambda: rag)
+
+    endpoint = _upload_endpoint()
+    result = asyncio.run(
+        endpoint(
+            request=_request({"can_use_documents": True}),
+            files=[_Upload()],
+        )
+    )
+
+    assert result["success"] is True
+    assert result["indexed_count"] == 1
+    assert rag.docs[0][0] == "hello from upload"
+    metadata = rag.docs[0][1]
+    assert metadata["owner"] == "alice"
+    assert Path(metadata["directory"]).name == "alice"


### PR DESCRIPTION
## Summary

Changed direct personal RAG uploads to require the existing `can_use_documents` privilege before the route touches RAG state or upload IO. The endpoint still indexes successful uploads under the authenticated owner, but users whose document privilege is disabled now fail closed with 403.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #2876 audit follow-up.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_personal_upload_privilege.py tests/test_personal_upload_isolation.py tests/test_auth_require_privilege_nondict.py`
2. Sign in as a user with `can_use_documents=false`, POST to `/api/personal/upload`, and confirm the route returns 403 without touching RAG.
3. Sign in as a user with `can_use_documents=true`, upload a small text file through `/api/personal/upload`, and confirm it indexes under that user's upload directory and owner metadata.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - no rendering, CSS, HTML, SVG, or static UI code changed.

### Screenshots / clips

N/A.
