### PR TITLE
docs: note dev branch status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Odysseus
 
+> **Branch note:** `dev` is the default branch and contains the latest development changes, but it may be unstable. For the more stable curated branch, use [`main`](https://github.com/pewdiepie-archdaemon/odysseus/tree/main).
+
 ```
 ───────────────────────────────────────────────
  ⊹ ࣪ ˖ ૮( ˶ᵔ ᵕ ᵔ˶ )っ  Odysseus vers. 1.0


### PR DESCRIPTION
## Summary
- Adds a short branch-status note at the top of the README on `dev`.
- Points users who want the vetted checkout to the `main` branch.

## Linked Issue

Fixes #2875

## Target branch

- [x] This PR targets `dev`.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I searched open issues and pull requests — this is not a duplicate.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the relevant checks. See "How to Test" below.

## Duplicate Search

Checked open PRs for:
- `#2875`
- `"development branch"`
- `"Branch note" README.md`
- `"latest vetted/stable checkout"`
- `"active dev branch"`

The matches I inspected were unrelated README/docs changes and did not add the requested dev-branch banner.

## How to Test

1. Open `README.md` on this branch and confirm the first content after the title is a short `dev` branch note linking to `main`.
2. Run `git diff --check origin/dev...HEAD` and confirm it reports no whitespace errors.
3. Run `git diff --stat origin/dev...HEAD` and confirm only `README.md` changes.
