### PR TITLE
fix(ui): pin tabbed modal heights so the window no longer resizes on …

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -9945,6 +9945,18 @@ details a:hover {
   position: relative;
   isolation: isolate;
 }
+/* Tab-size stability: pin the Brain window height so switching tabs
+   (Memories / Skills / Add / Settings — all different content heights)
+   does NOT resize the modal. The previous content-driven sizing let
+   the modal grow and shrink between tabs. A fixed `height` (capped at
+   the old max) keeps the chrome stable; the inner `.memory-modal-body`
+   (already `overflow-y:auto`) absorbs the rest. Scoped to desktop only
+   — mobile keeps its 100dvh bottom-sheet height from the 768px query. */
+@media (min-width: 769px) {
+  #memory-modal:not(.modal-right-docked):not(.modal-left-docked) .memory-modal-content {
+    height: min(78vh, 760px);
+  }
+}
 .memory-modal-content::before { content: none; }
 @keyframes memory-synapse-pulse {
   0%, 100% { opacity: 0.35; transform: scale(1); }
@@ -14371,6 +14383,22 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
   font-size: 12px;
   background: var(--bg);
 }
+/* Tab-size stability: pin the Doc Library height so switching tabs
+   (Chats / Documents / Research / Archive) does NOT resize the modal.
+   The previous `max-height` only meant "don't exceed 85vh" — the
+   content still drove the actual height, so the window jumped between
+   tabs. A fixed `height` (capped at the old max) keeps it stable; the
+   inner `.doclib-grid` (already `overflow-y:auto`) and the toolbar
+   above it stay put. Scoped to desktop only — mobile keeps its
+   100dvh bottom-sheet height. */
+@media (min-width: 769px) {
+  #doclib-modal:not(.modal-right-docked):not(.modal-left-docked):not(.doclib-fullscreen) .doclib-modal-content {
+    height: min(85vh, 760px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+}
 /* Anchor doclib modal to top so only the bottom edge moves on resize */
 #doclib-modal {
   align-items: flex-start;
@@ -15168,7 +15196,17 @@ body.right-dock-active:not(.email-doc-split-active) .doc-editor-pane {
 }
 @media (min-width: 769px) {
   body:not(.email-doc-split-active) #email-lib-modal:not(.email-lib-fullscreen):not(.modal-left-docked):not(.modal-right-docked) .modal-content {
-    min-height: min(560px, 85vh);
+    /* Tab-size stability: pin the Email Library height so switching
+       folders (Inbox / Sent / Drafts / etc.) does NOT resize the modal.
+       The previous `min-height` only set a floor — content above the
+       floor still drove the actual height, so the window jumped between
+       folders. A fixed `height` (with a sensible floor for very short
+       viewports) keeps it stable; the inner `.doclib-grid` (already
+       `overflow-y:auto`) absorbs the rest. */
+    height: min(85vh, 820px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 }
 
@@ -16713,6 +16751,22 @@ body:not(.email-doc-split-active) #email-lib-modal.email-lib-fullscreen:not(.mod
   width: min(820px, 94vw);
   max-height: 92vh;
   font-size: 12px;
+}
+/* Tab-size stability: pin the Gallery height so switching tabs
+   (Photos / Albums / Edit / image-detail overlay) does NOT resize the
+   modal. The previous `max-height` only set a ceiling — content drove
+   the actual height, so the window jumped between tabs. A fixed
+   `height` (capped at the old max) keeps the chrome stable; the inner
+   `.gallery-grid` (already `overflow-y:auto`) and the editor's
+   `.ge-right-panel` (also `overflow-y:auto`) absorb the rest. Scoped
+   to desktop only — mobile keeps its 100dvh bottom-sheet height. */
+@media (min-width: 769px) {
+  #gallery-modal:not(.modal-right-docked):not(.modal-left-docked) .gallery-modal-content {
+    height: min(92vh, 880px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
 }
 /* While the Edit tab is active the editor needs a *definite* height so
    the right-side tool panel (`.ge-right-panel { overflow-y:auto }`)
@@ -21287,6 +21341,22 @@ body.gallery-selecting .gallery-dl-btn,
   container-type: inline-size;
   container-name: settings-modal;
 }
+/* Tab-size stability: pin the Settings window height so switching between
+   tabs (Services / AI / Search / Integrations / etc. — all different
+   content heights) does NOT resize the modal. The previous `min/max-height`
+   pair let the layout grow to its tallest tab and shrink to the shortest,
+   so the whole window visibly jumped on every tab change. A fixed
+   `height` (capped at the old `max-height`) keeps the chrome stable; the
+   inner `.settings-panels` (already `overflow-y:auto`) absorbs the rest.
+   Scoped to desktop only — on mobile the bottom-sheet uses a real 100dvh
+   height via the existing 768px media query, so this would force an
+   awkward capped height on phones. */
+@media (min-width: 769px) {
+  #settings-modal:not(.modal-right-docked) .settings-modal-content {
+    height: min(85vh, 820px);
+    overflow: hidden;
+  }
+}
 
 /* Issue #208 — anchor the Settings window to the TOP of the chat area instead
    of vertically centering it. The base .modal uses `align-items:center`, so a
@@ -21311,8 +21381,14 @@ body.gallery-selecting .gallery-dl-btn,
 
 .settings-layout {
   display: flex;
-  min-height: 400px;
-  max-height: calc(85vh - 60px);
+  /* Fixed height (with a generous floor for very short viewports) — the
+     `min-height`/`max-height` pair above was the source of the tab-switch
+     resize jump, so the layout now fills its parent and the inner
+     `.settings-panels` scrolls when content overflows. On desktop the
+     parent is pinned to `min(85vh, 820px)` by the media query above; on
+     mobile the parent is full-height (`100dvh`) and the layout takes it. */
+  min-height: 0;
+  height: 100%;
 }
 
 .settings-modal-content[style*="height"],
