### PR TITLE
fix(chat): add horizontal scrolling for markdown tables

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -7722,7 +7722,13 @@ button.hamburger {
   border-collapse: collapse;
   margin: 0.5em 0;
   font-size: 0.9em;
-  width: auto;
+  display: block;
+  width: max-content;
+  min-width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  table-layout: auto;
 }
 .msg th {
   background: color-mix(in srgb, var(--fg) 7%, transparent);
@@ -7731,10 +7737,16 @@ button.hamburger {
   padding: 6px 12px;
   border: 1px solid var(--border);
   text-align: left;
+  min-width: 9ch;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 .msg td {
   padding: 5px 12px;
   border: 1px solid var(--border);
+  min-width: 9ch;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 /* Agent UI Styling */


### PR DESCRIPTION
## Summary

Adds horizontal scrolling for markdown tables in chat messages so wide tables remain readable on both desktop and mobile.

Previously, markdown tables could become cramped in the chat bubble. On narrow screens, columns could collapse so far that words wrapped one character per line. This change lets tables size to their content while staying contained inside the message area, with horizontal scrolling when needed.

## Linked Issue

Fixes #3199

## Type of Change

- [x] Bug fix
- [x] UI/layout fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## What Changed

- Allows markdown tables in chat messages to scroll horizontally when wider than the message area.
- Prevents table cells from collapsing into one-character vertical wrapping.
- Gives table cells a small readable minimum width.
- Keeps tables contained inside the chat message bubble.
- Preserves normal table behavior when the table fits within the available width.

## How to Test

1. Start Odysseus locally.
2. Open chat.
3. Send or paste a wide markdown table with several columns:

```markdown
| Feature / Area | Current mobile problem being tested | Expected behavior after fix | Long sample content to stress wrapping | Desktop expectation | Mobile expectation |
|---|---|---|---|---|---|
| Markdown tables | Columns become extremely narrow and words wrap one character per line | Table stays readable and scrolls horizontally if needed | This sentence is intentionally long enough to test whether normal prose wraps reasonably without breaking every word into single-letter columns. | Table looks normal without unnecessary horizontal scrolling | Table remains inside message bubble and can scroll sideways |
| Chat responses | Assistant answers with structured comparisons are hard to read on phones | Comparison tables remain useful on narrow screens | Purpose, tradeoffs, risks, and verification notes should all remain readable even when the viewport is small. | Columns use available width cleanly | User can swipe horizontally within the table |
| Code review notes | File paths and technical terms can crush layout | Technical terms should not destroy the table layout | `static/js/chatRenderer.js`, `routes/chat_routes.py`, `src/llm_core.py`, and `static/style.css` should remain readable. | Code-like text displays acceptably | Long code/file strings may scroll or wrap sensibly |
| Planning output | Roadmap tables often have many columns | Wide planning tables should not make the whole page overflow | Milestone, owner, dependency, acceptance criteria, risk, and next action are common columns in planning responses. | The chat column remains stable | The page itself should not horizontally scroll |
| User experience | Mobile reading flow breaks when table text stacks vertically | The user should be able to read rows without mental reconstruction | A table should feel like a table, not like a vertical stream of individual letters stacked down the page. | Normal markdown styling remains unchanged | No one-letter-per-line wrapping |
| Regression check | Non-table markdown could accidentally be affected by table CSS | Paragraphs, lists, links, and code blocks should render the same | This row exists to remind us that the CSS fix should be scoped to tables and not globally change all message text. | Other markdown unchanged | Other markdown unchanged |
```

4. Test at desktop width.
5. Test at mobile/narrow width.
6. Confirm wide tables scroll horizontally inside the message bubble.
7. Confirm table text remains readable.
8. Confirm words no longer wrap one character per line.
9. Confirm normal non-table markdown still renders correctly.

## Verification

- [x] Verified desktop table rendering
- [x] Verified mobile/narrow table rendering
- [x] Confirmed wide tables scroll horizontally inside the message area
- [x] Confirmed table cells no longer collapse into one-character vertical wrapping
- [x] Ran `git diff --check -- static/style.css`

## Checklist

- [x] I searched existing issues and pull requests for duplicates.
- [x] This PR targets `dev`.
- [x] This PR is limited to one focused bug fix.
- [x] I avoided unrelated refactors, formatting-only changes, and broad cleanup.
- [x] I tested the UI change locally.

## Screenshots

<details>
<summary>Desktop before / after</summary>

**Before**

<img width="900" alt="Desktop before: markdown table cramped in chat message" src="https://github.com/user-attachments/assets/2f06dcf1-224b-417b-9c30-8c702758d332" />

**After**

<img width="900" alt="Desktop after: markdown table horizontally scrolls when needed" src="https://github.com/user-attachments/assets/d4abbcf3-9f7f-43a7-b03b-9c0958f533ea" />

</details>

<details>
<summary>Mobile before / after</summary>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img width="280" alt="Mobile before: markdown table text wraps one character per line" src="https://github.com/user-attachments/assets/4c22de8c-a4a5-4451-b592-5363c83872de" />
    </td>
    <td>
      <img width="280" alt="Mobile after: markdown table remains readable with horizontal scrolling" src="https://github.com/user-attachments/assets/887d4d1c-19e0-43d1-80e5-b4b9a961b9b3" />
    </td>
  </tr>
</table>

</details>