### PR TITLE
fix: include in-memory templates in group participant character list

### DIFF
--- a/static/js/group.js
+++ b/static/js/group.js
@@ -6,7 +6,7 @@ import markdownModule from './markdown.js';
 import chatRenderer from './chatRenderer.js';
 import spinnerModule from './spinner.js';
 import { providerLogo } from './providers.js';
-import { PROMPT_TEMPLATES, getAllPresets } from './presets.js';
+import { PROMPT_TEMPLATES, getAllPresets, getUserTemplates } from './presets.js';
 import { sortModelObjects } from './modelSort.js';
 import Storage from './storage.js';
 
@@ -311,6 +311,18 @@ async function _getCharacterList() {
         chars.push({ id: t.id, name: t.name, prompt: t.system_prompt || t.prompt || '' });
       }
     });
+  } catch (e) {}
+  // Also merge in-memory templates from presets.js — these may include
+  // newly created characters whose async save-to-API hasn't completed yet.
+  try {
+    const memTemplates = getUserTemplates();
+    if (Array.isArray(memTemplates)) {
+      memTemplates.forEach(t => {
+        if (t.id && t.name && !chars.find(c => c.id === t.id)) {
+          chars.push({ id: t.id, name: t.name, prompt: t.system_prompt || t.prompt || '' });
+        }
+      });
+    }
   } catch (e) {}
   return chars;
 }

