### PR TITLE
fix: derive loopback base URL from APP_PORT instead of hardcoding port 7000

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2495,7 +2495,10 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
 # Cookbook routes loopback. The agent's tool calls run in-process but
 # need to reach admin-gated cookbook routes; we ride the per-process
 # internal token so require_admin lets us through. See core/middleware.py.
-_COOKBOOK_BASE = "http://localhost:7000"
+_COOKBOOK_BASE = os.environ.get(
+    "ODYSSEUS_INTERNAL_BASE",
+    f"http://127.0.0.1:{os.environ.get('APP_PORT', '7000')}",
+)
 
 
 def _internal_headers(owner: Optional[str] = None) -> Dict[str, str]:
@@ -4016,7 +4019,7 @@ async def do_edit_image(content: str, owner: Optional[str] = None) -> Dict:
         payload["scale"] = args["scale"]
     try:
         async with httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(f"http://localhost:7000/api/gallery/{action}", json=payload)
+            resp = await client.post(f"{_COOKBOOK_BASE}/api/gallery/{action}", json=payload)
             data = resp.json()
         if data.get("success") or data.get("id"):
             return {"output": f"Image edited ({action}). New image ID: {data.get('id', '?')}", "exit_code": 0}
@@ -4192,7 +4195,7 @@ async def do_resolve_contact(content: str, owner: Optional[str] = None) -> Dict:
     async with httpx.AsyncClient(timeout=30) as client:
         # 2. Email history (sent/received)
         try:
-            resp = await client.get("http://localhost:7000/api/email/resolve-contact", params={"name": name})
+            resp = await client.get(f"{_COOKBOOK_BASE}/api/email/resolve-contact", params={"name": name})
             if resp.status_code == 200:
                 for c in (resp.json().get("contacts") or []):
                     email = (c.get("email") or "").strip().lower()


### PR DESCRIPTION
## Summary

Agent tools that make internal loopback calls — `app_api`, `trigger_research`, cookbook state reads/writes, gallery edits, and email contact resolution — all hardcoded `http://localhost:7000` as the base URL. Any deployment not running on port 7000 (via `APP_PORT`, multiple instances, or a custom port) silently got "All connection attempts failed" from every one of these tools. `_COOKBOOK_BASE` now derives from `ODYSSEUS_INTERNAL_BASE` (explicit override) or `APP_PORT` (already used by docker-compose), falling back to `7000`. Two remaining hardcoded `http://localhost:7000` strings in the gallery and email tools are replaced with `_COOKBOOK_BASE` so they benefit from the same resolution.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2752

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run Odysseus on a non-default port: `uvicorn app:app --port 7014` (or set `APP_PORT=7014` in `.env` and `docker compose up`).
2. From an agent chat, ask the model to trigger a deep research task or call `app_api` against any internal endpoint (e.g. "check cookbook state").
3. Confirm the tool call succeeds instead of returning "All connection attempts failed".
4. Run again without setting `APP_PORT` (default port 7000) and confirm existing behaviour is unchanged.

**Checks run**
- `python -m py_compile app.py src/tool_implementations.py` — passed
- `node --check static/js/*.js` — passed (72 files)
