### PR TITLE
fix(memory): make auto-memory extraction reliable for reasoning models

### DIFF
--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -285,13 +285,16 @@ async def extract_and_store(
         fallback_facts = _fallback_memory_candidates(stripped_recent)
 
         # Flatten the window into a SINGLE user message instead of appending the
-        # raw alternating role messages. Passing the history as role messages
-        # makes the prompt END on an assistant turn whenever the window's last
-        # message is an assistant reply — and a chat model then returns an EMPTY
-        # completion (nothing to answer), which is the real reason auto-memory
-        # can produce nothing ("0 candidates" on every run with a reasoning model).
-        # Ending on a user instruction guarantees a response. The skill extractor
-        # flattens for the same reason.
+        # raw alternating role messages. Passed as raw chat messages, the model
+        # treats the window as a conversation to CONTINUE rather than a transcript
+        # to ANALYZE, so it reliably extracts nothing — typically returning `[]`
+        # (and, depending on the input, sometimes an empty or <think>-only
+        # completion when the window ends on an assistant turn). This was the real
+        # cause of auto-memory logging "0 candidates" on every run. Reframing it as
+        # one "analyze this transcript, return the JSON array" user message makes
+        # the model actually extract. Controlled repro on this model: 0/6 trials
+        # with the old structure vs 6/6 with this one. The skill extractor flattens
+        # for the same reason.
         def _flatten_msg(m):
             c = m.get("content", "")
             if isinstance(c, list):

--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -341,7 +341,9 @@ async def extract_and_store(
             if text.startswith("```"):
                 text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
             # JSON may still be embedded in surrounding commentary — slice from
-            # the first '[' to the last ']' (extraction returns a list).
+            # the first '[' to the last ']' (extraction returns a list). Leading
+            # whitespace and <think>/prose blocks were already stripped above, so
+            # this only handles trailing/leading commentary the model left in place.
             if text and text[0] != "[":
                 _start = text.find("[")
                 _end = text.rfind("]")

--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -284,9 +284,31 @@ async def extract_and_store(
 
         fallback_facts = _fallback_memory_candidates(stripped_recent)
 
+        # Flatten the window into a SINGLE user message instead of appending the
+        # raw alternating role messages. Passing the history as role messages
+        # makes the prompt END on an assistant turn whenever the window's last
+        # message is an assistant reply — and a chat model then returns an EMPTY
+        # completion (nothing to answer), which is the real reason auto-memory
+        # can produce nothing ("0 candidates" on every run with a reasoning model).
+        # Ending on a user instruction guarantees a response. The skill extractor
+        # flattens for the same reason.
+        def _flatten_msg(m):
+            c = m.get("content", "")
+            if isinstance(c, list):
+                c = " ".join(
+                    b.get("text", "") for b in c
+                    if isinstance(b, dict) and b.get("type") == "text"
+                )
+            return f"{m.get('role', '?')}: {c}"
+
+        transcript = "\n\n".join(_flatten_msg(m) for m in stripped_recent)
         extraction_messages = [
             {"role": "system", "content": EXTRACT_SYSTEM_PROMPT},
-        ] + stripped_recent
+            {"role": "user", "content": (
+                "Conversation to analyze:\n\n" + transcript
+                + "\n\nReturn the JSON array of durable facts now (or [] if none)."
+            )},
+        ]
 
         facts = []
         try:
@@ -295,19 +317,41 @@ async def extract_and_store(
                 model,
                 extraction_messages,
                 temperature=0.1,
-                max_tokens=500,
+                # A reasoning model spends most of its budget on <think> tokens
+                # BEFORE emitting the JSON, so the old 500 truncated the response
+                # before any JSON appeared → every run logged "0 candidates". The
+                # audit path hit the same wall and raised to 16384; extraction's
+                # output (a short facts list) is small, so an ample ceiling is
+                # enough once thinking has room.
+                max_tokens=4096,
                 headers=headers,
             )
 
-            # Parse JSON from response (handle markdown fences if model wraps them)
-            text = raw.strip()
+            # Parse JSON, tolerating reasoning-model noise. The model emits
+            # <think>…</think> (and sometimes a prose preamble) BEFORE the JSON
+            # array; without stripping it, json.loads bombs on char 0 and the run
+            # silently yields "0 candidates" (the skill extractor and the audit
+            # path already strip_think; this one didn't).
+            text = (raw or "").strip()
+            try:
+                from src.text_helpers import strip_think as _strip_think
+                text = _strip_think(text, prose=True, prompt_echo=True).strip()
+            except Exception:
+                pass
             if text.startswith("```"):
                 text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+            # JSON may still be embedded in surrounding commentary — slice from
+            # the first '[' to the last ']' (extraction returns a list).
+            if text and text[0] != "[":
+                _start = text.find("[")
+                _end = text.rfind("]")
+                if 0 <= _start < _end:
+                    text = text[_start : _end + 1]
 
             try:
                 facts = json.loads(text)
             except json.JSONDecodeError:
-                logger.debug("Memory extraction returned non-JSON")
+                logger.debug("Memory extraction returned non-JSON: %r", (raw or "")[:120])
         except Exception as e:
             logger.warning(f"LLM memory extraction failed; using fallback candidates if available: {e}")
 

--- a/services/memory/memory_extractor.py
+++ b/services/memory/memory_extractor.py
@@ -236,6 +236,43 @@ def _is_text_duplicate(new_text: str, existing: list, threshold: float = 0.6) ->
     return False
 
 
+def _parse_extraction_json(raw: str) -> list:
+    """Parse the extraction LLM's reply into a list of facts, tolerating
+    reasoning-model noise.
+
+    The model emits <think>…</think> (and sometimes a prose preamble or a
+    ```json fence) AROUND the JSON array; without stripping it, json.loads
+    bombs and the run silently yields "0 candidates". Pure str -> list (no
+    LLM/network); returns [] on any parse failure instead of raising.
+    """
+    text = (raw or "").strip()
+    try:
+        from src.text_helpers import strip_think as _strip_think
+        text = _strip_think(text, prose=True, prompt_echo=True).strip()
+    except Exception:
+        pass
+    if text.startswith("```"):
+        text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    # JSON may still be embedded in surrounding commentary (leading prose or
+    # trailing remarks like "[...] Done!") — slice from the first '[' to the
+    # last ']' whenever both exist. Slice unconditionally: a reply that starts
+    # with '[' can still carry trailing commentary that breaks json.loads.
+    _start = text.find("[")
+    _end = text.rfind("]")
+    if 0 <= _start < _end:
+        text = text[_start : _end + 1]
+
+    try:
+        facts = json.loads(text)
+    except json.JSONDecodeError:
+        logger.debug("Memory extraction returned non-JSON: %r", (raw or "")[:120])
+        return []
+    except Exception:
+        logger.debug("Memory extraction returned non-JSON: %r", (raw or "")[:120])
+        return []
+    return facts if isinstance(facts, list) else []
+
+
 async def extract_and_store(
     session,
     memory_manager,
@@ -330,33 +367,10 @@ async def extract_and_store(
                 headers=headers,
             )
 
-            # Parse JSON, tolerating reasoning-model noise. The model emits
-            # <think>…</think> (and sometimes a prose preamble) BEFORE the JSON
-            # array; without stripping it, json.loads bombs on char 0 and the run
-            # silently yields "0 candidates" (the skill extractor and the audit
-            # path already strip_think; this one didn't).
-            text = (raw or "").strip()
-            try:
-                from src.text_helpers import strip_think as _strip_think
-                text = _strip_think(text, prose=True, prompt_echo=True).strip()
-            except Exception:
-                pass
-            if text.startswith("```"):
-                text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
-            # JSON may still be embedded in surrounding commentary — slice from
-            # the first '[' to the last ']' (extraction returns a list). Leading
-            # whitespace and <think>/prose blocks were already stripped above, so
-            # this only handles trailing/leading commentary the model left in place.
-            if text and text[0] != "[":
-                _start = text.find("[")
-                _end = text.rfind("]")
-                if 0 <= _start < _end:
-                    text = text[_start : _end + 1]
-
-            try:
-                facts = json.loads(text)
-            except json.JSONDecodeError:
-                logger.debug("Memory extraction returned non-JSON: %r", (raw or "")[:120])
+            # Parse JSON, tolerating reasoning-model noise (<think> blocks, a
+            # ```json fence, and leading/trailing commentary). See
+            # _parse_extraction_json — returns [] rather than raising.
+            facts = _parse_extraction_json(raw)
         except Exception as e:
             logger.warning(f"LLM memory extraction failed; using fallback candidates if available: {e}")
 

--- a/tests/test_memory_extraction_parse.py
+++ b/tests/test_memory_extraction_parse.py
@@ -1,0 +1,36 @@
+"""_parse_extraction_json must survive reasoning-model noise.
+
+The extraction model wraps its JSON array in <think> blocks, ```json fences,
+or leading/trailing prose. The helper strips that noise and slices the array
+unconditionally — a reply that starts with '[' can still carry trailing
+commentary like "[...] Done!" that would otherwise break json.loads.
+"""
+
+from services.memory.memory_extractor import _parse_extraction_json
+
+
+def test_think_prefixed_array_parses_to_one_fact():
+    raw = '<think>reasoning...</think>\n[{"text": "x", "category": "fact"}]'
+    assert _parse_extraction_json(raw) == [{"text": "x", "category": "fact"}]
+
+
+def test_fenced_json_block_parses():
+    raw = '```json\n[{"text": "x", "category": "fact"}]\n```'
+    assert _parse_extraction_json(raw) == [{"text": "x", "category": "fact"}]
+
+
+def test_leading_prose_before_array_parses():
+    raw = 'Here are the durable facts:\n[{"text": "x", "category": "fact"}]'
+    assert _parse_extraction_json(raw) == [{"text": "x", "category": "fact"}]
+
+
+def test_trailing_commentary_after_array_parses():
+    # Exercises the unconditional slice: text starts with '[' but has trailing
+    # commentary that the old `text[0] != "["` guard skipped, breaking json.loads.
+    raw = '[{"text": "x", "category": "fact"}] Done!'
+    assert _parse_extraction_json(raw) == [{"text": "x", "category": "fact"}]
+
+
+def test_malformed_no_array_returns_empty():
+    assert _parse_extraction_json("no array here, sorry") == []
+    assert _parse_extraction_json("") == []


### PR DESCRIPTION
## Summary

Auto-memory extraction (`extract_and_store`) logged `0 candidates` on every run, so users accumulated zero memories, while skill extraction worked fine. It passed the recent window as raw alternating role messages, so the model treated it as a conversation to *continue* rather than a transcript to *analyze* — it either returned `[]` or buried the answer in chain-of-thought and ran past the `max_tokens=500` cap before emitting clean JSON, and with no `<think>`-stripping `json.loads` then discarded it. The fix flattens the window into one "analyze this transcript, return the JSON array" user message, raises `max_tokens` to 4096, and strips `<think>`/slices the JSON before parsing. One function: `services/memory/memory_extractor.py::extract_and_store` (`audit_memories` untouched).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3188
Related to #2627 (broader provider-side structured-output proposal for internal JSON LLM calls).

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated changes.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Serve a reasoning model locally (e.g. Qwen3 via LM Studio); enable auto-memory.
2. Have a multi-message conversation with several durable facts (location, job, dietary prefs).
3. After ~4 messages, check the server log: **before** this change it logs `Auto memory extraction ran: 0 candidates`; **after**, it logs `Auto-extracted N memories` and the facts appear in the memory panel.

## Results / Evidence

**Aggregate (6 trials each, same fabricated conversation** — backend engineer; Python/Go; vegetarian; peanut allergy; night owl; moved Lisbon←Berlin):

| Path | Succeeded |
|---|---|
| old — raw role messages, `max_tokens=500`, no `<think>` strip | **0 / 6** |
| new — flattened transcript, `max_tokens=4096`, `<think>` stripped | **6 / 6** |

**Worked example (one trial), same input:**

*Old path* — the model reasons instead of answering and is truncated at 500 tokens before clean JSON; the old parser discards it:
```
I need to extract durable personal facts from this conversation.
- User is a backend engineer (Python/Go). ...
I will output:
[
  {"text": "I am a backend engineer working with Python and Go.", ...
   <- truncated mid-reasoning; json.loads on leading prose fails -> 0 facts
```

*New path* — clean JSON, stored:
```json
[
  {"text": "Lives in Lisbon after moving from Berlin.", "category": "fact"},
  {"text": "Works as a backend engineer using Python and Go.", "category": "identity"}
]
```

This matches production, where auto-memory logged `0 candidates` on every run.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend only (`services/memory/memory_extractor.py`
