### PR TITLE
feat: add GitHub Trending tool with DB caching, history and AI interpretation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,15 @@ FROM python:3.12-slim
 # nodejs/npm provide npx for the optional built-in Browser MCP server.
 # gosu lets the entrypoint drop privileges cleanly so signals still reach
 # uvicorn directly (no extra shell layer like `su`/`sudo` would add).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN printf '%s\n' \
+    'Types: deb' \
+    'URIs: https://deb.debian.org/debian' \
+    'Suites: trixie trixie-updates' \
+    'Components: main' \
+    'Signed-By: /usr/share/keyrings/debian-archive-keyring.pgp' \
+    > /etc/apt/sources.list.d/debian.sources \
+    && apt-get -o Acquire::Retries=5 -o Acquire::http::Pipeline-Depth=0 update \
+    && apt-get -o Acquire::Retries=5 -o Acquire::http::Pipeline-Depth=0 install -y --no-install-recommends \
     build-essential \
     cmake \
     curl \
@@ -22,9 +30,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Install Python deps first (layer cache)
+# Install Python deps first (layer cache). Use isolated pip config plus
+# explicit retries/timeouts so transient proxy/PyPI stalls do not leave
+# the rebuild half-finished after we've already cleared the old image.
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_REQUIRE_HASHES=0 \
+    PIP_DEFAULT_TIMEOUT=180 \
+    python -m pip install \
+    --isolated \
+    --retries 10 \
+    --timeout 180 \
+    -r requirements.txt
 
 # Copy app code
 COPY . .

--- a/app.py
+++ b/app.py
@@ -720,6 +720,11 @@ app.include_router(setup_contacts_routes())
 from companion import setup_companion_routes
 app.include_router(setup_companion_routes())
 
+# GitHub Trending standalone page
+from routes.github_trending_routes import setup_github_trending_routes, register_github_trending_page
+app.include_router(setup_github_trending_routes())
+register_github_trending_page(app)
+
 # ========= ROUTES (kept in app.py) =========
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:

--- a/core/database.py
+++ b/core/database.py
@@ -2,7 +2,7 @@ import os
 import logging
 import sqlite3
 from datetime import datetime, timezone
-from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, func, text
+from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, UniqueConstraint, func, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
@@ -1430,6 +1430,32 @@ class Note(TimestampMixin, Base):
     # Chat session spawned by the note's "Agent" button (solve-this-todo).
     # The note shows a clickable tag that opens this session for review.
     agent_session_id  = Column(String, nullable=True)
+
+
+class GithubTrending(TimestampMixin, Base):
+    """Cached GitHub Trending snapshot — one row per date+period."""
+    __tablename__ = "github_trending"
+
+    id         = Column(Integer, primary_key=True, autoincrement=True)
+    date       = Column(String(10), nullable=False, index=True)   # YYYY-MM-DD
+    period     = Column(String(10), nullable=False)                # daily/weekly/monthly
+    repos_json = Column(Text, nullable=False)                      # JSON array of repo dicts
+    # Future AI expansion columns (added via migration when needed)
+    # ai_summary = Column(Text, nullable=True)   # AI overall trend analysis
+    # ai_json    = Column(Text, nullable=True)   # per-repo AI interpretation + translation
+
+    __table_args__ = (
+        UniqueConstraint("date", "period", name="uq_gh_trending_date_period"),
+    )
+
+
+class GithubTrendingRepoAI(TimestampMixin, Base):
+    """Per-repo AI interpretation cache — shared across all periods/dates."""
+    __tablename__ = "github_trending_repo_ai"
+
+    repo_name      = Column(String, primary_key=True)
+    desc_zh        = Column(Text, nullable=True)     # Chinese translation of description
+    interpretation = Column(Text, nullable=True)     # AI analysis of why it's trending
 
 
 class CalendarCal(TimestampMixin, Base):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
   chromadb:
     image: docker.io/chromadb/chroma:latest
     ports:
-      - "${CHROMADB_BIND:-127.0.0.1}:8100:8000"
+      - "${CHROMADB_BIND:-127.0.0.1}:${CHROMADB_HOST_PORT:-8100}:8000"
     volumes:
       - chromadb-data:/chroma/chroma
     environment:
@@ -99,7 +99,7 @@ services:
         fi
         exec /usr/local/searxng/entrypoint.sh
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${SEARXNG_BIND:-127.0.0.1}:${SEARXNG_PORT:-8080}:8080"
     volumes:
       - searxng-data:/etc/searxng
       - ./config/searxng/settings.yml:/tmp/searxng-settings.yml.template:ro,z
@@ -132,7 +132,7 @@ services:
     image: docker.io/binwiederhier/ntfy
     command: serve
     ports:
-      - "${NTFY_BIND:-127.0.0.1}:8091:80"
+      - "${NTFY_BIND:-127.0.0.1}:${NTFY_PORT:-8091}:80"
     volumes:
       - ntfy-cache:/var/cache/ntfy
     environment:

