### PR TITLE
Harden gallery album assignment scope

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -76,6 +76,9 @@ def setup_gallery_routes() -> APIRouter:
         file_hash = hashlib.sha256(content).hexdigest()
         db = SessionLocal()
         try:
+            if album_id and user is not None:
+                _get_or_404_album(db, album_id, user)
+
             # SECURITY: scope the dup-detect to THIS user — otherwise a
             # caller can probe whether someone else uploaded the same
             # file (the response leaks the existing row's id+filename).
@@ -1669,9 +1672,10 @@ def setup_gallery_routes() -> APIRouter:
         db = SessionLocal()
         try:
             album = _get_or_404_album(db, album_id, user)
-            db.query(GalleryImage).filter(GalleryImage.album_id == album_id).update(
-                {"album_id": None}, synchronize_session=False
-            )
+            q = db.query(GalleryImage).filter(GalleryImage.album_id == album_id)
+            if user is not None:
+                q = q.filter(GalleryImage.owner == user)
+            q.update({"album_id": None}, synchronize_session=False)
             db.delete(album)
             db.commit()
             return {"ok": True}

--- a/tests/test_gallery_album_owner_scope.py
+++ b/tests/test_gallery_album_owner_scope.py
@@ -30,12 +30,27 @@ def test_patch_validates_target_album_ownership():
     assert "_get_or_404_album(db, req.album_id, user)" in body
 
 
+def test_upload_validates_target_album_ownership():
+    fns = _function_sources()
+    body = fns["gallery_upload"]
+    assert "album_id" in body
+    assert "_get_or_404_album(db, album_id, user)" in body
+
+
 def test_list_albums_count_and_cover_are_owner_scoped():
     fns = _function_sources()
     body = fns["list_albums"]
     # Both the per-album image count and the cover-fallback query must owner-scope
     # by GalleryImage.owner (the album list itself already filters by owner).
     assert body.count("GalleryImage.owner == user") >= 2
+
+
+def test_delete_album_cleanup_is_owner_scoped():
+    fns = _function_sources()
+    body = fns["delete_album"]
+    assert "GalleryImage.album_id == album_id" in body
+    assert "GalleryImage.owner == user" in body
+    assert 'q.update({"album_id": None}' in body
 
 
 def test_get_or_404_album_enforces_owner():


### PR DESCRIPTION
## Summary

Hardens gallery album ownership checks that were still open after the earlier album owner-scope fix. Uploads now validate a submitted `album_id` against the authenticated caller before storing it, and album deletion only clears album membership on the caller's own gallery images so legacy or malicious foreign rows with the same album id are not modified.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Follow-up hardening for #2754.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_gallery_album_owner_scope.py tests/test_gallery_filename_confinement.py tests/test_gallery_image_privileges.py`
2. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_gallery_album_owner_scope.py tests/test_gallery_filename_confinement.py tests/test_gallery_image_privileges.py tests/test_gallery_owner_filter_single_user.py tests/test_generated_image_confinement.py tests/test_gallery_endpoint_matching.py tests/test_gallery_endpoint_ssrf.py tests/test_gallery_exif_orientation.py tests/test_admin_wipe_gallery.py`
3. `/home/moloch/odysseus/venv/bin/python -m py_compile routes/gallery_routes.py tests/test_gallery_album_owner_scope.py`
4. `git diff --check`

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - no rendering, CSS, HTML, SVG, or static UI code changed.

### Screenshots / clips

N/A.
