### PR TITLE
fix(security): add HSTS and Permissions-Policy to SecurityHeadersMiddleware

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -63,7 +63,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Referrer-Policy"] = "no-referrer"
-        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+        response.headers["Permissions-Policy"] = "camera=(), microphone=(self), geolocation=()"
 
         is_https = (
             request.url.scheme == "https"

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -63,6 +63,14 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+
+        is_https = (
+            request.url.scheme == "https"
+            or request.headers.get("X-Forwarded-Proto") == "https"
+        )
+        if is_https:
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
 
         if is_report:
             response.headers["Content-Security-Policy"] = (

--- a/tests/test_security_headers_middleware.py
+++ b/tests/test_security_headers_middleware.py
@@ -1,0 +1,67 @@
+# tests/test_security_headers_middleware.py
+"""
+Focused regression coverage for `SecurityHeadersMiddleware`
+(core/middleware.py), added alongside the HSTS + Permissions-Policy
+hardening:
+
+  1. HSTS is emitted only for HTTPS requests, including those reaching
+     the app over a reverse proxy (`X-Forwarded-Proto: https`).
+  2. HSTS is absent on plain HTTP so local/dev deployments are unaffected.
+  3. `Permissions-Policy` locks down camera/geolocation but preserves
+     same-origin microphone access (`microphone=(self)`), so the app's
+     own voice/STT flow (`getUserMedia({ audio: true })`) keeps working.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.middleware import SecurityHeadersMiddleware
+
+
+def _build_app():
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/")
+    def root():
+        return {"ok": True}
+
+    return app
+
+
+def _client(base_url="http://testserver"):
+    return TestClient(_build_app(), base_url=base_url)
+
+
+def test_hsts_absent_on_plain_http():
+    response = _client().get("/")
+
+    assert "strict-transport-security" not in response.headers
+
+
+def test_hsts_present_for_direct_https_requests():
+    response = _client(base_url="https://testserver").get("/")
+
+    assert response.headers["strict-transport-security"] == (
+        "max-age=31536000; includeSubDomains"
+    )
+
+
+def test_hsts_present_via_x_forwarded_proto_https():
+    response = _client().get("/", headers={"X-Forwarded-Proto": "https"})
+
+    assert response.headers["strict-transport-security"] == (
+        "max-age=31536000; includeSubDomains"
+    )
+
+
+def test_permissions_policy_locks_camera_and_geolocation_but_allows_self_microphone():
+    response = _client().get("/")
+
+    policy = response.headers["permissions-policy"]
+    assert policy == "camera=(), microphone=(self), geolocation=()"
+
+    # Explicitly pin the contract the reviewer flagged: an empty allowlist
+    # would also block the app's own same-origin voice/STT button.
+    assert "microphone=()" not in policy
+    assert "microphone=(self)" in policy


### PR DESCRIPTION
## Summary

`SecurityHeadersMiddleware` in `core/middleware.py` was missing two standard browser security headers. This adds them with appropriate conditions so they don't break HTTP-only or reverse-proxy deployments, and scopes the `Permissions-Policy` microphone directive to same-origin per reviewer feedback.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3080

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## Review feedback addressed

`alteixeira20` and `NubsCarson` flagged that the original `Permissions-Policy: camera=(), microphone=(), geolocation=()` used an empty allowlist for `microphone`, which disables mic access for *all* origins — including same-origin (`self`). Since this middleware is global, that broke Odysseus's own voice/STT button (`getUserMedia({ audio: true })` in `static/js/voiceRecorder.js`).

Fixed by scoping the directive to `microphone=(self)`: third-party origins stay locked out, but the app's own UI keeps mic access. `camera` and `geolocation` remain `()` since they're genuinely unused in the frontend.

Also added `tests/test_security_headers_middleware.py`, a focused middleware test suite covering exactly what was requested:
1. HSTS present for HTTPS (direct scheme and via `X-Forwarded-Proto: https`)
2. HSTS absent on plain HTTP
3. `Permissions-Policy` locks `camera`/`geolocation` to `()` while preserving same-origin microphone (`microphone=(self)`)

## How to Test

1. Start the app: `uvicorn app:app --host 0.0.0.0 --port 8000`
2. Check that `Permissions-Policy` is present and scopes the microphone to same-origin:
   ```
   curl -si http://localhost:8000/ | grep -i permissions-policy
   # Expected: Permissions-Policy: camera=(), microphone=(self), geolocation=()
   ```
3. Check that `Strict-Transport-Security` is absent over plain HTTP (correct — HSTS must not be sent over HTTP):
   ```
   curl -si http://localhost:8000/ | grep -i strict-transport
   # Expected: (no output)
   ```
4. Check that HSTS is sent when `X-Forwarded-Proto: https` is present (simulates a reverse proxy):
   ```
   curl -si http://localhost:8000/ -H "X-Forwarded-Proto: https" | grep -i strict-transport
   # Expected: Strict-Transport-Security: max-age=31536000; includeSubDomains
   ```
5. Run the new focused middleware tests:
   ```
   pytest tests/test_security_headers_middleware.py -v
   ```