### PR TITLE
fix: group chat per-participant endpoints + character name display

### DIFF
--- a/.env.dgx.example
+++ b/.env.dgx.example
@@ -1,0 +1,57 @@
+# .env.dgx.example — DGX Spark deployment template.
+#
+# Copy to .env and fill in your values.
+#   cp .env.dgx.example .env
+#   nano .env
+#
+# .env is gitignored (see .gitignore) — never commit real credentials.
+# This template IS tracked on the rts-integration branch.
+
+# ── GPU ───────────────────────────────────────────────────────────────────────
+# Enable the NVIDIA GPU overlay (see docker/gpu.nvidia.yml).
+# Requires nvidia-container-toolkit on the host and Docker configured for it.
+#   sudo apt install nvidia-container-toolkit
+#   sudo nvidia-ctk runtime configure --runtime=docker
+#   sudo systemctl restart docker
+COMPOSE_FILE=docker-compose.yml:docker/gpu.nvidia.yml
+
+# ── Network ───────────────────────────────────────────────────────────────────
+# Bind ONLY to the Tailscale interface.  Do not use 0.0.0.0 or a public IP.
+# Tailscale Serve (set up by rts-hub's launch_hub.sh) provides HTTPS on this
+# port to tailnet peers — Odysseus is never directly on the public internet.
+#
+# Find your Tailscale IP:  tailscale ip -4
+APP_BIND=100.70.71.24
+APP_PORT=7000
+
+# ── Host user mapping ─────────────────────────────────────────────────────────
+# The container drops to this user before running.  Match to the host user
+# that owns /srv/odysseus so bind-mounted files stay writable.
+# Find with:  id -u  /  id -g
+PUID=1000
+PGID=1000
+
+# ── Auth — set BEFORE first docker compose up ─────────────────────────────────
+# Canonical public URL used in email links and OAuth callbacks.
+# Set to your Tailscale HTTPS hostname:port (no trailing slash).
+WEBUI_URL=https://spark-8fe4.tailec282b.ts.net:7000
+
+# Disable self-registration.  Only admin can create users (via sync_users.sh
+# or the Odysseus admin UI).  Applied on startup; restart container to take effect.
+ENABLE_SIGNUP=false
+
+# ── LLM ───────────────────────────────────────────────────────────────────────
+# If Ollama is running on dgx-spark:
+OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
+
+# Uncomment if you want to use OpenAI models alongside local ones:
+# OPENAI_API_KEY=sk-...
+
+# ── Optional: SearXNG secret ──────────────────────────────────────────────────
+# If blank, a secret is auto-generated on first boot and stored in the volume.
+# Uncomment and set if you want a stable, reproducible secret.
+# SEARXNG_SECRET=
+
+# ── ntfy push URL ─────────────────────────────────────────────────────────────
+# Points to the ntfy container on the loopback.  Usually leave as default.
+NTFY_BASE_URL=http://localhost:8091

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,132 @@
+# Deployment Guide — RTS Hub Integration
+
+This file is tracked on the `rts-integration` branch only.
+Do NOT submit it upstream.
+
+## Repository layout
+
+```
+upstream:         https://github.com/pewdiepie-archdaemon/odysseus  (main)
+our fork:         https://github.com/yegorsb/odysseus
+our branch:       rts-integration
+```
+
+### Remote setup (already configured on the local clone)
+
+```
+origin    → git@github.com:yegorsb/odysseus.git   (your fork, push here)
+upstream  → https://github.com/pewdiepie-archdaemon/odysseus.git  (pull only)
+```
+
+---
+
+## Pulling upstream updates
+
+Run this whenever pewdiepie-archdaemon ships a new release:
+
+```bash
+# 1. Fetch upstream changes
+git fetch upstream
+
+# 2. Merge into your local main (no custom commits live here)
+git checkout main
+git merge upstream/main
+git push origin main          # keep fork's main in sync
+
+# 3. Rebase rts-integration on the updated main
+git checkout rts-integration
+git rebase main               # resolve any conflicts here
+git push origin rts-integration --force-with-lease
+```
+
+---
+
+## First-time deployment on dgx-spark
+
+```bash
+ssh ts_dgx
+
+# Clone your fork, rts-integration branch
+sudo mkdir -p /srv/odysseus
+sudo git clone --branch rts-integration \
+    git@github.com:yegorsb/odysseus.git /srv/odysseus
+
+cd /srv/odysseus
+
+# Create .env from the DGX template
+sudo cp .env.dgx.example .env
+sudo nano .env
+# → Fill in WEBUI_URL with your Tailscale hostname
+# → Confirm APP_BIND matches your Tailscale IP (tailscale ip -4)
+# → Set PUID/PGID to match the /srv owner
+
+# Start all services
+sudo docker compose up -d
+
+# Run one-time hardening (disables signup, creates .mgmt.conf)
+cd /srv/rts-hub/odysseus
+sudo ./setup.sh
+
+# Import existing 'ai' group members as Odysseus users
+./sync_users.sh
+```
+
+---
+
+## Updating the deployment on dgx-spark
+
+```bash
+ssh ts_dgx
+cd /srv/odysseus
+
+# Pull latest rts-integration commits
+sudo git pull origin rts-integration
+
+# Rebuild and restart (only odysseus container if only Python changed)
+sudo docker compose up -d --build odysseus
+
+# Or restart everything
+sudo docker compose down && sudo docker compose up -d
+```
+
+---
+
+## Adding a new user
+
+```bash
+# On dgx-spark:
+sudo usermod -aG ai <newusername>        # add to Linux ai group
+cd /srv/rts-hub/odysseus
+./sync_users.sh                          # creates Odysseus account + prints temp password
+# → Send temp password to the user; they must change it on first login
+```
+
+## Resetting a user's password
+
+```bash
+cd /srv/rts-hub/odysseus
+./reset_user.sh <username>
+```
+
+---
+
+## Importing the RTS Games Tool into Odysseus
+
+After any fresh database setup, re-import the tool:
+
+1. Open `https://<ts-host>:7000` → Admin → Workspace → Functions
+2. [+] New Function → paste contents of `tools/rts_games_tool.py` → Save
+
+See `tools/README.md` for full usage including Monte Carlo group chat setup.
+
+---
+
+## Files tracked on rts-integration (not sent upstream)
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.override.yml` | DGX port fix (SearXNG 8080→8088) |
+| `.env.dgx.example` | .env template for dgx-spark |
+| `tools/rts_games_tool.py` | Open WebUI Function for RTS game integration |
+| `tools/README.md` | Tool usage docs |
+| `DEPLOYMENT.md` | This file |

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,24 @@
+# docker-compose.override.yml — DGX Spark deployment overrides.
+#
+# Docker Compose automatically merges this file; no extra flags needed.
+# Tracked on rts-integration branch — do NOT merge into upstream main.
+#
+# What this changes:
+#   • SearXNG host port remapped from 8080 → 8088
+#     (port 8080 is occupied on dgx-spark by another service)
+#
+# What stays in .env (not tracked in git):
+#   • APP_BIND, APP_PORT         — network binding
+#   • COMPOSE_FILE               — GPU overlay activation
+#   • ENABLE_SIGNUP, WEBUI_URL   — auth hardening (see setup.sh)
+#   • PUID, PGID                 — host user mapping
+#
+# See .env.dgx.example for a full template.
+
+services:
+  searxng:
+    # Port 8080 conflicts with another service on dgx-spark.
+    # Remap to 8088 on the loopback only.  Internal container-to-container
+    # traffic (SEARXNG_INSTANCE=http://searxng:8080) is unaffected.
+    ports:
+      - "127.0.0.1:8088:8080"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,6 +6,14 @@
 # What this changes:
 #   • SearXNG host port remapped from 8080 → 8088
 #     (port 8080 is occupied on dgx-spark by another service)
+#   • Odysseus HuggingFace cache → /srv/ai-stack/models/llms/huggingface
+#     (349 GB of already-downloaded models; no re-download needed)
+#     Models available:
+#       - Qwen/Qwen2.5-32B-Instruct           (62 GB)
+#       - mistralai/Devstral-Small-2-24B       (49 GB)
+#       - google/gemma-3-27b-it                (52 GB)
+#       - huihui-ai/Huihui-Qwen3-Coder-30B-A3B (57 GB, MoE 3B active)
+#       - deepseek-ai/DeepSeek-R1-Distill-Llama-70B (132 GB)
 #
 # What stays in .env (not tracked in git):
 #   • APP_BIND, APP_PORT         — network binding
@@ -16,6 +24,14 @@
 # See .env.dgx.example for a full template.
 
 services:
+  odysseus:
+    volumes:
+      # Point the HuggingFace cache at the shared model store.
+      # The container sees /app/.cache/huggingface/hub/models--org--name/...
+      # which is exactly the structure already on disk.
+      # All 349 GB of models are immediately available — no download needed.
+      - /srv/ai-stack/models/llms/huggingface:/app/.cache/huggingface
+
   searxng:
     # Port 8080 conflicts with another service on dgx-spark.
     # Remap to 8088 on the loopback only.  Internal container-to-container

--- a/static/js/group.js
+++ b/static/js/group.js
@@ -259,7 +259,8 @@ function _initGroupTab() {
             if (!model) { console.warn('[group] Preset participant not found, skipping:', p); return; }
             const entry = { model, character: null };
             if (p.characterId) {
-              entry.character = chars.find(c => c.id === p.characterId) || null;
+              entry.character = chars.find(c => c.id === p.characterId)
+                || (p.characterName ? { id: p.characterId, name: p.characterName, prompt: '' } : null);
             }
             _groupParticipants.push(entry);
           });
@@ -312,7 +313,9 @@ async function _getCharacterList() {
   try {
     const r = await fetch(API_BASE + '/api/presets/templates', { credentials: 'same-origin' });
     const data = await r.json();
-    (data.templates || []).forEach(t => {
+    // API returns a plain array; older code expected {templates:[]} — handle both
+    const tList = Array.isArray(data) ? data : (data.templates || []);
+    tList.forEach(t => {
       if (t.isCharacter && !chars.find(c => c.id === t.id)) {
         chars.push({ id: t.id, name: t.name, prompt: t.prompt || '' });
       }

--- a/static/js/group.js
+++ b/static/js/group.js
@@ -172,6 +172,8 @@ function _initGroupTab() {
           modelDisplay: p.display,
           characterId: p.character?.characterId || null,
           characterName: p.character?.characterName || null,
+          endpointId: p.endpointId || null,
+          url: p.url || null,
         })),
       };
       try {
@@ -246,12 +248,20 @@ function _initGroupTab() {
           const [models, chars] = await Promise.all([_getModels(), _getCharacterList()]);
           _groupParticipants.length = 0;
           (g.participants || []).forEach(p => {
-            const model = models.find(m => m.mid === p.modelId) || models[0];
-            const entry = { model: model || null, character: null };
+            let model = null;
+            // Prefer exact match on both modelId + endpointId
+            if (p.endpointId) model = models.find(m => m.mid === p.modelId && m.endpointId === p.endpointId);
+            // Fall back to modelId-only match
+            if (!model) model = models.find(m => m.mid === p.modelId);
+            // If not in live model list but we have stored endpoint info, reconstruct
+            if (!model && p.url) model = { mid: p.modelId, display: p.modelDisplay || p.modelId.split('/').pop(), url: p.url, endpointId: p.endpointId || '' };
+            // Don't silently fall back to models[0] — that routes to the wrong endpoint
+            if (!model) { console.warn('[group] Preset participant not found, skipping:', p); return; }
+            const entry = { model, character: null };
             if (p.characterId) {
               entry.character = chars.find(c => c.id === p.characterId) || null;
             }
-            if (entry.model) _groupParticipants.push(entry);
+            _groupParticipants.push(entry);
           });
           _mode = g.mode || 'parallel';
           _render();

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,57 @@
+# Odysseus Custom Tools — RTS Hub Integration
+
+This directory holds custom Open WebUI **Functions** for the RTS Hub deployment.
+Functions are stored in the Odysseus database (not loaded from disk), so they
+must be imported via the admin UI after each fresh database setup.
+
+## Importing a Function
+
+1. Open Odysseus at `https://<tailscale-host>:7000`
+2. Sign in as admin
+3. Go to **Admin → Workspace → Functions**
+4. Click **[+] New Function**
+5. Paste the contents of the `.py` file
+6. Click **Save**
+
+The function is now available to all models in the workspace.
+
+---
+
+## `rts_games_tool.py` — RTS Games Integration
+
+Gives AI models live access to the RTS Chess and RTS Checkers game servers.
+
+### Capabilities
+
+| Tool call | What it does |
+|-----------|-------------|
+| `get_server_status()` | Check if Chess / Checkers / Odysseus servers are online |
+| `get_chess_rules()` | Full RTS Chess mechanics reference (influence fields, LOCKED/DISABLED states, King-only capture, path interception, etc.) |
+| `get_checkers_rules()` | Full RTS Checkers mechanics reference |
+| `analyze_chess_position(description)` | Strategic analysis of a described board position |
+| `monte_carlo_branch(game, position, branch_id, depth)` | Explore one MCTS branch |
+| `aggregate_monte_carlo(branch_reports)` | Pick best move from branch evaluations |
+
+### Configuring Valves
+
+After importing, click the ⚙️ icon on the function to set:
+
+| Valve | Default | Notes |
+|-------|---------|-------|
+| `HUB_STATUS_URL` | `http://localhost:8185/api/status` | Hub status API (internal) |
+| `CHESS_HTTP_URL` | `http://localhost:8183` | RTS Chess HTTP server |
+| `CHECKERS_HTTP_URL` | `http://localhost:8181` | RTS Checkers HTTP server |
+| `CHESS_WS_PORT` | `7777` | RTS Chess WebSocket port |
+| `CHECKERS_WS_PORT` | `7778` | RTS Checkers WebSocket port |
+
+All defaults are correct for the standard dgx-spark deployment.
+
+### Monte Carlo via Group Chat
+
+1. In Odysseus, create a **Group Chat**
+2. Add 3–4 model instances (e.g., 3× `qwen2.5:72b`)
+3. Enable `rts_games_tool` for the chat
+4. Prompt: *"Use monte_carlo_branch to explore Branch A / B / C for this position: [paste position]. Then aggregate_monte_carlo to pick the best move."*
+5. Each model explores independently; the last model aggregates
+
+This setup simulates parallel MCTS with the GPU running all branches simultaneously.

