### PR TITLE
fix: redirect /login to / when AUTH_ENABLED=false

### DIFF
--- a/app.py
+++ b/app.py
@@ -784,6 +784,8 @@ async def serve_backgrounds(request: Request):
 
 @app.get("/login")
 async def serve_login(request: Request):
+    if not AUTH_ENABLED:
+        return RedirectResponse(url="/", status_code=302)
     return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/login.html"))
 
 @app.get("/api/version")


### PR DESCRIPTION
## Summary

When `AUTH_ENABLED=false` the `/login` route served the login page unconditionally. Added an early redirect so visiting `/login` with auth disabled returns a 302 to `/` instead of showing a login form that does nothing.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3075

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Start Odysseus with `AUTH_ENABLED=false` (set in `.env` or as an env var).
2. Navigate to `http://localhost:7000/login` in a browser.
3. Confirm you are immediately redirected to `/` (the main app) instead of seeing the login form.
4. Restart with `AUTH_ENABLED=true` and confirm `/login` still serves the login page normally.

**Checks run**
- `python -m py_compile app.py` — passed
- `node --check static/js/*.js` — passed (72 files)
