### PR TITLE
fix(group): refresh character dropdown on tab focus

### DIFF
--- a/static/js/group.js
+++ b/static/js/group.js
@@ -88,7 +88,7 @@ function _initGroupTab() {
     picker.style.cssText = 'display:flex;gap:4px;align-items:center;';
 
     const charSel = document.createElement('select');
-    charSel.className = 'preset-input';
+    charSel.className = 'preset-input char-sel';
     charSel.style.cssText = 'font-size:11px;flex:1;height:26px;';
     charSel.innerHTML = '<option value="">Empty...</option>' +
       characters.map(c => '<option value="' + c.id + '">' + uiModule.esc(c.name) + '</option>').join('');
@@ -100,12 +100,16 @@ function _initGroupTab() {
       models.map(m => '<option value="' + m.mid + '">' + uiModule.esc(m.display) + '</option>').join('');
 
     // Auto-add when model is selected
-    modelSel.addEventListener('change', () => {
+    modelSel.addEventListener('change', async () => {
       if (!modelSel.value) return;
       if (_groupParticipants.length >= 8) { uiModule.showToast('Max 8'); return; }
       const entry = { character: null, model: null };
       entry.model = models.find(m => m.mid === modelSel.value) || null;
-      if (charSel.value) entry.character = characters.find(c => c.id === charSel.value) || null;
+      if (charSel.value) {
+        // Fetch fresh characters list just in case one was added or edited in the background
+        const freshCharacters = await _getCharacterList();
+        entry.character = freshCharacters.find(c => c.id === charSel.value) || null;
+      }
       _groupParticipants.push(entry);
       picker.remove();
       _render();
@@ -196,10 +200,23 @@ function _initGroupTab() {
   });
 
   const groupTab = document.querySelector('.preset-tab[data-chartab="group"]');
-  if (groupTab) groupTab.addEventListener('click', () => {
+  if (groupTab) groupTab.addEventListener('click', async () => {
     _modelsCache = null;
     if (startBtn) startBtn.textContent = 'Start Group';
     _loadGroupPresets();
+    
+    // Refresh all character dropdowns to include newly created characters
+    const characters = await _getCharacterList();
+    const charSels = participantsEl.querySelectorAll('select.char-sel');
+    charSels.forEach(sel => {
+      const currentVal = sel.value;
+      sel.innerHTML = '<option value="">Empty...</option>' +
+        characters.map(c => '<option value="' + c.id + '">' + uiModule.esc(c.name) + '</option>').join('');
+      if (characters.find(c => c.id === currentVal)) {
+        sel.value = currentVal;
+      }
+    });
+
     if (_groupParticipants.length === 0) {
       setTimeout(() => addBtn.click(), 100);
     }


### PR DESCRIPTION
## Summary

This fixes an issue where newly created characters were not appearing in the Group Chat participant dropdown. The UI previously only fetched the character list once when generating the row. The group tab now refreshes all existing character dropdowns with the latest characters whenever the tab is focused, ensuring any new characters created in the adjacent Character tab are instantly available.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3207

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open Prompt Modal -> click the "Group" tab -> click "Add participant" (this generates a row with character and model dropdowns).
2. Switch to the "Character" tab -> create a new character -> save.
3. Switch back to the "Group" tab -> click the character dropdown in the existing row. Verify the newly created character immediately appears as a selectable option.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<img width="500" height="459" alt="image" src="https://github.com/user-attachments/assets/63ac6623-d7b9-4daa-858b-cfcc500b2067" />