--- a/tools/rts_games_tool.py
+++ b/tools/rts_games_tool.py
@@ -1,0 +1,280 @@
+"""
+RTS Games Tool — Open WebUI Function
+=====================================
+Install in Odysseus:
+  Admin → Workspace → Functions → [+] New Function → paste this file → Save
+
+Gives AI models access to the RTS game servers so they can:
+  • Check whether Chess / Checkers servers are online
+  • Describe current game rules and mechanics for analysis
+  • Query active game rooms
+  • Accept a board state (as text/JSON) and provide strategic analysis
+  • Coordinate Monte Carlo tree search across a group chat
+
+Monte Carlo setup:
+  In Odysseus, create a Group Chat with 3-4 model instances and enable this
+  Function.  Each model explores a different branch and reports evaluation
+  scores back to the group.  The "orchestrator" message declares the winner.
+
+Configuration (edit the Valves below to match your deployment):
+  HUB_URL   — internal URL of the hub status API (default: http://localhost:8185)
+  CHESS_WS_PORT / CHECKERS_WS_PORT — used to construct WebSocket addresses
+"""
+
+import json
+import urllib.request
+import urllib.error
+from pydantic import BaseModel, Field
+
+
+# ── Valves (admin-configurable in Odysseus UI) ────────────────────────────────
+
+class Valves(BaseModel):
+    HUB_STATUS_URL: str = Field(
+        default="http://localhost:8185/api/status",
+        description="Internal URL to the hub status.py health endpoint.",
+    )
+    CHESS_HTTP_URL: str = Field(
+        default="http://localhost:8183",
+        description="Internal HTTP URL for the RTS Chess game server.",
+    )
+    CHECKERS_HTTP_URL: str = Field(
+        default="http://localhost:8181",
+        description="Internal HTTP URL for the RTS Checkers game server.",
+    )
+    CHESS_WS_PORT: int = Field(
+        default=7777,
+        description="WebSocket port for RTS Chess Godot server.",
+    )
+    CHECKERS_WS_PORT: int = Field(
+        default=7778,
+        description="WebSocket port for RTS Checkers Godot server.",
+    )
+    TIMEOUT_SECONDS: float = Field(
+        default=2.0,
+        description="HTTP request timeout in seconds.",
+    )
+
+
+# ── Tool class ────────────────────────────────────────────────────────────────
+
+class Tools:
+    def __init__(self):
+        self.valves = Valves()
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _get(self, url: str) -> dict | None:
+        try:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=self.valves.TIMEOUT_SECONDS) as resp:
+                return json.loads(resp.read())
+        except Exception:
+            return None
+
+    # ── Public tools ──────────────────────────────────────────────────────────
+
+    def get_server_status(self) -> str:
+        """
+        Check whether the RTS Chess, RTS Checkers, and Odysseus servers are
+        currently online.  Returns a plain-text summary.
+        """
+        data = self._get(self.valves.HUB_STATUS_URL)
+        if data is None:
+            return "Could not reach the hub status API. The hub may be offline."
+
+        lines = ["RTS Game Server Status", "=" * 30]
+        for name, info in data.items():
+            if name == "odysseus":
+                state = "online" if info.get("ui") else "offline"
+                lines.append(f"Odysseus  : {state}")
+            else:
+                ws   = "✓" if info.get("ws")   else "✗"
+                http = "✓" if info.get("http") else "✗"
+                both = info.get("ws") and info.get("http")
+                state = "online" if both else ("partial" if info.get("ws") else "offline")
+                lines.append(f"{name.capitalize():<10}: {state}  (WS {ws}  HTTP {http})")
+        return "\n".join(lines)
+
+    def get_chess_rules(self) -> str:
+        """
+        Return a concise description of the RTS Chess game mechanics.
+        Use this when planning strategy, tutoring a player, or setting up a
+        Monte Carlo simulation.
+        """
+        return """
+RTS CHESS — GAME MECHANICS REFERENCE
+======================================
+
+This is NOT standard chess. Key differences:
+
+INFLUENCE FIELDS
+  Each piece projects an influence field (BFS, radius = influence_range).
+  Blocked by occupied tiles unless the piece has through-flags set.
+  Incoming influence from each opponent is summed per piece.
+
+PIECE STATES
+  ACTIVE    — can move, projects full influence
+  LOCKED    — two pieces have equal mutual influence; neither can move,
+               but both still project
+  DISABLED  — incoming influence > own influence_range; cannot move AND
+               cannot project (effectively "frozen")
+  CAPTURED  — removed from board
+
+ONLY THE KING CAN CAPTURE
+  A King may move onto a DISABLED enemy piece to capture it.
+  The King itself must not be under any opposing influence when it captures.
+
+WIN CONDITION
+  Capture the enemy King.
+
+MOVEMENT
+  BFS within move_range steps.
+  PATH INTERCEPTION: a piece stops mid-path if any tile in its route would
+  LOCK or DISABLE it.
+
+SPECIAL PIECES
+  Knight  — move_through_friendly = true, move_through_enemy = true
+             (jumps over all pieces, cannot be intercepted mid-path)
+  Bishop  — vision_through_friendly = true, vision_through_enemy = true
+
+SQUAD MOVES
+  Tight formations can move as a unit (one compass step per activation).
+
+FOG OF WAR
+  Each piece has vision_range. Hidden enemies still project influence.
+
+OSCILLATION RESOLUTION
+  3-pass detection; paradoxes resolved by local force-based split.
+
+BOARD TYPES
+  Square   — 8×8, starting layout: Knight-King-Knight + 4 Pawns per side
+  Triangle — 14×10, full piece set
+
+MODES
+  Turn-based  — alternating moves with full deliberation time
+  RTS         — simultaneous moves, per-piece cooldown timers
+""".strip()
+
+    def get_checkers_rules(self) -> str:
+        """
+        Return a concise description of the RTS Checkers game mechanics.
+        """
+        return """
+RTS CHECKERS — GAME MECHANICS REFERENCE
+=========================================
+
+Standard 8×8 draughts rules plus RTS extensions.
+
+STANDARD RULES
+  • Pieces move diagonally forward only (kings move in all directions)
+  • Captures are mandatory; multi-jump chains must be completed
+  • A piece reaching the far rank is kinged
+
+RTS MODE EXTENSIONS
+  • Both players submit moves simultaneously
+  • No waiting for opponent — real-time race to capture
+  • Move cooldown per piece prevents instant spam
+
+AI LEARNING
+  • Each completed game exports a replay
+  • Replays are sent to the DGX Spark GPU server for Monte Carlo training
+  • Trained weights are hot-loaded before the next game
+""".strip()
+
+    def analyze_chess_position(self, board_state_description: str) -> str:
+        """
+        Analyze a described RTS Chess board position and suggest the best
+        strategic action.
+
+        Args:
+            board_state_description: Natural language or structured description
+                of piece positions, their states (ACTIVE/LOCKED/DISABLED), and
+                current influence projections.
+
+        Returns strategic analysis including: threats, influence control,
+        recommended moves, and win conditions.
+        """
+        # The actual analysis is performed by the LLM using the rules context
+        # injected below.  This function packages the prompt context.
+        rules = self.get_chess_rules()
+        return (
+            f"{rules}\n\n"
+            "--- POSITION TO ANALYZE ---\n"
+            f"{board_state_description}\n\n"
+            "Analyze this position using the mechanics above:\n"
+            "1. Which pieces are LOCKED or DISABLED and why?\n"
+            "2. Who has influence dominance over the center?\n"
+            "3. Can any King make a capture this turn?\n"
+            "4. What is the most forcing sequence of moves?\n"
+            "5. Monte Carlo evaluation: estimate win probability for each player."
+        )
+
+    def monte_carlo_branch(
+        self,
+        game: str,
+        position_description: str,
+        branch_id: str,
+        depth: int = 3,
+    ) -> str:
+        """
+        Explore one branch of a Monte Carlo tree for the given game position.
+        Use this in a Group Chat where each model instance receives a different
+        branch_id and explores independently.
+
+        Args:
+            game: "chess" or "checkers"
+            position_description: Current board state (text description or JSON).
+            branch_id: Label for this branch (e.g. "A", "B", "C").
+                Each model in the group chat should receive a unique branch_id.
+            depth: How many half-moves deep to explore (default 3).
+
+        Returns a branch evaluation: move sequence, resulting position, and
+        a win-probability score between 0.0 (certain loss) and 1.0 (certain win).
+        """
+        rules = self.get_chess_rules() if game == "chess" else self.get_checkers_rules()
+        return (
+            f"{rules}\n\n"
+            f"MONTE CARLO BRANCH EXPLORATION — Branch {branch_id}\n"
+            f"Depth: {depth} half-moves\n\n"
+            f"Starting position:\n{position_description}\n\n"
+            f"Instructions for Branch {branch_id}:\n"
+            f"1. Choose a promising move sequence to explore (different from other branches).\n"
+            f"2. Play out {depth} half-moves, alternating sides.\n"
+            f"3. Evaluate the resulting position.\n"
+            f"4. Report: move_sequence, final_position_summary, win_probability (0.0–1.0)\n\n"
+            f"Format your response as:\n"
+            f"BRANCH: {branch_id}\n"
+            f"MOVES: [move1, move2, ...]\n"
+            f"RESULT: <position description>\n"
+            f"SCORE: <float 0.0–1.0 for the side that moved first>\n"
+            f"REASONING: <brief justification>"
+        )
+
+    def aggregate_monte_carlo(self, branch_reports: str) -> str:
+        """
+        Aggregate branch evaluation reports from a Monte Carlo group chat
+        session and declare the best move.
+
+        Args:
+            branch_reports: Concatenated output from all Branch models in the
+                group chat (each starting with 'BRANCH: X').
+
+        Returns the best move, average score, and confidence.
+        """
+        return (
+            "MONTE CARLO AGGREGATION\n"
+            "=======================\n\n"
+            "Branch reports received:\n"
+            f"{branch_reports}\n\n"
+            "Instructions:\n"
+            "1. Parse each BRANCH / MOVES / SCORE block above.\n"
+            "2. Average the scores for each unique first move.\n"
+            "3. Select the first move with the highest average score.\n"
+            "4. Report:\n"
+            "   BEST_MOVE: <move>\n"
+            "   AVG_SCORE: <float>\n"
+            "   CONFIDENCE: <low|medium|high> based on variance across branches\n"
+            "   BRANCHES_SAMPLED: <count>\n"
+            "   SUMMARY: <one sentence justification>"
+        )


### PR DESCRIPTION
## Summary

- **Per-participant endpoint support**: group preset loading now looks up by `endpointId + modelId` first, falls back to `modelId`-only, then reconstructs from stored `url` — removes the silent `models[0]` fallback that routed all participants to the wrong endpoint when mixing vLLM and Anthropic.
- **Preset saving**: now stores `endpointId` and `url` per participant so future lookups are reliable.
- **Character name display**: `_getCharacterList()` was reading `data.templates` on an API that returns a plain array — all user characters (Alpha, Beta, Claude) were silently dropped. Fixed to handle both response shapes. Added `characterName` fallback so the stored name always shows even if the live lookup fails.

## Test plan
- [ ] Open Odysseus → Group → "Dev Team — Alpha, Beta & Claude" preset
- [ ] Verify Alpha shows "Alpha", Beta shows "Beta", Claude shows "Claude"
- [ ] Verify Claude's model is `claude-sonnet-4-6` (Anthropic endpoint), not haiku
- [ ] Start group chat — Alpha/Beta responses come from vLLM, Claude from Anthropic

🤖 Generated with [Claude Code](https://claude.com/claude-code)