### PR TITLE
fix(auth): redirect /login to / when AUTH_ENABLED=false

### DIFF
--- a/app.py
+++ b/app.py
@@ -784,6 +784,8 @@ async def serve_backgrounds(request: Request):
 
 @app.get("/login")
 async def serve_login(request: Request):
+    if not AUTH_ENABLED:
+        return RedirectResponse(url="/", status_code=302)
     return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/login.html"))
 
 @app.get("/api/version")


### PR DESCRIPTION
## Summary

When `AUTH_ENABLED` is set to `false`, visiting the `/login` route still serves the login HTML page and allows users to submit credentials, instead of redirecting them to the home page (`/`). This PR adds a redirect guard in `serve_login` within `app.py` to issue a `302 RedirectResponse` to `/` if `AUTH_ENABLED` is disabled.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #3075

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure `AUTH_ENABLED=false` (e.g., in `.env`).
2. Run the application (e.g. `python -m uvicorn app:app --host 127.0.0.1 --port 7000`).
3. Open a browser window in Incognito/Private mode and go to `http://127.0.0.1:7000/login`.
4. Verify you are automatically redirected back to `http://127.0.0.1:7000/`.
5. Set `AUTH_ENABLED=true` and verify the `/login` page is served normally.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **I am not an LLM agent submitting a bulk PR.**
