### PR TITLE
fix(macos): rebuild incomplete venv instead of failing on re-run

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -130,11 +130,12 @@ fi
 # 3. Python environment + dependencies (kept inside the repo, in venv/).
 #    Named `venv` to match the manual steps and build-macos-app.sh, so the
 #    clickable .app reuses this same environment.
-if [ ! -d venv ]; then
+VENV_PY="./venv/bin/python3"
+if [ ! -x "$VENV_PY" ] || ! "$VENV_PY" -m pip --version >/dev/null 2>&1; then
+    [ -d venv ] && { echo "▶ Existing venv is incomplete (no working pip) — rebuilding…"; rm -rf venv; }
     echo "▶ Creating Python environment…"
     "$PY" -m venv venv
 fi
-VENV_PY="./venv/bin/python3"
 REQ_HASH="$(md5 -q requirements.txt 2>/dev/null || md5sum requirements.txt | cut -d' ' -f1)"
 REQ_HASH_FILE="venv/.requirements_hash"
 if [ ! -f "$REQ_HASH_FILE" ] || [ "$REQ_HASH" != "$(cat "$REQ_HASH_FILE" 2>/dev/null)" ]; then


### PR DESCRIPTION
## Summary

`start-macos.sh` guarded venv creation with `if [ ! -d venv ]`, which trusts any existing `venv/` directory even when a previous run was interrupted (Ctrl-C, sleep, crash) after the directory was created but before pip was bootstrapped into it. Every subsequent run then skipped recreation, jumped straight to `pip install`, and failed with `No module named pip` — never self-healing, which contradicts the script's own "safe to re-run" promise. This changes the guard to verify the venv actually has a working pip and rebuild it if not.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3105

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Simulate an interrupted first run by creating a venv with no pip:
   `python3 -m venv --without-pip venv` (or interrupt `./start-macos.sh` mid "Creating Python environment…").
2. On `dev`, run `./start-macos.sh` → it fails with `No module named pip` and stays wedged on every re-run.
3. With this change, run `./start-macos.sh` → it prints `▶ Existing venv is incomplete (no working pip) — rebuilding…`, recreates the venv, installs dependencies, and starts the server successfully.
4. Re-run on a healthy venv → the guard passes and setup is skipped as before (no behaviour change on the happy path).

Verified locally on macOS (Apple Silicon, Homebrew Python 3.13): reproduced the failure, applied the fix, and confirmed setup completes and the server launches at `http://127.0.0.1:7860`.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — shell script only, no rendering changes.
