### PR TITLE
fix(deep-research): wrap fetched webpage content in untrusted-context sandbox

### DIFF
--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -16,7 +16,8 @@ from typing import Callable, Dict, List, Optional, Set
 
 from src.research_utils import strip_thinking, is_low_quality
 
-from src.goal_based_extractor import EXTRACTOR_PROMPT
+from src.goal_based_extractor import EXTRACTOR_SYSTEM
+from src.prompt_security import untrusted_context_message
 
 logger = logging.getLogger(__name__)
 
@@ -625,11 +626,12 @@ class DeepResearcher:
             else:
                 content = truncated
 
-        prompt = EXTRACTOR_PROMPT.format(webpage_content=content, goal=question)
-
         try:
             response = await self._llm(
-                [{"role": "user", "content": prompt}],
+                [
+                    {"role": "user", "content": EXTRACTOR_SYSTEM.format(goal=question)},
+                    untrusted_context_message("webpage", content),
+                ],
                 temperature=0.2,
                 max_tokens=2048,
                 timeout=self.extraction_timeout,

--- a/src/goal_based_extractor.py
+++ b/src/goal_based_extractor.py
@@ -3,22 +3,18 @@
 Goal-based content extraction prompt inspired by Alibaba Tongyi DeepResearch.
 """
 
-EXTRACTOR_PROMPT = """Please process the following webpage content and user goal to extract relevant information:
+EXTRACTOR_SYSTEM = """Extract relevant information from a webpage for a given research goal.
 
-## **Webpage Content**
-{webpage_content}
+Goal: {goal}
 
-## **User Goal**
-{goal}
+Task guidelines:
+1. Locate the specific sections directly related to the goal within the provided webpage content.
+2. Identify and extract the most relevant information; output full original context where possible, up to three or more paragraphs.
+3. Organize into a concise paragraph with logical flow, judging each piece of information's contribution to the goal.
 
-## **Task Guidelines**
-1. **Content Scanning for Rational**: Locate the **specific sections/data** directly related to the user's goal within the webpage content
-2. **Key Extraction for Evidence**: Identify and extract the **most relevant information** from the content, you never miss any important information, output the **full original context** of the content as far as possible, it can be more than three paragraphs.
-3. **Summary Output for Summary**: Organize into a concise paragraph with logical flow, prioritizing clarity and judge the contribution of the information to the goal.
+Respond in JSON with exactly these fields: "rational", "evidence", "summary".
 
-**Final Output Format using JSON format has "rational", "evidence", "summary" fields**
-
-Example output:
+Example:
 {{
     "rational": "This section discusses X which directly relates to the goal of understanding Y",
     "evidence": "Full quotes and context from the page...",


### PR DESCRIPTION
## Summary

The Deep Research extraction path fetched arbitrary public URLs and injected
their raw content directly into the LLM prompt via Python string substitution
(`EXTRACTOR_PROMPT.format(webpage_content=content, ...)`). This bypassed the
prompt-injection hardening infrastructure already present in
`src/prompt_security.py`, which is used by every other external-content
injection site in the codebase (`agent_loop.py`, `chat_processor.py`,
`chat_routes.py`).

The fix splits the monolithic `EXTRACTOR_PROMPT` template into two messages:
a trusted system instruction (`EXTRACTOR_SYSTEM`, carrying the goal and task
guidelines) and an untrusted content message built with the existing
`untrusted_context_message("webpage", content)` helper, which wraps the raw
page text in `<<<UNTRUSTED_SOURCE_DATA>>>` guards with an explicit
refusal-policy header. The extraction model now has a structural boundary
between task instructions and untrusted external data, consistent with how the
rest of the codebase handles web results, documents, memories, and skills.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3044

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

> **Note on end-to-end verification**: The Deep Research flow requires a running
> LLM backend and live web access. The fix is a structural change to how the
> extraction messages are assembled — the LLM call signature, output format, and
> JSON parsing logic are all unchanged. All existing extraction tests pass (see
> below). A maintainer with a live instance can verify by running a deep research
> query against a page that embeds adversarial text; the extraction model should
> treat the injected instruction as data rather than a command.

## How to Test

1. Start Odysseus with a working LLM endpoint.
2. Run a Deep Research query (e.g. "What is the capital of France?").
3. In `src/deep_research.py`, temporarily add `print(messages)` before the
   `_llm(...)` call in `_fetch_and_extract` to confirm the second message has
   `role: user` and its content contains `<<<UNTRUSTED_SOURCE_DATA>>>`.
4. Verify the research report is produced normally and the extraction result
   (`rational`, `evidence`, `summary`) is populated as before.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no UI, CSS, HTML, or JS changes.

## Checks Run

```
uv run pytest tests/test_deep_research_extraction_controls.py \
              tests/test_deep_research_date_context.py \
              tests/test_deep_research_search_error.py \
              tests/test_deep_research_synthesis_resilience.py \
              tests/test_deep_research_parse_json_array_echo.py \
              -v --tb=short

13 passed, 1 warning in 0.16s

python3 -m py_compile src/goal_based_extractor.py src/deep_research.py
# exit 0

git diff --stat HEAD~1..HEAD
 src/deep_research.py        | 10 ++++++----
 src/goal_based_extractor.py | 20 ++++++++------------
 2 files changed, 14 insertions(+), 16 deletions(-)
```