### PR TITLE
fix(auth): redirect login when auth is disabled

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,7 @@ from core.exceptions import (
 import bcrypt as _bcrypt
 
 from src.app_helpers import abs_join
+from src.auth_helpers import _auth_disabled
 from src.generated_images import GENERATED_IMAGE_HEADERS, resolve_generated_image_path
 from starlette.responses import RedirectResponse
 
@@ -784,6 +785,8 @@ async def serve_backgrounds(request: Request):
 
 @app.get("/login")
 async def serve_login(request: Request):
+    if _auth_disabled():
+        return RedirectResponse(url="/", status_code=302)
     return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/login.html"))
 
 @app.get("/api/version")

--- a/tests/test_login_disabled_redirect.py
+++ b/tests/test_login_disabled_redirect.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+from starlette.responses import RedirectResponse
+
+
+def _load_serve_login():
+    source = Path("app.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    serve_login = next(
+        node for node in module.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "serve_login"
+    )
+    ast.fix_missing_locations(serve_login)
+    class _App:
+        def get(self, _path):
+            return lambda func: func
+
+    namespace = {
+        "app": _App(),
+        "_auth_disabled": lambda: True,
+        "RedirectResponse": RedirectResponse,
+        "_serve_html_with_nonce": lambda request, path: "login page",
+        "abs_join": lambda *parts: "/".join(parts),
+        "BASE_DIR": "/tmp/odysseus",
+        "Request": object,
+    }
+    exec(compile(ast.Module(body=[serve_login], type_ignores=[]), "app.py", "exec"), namespace)
+    return namespace["serve_login"]
+
+
+async def test_login_route_redirects_home_when_auth_disabled():
+    response = await _load_serve_login()(request=object())
+
+    assert isinstance(response, RedirectResponse)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"


### PR DESCRIPTION
## Summary

When authentication is disabled, `/login` now redirects to `/` instead of serving the login page. This matches the operator's `AUTH_ENABLED=false` intent and fixes the stale login-route behavior reported in #3075.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on the PR and change the base — no rebase needed.

## Linked Issue

Fixes #3075

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Set `AUTH_ENABLED=false`.
2. Start Odysseus and open `/login`.
3. Confirm the response redirects to `/` instead of rendering `static/login.html`.

Automated verification run locally:

```bash
pytest tests/test_login_disabled_redirect.py tests/test_security_regressions.py::test_require_user_accepts_anyone_when_auth_disabled -q
git diff --check
```

Result:

```text
2 passed
```

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual rendering changes. This only changes `/login` routing behavior when auth is disabled.

### Screenshots / clips

N/A — no UI rendering change.