--- a/routes/github_trending_routes.py
+++ b/routes/github_trending_routes.py
@@ -1,0 +1,383 @@
+# routes/github_trending_routes.py
+# GitHub Trending with SQLite caching + history + AI interpretation.
+import json
+import logging
+import re
+import httpx
+from datetime import date, datetime
+from pathlib import Path
+from fastapi import APIRouter, Request, Query
+from fastapi.responses import HTMLResponse, JSONResponse
+
+logger = logging.getLogger(__name__)
+_HTML_PATH = Path(__file__).resolve().parent.parent / "static" / "github-trending.html"
+
+# ── Lazy DB import (avoids circular at module level) ──
+
+def _get_session():
+    from core.database import SessionLocal
+    return SessionLocal()
+
+
+def _today_str():
+    return date.today().isoformat()
+
+
+# ── GitHub scraping ──
+
+def _fetch_trending(language: str = "", period: str = "daily") -> list:
+    """Fetch + parse GitHub Trending page, return list of repo dicts."""
+    if period not in ("daily", "weekly", "monthly"):
+        period = "daily"
+
+    if language:
+        url = f"https://github.com/trending/{language}?since={period}"
+    else:
+        url = f"https://github.com/trending?since={period}"
+
+    try:
+        with httpx.Client(
+            timeout=15,
+            follow_redirects=True,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; Odysseus/1.0)"}
+        ) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+            html = resp.text
+    except Exception as e:
+        logger.warning("github trending fetch failed: %s", e)
+        return []
+
+    articles = re.findall(r'<article[^>]*>(.*?)</article>', html, re.DOTALL | re.IGNORECASE)
+    results = []
+    for art in articles[:25]:
+        h2 = re.search(r'<h2[^>]*>(.*?)</h2>', art, re.DOTALL)
+        repo_path = ""
+        if h2:
+            h2_links = re.findall(r'href="(/[^"]+/[^"]+)"', h2.group(1))
+            for lnk in h2_links:
+                if lnk.count('/') == 2 and not any(
+                    lnk.endswith(s) for s in ('/stargazers', '/forks', '/network', '/issues', '/pulls')
+                ):
+                    repo_path = lnk
+                    break
+        if not repo_path:
+            continue
+
+        desc = ""
+        desc_match = re.search(r'<p[^>]+class="[^"]*col-9[^"]*"[^>]*>(.*?)</p>', art, re.DOTALL)
+        if desc_match:
+            desc = re.sub(r'<[^>]+>', '', desc_match.group(1))
+            desc = re.sub(r'\s+', ' ', desc).strip()
+
+        lang_val = ""
+        lang_match = re.search(r'itemprop="programmingLanguage">(.*?)<', art, re.DOTALL | re.IGNORECASE)
+        if lang_match:
+            lang_val = lang_match.group(1).strip()
+
+        stars_today = ""
+        today_match = re.search(r'([\d][\d,]*)\s+stars?\s+(today|this\s+week|this\s+month)', art, re.DOTALL | re.IGNORECASE)
+        if today_match:
+            stars_today = today_match.group(1).strip()
+
+        total_stars = ""
+        stars_match = re.search(r'/stargazers">.*?([\d,]+)\s*<', art, re.DOTALL)
+        if stars_match:
+            total_stars = stars_match.group(1).strip()
+
+        forks = ""
+        forks_match = re.search(r'/forks">.*?([\d,]+)\s*<', art, re.DOTALL)
+        if forks_match:
+            forks = forks_match.group(1).strip()
+
+        results.append({
+            "name": repo_path.lstrip('/'),
+            "url": f"https://github.com{repo_path}",
+            "desc": desc,
+            "lang": lang_val,
+            "stars_today": stars_today,
+            "total_stars": total_stars,
+            "forks": forks,
+        })
+
+    return results
+
+
+# ── Cache helpers ──
+
+def _save_to_cache(period: str, repos: list, snapshot_date: str | None = None):
+    """Save trending repos to database."""
+    from core.database import GithubTrending
+    d = snapshot_date or _today_str()
+    session = _get_session()
+    try:
+        existing = session.query(GithubTrending).filter_by(date=d, period=period).first()
+        if existing:
+            existing.repos_json = json.dumps(repos, ensure_ascii=False)
+            existing.updated_at = datetime.utcnow()
+        else:
+            row = GithubTrending(date=d, period=period, repos_json=json.dumps(repos, ensure_ascii=False))
+            session.add(row)
+        session.commit()
+    except Exception as e:
+        logger.warning("github trending cache save failed: %s", e)
+        session.rollback()
+    finally:
+        session.close()
+
+
+def _load_from_cache(period: str, snapshot_date: str | None = None):
+    """Load cached trending repos. Returns list or None."""
+    from core.database import GithubTrending
+    d = snapshot_date or _today_str()
+    session = _get_session()
+    try:
+        row = session.query(GithubTrending).filter_by(date=d, period=period).first()
+        if row and row.repos_json:
+            return json.loads(row.repos_json)
+        return None
+    except Exception as e:
+        logger.warning("github trending cache load failed: %s", e)
+        return None
+    finally:
+        session.close()
+
+
+# ── AI data helpers ──
+
+def _enrich_with_ai(repos: list) -> list:
+    """Attach desc_zh and interpretation from github_trending_repo_ai to each repo."""
+    if not repos:
+        return repos
+    from core.database import GithubTrendingRepoAI
+    session = _get_session()
+    try:
+        names = [r["name"] for r in repos]
+        ai_rows = session.query(GithubTrendingRepoAI).filter(
+            GithubTrendingRepoAI.repo_name.in_(names)
+        ).all()
+        ai_map = {row.repo_name: row for row in ai_rows}
+        for repo in repos:
+            ai = ai_map.get(repo["name"])
+            repo["desc_zh"] = ai.desc_zh if ai else None
+            repo["interpretation"] = ai.interpretation if ai else None
+        return repos
+    except Exception as e:
+        logger.warning("github trending AI enrich failed: %s", e)
+        for repo in repos:
+            repo.setdefault("desc_zh", None)
+            repo.setdefault("interpretation", None)
+        return repos
+    finally:
+        session.close()
+
+
+def _save_ai_batch(results: list):
+    """Save a batch of AI interpretation results to DB. results = [{name, desc_zh, interpretation}]"""
+    from core.database import GithubTrendingRepoAI
+    session = _get_session()
+    try:
+        for item in results:
+            name = item.get("name", "").strip()
+            if not name:
+                continue
+            existing = session.query(GithubTrendingRepoAI).filter_by(repo_name=name).first()
+            if existing:
+                if item.get("desc_zh"):
+                    existing.desc_zh = item["desc_zh"]
+                if item.get("interpretation"):
+                    existing.interpretation = item["interpretation"]
+                existing.updated_at = datetime.utcnow()
+            else:
+                row = GithubTrendingRepoAI(
+                    repo_name=name,
+                    desc_zh=item.get("desc_zh", ""),
+                    interpretation=item.get("interpretation", ""),
+                )
+                session.add(row)
+        session.commit()
+    except Exception as e:
+        logger.warning("github trending AI save failed: %s", e)
+        session.rollback()
+    finally:
+        session.close()
+
+
+# ── Public action (called by TaskScheduler) ──
+
+def fetch_and_cache_all_periods():
+    """Fetch trending for all three periods and cache. Called by scheduled task."""
+    for period in ("daily", "weekly", "monthly"):
+        repos = _fetch_trending(period=period)
+        if repos:
+            _save_to_cache(period, repos)
+            logger.info("github trending: cached %d repos for %s/%s", len(repos), _today_str(), period)
+
+
+# ── Routes ──
+
+def setup_github_trending_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/github-trending", tags=["github-trending"])
+
+    @router.get("/list")
+    def github_trending_list(
+        period: str = Query("daily"),
+        date: str = Query(None, alias="date"),
+        force: int = Query(0),
+    ):
+        """Return GitHub trending repos with AI data. Uses DB cache unless force=1."""
+        if period not in ("daily", "weekly", "monthly"):
+            period = "daily"
+
+        # If requesting a specific historical date, only use cache
+        if date and date != _today_str():
+            cached = _load_from_cache(period, snapshot_date=date)
+            if cached is not None:
+                return {"repos": _enrich_with_ai(cached), "date": date, "period": period, "cached": True}
+            return {"repos": [], "date": date, "period": period, "cached": False}
+
+        # Today: check cache first (unless force)
+        if not force:
+            cached = _load_from_cache(period)
+            if cached is not None:
+                return {"repos": _enrich_with_ai(cached), "date": _today_str(), "period": period, "cached": True}
+
+        # Fetch from GitHub
+        repos = _fetch_trending(period=period)
+        if repos:
+            _save_to_cache(period, repos)
+        return {"repos": _enrich_with_ai(repos), "date": _today_str(), "period": period, "cached": False}
+
+    @router.get("/history")
+    def github_trending_history():
+        """Return available cached dates."""
+        from core.database import GithubTrending
+        session = _get_session()
+        try:
+            rows = session.query(GithubTrending.date, GithubTrending.period)\
+                .order_by(GithubTrending.date.desc())\
+                .limit(90).all()
+            dates = {}
+            for row in rows:
+                if row.date not in dates:
+                    dates[row.date] = []
+                if row.period not in dates[row.date]:
+                    dates[row.date].append(row.period)
+            return {"dates": [
+                {"date": d, "periods": sorted(ps)} for d, ps in sorted(dates.items(), reverse=True)
+            ]}
+        except Exception as e:
+            logger.warning("github trending history query failed: %s", e)
+            return {"dates": []}
+        finally:
+            session.close()
+
+    @router.post("/interpret")
+    async def github_trending_interpret(
+        period: str = Query("daily"),
+        date: str = Query(None, alias="date"),
+    ):
+        """Use LLM to generate Chinese translation + AI interpretation for repos.
+        Caches per-repo (cross-period reuse). Only calls LLM for uncached repos."""
+        if period not in ("daily", "weekly", "monthly"):
+            period = "daily"
+
+        d = date or _today_str()
+        repos = _load_from_cache(period, snapshot_date=d)
+        if repos is None:
+            return JSONResponse({"error": "No cached data for this date/period"}, status_code=404)
+
+        # Find which repos already have AI data
+        from core.database import GithubTrendingRepoAI
+        session = _get_session()
+        try:
+            names = [r["name"] for r in repos]
+            existing_ai = session.query(GithubTrendingRepoAI.repo_name)\
+                .filter(GithubTrendingRepoAI.repo_name.in_(names)).all()
+            cached_names = {row[0] for row in existing_ai}
+        finally:
+            session.close()
+
+        # Filter to only repos needing AI
+        uncached = [r for r in repos if r["name"] not in cached_names]
+        if not uncached:
+            # All already cached — just return enriched data
+            return {"repos": _enrich_with_ai(repos), "date": d, "period": period, "ai_cached": True}
+
+        # Resolve LLM endpoint
+        from src.endpoint_resolver import resolve_endpoint
+        url, model, headers = resolve_endpoint("utility")
+        if not url or not model:
+            url, model, headers = resolve_endpoint("default")
+        if not url or not model:
+            return JSONResponse({"error": "No AI model configured. Set a utility or default model in settings."}, status_code=400)
+
+        # Build prompt
+        repo_lines = []
+        for i, repo in enumerate(uncached, 1):
+            repo_lines.append(f'{i}. {repo["name"]} - {repo.get("desc", "No description")}')
+
+        system_prompt = (
+            "你是 GitHub 热榜分析师。对以下项目逐一提供：\n"
+            "1. desc_zh: 项目描述的中文翻译（保留技术术语如 API、SDK、LLM 等原文）\n"
+            "2. interpretation: 一句话中文解读这个项目为什么值得关注、解决什么问题\n"
+            "严格按 JSON 数组格式返回，不要加 markdown 代码块或额外文字。\n"
+            '格式: [{"name":"owner/repo","desc_zh":"中文翻译","interpretation":"AI解读"}]'
+        )
+        user_prompt = "\n".join(repo_lines)
+
+        # Call LLM
+        from src.llm_core import llm_call_async
+        try:
+            raw = await llm_call_async(
+                url=url, model=model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.3, max_tokens=4096,
+                headers=headers, timeout=120,
+            )
+        except Exception as e:
+            logger.warning("github trending AI interpret failed: %s", e)
+            return JSONResponse({"error": f"LLM call failed: {e}"}, status_code=500)
+
+        # Parse LLM response
+        try:
+            # Strip markdown code fences if present
+            clean = raw.strip()
+            if clean.startswith("```"):
+                clean = re.sub(r'^```\w*\n?', '', clean)
+                clean = re.sub(r'\n?```$', '', clean)
+            ai_results = json.loads(clean)
+            if not isinstance(ai_results, list):
+                raise ValueError("Expected JSON array")
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning("github trending AI parse failed: %s, raw: %s", e, raw[:200])
+            return JSONResponse({"error": f"Failed to parse AI response: {e}"}, status_code=500)
+
+        # Save to DB
+        _save_ai_batch(ai_results)
+
+        # Return enriched data
+        return {"repos": _enrich_with_ai(repos), "date": d, "period": period, "ai_cached": False, "interpreted": len(ai_results)}
+
+    return router
+
+
+def register_github_trending_page(app):
+    """Register GET /github-trending to serve the HTML page."""
+    @app.get("/github-trending", response_class=HTMLResponse)
+    def serve_github_trending_page(request: Request):
+        if not _HTML_PATH.exists():
+            return HTMLResponse(
+                "<h1>Page not found</h1><p>static/github-trending.html is missing.</p>",
+                status_code=404,
+            )
+        with open(_HTML_PATH, "r", encoding="utf-8") as f:
+            html = f.read()
+        nonce = getattr(request.state, "csp_nonce", "") if hasattr(request.state, "csp_nonce") else ""
+        if nonce:
+            html = html.replace('nonce="{{CSP_NONCE}}"', f'nonce="{nonce}"')
+            html = html.replace('{{CSP_NONCE}}', nonce)
+        return HTMLResponse(html)

