### PR TITLE
Forward RAG owner args through manager wrapper

### DIFF
--- a/src/rag_manager.py
+++ b/src/rag_manager.py
@@ -5,7 +5,7 @@ A thin wrapper around VectorRAG for backward compatibility and additional featur
 """
 
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 # Try to import from different possible locations
 try:
@@ -34,9 +34,18 @@ class RAGManager:
         """Search for documents - delegates to VectorRAG."""
         return self.vector_rag.search(query, k)
     
-    def index_personal_documents(self, directory: str) -> Dict[str, Any]:
+    def index_personal_documents(
+        self,
+        directory: str,
+        file_extensions: Optional[set] = None,
+        owner: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Index documents - delegates to VectorRAG."""
-        return self.vector_rag.index_personal_documents(directory)
+        return self.vector_rag.index_personal_documents(
+            directory,
+            file_extensions=file_extensions,
+            owner=owner,
+        )
     
     def retrieve(self, query: str, k: int = 5) -> List[str]:
         """Retrieve relevant chunks - delegates to VectorRAG."""

--- a/tests/test_rag_manager_owner_compat.py
+++ b/tests/test_rag_manager_owner_compat.py
@@ -1,0 +1,38 @@
+from src.rag_manager import RAGManager
+
+
+class _FakeVectorRAG:
+    def __init__(self):
+        self.calls = []
+
+    def index_personal_documents(self, directory, file_extensions=None, owner=None):
+        self.calls.append(
+            {
+                "directory": directory,
+                "file_extensions": file_extensions,
+                "owner": owner,
+            }
+        )
+        return {"success": True, "indexed_count": 1}
+
+
+def test_rag_manager_forwards_owner_and_file_extensions():
+    fake = _FakeVectorRAG()
+    manager = RAGManager.__new__(RAGManager)
+    manager.vector_rag = fake
+    extensions = {".md", ".txt"}
+
+    result = manager.index_personal_documents(
+        "/tmp/personal",
+        file_extensions=extensions,
+        owner="alice",
+    )
+
+    assert result == {"success": True, "indexed_count": 1}
+    assert fake.calls == [
+        {
+            "directory": "/tmp/personal",
+            "file_extensions": extensions,
+            "owner": "alice",
+        }
+    ]


### PR DESCRIPTION
## Summary

Updated the legacy `RAGManager` wrapper so its `index_personal_documents` method accepts and forwards the same `file_extensions` and `owner` arguments as `VectorRAG`. This prevents owner-stamped indexing call sites from failing when they are given the wrapper instead of the singleton `VectorRAG` instance.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #2876 audit follow-up.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_rag_manager_owner_compat.py tests/test_rag_remove_directory_scope.py`
2. Instantiate `RAGManager` with a `VectorRAG` backend and call `index_personal_documents(path, owner="alice")`; confirm the call no longer raises `TypeError`.
3. Index a personal directory through a route or manager path that passes `owner=` and confirm the resulting metadata keeps the owner stamp.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - no rendering, CSS, HTML, SVG, or static UI code changed.

### Screenshots / clips

N/A.