--- a/static/js/presets.js
+++ b/static/js/presets.js
@@ -837,7 +837,7 @@ export async function saveCustomPreset(showToast, showError) {
       if (saveName) {
         const _existing = userTemplates.find(t => t.name === saveName);
         const _entry = {
-          id: (_existing && _existing.id) || '',
+          id: (_existing && _existing.id) || ('user-' + Math.random().toString(16).slice(2, 10)),
           name: saveName,
           system_prompt: system_prompt || '',
           temperature: config.temperature,
@@ -906,7 +906,7 @@ export function getAllPresets() {
  * Get the in-memory user templates list (may be stale; call loadUserTemplates first if freshness matters).
  */
 export function getUserTemplates() {
-  return userTemplates;
+  return [...userTemplates];
 }
 
 /**

--- a/static/js/presets.js
+++ b/static/js/presets.js
@@ -884,6 +884,13 @@ export function getAllPresets() {
 }
 
 /**
+ * Get the in-memory user templates list (may be stale; call loadUserTemplates first if freshness matters).
+ */
+export function getUserTemplates() {
+  return userTemplates;
+}
+
+/**
  * Get the character name (if set)
  */
 export function getCharacterName() {
@@ -1099,6 +1106,7 @@ const presetsModule = {
   getSelectedPreset,
   getPreset,
   getAllPresets,
+  getUserTemplates,
   getCharacterName,
   onSessionSwitch,
   isPersistentChat,

--- a/static/js/presets.js
+++ b/static/js/presets.js
@@ -830,6 +830,25 @@ export async function saveCustomPreset(showToast, showError) {
       const _selVal = document.getElementById('char-template-select')?.value || '';
       const isBuiltinPreset = PROMPT_TEMPLATES.some(t => t.isPreset && (t.name === name || t.name === _selVal));
       const saveName = isBuiltinPreset ? null : (name || null);
+      // Optimistically update the in-memory templates list so that any code
+      // reading getUserTemplates() (e.g. the Group participant dropdown) sees
+      // the new character immediately — before the async templates POST below
+      // completes and triggers loadUserTemplates().
+      if (saveName) {
+        const _existing = userTemplates.find(t => t.name === saveName);
+        const _entry = {
+          id: (_existing && _existing.id) || '',
+          name: saveName,
+          system_prompt: system_prompt || '',
+          temperature: config.temperature,
+          max_tokens: config.max_tokens,
+        };
+        if (_existing) {
+          Object.assign(_existing, _entry);
+        } else {
+          userTemplates.push(_entry);
+        }
+      }
       if (saveName) {
         fetch(`${API_BASE}/api/presets/templates`, {
           method: 'POST',

--- a/tests/test_group_character_dropdown.py
+++ b/tests/test_group_character_dropdown.py
@@ -48,5 +48,13 @@ def test_presets_optimistic_update_on_save():
 
 
 def test_presets_getUserTemplates_returns_array():
-    """getUserTemplates should return the userTemplates array directly."""
-    assert "return userTemplates" in PRESETS_JS
+    """getUserTemplates should return a shallow copy of userTemplates."""
+    assert "return [...userTemplates]" in PRESETS_JS
+
+
+def test_presets_optimistic_id_not_empty():
+    """Optimistic update must generate a client-side id for new characters (not empty string)."""
+    # The id generation uses 'user-' prefix matching server's uuid convention
+    assert "user-' + Math.random" in PRESETS_JS
+    # Must NOT use empty string as fallback (that was the bug)
+    assert "(_existing && _existing.id) || ''" not in PRESETS_JS

--- a/tests/test_group_character_dropdown.py
+++ b/tests/test_group_character_dropdown.py
@@ -1,0 +1,52 @@
+"""Issue #3207 — newly created characters missing from Group participant dropdown.
+
+The fix has two parts:
+1. group.js _getCharacterList() merges in-memory userTemplates from presets.js
+   as a fallback (covers the gap while the async templates API save is in-flight).
+2. presets.js saveCustomPreset() does an optimistic in-memory update of
+   userTemplates immediately on success (bridges the timing race where
+   loadUserTemplates hasn't been triggered yet).
+
+These tests assert the source patterns exist so they can't be silently removed.
+"""
+from pathlib import Path
+
+GROUP_JS = Path("static/js/group.js").read_text(encoding="utf-8")
+PRESETS_JS = Path("static/js/presets.js").read_text(encoding="utf-8")
+
+
+# --- group.js: in-memory template merge in _getCharacterList ---
+
+def test_group_imports_getUserTemplates():
+    """group.js must import getUserTemplates from presets.js."""
+    assert "getUserTemplates" in GROUP_JS
+    assert "from './presets.js'" in GROUP_JS or 'from "./presets.js"' in GROUP_JS
+
+
+def test_group_merges_in_memory_templates():
+    """_getCharacterList must call getUserTemplates() and merge results."""
+    assert "getUserTemplates()" in GROUP_JS
+    # The merge loop should check for duplicates by id
+    assert "!chars.find(c => c.id === t.id)" in GROUP_JS
+
+
+# --- presets.js: optimistic in-memory update on save ---
+
+def test_presets_exports_getUserTemplates():
+    """getUserTemplates must be exported from presets.js."""
+    assert "export function getUserTemplates()" in PRESETS_JS
+
+
+def test_presets_optimistic_update_on_save():
+    """saveCustomPreset must update userTemplates in-memory before the async POST."""
+    # Find the optimistic update block
+    assert "Optimistically update the in-memory templates list" in PRESETS_JS
+    # Must push to userTemplates for new entries
+    assert "userTemplates.push(_entry)" in PRESETS_JS
+    # Must Object.assign for existing entries
+    assert "Object.assign(_existing, _entry)" in PRESETS_JS
+
+
+def test_presets_getUserTemplates_returns_array():
+    """getUserTemplates should return the userTemplates array directly."""
+    assert "return userTemplates" in PRESETS_JS


### PR DESCRIPTION
## Summary

When a character is created in the Character tab, the save to the templates API is async (fire-and-forget). If the user switches to the Group tab before that request completes, `_getCharacterList()` fetches from the API and misses the newly created character. The `getAllPresets().custom` path always shows the current custom character, which is why the "chosen character" appears consistently — but other saved templates can be missing.

Fix: export `getUserTemplates()` from `presets.js` (returns the in-memory `userTemplates` array) and merge it as a fallback in `_getCharacterList()`. The in-memory array is updated as soon as any async template save completes (via the `loadUserTemplates` callback), bridging the timing gap between character creation and API persistence. The existing dedup check (`!chars.find(c => c.id === t.id)`) prevents duplicates.

## Linked Issue

Fixes #3207

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I searched existing issues and PRs and found no duplicates.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## How to Test

1. Open Odysseus, go to the Character tab
2. Create a new character with a name and system prompt
3. Immediately switch to the Group tab (no page refresh)
4. Click "Add participant" — the newly created character should appear in the dropdown
5. Create a second character, repeat — both should appear
6. Refresh the page and verify all characters still appear in the Group participant selector

## Notes

- Follows up on #1770 which fixed the template API read (`data.templates` → `Array.isArray(data) ? data : ...`). This addresses the timing gap between async save and fetch.
- No visual changes — only the data source for the dropdown is affected.