--- a/src/agent_tools.py
+++ b/src/agent_tools.py
@@ -58,7 +58,9 @@ TOOL_TAGS = {"bash", "python", "web_search", "web_fetch", "read_file", "write_fi
              # Generic loopback to any UI-button endpoint (cookbook,
              # gallery, email folders, etc.) — agent uses this when
              # there's no named tool wrapper for the action.
-             "app_api"}
+             "app_api",
+             "github_trending",
+}
 
 ToolBlock = namedtuple("ToolBlock", ["tool_type", "content"])
 
@@ -136,4 +138,5 @@ from src.tool_implementations import (  # noqa: E402, F401
     do_manage_documents,
     do_manage_settings,
     do_api_call,
+    do_github_trending,
 )

--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -1998,6 +1998,19 @@ async def action_check_email_urgency(owner: str, **kwargs) -> Tuple[str, bool]:
         return str(e), False
 
 
+async def action_github_trending_fetch(owner: str, **kwargs) -> Tuple[str, bool]:
+    """Fetch GitHub Trending for all three periods and cache to DB."""
+    try:
+        from routes.github_trending_routes import fetch_and_cache_all_periods
+        import asyncio
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, fetch_and_cache_all_periods)
+        return "GitHub trending fetched and cached", True
+    except Exception as e:
+        logger.exception("github_trending_fetch action failed")
+        return str(e), False
+
+
 BUILTIN_ACTIONS = {
     "tidy_sessions": action_tidy_sessions,
     "tidy_documents": action_tidy_documents,
@@ -2017,6 +2030,7 @@ BUILTIN_ACTIONS = {
     "test_skills": action_test_skills,
     "audit_skills": action_audit_skills,
     "check_email_urgency": action_check_email_urgency,
+    "github_trending_fetch": action_github_trending_fetch,
     # ping_notes removed from the registry — runs only inside `_note_pings_loop`.
 }
 

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -213,6 +213,7 @@ HOUSEKEEPING_DEFAULTS = {
     "classify_events":      {"name": "Calendar Classify Events", "schedule": "cron",  "scheduled_time": None,    "cron_expression": "0 6,18 * * *", "ship_paused": True, "legacy_names": ["Classify Calendar Events"]},
     "check_email_urgency":   {"name": "Email Tags",               "schedule": "cron",  "scheduled_time": None,    "cron_expression": "0 * * * *", "ship_paused": True, "old_cron_expressions": ["*/15 * * * *"], "legacy_names": ["Email Triage", "Urgent Email"]},
     "audit_skills":          {"name": "Skills Audit",             "trigger_type": "event", "trigger_event": "skill_added", "trigger_count": 5, "schedule": None, "scheduled_time": None, "cron_expression": None, "legacy_names": ["Audit Skills"]},
+    "github_trending_fetch": {"name": "GitHub Trending Fetch",    "schedule": "cron",  "scheduled_time": None,    "cron_expression": "0 8 * * *", "ship_paused": False},
 }
 
 RETIRED_HOUSEKEEPING_ACTIONS = frozenset({
@@ -955,6 +956,7 @@ class TaskScheduler:
         "tidy_research",
         "test_skills",
         "audit_skills",
+        "github_trending_fetch",
     })
 
     _MODEL_BACKED_ACTIONS = frozenset({

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -706,6 +706,7 @@ async def execute_tool_block(
         do_edit_image, do_trigger_research, do_manage_research, do_resolve_contact,
         do_manage_contact,
         do_vault_search, do_vault_get, do_vault_unlock,
+        do_github_trending,
         do_app_api,
     )
 
@@ -915,6 +916,9 @@ async def execute_tool_block(
     elif tool == "vault_unlock":
         desc = "vault_unlock"
         result = await do_vault_unlock(content, owner=owner)
+    elif tool == "github_trending":
+        desc = "github_trending"
+        result = await do_github_trending(content, owner=owner)
     elif tool.startswith("mcp__"):
         # MCP tool dispatch
         mcp = get_mcp_manager()

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -4142,3 +4142,119 @@ async def do_vault_unlock(content: str, owner: Optional[str] = None) -> Dict:
         pass
 
     return {"output": "Vault unlocked. Session saved.", "exit_code": 0}
+
+
+# ---------------------------------------------------------------------------
+# GitHub Trending tool
+# ---------------------------------------------------------------------------
+
+async def do_github_trending(content: str, owner: Optional[str] = None) -> Dict:
+    """Fetch GitHub trending repos and return a formatted Chinese report."""
+    import re as _re
+    try:
+        args = _parse_tool_args(content)
+    except ValueError:
+        args = {}
+
+    language = (args.get("language") or "").strip().lower()
+    period = (args.get("period") or "daily").strip().lower()
+    if period not in ("daily", "weekly", "monthly"):
+        period = "daily"
+
+    if language:
+        url = f"https://github.com/trending/{language}?since={period}"
+    else:
+        url = f"https://github.com/trending?since={period}"
+
+    try:
+        import httpx as _httpx
+        async with _httpx.AsyncClient(
+            timeout=15,
+            follow_redirects=True,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; Odysseus/1.0)"}
+        ) as _client:
+            _resp = await _client.get(url)
+            _resp.raise_for_status()
+            _html = _resp.text
+    except Exception as _e:
+        return {"error": f"获取 GitHub Trending 失败：{_e}", "exit_code": 1}
+
+    _articles = _re.findall(r'<article[^>]*>(.*?)</article>', _html, _re.DOTALL | _re.IGNORECASE)
+    if not _articles:
+        return {"error": "无法解析 GitHub Trending 页面，页面结构可能已变化。", "exit_code": 1}
+
+    _PERIOD_LABEL = {"daily": "今日", "weekly": "本周", "monthly": "本月"}
+    _results = []
+    for _art in _articles[:25]:
+        _h2 = _re.search(r'<h2[^>]*>(.*?)</h2>', _art, _re.DOTALL)
+        _repo_path = ""
+        if _h2:
+            _h2_links = _re.findall(r'href="(/[^"]+/[^"]+)"', _h2.group(1))
+            for _lnk in _h2_links:
+                if _lnk.count('/') == 1 and not any(
+                    _lnk.endswith(s) for s in ('/stargazers', '/forks', '/network', '/issues', '/pulls')
+                ):
+                    _repo_path = _lnk
+                    break
+        if not _repo_path:
+            continue
+        _repo_url = f"https://github.com{_repo_path}"
+
+        _desc = ""
+        _desc_match = _re.search(r'<p[^>]+class="[^"]*col-9[^"]*"[^>]*>(.*?)</p>', _art, _re.DOTALL)
+        if _desc_match:
+            _desc = _re.sub(r'<[^>]+>', '', _desc_match.group(1))
+            _desc = _re.sub(r'\s+', ' ', _desc).strip()
+
+        _lang = ""
+        _lang_match = _re.search(r'itemprop="programmingLanguage">(.*?)<', _art, _re.DOTALL | _re.IGNORECASE)
+        if _lang_match:
+            _lang = _lang_match.group(1).strip()
+
+        _stars_today = ""
+        _today_match = _re.search(r'([\d][\d,]*)\s+stars?\s+(today|this\s+week|this\s+month)', _art, _re.DOTALL | _re.IGNORECASE)
+        if _today_match:
+            _stars_today = _today_match.group(1).strip()
+
+        _total_stars = ""
+        _stars_match = _re.search(r'/stargazers">.*?([\d,]+)\s*<', _art, _re.DOTALL)
+        if _stars_match:
+            _total_stars = _stars_match.group(1).strip()
+
+        _forks = ""
+        _forks_match = _re.search(r'/forks">.*?([\d,]+)\s*<', _art, _re.DOTALL)
+        if _forks_match:
+            _forks = _forks_match.group(1).strip()
+
+        _results.append({"name": _repo_path.lstrip('/'), "url": _repo_url, "desc": _desc, "lang": _lang, "stars_today": _stars_today, "total_stars": _total_stars, "forks": _forks})
+
+    if not _results:
+        return {"error": "未能提取到任何项目信息，页面结构可能已变化。", "exit_code": 1}
+
+    _period_cn = _PERIOD_LABEL.get(period, period)
+    _lang_cn = f" · {language.upper()}" if language else ""
+    _lines = [
+        f"# ⭐ GitHub {_period_cn}热榜{_lang_cn}",
+        f"",
+        f"共找到 {len(_results)} 个热门项目，按热度排列：",
+        f"",
+    ]
+    for _i, _r in enumerate(_results, 1):
+        _lines.append(f"## {_i}. [{_r['name']}]({_r['url']})")
+        if _r["desc"]:
+            _lines.append(f"> {_r['desc']}")
+        _info = []
+        if _r["lang"]:
+            _info.append(f"语言：{_r['lang']}")
+        if _r["total_stars"]:
+            _info.append(f"⭐ {_r['total_stars']}")
+        if _r["stars_today"]:
+            _info.append(f"今日新增：+{_r['stars_today']}")
+        elif _r["forks"]:
+            _info.append(f" Fork：{_r['forks']}")
+        if _info:
+            _lines.append(" | ".join(_info))
+        _lines.append("")
+
+    return {"output": "\n".join(_lines), "exit_code": 0}
+

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -1056,6 +1056,21 @@ FUNCTION_TOOL_SCHEMAS = [
             }
         }
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "github_trending",
+            "description": "查看 GitHub 实时热门项目（Trending）。返回按星标增长排列的项目列表，包含项目描述、语言、星标数和链接。当用户问 GitHub 有什么热门项目、最近什么项目火、今天 GitHub trending、GitHub 热榜等时调用此工具。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "language": {"type": "string", "description": "编程语言筛选，如 python、typescript、go、rust，留空则为全部语言"},
+                    "period": {"type": "string", "enum": ["daily", "weekly", "monthly"], "description": "时间范围：daily（今日热榜）、weekly（本周热榜）、monthly（本月热榜），默认 daily"}
+                },
+                "required": []
+            }
+        }
+    },
 ]
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -22,6 +22,7 @@ import censorModule from './js/censor.js';
 import galleryModule from './js/gallery.js';
 import tasksModule from './js/tasks.js';
 import calendarModule from './js/calendar.js';
