### PR TITLE
fix(sessions): retry resumeStream in poll loop when chatModule loads late

### DIFF
--- a/static/js/sessions.js
+++ b/static/js/sessions.js
@@ -2184,12 +2184,26 @@ async function _checkServerStream(sessionId) {
     box.appendChild(holder);
     uiModule.scrollHistory();
 
+    // sessions.js executes before chat.js in module order, so window.chatModule
+    // may not be set yet when _checkServerStream first runs. Retry resumeStream
+    // on the first poll tick where it becomes available.
+    let _resumeRetried = false;
     const pollId = setInterval(async () => {
       if (getCurrentSessionId() !== sessionId) {
         clearInterval(pollId);
         spinner.destroy();
         if (holder.parentNode) holder.remove();
         return;
+      }
+      if (!_resumeRetried && window.chatModule && window.chatModule.resumeStream) {
+        _resumeRetried = true;
+        const attached = await window.chatModule.resumeStream(sessionId);
+        if (attached) {
+          clearInterval(pollId);
+          spinner.destroy();
+          if (holder.parentNode) holder.remove();
+          return;
+        }
       }
       try {
         const r = await fetch(`${API_BASE}/api/chat/stream_status/${sessionId}`);


### PR DESCRIPTION
## Summary

When a session has an active server-side agent run and the user refreshes the page, the UI fell into the spinner-and-poll fallback and stayed there for the entire duration of the run, never reconnecting to the live stream.

**Root cause:** `sessions.js` is loaded before `chat.js` in `index.html` (`<script type="module">` executes in document order). `sessions.js` initialises, selects the current session, and calls `_checkServerStream()` before `chat.js` has set `window.chatModule`. The guard `if (window.chatModule && window.chatModule.resumeStream)` evaluates false; execution falls through to the spinner path. That path polls `/api/chat/stream_status` every 1.5 s but never retries `resumeStream`, so the spinner persists indefinitely.

**Fix:** add a one-shot retry at the top of the polling callback. On the first tick where `window.chatModule.resumeStream` is available (typically the very first poll, 1.5 s after load), it attempts to attach. If `resumeStream` succeeds, the interval is cleared, the spinner is removed, and live SSE streaming takes over. If the run has already finished (server returns 404), the flag is set and subsequent ticks fall through to the existing status-poll path, which calls `selectSession` once the run is done. The `_resumeRetried` flag ensures only one attach attempt is made regardless of how many ticks fire.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #3048

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

> **Note on end-to-end verification:** Reproducing this requires a live Odysseus instance with a long-running agent task. The fix is localised to one code path in `_checkServerStream` (the spinner fallback that fires when `window.chatModule` is not yet available). The logic is straightforward to trace: the first poll tick calls `resumeStream`, which calls `/api/chat/resume`, which returns a streaming response that the existing reader loop handles.

## How to Test

1. Start Odysseus and begin a long Agent run (a task that takes 30+ seconds).
2. While it is running, refresh the page.
3. Select (or wait for auto-selection of) the session with the active run.
4. **Before fix:** static spinner, no content, spinner persists until run finishes.
5. **After fix:** spinner appears briefly (~1.5 s), then content starts streaming in as the live SSE reader attaches.

## Visual / UI Changes

N/A — no CSS, HTML layout, or new component patterns. The spinner already existed; this fix makes it disappear sooner and hands off to the live stream.

## Checks Run

```
node --check static/js/sessions.js
# exit 0

uv run pytest tests/test_agent_rounds_exhausted.py \
              tests/test_agent_loop.py \
              tests/test_deep_research_extraction_controls.py \
              tests/test_api_chat_security.py \
              tests/test_action_intents.py \
              tests/test_active_document_clear.py \
              -q --tb=short

185 passed, 1 warning

git diff --stat HEAD~1..HEAD
 static/js/sessions.js | 14 ++++++++++++++
 1 file changed, 14 insertions(+)
```