### PR TITLE
fix: avoid double bcrypt on login by using create_session_trusted

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -447,6 +447,12 @@ class AuthManager:
         username = username.strip().lower()
         if not self.verify_password(username, password):
             return None
+        return self.create_session_trusted(username)
+
+    def create_session_trusted(self, username: str) -> str:
+        """Issue a session token for an already-verified user.
+        Call only after verify_password (and TOTP if enabled) have passed."""
+        username = username.strip().lower()
         token = secrets.token_hex(32)
         with self._sessions_lock:
             self._sessions[token] = {

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -131,10 +131,8 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
                 return {"ok": False, "requires_totp": True, "username": username}
             if not auth_manager.totp_verify(username, body.totp_code):
                 raise HTTPException(401, "Invalid 2FA code")
-        # All checks passed — create session
-        token = await asyncio.to_thread(auth_manager.create_session, username, body.password)
-        if not token:
-            raise HTTPException(401, "Invalid credentials")
+        # All checks passed — create session (password already verified above)
+        token = await asyncio.to_thread(auth_manager.create_session_trusted, username)
         cookie_kwargs = dict(
             key=SESSION_COOKIE,
             value=token,

--- a/tests/test_auth_event_loop.py
+++ b/tests/test_auth_event_loop.py
@@ -95,7 +95,7 @@ def test_login_offloads_bcrypt_bearing_calls(monkeypatch):
     monkeypatch.setattr("routes.auth_routes.asyncio.to_thread", fake_to_thread)
     auth.verify_password.return_value = True
     auth.totp_enabled.return_value = False
-    auth.create_session.return_value = "tok-123"
+    auth.create_session_trusted.return_value = "tok-123"
 
     login = _login_endpoint(auth)
 
@@ -107,7 +107,7 @@ def test_login_offloads_bcrypt_bearing_calls(monkeypatch):
 
     assert result["ok"] is True
     auth.verify_password.assert_called_once()
-    auth.create_session.assert_called_once()
+    auth.create_session_trusted.assert_called_once()
     # The whole point: the expensive bcrypt-bearing calls go through
     # asyncio.to_thread rather than running inline in the request coroutine.
-    assert calls == [auth.verify_password, auth.create_session]
+    assert calls == [auth.verify_password, auth.create_session_trusted]


### PR DESCRIPTION
## Summary

The login route called `verify_password` explicitly to check credentials, then called `create_session` which called `verify_password` again internally — running bcrypt twice per login for no reason. Added `create_session_trusted(username)` which issues a session token without re-verifying, and switched the login route to use it after credentials and TOTP are already confirmed. `create_session` is unchanged for any other callers that pass raw credentials.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3230

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Start Odysseus with `AUTH_ENABLED=true` and a configured user.
2. Log in with correct credentials — login should complete in roughly half the previous time (one bcrypt round instead of two).
3. Log in with wrong credentials — confirm the 401 is still returned correctly (the explicit `verify_password` check still runs).
4. If TOTP is enabled on an account, confirm that 2FA login still works end-to-end.

**Checks run**
- `python -m py_compile app.py routes/auth_routes.py core/auth.py` — passed
- `node --check static/js/*.js` — passed (72 files)