+import githubTrendingModule from './js/githubTrending.js';
 import notesModule from './js/notes.js';
 import adminModule from './js/admin.js';
 import settingsModule from './js/settings.js';
@@ -905,6 +906,15 @@ function initializeEventListeners() {
     });
   }
 
+  // GitHub Trending tool button — toggles inline page
+  const toolGithubTrendingBtn = el('tool-github-trending-btn');
+  if (toolGithubTrendingBtn) {
+    toolGithubTrendingBtn.addEventListener('click', () => {
+      if (githubTrendingModule.isOpen()) githubTrendingModule.closePanel();
+      else githubTrendingModule.openPanel();
+    });
+  }
+
   // Notes tool button
   const toolNotesBtn = el('tool-notes-btn');
   if (toolNotesBtn) {
@@ -1006,6 +1016,7 @@ function initializeEventListeners() {
     },
     '/calendar': () => calendarModule && calendarModule.openCalendar(),
     '/cookbook': () => document.getElementById('tool-cookbook-btn')?.click(),
+    '/github-trending': () => githubTrendingModule && githubTrendingModule.openPanel(),
     '/email':    () => {
       // Collapse the wide sidebar → icon rail (48px) so the user keeps
       // navigation visible alongside the fullscreen email view.
@@ -2389,6 +2400,7 @@ function initializeEventListeners() {
     'tool-calendar':       '#tool-calendar-btn',
     'tool-compare':        '#tool-compare-btn',
     'tool-cookbook':       '#tool-cookbook-btn',
+    'tool-github-trending':'#tool-github-trending-btn',
     'tool-research':       '#tool-research-btn',
     'tool-gallery':        '#tool-gallery-btn',
     'tool-library':        '#tool-library-btn',
@@ -3450,6 +3462,7 @@ function startOdysseusApp() {
     'rail-compare':   'tool-compare-btn',
     'rail-research':  'tool-research-btn',
     'rail-cookbook':   'tool-cookbook-btn',
+    'rail-github-trending': 'tool-github-trending-btn',
     'rail-archive':   'tool-library-btn',
     'rail-gallery':   'tool-gallery-btn',
     'rail-tasks':     'tool-tasks-btn',

--- a/static/github-trending.html
+++ b/static/github-trending.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8"/>
+<title>GitHub 热榜 - Odysseus</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: #0d1117;
+    color: #c9d1d9;
+    min-height: 100vh;
+  }
+  a { color: #58a6ff; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  /* Header */
+  .header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 16px 24px;
+    border-bottom: 1px solid #21262d;
+    background: #161b22;
+  }
+  .header h1 { font-size: 20px; font-weight: 600; color: #f0f6fc; }
+  .header h1 span { color: #f78166; }
+  .controls { display: flex; gap: 12px; align-items: center; }
+  select {
+    background: #21262d; color: #c9d1d9; border: 1px solid #30363d;
+    border-radius: 6px; padding: 6px 12px; font-size: 14px;
+  }
+  select:focus { outline: none; border-color: #58a6ff; }
+  .refresh-btn {
+    background: #238636; color: #fff; border: none; border-radius: 6px;
+    padding: 6px 16px; font-size: 14px; cursor: pointer;
+  }
+  .refresh-btn:hover { background: #2ea043; }
+
+  /* Period tabs */
+  .tabs {
+    display: flex; gap: 0; border-bottom: 1px solid #21262d;
+    padding: 0 24px; background: #161b22;
+  }
+  .tab {
+    padding: 10px 16px; font-size: 14px; color: #8b949e; cursor: pointer;
+    border-bottom: 2px solid transparent; background: none; border-top: none;
+    border-left: none; border-right: none;
+  }
+  .tab:hover { color: #c9d1d9; }
+  .tab.active { color: #f0f6fc; border-bottom-color: #f78166; }
+
+  /* Repo list */
+  .list { max-width: 900px; margin: 0 auto; padding: 16px 24px; }
+  .repo-card {
+    display: flex; flex-direction: column; gap: 4px;
+    padding: 16px 0; border-bottom: 1px solid #21262d;
+  }
+  .repo-card:last-child { border-bottom: none; }
+  .repo-rank {
+    font-size: 12px; color: #8b949e; font-weight: 600; min-width: 24px;
+    display: inline-block;
+  }
+  .repo-name { font-size: 16px; font-weight: 600; color: #58a6ff; }
+  .repo-desc { font-size: 14px; color: #8b949e; margin-top: 4px; }
+  .repo-meta { display: flex; gap: 16px; margin-top: 8px; flex-wrap: wrap; }
+  .meta-item { font-size: 12px; color: #8b949e; display: flex; align-items: center; gap: 4px; }
+  .lang-dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+
+  /* Loading */
+  .loading { text-align: center; padding: 80px 20px; color: #8b949e; }
+  .spinner {
+    width: 32px; height: 32px; border: 3px solid #21262d;
+    border-top-color: #58a6ff; border-radius: 50%;
+    animation: spin 0.8s linear infinite; margin: 0 auto 16px;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* Error */
+  .error { text-align: center; padding: 80px 20px; color: #f85149; }
+  .error button {
+    margin-top: 16px; background: #21262d; color: #c9d1d9;
+    border: 1px solid #30363d; border-radius: 6px; padding: 8px 20px;
+    cursor: pointer; font-size: 14px;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1><span>⭐</span> GitHub 热榜</h1>
+  <div class="controls">
+    <select id="lang-select">
+      <option value="">全部语言</option>
+      <option value="python">Python</option>
+      <option value="javascript">JavaScript</option>
+      <option value="typescript">TypeScript</option>
+      <option value="go">Go</option>
+      <option value="rust">Rust</option>
+      <option value="java">Java</option>
+      <option value="cpp">C++</option>
+      <option value="c">C</option>
+      <option value="swift">Swift</option>
+      <option value="kotlin">Kotlin</option>
+    </select>
+    <button class="refresh-btn" id="refresh-btn">🔄 刷新</button>
+  </div>
+</div>
+
+<div class="tabs">
+  <button class="tab active" data-period="daily">今日</button>
+  <button class="tab" data-period="weekly">本周</button>
+  <button class="tab" data-period="monthly">本月</button>
+</div>
+
+<div class="list" id="repo-list">
+  <div class="loading">
+    <div class="spinner"></div>
+    <p>正在获取热榜数据...</p>
+  </div>
+</div>
+
+<script nonce="{{CSP_NONCE}}">
+let currentPeriod = 'daily';
+let currentLang = '';
+
+const LANG_COLORS = {
+  'Python': '#3572A5', 'JavaScript': '#f1e05a', 'TypeScript': '#3178c6',
+  'Go': '#00ADD8', 'Rust': '#dea584', 'Java': '#b07219',
+  'C++': '#f34b7d', 'C': '#555555', 'Swift': '#F05138',
+  'Kotlin': '#A97BFF', 'Vue': '#41b883', 'Shell': '#89e051',
+  'Ruby': '#701516', 'PHP': '#4F5D95', 'Dart': '#00B4AB',
+};
+
+async function loadTrending() {
+  const list = document.getElementById('repo-list');
+  list.innerHTML = '<div class="loading"><div class="spinner"></div><p>正在获取热榜数据...</p></div>';
+
+  const params = new URLSearchParams();
+  if (currentLang) params.set('language', currentLang);
+  params.set('period', currentPeriod);
+
+  try {
+    const resp = await fetch(`/api/github-trending/list?${params}`);
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '请求失败');
+    renderRepos(data.repos || []);
+  } catch (e) {
+    list.innerHTML = `<div class="error"><p>获取失败：${e.message}</p><button onclick="loadTrending()">重试</button></div>`;
+  }
+}
+
+function renderRepos(repos) {
+  const list = document.getElementById('repo-list');
+  if (!repos.length) {
+    list.innerHTML = '<div class="loading"><p>暂无数据</p></div>';
+    return;
+  }
+
+  const periodLabel = { daily: '今日', weekly: '本周', monthly: '本月' };
+  let html = `<p style="color:#8b949e;font-size:13px;margin-bottom:12px;">${periodLabel[currentPeriod]}热榜 · 共 ${repos.length} 个项目</p>`;
+
+  repos.forEach((repo, i) => {
+    const dotColor = LANG_COLORS[repo.lang] || '#8b949e';
+    const descHtml = repo.desc ? `<div class="repo-desc">${repo.desc}</div>` : '';
+    const langHtml = repo.lang ? `<span class="meta-item"><span class="lang-dot" style="background:${dotColor}"></span>${repo.lang}</span>` : '';
+    const starsHtml = repo.total_stars ? `<span class="meta-item">⭐ ${repo.total_stars}</span>` : '';
+    const todayHtml = repo.stars_today ? `<span class="meta-item">📈 +${repo.stars_today} ${currentPeriod === 'daily' ? '今日' : currentPeriod === 'weekly' ? '本周' : '本月'}</span>` : '';
+    const forksHtml = repo.forks ? `<span class="meta-item">🔀 ${repo.forks}</span>` : '';
+
+    html += `
+      <div class="repo-card">
+        <div>
+          <span class="repo-rank">${i + 1}.</span>
+          <a class="repo-name" href="${repo.url}" target="_blank">${repo.name}</a>
+        </div>
+        ${descHtml}
+        <div class="repo-meta">
+          ${langHtml}${starsHtml}${todayHtml}${forksHtml}
+        </div>
+      </div>`;
+  });
+
+  list.innerHTML = html;
+}
+
+// Tab switching
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelector('.tab.active').classList.remove('active');
+    tab.classList.add('active');
+    currentPeriod = tab.dataset.period;
+    loadTrending();
+  });
+});
+
+// Language select
+document.getElementById('lang-select').addEventListener('change', e => {
+  currentLang = e.target.value;
+  loadTrending();
+});
+
+// Refresh button
+document.getElementById('refresh-btn').addEventListener('click', loadTrending);
+
+// Initial load
+loadTrending();
+</script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8" />
   <title>Odysseus Chat</title>
+  <script nonce="{{CSP_NONCE}}">window.__odysseusLocaleDefault = 'zh-CN';</script>
+  <script nonce="{{CSP_NONCE}}" src="/static/js/i18n.js"></script>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath d='M16 4L16 22L6 22Z' fill='%23e06c75'/%3E%3Cpath d='M16 8L16 22L24 22Z' fill='%23e06c75' opacity='0.6'/%3E%3Cpath d='M4 24Q10 20 16 24Q22 28 28 24' stroke='%23e06c75' stroke-width='2.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E">
   <link rel="manifest" href="/static/manifest.json">
   <meta name="theme-color" content="#282c34">
@@ -656,6 +658,7 @@
     <button class="icon-rail-btn" id="rail-calendar" title="Calendar"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></button>
     <button class="icon-rail-btn" id="rail-compare" title="Compare"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M11 18H8a2 2 0 0 1-2-2V9"/></svg></button>
     <button class="icon-rail-btn" id="rail-cookbook" title="Cookbook"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.7"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></svg></button>
+    <button class="icon-rail-btn" id="rail-github-trending" title="GitHub 热榜"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.92-.19-.42-.42-.89-.89-1.09-.31-.09-.72-.2-.14-.92.49-.49.93-.72.93-1.71 0-.95-.49-1.47-.49-2.45 0-.61.23-1.13.64-1.4-.02-.06-.14-.71.06-1.48 0 0 .52-.17 1.7.63.49-.14 1.02-.21 1.54-.21s1.04.07 1.54.21c1.18-.79 1.7-.63 1.7-.63.2.77.08 1.42.06 1.48.41.28.64.79.64 1.4 0 .98-.45 1.5-.45 2.45 0 .99.44 1.22.93 1.71.58.72.17.83-.14.92-.47.2-.7.67-.89 1.09-.16.43-.68.49-2.69.92 0 .67.01 1.3.01 1.49 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></button>
     <button class="icon-rail-btn" id="rail-research" title="Deep Research"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg></button>
     <button class="icon-rail-btn" id="rail-email" title="Email"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg></button>
     <button class="icon-rail-btn" id="rail-gallery" title="Gallery"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg></button>
@@ -845,6 +848,13 @@
           <span class="grow">Cookbook</span>
           <span id="cookbook-bg-status" style="display:none;font-size:9px;opacity:0.5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-right:12px;flex-shrink:1;min-width:0;position:relative;top:-1px;"></span>
           <span class="cookbook-notif-dot" id="cookbook-notif-dot" style="display:none;margin-left:6px;margin-right:4px;position:relative;top:-1px;left:0px;"></span>
+        </div>
+        <div class="list-item" id="tool-github-trending-btn">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"
+            style="flex-shrink:0;opacity:0.5;">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.92-.19-.42-.42-.89-.89-1.09-.31-.09-.72-.2-.14-.92.49-.49.93-.72.93-1.71 0-.95-.49-1.47-.49-2.45 0-.61.23-1.13.64-1.4-.02-.06-.14-.71.06-1.48 0 0 .52-.17 1.7.63.49-.14 1.02-.21 1.54-.21s1.04.07 1.54.21c1.18-.79 1.7-.63 1.7-.63.2.77.08 1.42.06 1.48.41.28.64.79.64 1.4 0 .98-.45 1.5-.45 2.45 0 .99.44 1.22.93 1.71.58.72.17.83-.14.92-.47.2-.7.67-.89 1.09-.16.43-.68.49-2.69.92 0 .67.01 1.3.01 1.49 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+          </svg>
+          <span class="grow">GitHub 热榜</span>
         </div>
         <div class="list-item" id="tool-research-btn">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;opacity:0.5;"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
@@ -1698,6 +1708,11 @@
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/><path d="M9 7h6M9 11h4"/></svg></span>
                 <span class="vis-label">Cookbook</span>
                 <input type="checkbox" checked data-ui-key="tool-cookbook"><span class="vis-switch"></span>
+              </label>
+              <label class="vis-row">
+                <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.92-.19-.42-.42-.89-.89-1.09-.31-.09-.72-.2-.14-.92.49-.49.93-.72.93-1.71 0-.95-.49-1.47-.49-2.45 0-.61.23-1.13.64-1.4-.02-.06-.14-.71.06-1.48 0 0 .52-.17 1.7.63.49-.14 1.02-.21 1.54-.21s1.04.07 1.54.21c1.18-.79 1.7-.63 1.7-.63.2.77.08 1.42.06 1.48.41.28.64.79.64 1.4 0 .98-.45 1.5-.45 2.45 0 .99.44 1.22.93 1.71.58.72.17.83-.14.92-.47.2-.7.67-.89 1.09-.16.43-.68.49-2.69.92 0 .67.01 1.3.01 1.49 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></span>
+                <span class="vis-label">GitHub 热榜</span>
+                <input type="checkbox" checked data-ui-key="tool-github-trending"><span class="vis-switch"></span>
               </label>
               <label class="vis-row">
                 <span class="vis-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg></span>

--- a/static/js/githubTrending.js
+++ b/static/js/githubTrending.js
@@ -1,0 +1,393 @@
+// static/js/githubTrending.js
+// GitHub Trending inline page for Odysseus.
+// Renders directly in #chat-container. DB-cached with history + AI interpretation.
+
+let _open = false;
+let _currentPeriod = 'daily';
+let _currentDate = null;
+let _historyDates = [];
+let _currentRepos = [];   // keep loaded repos for AI interpret
+let _currentDataDate = null;
+let _escHandler = null;
+const _WRAPPER_ID = 'gh-trending-page';
+
+const LANG_COLORS = {
+  Python: '#3572A5', JavaScript: '#f1e05a', TypeScript: '#3178c6',
+  Go: '#00ADD8', Rust: '#dea584', Java: '#b07219',
+  'C++': '#f34b7d', C: '#555555', Swift: '#F05138',
+  Kotlin: '#A97BFF', Vue: '#41b883', Shell: '#89e051',
+  Ruby: '#701516', PHP: '#4F5D95', Dart: '#00B4AB',
+};
+
+const PERIOD_LABELS = { daily: '今日', weekly: '本周', monthly: '本月' };
+
+function openPanel() {
+  if (_open) return;
+  _open = true;
+
+  _injectStyles();
+
+  const container = document.getElementById('chat-container');
+  if (container) {
+    Array.from(container.children).forEach(child => {
+      if (child.id === _WRAPPER_ID) return;
+      if (child.style.display === 'none') return;
+      child.dataset.ghHidden = '1';
+      child.style.display = 'none';
+    });
+    container.classList.add('gh-trending-active');
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.id = _WRAPPER_ID;
+  wrapper.className = 'gh-trending-page';
+  wrapper.innerHTML = _buildHTML();
+  if (container) container.appendChild(wrapper);
+
+  _wireEvents();
+
+  _escHandler = (e) => { if (e.key === 'Escape') closePanel(); };
+  document.addEventListener('keydown', _escHandler);
+
+  _loadHistory();
+  _loadTrending();
+}
+
+function closePanel() {
+  if (!_open) return;
+  _open = false;
+
+  const wrapper = document.getElementById(_WRAPPER_ID);
+  if (wrapper) wrapper.remove();
+
+  const container = document.getElementById('chat-container');
+  if (container) {
+    container.classList.remove('gh-trending-active');
+    Array.from(container.children).forEach(child => {
+      if (child.dataset.ghHidden === '1') {
+        delete child.dataset.ghHidden;
+        child.style.display = '';
+      }
+    });
+  }
+
+  if (_escHandler) {
+    document.removeEventListener('keydown', _escHandler);
+    _escHandler = null;
+  }
+  _currentDate = null;
+  _currentRepos = [];
+  _currentDataDate = null;
+}
+
+function isOpen() {
+  return _open;
+}
+
+function _buildHTML() {
+  return `
+    <div class="gh-header">
+      <div class="gh-header-left">
+        <svg class="gh-header-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.92-.19-.42-.42-.89-.89-1.09-.31-.09-.72-.2-.14-.92.49-.49.93-.72.93-1.71 0-.95-.49-1.47-.49-2.45 0-.61.23-1.13.64-1.4-.02-.06-.14-.71.06-1.48 0 0 .52-.17 1.7.63.49-.14 1.02-.21 1.54-.21s1.04.07 1.54.21c1.18-.79 1.7-.63 1.7-.63.2.77.08 1.42.06 1.48.41.28.64.79.64 1.4 0 .98-.45 1.5-.45 2.45 0 .99.44 1.22.93 1.71.58.72.17.83-.14.92-.47.2-.7.67-.89 1.09-.16.43-.68.49-2.69.92 0 .67.01 1.3.01 1.49 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        <span class="gh-header-title">GitHub 热榜</span>
+      </div>
+      <div class="gh-header-right">
+        <div class="gh-tabs">
+          <button class="gh-tab active" data-period="daily">今日</button>
+          <button class="gh-tab" data-period="weekly">本周</button>
+          <button class="gh-tab" data-period="monthly">本月</button>
+        </div>
+        <select class="gh-date-select" id="gh-date-select" title="历史日期">
+          <option value="">最新</option>
+        </select>
+        <button class="gh-ai-btn" id="gh-ai-btn" title="AI 中文解读">AI 解读</button>
+        <button class="gh-refresh-btn" id="gh-refresh-btn" title="强制刷新">刷新</button>
+        <button class="gh-close-btn" id="gh-close-btn" title="关闭">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="gh-body" id="gh-body"></div>`;
+}
+
+function _wireEvents() {
+  const wrapper = document.getElementById(_WRAPPER_ID);
+  if (!wrapper) return;
+
+  wrapper.querySelector('#gh-close-btn')?.addEventListener('click', closePanel);
+
+  wrapper.querySelectorAll('.gh-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      wrapper.querySelector('.gh-tab.active')?.classList.remove('active');
+      tab.classList.add('active');
+      _currentPeriod = tab.dataset.period;
+      _currentDate = null;
+      const sel = wrapper.querySelector('#gh-date-select');
+      if (sel) sel.value = '';
+      _loadTrending();
+    });
+  });
+
+  wrapper.querySelector('#gh-date-select')?.addEventListener('change', (e) => {
+    _currentDate = e.target.value || null;
+    _loadTrending();
+  });
+
+  wrapper.querySelector('#gh-refresh-btn')?.addEventListener('click', () => _loadTrending(true));
+  wrapper.querySelector('#gh-ai-btn')?.addEventListener('click', () => _interpretRepos());
+}
+
+function _injectStyles() {
+  if (document.getElementById('gh-page-styles')) return;
+  const s = document.createElement('style');
+  s.id = 'gh-page-styles';
+  s.textContent = `
+    .gh-trending-page {
+      display: flex; flex-direction: column;
+      height: 100%; width: 100%; overflow: hidden;
+    }
+    .gh-trending-active { display: flex !important; flex-direction: column !important; }
+    .gh-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 16px; border-bottom: 1px solid var(--border);
+      flex-shrink: 0; background: var(--panel); flex-wrap: wrap; gap: 6px;
+    }
+    .gh-header-left { display: flex; align-items: center; gap: 8px; }
+    .gh-header-icon { color: var(--text-muted); }
+    .gh-header-title { font-size: 15px; font-weight: 600; color: var(--text); }
+    .gh-header-right { display: flex; align-items: center; gap: 8px; }
+    .gh-tabs { display: flex; gap: 0; }
+    .gh-tab {
+      padding: 5px 12px; font-size: 13px; color: var(--text-muted);
+      cursor: pointer; background: none; border: none;
+      border-bottom: 2px solid transparent; font-family: inherit;
+    }
+    .gh-tab:hover { color: var(--text); }
+    .gh-tab.active { color: var(--text) !important; border-bottom-color: var(--accent) !important; }
+    .gh-date-select {
+      background: var(--border); color: var(--text); border: none;
+      border-radius: 6px; padding: 4px 8px; font-size: 13px;
+      cursor: pointer; font-family: inherit; max-width: 140px;
+    }
+    .gh-date-select:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+    .gh-ai-btn {
+      background: var(--accent); color: #fff; border: none;
+      border-radius: 6px; padding: 4px 12px; font-size: 13px;
+      cursor: pointer; font-family: inherit; font-weight: 500;
+      transition: opacity 0.15s;
+    }
+    .gh-ai-btn:hover { opacity: 0.85; }
+    .gh-ai-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .gh-ai-btn.loading { opacity: 0.7; }
+    .gh-refresh-btn {
+      background: var(--border); color: var(--text); border: none;
+      border-radius: 6px; padding: 4px 12px; font-size: 13px;
+      cursor: pointer; font-family: inherit;
+    }
+    .gh-refresh-btn:hover { opacity: 0.85; }
+    .gh-close-btn {
+      background: none; border: none; color: var(--text-muted);
+      cursor: pointer; padding: 4px; display: flex; align-items: center;
+      border-radius: 4px;
+    }
+    .gh-close-btn:hover { color: var(--text); background: var(--border); }
+    .gh-body { flex: 1; overflow-y: auto; padding: 16px 20px; }
+    .gh-repo-card {
+      display: flex; flex-direction: column; gap: 4px;
+      padding: 14px 0; border-bottom: 1px solid var(--border);
+    }
+    .gh-repo-card:last-child { border-bottom: none; }
+    .gh-repo-rank {
+      font-size: 12px; color: var(--text-muted); font-weight: 600;
+      min-width: 22px; display: inline-block;
+    }
+    .gh-repo-name {
+      font-size: 15px; font-weight: 600; color: var(--accent);
+      text-decoration: none;
+    }
+    .gh-repo-name:hover { text-decoration: underline; }
+    .gh-repo-desc { font-size: 13px; color: var(--text-muted); margin-top: 2px; }
+    .gh-repo-desc-zh { font-size: 13px; color: var(--text); margin-top: 2px; }
+    .gh-repo-interpretation {
+      font-size: 12px; color: var(--accent); margin-top: 3px;
+      padding: 4px 8px; background: var(--border); border-radius: 4px;
+      display: inline-block;
+    }
+    .gh-repo-meta { display: flex; gap: 14px; margin-top: 6px; flex-wrap: wrap; }
+    .gh-meta-item {
+      font-size: 12px; color: var(--text-muted);
+      display: inline-flex; align-items: center; gap: 4px;
+    }
+    .gh-lang-dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .gh-loading {
+      text-align: center; padding: 60px 20px; color: var(--text-muted);
+    }
+    .gh-spinner {
+      width: 28px; height: 28px; border: 3px solid var(--border);
+      border-top-color: var(--accent); border-radius: 50%;
+      animation: gh-spin 0.8s linear infinite; margin: 0 auto 12px;
+    }
+    .gh-error { text-align: center; padding: 60px 20px; color: var(--error,#f85149); }
+    .gh-retry-btn {
+      margin-top: 12px; background: var(--border); color: var(--text);
+      border: 1px solid var(--border); border-radius: 6px;
+      padding: 6px 16px; cursor: pointer; font-size: 13px; font-family: inherit;
+    }
+    .gh-summary {
+      color: var(--text-muted); font-size: 12px; margin-bottom: 8px;
+    }
+    .gh-cached-badge {
+      display: inline-block; font-size: 11px; color: var(--accent);
+      background: var(--border); border-radius: 4px; padding: 1px 6px;
+      margin-left: 8px;
+    }
+    .gh-ai-status {
+      text-align: center; padding: 12px; color: var(--text-muted); font-size: 13px;
+      border-bottom: 1px solid var(--border);
+    }
+    @keyframes gh-spin { to { transform: rotate(360deg); } }
+  `;
+  document.head.appendChild(s);
+}
+
+async function _loadHistory() {
+  try {
+    const resp = await fetch('/api/github-trending/history');
+    const data = await resp.json();
+    _historyDates = data.dates || [];
+    _populateDateSelect();
+  } catch (_) { /* non-critical */ }
+}
+
+function _populateDateSelect() {
+  const sel = document.getElementById('gh-date-select');
+  if (!sel) return;
+  const today = new Date().toISOString().slice(0, 10);
+  sel.innerHTML = '<option value="">最新</option>';
+  _historyDates.forEach(item => {
+    if (item.date === today) return;
+    const opt = document.createElement('option');
+    opt.value = item.date;
+    opt.textContent = item.date;
+    sel.appendChild(opt);
+  });
+}
+
+async function _loadTrending(force = false) {
+  const body = document.getElementById('gh-body');
+  if (!body) return;
+
+  body.innerHTML = '<div class="gh-loading"><div class="gh-spinner"></div><p>正在获取热榜数据...</p></div>';
+
+  try {
+    const params = new URLSearchParams({ period: _currentPeriod });
+    if (_currentDate) params.set('date', _currentDate);
+    if (force && !_currentDate) params.set('force', '1');
+
+    const resp = await fetch(`/api/github-trending/list?${params}`);
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.detail || data.error || '请求失败');
+
+    if (force) _loadHistory();
+
+    _currentRepos = data.repos || [];
+    _currentDataDate = data.date || null;
+    _renderRepos(_currentRepos, data.cached, data.date);
+  } catch (e) {
+    body.innerHTML = `<div class="gh-error"><p>获取失败：${e.message}</p><button class="gh-retry-btn" onclick="document.getElementById('gh-refresh-btn').click()">重试</button></div>`;
+  }
+}
+
+async function _interpretRepos() {
+  const btn = document.getElementById('gh-ai-btn');
+  const body = document.getElementById('gh-body');
+  if (!btn || !body || !_currentRepos.length) return;
+
+  btn.disabled = true;
+  btn.classList.add('loading');
+  btn.textContent = '解读中...';
+
+  // Show status at top
+  const statusDiv = document.createElement('div');
+  statusDiv.className = 'gh-ai-status';
+  statusDiv.innerHTML = '<div class="gh-spinner" style="width:18px;height:18px;margin:0 auto 8px;border-width:2px;"></div>AI 正在解读项目...';
+  body.insertBefore(statusDiv, body.firstChild);
+
+  try {
+    const params = new URLSearchParams({ period: _currentPeriod });
+    if (_currentDataDate) params.set('date', _currentDataDate);
+
+    const resp = await fetch(`/api/github-trending/interpret?${params}`, { method: 'POST' });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '解读失败');
+
+    _currentRepos = data.repos || _currentRepos;
+    _renderRepos(_currentRepos, true, _currentDataDate);
+
+    if (data.ai_cached) {
+      // Already all cached — no new interpretation needed
+    }
+  } catch (e) {
+    statusDiv.innerHTML = `<span style="color:var(--error,#f85149);">解读失败：${e.message}</span>`;
+    setTimeout(() => statusDiv.remove(), 3000);
+  } finally {
+    btn.disabled = false;
+    btn.classList.remove('loading');
+    btn.textContent = 'AI 解读';
+  }
+}
+
+function _renderRepos(repos, cached, dateStr) {
+  const body = document.getElementById('gh-body');
+  if (!body) return;
+  if (!repos.length) {
+    body.innerHTML = '<div class="gh-loading"><p>暂无数据</p></div>';
+    return;
+  }
+
+  const dateLabel = dateStr || '';
+  const cachedBadge = cached ? '<span class="gh-cached-badge">缓存</span>' : '';
+
+  // Count how many have AI data
+  const aiCount = repos.filter(r => r.desc_zh || r.interpretation).length;
+  const aiBadge = aiCount > 0 ? `<span class="gh-cached-badge">AI ${aiCount}/${repos.length}</span>` : '';
+
+  let html = `<p class="gh-summary">${dateLabel} ${PERIOD_LABELS[_currentPeriod]}热榜 · 共 ${repos.length} 个项目${cachedBadge}${aiBadge}</p>`;
+
+  repos.forEach((repo, i) => {
+    const dotColor = LANG_COLORS[repo.lang] || 'var(--text-muted)';
+
+    // Original English desc
+    const descHtml = repo.desc ? `<div class="gh-repo-desc">${repo.desc}</div>` : '';
+
+    // Chinese translation
+    const descZhHtml = repo.desc_zh ? `<div class="gh-repo-desc-zh">${repo.desc_zh}</div>` : '';
+
+    // AI interpretation
+    const interpHtml = repo.interpretation ? `<div class="gh-repo-interpretation">${repo.interpretation}</div>` : '';
+
+    const langHtml = repo.lang ? `<span class="gh-meta-item"><span class="gh-lang-dot" style="background:${dotColor}"></span>${repo.lang}</span>` : '';
+    const starsHtml = repo.total_stars ? `<span class="gh-meta-item">⭐ ${repo.total_stars}</span>` : '';
+    const todayHtml = repo.stars_today ? `<span class="gh-meta-item">📈 +${repo.stars_today} ${PERIOD_LABELS[_currentPeriod]}</span>` : '';
+    const forksHtml = repo.forks ? `<span class="gh-meta-item">🔀 ${repo.forks}</span>` : '';
+
+    html += `
+      <div class="gh-repo-card">
+        <div>
+          <span class="gh-repo-rank">${i + 1}.</span>
+          <a class="gh-repo-name" href="${repo.url}" target="_blank" rel="noopener">${repo.name}</a>
+        </div>
+        ${descHtml}
+        ${descZhHtml}
+        ${interpHtml}
+        <div class="gh-repo-meta">${langHtml}${starsHtml}${todayHtml}${forksHtml}</div>
+      </div>`;
+  });
+
+  body.innerHTML = html;
+}
+
+export { openPanel, closePanel, isOpen };
+export default { openPanel, closePanel, isOpen };

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 //   - Other static assets (images/fonts/libs): cache-first with bg refresh.
 //   - API / non-GET: never cached.
 // Bump CACHE_NAME whenever the precache list or SW logic changes.
-const CACHE_NAME = 'odysseus-v326';
+const CACHE_NAME = 'odysseus-v328';
 
 // Core shell precached on install so repeat opens are instant without any
 // network wait. Keep this list in sync with the <script type="module"> tags
@@ -16,6 +16,9 @@ const PRECACHE = [
   '/',
   '/static/style.css',
   '/static/app.js',
+  '/static/js/i18n.js',
+  '/static/locales/en.json',
+  '/static/locales/zh-CN.json',
   '/static/js/storage.js',
   '/static/js/ui.js',
   '/static/js/markdown.js',
@@ -59,6 +62,7 @@ const PRECACHE = [
   '/static/js/group.js',
   '/static/js/keyboard-shortcuts.js',
   '/static/js/sidebar-layout.js',
+  '/static/js/githubTrending.js',
   '/static/js/section-management.js',
   '/static/lib/highlight.min.js',
 ];


### PR DESCRIPTION
## Summary

- GitHub Trending inline panel in chat area with daily/weekly/monthly tabs
- SQLite caching in github_trending table, instant load on revisit
- Date picker to browse historical cached snapshots
- Daily auto-fetch at 08:00 via TaskScheduler
- Per-repo AI interpretation cached in github_trending_repo_ai table, cross-period reuse
- POST /api/github-trending/interpret batch LLM call for Chinese translation + AI analysis
- Docker build hardening with retries and configurable ports

## Test plan

- [ ] Open GitHub Trending from sidebar, verify inline panel renders
- [ ] First open fetches from GitHub, subsequent opens use DB cache
- [ ] Period tabs switch correctly
- [ ] Date selector shows cached history
- [ ] AI interpret button generates Chinese translations
- [ ] Same repo across periods reuses cached AI data

Generated with Claude Code