### PR TITLE
feat(providers): recognize Perplexity as a first-class provider

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -415,6 +415,8 @@ def _detect_provider(url: str) -> str:
         return "openrouter"
     if _host_match(url, "groq.com"):
         return "groq"
+    if _host_match(url, "perplexity.ai"):
+        return "perplexity"
     from src.copilot import is_copilot_base
     if is_copilot_base(url):
         return "copilot"
@@ -428,6 +430,12 @@ def _provider_headers(provider: str, headers: Optional[Dict] = None) -> Dict[str
     if provider == "openrouter":
         h.setdefault("HTTP-Referer", "https://github.com/pewdiepie-archdaemon/odysseus")
         h.setdefault("X-OpenRouter-Title", "Odysseus")
+    if provider == "perplexity":
+        # Perplexity's integration-attribution header (same convention every
+        # official Perplexity wrapper uses). Lets them see traffic comes from
+        # Odysseus. Their API is otherwise plain OpenAI-compatible.
+        from src.constants import APP_VERSION
+        h.setdefault("X-Pplx-Integration", f"odysseus/{APP_VERSION}")
     if provider == "copilot":
         # Ensure the Copilot-required headers are present even when the caller
         # didn't pass pre-built headers (e.g. model listing). build_headers()
@@ -449,6 +457,7 @@ def _provider_label(url: str) -> str:
     if _host_match(url, "openai.com"): return "OpenAI"
     if _host_match(url, "openrouter.ai"): return "OpenRouter"
     if _host_match(url, "groq.com"): return "Groq"
+    if _host_match(url, "perplexity.ai"): return "Perplexity"
     from src.copilot import is_copilot_base
     if is_copilot_base(url): return "GitHub Copilot"
     if _host_match(url, "mistral.ai"): return "Mistral"

--- a/src/model_context.py
+++ b/src/model_context.py
@@ -171,6 +171,8 @@ KNOWN_CONTEXT_WINDOWS = {
     # --- Perplexity ---
     'sonar-pro': 200000,
     'sonar': 128000,
+    'sonar-reasoning-pro': 128000,
+    'sonar-reasoning': 128000,
 
     # --- MiniMax ---
     'minimax': 1000000,

--- a/tests/test_provider_classification.py
+++ b/tests/test_provider_classification.py
@@ -23,6 +23,7 @@ import pytest
 
 from src.llm_core import (
     _detect_provider,
+    _provider_headers,
     _provider_label,
     _format_upstream_error,
     _uses_max_completion_tokens,
@@ -40,6 +41,7 @@ class TestDetectProvider:
         ("https://anthropic.com/v1", "anthropic"),
         ("https://openrouter.ai/api/v1", "openrouter"),
         ("https://api.groq.com/openai/v1", "groq"),
+        ("https://api.perplexity.ai", "perplexity"),
         ("http://localhost:11434/api", "ollama"),
         ("https://ollama.com", "ollama"),
         # xAI, DeepSeek and Gemini's OpenAI-compatible surface are NOT
@@ -84,6 +86,7 @@ class TestProviderLabel:
         ("https://api.openai.com/v1", "OpenAI"),
         ("https://openrouter.ai/api/v1", "OpenRouter"),
         ("https://api.groq.com/openai/v1", "Groq"),
+        ("https://api.perplexity.ai", "Perplexity"),
         ("https://api.mistral.ai/v1", "Mistral"),
         ("https://api.deepseek.com", "DeepSeek"),
         ("https://generativelanguage.googleapis.com/v1beta/openai", "Google"),
@@ -106,6 +109,25 @@ class TestProviderLabel:
     @pytest.mark.parametrize("url", ["", None])
     def test_empty_returns_generic(self, url):
         assert _provider_label(url) == "provider"
+
+
+# ── _provider_headers ──
+# Per-provider default headers (auth-attribution / routing).
+
+class TestProviderHeaders:
+    def test_perplexity_sends_integration_header(self):
+        # Perplexity gets the X-Pplx-Integration attribution header, mirroring
+        # the X-OpenRouter-Title convention for OpenRouter.
+        h = _provider_headers("perplexity")
+        assert h.get("X-Pplx-Integration", "").startswith("odysseus/")
+
+    def test_perplexity_does_not_clobber_caller_header(self):
+        h = _provider_headers("perplexity", {"X-Pplx-Integration": "custom/1"})
+        assert h["X-Pplx-Integration"] == "custom/1"
+
+    def test_openai_has_no_integration_header(self):
+        # Generic OpenAI-compatible endpoints must stay clean.
+        assert "X-Pplx-Integration" not in _provider_headers("openai")
 
 
 # ── _format_upstream_error ──

--- a/tests/test_provider_detection.py
+++ b/tests/test_provider_detection.py
@@ -52,6 +52,9 @@ class TestDetectProviderRealHosts:
         # Groq's base carries an /openai/v1 path; detection must still see the host.
         assert llm_core._detect_provider("https://api.groq.com/openai/v1") == "groq"
 
+    def test_perplexity(self):
+        assert llm_core._detect_provider("https://api.perplexity.ai") == "perplexity"
+
     def test_ollama_native_unchanged(self):
         assert llm_core._detect_provider("https://ollama.com/api") == "ollama"
 


### PR DESCRIPTION
## Summary

Makes **Perplexity** (`api.perplexity.ai`) a recognized first-class provider, the same way OpenRouter, Groq, and Copilot are already special-cased in `src/llm_core.py`. Perplexity's chat API is OpenAI-compatible, so it already *works* today via the generic `openai` fallback — this just teaches the provider-detection layer to name it, label it correctly in error messages, and send Perplexity's integration-attribution header.

The frontend already ships a Perplexity logo and endpoint label (`static/js/providers.js`), and `model_context.py` already knows the Sonar context windows, so this is purely the backend half catching up. No UI changes.

## What's changed

- **`src/llm_core.py`**
  - `_detect_provider` — add a `perplexity.ai` → `"perplexity"` branch (hostname match, consistent with the existing providers).
  - `_provider_headers` — for the `perplexity` provider, set `X-Pplx-Integration: odysseus/<APP_VERSION>` via `setdefault`, mirroring the existing `X-OpenRouter-Title` attribution header for OpenRouter. This is the same `X-Pplx-Integration: <slug>/<version>` convention Perplexity's other official integrations use; `setdefault` means a caller-supplied value is never clobbered.
  - `_provider_label` — add `perplexity.ai` → `"Perplexity"` so degraded-state / upstream-error messages read "Perplexity rejected the API key" instead of the bare host.
- **`src/model_context.py`** — add `sonar-reasoning-pro` and `sonar-reasoning` (128k) to the known context windows, alongside the existing `sonar` / `sonar-pro` entries.
- **Tests**
  - `tests/test_provider_detection.py` — `test_perplexity` asserts host detection.
  - `tests/test_provider_classification.py` — Perplexity rows added to the `_detect_provider` and `_provider_label` parametrized cases, plus a new `TestProviderHeaders` class covering: the integration header is sent, a caller header is not clobbered, and generic `openai` endpoints stay clean (no stray header).

## How to use it

Add a Model Endpoint pointing at `https://api.perplexity.ai` with a Perplexity API key, then pick a model (`sonar`, `sonar-pro`, `sonar-reasoning`, `sonar-reasoning-pro`). No new env vars or config required.

## Tests run

```
python -m py_compile src/llm_core.py src/model_context.py        # clean
python -m pytest tests/test_provider_detection.py \
                 tests/test_provider_classification.py \
                 tests/test_model_context.py -q                   # 129 passed
```

No UI was changed, so no screenshots are attached (per CONTRIBUTING's visual-change rule, this is backend-only).

## Notes

Scoped intentionally small and additive — no refactors, no formatting-only churn, one provider per PR. Opened as a **draft** for maintainer feedback on whether you'd like Perplexity surfaced anywhere else (e.g. a setup preset) before marking it ready.
