### PR TITLE
Scope model helper endpoint resolution

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -1368,7 +1368,7 @@ def setup_calendar_routes() -> APIRouter:
         "tomorrow", "next Tuesday", "in 30 minutes" resolve correctly.
         Uses the "utility" endpoint (small / fast model) to keep latency low.
         """
-        _require_user(request)
+        owner = _require_user(request)
         from src.endpoint_resolver import resolve_endpoint
         from src.llm_core import llm_call_async
         from src.text_helpers import strip_think
@@ -1394,9 +1394,9 @@ def setup_calendar_routes() -> APIRouter:
         if tz_hint:
             set_user_tz_name(tz_hint)
 
-        url, model, headers = resolve_endpoint("utility")
+        url, model, headers = resolve_endpoint("utility", owner=owner or None)
         if not url:
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=owner or None)
         if not url or not model:
             return {"ok": False, "error": "No LLM endpoint configured"}
 

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -853,10 +853,10 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         from src.llm_core import llm_call_async
 
         user = get_current_user(request)
-        url, model, headers = resolve_task_endpoint()
+        url, model, headers = resolve_task_endpoint(owner=user or None)
         if not url or not model:
             # Fall back to default endpoint
-            url, model, headers = resolve_endpoint("default")
+            url, model, headers = resolve_endpoint("default", owner=user or None)
         if not url or not model:
             raise HTTPException(500, "No endpoint configured for AI tidy")
 

--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -522,6 +522,8 @@ def setup_history_routes(session_manager) -> APIRouter:
     async def compact_session(request: Request, session_id: str):
         """Manually trigger context compaction for a session."""
         _verify_session_owner(request, session_id)
+        from src.auth_helpers import effective_user
+        owner = effective_user(request)
         try:
             session = session_manager.get_session(session_id)
         except KeyError:
@@ -555,7 +557,7 @@ def setup_history_routes(session_manager) -> APIRouter:
             )
 
             # Use utility model if available
-            util_url, util_model, util_headers = resolve_endpoint("utility")
+            util_url, util_model, util_headers = resolve_endpoint("utility", owner=owner or None)
             compact_url = util_url or session.endpoint_url
             compact_model = util_model or session.model
             compact_headers = util_headers if util_url else session.headers

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -181,9 +181,9 @@ async def dispatch_reminder(
         try:
             from src.endpoint_resolver import resolve_endpoint
             from src.llm_core import llm_call_async
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=owner or None)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=owner or None)
             if url and model:
                 raw = await llm_call_async(
                     url=url, model=model,

--- a/routes/task_routes.py
+++ b/routes/task_routes.py
@@ -1047,6 +1047,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
         desc = (body.get("description") or "").strip()
         if not desc:
             return {"success": False, "message": "Nothing to parse"}
+        user = _owner(request)
 
         now = _dt.now()
         # Give the model the current date/time + weekday so relative phrasing
@@ -1073,9 +1074,9 @@ def setup_task_routes(task_scheduler) -> APIRouter:
             "use cron '0 H * * 1-5'. Keep the prompt actionable and self-contained."
         )
         try:
-            url, model, headers = resolve_endpoint("utility")
+            url, model, headers = resolve_endpoint("utility", owner=user or None)
             if not url:
-                url, model, headers = resolve_endpoint("default")
+                url, model, headers = resolve_endpoint("default", owner=user or None)
             if not (url and model):
                 return {"success": False, "message": "No model endpoint configured"}
             raw = await llm_call_async(

--- a/tests/test_model_helper_owner_scope.py
+++ b/tests/test_model_helper_owner_scope.py
@@ -1,0 +1,45 @@
+"""Model-assisted route helpers must resolve endpoints with owner scope."""
+
+import ast
+from pathlib import Path
+
+
+def _function_source(path: str, name: str) -> str:
+    source = Path(path).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return ast.get_source_segment(source, node) or ""
+    raise AssertionError(f"{name} not found in {path}")
+
+
+def test_document_ai_tidy_resolves_with_owner_scope():
+    body = _function_source("routes/document_routes.py", "ai_tidy_documents")
+    assert "resolve_task_endpoint(owner=user or None)" in body
+    assert 'resolve_endpoint("default", owner=user or None)' in body
+
+
+def test_calendar_quick_parse_resolves_with_owner_scope():
+    body = _function_source("routes/calendar_routes.py", "quick_parse")
+    assert "owner = _require_user(request)" in body
+    assert 'resolve_endpoint("utility", owner=owner or None)' in body
+    assert 'resolve_endpoint("default", owner=owner or None)' in body
+
+
+def test_task_parse_resolves_with_owner_scope():
+    body = _function_source("routes/task_routes.py", "parse_task")
+    assert "user = _owner(request)" in body
+    assert 'resolve_endpoint("utility", owner=user or None)' in body
+    assert 'resolve_endpoint("default", owner=user or None)' in body
+
+
+def test_history_compact_resolves_with_owner_scope():
+    body = _function_source("routes/history_routes.py", "compact_session")
+    assert "owner = effective_user(request)" in body
+    assert 'resolve_endpoint("utility", owner=owner or None)' in body
+
+
+def test_note_reminder_synthesis_resolves_with_owner_scope():
+    body = _function_source("routes/note_routes.py", "dispatch_reminder")
+    assert 'resolve_endpoint("utility", owner=owner or None)' in body
+    assert 'resolve_endpoint("default", owner=owner or None)' in body


### PR DESCRIPTION
## Summary

Threads the current owner into model-assisted helper endpoint resolution for document AI tidy, calendar quick-parse, task parse, manual session compaction, and note reminder synthesis. These helpers already know the caller or row owner; they now resolve utility/default/task endpoints only within that owner's visible endpoint set instead of falling back to a global endpoint/API key lookup.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #2413.

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' /home/moloch/odysseus/venv/bin/python -m pytest -q tests/test_model_helper_owner_scope.py tests/test_security_regressions.py tests/test_review_regressions.py tests/test_calendar_owner_scope.py tests/test_document_tool_owner_scope.py tests/test_settings_scrub.py`
2. `/home/moloch/odysseus/venv/bin/python -m py_compile routes/document_routes.py routes/calendar_routes.py routes/task_routes.py routes/history_routes.py routes/note_routes.py tests/test_model_helper_owner_scope.py`
3. `git diff --check`

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - no rendering, CSS, HTML, SVG, or static UI code changed.

### Screenshots / clips

N/A.
