### PR TITLE
feat: Add Railway multi-service Dockerfiles for chromadb, searxng, ntfy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 EXPOSE 7000
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "7000"]
+CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-7000}"]

--- a/docker/chromadb/Dockerfile
+++ b/docker/chromadb/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/chromadb/chroma:latest
+
+ENV ANONYMIZED_TELEMETRY=FALSE

--- a/docker/chromadb/railway.toml
+++ b/docker/chromadb/railway.toml
@@ -1,0 +1,6 @@
+[build]
+builder = "DOCKERFILE"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/docker/ntfy/Dockerfile
+++ b/docker/ntfy/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/binwiederhier/ntfy
+
+CMD ["serve"]

--- a/docker/ntfy/railway.toml
+++ b/docker/ntfy/railway.toml
@@ -1,0 +1,6 @@
+[build]
+builder = "DOCKERFILE"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/docker/searxng/Dockerfile
+++ b/docker/searxng/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.io/searxng/searxng:2026.5.31-7159b8aed
+
+USER root
+
+COPY settings.yml /tmp/searxng-settings.yml.template
+COPY entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# The official searxng image runs as the non-root `searxng` user.
+# Our entrypoint runs as root so it can write /etc/searxng/settings.yml
+# on first boot, then exec the original entrypoint which drops privs.
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/searxng/entrypoint.sh
+++ b/docker/searxng/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if [ ! -s /etc/searxng/settings.yml ] || grep -q '__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
+  secret="${SEARXNG_SECRET:-}"
+  if [ -z "$secret" ]; then
+    secret="$(python -c 'import secrets; print(secrets.token_urlsafe(48))')"
+  fi
+  sed "s|__SEARXNG_SECRET__|$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
+fi
+
+exec /usr/local/searxng/entrypoint.sh

--- a/docker/searxng/railway.toml
+++ b/docker/searxng/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "DOCKERFILE"
+
+[deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 120
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/docker/searxng/settings.yml
+++ b/docker/searxng/settings.yml
@@ -1,0 +1,9 @@
+use_default_settings: true
+
+server:
+  secret_key: "__SEARXNG_SECRET__"
+
+search:
+  formats:
+    - html
+    - json

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/api/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
Adds Dockerfiles and Railway config for deploying supporting services alongside the main Odysseus app on Railway:

- `docker/chromadb/` — wraps `chromadb/chroma:latest` with telemetry disabled
- `docker/searxng/` — wraps pinned `searxng/searxng:2026.5.31-7159b8aed` with custom entrypoint for secret injection
- `docker/ntfy/` — wraps `binwiederhier/ntfy` with `CMD serve`

These are meant to be used as separate Railway services, each pointing to its subdirectory as the root.