### PR TITLE
ci: SHA-pin floating action refs in pr-description-check.yml

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -18,11 +18,11 @@ jobs:
     # Skip bots — they open PRs programmatically and have their own process.
     if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: ${{ github.base_ref }}
           sparse-checkout: .github/scripts
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: return require('./.github/scripts/check-pr-description.js')({github, context, core})


### PR DESCRIPTION
Fixes #3083

## Summary

Pins the two floating action tags in `pr-description-check.yml` to their current commit SHAs, matching the pattern already used in `ci.yml`.

```yaml
# Before
uses: actions/checkout@v4
uses: actions/github-script@v7

# After
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
```

This workflow uses `pull_request_target` (base-repo context, has secrets). SHA pins are immutable — a tag can be moved, a SHA cannot.

## Test plan

- [x] YAML validated (no syntax errors)
- [x] Behaviour unchanged — only the action refs are updated, no logic changes