### PR TITLE
fix(cookbook): don't infer server OS from the browser's user-agent

### DIFF
--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -162,13 +162,27 @@ function _getPort(hostOrTask) {
 /** Get platform for a given host (or task object). Returns 'windows', 'termux', 'linux', or '' */
 export function _getPlatform(hostOrTask) {
   const isWinBrowser = (window.navigator.userAgent || window.navigator.platform || '').toLowerCase().includes('win');
+  // The browser's OS is NOT the server's OS when the UI is opened remotely —
+  // e.g. a Windows browser driving a Mac/Linux homeserver. Trusting the
+  // user-agent there makes the serve builder emit the Windows python-only
+  // shape (`python -m llama_cpp.server`, no `llama-server ||` fallback), which
+  // then fails on the actual Unix server. The local hardware probe is
+  // authoritative: it reports a backend (metal/cuda/rocm/cpu_*) for any Unix
+  // server and carries platform:"windows" for local Windows (which sets
+  // _envState.platform, short-circuiting below). So only fall back to the
+  // browser hint when we have no server-side signal at all.
+  const localPlatform = () => {
+    if (_envState.platform) return _envState.platform;
+    if (String(_hwfitCache?.system?.backend || '')) return '';
+    return isWinBrowser ? 'windows' : '';
+  };
   if (!hostOrTask || hostOrTask === 'local') {
-    return _envState.platform || (isWinBrowser ? 'windows' : '');
+    return localPlatform();
   }
   if (typeof hostOrTask === 'object') {
     const h = hostOrTask.remoteHost;
     if (!h || h === 'local') {
-      return hostOrTask.platform || _envState.platform || (isWinBrowser ? 'windows' : '');
+      return hostOrTask.platform || localPlatform();
     }
     return hostOrTask.platform || _getPlatform(h);
   }


### PR DESCRIPTION
## Summary

`_getPlatform('local')` in `static/js/cookbook.js` inferred the **server's** OS from the **browser's** `navigator.userAgent`. On a Mac/Linux homeserver opened from a **Windows browser**, this returned `'windows'`, so `_isWindows()` was `true` and the GGUF serve builder emitted the Windows python-only command shape (`python -m llama_cpp.server`, with **no** `llama-server ||` fallback). That command fails on the Unix host:

```
/path/to/venv/bin/python: ... ModuleNotFoundError: No module named 'llama_cpp'
=== Process exited with code 1 ===
```

…even when native `llama-server` is installed and already serving other models — and the diagnosis then misleadingly tells the user to `pip install "llama-cpp-python[server]"`.

### Fix

Trust the server-side hardware probe over the user-agent. A non-empty probe `backend` (`metal`/`cuda`/`rocm`/`cpu_*`) means a Unix server; local Windows instead carries `platform: "windows"`, which already sets `_envState.platform` and short-circuits before the backend check. The `navigator.userAgent` hint is only used when there is no server-side signal at all — so #1389/#2961's local-Windows detection still works.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3221

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Related

- #2961 (open) iterates on the same `navigator.userAgent` detection but does not touch the GGUF serve-command builder branch, so this remote-browser case still misfires there.
- #1389 (merged) introduced the `navigator.userAgent` heuristic (valid for local desktop deployments where browser == server).
- #2710 — same `gemma-4-E4B` model, different (Windows-native) cause.

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change.

## How to Test

1. Run Odysseus on a Mac/Linux host.
2. Open the UI from a **Windows browser**.
3. Cookbook → Serve → a GGUF model on the llama.cpp backend → Launch.
4. Before: serve runs `python -m llama_cpp.server` and fails with "No module named llama_cpp". After: serve runs native `llama-server` (`|| python3 -m llama_cpp.server` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
