### PR TITLE
fix: catch all exceptions in package import probe to prevent 500

### DIFF
--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -1019,9 +1019,7 @@ def setup_shell_routes() -> APIRouter:
                     importlib.import_module(pkg["name"])
                     importlib_metadata.version(_pip_dist_name(pkg))
                     pkg["installed"] = True
-                except ImportError:
-                    pkg["installed"] = False
-                except importlib_metadata.PackageNotFoundError:
+                except Exception:
                     pkg["installed"] = False
 
             if pkg.get("installed"):


### PR DESCRIPTION
## Summary

`GET /api/cookbook/packages` probed each optional package with `importlib.import_module()` but only caught `ImportError` and `PackageNotFoundError`. Any other exception — for example, `FileNotFoundError` when a CUDA build of `llama-cpp-python` calls `os.add_dll_directory()` on a missing CUDA path, or `AttributeError` when `basicsr` references a removed `torchvision` symbol — propagated out of the loop and returned a 500 with plain-text "Internal Server Error", breaking the entire panel for all packages. Changed the except clauses to `except Exception` so any broken package is reported as not-installed without taking down the endpoint.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2637

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Install a package that raises a non-`ImportError` on import (e.g. a CUDA build of `llama-cpp-python` without the CUDA toolkit present, or remove the CUDA_PATH so `os.add_dll_directory` raises `FileNotFoundError`).
2. Open the Cookbook Dependencies panel (`GET /api/cookbook/packages`).
3. Before fix: the entire panel returns 500 and shows "Error loading packages: Unexpected token...".
4. After fix: the panel loads normally; the broken package row shows as not-installed instead of crashing everything.

**Checks run**
- `python -m py_compile app.py routes/shell_routes.py` — passed
- `node --check static/js/*.js` — passed (72 files)