@@ -21714,6 +21790,22 @@ body:not(.welcome-ready) #welcome-screen {
 
 /* ── Tasks ── */
 .tasks-modal-content { max-width: 600px; width: min(600px, 92vw); background: var(--bg); font-size: 12px; }
+/* Tab-size stability: pin the Tasks height so switching tabs
+   (Tasks / Activity / Add) does NOT resize the modal. The previous
+   rule had no height at all, so the modal-content sized to the
+   tallest tab and shrank back to the shortest on every switch. A
+   fixed `height` (capped at 75vh) keeps the chrome stable; the inner
+   `.modal-body` (already `overflow:hidden` with `flex:1` children)
+   absorbs the rest. Scoped to desktop only — mobile keeps its
+   100dvh bottom-sheet height. */
+@media (min-width: 769px) {
+  #tasks-modal:not(.modal-right-docked):not(.modal-left-docked) .tasks-modal-content {
+    height: min(75vh, 720px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+}
 
 /* Tasks tabs reuse the .memory-tab look. The Brain window's tab bar is
    full-bleed (its underline spans the whole modal width). The Tasks bar is a
@@ -33128,6 +33220,22 @@ body.notes-mobile-mode.notes-drag-mode .note-card-pin.active {
 
 /* ── Calendar ── */
 .cal-modal-content { width:min(680px, 94vw); max-height:88vh; overflow-x:hidden; }
+/* Tab-size stability: pin the Calendar height so switching views
+   (Month / Week / Day / Agenda — all very different content heights)
+   does NOT resize the modal. The previous `max-height` only set a
+   ceiling — content drove the actual height, so the window jumped
+   between views. A fixed `height` (capped at the old max) keeps it
+   stable; the inner `#cal-body` (already a flex column with
+   `overflow:hidden`) and the `.cal-grid` (already `overflow-y:auto`)
+   absorb the rest. Scoped to desktop only — mobile keeps its 100dvh
+   bottom-sheet height. */
+@media (min-width: 769px) {
+  #calendar-modal:not(.modal-right-docked):not(.modal-left-docked) .cal-modal-content {
+    height: min(88vh, 820px);
+    display: flex;
+    flex-direction: column;
+  }
+}
 /* Was overflow-y:auto with grid + day-detail flowing naturally. Now uses a
    true splitter layout: the body is a flex column that doesn't scroll
    itself; the grid takes the remaining space and scrolls if needed; the


### PR DESCRIPTION
…tab change
Settings, Memory, Doc Library, Email Library, Gallery, Tasks, and Calendar modals all sized their content area via min/max-height, so switching tabs caused the modal to grow or shrink to fit the new content. The earlier Issue #208 fix (62c60fc) only anchored the Settings modal to the top; the height itself still jumped between tabs.
Pin each modal's content area to a fixed height (capped at the previous max). Inner panels already scroll, so the modal stays put and the active panel scrolls internally. Scoped to desktop only; mobile bottom-sheet behavior is unchanged. Window drag, fullscreen, and side-dock paths are preserved via :not(...) guards.
Summary
The Settings, Memory, Doc Library, Email Library, Gallery, Tasks, and Calendar modals all grew or shrank visibly every time the user switched between tabs because their content area was sized by min/max-height driven by the active tab's content. A previous fix (62c60fc, Issue #208) only anchored the Settings modal to the top of the viewport — the height itself still jumped. This change pins each modal's content area to a fixed height (capped at the previous maximum) and lets the existing inner scroll surfaces absorb the rest. As a result, switching tabs no longer resizes the window, and the inner panel scrolls internally when content exceeds the cap. The fix is scoped to desktop; mobile bottom-sheet behavior, window drag, fullscreen, and side-dock paths are all preserved.
Target branch
- [x] This PR targets dev, not main. All PRs land in dev; main is curated by the maintainer at each release. If your PR is on main by accident, click "Edit" on this PR and change the base.
Linked Issue
<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->
Fixes #
Related: #208 (62c60fc — the partial fix that anchored Settings to the top but did not pin its height)
Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
Checklist
- [x] I searched open issues (https://github.com/pewdiepie-archdaemon/odysseus/issues) and open PRs (https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets dev
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (docker compose up or uvicorn app:app) and verified the change works end-to-end. Type-checks and unit tests are not enough.
How to Test
<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->
1. Open each of the seven affected modals on a desktop browser (Settings, Brain/Memory, Documents, Email, Gallery, Tasks, Calendar) and switch through every tab/view — the window should not change size on any switch. Pay special attention to Settings (Services ↔ AI Defaults ↔ Search ↔ Integrations ↔ Email ↔ Reminders ↔ Appearance ↔ Shortcuts ↔ Account ↔ Tools/Users/System) and Memory (Memories ↔ Skills ↔ Add ↔ Settings), which are the most visibly affected.
2. Drag a window to a new position, then switch tabs inside it — the drag position and size must be preserved (the drag handler writes inline top/left/height which overrides the new rules via specificity).
3. Right-dock and fullscreen each modal — the existing pinned sizes from the dock/fullscreen rules must still apply (the new rules carry :not(.modal-right-docked):not(.modal-left-docked):not(.*-fullscreen) guards).
4. Resize the browser to ≤600px wide and reopen the modals — they must remain full-height bottom sheets (the existing @media (max-width: 768px) block at line 6553 sets height: 100dvh !important on these modals, which overrides the new rules on mobile).
5. For a regression check, confirm the existing Gallery "Edit" tab still works: the editor's right-side tool panel (.ge-right-panel) should scroll internally as before — that path's existing height: 92vh rule is preserved by :has() specificity.
Visual / UI changes — REQUIRED if you touched anything that renders
Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any static/js/ module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.
- [x] Screenshot or short clip of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] Style match: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (--red, --fg, --bg, --card, --border, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - No Unicode emoji in UI or code. Use inline SVG (matching the monochrome icon style already in static/index.html) or plain text.
  - Monospaced font (Fira Code) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] No new component patterns. If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] I am not an LLM agent submitting a bulk PR. If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
Screenshots / clips
<img width="1892" height="901" alt="image" src="https://github.com/user-attachments/assets/a6628f7b-4374-4919-a324-fad356004b83" />
---