### PR TITLE
fix(memory): store dislikes correctly instead of as preferences (#2429)

### DIFF
--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -192,11 +192,15 @@ def _fallback_memory_candidates(messages) -> list[dict]:
             if place:
                 add(f"User lives in {place}.", "identity")
 
-        m = re.search(r"\bi (?:prefer|like|love|hate|do not like|don't like)\s+([^.!?\n]{4,100})", text, re.I)
+        m = re.search(r"\bi (prefer|like|love|hate|do not like|don't like)\s+([^.!?\n]{4,100})", text, re.I)
         if m:
-            preference = _clean_memory_value(m.group(1), 100)
-            if preference:
-                add(f"User prefers {preference}.", "preference")
+            verb = m.group(1).lower()
+            thing = _clean_memory_value(m.group(2), 100)
+            if thing:
+                if verb in {"hate", "do not like", "don't like"}:
+                    add(f"User dislikes {thing}.", "preference")
+                else:
+                    add(f"User prefers {thing}.", "preference")
 
         m = re.search(
             r"\bi (?:(?:want|would like|plan|hope) to|wanna) "


### PR DESCRIPTION
## Summary

The regex in `_fallback_memory_candidates` matched `hate`, `do not like`, and
`don't like` under a non-capturing group alongside positive verbs, then always
formatted the result as `"User prefers …"`. This caused dislikes to be stored
with the opposite meaning and re-injected into the model's context on every
subsequent message, actively misleading the assistant. The fix captures the
matched verb in its own group and emits `"User dislikes …"` for negative
sentiment verbs and `"User prefers …"` for positive ones.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2429

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Open a Python shell in the project root with the venv active.
2. Run:
   ```python
   from services.memory.memory_extractor import _fallback_memory_candidates
   print(_fallback_memory_candidates([{"role": "user", "content": "I hate cilantro in my food"}]))
   print(_fallback_memory_candidates([{"role": "user", "content": "I love spicy food"}]))
3. Before this fix: both return "User prefers …".
After this fix: first returns "User dislikes cilantro in my food.", second returns "User prefers spicy food.".