### PR TITLE
fix(auth): avoid double bcrypt on login

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -447,6 +447,13 @@ class AuthManager:
         username = username.strip().lower()
         if not self.verify_password(username, password):
             return None
+        return self.create_session_for_user(username)
+
+    def create_session_for_user(self, username: str) -> str:
+        """Issue a session token for a user whose credentials have already been
+        verified by the caller.  Skips the bcrypt re-check so the login route
+        does not hash the password twice (verify_password + create_session)."""
+        username = username.strip().lower()
         token = secrets.token_hex(32)
         with self._sessions_lock:
             self._sessions[token] = {

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -131,8 +131,10 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
                 return {"ok": False, "requires_totp": True, "username": username}
             if not auth_manager.totp_verify(username, body.totp_code):
                 raise HTTPException(401, "Invalid 2FA code")
-        # All checks passed — create session
-        token = await asyncio.to_thread(auth_manager.create_session, username, body.password)
+        # All checks passed — issue token without re-verifying the password.
+        # create_session_for_user skips the bcrypt re-check; the password was
+        # already verified above (and TOTP checked if enabled).
+        token = await asyncio.to_thread(auth_manager.create_session_for_user, username)
         if not token:
             raise HTTPException(401, "Invalid credentials")
         cookie_kwargs = dict(

--- a/tests/test_auth_login_double_bcrypt_and_totp_revoke.py
+++ b/tests/test_auth_login_double_bcrypt_and_totp_revoke.py
@@ -1,0 +1,159 @@
+"""Regression tests for the double-bcrypt fix:
+
+login must not run bcrypt twice — create_session_for_user skips the
+re-verification that create_session used to perform unconditionally.
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from tests.helpers.import_state import clear_module
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrors test_auth_session_revocation.py)
+# ---------------------------------------------------------------------------
+
+def _real_core_package():
+    root = Path(__file__).resolve().parent.parent
+    core_path = str(root / "core")
+    core = sys.modules.get("core")
+    if core is None:
+        core = types.ModuleType("core")
+        sys.modules["core"] = core
+    core.__path__ = [core_path]
+    clear_module("core.auth")
+    return core
+
+
+def _auth_module():
+    _real_core_package()
+    return importlib.import_module("core.auth")
+
+
+def _make_manager(tmp_path):
+    auth_mod = _auth_module()
+    auth_mod._hash_password = lambda password: f"hash:{password}"
+    auth_mod._verify_password = lambda password, hashed: hashed == f"hash:{password}"
+    auth_path = tmp_path / "auth.json"
+    mgr = auth_mod.AuthManager(str(auth_path))
+    assert mgr.create_user("alice", "secret", is_admin=False)
+    assert mgr.create_user("bob", "bobpass", is_admin=False)
+    return mgr
+
+
+async def _immediate_to_thread(fn, *args, **kwargs):
+    return fn(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# create_session_for_user unit tests
+# ---------------------------------------------------------------------------
+
+def test_create_session_for_user_returns_valid_token(tmp_path):
+    """create_session_for_user must issue a token without re-checking creds."""
+    mgr = _make_manager(tmp_path)
+    token = mgr.create_session_for_user("alice")
+    assert token is not None
+    assert mgr.validate_token(token) is True
+
+
+def test_create_session_for_user_strips_and_lowercases(tmp_path):
+    """Username normalisation must match what the rest of auth uses."""
+    mgr = _make_manager(tmp_path)
+    token = mgr.create_session_for_user("  Alice  ")
+    assert mgr.validate_token(token) is True
+    assert mgr.get_username_for_token(token) == "alice"
+
+
+def test_create_session_for_user_does_not_call_verify_password(tmp_path):
+    """The whole point: verify_password must not be called inside
+    create_session_for_user so the login route does not hash twice."""
+    mgr = _make_manager(tmp_path)
+    with patch.object(mgr, "verify_password", wraps=mgr.verify_password) as spy:
+        mgr.create_session_for_user("alice")
+        spy.assert_not_called()
+
+
+def test_create_session_delegates_to_create_session_for_user(tmp_path):
+    """create_session (password path) must still work and produce a valid
+    token — the refactor must not break existing callers."""
+    mgr = _make_manager(tmp_path)
+    token = mgr.create_session("alice", "secret")
+    assert token is not None
+    assert mgr.validate_token(token) is True
+
+
+def test_create_session_wrong_password_returns_none(tmp_path):
+    """create_session must still reject wrong passwords."""
+    mgr = _make_manager(tmp_path)
+    assert mgr.create_session("alice", "wrong") is None
+
+
+# ---------------------------------------------------------------------------
+# Login route tests
+# ---------------------------------------------------------------------------
+
+def _login_endpoint(auth_manager):
+    """Load the login route endpoint from a fresh import of auth_routes."""
+    sys.modules.pop("routes.auth_routes", None)
+    _real_core_package()
+    from routes.auth_routes import LoginRequest, setup_auth_routes
+
+    router = setup_auth_routes(auth_manager)
+    for route in router.routes:
+        if getattr(route, "path", None) == "/api/auth/login":
+            return route.endpoint, LoginRequest
+    raise AssertionError("login route not found")
+
+
+def test_login_route_calls_create_session_for_user_not_create_session(monkeypatch):
+    """The login route must call create_session_for_user after verifying the
+    password, not create_session (which would re-run bcrypt)."""
+    auth = MagicMock()
+    auth.verify_password.return_value = True
+    auth.totp_enabled.return_value = False
+    auth.create_session_for_user.return_value = "tok123"
+    monkeypatch.setattr(
+        "routes.auth_routes.asyncio.to_thread",
+        lambda fn, *args, **kwargs: _immediate_to_thread(fn, *args, **kwargs),
+    )
+    endpoint, LoginRequest = _login_endpoint(auth)
+    request = SimpleNamespace(cookies={}, client=SimpleNamespace(host="127.0.0.1"))
+    response = MagicMock()
+    body = LoginRequest(username="alice", password="secret")
+
+    result = asyncio.run(endpoint(body=body, request=request, response=response))
+
+    assert result == {"ok": True, "username": "alice"}
+    auth.create_session_for_user.assert_called_once_with("alice")
+    auth.create_session.assert_not_called()
+
+
+def test_login_route_does_not_call_create_session_for_user_on_wrong_password(monkeypatch):
+    """If password verification fails, create_session_for_user must never run."""
+    auth = MagicMock()
+    auth.verify_password.return_value = False
+    monkeypatch.setattr(
+        "routes.auth_routes.asyncio.to_thread",
+        lambda fn, *args, **kwargs: _immediate_to_thread(fn, *args, **kwargs),
+    )
+    endpoint, LoginRequest = _login_endpoint(auth)
+    request = SimpleNamespace(cookies={}, client=SimpleNamespace(host="127.0.0.1"))
+    response = MagicMock()
+    body = LoginRequest(username="alice", password="wrong")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(endpoint(body=body, request=request, response=response))
+
+    assert exc.value.status_code == 401
+    auth.create_session_for_user.assert_not_called()
+    auth.create_session.assert_not_called()


### PR DESCRIPTION
## Summary

Every successful login was computing bcrypt twice. \`routes/auth_routes.py\` called \`auth_manager.verify_password()\` to check the credentials, then immediately called \`auth_manager.create_session(username, password)\`, which called \`verify_password\` again internally before issuing the token. At the default bcrypt cost factor this doubles login latency (~400–600 ms instead of ~200–300 ms) with no security benefit — the second check runs after the password has already been accepted and any TOTP code verified.

Added \`create_session_for_user(username)\` to \`AuthManager\`: same token-issuance logic as \`create_session\` without the redundant bcrypt re-check. \`create_session\` now delegates to it after its own verify step, so existing callers are unaffected. The login route calls \`create_session_for_user\` after the password (and optional TOTP) has already been verified.

## Target branch

- [x] This PR targets **\`dev\`**, not \`main\`. All PRs land in \`dev\`; \`main\` is curated by the maintainer at each release. If your PR is on \`main\` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3230

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets \`dev\`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (\`uvicorn app:app\`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start the app: \`python3 -m uvicorn app:app --host 0.0.0.0 --port 7000\`
2. Log in with valid credentials — confirm the session cookie is set and the UI loads normally.
3. Log in with an incorrect password — confirm a 401 is returned and no cookie is set.
4. If TOTP is enabled on the account, complete the two-step login flow and confirm it still works.
5. Run the automated tests:
   \`\`\`
   python3 -m pytest tests/test_auth_login_double_bcrypt_and_totp_revoke.py tests/test_auth_session_revocation.py tests/test_auth_regressions.py -v
   \`\`\`
   All 27 tests pass.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI changes. This fix is entirely in \`core/auth.py\` and \`routes/auth_routes.py\`.