### PR TITLE
chore: add warnings to silent except Exception blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -332,7 +332,7 @@ if AUTH_ENABLED:
                     request.state.api_token = False
                     return await call_next(request)
             except Exception as _e:
-                logger.warning("Internal tool auth header check failed: %s", _e)
+                logger.warning("Internal tool auth header check failed", exc_info=_e)
             # Allow DIRECT localhost requests (internal service calls from
             # heartbeats etc.). Tunnel/proxy-forwarded requests are excluded by
             # _is_trusted_loopback so LOCALHOST_BYPASS can't be abused over a
@@ -386,7 +386,7 @@ if AUTH_ENABLED:
                             try:
                                 await _asyncio.to_thread(_do)
                             except Exception as _e:
-                                logger.debug("Failed to update token last_used_at: %s", _e)
+                                logger.debug("Failed to update token last_used_at", exc_info=_e)
                         _asyncio.create_task(_touch_last_used(matched_id))
                         # Keep bearer-token callers out of normal cookie/user
                         request.state.current_user = "api"
@@ -464,7 +464,7 @@ async def serve_generated_image(filename: str, request: Request):
     except HTTPException:
         raise
     except Exception as _e:
-        logger.warning("Image ownership verification failed for %r: %s", filename, _e)
+        logger.warning("Image ownership verification failed for %r", filename, exc_info=_e)
     ext = filename.rsplit('.', 1)[-1].lower()
     mime = {
         "png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg",

--- a/app.py
+++ b/app.py
@@ -331,8 +331,8 @@ if AUTH_ENABLED:
                         request.state.current_user = "internal-tool"
                     request.state.api_token = False
                     return await call_next(request)
-            except Exception:
-                pass
+            except Exception as _e:
+                logger.warning("Internal tool auth header check failed: %s", _e)
             # Allow DIRECT localhost requests (internal service calls from
             # heartbeats etc.). Tunnel/proxy-forwarded requests are excluded by
             # _is_trusted_loopback so LOCALHOST_BYPASS can't be abused over a
@@ -385,11 +385,10 @@ if AUTH_ENABLED:
                                     _db.close()
                             try:
                                 await _asyncio.to_thread(_do)
-                            except Exception:
-                                pass
+                            except Exception as _e:
+                                logger.debug("Failed to update token last_used_at: %s", _e)
                         _asyncio.create_task(_touch_last_used(matched_id))
                         # Keep bearer-token callers out of normal cookie/user
-                        # routes. API-aware routes can read api_token_owner.
                         request.state.current_user = "api"
                         request.state.api_token = True
                         request.state.api_token_id = matched_id
@@ -464,8 +463,8 @@ async def serve_generated_image(filename: str, request: Request):
                 _db.close()
     except HTTPException:
         raise
-    except Exception:
-        pass
+    except Exception as _e:
+        logger.warning("Image ownership verification failed for %r: %s", filename, _e)
     ext = filename.rsplit('.', 1)[-1].lower()
     mime = {
         "png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg",

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -127,7 +127,7 @@ def _clear_orphaned_session_endpoint(sess, owner: str | None = None) -> bool:
         sess.headers = {}
         return True
     except Exception as e:
-        logger.warning("Failed to clear orphaned session endpoint: %s", e)
+        logger.warning("Failed to clear orphaned session endpoint", exc_info=e)
         db.rollback()
         return False
     finally:
@@ -146,7 +146,7 @@ def _endpoint_cache_contains_model(endpoint, model: str) -> bool:
     try:
         models = json.loads(raw) if isinstance(raw, str) else raw
     except Exception as e:
-        logger.warning("Failed to parse cached models list, treating as containing model: %s", e)
+        logger.warning("Failed to parse cached models list, treating as containing model", exc_info=e)
         return True
     if not isinstance(models, list) or not models:
         return True
@@ -239,7 +239,7 @@ def _recover_empty_session_model(sess, session_id: str, owner: str | None = None
         try:
             cached = json.loads(ep.cached_models) if isinstance(ep.cached_models, str) else (ep.cached_models or [])
         except Exception as e:
-            logger.warning("Failed to parse cached_models for endpoint %r: %s", getattr(ep, "id", "?"), e)
+            logger.warning("Failed to parse cached_models for endpoint %r", getattr(ep, "id", "?"), exc_info=e)
             cached = []
         if not cached:
             visible = []
@@ -650,7 +650,7 @@ def setup_chat_routes(
             try:
                 att_ids = [str(x) for x in json.loads(attachments)]
             except Exception as e:
-                logger.warning("Failed to parse attachments JSON, ignoring attachments: %s", e)
+                logger.warning("Failed to parse attachments JSON, ignoring attachments", exc_info=e)
 
         no_memory = str(form_data.get("no_memory", "")).lower() == "true"
         pre_context_tool_policy = build_effective_tool_policy(

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -126,7 +126,8 @@ def _clear_orphaned_session_endpoint(sess, owner: str | None = None) -> bool:
         sess.model = ""
         sess.headers = {}
         return True
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to clear orphaned session endpoint: %s", e)
         db.rollback()
         return False
     finally:
@@ -144,7 +145,8 @@ def _endpoint_cache_contains_model(endpoint, model: str) -> bool:
         return True
     try:
         models = json.loads(raw) if isinstance(raw, str) else raw
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to parse cached models list, treating as containing model: %s", e)
         return True
     if not isinstance(models, list) or not models:
         return True
@@ -236,7 +238,8 @@ def _recover_empty_session_model(sess, session_id: str, owner: str | None = None
                 is_chatgpt_subscription = False
         try:
             cached = json.loads(ep.cached_models) if isinstance(ep.cached_models, str) else (ep.cached_models or [])
-        except Exception:
+        except Exception as e:
+            logger.warning("Failed to parse cached_models for endpoint %r: %s", getattr(ep, "id", "?"), e)
             cached = []
         if not cached:
             visible = []
@@ -646,8 +649,8 @@ def setup_chat_routes(
         elif attachments:
             try:
                 att_ids = [str(x) for x in json.loads(attachments)]
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to parse attachments JSON, ignoring attachments: %s", e)
 
         no_memory = str(form_data.get("no_memory", "")).lower() == "true"
         pre_context_tool_policy = build_effective_tool_policy(

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -504,7 +504,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         try:
             data = await request.json()
         except Exception as e:
-            logger.warning("Failed to parse export request body, defaulting to empty: %s", e)
+            logger.warning("Failed to parse export request body, defaulting to empty", exc_info=e)
             data = {}
         ids = data.get("ids") or []
         if not ids:
@@ -647,7 +647,7 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                         from src.agent_tools.document_tools import clear_active_document
                         clear_active_document(doc_id)
                     except Exception as e:
-                        logger.warning("Failed to clear active document %r on detach: %s", doc_id, e)
+                        logger.warning("Failed to clear active document %r on detach", doc_id, exc_info=e)
             db.commit()
             db.refresh(doc)
             return _doc_to_dict(doc)

--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -503,7 +503,8 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         user = get_current_user(request)
         try:
             data = await request.json()
-        except Exception:
+        except Exception as e:
+            logger.warning("Failed to parse export request body, defaulting to empty: %s", e)
             data = {}
         ids = data.get("ids") or []
         if not ids:
@@ -645,8 +646,8 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
                     try:
                         from src.agent_tools.document_tools import clear_active_document
                         clear_active_document(doc_id)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning("Failed to clear active document %r on detach: %s", doc_id, e)
             db.commit()
             db.refresh(doc)
             return _doc_to_dict(doc)

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -80,7 +80,7 @@ def _email_tag_owner_aliases(account_id: str | None, owner: str = "") -> list[st
                         cfg.get("from_address") or "",
                     ])
                 except Exception as _e:
-                    logger.warning("Failed to resolve email account alias: %s", _e)
+                    logger.warning("Failed to resolve email account alias", exc_info=_e)
                     resolved_account_id = None
             row = db.get(_EA, resolved_account_id) if resolved_account_id else None
             if row:
@@ -88,7 +88,7 @@ def _email_tag_owner_aliases(account_id: str | None, owner: str = "") -> list[st
         finally:
             db.close()
     except Exception as _e:
-        logger.warning("Failed to load email aliases: %s", _e)
+        logger.warning("Failed to load email aliases", exc_info=_e)
     out = []
     for a in aliases:
         a = (a or "").strip()

--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -79,15 +79,16 @@ def _email_tag_owner_aliases(account_id: str | None, owner: str = "") -> list[st
                         cfg.get("smtp_user") or "",
                         cfg.get("from_address") or "",
                     ])
-                except Exception:
+                except Exception as _e:
+                    logger.warning("Failed to resolve email account alias: %s", _e)
                     resolved_account_id = None
             row = db.get(_EA, resolved_account_id) if resolved_account_id else None
             if row:
                 aliases.extend([row.owner or "", row.imap_user or "", row.from_address or ""])
         finally:
             db.close()
-    except Exception:
-        pass
+    except Exception as _e:
+        logger.warning("Failed to load email aliases: %s", _e)
     out = []
     for a in aliases:
         a = (a or "").strip()

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -524,7 +524,7 @@ def get_builtin_overrides() -> dict:
         ov = get_setting("builtin_tool_overrides", {})
         return ov if isinstance(ov, dict) else {}
     except Exception as e:
-        logger.warning("Failed to load builtin tool overrides, using defaults: %s", e)
+        logger.warning("Failed to load builtin tool overrides, using defaults", exc_info=e)
         return {}
 
 
@@ -974,7 +974,7 @@ def _build_system_prompt(
                 from src.pdf_form_doc import find_source_upload_id
                 _is_form_backed = bool(find_source_upload_id(active_document.current_content or ""))
             except Exception as e:
-                logger.warning("Failed to detect if document is form-backed, assuming plain: %s", e)
+                logger.warning("Failed to detect if document is form-backed, assuming plain", exc_info=e)
 
             if _is_form_backed:
                 doc_ctx = (

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -524,7 +524,7 @@ def get_builtin_overrides() -> dict:
         ov = get_setting("builtin_tool_overrides", {})
         return ov if isinstance(ov, dict) else {}
     except Exception as e:
-        logger.warning('Failed to load builtin tool overrides: %s', e)
+        logger.warning("Failed to load builtin tool overrides, using defaults: %s", e)
         return {}
 
 
@@ -929,8 +929,8 @@ def _build_system_prompt(
     try:
         from src.user_time import current_datetime_context_message
         _datetime_message = current_datetime_context_message()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to build datetime context message", exc_info=e)
 
     # Document context is kept as a SEPARATE message (not merged into the tool
     # prompt) so the context trimmer doesn't destroy it when truncating the
@@ -973,8 +973,8 @@ def _build_system_prompt(
             try:
                 from src.pdf_form_doc import find_source_upload_id
                 _is_form_backed = bool(find_source_upload_id(active_document.current_content or ""))
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to detect if document is form-backed, assuming plain: %s", e)
 
             if _is_form_backed:
                 doc_ctx = (

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -284,7 +284,7 @@ def _is_ollama_native_url(url: str) -> bool:
     try:
         parsed = urlparse(url or "")
     except Exception as e:
-        logger.warning("Failed to parse URL for Ollama detection %r: %s", url, e)
+        logger.warning("Failed to parse URL for Ollama detection %r", url, exc_info=e)
         return False
     host = parsed.hostname or ""
     path = (parsed.path or "").rstrip("/")
@@ -1347,7 +1347,7 @@ def list_model_ids(
                 r.raise_for_status()
                 return [m.get("name") or m.get("model") for m in (r.json().get("models") or []) if m.get("name") or m.get("model")]
         except Exception as e:
-            logger.warning("Failed to fetch model list from endpoint %r: %s", base_chat_url, e)
+            logger.warning("Failed to fetch model list from endpoint %r", base_chat_url, exc_info=e)
         return []
 
 def normalize_model_id(

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -283,7 +283,8 @@ def _is_ollama_native_url(url: str) -> bool:
     """Return True for native Ollama API URLs, including Ollama Cloud."""
     try:
         parsed = urlparse(url or "")
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to parse URL for Ollama detection %r: %s", url, e)
         return False
     host = parsed.hostname or ""
     path = (parsed.path or "").rstrip("/")
@@ -1345,8 +1346,8 @@ def list_model_ids(
                 r = httpx.get(root + "/api/tags", timeout=timeout)
                 r.raise_for_status()
                 return [m.get("name") or m.get("model") for m in (r.json().get("models") or []) if m.get("name") or m.get("model")]
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to fetch model list from endpoint %r: %s", base_chat_url, e)
         return []
 
 def normalize_model_id(

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -284,7 +284,7 @@ def _is_ollama_native_url(url: str) -> bool:
     try:
         parsed = urlparse(url or "")
     except Exception as e:
-        logger.warning("Failed to parse URL for Ollama detection %r", url, exc_info=e)
+        logger.warning("Failed to parse URL for Ollama detection", exc_info=e)
         return False
     host = parsed.hostname or ""
     path = (parsed.path or "").rstrip("/")
@@ -1347,7 +1347,7 @@ def list_model_ids(
                 r.raise_for_status()
                 return [m.get("name") or m.get("model") for m in (r.json().get("models") or []) if m.get("name") or m.get("model")]
         except Exception as e:
-            logger.warning("Failed to fetch model list from endpoint %r", base_chat_url, exc_info=e)
+            logger.warning("Failed to fetch model list from configured endpoint", exc_info=e)
         return []
 
 def normalize_model_id(


### PR DESCRIPTION
## Summary

Splits out the silent-except logging sweep that was originally bundled into #1530 (per [alteixeira20's review feedback](https://github.com/pewdiepie-archdaemon/odysseus/pull/1530#pullrequestreview-3743948)) into its own focused PR.

Replaces several silent `except Exception: pass` blocks with `except Exception as e: logger.warning(...)` (or `.debug(...)`) across:

- `app.py`
- `routes/chat_routes.py`
- `routes/document_routes.py`
- `routes/email_routes.py`
- `src/agent_loop.py`
- `src/llm_core.py`

These are pure observability changes — the `except` still catches and continues in every case, so there is **no control-flow change**. The only difference is that previously-silent failures now leave a log line, which should make debugging these paths easier (in the same spirit as the sweep landed in #1545).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #1530 (split out per review — see summary above)

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and exercised the affected code paths (chat streaming, document upload, email send, agent tool loop) to confirm the new log lines fire on the expected failure conditions without changing behaviour.

## How to Test

1. Check out the branch and run `python -m pytest` — no test should change behaviour or fail (these are log-line additions only).
2. Grep the changed files for `logger.warning` / `logger.debug` added next to each touched `except Exception` block and confirm the surrounding `try`/`except` still falls through to the same return value / continuation as before (no new raises, no swallowed-then-rethrown changes).
3. Optionally trigger one of the affected paths locally (e.g. send a chat message that hits a transient LLM error, or upload a malformed document) and confirm a `WARNING`/`DEBUG` log line now appears where previously nothing was logged.