### PR TITLE
fix: lower minimized-dock z-index so modals stack above it

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -842,7 +842,7 @@ body.bg-pattern-sparkles {
       display: flex; gap: 6px; flex-wrap: wrap;
       max-width: calc(100vw - 24px);
       padding: 4px;
-      z-index: 10020;
+      z-index: 100;
       pointer-events: none;
     }
     .minimized-dock-chip {


### PR DESCRIPTION
## Summary

The minimized modal dock sits at `z-index: 10020`, far above every tool modal (base z-index 250, bumped to 300+). When a modal is open and another is minimized, the chip from the minimized modal renders on top of the open one. This lowers the dock z-index to `100` — above normal page content but below the modal stacking range.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3069 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.


## How to Test

1. Open a modal (e.g. Brain or Gallery) and minimize it — a chip appears in the dock at the bottom.
2. Open a second modal (e.g. Compare or Cookbook).
3. Verify the minimized chip from step 1 stays **behind** the open modal and does not overlay it.

## Visual / UI changes

One-line CSS z-index change. The dock sits in the same visual position but no longer renders above modals.

### Before Fix: minimized-doc-chip sits above opened modals.
<img width="1067" height="853" alt="Screenshot 2026-06-06 143344" src="https://github.com/user-attachments/assets/888e95b1-7752-45f2-84b6-8dc1d7a58eb3" />


### After Fix: minimized-doc-chip sits below.
<img width="800" height="725" alt="image" src="https://github.com/user-attachments/assets/f43cf767-de24-4d69-9a93-dfe43442a023" />

