### PR TITLE
fix: fall back to /models probe when base URL returns 404

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -755,7 +755,26 @@ def _ping_endpoint(base_url: str, api_key: str = None, timeout: float = 1.5) -> 
 
     try:
         r = httpx.get(base, headers=headers, timeout=timeout, verify=llm_verify())
-        return _result_from_response(r)
+        result = _result_from_response(r)
+        # If the bare base URL returns a non-auth 4xx (e.g. 404), try /models
+        # as a fallback. OpenAI-compatible servers like llama-swap return 404
+        # on the base /v1 prefix but 200 on /v1/models.  Auth failures (401/403)
+        # are definitive — probing /models would just repeat the same rejection.
+        if (
+            not result["reachable"]
+            and result.get("status_code") is not None
+            and 400 <= result["status_code"] < 500
+            and result["status_code"] not in (401, 403)
+        ):
+            models_url = base.rstrip("/") + "/models"
+            try:
+                r2 = httpx.get(models_url, headers=headers, timeout=timeout, verify=llm_verify())
+                result2 = _result_from_response(r2)
+                if result2["reachable"]:
+                    return result2
+            except Exception:
+                pass
+        return result
     except Exception as e:
         last_error = str(e)[:120]
 

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -360,6 +360,48 @@ class TestClassifyEndpoint:
         assert seen == [("GET", "http://100.117.136.97:34521/v1")]
         assert all(not url.endswith("/models") for _, url in seen)
 
+    def test_ping_endpoint_falls_back_to_models_on_404(self, monkeypatch):
+        """llama-swap returns 404 on /v1 but 200 on /v1/models."""
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+        seen = []
+
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
+            seen.append(url)
+            request = httpx.Request("GET", url)
+            if url.endswith("/models"):
+                return httpx.Response(200, request=request)
+            return httpx.Response(404, request=request)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+
+        result = _ping_endpoint("http://172.17.0.1:8081/v1", timeout=1)
+
+        assert result["reachable"] is True
+        assert result["status_code"] == 200
+        assert seen == [
+            "http://172.17.0.1:8081/v1",
+            "http://172.17.0.1:8081/v1/models",
+        ]
+
+    def test_ping_endpoint_no_models_fallback_on_auth_failure(self, monkeypatch):
+        """401/403 are definitive — don't probe /models."""
+        monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url, raising=False)
+        seen = []
+
+        def fake_get(url, headers=None, timeout=None, verify=None, **kwargs):
+            seen.append(url)
+            request = httpx.Request("GET", url)
+            return httpx.Response(401, request=request)
+
+        monkeypatch.setattr(model_routes.httpx, "get", fake_get)
+
+        result = _ping_endpoint("http://10.0.0.1:8080/v1", "bad-key", timeout=1)
+
+        assert result["reachable"] is False
+        assert result["status_code"] == 401
+        # Should NOT have tried /models — 401 is definitive
+        assert len(seen) == 1
+
 
 # ── setup probing ──
 


### PR DESCRIPTION
## Summary

`_ping_endpoint()` probes the bare base URL to check if a model endpoint is reachable. For OpenAI-compatible servers like llama-swap running outside Docker, the base URL (e.g. `http://host:8081/v1`) returns 404, but `/v1/models` returns 200. The probe treats the 404 as unreachable, so the UI marks the endpoint "offline" even though inference works fine.

This adds a fallback: when the base URL returns a non-auth 4xx (like 404), try `base + "/models"` before giving up. Auth failures (401/403) are treated as definitive since probing `/models` would just repeat the same rejection. The happy path is unchanged — if the base URL returns 2xx, `/models` is never probed.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3181

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Set up llama-swap or llama.cpp on the host (outside Docker) with an OpenAI-compatible endpoint.
2. In Odysseus Settings → Add Models, add the endpoint URL (e.g. `http://172.17.0.1:8081/v1`).
3. Before this fix: models show as "offline" despite inference working. After: models show as online.
4. Run the unit tests: `python -m pytest tests/test_model_routes.py tests/test_endpoint_probing.py -x` — all should pass, including the two new tests (`test_ping_endpoint_falls_back_to_models_on_404` and `test_ping_endpoint_no_models_fallback_on_auth_failure`).
