### PR TITLE
Mobile companion app + /api/companion/* bridge

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ from core.constants import (
     REQUEST_TIMEOUT, OPENAI_API_KEY,
 )
 from core.database import SessionLocal, ApiToken
-from core.middleware import SecurityHeadersMiddleware
+from core.middleware import SecurityHeadersMiddleware, is_cors_preflight
 from core.auth import AuthManager
 from core.exceptions import (
     SessionNotFoundError, InvalidFileUploadError,
@@ -258,7 +258,7 @@ if AUTH_ENABLED:
             # answered. Gating it on auth would 401 the preflight, so every
             # cross-origin request from a browser/WebView client (e.g. the
             # companion app) fails before the real request is ever sent.
-            if request.method == "OPTIONS" and "access-control-request-method" in request.headers:
+            if is_cors_preflight(request.method, request.headers):
                 return await call_next(request)
             if _is_auth_exempt(path):
                 return await call_next(request)

--- a/app.py
+++ b/app.py
@@ -253,6 +253,13 @@ if AUTH_ENABLED:
     class AuthMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
             path = request.url.path
+            # CORS preflight (OPTIONS + Access-Control-Request-Method) carries no
+            # credentials by design and must reach the CORS middleware to be
+            # answered. Gating it on auth would 401 the preflight, so every
+            # cross-origin request from a browser/WebView client (e.g. the
+            # companion app) fails before the real request is ever sent.
+            if request.method == "OPTIONS" and "access-control-request-method" in request.headers:
+                return await call_next(request)
             if _is_auth_exempt(path):
                 return await call_next(request)
             # In-process internal-tool token bypass. Used by the agent
@@ -719,7 +726,7 @@ from routes.contacts_routes import setup_contacts_routes
 app.include_router(setup_contacts_routes())
 
 from companion import setup_companion_routes
-app.include_router(setup_companion_routes())
+app.include_router(setup_companion_routes(session_manager))
 
 # ========= ROUTES (kept in app.py) =========
 

--- a/app.py
+++ b/app.py
@@ -726,7 +726,7 @@ from routes.contacts_routes import setup_contacts_routes
 app.include_router(setup_contacts_routes())
 
 from companion import setup_companion_routes
-app.include_router(setup_companion_routes(session_manager))
+app.include_router(setup_companion_routes(session_manager, upload_handler))
 
 # ========= ROUTES (kept in app.py) =========
 

--- a/companion/README.md
+++ b/companion/README.md
@@ -51,3 +51,43 @@ works on the next request without a restart.
 The pairing/scoping rules live in small, tested units (`token_owner`,
 `owner_can_see`, `mint_pairing_token`, `pairing.*`) — see
 `tests/test_companion_readonly.py` and `tests/test_companion_pairing.py`.
+
+## What this bridge depends on (coupling points)
+
+This layer is deliberately thin, so it leans on a handful of existing internals.
+If you change any of these, the matching companion endpoint is what will need a
+look (the rest of the app is unaffected). Most imports are lazy (inside
+handlers), so a rename surfaces at call time, not at import; the mobile client
+renders missing/renamed response fields as blanks rather than crashing.
+
+- **Owner-impersonation loopback.** The tool proxies (`/api/companion/email|
+  calendar|notes|tasks|search|stt|...`) reach the existing owner-scoped routes
+  by an in-process loopback carrying `X-Odysseus-Internal-Token` +
+  `X-Odysseus-Owner` -- the same impersonation the agent tool layer uses
+  (`app.py` `AuthMiddleware`). They do not reimplement those routes; they proxy
+  them as the resolved owner.
+- **`/api/chat_stream` form fields.** Starting a chat / follow-up posts
+  `message`, `session`, and the toggle fields `mode`, `allow_bash`,
+  `allow_web_search`, `use_web`, `use_research`, `attachments` -- the same
+  fields the desktop `static/js/chat.js` sends. See `_chat_run_options`
+  (unit-tested in `tests/test_companion_chat_options.py`).
+- **Proxied route shapes.** The tool endpoints expect today's request/response
+  shapes of `/api/email/*`, `/api/calendar/{calendars,events}`, `/api/notes`,
+  `/api/tasks/*`, `/api/search`, `/api/stt/transcribe`, and `/api/upload`. Path
+  or field renames there are the most likely source of drift.
+- **Detached-run + session APIs.** `agent_runs.{start,subscribe,is_active,
+  get_status,stop}` and `session_manager.{get_sessions_for_user,create_session,
+  get_session}`.
+- **Internal helpers** imported from the rest of the app:
+  `routes.session_routes._verify_session_owner` / `_content_to_text` /
+  `_public_model` / `_HIDDEN_SYSTEM_SESSION_NAMES`,
+  `src.endpoint_resolver.{build_chat_url,normalize_base,build_headers}`,
+  `src.tool_security.owner_is_admin_or_single_user`,
+  `src.upload_handler.count_recent_uploads`, and
+  `src.auth_helpers.{effective_user,get_current_user}`.
+- **Pairing host/QR** (`companion/pairing.py`): `lan_ip_candidates`,
+  `pairing_payload`, `pairing_qr_png_data_uri` (optional `qrcode` dep).
+
+The CORS-preflight bypass the app relies on for cross-origin clients is the pure
+`core.middleware.is_cors_preflight` (regression-tested in
+`tests/test_companion_cors_preflight.py`).

--- a/companion/README.md
+++ b/companion/README.md
@@ -8,11 +8,36 @@ Odysseus server offers and pair to it, without duplicating any LLM logic.
 | GET | `/api/companion/ping` | session or token | cheap, auth-validated health check |
 | GET | `/api/companion/info` | session or token | server identity + capability flags |
 | GET | `/api/companion/models` | session or token | the **caller's own** model endpoints |
+| GET | `/api/companion/sessions` | session or token | the **caller's own** sessions, annotated with live run state |
+| GET | `/api/companion/sessions/{id}/stream` | session or token | live SSE for one session (replay buffer + live) |
+| POST | `/api/companion/sessions/{id}/stop` | session or token | stop/interrupt a running session |
 | GET | `/api/companion/pair` | **admin cookie** | pairing page (a form; never mints) |
 | POST | `/api/companion/pair` | **admin cookie** | mint a one-time pairing token (`?format=json` for an in-app screen) |
 
 `/models` scopes to the caller's real owner plus legacy null-owner shared rows
 (same rule as `owner_filter`) and never returns API-key material.
+
+## Sessions (remote control)
+
+The `sessions/*` endpoints are a thin, owner-scoped layer over the existing
+detached-run machinery (`src/agent_runs.py`) that the desktop UI already uses —
+no new LLM logic. A paired phone (mobile app under `companion/mobile/`) uses
+them to remote-control the PC: list the owner's sessions, watch one stream live,
+and stop it.
+
+- **Owner scoping is mandatory.** All three resolve the caller's real owner via
+  `token_owner` / `_verify_session_owner` (which reads the bearer token's owner,
+  not the sandboxed `api` pseudo-user). `GET /sessions` returns an **empty** list
+  for an unresolved owner — never the global set, because
+  `get_sessions_for_user(None)` returns *all* sessions.
+- **Streaming reuses `agent_runs.subscribe`**, so a phone connecting mid-run
+  replays everything so far then streams live, and disconnecting the SSE does
+  **not** kill the run (it's detached). `POST /sessions/{id}/stop` is the
+  explicit interrupt.
+- **Reaching it from outside the LAN:** the endpoints are address-agnostic — a
+  client pairs with whatever host/port reaches the server. For access beyond the
+  LAN, prefer a private tunnel (e.g. Tailscale) over exposing ports to the
+  public internet; see `THREAT_MODEL.md`.
 
 ## Pairing CSRF posture
 

--- a/companion/mobile/.gitignore
+++ b/companion/mobile/.gitignore
@@ -7,3 +7,7 @@ dist/
 android/
 ios/
 .gradle/
+
+# Built app binaries
+*.apk
+*.aab

--- a/companion/mobile/.gitignore
+++ b/companion/mobile/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.local
+
+# Capacitor native projects are generated locally with `npx cap add android`.
+# Keep them out of the PR; document the command in README instead.
+android/
+ios/
+.gradle/

--- a/companion/mobile/README.md
+++ b/companion/mobile/README.md
@@ -58,15 +58,17 @@ first Gradle build:
 1. **SDK level** - `android/variables.gradle`: set `compileSdkVersion` and
    `targetSdkVersion` to a platform you actually have installed (e.g. `35`).
    Capacitor 6 defaults to `34`.
-2. **Camera permission** for the QR scanner - add to
+2. **Camera + microphone permissions** (QR scanner + voice dictation) - add to
    `android/app/src/main/AndroidManifest.xml`:
    ```xml
    <uses-permission android:name="android.permission.CAMERA" />
    <uses-feature android:name="android.hardware.camera" android:required="false" />
+   <uses-permission android:name="android.permission.RECORD_AUDIO" />
+   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
    ```
 
 Build the APK (point Gradle at a JDK 17/21 if your system default is newer -
-Android Studio ships one under `…/Android Studio/jbr`):
+Android Studio ships one under `.../Android Studio/jbr`):
 
 ```bash
 cd android

--- a/companion/mobile/README.md
+++ b/companion/mobile/README.md
@@ -2,8 +2,12 @@
 
 A thin **remote control** for an Odysseus server, built with Vite + React + TypeScript and packaged for Android via Capacitor. The phone does no AI work - it pairs with your PC and talks to the `/api/companion/*` endpoints to list sessions, watch one stream live, and stop it.
 
-> Status: MVP. Implemented: pair -> list sessions -> live stream -> stop.
-> Planned: QR pairing, start a new session, push notifications (silent/loud).
+> Implemented: QR / manual pairing; list & open any session; start a chat and
+> send follow-ups; switch model mid-chat; reasoning ("thinking") view;
+> agent / web-search / terminal toggles; attach images from the phone or a PC
+> file; chat search; and the desktop tools (email read/AI-summary/AI-reply/send,
+> calendar, notes, tasks).
+> Planned: voice dictation, push notifications (needs HTTPS / a tunnel).
 
 ## How it talks to the PC
 
@@ -37,15 +41,43 @@ token minted at `<server>/api/companion/pair` (admin only).
 
 ## Build the Android app
 
+Requires Android Studio (for the SDK + a bundled JDK 17/21). The generated
+`android/` folder is gitignored - regenerate it locally; only the web app and
+`capacitor.config.ts` are committed.
+
 ```bash
+npm install
 npm run build              # vite build -> dist/
 npx cap add android        # one-time: generates the native android/ project
-npm run cap:sync           # copy web build into the native project
-npm run cap:android        # build + run on a connected device/emulator
+npx cap sync android       # copy the web build + plugins into android/
 ```
 
-Requires Android Studio + SDK. The generated `android/` folder is gitignored
-(regenerate locally); only the web app and `capacitor.config.ts` are committed.
+Then apply two project tweaks (Capacitor's defaults need nudging) before the
+first Gradle build:
+
+1. **SDK level** - `android/variables.gradle`: set `compileSdkVersion` and
+   `targetSdkVersion` to a platform you actually have installed (e.g. `35`).
+   Capacitor 6 defaults to `34`.
+2. **Camera permission** for the QR scanner - add to
+   `android/app/src/main/AndroidManifest.xml`:
+   ```xml
+   <uses-permission android:name="android.permission.CAMERA" />
+   <uses-feature android:name="android.hardware.camera" android:required="false" />
+   ```
+
+Build the APK (point Gradle at a JDK 17/21 if your system default is newer -
+Android Studio ships one under `…/Android Studio/jbr`):
+
+```bash
+cd android
+# optional, if your default `java` is >21:
+#   echo "org.gradle.java.home=/path/to/Android Studio/jbr" >> gradle.properties
+./gradlew assembleDebug     # -> app/build/outputs/apk/debug/app-debug.apk
+```
+
+Install the resulting `app-debug.apk` on a phone (enable "install from unknown
+sources"). `cleartext: true` in `capacitor.config.ts` lets the installed app
+reach a plain-http LAN server; drop it once you front Odysseus with HTTPS.
 
 ## Reaching it from anywhere
 

--- a/companion/mobile/README.md
+++ b/companion/mobile/README.md
@@ -1,0 +1,72 @@
+# Odysseus companion (mobile)
+
+A thin **remote control** for an Odysseus server, built with Vite + React + TypeScript and packaged for Android via Capacitor. The phone does no AI work - it pairs with your PC and talks to the `/api/companion/*` endpoints to list sessions, watch one stream live, and stop it.
+
+> Status: MVP. Implemented: pair -> list sessions -> live stream -> stop.
+> Planned: QR pairing, start a new session, push notifications (silent/loud).
+
+## How it talks to the PC
+
+```
+ phone (this app) --HTTP+SSE-->  GET  /api/companion/sessions          list
+                                 GET  /api/companion/sessions/:id/stream  watch (SSE)
+                                 POST /api/companion/sessions/:id/stop    stop
+                                 GET  /api/companion/ping                 validate pairing
+```
+
+Every request carries the pairing token as `Authorization: Bearer ody_...`. The
+server resolves it to the token's owner and scopes everything to that user, so
+the phone sees exactly what the owner's desktop UI sees. See `../README.md` and
+`../routes.py`.
+
+## Run it (web, fastest loop)
+
+```bash
+cd companion/mobile
+npm install
+# Point dev requests at your PC to dodge browser CORS (see vite.config.ts):
+VITE_PROXY_TARGET=http://<your-pc-ip>:7000 npm run dev
+```
+
+Open the printed URL. On the pairing screen, enter your server address and a
+token minted at `<server>/api/companion/pair` (admin only).
+
+> Without the proxy, a browser blocks cross-origin calls to your PC. Either use
+> `VITE_PROXY_TARGET` (above) or add your dev origin to the server's
+> `ALLOWED_ORIGINS`. The packaged Android app has no such restriction.
+
+## Build the Android app
+
+```bash
+npm run build              # vite build -> dist/
+npx cap add android        # one-time: generates the native android/ project
+npm run cap:sync           # copy web build into the native project
+npm run cap:android        # build + run on a connected device/emulator
+```
+
+Requires Android Studio + SDK. The generated `android/` folder is gitignored
+(regenerate locally); only the web app and `capacitor.config.ts` are committed.
+
+## Reaching it from anywhere
+
+The app is address-agnostic - it just needs a reachable URL. **Don't** forward
+ports from your router to expose Odysseus to the public internet. Instead put
+your phone and PC on a private tunnel:
+
+- **Tailscale** (recommended): install on both, pair with the PC's Tailscale
+  address. Works on any network, no port-forwarding.
+- **Cloudflare Tunnel**: gives an https hostname; also lets you drop the Android
+  cleartext allowance in `capacitor.config.ts`.
+
+See the repo's `THREAT_MODEL.md`.
+
+## Layout
+
+```
+src/
+  lib/connection.ts   paired server + token, persisted via @capacitor/preferences
+  lib/api.ts          typed client for /api/companion/*
+  lib/sse.ts          fetch-based SSE reader (EventSource can't send a Bearer token)
+  screens/            Pair, Sessions, Session (stream+stop), Settings
+  components/         BottomNav
+```

--- a/companion/mobile/capacitor.config.ts
+++ b/companion/mobile/capacitor.config.ts
@@ -5,11 +5,17 @@ const config: CapacitorConfig = {
   appName: 'Odysseus',
   webDir: 'dist',
   // The app talks to YOUR Odysseus server over the network -- there is no
-  // bundled backend. On a home LAN that server is plain http://, which Android
-  // blocks as cleartext by default; allow it here. For access from anywhere,
-  // prefer an https tunnel (e.g. Tailscale) so you can turn this back off.
+  // bundled backend. On a home LAN that server is plain http://. Serve the app
+  // itself over http://localhost (androidScheme 'http') for two reasons:
+  //   1. no https->http "mixed content" block when fetching the http LAN server;
+  //   2. the app's origin becomes http://localhost, which Odysseus already
+  //      allows by default (ALLOWED_ORIGINS), so cross-origin fetch + SSE work
+  //      without extra CORS config.
+  // localhost is still a secure context, so the camera (QR) and mic (voice)
+  // keep working. cleartext allows the http LAN calls. For access from anywhere,
+  // prefer an https tunnel (e.g. Tailscale).
   server: {
-    androidScheme: 'https',
+    androidScheme: 'http',
     cleartext: true,
   },
 };

--- a/companion/mobile/capacitor.config.ts
+++ b/companion/mobile/capacitor.config.ts
@@ -1,0 +1,17 @@
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'app.odysseus.companion',
+  appName: 'Odysseus',
+  webDir: 'dist',
+  // The app talks to YOUR Odysseus server over the network -- there is no
+  // bundled backend. On a home LAN that server is plain http://, which Android
+  // blocks as cleartext by default; allow it here. For access from anywhere,
+  // prefer an https tunnel (e.g. Tailscale) so you can turn this back off.
+  server: {
+    androidScheme: 'https',
+    cleartext: true,
+  },
+};
+
+export default config;

--- a/companion/mobile/index.html
+++ b/companion/mobile/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
+    />
+    <meta name="theme-color" content="#16161a" />
+    <title>Odysseus</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/companion/mobile/package-lock.json
+++ b/companion/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/app": "^6.0.1",
         "@capacitor/core": "^6.1.2",
         "@capacitor/preferences": "^6.0.2",
+        "dompurify": "^3.4.8",
         "jsqr": "^1.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1491,6 +1492,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1802,6 +1810,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/companion/mobile/package-lock.json
+++ b/companion/mobile/package-lock.json
@@ -1,0 +1,2994 @@
+{
+  "name": "odysseus-companion",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "odysseus-companion",
+      "version": "0.1.0",
+      "dependencies": {
+        "@capacitor/android": "^6.1.2",
+        "@capacitor/app": "^6.0.1",
+        "@capacitor/core": "^6.1.2",
+        "@capacitor/preferences": "^6.0.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@capacitor/cli": "^6.1.2",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capacitor/android": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-6.2.1.tgz",
+      "integrity": "sha512-8gd4CIiQO5LAIlPIfd5mCuodBRxMMdZZEdj8qG8m+dQ1sQ2xyemVpzHmRK8qSCHorsBUCg3D62j2cp6bEBAkdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.2.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-6.0.3.tgz",
+      "integrity": "sha512-4gFUCbcVz0N/YYN32OBFerocWXslIv3Nc90gDiRsBkJc0plwK6kIUT6PKa5WtW2kfhteUeCVXQbvArH2fH+0Ug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-6.2.1.tgz",
+      "integrity": "sha512-JKl0FpFge8PgQNInw12kcKieQ4BmOyazQ4JGJOfEpVXlgrX1yPhSZTPjngupzTCiK3I7q7iGG5kjun0fDqgSCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.5",
+        "@ionic/utils-fs": "^3.1.6",
+        "@ionic/utils-subprocess": "2.1.11",
+        "@ionic/utils-terminal": "^2.3.3",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4",
+        "env-paths": "^2.2.0",
+        "kleur": "^4.1.4",
+        "native-run": "^2.0.0",
+        "open": "^8.4.0",
+        "plist": "^3.0.5",
+        "prompts": "^2.4.2",
+        "rimraf": "^4.4.1",
+        "semver": "^7.3.7",
+        "tar": "^6.1.11",
+        "tslib": "^2.4.0",
+        "xml2js": "^0.5.0"
+      },
+      "bin": {
+        "cap": "bin/capacitor",
+        "capacitor": "bin/capacitor"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-6.0.4.tgz",
+      "integrity": "sha512-ziauSI1pgdyl+gduvvf8lInvzF3Wdyu/ok+u7NlnhKp8XOj9plJgtnXZWFiR8CiCK5wMvo+gFaNh3zhMyEUwpA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@ionic/cli-framework-output": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-array": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.5.tgz",
+      "integrity": "sha512-HD72a71IQVBmQckDwmA8RxNVMTbxnaLbgFOl+dO5tbvW9CkkSFCv41h6fUuNsSEVgngfkn0i98HDuZC8mk+lTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-object": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.5.tgz",
+      "integrity": "sha512-XnYNSwfewUqxq+yjER1hxTKggftpNjFLJH0s37jcrNDwbzmbpFTQTVAp4ikNK4rd9DOebX/jbeZb8jfD86IYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-process": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.10.tgz",
+      "integrity": "sha512-mZ7JEowcuGQK+SKsJXi0liYTcXd2bNMR3nE0CyTROpMECUpJeAvvaBaPGZf5ERQUPeWBVuwqAqjUmIdxhz5bxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-object": "2.1.5",
+        "@ionic/utils-terminal": "2.3.3",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-process/node_modules/@ionic/utils-terminal": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
+      "integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-stream": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.5.tgz",
+      "integrity": "sha512-hkm46uHvEC05X/8PHgdJi4l4zv9VQDELZTM+Kz69odtO9zZYfnt8DkfXHJqJ+PxmtiE5mk/ehJWLnn/XAczTUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-2.1.11.tgz",
+      "integrity": "sha512-6zCDixNmZCbMCy5np8klSxOZF85kuDyzZSTTQKQP90ZtYNCcPYmuFSzaqDwApJT4r5L3MY3JrqK1gLkc6xiUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-array": "2.1.5",
+        "@ionic/utils-fs": "3.1.6",
+        "@ionic/utils-process": "2.1.10",
+        "@ionic/utils-stream": "3.1.5",
+        "@ionic/utils-terminal": "2.3.3",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-fs": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.6.tgz",
+      "integrity": "sha512-eikrNkK89CfGPmexjTfSWl4EYqsPSBh0Ka7by4F0PLc1hJZYtJxUZV3X4r5ecA8ikjicUmcbU7zJmAjmqutG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess/node_modules/@ionic/utils-terminal": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.3.tgz",
+      "integrity": "sha512-RnuSfNZ5fLEyX3R5mtcMY97cGD1A0NVBbarsSQ6yMMfRJ5YHU7hHVyUfvZeClbqkBC/pAqI/rYJuXKCT9YeMCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
+      "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.368",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
+      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sax": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/native-run": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-fs": "^3.1.7",
+        "@ionic/utils-terminal": "^2.3.4",
+        "bplist-parser": "^0.3.2",
+        "debug": "^4.3.4",
+        "elementtree": "^0.1.7",
+        "ini": "^4.1.1",
+        "plist": "^3.1.0",
+        "split2": "^4.2.0",
+        "through2": "^4.0.2",
+        "tslib": "^2.6.2",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "native-run": "bin/native-run"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/companion/mobile/package-lock.json
+++ b/companion/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/app": "^6.0.1",
         "@capacitor/core": "^6.1.2",
         "@capacitor/preferences": "^6.0.2",
+        "jsqr": "^1.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2114,6 +2115,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/kleur": {
       "version": "4.1.5",

--- a/companion/mobile/package.json
+++ b/companion/mobile/package.json
@@ -16,6 +16,7 @@
     "@capacitor/app": "^6.0.1",
     "@capacitor/core": "^6.1.2",
     "@capacitor/preferences": "^6.0.2",
+    "dompurify": "^3.4.8",
     "jsqr": "^1.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/companion/mobile/package.json
+++ b/companion/mobile/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "odysseus-companion",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Mobile companion (remote control) for an Odysseus server — thin client, all processing stays on the PC.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "cap:sync": "cap sync",
+    "cap:android": "cap run android"
+  },
+  "dependencies": {
+    "@capacitor/android": "^6.1.2",
+    "@capacitor/app": "^6.0.1",
+    "@capacitor/core": "^6.1.2",
+    "@capacitor/preferences": "^6.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^6.1.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}

--- a/companion/mobile/package.json
+++ b/companion/mobile/package.json
@@ -16,6 +16,7 @@
     "@capacitor/app": "^6.0.1",
     "@capacitor/core": "^6.1.2",
     "@capacitor/preferences": "^6.0.2",
+    "jsqr": "^1.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/companion/mobile/src/App.tsx
+++ b/companion/mobile/src/App.tsx
@@ -6,6 +6,11 @@ import SessionsScreen from './screens/SessionsScreen';
 import SessionScreen from './screens/SessionScreen';
 import NewSessionScreen from './screens/NewSessionScreen';
 import SettingsScreen from './screens/SettingsScreen';
+import ToolsScreen, { type ToolName } from './screens/ToolsScreen';
+import EmailScreen from './screens/EmailScreen';
+import CalendarScreen from './screens/CalendarScreen';
+import NotesScreen from './screens/NotesScreen';
+import TasksScreen from './screens/TasksScreen';
 import BottomNav, { type Tab } from './components/BottomNav';
 
 // Top-level state machine. Intentionally tiny -- no router dependency for a
@@ -18,6 +23,7 @@ export default function App() {
   const [tab, setTab] = useState<Tab>('sessions');
   const [openSessionId, setOpenSessionId] = useState<string | null>(null);
   const [composing, setComposing] = useState(false);
+  const [openTool, setOpenTool] = useState<ToolName | null>(null);
 
   useEffect(() => {
     loadConnection().then((c) => {
@@ -57,12 +63,22 @@ export default function App() {
     );
   }
 
+  if (openTool) {
+    const back = () => setOpenTool(null);
+    if (openTool === 'email') return <EmailScreen conn={conn} onBack={back} />;
+    if (openTool === 'calendar') return <CalendarScreen conn={conn} onBack={back} />;
+    if (openTool === 'notes') return <NotesScreen conn={conn} onBack={back} />;
+    if (openTool === 'tasks') return <TasksScreen conn={conn} onBack={back} />;
+  }
+
   return (
     <div className="app">
       <main className="app-body">
-        {tab === 'sessions' ? (
+        {tab === 'sessions' && (
           <SessionsScreen conn={conn} onOpen={setOpenSessionId} onNew={() => setComposing(true)} />
-        ) : (
+        )}
+        {tab === 'tools' && <ToolsScreen onOpen={setOpenTool} />}
+        {tab === 'settings' && (
           <SettingsScreen
             conn={conn}
             onDisconnect={() => {

--- a/companion/mobile/src/App.tsx
+++ b/companion/mobile/src/App.tsx
@@ -6,6 +6,7 @@ import SessionsScreen from './screens/SessionsScreen';
 import SessionScreen from './screens/SessionScreen';
 import NewSessionScreen from './screens/NewSessionScreen';
 import SettingsScreen from './screens/SettingsScreen';
+import SearchScreen from './screens/SearchScreen';
 import ToolsScreen, { type ToolName } from './screens/ToolsScreen';
 import EmailScreen from './screens/EmailScreen';
 import CalendarScreen from './screens/CalendarScreen';
@@ -23,6 +24,7 @@ export default function App() {
   const [tab, setTab] = useState<Tab>('sessions');
   const [openSessionId, setOpenSessionId] = useState<string | null>(null);
   const [composing, setComposing] = useState(false);
+  const [searching, setSearching] = useState(false);
   const [openTool, setOpenTool] = useState<ToolName | null>(null);
 
   useEffect(() => {
@@ -53,6 +55,19 @@ export default function App() {
     );
   }
 
+  if (searching) {
+    return (
+      <SearchScreen
+        conn={conn}
+        onBack={() => setSearching(false)}
+        onOpen={(sid) => {
+          setSearching(false);
+          setOpenSessionId(sid);
+        }}
+      />
+    );
+  }
+
   if (openSessionId) {
     return (
       <SessionScreen
@@ -75,7 +90,12 @@ export default function App() {
     <div className="app">
       <main className="app-body">
         {tab === 'sessions' && (
-          <SessionsScreen conn={conn} onOpen={setOpenSessionId} onNew={() => setComposing(true)} />
+          <SessionsScreen
+            conn={conn}
+            onOpen={setOpenSessionId}
+            onNew={() => setComposing(true)}
+            onSearch={() => setSearching(true)}
+          />
         )}
         {tab === 'tools' && <ToolsScreen onOpen={setOpenTool} />}
         {tab === 'settings' && (

--- a/companion/mobile/src/App.tsx
+++ b/companion/mobile/src/App.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import type { Connection } from './lib/connection';
+import { loadConnection } from './lib/connection';
+import PairScreen from './screens/PairScreen';
+import SessionsScreen from './screens/SessionsScreen';
+import SessionScreen from './screens/SessionScreen';
+import SettingsScreen from './screens/SettingsScreen';
+import BottomNav, { type Tab } from './components/BottomNav';
+
+// Top-level state machine. Intentionally tiny -- no router dependency for a
+// two-tab remote. Until a server is paired we show the pairing screen
+// full-bleed; after that it's Sessions / Settings with a session detail
+// overlay.
+export default function App() {
+  const [conn, setConn] = useState<Connection | null>(null);
+  const [booted, setBooted] = useState(false);
+  const [tab, setTab] = useState<Tab>('sessions');
+  const [openSessionId, setOpenSessionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadConnection().then((c) => {
+      setConn(c);
+      setBooted(true);
+    });
+  }, []);
+
+  if (!booted) {
+    return <div className="screen center muted">Loading...</div>;
+  }
+
+  if (!conn) {
+    return <PairScreen onPaired={setConn} />;
+  }
+
+  if (openSessionId) {
+    return (
+      <SessionScreen
+        conn={conn}
+        sessionId={openSessionId}
+        onBack={() => setOpenSessionId(null)}
+      />
+    );
+  }
+
+  return (
+    <div className="app">
+      <main className="app-body">
+        {tab === 'sessions' ? (
+          <SessionsScreen conn={conn} onOpen={setOpenSessionId} />
+        ) : (
+          <SettingsScreen
+            conn={conn}
+            onDisconnect={() => {
+              setConn(null);
+              setTab('sessions');
+            }}
+          />
+        )}
+      </main>
+      <BottomNav active={tab} onChange={setTab} />
+    </div>
+  );
+}

--- a/companion/mobile/src/App.tsx
+++ b/companion/mobile/src/App.tsx
@@ -4,6 +4,7 @@ import { loadConnection } from './lib/connection';
 import PairScreen from './screens/PairScreen';
 import SessionsScreen from './screens/SessionsScreen';
 import SessionScreen from './screens/SessionScreen';
+import NewSessionScreen from './screens/NewSessionScreen';
 import SettingsScreen from './screens/SettingsScreen';
 import BottomNav, { type Tab } from './components/BottomNav';
 
@@ -16,6 +17,7 @@ export default function App() {
   const [booted, setBooted] = useState(false);
   const [tab, setTab] = useState<Tab>('sessions');
   const [openSessionId, setOpenSessionId] = useState<string | null>(null);
+  const [composing, setComposing] = useState(false);
 
   useEffect(() => {
     loadConnection().then((c) => {
@@ -32,6 +34,19 @@ export default function App() {
     return <PairScreen onPaired={setConn} />;
   }
 
+  if (composing) {
+    return (
+      <NewSessionScreen
+        conn={conn}
+        onBack={() => setComposing(false)}
+        onCreated={(sid) => {
+          setComposing(false);
+          setOpenSessionId(sid);
+        }}
+      />
+    );
+  }
+
   if (openSessionId) {
     return (
       <SessionScreen
@@ -46,7 +61,7 @@ export default function App() {
     <div className="app">
       <main className="app-body">
         {tab === 'sessions' ? (
-          <SessionsScreen conn={conn} onOpen={setOpenSessionId} />
+          <SessionsScreen conn={conn} onOpen={setOpenSessionId} onNew={() => setComposing(true)} />
         ) : (
           <SettingsScreen
             conn={conn}

--- a/companion/mobile/src/components/Attachments.tsx
+++ b/companion/mobile/src/components/Attachments.tsx
@@ -1,25 +1,26 @@
 import { useRef } from 'react';
-import { PaperclipIcon, XIcon } from './icons';
+import { FileIcon, MonitorIcon, PaperclipIcon, XIcon } from './icons';
 
-// One file the user has picked but not yet uploaded. `url` is a local object URL
-// for the preview thumbnail (revoked when removed).
-export interface PendingFile {
-  file: File;
-  url: string;
+// A queued attachment, either a local file from the phone (uploaded on send) or
+// a PC file already copied into an attachment server-side (has an id already).
+export type Pending =
+  | { kind: 'local'; file: File; url: string }
+  | { kind: 'remote'; id: string; name: string; mime: string };
+
+export function makeLocal(files: FileList | File[]): Pending[] {
+  return Array.from(files).map((file) => ({
+    kind: 'local' as const,
+    file,
+    url: URL.createObjectURL(file),
+  }));
 }
 
-export function makePending(files: FileList | File[]): PendingFile[] {
-  return Array.from(files).map((file) => ({ file, url: URL.createObjectURL(file) }));
-}
-
-// Paperclip button that opens the native file picker. On a phone this offers
-// the camera, photo library, and files, so "from your phone" is covered without
-// a native plugin. `accept="image/*"` keeps it to photos.
+// Paperclip -> native picker (camera/photo library/files on a phone).
 export function AttachButton({
   onPick,
   disabled,
 }: {
-  onPick: (files: PendingFile[]) => void;
+  onPick: (picked: Pending[]) => void;
   disabled?: boolean;
 }) {
   const ref = useRef<HTMLInputElement>(null);
@@ -30,7 +31,7 @@ export function AttachButton({
         className="ghost attach"
         onClick={() => ref.current?.click()}
         disabled={disabled}
-        aria-label="Attach image"
+        aria-label="Attach from phone"
       >
         <PaperclipIcon size={22} />
       </button>
@@ -41,7 +42,7 @@ export function AttachButton({
         multiple
         hidden
         onChange={(e) => {
-          if (e.target.files?.length) onPick(makePending(e.target.files));
+          if (e.target.files?.length) onPick(makeLocal(e.target.files));
           e.target.value = ''; // allow re-picking the same file
         }}
       />
@@ -49,38 +50,62 @@ export function AttachButton({
   );
 }
 
-// Row of thumbnails for the files queued to send, each with a remove button.
+// Monitor -> open the PC file browser.
+export function PcFilesButton({ onClick, disabled }: { onClick: () => void; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      className="ghost attach"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Attach a file from the PC"
+    >
+      <MonitorIcon size={22} />
+    </button>
+  );
+}
+
+// Thumbnails for the queued attachments, each with a remove button. Local images
+// preview from their object URL; everything else shows a labelled file chip.
 export function AttachPreviews({
   pending,
   onRemove,
   disabled,
 }: {
-  pending: PendingFile[];
+  pending: Pending[];
   onRemove: (index: number) => void;
   disabled?: boolean;
 }) {
   if (pending.length === 0) return null;
   return (
     <div className="attach-previews">
-      {pending.map((p, i) => (
-        <div className="thumb" key={p.url}>
-          {p.file.type.startsWith('image/') ? (
-            <img src={p.url} alt={p.file.name} />
-          ) : (
-            <span className="thumb-file">{p.file.name}</span>
-          )}
-          {!disabled && (
-            <button
-              type="button"
-              className="thumb-x"
-              onClick={() => onRemove(i)}
-              aria-label={`Remove ${p.file.name}`}
-            >
-              <XIcon size={13} />
-            </button>
-          )}
-        </div>
-      ))}
+      {pending.map((p, i) => {
+        const key = p.kind === 'local' ? p.url : p.id;
+        const name = p.kind === 'local' ? p.file.name : p.name;
+        const isLocalImage = p.kind === 'local' && p.file.type.startsWith('image/');
+        return (
+          <div className="thumb" key={key}>
+            {isLocalImage ? (
+              <img src={p.url} alt={name} />
+            ) : (
+              <span className="thumb-file">
+                <FileIcon size={18} />
+                <span className="thumb-name">{name}</span>
+              </span>
+            )}
+            {!disabled && (
+              <button
+                type="button"
+                className="thumb-x"
+                onClick={() => onRemove(i)}
+                aria-label={`Remove ${name}`}
+              >
+                <XIcon size={13} />
+              </button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/companion/mobile/src/components/Attachments.tsx
+++ b/companion/mobile/src/components/Attachments.tsx
@@ -1,0 +1,86 @@
+import { useRef } from 'react';
+import { PaperclipIcon, XIcon } from './icons';
+
+// One file the user has picked but not yet uploaded. `url` is a local object URL
+// for the preview thumbnail (revoked when removed).
+export interface PendingFile {
+  file: File;
+  url: string;
+}
+
+export function makePending(files: FileList | File[]): PendingFile[] {
+  return Array.from(files).map((file) => ({ file, url: URL.createObjectURL(file) }));
+}
+
+// Paperclip button that opens the native file picker. On a phone this offers
+// the camera, photo library, and files, so "from your phone" is covered without
+// a native plugin. `accept="image/*"` keeps it to photos.
+export function AttachButton({
+  onPick,
+  disabled,
+}: {
+  onPick: (files: PendingFile[]) => void;
+  disabled?: boolean;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <button
+        type="button"
+        className="ghost attach"
+        onClick={() => ref.current?.click()}
+        disabled={disabled}
+        aria-label="Attach image"
+      >
+        <PaperclipIcon size={22} />
+      </button>
+      <input
+        ref={ref}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={(e) => {
+          if (e.target.files?.length) onPick(makePending(e.target.files));
+          e.target.value = ''; // allow re-picking the same file
+        }}
+      />
+    </>
+  );
+}
+
+// Row of thumbnails for the files queued to send, each with a remove button.
+export function AttachPreviews({
+  pending,
+  onRemove,
+  disabled,
+}: {
+  pending: PendingFile[];
+  onRemove: (index: number) => void;
+  disabled?: boolean;
+}) {
+  if (pending.length === 0) return null;
+  return (
+    <div className="attach-previews">
+      {pending.map((p, i) => (
+        <div className="thumb" key={p.url}>
+          {p.file.type.startsWith('image/') ? (
+            <img src={p.url} alt={p.file.name} />
+          ) : (
+            <span className="thumb-file">{p.file.name}</span>
+          )}
+          {!disabled && (
+            <button
+              type="button"
+              className="thumb-x"
+              onClick={() => onRemove(i)}
+              aria-label={`Remove ${p.file.name}`}
+            >
+              <XIcon size={13} />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/companion/mobile/src/components/Attachments.tsx
+++ b/companion/mobile/src/components/Attachments.tsx
@@ -1,4 +1,6 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import { attachmentUrl } from '../lib/api';
 import { FileIcon, MonitorIcon, PaperclipIcon, XIcon } from './icons';
 
 // A queued attachment, either a local file from the phone (uploaded on send) or
@@ -63,6 +65,41 @@ export function PcFilesButton({ onClick, disabled }: { onClick: () => void; disa
       <MonitorIcon size={22} />
     </button>
   );
+}
+
+// An <img> for a server-stored attachment. EventSource-style problem: an <img
+// src> can't carry the bearer header, so we fetch the bytes with auth and show
+// the result as a blob URL (revoked on unmount). Falls back to a file chip.
+export function AuthImage({ conn, id, alt }: { conn: Connection; id: string; alt: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    fetch(attachmentUrl(conn, id, true), { headers: { Authorization: `Bearer ${conn.token}` } })
+      .then((r) => (r.ok ? r.blob() : Promise.reject(new Error(String(r.status)))))
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => !cancelled && setFailed(true));
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [conn, id]);
+
+  if (failed) {
+    return (
+      <span className="thumb-file">
+        <FileIcon size={18} />
+        <span className="thumb-name">{alt}</span>
+      </span>
+    );
+  }
+  if (!url) return <span className="att-loading" aria-label="Loading" />;
+  return <img src={url} alt={alt} />;
 }
 
 // Thumbnails for the queued attachments, each with a remove button. Local images

--- a/companion/mobile/src/components/BottomNav.tsx
+++ b/companion/mobile/src/components/BottomNav.tsx
@@ -1,10 +1,11 @@
 import type { ComponentType } from 'react';
-import { SessionsIcon, SettingsIcon } from './icons';
+import { SessionsIcon, SettingsIcon, ToolsIcon } from './icons';
 
-export type Tab = 'sessions' | 'settings';
+export type Tab = 'sessions' | 'tools' | 'settings';
 
 const TABS: { id: Tab; label: string; Icon: ComponentType<{ size?: number }> }[] = [
   { id: 'sessions', label: 'Sessions', Icon: SessionsIcon },
+  { id: 'tools', label: 'Tools', Icon: ToolsIcon },
   { id: 'settings', label: 'Settings', Icon: SettingsIcon },
 ];
 

--- a/companion/mobile/src/components/BottomNav.tsx
+++ b/companion/mobile/src/components/BottomNav.tsx
@@ -1,0 +1,35 @@
+import type { ComponentType } from 'react';
+import { SessionsIcon, SettingsIcon } from './icons';
+
+export type Tab = 'sessions' | 'settings';
+
+const TABS: { id: Tab; label: string; Icon: ComponentType<{ size?: number }> }[] = [
+  { id: 'sessions', label: 'Sessions', Icon: SessionsIcon },
+  { id: 'settings', label: 'Settings', Icon: SettingsIcon },
+];
+
+export default function BottomNav({
+  active,
+  onChange,
+}: {
+  active: Tab;
+  onChange: (t: Tab) => void;
+}) {
+  return (
+    <nav className="bottom-nav">
+      {TABS.map(({ id, label, Icon }) => (
+        <button
+          key={id}
+          className={'nav-item' + (active === id ? ' active' : '')}
+          onClick={() => onChange(id)}
+          type="button"
+        >
+          <span className="nav-icon">
+            <Icon size={22} />
+          </span>
+          <span className="nav-label">{label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/companion/mobile/src/components/FsBrowser.tsx
+++ b/companion/mobile/src/components/FsBrowser.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { Attachment, FsListing } from '../lib/api';
+import { fsAttach, fsBrowse } from '../lib/api';
+import { ChevronLeftIcon, FileIcon, FolderIcon, XIcon } from './icons';
+
+// Full-screen overlay that browses the PC filesystem (admin-only on the server)
+// so the user can pick a file to attach. Tapping a folder navigates; tapping a
+// file copies it into an attachment and hands it back via onPick.
+export default function FsBrowser({
+  conn,
+  onClose,
+  onPick,
+}: {
+  conn: Connection;
+  onClose: () => void;
+  onPick: (att: Attachment) => void;
+}) {
+  const [listing, setListing] = useState<FsListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [attaching, setAttaching] = useState<string | null>(null);
+
+  const go = useCallback(
+    async (path: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        setListing(await fsBrowse(conn, path));
+      } catch (e) {
+        setError(
+          e instanceof Error && /403/.test(e.message)
+            ? 'File browsing is admin-only on this server.'
+            : 'Could not read that folder.',
+        );
+        console.warn('fsBrowse failed', e);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [conn],
+  );
+
+  useEffect(() => {
+    go('');
+  }, [go]);
+
+  async function pickFile(path: string) {
+    setAttaching(path);
+    setError(null);
+    try {
+      onPick(await fsAttach(conn, path));
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not attach that file.');
+      console.warn('fsAttach failed', e);
+      setAttaching(null);
+    }
+  }
+
+  return (
+    <div className="screen detail fs">
+      <header className="detail-header">
+        <button className="ghost" onClick={onClose} type="button" aria-label="Cancel">
+          <XIcon size={24} />
+        </button>
+        <span className="fs-path">{listing?.path || 'PC files'}</span>
+      </header>
+
+      {error && <div className="error">{error}</div>}
+
+      <ul className="rows fs-rows">
+        {listing?.parent && (
+          <li>
+            <button className="row" onClick={() => go(listing.parent as string)} type="button">
+              <span className="chev">
+                <ChevronLeftIcon size={20} />
+              </span>
+              <span className="row-main">
+                <span className="row-title">..</span>
+              </span>
+            </button>
+          </li>
+        )}
+
+        {listing?.dirs.map((d) => (
+          <li key={d.path}>
+            <button className="row" onClick={() => go(d.path)} type="button">
+              <span className="fs-icon">
+                <FolderIcon size={20} />
+              </span>
+              <span className="row-main">
+                <span className="row-title">{d.name}</span>
+              </span>
+            </button>
+          </li>
+        ))}
+
+        {listing?.files.map((f) => (
+          <li key={f.path}>
+            <button
+              className="row"
+              onClick={() => pickFile(f.path)}
+              type="button"
+              disabled={attaching !== null}
+            >
+              <span className="fs-icon">
+                <FileIcon size={20} />
+              </span>
+              <span className="row-main">
+                <span className="row-title">{f.name}</span>
+                <span className="row-sub">
+                  <span>{attaching === f.path ? 'Attaching...' : formatSize(f.size)}</span>
+                </span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {loading && <div className="muted pad">Loading...</div>}
+      {!loading && listing && listing.dirs.length === 0 && listing.files.length === 0 && (
+        <div className="muted pad">Empty folder.</div>
+      )}
+    </div>
+  );
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/companion/mobile/src/components/QrScanner.tsx
+++ b/companion/mobile/src/components/QrScanner.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import jsQR from 'jsqr';
+import { XIcon } from './icons';
+
+// Camera QR scanner for pairing. Uses getUserMedia + jsQR so it needs no native
+// plugin and works the same in the installed app and on localhost. getUserMedia
+// requires a secure context (https or localhost), so over a plain-http LAN
+// preview it shows a clear message and the user falls back to manual entry.
+export default function QrScanner({
+  onResult,
+  onClose,
+}: {
+  onResult: (text: string) => void;
+  onClose: () => void;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let raf = 0;
+    let stopped = false;
+    const canvas = document.createElement('canvas');
+
+    async function start() {
+      if (!navigator.mediaDevices?.getUserMedia || !window.isSecureContext) {
+        setError(
+          'Camera needs a secure connection. It works in the installed app; ' +
+            'for now enter the details below by hand.',
+        );
+        return;
+      }
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+      } catch {
+        setError('Could not open the camera. Check the permission, then try again.');
+        return;
+      }
+      const video = videoRef.current;
+      if (!video) return;
+      video.srcObject = stream;
+      try {
+        await video.play();
+      } catch {
+        /* autoplay can reject silently; the frame loop still runs */
+      }
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+      const tick = () => {
+        if (stopped) return;
+        if (ctx && video.readyState === video.HAVE_ENOUGH_DATA) {
+          canvas.width = video.videoWidth;
+          canvas.height = video.videoHeight;
+          ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+          const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+          const code = jsQR(img.data, img.width, img.height, { inversionAttempts: 'dontInvert' });
+          if (code?.data) {
+            onResult(code.data);
+            return; // stop scanning; parent unmounts us
+          }
+        }
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    }
+
+    start();
+    return () => {
+      stopped = true;
+      cancelAnimationFrame(raf);
+      stream?.getTracks().forEach((t) => t.stop());
+    };
+  }, [onResult]);
+
+  return (
+    <div className="screen detail qr-scan">
+      <header className="detail-header">
+        <button className="ghost" onClick={onClose} type="button" aria-label="Cancel">
+          <XIcon size={24} />
+        </button>
+        <span className="status-pill">Scan pairing code</span>
+      </header>
+
+      {error ? (
+        <div className="error">{error}</div>
+      ) : (
+        <div className="qr-viewport">
+          <video ref={videoRef} playsInline muted />
+          <div className="qr-frame" />
+        </div>
+      )}
+      {!error && (
+        <p className="muted pad">Point the camera at the QR on your PC&apos;s pairing page.</p>
+      )}
+    </div>
+  );
+}

--- a/companion/mobile/src/components/ToolToggles.tsx
+++ b/companion/mobile/src/components/ToolToggles.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from 'react';
 import type { ChatOptions } from '../lib/api';
-import { BotIcon, GlobeIcon, TerminalIcon } from './icons';
+import { BotIcon, GlobeIcon, ResearchIcon, TerminalIcon } from './icons';
 
 // The per-turn capability chips that mirror the desktop's chat toggles. Agent
 // mode is the master switch for tools; terminal (bash) is an agent-only tool,
-// so turning it on implies agent mode and turning agent off clears it.
+// so turning it on implies agent mode and turning agent off clears it. Deep
+// research is a self-contained mode, mutually exclusive with the agent tools.
 export default function ToolToggles({
   value,
   onChange,
@@ -16,6 +17,17 @@ export default function ToolToggles({
 }) {
   function set(patch: Partial<ChatOptions>) {
     const next = { ...value, ...patch };
+    if (patch.research !== undefined) {
+      // Turning research on clears the agent tools (research does its own work).
+      if (next.research) {
+        next.agent = false;
+        next.terminal = false;
+        next.web = false;
+      }
+    } else if (next.agent || next.web || next.terminal) {
+      // Touching an agent tool drops research.
+      next.research = false;
+    }
     if (next.terminal) next.agent = true; // bash only exists as an agent tool
     if (!next.agent) next.terminal = false; // no tools without agent mode
     onChange(next);
@@ -43,6 +55,13 @@ export default function ToolToggles({
         onClick={() => set({ terminal: !value.terminal })}
         icon={<TerminalIcon size={16} />}
         label="Terminal"
+      />
+      <Chip
+        active={value.research}
+        disabled={disabled}
+        onClick={() => set({ research: !value.research })}
+        icon={<ResearchIcon size={16} />}
+        label="Research"
       />
     </div>
   );

--- a/companion/mobile/src/components/ToolToggles.tsx
+++ b/companion/mobile/src/components/ToolToggles.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import type { ChatOptions } from '../lib/api';
+import { BotIcon, GlobeIcon, TerminalIcon } from './icons';
+
+// The per-turn capability chips that mirror the desktop's chat toggles. Agent
+// mode is the master switch for tools; terminal (bash) is an agent-only tool,
+// so turning it on implies agent mode and turning agent off clears it.
+export default function ToolToggles({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: ChatOptions;
+  onChange: (next: ChatOptions) => void;
+  disabled?: boolean;
+}) {
+  function set(patch: Partial<ChatOptions>) {
+    const next = { ...value, ...patch };
+    if (next.terminal) next.agent = true; // bash only exists as an agent tool
+    if (!next.agent) next.terminal = false; // no tools without agent mode
+    onChange(next);
+  }
+
+  return (
+    <div className="toggles">
+      <Chip
+        active={value.agent}
+        disabled={disabled}
+        onClick={() => set({ agent: !value.agent })}
+        icon={<BotIcon size={16} />}
+        label="Agent"
+      />
+      <Chip
+        active={value.web}
+        disabled={disabled}
+        onClick={() => set({ web: !value.web })}
+        icon={<GlobeIcon size={16} />}
+        label="Web"
+      />
+      <Chip
+        active={value.terminal}
+        disabled={disabled}
+        onClick={() => set({ terminal: !value.terminal })}
+        icon={<TerminalIcon size={16} />}
+        label="Terminal"
+      />
+    </div>
+  );
+}
+
+function Chip({
+  active,
+  disabled,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      className={'chip' + (active ? ' active' : '')}
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/companion/mobile/src/components/VoiceButton.tsx
+++ b/companion/mobile/src/components/VoiceButton.tsx
@@ -1,0 +1,91 @@
+import { useRef, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import { transcribeAudio } from '../lib/api';
+import { MicIcon } from './icons';
+
+// Push-to-dictate: tap to record, tap again to stop -> uploads the audio to the
+// PC's STT service and hands back the text. getUserMedia needs a secure context,
+// so it works in the installed app (and localhost) but not the plain-http LAN
+// preview -- it reports that instead of failing silently.
+type State = 'idle' | 'recording' | 'working';
+
+export default function VoiceButton({
+  conn,
+  onText,
+  onError,
+  disabled,
+}: {
+  conn: Connection;
+  onText: (text: string) => void;
+  onError?: (msg: string) => void;
+  disabled?: boolean;
+}) {
+  const [state, setState] = useState<State>('idle');
+  const recRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  function cleanupStream() {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }
+
+  async function handleStop() {
+    const rec = recRef.current;
+    cleanupStream();
+    setState('working');
+    try {
+      const blob = new Blob(chunksRef.current, { type: rec?.mimeType || 'audio/webm' });
+      if (!blob.size) {
+        onError?.('No audio captured.');
+        return;
+      }
+      const text = await transcribeAudio(conn, blob);
+      if (text.trim()) onText(text.trim());
+      else onError?.('No speech detected.');
+    } catch (e) {
+      onError?.(e instanceof Error ? e.message : 'Transcription failed.');
+    } finally {
+      setState('idle');
+    }
+  }
+
+  async function start() {
+    if (!navigator.mediaDevices?.getUserMedia || !window.isSecureContext) {
+      onError?.('Microphone needs the installed app (or an HTTPS connection).');
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const rec = new MediaRecorder(stream);
+      chunksRef.current = [];
+      rec.ondataavailable = (e) => {
+        if (e.data.size) chunksRef.current.push(e.data);
+      };
+      rec.onstop = handleStop;
+      rec.start();
+      recRef.current = rec;
+      setState('recording');
+    } catch {
+      cleanupStream();
+      onError?.('Could not access the microphone.');
+    }
+  }
+
+  function stop() {
+    recRef.current?.stop();
+  }
+
+  return (
+    <button
+      type="button"
+      className={'ghost attach voice voice-' + state}
+      onClick={state === 'recording' ? stop : start}
+      disabled={disabled || state === 'working'}
+      aria-label={state === 'recording' ? 'Stop recording' : 'Dictate'}
+    >
+      <MicIcon size={22} />
+    </button>
+  );
+}

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -130,6 +130,49 @@ export const FileIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const ToolsIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+  </Svg>
+);
+
+export const MailIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <rect width="20" height="16" x="2" y="4" rx="2" />
+    <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  </Svg>
+);
+
+export const CalendarIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M8 2v4" />
+    <path d="M16 2v4" />
+    <rect width="18" height="18" x="3" y="4" rx="2" />
+    <path d="M3 10h18" />
+  </Svg>
+);
+
+export const NoteIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M15.5 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8.5z" />
+    <path d="M15 3v6h6" />
+  </Svg>
+);
+
+export const CheckSquareIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="m9 11 3 3L22 4" />
+    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+  </Svg>
+);
+
+export const SendIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
+    <path d="m21.854 2.147-10.94 10.939" />
+  </Svg>
+);
+
 export const QrIcon = (p: IconProps) => (
   <Svg {...p}>
     <rect width="5" height="5" x="3" y="3" rx="1" />

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -137,6 +137,15 @@ export const SearchIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const ResearchIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+    <line x1="11" x2="11" y1="8" y2="14" />
+    <line x1="8" x2="14" y1="11" y2="11" />
+  </Svg>
+);
+
 export const ToolsIcon = (p: IconProps) => (
   <Svg {...p}>
     <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -137,6 +137,14 @@ export const SearchIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const MicIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+    <line x1="12" x2="12" y1="19" y2="22" />
+  </Svg>
+);
+
 export const ResearchIcon = (p: IconProps) => (
   <Svg {...p}>
     <circle cx="11" cy="11" r="8" />

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -130,6 +130,13 @@ export const FileIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const SearchIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />
+  </Svg>
+);
+
 export const ToolsIcon = (p: IconProps) => (
   <Svg {...p}>
     <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -96,6 +96,19 @@ export const TerminalIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const PaperclipIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+  </Svg>
+);
+
+export const XIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </Svg>
+);
+
 // The Odysseus mark: filled sail + wave, reused from the web app's favicon.
 export const BrandMark = ({ size = 28 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -1,0 +1,79 @@
+// Monochrome line icons in the same style the web app uses (24x24, currentColor,
+// stroke-width 2, round caps). Inline SVG, no icon font and no emoji -- per the
+// project's visual rules.
+import type { SVGProps } from 'react';
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number };
+
+function Svg({ size = 22, children, ...rest }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const SessionsIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </Svg>
+);
+
+export const SettingsIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <line x1="21" x2="14" y1="6" y2="6" />
+    <line x1="10" x2="3" y1="6" y2="6" />
+    <line x1="21" x2="12" y1="12" y2="12" />
+    <line x1="8" x2="3" y1="12" y2="12" />
+    <line x1="21" x2="16" y1="18" y2="18" />
+    <line x1="12" x2="3" y1="18" y2="18" />
+    <line x1="14" x2="14" y1="4" y2="8" />
+    <line x1="8" x2="8" y1="10" y2="14" />
+    <line x1="16" x2="16" y1="16" y2="20" />
+  </Svg>
+);
+
+export const RefreshIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M21 12a9 9 0 1 1-9-9c2.5 0 4.85.99 6.6 2.6L21 8" />
+    <path d="M21 3v5h-5" />
+  </Svg>
+);
+
+export const ChevronLeftIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="m15 18-6-6 6-6" />
+  </Svg>
+);
+
+export const ChevronRightIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="m9 18 6-6-6-6" />
+  </Svg>
+);
+
+// The Odysseus mark: filled sail + wave, reused from the web app's favicon.
+export const BrandMark = ({ size = 28 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">
+    <path d="M16 4L16 22L6 22Z" fill="var(--red)" />
+    <path d="M16 8L16 22L24 22Z" fill="var(--red)" opacity="0.6" />
+    <path
+      d="M4 24Q10 20 16 24Q22 28 28 24"
+      stroke="var(--red)"
+      strokeWidth="2.5"
+      fill="none"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -70,6 +70,32 @@ export const ChevronRightIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const BotIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 8V4H8" />
+    <rect width="16" height="12" x="4" y="8" rx="2" />
+    <path d="M2 14h2" />
+    <path d="M20 14h2" />
+    <path d="M15 13v2" />
+    <path d="M9 13v2" />
+  </Svg>
+);
+
+export const GlobeIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+    <path d="M2 12h20" />
+  </Svg>
+);
+
+export const TerminalIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <polyline points="4 17 10 11 4 5" />
+    <line x1="12" x2="20" y1="19" y2="19" />
+  </Svg>
+);
+
 // The Odysseus mark: filled sail + wave, reused from the web app's favicon.
 export const BrandMark = ({ size = 28 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -51,6 +51,13 @@ export const RefreshIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const PlusIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <line x1="12" x2="12" y1="5" y2="19" />
+    <line x1="5" x2="19" y1="12" y2="12" />
+  </Svg>
+);
+
 export const ChevronLeftIcon = (p: IconProps) => (
   <Svg {...p}>
     <path d="m15 18-6-6 6-6" />

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -109,6 +109,27 @@ export const XIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const MonitorIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <rect width="20" height="14" x="2" y="3" rx="2" />
+    <line x1="8" x2="16" y1="21" y2="21" />
+    <line x1="12" x2="12" y1="17" y2="21" />
+  </Svg>
+);
+
+export const FolderIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+  </Svg>
+);
+
+export const FileIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+    <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+  </Svg>
+);
+
 // The Odysseus mark: filled sail + wave, reused from the web app's favicon.
 export const BrandMark = ({ size = 28 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">

--- a/companion/mobile/src/components/icons.tsx
+++ b/companion/mobile/src/components/icons.tsx
@@ -130,6 +130,23 @@ export const FileIcon = (p: IconProps) => (
   </Svg>
 );
 
+export const QrIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <rect width="5" height="5" x="3" y="3" rx="1" />
+    <rect width="5" height="5" x="16" y="3" rx="1" />
+    <rect width="5" height="5" x="3" y="16" rx="1" />
+    <path d="M21 16h-3a2 2 0 0 0-2 2v3" />
+    <path d="M21 21v.01" />
+    <path d="M12 7v3a2 2 0 0 1-2 2H7" />
+    <path d="M3 12h.01" />
+    <path d="M12 3h.01" />
+    <path d="M12 16v.01" />
+    <path d="M16 12h1" />
+    <path d="M21 12v.01" />
+    <path d="M12 21v-1" />
+  </Svg>
+);
+
 // The Odysseus mark: filled sail + wave, reused from the web app's favicon.
 export const BrandMark = ({ size = 28 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -305,6 +305,34 @@ export function taskAction(conn: Connection, id: string, action: 'pause' | 'resu
   return postJSON(conn, `/api/companion/tasks/${encodeURIComponent(id)}/${action}`, {});
 }
 
+/** Transcribe a voice recording via the PC's STT service. Throws a friendly
+ *  message when STT isn't enabled on the server (503). */
+export async function transcribeAudio(conn: Connection, blob: Blob): Promise<string> {
+  const fd = new FormData();
+  fd.append('file', blob, 'audio.webm');
+  const resp = await fetch(`${conn.baseUrl}/api/companion/stt/transcribe`, {
+    method: 'POST',
+    headers: authHeaders(conn),
+    body: fd,
+  });
+  if (!resp.ok) {
+    if (resp.status === 503) {
+      throw new Error('Voice isn\'t enabled on your PC yet (Settings -> Speech).');
+    }
+    let msg = `HTTP ${resp.status}`;
+    try {
+      const j = (await resp.json()) as { detail?: { message?: string } | string; message?: string };
+      const d = j.detail;
+      msg = (typeof d === 'object' ? d?.message : d) || j.message || msg;
+    } catch {
+      /* keep status */
+    }
+    throw new Error(msg);
+  }
+  const { text } = (await resp.json()) as { text?: string };
+  return text || '';
+}
+
 export interface SearchHit {
   session_id: string;
   session_name: string;

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -190,6 +190,10 @@ export interface EmailRead {
   body_text?: string;
   body_html?: string;
   body?: string;
+  message_id?: string;
+  folder?: string;
+  cached_summary?: string | null;
+  cached_ai_reply?: string | null;
 }
 
 export async function listEmailAccounts(conn: Connection): Promise<EmailAccount[]> {
@@ -232,6 +236,18 @@ export function flagEmail(
 }
 export function sendEmail(conn: Connection, body: Record<string, unknown>): Promise<unknown> {
   return postJSON(conn, '/api/companion/email/send', body);
+}
+export function summarizeEmail(
+  conn: Connection,
+  body: Record<string, unknown>,
+): Promise<{ success: boolean; summary?: string; error?: string }> {
+  return postJSON(conn, '/api/companion/email/summarize', body);
+}
+export function aiReplyEmail(
+  conn: Connection,
+  body: Record<string, unknown>,
+): Promise<{ success: boolean; reply?: string; error?: string }> {
+  return postJSON(conn, '/api/companion/email/ai-reply', body);
 }
 
 export interface CalEvent {

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -299,6 +299,18 @@ export function taskAction(conn: Connection, id: string, action: 'pause' | 'resu
   return postJSON(conn, `/api/companion/tasks/${encodeURIComponent(id)}/${action}`, {});
 }
 
+export interface SearchHit {
+  session_id: string;
+  session_name: string;
+  role: string;
+  content_snippet: string;
+  timestamp: string | null;
+}
+/** Search the owner's chat history. Returns most-recent matches first. */
+export function searchChats(conn: Connection, q: string, limit = 25): Promise<SearchHit[]> {
+  return getJSON(conn, '/api/companion/search' + qs({ q, limit }));
+}
+
 export interface FsDir {
   name: string;
   path: string;

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -77,9 +77,15 @@ export interface ChatOptions {
   agent: boolean;
   web: boolean;
   terminal: boolean;
+  research: boolean;
 }
 
-export const DEFAULT_OPTIONS: ChatOptions = { agent: false, web: false, terminal: false };
+export const DEFAULT_OPTIONS: ChatOptions = {
+  agent: false,
+  web: false,
+  terminal: false,
+  research: false,
+};
 
 export interface Attachment {
   id: string;

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -133,6 +133,156 @@ export async function startSession(
   return (await resp.json()) as { session_id: string; name: string };
 }
 
+// ------------------------------------------------------------------ //
+// Tools (email / calendar / notes / tasks). These hit the companion's
+// owner-impersonating proxies over the desktop's existing routes.
+// ------------------------------------------------------------------ //
+async function postJSON<T>(conn: Connection, path: string, body: unknown): Promise<T> {
+  const resp = await fetch(conn.baseUrl + path, {
+    method: 'POST',
+    headers: { ...authHeaders(conn), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!resp.ok) {
+    let detail = `HTTP ${resp.status}`;
+    try {
+      detail = ((await resp.json()) as { detail?: string }).detail || detail;
+    } catch {
+      /* keep status */
+    }
+    throw new Error(detail);
+  }
+  return (await resp.json().catch(() => ({}))) as T;
+}
+
+function qs(params: Record<string, string | number | undefined>): string {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) if (v !== undefined && v !== '') p.set(k, String(v));
+  const s = p.toString();
+  return s ? `?${s}` : '';
+}
+
+export interface EmailAccount {
+  id: string;
+  email?: string;
+  address?: string;
+  name?: string;
+  is_default?: boolean;
+}
+export interface EmailItem {
+  uid: string | number;
+  subject: string;
+  from_name?: string;
+  from_address?: string;
+  date?: string;
+  date_display?: string;
+  is_read?: boolean;
+  has_attachments?: boolean;
+}
+export interface EmailRead {
+  uid: string | number;
+  subject?: string;
+  from_name?: string;
+  from_address?: string;
+  to?: string;
+  date?: string;
+  date_display?: string;
+  body_text?: string;
+  body_html?: string;
+  body?: string;
+}
+
+export async function listEmailAccounts(conn: Connection): Promise<EmailAccount[]> {
+  const { accounts } = await getJSON<{ accounts: EmailAccount[] }>(conn, '/api/companion/email/accounts');
+  return accounts || [];
+}
+export function listEmails(
+  conn: Connection,
+  opts: { folder?: string; limit?: number; filter?: string; accountId?: string } = {},
+): Promise<{ emails: EmailItem[]; total?: number; error?: string }> {
+  return getJSON(
+    conn,
+    '/api/companion/email/list' +
+      qs({ folder: opts.folder, limit: opts.limit ?? 40, filter: opts.filter, account_id: opts.accountId }),
+  );
+}
+export function readEmail(
+  conn: Connection,
+  uid: string | number,
+  opts: { folder?: string; accountId?: string } = {},
+): Promise<EmailRead> {
+  return getJSON(
+    conn,
+    `/api/companion/email/read/${encodeURIComponent(String(uid))}` +
+      qs({ folder: opts.folder, account_id: opts.accountId }),
+  );
+}
+export function flagEmail(
+  conn: Connection,
+  uid: string | number,
+  action: 'mark-read' | 'mark-unread' | 'archive',
+  opts: { folder?: string; accountId?: string } = {},
+): Promise<unknown> {
+  return postJSON(
+    conn,
+    `/api/companion/email/${encodeURIComponent(String(uid))}/flag` +
+      qs({ action, folder: opts.folder, account_id: opts.accountId }),
+    {},
+  );
+}
+export function sendEmail(conn: Connection, body: Record<string, unknown>): Promise<unknown> {
+  return postJSON(conn, '/api/companion/email/send', body);
+}
+
+export interface CalEvent {
+  title?: string;
+  summary?: string;
+  dtstart?: string;
+  dtend?: string;
+  all_day?: boolean;
+  location?: string;
+}
+export function listEvents(conn: Connection, startISO: string, endISO: string): Promise<{ events: CalEvent[] }> {
+  return getJSON(conn, '/api/companion/calendar/events' + qs({ start: startISO, end: endISO }));
+}
+
+export interface Note {
+  id: string;
+  title?: string;
+  content?: string;
+  items?: { text: string; checked?: boolean }[] | null;
+  note_type?: string;
+  pinned?: boolean;
+  label?: string;
+  updated_at?: string;
+}
+export async function listNotes(conn: Connection): Promise<Note[]> {
+  const { notes } = await getJSON<{ notes: Note[] }>(conn, '/api/companion/notes');
+  return notes || [];
+}
+export function createNote(conn: Connection, body: { title?: string; content?: string }): Promise<unknown> {
+  return postJSON(conn, '/api/companion/notes', body);
+}
+
+export interface TaskRow {
+  id: string;
+  name?: string;
+  status?: string;
+  task_type?: string;
+  action?: string;
+  schedule?: string | null;
+  next_run?: string | null;
+  last_run?: string | null;
+  trigger_type?: string | null;
+}
+export async function listTasks(conn: Connection): Promise<TaskRow[]> {
+  const { tasks } = await getJSON<{ tasks: TaskRow[] }>(conn, '/api/companion/tasks');
+  return tasks || [];
+}
+export function taskAction(conn: Connection, id: string, action: 'pause' | 'resume' | 'run'): Promise<unknown> {
+  return postJSON(conn, `/api/companion/tasks/${encodeURIComponent(id)}/${action}`, {});
+}
+
 export interface FsDir {
   name: string;
   path: string;

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -94,13 +94,42 @@ export interface ChatMsg {
   content: string;
 }
 
+export interface SessionHistory {
+  messages: ChatMsg[];
+  /** The session's current model, so the in-chat picker can default to it. */
+  model: string;
+  name: string;
+}
+
 /** Saved conversation for a session (works for finished sessions too). */
-export async function getMessages(conn: Connection, id: string): Promise<ChatMsg[]> {
-  const { messages } = await getJSON<{ messages: ChatMsg[] }>(
+export async function getMessages(conn: Connection, id: string): Promise<SessionHistory> {
+  const data = await getJSON<{ messages: ChatMsg[]; model?: string; name?: string }>(
     conn,
     `/api/companion/sessions/${encodeURIComponent(id)}/messages`,
   );
-  return messages;
+  return { messages: data.messages, model: data.model || '', name: data.name || '' };
+}
+
+/** Send a follow-up turn into an existing session. Optionally switches the
+ *  model first (the in-chat picker). The run streams via streamSession. */
+export async function sendMessage(
+  conn: Connection,
+  id: string,
+  opts: { message: string; endpointId?: string; model?: string },
+): Promise<void> {
+  const resp = await fetch(
+    `${conn.baseUrl}/api/companion/sessions/${encodeURIComponent(id)}/message`,
+    {
+      method: 'POST',
+      headers: { ...authHeaders(conn), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: opts.message,
+        endpoint_id: opts.endpointId,
+        model: opts.model,
+      }),
+    },
+  );
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} sending message`);
 }
 
 export async function stopSession(conn: Connection, id: string): Promise<boolean> {

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -81,10 +81,42 @@ export interface ChatOptions {
 
 export const DEFAULT_OPTIONS: ChatOptions = { agent: false, web: false, terminal: false };
 
+export interface Attachment {
+  id: string;
+  name: string;
+  mime: string;
+  size: number;
+  width?: number | null;
+  height?: number | null;
+}
+
+/** Upload files from the phone (camera/gallery). Returns attachment ids to pass
+ *  as `attachments` on a chat send. The ids are owned by the token's real owner,
+ *  so the chat pipeline resolves them. */
+export async function uploadFiles(conn: Connection, files: File[]): Promise<Attachment[]> {
+  const fd = new FormData();
+  for (const f of files) fd.append('files', f);
+  // Note: do NOT set Content-Type -- the browser adds the multipart boundary.
+  const resp = await fetch(`${conn.baseUrl}/api/companion/upload`, {
+    method: 'POST',
+    headers: authHeaders(conn),
+    body: fd,
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} uploading`);
+  const { files: out } = (await resp.json()) as { files: Attachment[] };
+  return out;
+}
+
 /** Start a new chat. Returns the new session id to open + watch. */
 export async function startSession(
   conn: Connection,
-  opts: { message: string; endpointId: string; model: string; options?: ChatOptions },
+  opts: {
+    message: string;
+    endpointId: string;
+    model: string;
+    options?: ChatOptions;
+    attachments?: string[];
+  },
 ): Promise<{ session_id: string; name: string }> {
   const resp = await fetch(`${conn.baseUrl}/api/companion/sessions`, {
     method: 'POST',
@@ -93,6 +125,7 @@ export async function startSession(
       message: opts.message,
       endpoint_id: opts.endpointId,
       model: opts.model,
+      attachments: opts.attachments,
       ...opts.options,
     }),
   });
@@ -126,7 +159,13 @@ export async function getMessages(conn: Connection, id: string): Promise<Session
 export async function sendMessage(
   conn: Connection,
   id: string,
-  opts: { message: string; endpointId?: string; model?: string; options?: ChatOptions },
+  opts: {
+    message: string;
+    endpointId?: string;
+    model?: string;
+    options?: ChatOptions;
+    attachments?: string[];
+  },
 ): Promise<void> {
   const resp = await fetch(
     `${conn.baseUrl}/api/companion/sessions/${encodeURIComponent(id)}/message`,
@@ -137,6 +176,7 @@ export async function sendMessage(
         message: opts.message,
         endpoint_id: opts.endpointId,
         model: opts.model,
+        attachments: opts.attachments,
         ...opts.options,
       }),
     },

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -71,10 +71,20 @@ export async function listModels(conn: Connection): Promise<ModelOption[]> {
   return out;
 }
 
+/** Per-turn capability toggles, mirroring the desktop: agent mode unlocks
+ *  tools, web adds search, terminal allows the shell (and implies agent). */
+export interface ChatOptions {
+  agent: boolean;
+  web: boolean;
+  terminal: boolean;
+}
+
+export const DEFAULT_OPTIONS: ChatOptions = { agent: false, web: false, terminal: false };
+
 /** Start a new chat. Returns the new session id to open + watch. */
 export async function startSession(
   conn: Connection,
-  opts: { message: string; endpointId: string; model: string },
+  opts: { message: string; endpointId: string; model: string; options?: ChatOptions },
 ): Promise<{ session_id: string; name: string }> {
   const resp = await fetch(`${conn.baseUrl}/api/companion/sessions`, {
     method: 'POST',
@@ -83,6 +93,7 @@ export async function startSession(
       message: opts.message,
       endpoint_id: opts.endpointId,
       model: opts.model,
+      ...opts.options,
     }),
   });
   if (!resp.ok) throw new Error(`HTTP ${resp.status} starting session`);
@@ -115,7 +126,7 @@ export async function getMessages(conn: Connection, id: string): Promise<Session
 export async function sendMessage(
   conn: Connection,
   id: string,
-  opts: { message: string; endpointId?: string; model?: string },
+  opts: { message: string; endpointId?: string; model?: string; options?: ChatOptions },
 ): Promise<void> {
   const resp = await fetch(
     `${conn.baseUrl}/api/companion/sessions/${encodeURIComponent(id)}/message`,
@@ -126,6 +137,7 @@ export async function sendMessage(
         message: opts.message,
         endpoint_id: opts.endpointId,
         model: opts.model,
+        ...opts.options,
       }),
     },
   );

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -176,9 +176,22 @@ export async function fsAttach(conn: Connection, path: string): Promise<Attachme
   return (await resp.json()) as Attachment;
 }
 
+export interface MsgAttachment {
+  id: string;
+  name: string;
+  mime: string;
+}
+
 export interface ChatMsg {
   role: 'user' | 'assistant';
   content: string;
+  attachments?: MsgAttachment[];
+}
+
+/** URL for an attachment's bytes. Needs the bearer header, so callers fetch it
+ *  rather than dropping it straight into an <img src> (see AuthImage). */
+export function attachmentUrl(conn: Connection, id: string, thumb = true): string {
+  return `${conn.baseUrl}/api/companion/upload/${encodeURIComponent(id)}${thumb ? '?thumb=1' : ''}`;
 }
 
 export interface SessionHistory {

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -1,0 +1,99 @@
+import type { Connection } from './connection';
+import { openSSE } from './sse';
+
+// Typed client for the PC's /api/companion/* endpoints. Every call carries the
+// pairing token as a Bearer header; the server resolves it to the token's real
+// owner and scopes everything to that user (see companion/routes.py).
+
+export interface PingResult {
+  ok: boolean;
+  name: string;
+  version: string;
+  auth: 'token' | 'session';
+}
+
+export interface SessionRow {
+  id: string;
+  name: string;
+  model: string;
+  message_count: number;
+  is_important: boolean;
+  active: boolean;
+  status: string | null;
+}
+
+/** One decoded stream event. Text arrives as `{delta}`; everything else is a
+ *  typed control/status event (`{type: 'tool_start' | 'model_info' | ...}`). */
+export type StreamEvent =
+  | { kind: 'delta'; text: string; thinking: boolean }
+  | { kind: 'event'; type: string; raw: Record<string, unknown> }
+  | { kind: 'done' };
+
+function authHeaders(conn: Connection): Record<string, string> {
+  return { Authorization: `Bearer ${conn.token}` };
+}
+
+async function getJSON<T>(conn: Connection, path: string): Promise<T> {
+  const resp = await fetch(conn.baseUrl + path, { headers: authHeaders(conn) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} on ${path}`);
+  return (await resp.json()) as T;
+}
+
+export function ping(conn: Connection): Promise<PingResult> {
+  return getJSON<PingResult>(conn, '/api/companion/ping');
+}
+
+export async function listSessions(conn: Connection): Promise<SessionRow[]> {
+  const { sessions } = await getJSON<{ sessions: SessionRow[] }>(
+    conn,
+    '/api/companion/sessions',
+  );
+  return sessions;
+}
+
+export async function stopSession(conn: Connection, id: string): Promise<boolean> {
+  const resp = await fetch(
+    `${conn.baseUrl}/api/companion/sessions/${encodeURIComponent(id)}/stop`,
+    { method: 'POST', headers: authHeaders(conn) },
+  );
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} stopping session`);
+  const { stopped } = (await resp.json()) as { stopped: boolean };
+  return stopped;
+}
+
+/** Open the live SSE for a session and dispatch decoded events. Returns nothing;
+ *  cancel by aborting the supplied signal. */
+export function streamSession(
+  conn: Connection,
+  id: string,
+  onEvent: (ev: StreamEvent) => void,
+  opts: { signal?: AbortSignal; onError?: (e: unknown) => void; onClose?: () => void } = {},
+): void {
+  const url = `${conn.baseUrl}/api/companion/sessions/${encodeURIComponent(id)}/stream`;
+  void openSSE(url, {
+    headers: authHeaders(conn),
+    signal: opts.signal,
+    onError: opts.onError,
+    onClose: opts.onClose,
+    onData: (data) => {
+      if (data === '[DONE]') {
+        onEvent({ kind: 'done' });
+        return;
+      }
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(data);
+      } catch {
+        // Non-JSON payloads are rare; surface them as raw text so nothing is lost.
+        onEvent({ kind: 'delta', text: data, thinking: false });
+        return;
+      }
+      if (typeof obj.delta === 'string') {
+        // Odysseus flags reasoning tokens with thinking:true (src/llm_core.py).
+        onEvent({ kind: 'delta', text: obj.delta, thinking: obj.thinking === true });
+      } else if (typeof obj.type === 'string') {
+        onEvent({ kind: 'event', type: obj.type, raw: obj });
+      }
+    },
+  });
+}

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -51,6 +51,58 @@ export async function listSessions(conn: Connection): Promise<SessionRow[]> {
   return sessions;
 }
 
+export interface ModelOption {
+  endpointId: string;
+  endpointName: string;
+  model: string;
+}
+
+/** Flatten the caller's endpoints into pickable (endpoint, model) options. */
+export async function listModels(conn: Connection): Promise<ModelOption[]> {
+  const { endpoints } = await getJSON<{
+    endpoints: { endpoint_id: string; name: string; models: string[] }[];
+  }>(conn, '/api/companion/models');
+  const out: ModelOption[] = [];
+  for (const ep of endpoints) {
+    for (const model of ep.models) {
+      out.push({ endpointId: ep.endpoint_id, endpointName: ep.name, model });
+    }
+  }
+  return out;
+}
+
+/** Start a new chat. Returns the new session id to open + watch. */
+export async function startSession(
+  conn: Connection,
+  opts: { message: string; endpointId: string; model: string },
+): Promise<{ session_id: string; name: string }> {
+  const resp = await fetch(`${conn.baseUrl}/api/companion/sessions`, {
+    method: 'POST',
+    headers: { ...authHeaders(conn), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: opts.message,
+      endpoint_id: opts.endpointId,
+      model: opts.model,
+    }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} starting session`);
+  return (await resp.json()) as { session_id: string; name: string };
+}
+
+export interface ChatMsg {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** Saved conversation for a session (works for finished sessions too). */
+export async function getMessages(conn: Connection, id: string): Promise<ChatMsg[]> {
+  const { messages } = await getJSON<{ messages: ChatMsg[] }>(
+    conn,
+    `/api/companion/sessions/${encodeURIComponent(id)}/messages`,
+  );
+  return messages;
+}
+
 export async function stopSession(conn: Connection, id: string): Promise<boolean> {
   const resp = await fetch(
     `${conn.baseUrl}/api/companion/sessions/${encodeURIComponent(id)}/stop`,

--- a/companion/mobile/src/lib/api.ts
+++ b/companion/mobile/src/lib/api.ts
@@ -133,6 +133,49 @@ export async function startSession(
   return (await resp.json()) as { session_id: string; name: string };
 }
 
+export interface FsDir {
+  name: string;
+  path: string;
+}
+export interface FsFile {
+  name: string;
+  path: string;
+  size: number;
+}
+export interface FsListing {
+  path: string;
+  parent: string | null;
+  dirs: FsDir[];
+  files: FsFile[];
+}
+
+/** Browse the PC filesystem (admin-only on the server). Empty path => home. */
+export async function fsBrowse(conn: Connection, path = ''): Promise<FsListing> {
+  return getJSON<FsListing>(
+    conn,
+    `/api/companion/fs/browse?path=${encodeURIComponent(path)}`,
+  );
+}
+
+/** Copy a PC file into an attachment and return its metadata (incl. id). */
+export async function fsAttach(conn: Connection, path: string): Promise<Attachment> {
+  const resp = await fetch(`${conn.baseUrl}/api/companion/fs/attach`, {
+    method: 'POST',
+    headers: { ...authHeaders(conn), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  });
+  if (!resp.ok) {
+    let detail = `HTTP ${resp.status}`;
+    try {
+      detail = ((await resp.json()) as { detail?: string }).detail || detail;
+    } catch {
+      /* keep status */
+    }
+    throw new Error(detail);
+  }
+  return (await resp.json()) as Attachment;
+}
+
 export interface ChatMsg {
   role: 'user' | 'assistant';
   content: string;

--- a/companion/mobile/src/lib/connection.ts
+++ b/companion/mobile/src/lib/connection.ts
@@ -22,6 +22,22 @@ export function normalizeBaseUrl(raw: string): string {
   return u.replace(/\/+$/, '');
 }
 
+// Decode a scanned pairing QR. The PC encodes compact JSON
+// {v, host, port, token} (companion/pairing.py); turn it into a Connection.
+// Returns null for anything that isn't a valid pairing payload.
+export function parsePairingPayload(raw: string): Connection | null {
+  try {
+    const obj = JSON.parse(raw) as { host?: unknown; port?: unknown; token?: unknown };
+    if (typeof obj.host !== 'string' || !obj.host || !obj.token) return null;
+    const port = obj.port ? `:${obj.port}` : '';
+    const baseUrl = normalizeBaseUrl(`${obj.host}${port}`);
+    if (!baseUrl) return null;
+    return { baseUrl, token: String(obj.token) };
+  } catch {
+    return null;
+  }
+}
+
 export async function loadConnection(): Promise<Connection | null> {
   const { value } = await Preferences.get({ key: KEY });
   if (!value) return null;

--- a/companion/mobile/src/lib/connection.ts
+++ b/companion/mobile/src/lib/connection.ts
@@ -1,0 +1,41 @@
+import { Preferences } from '@capacitor/preferences';
+
+// A paired server: where it is + the chat-scoped token minted by the PC's
+// `/api/companion/pair` screen. This is the ONLY state the app needs to act as a
+// remote -- the phone stores no chat data of its own.
+export interface Connection {
+  /** Base URL, no trailing slash, e.g. "http://192.168.1.50:7000" or a tunnel. */
+  baseUrl: string;
+  /** The `ody_...` pairing token. Sent as `Authorization: Bearer`. */
+  token: string;
+  /** Optional friendly label + resolved owner, filled in after a successful ping. */
+  name?: string;
+  owner?: string;
+}
+
+const KEY = 'odysseus.connection';
+
+export function normalizeBaseUrl(raw: string): string {
+  let u = raw.trim();
+  if (!u) return '';
+  if (!/^https?:\/\//i.test(u)) u = 'http://' + u; // bare host/IP -> http
+  return u.replace(/\/+$/, '');
+}
+
+export async function loadConnection(): Promise<Connection | null> {
+  const { value } = await Preferences.get({ key: KEY });
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as Connection;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveConnection(conn: Connection): Promise<void> {
+  await Preferences.set({ key: KEY, value: JSON.stringify(conn) });
+}
+
+export async function clearConnection(): Promise<void> {
+  await Preferences.remove({ key: KEY });
+}

--- a/companion/mobile/src/lib/sse.ts
+++ b/companion/mobile/src/lib/sse.ts
@@ -1,0 +1,80 @@
+// Minimal SSE reader built on fetch, because the browser's native EventSource
+// cannot send an Authorization header -- and our pairing token must ride as a
+// Bearer header. We read the response body as a stream and split it into SSE
+// frames ourselves (events are separated by a blank line; payload lines start
+// with "data:"; lines starting with ":" are comments/heartbeats we ignore).
+
+export interface SSEHandlers {
+  /** One decoded `data:` payload (already stripped of the "data: " prefix). */
+  onData: (data: string) => void;
+  onError?: (err: unknown) => void;
+  /** Stream ended cleanly (server closed or `[DONE]` was handled upstream). */
+  onClose?: () => void;
+}
+
+export interface SSEOptions extends SSEHandlers {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+export async function openSSE(url: string, opts: SSEOptions): Promise<void> {
+  try {
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream', ...(opts.headers || {}) },
+      signal: opts.signal,
+    });
+    if (!resp.ok || !resp.body) {
+      throw new Error(`stream failed: HTTP ${resp.status}`);
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+
+      // Dispatch every complete frame (separated by a blank line). Handle both
+      // \n\n and \r\n\r\n.
+      let sep: number;
+      while ((sep = indexOfFrameEnd(buf)) !== -1) {
+        const frame = buf.slice(0, sep);
+        buf = buf.slice(sep).replace(/^(\r?\n){2}/, '');
+        const data = parseFrame(frame);
+        if (data !== null) opts.onData(data);
+      }
+    }
+    opts.onClose?.();
+  } catch (err) {
+    // An aborted fetch is an expected, quiet teardown -- not an error to surface.
+    if ((err as { name?: string })?.name === 'AbortError') {
+      opts.onClose?.();
+      return;
+    }
+    opts.onError?.(err);
+  }
+}
+
+function indexOfFrameEnd(s: string): number {
+  const a = s.indexOf('\n\n');
+  const b = s.indexOf('\r\n\r\n');
+  if (a === -1) return b;
+  if (b === -1) return a;
+  return Math.min(a, b);
+}
+
+/** Pull the concatenated `data:` lines out of one SSE frame, or null if none. */
+function parseFrame(frame: string): string | null {
+  const lines = frame.split(/\r?\n/);
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith(':')) continue; // comment / heartbeat
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).replace(/^ /, ''));
+    }
+  }
+  return dataLines.length ? dataLines.join('\n') : null;
+}

--- a/companion/mobile/src/lib/thinking.ts
+++ b/companion/mobile/src/lib/thinking.ts
@@ -1,0 +1,30 @@
+// Some reasoning models (e.g. DeepSeek-R1) emit their chain-of-thought inline as
+// <think>...</think> within the normal token stream, rather than via the
+// thinking:true flag. Split the accumulated answer text into the visible answer
+// and the reasoning. We re-parse the whole accumulated string each update (it's
+// small) so tags that straddle two stream chunks are handled without tracking
+// partial-tag state.
+export function splitThinking(raw: string): { answer: string; thinking: string } {
+  const OPEN = '<think>';
+  const CLOSE = '</think>';
+  let answer = '';
+  let thinking = '';
+  let i = 0;
+  while (i < raw.length) {
+    const open = raw.indexOf(OPEN, i);
+    if (open === -1) {
+      answer += raw.slice(i);
+      break;
+    }
+    answer += raw.slice(i, open);
+    const close = raw.indexOf(CLOSE, open + OPEN.length);
+    if (close === -1) {
+      // Still inside an unclosed block: everything after <think> is reasoning.
+      thinking += raw.slice(open + OPEN.length);
+      break;
+    }
+    thinking += raw.slice(open + OPEN.length, close);
+    i = close + CLOSE.length;
+  }
+  return { answer, thinking };
+}

--- a/companion/mobile/src/main.tsx
+++ b/companion/mobile/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/companion/mobile/src/screens/CalendarScreen.tsx
+++ b/companion/mobile/src/screens/CalendarScreen.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { CalEvent } from '../lib/api';
+import { listEvents } from '../lib/api';
+import { ChevronLeftIcon } from '../components/icons';
+
+// Read-only agenda: the owner's events for the next 30 days, grouped by day.
+export default function CalendarScreen({ conn, onBack }: { conn: Connection; onBack: () => void }) {
+  const [events, setEvents] = useState<CalEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const now = new Date();
+    const end = new Date(now.getTime() + 30 * 24 * 3600 * 1000);
+    listEvents(conn, now.toISOString(), end.toISOString())
+      .then((r) => setEvents(r.events || []))
+      .catch(() => setError('Could not load your calendar.'))
+      .finally(() => setLoading(false));
+  }, [conn]);
+
+  const groups = groupByDay(events);
+
+  return (
+    <div className="screen detail">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <span className="status-pill">Calendar</span>
+      </header>
+      <div className="detail-body">
+        {error && <div className="error">{error}</div>}
+        {loading && <div className="muted pad">Loading...</div>}
+        {!loading && !error && events.length === 0 && (
+          <div className="muted pad">Nothing in the next 30 days.</div>
+        )}
+        {groups.map(([day, evs]) => (
+          <div key={day} className="agenda-day">
+            <div className="agenda-date">{day}</div>
+            {evs.map((e, i) => (
+              <div key={i} className="agenda-event">
+                <div className="agenda-time">{eventTime(e)}</div>
+                <div className="agenda-title">{e.title || e.summary || '(untitled)'}</div>
+                {e.location && <div className="agenda-loc">{e.location}</div>}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function dayKey(iso?: string): string {
+  if (!iso) return 'Undated';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return 'Undated';
+  return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function eventTime(e: CalEvent): string {
+  if (e.all_day || !e.dtstart) return 'All day';
+  const d = new Date(e.dtstart);
+  if (isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+function groupByDay(events: CalEvent[]): [string, CalEvent[]][] {
+  const map = new Map<string, CalEvent[]>();
+  for (const e of events) {
+    const k = dayKey(e.dtstart);
+    if (!map.has(k)) map.set(k, []);
+    map.get(k)!.push(e);
+  }
+  return Array.from(map.entries());
+}

--- a/companion/mobile/src/screens/EmailScreen.tsx
+++ b/companion/mobile/src/screens/EmailScreen.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { EmailAccount, EmailItem, EmailRead } from '../lib/api';
+import {
+  flagEmail,
+  listEmailAccounts,
+  listEmails,
+  readEmail,
+  sendEmail,
+} from '../lib/api';
+import { ChevronLeftIcon, RefreshIcon, SendIcon } from '../components/icons';
+
+type View = 'list' | 'read' | 'compose';
+
+// Email: list the inbox, open a message, reply or compose, archive / mark read.
+// All owner-scoped via the companion email proxies.
+export default function EmailScreen({ conn, onBack }: { conn: Connection; onBack: () => void }) {
+  const [accounts, setAccounts] = useState<EmailAccount[] | null>(null);
+  const [accountId, setAccountId] = useState<string | undefined>(undefined);
+  const [emails, setEmails] = useState<EmailItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<View>('list');
+  const [open, setOpen] = useState<EmailRead | null>(null);
+
+  // compose state
+  const [to, setTo] = useState('');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    listEmailAccounts(conn)
+      .then((a) => {
+        setAccounts(a);
+        if (a.length) setAccountId(a[0].id);
+      })
+      .catch(() => setError('Could not load email accounts.'));
+  }, [conn]);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    listEmails(conn, { accountId, limit: 40 })
+      .then((r) => {
+        if (r.error) setError(r.error);
+        setEmails(r.emails || []);
+      })
+      .catch(() => setError('Could not load your inbox.'))
+      .finally(() => setLoading(false));
+  }, [conn, accountId]);
+
+  useEffect(() => {
+    if (accounts && accounts.length) refresh();
+    else if (accounts) setLoading(false);
+  }, [accounts, refresh]);
+
+  async function openEmail(item: EmailItem) {
+    setView('read');
+    setOpen(null);
+    try {
+      const full = await readEmail(conn, item.uid, { accountId });
+      setOpen(full);
+      if (!item.is_read) flagEmail(conn, item.uid, 'mark-read', { accountId }).catch(() => {});
+    } catch {
+      setError('Could not open that email.');
+      setView('list');
+    }
+  }
+
+  async function archive(uid: string | number) {
+    try {
+      await flagEmail(conn, uid, 'archive', { accountId });
+      setView('list');
+      setEmails((es) => es.filter((e) => e.uid !== uid));
+    } catch {
+      setError('Could not archive.');
+    }
+  }
+
+  function startReply(e: EmailRead) {
+    setTo(e.from_address || '');
+    setSubject(/^re:/i.test(e.subject || '') ? e.subject || '' : `Re: ${e.subject || ''}`);
+    setBody('');
+    setView('compose');
+  }
+
+  function startCompose() {
+    setTo('');
+    setSubject('');
+    setBody('');
+    setView('compose');
+  }
+
+  async function doSend() {
+    if (!to.trim()) return;
+    setSending(true);
+    try {
+      await sendEmail(conn, { to: to.trim(), subject: subject.trim(), body, account_id: accountId });
+      setView('list');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not send.');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  // ---- compose view ----
+  if (view === 'compose') {
+    return (
+      <div className="screen detail">
+        <header className="detail-header">
+          <button className="ghost" onClick={() => setView('list')} type="button" aria-label="Back">
+            <ChevronLeftIcon size={24} />
+          </button>
+          <span className="status-pill">Compose</span>
+          <button className="stop send" onClick={doSend} type="button" disabled={sending || !to.trim()}>
+            {sending ? '...' : 'Send'}
+          </button>
+        </header>
+        <div className="compose-body">
+          <label className="field">
+            <span>To</span>
+            <input className="note-input" value={to} onChange={(e) => setTo(e.target.value)} autoCapitalize="none" placeholder="name@example.com" inputMode="email" />
+          </label>
+          <label className="field">
+            <span>Subject</span>
+            <input className="note-input" value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="Subject" />
+          </label>
+          <label className="field grow">
+            <span>Message</span>
+            <textarea value={body} onChange={(e) => setBody(e.target.value)} placeholder="Write your message..." />
+          </label>
+          {error && <div className="error">{error}</div>}
+        </div>
+      </div>
+    );
+  }
+
+  // ---- read view ----
+  if (view === 'read') {
+    const text = open ? open.body_text || stripHtml(open.body_html) || open.body || '' : '';
+    return (
+      <div className="screen detail">
+        <header className="detail-header">
+          <button className="ghost" onClick={() => setView('list')} type="button" aria-label="Back">
+            <ChevronLeftIcon size={24} />
+          </button>
+          <span className="status-pill">Email</span>
+          {open && (
+            <button className="ghost" onClick={() => archive(open.uid)} type="button">
+              Archive
+            </button>
+          )}
+        </header>
+        <div className="detail-body">
+          {!open && <div className="muted pad">Loading...</div>}
+          {open && (
+            <>
+              <h2 className="email-subject">{open.subject || '(no subject)'}</h2>
+              <div className="email-from">{open.from_name || open.from_address}</div>
+              <div className="email-date">{open.date_display || open.date}</div>
+              <pre className="msg-text email-body">{text}</pre>
+              <button className="stop send email-reply" onClick={() => startReply(open)} type="button">
+                <SendIcon size={16} /> Reply
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ---- list view ----
+  return (
+    <div className="screen detail">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <span className="status-pill">Inbox</span>
+        <div className="header-actions">
+          <button className="ghost" onClick={refresh} type="button" aria-label="Refresh">
+            <RefreshIcon size={20} />
+          </button>
+          {accounts && accounts.length > 0 && (
+            <button className="ghost" onClick={startCompose} type="button" aria-label="Compose">
+              <SendIcon size={20} />
+            </button>
+          )}
+        </div>
+      </header>
+      <div className="detail-body">
+        {accounts && accounts.length === 0 && (
+          <div className="muted pad">No email account yet. Add one on your PC under Settings &rarr; Email.</div>
+        )}
+        {error && <div className="error">{error}</div>}
+        {loading && <div className="muted pad">Loading...</div>}
+        {emails.map((e) => (
+          <button key={String(e.uid)} className="row email-row" onClick={() => openEmail(e)} type="button">
+            <span className={'dot' + (e.is_read ? '' : ' live')} aria-hidden />
+            <span className="row-main">
+              <span className="row-title">{e.from_name || e.from_address || 'Unknown'}</span>
+              <span className="email-subj">{e.subject || '(no subject)'}</span>
+            </span>
+            <span className="email-when">{shortDate(e.date_display || e.date)}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function stripHtml(html?: string): string {
+  if (!html) return '';
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  return (tmp.textContent || '').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function shortDate(d?: string): string {
+  if (!d) return '';
+  const dt = new Date(d);
+  if (isNaN(dt.getTime())) return d.slice(0, 10);
+  const today = new Date();
+  if (dt.toDateString() === today.toDateString())
+    return dt.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  return dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}

--- a/companion/mobile/src/screens/EmailScreen.tsx
+++ b/companion/mobile/src/screens/EmailScreen.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
+import DOMPurify from 'dompurify';
 import type { Connection } from '../lib/connection';
 import type { EmailAccount, EmailItem, EmailRead } from '../lib/api';
 import {
+  aiReplyEmail,
   flagEmail,
   listEmailAccounts,
   listEmails,
   readEmail,
   sendEmail,
+  summarizeEmail,
 } from '../lib/api';
 import { ChevronLeftIcon, RefreshIcon, SendIcon } from '../components/icons';
 
@@ -22,6 +25,9 @@ export default function EmailScreen({ conn, onBack }: { conn: Connection; onBack
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<View>('list');
   const [open, setOpen] = useState<EmailRead | null>(null);
+  const [summary, setSummary] = useState<string | null>(null);
+  const [summarizing, setSummarizing] = useState(false);
+  const [aiBusy, setAiBusy] = useState(false);
 
   // compose state
   const [to, setTo] = useState('');
@@ -58,13 +64,63 @@ export default function EmailScreen({ conn, onBack }: { conn: Connection; onBack
   async function openEmail(item: EmailItem) {
     setView('read');
     setOpen(null);
+    setSummary(null);
     try {
       const full = await readEmail(conn, item.uid, { accountId });
       setOpen(full);
+      setSummary(full.cached_summary || null);
       if (!item.is_read) flagEmail(conn, item.uid, 'mark-read', { accountId }).catch(() => {});
     } catch {
       setError('Could not open that email.');
       setView('list');
+    }
+  }
+
+  async function doSummary(e: EmailRead, text: string) {
+    setSummarizing(true);
+    setError(null);
+    try {
+      const r = await summarizeEmail(conn, {
+        uid: e.uid,
+        folder: e.folder,
+        account_id: accountId,
+        body: text,
+        subject: e.subject,
+        from: e.from_address,
+      });
+      if (r.success && r.summary) setSummary(r.summary);
+      else setError(r.error || 'Could not summarize.');
+    } catch {
+      setError('Could not summarize.');
+    } finally {
+      setSummarizing(false);
+    }
+  }
+
+  async function doAiReply(e: EmailRead, text: string) {
+    setAiBusy(true);
+    setError(null);
+    try {
+      const r = await aiReplyEmail(conn, {
+        to: e.from_address,
+        subject: e.subject,
+        original_body: text,
+        uid: e.uid,
+        folder: e.folder,
+        message_id: e.message_id,
+      });
+      if (r.success && r.reply) {
+        setTo(e.from_address || '');
+        setSubject(/^re:/i.test(e.subject || '') ? e.subject || '' : `Re: ${e.subject || ''}`);
+        setBody(r.reply);
+        setView('compose');
+      } else {
+        setError(r.error || 'Could not draft a reply.');
+      }
+    } catch {
+      setError('Could not draft a reply.');
+    } finally {
+      setAiBusy(false);
     }
   }
 
@@ -139,7 +195,8 @@ export default function EmailScreen({ conn, onBack }: { conn: Connection; onBack
 
   // ---- read view ----
   if (view === 'read') {
-    const text = open ? open.body_text || stripHtml(open.body_html) || open.body || '' : '';
+    const html = open ? open.body_html || (looksLikeHtml(open.body) ? open.body || '' : '') : '';
+    const text = open ? open.body || stripHtml(open.body_html) || '' : '';
     return (
       <div className="screen detail">
         <header className="detail-header">
@@ -160,7 +217,44 @@ export default function EmailScreen({ conn, onBack }: { conn: Connection; onBack
               <h2 className="email-subject">{open.subject || '(no subject)'}</h2>
               <div className="email-from">{open.from_name || open.from_address}</div>
               <div className="email-date">{open.date_display || open.date}</div>
-              <pre className="msg-text email-body">{text}</pre>
+
+              <div className="email-ai-bar">
+                <button
+                  className="chip"
+                  type="button"
+                  disabled={summarizing}
+                  onClick={() => doSummary(open, text)}
+                >
+                  {summarizing ? 'Summarizing...' : 'AI summary'}
+                </button>
+                <button
+                  className="chip"
+                  type="button"
+                  disabled={aiBusy}
+                  onClick={() => doAiReply(open, text)}
+                >
+                  {aiBusy ? 'Drafting...' : 'AI reply'}
+                </button>
+              </div>
+
+              {summary && (
+                <div className="email-summary">
+                  <div className="email-summary-label">AI summary</div>
+                  <p>{summary}</p>
+                </div>
+              )}
+
+              {error && <div className="error">{error}</div>}
+
+              {html ? (
+                <div
+                  className="email-html"
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
+                />
+              ) : (
+                <pre className="msg-text email-body">{text}</pre>
+              )}
+
               <button className="stop send email-reply" onClick={() => startReply(open)} type="button">
                 <SendIcon size={16} /> Reply
               </button>
@@ -216,6 +310,12 @@ function stripHtml(html?: string): string {
   const tmp = document.createElement('div');
   tmp.innerHTML = html;
   return (tmp.textContent || '').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+// Some servers put the HTML part in `body` with an empty `body_html`. Render it
+// as HTML if it clearly contains tags, otherwise treat it as plain text.
+function looksLikeHtml(s?: string): boolean {
+  return !!s && /<(\/?[a-z][\s\S]*?|!doctype)>/i.test(s);
 }
 
 function shortDate(d?: string): string {

--- a/companion/mobile/src/screens/NewSessionScreen.tsx
+++ b/companion/mobile/src/screens/NewSessionScreen.tsx
@@ -11,6 +11,7 @@ import {
   type Pending,
 } from '../components/Attachments';
 import FsBrowser from '../components/FsBrowser';
+import VoiceButton from '../components/VoiceButton';
 
 // Compose + start a new chat from the phone. Pick a model (flattened from the
 // server's endpoints), type a first message, send -> the server starts the run
@@ -141,6 +142,12 @@ export default function NewSessionScreen({
             disabled={busy}
           />
           <PcFilesButton onClick={() => setShowBrowser(true)} disabled={busy} />
+          <VoiceButton
+            conn={conn}
+            disabled={busy}
+            onText={(t) => setMessage((m) => (m ? m + ' ' + t : t))}
+            onError={setError}
+          />
           <ToolToggles value={options} onChange={setOptions} disabled={busy} />
         </div>
         <AttachPreviews pending={pending} onRemove={removeAttachment} disabled={busy} />

--- a/companion/mobile/src/screens/NewSessionScreen.tsx
+++ b/companion/mobile/src/screens/NewSessionScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import type { Connection } from '../lib/connection';
 import type { ChatOptions, ModelOption } from '../lib/api';
-import { DEFAULT_OPTIONS, listModels, startSession } from '../lib/api';
+import { DEFAULT_OPTIONS, listModels, startSession, uploadFiles } from '../lib/api';
 import { ChevronLeftIcon } from '../components/icons';
 import ToolToggles from '../components/ToolToggles';
+import { AttachButton, AttachPreviews, type PendingFile } from '../components/Attachments';
 
 // Compose + start a new chat from the phone. Pick a model (flattened from the
 // server's endpoints), type a first message, send -> the server starts the run
@@ -21,8 +22,16 @@ export default function NewSessionScreen({
   const [picked, setPicked] = useState(0);
   const [message, setMessage] = useState('');
   const [options, setOptions] = useState<ChatOptions>(DEFAULT_OPTIONS);
+  const [pending, setPending] = useState<PendingFile[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  function removeAttachment(i: number) {
+    setPending((p) => {
+      URL.revokeObjectURL(p[i]?.url);
+      return p.filter((_, j) => j !== i);
+    });
+  }
 
   useEffect(() => {
     listModels(conn)
@@ -35,15 +44,21 @@ export default function NewSessionScreen({
 
   async function send() {
     const model = models[picked];
-    if (!model || !message.trim()) return;
+    if (!model || (!message.trim() && pending.length === 0)) return;
     setBusy(true);
     setError(null);
     try {
+      let attachments: string[] = [];
+      if (pending.length) {
+        const up = await uploadFiles(conn, pending.map((p) => p.file));
+        attachments = up.map((a) => a.id);
+      }
       const { session_id } = await startSession(conn, {
         message: message.trim(),
         endpointId: model.endpointId,
         model: model.model,
         options,
+        attachments,
       });
       onCreated(session_id);
     } catch (e) {
@@ -64,7 +79,7 @@ export default function NewSessionScreen({
           className="stop send"
           onClick={send}
           type="button"
-          disabled={busy || !message.trim() || models.length === 0}
+          disabled={busy || (!message.trim() && pending.length === 0) || models.length === 0}
         >
           {busy ? 'Starting...' : 'Send'}
         </button>
@@ -99,7 +114,14 @@ export default function NewSessionScreen({
           />
         </label>
 
-        <ToolToggles value={options} onChange={setOptions} disabled={busy} />
+        <div className="compose-attach">
+          <AttachButton
+            onPick={(picked) => setPending((p) => [...p, ...picked])}
+            disabled={busy}
+          />
+          <ToolToggles value={options} onChange={setOptions} disabled={busy} />
+        </div>
+        <AttachPreviews pending={pending} onRemove={removeAttachment} disabled={busy} />
 
         {error && <div className="error">{error}</div>}
       </div>

--- a/companion/mobile/src/screens/NewSessionScreen.tsx
+++ b/companion/mobile/src/screens/NewSessionScreen.tsx
@@ -4,7 +4,13 @@ import type { ChatOptions, ModelOption } from '../lib/api';
 import { DEFAULT_OPTIONS, listModels, startSession, uploadFiles } from '../lib/api';
 import { ChevronLeftIcon } from '../components/icons';
 import ToolToggles from '../components/ToolToggles';
-import { AttachButton, AttachPreviews, type PendingFile } from '../components/Attachments';
+import {
+  AttachButton,
+  AttachPreviews,
+  PcFilesButton,
+  type Pending,
+} from '../components/Attachments';
+import FsBrowser from '../components/FsBrowser';
 
 // Compose + start a new chat from the phone. Pick a model (flattened from the
 // server's endpoints), type a first message, send -> the server starts the run
@@ -22,13 +28,15 @@ export default function NewSessionScreen({
   const [picked, setPicked] = useState(0);
   const [message, setMessage] = useState('');
   const [options, setOptions] = useState<ChatOptions>(DEFAULT_OPTIONS);
-  const [pending, setPending] = useState<PendingFile[]>([]);
+  const [pending, setPending] = useState<Pending[]>([]);
+  const [showBrowser, setShowBrowser] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   function removeAttachment(i: number) {
     setPending((p) => {
-      URL.revokeObjectURL(p[i]?.url);
+      const item = p[i];
+      if (item?.kind === 'local') URL.revokeObjectURL(item.url);
       return p.filter((_, j) => j !== i);
     });
   }
@@ -48,10 +56,11 @@ export default function NewSessionScreen({
     setBusy(true);
     setError(null);
     try {
-      let attachments: string[] = [];
-      if (pending.length) {
-        const up = await uploadFiles(conn, pending.map((p) => p.file));
-        attachments = up.map((a) => a.id);
+      const locals = pending.filter((p) => p.kind === 'local');
+      let attachments = pending.filter((p) => p.kind === 'remote').map((p) => p.id);
+      if (locals.length) {
+        const up = await uploadFiles(conn, locals.map((p) => (p as { file: File }).file));
+        attachments = [...up.map((a) => a.id), ...attachments];
       }
       const { session_id } = await startSession(conn, {
         message: message.trim(),
@@ -66,6 +75,18 @@ export default function NewSessionScreen({
       console.warn('startSession failed', e);
       setBusy(false);
     }
+  }
+
+  if (showBrowser) {
+    return (
+      <FsBrowser
+        conn={conn}
+        onClose={() => setShowBrowser(false)}
+        onPick={(att) =>
+          setPending((p) => [...p, { kind: 'remote', id: att.id, name: att.name, mime: att.mime }])
+        }
+      />
+    );
   }
 
   return (
@@ -119,6 +140,7 @@ export default function NewSessionScreen({
             onPick={(picked) => setPending((p) => [...p, ...picked])}
             disabled={busy}
           />
+          <PcFilesButton onClick={() => setShowBrowser(true)} disabled={busy} />
           <ToolToggles value={options} onChange={setOptions} disabled={busy} />
         </div>
         <AttachPreviews pending={pending} onRemove={removeAttachment} disabled={busy} />

--- a/companion/mobile/src/screens/NewSessionScreen.tsx
+++ b/companion/mobile/src/screens/NewSessionScreen.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { ModelOption } from '../lib/api';
+import { listModels, startSession } from '../lib/api';
+import { ChevronLeftIcon } from '../components/icons';
+
+// Compose + start a new chat from the phone. Pick a model (flattened from the
+// server's endpoints), type a first message, send -> the server starts the run
+// and we hand the new session id back so it opens in the stream view.
+export default function NewSessionScreen({
+  conn,
+  onBack,
+  onCreated,
+}: {
+  conn: Connection;
+  onBack: () => void;
+  onCreated: (sessionId: string) => void;
+}) {
+  const [models, setModels] = useState<ModelOption[]>([]);
+  const [picked, setPicked] = useState(0);
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listModels(conn)
+      .then((m) => {
+        setModels(m);
+        setError(m.length ? null : 'No models available. Add one on your PC first.');
+      })
+      .catch(() => setError('Could not load models from the server.'));
+  }, [conn]);
+
+  async function send() {
+    const model = models[picked];
+    if (!model || !message.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { session_id } = await startSession(conn, {
+        message: message.trim(),
+        endpointId: model.endpointId,
+        model: model.model,
+      });
+      onCreated(session_id);
+    } catch (e) {
+      setError('Could not start the chat. Is the model reachable?');
+      console.warn('startSession failed', e);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="screen compose">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <span className="status-pill">New chat</span>
+        <button
+          className="stop send"
+          onClick={send}
+          type="button"
+          disabled={busy || !message.trim() || models.length === 0}
+        >
+          {busy ? 'Starting...' : 'Send'}
+        </button>
+      </header>
+
+      <div className="compose-body">
+        <label className="field">
+          <span>Model</span>
+          <select
+            value={picked}
+            onChange={(e) => setPicked(Number(e.target.value))}
+            disabled={models.length === 0}
+          >
+            {models.map((m, i) => (
+              <option key={m.endpointId + m.model} value={i}>
+                {m.model}
+                {models.some((o) => o.model === m.model && o.endpointId !== m.endpointId)
+                  ? ` (${m.endpointName})`
+                  : ''}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="field grow">
+          <span>Message</span>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Ask Odysseus something..."
+            autoFocus
+          />
+        </label>
+
+        {error && <div className="error">{error}</div>}
+      </div>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/NewSessionScreen.tsx
+++ b/companion/mobile/src/screens/NewSessionScreen.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import type { Connection } from '../lib/connection';
-import type { ModelOption } from '../lib/api';
-import { listModels, startSession } from '../lib/api';
+import type { ChatOptions, ModelOption } from '../lib/api';
+import { DEFAULT_OPTIONS, listModels, startSession } from '../lib/api';
 import { ChevronLeftIcon } from '../components/icons';
+import ToolToggles from '../components/ToolToggles';
 
 // Compose + start a new chat from the phone. Pick a model (flattened from the
 // server's endpoints), type a first message, send -> the server starts the run
@@ -19,6 +20,7 @@ export default function NewSessionScreen({
   const [models, setModels] = useState<ModelOption[]>([]);
   const [picked, setPicked] = useState(0);
   const [message, setMessage] = useState('');
+  const [options, setOptions] = useState<ChatOptions>(DEFAULT_OPTIONS);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,6 +43,7 @@ export default function NewSessionScreen({
         message: message.trim(),
         endpointId: model.endpointId,
         model: model.model,
+        options,
       });
       onCreated(session_id);
     } catch (e) {
@@ -95,6 +98,8 @@ export default function NewSessionScreen({
             autoFocus
           />
         </label>
+
+        <ToolToggles value={options} onChange={setOptions} disabled={busy} />
 
         {error && <div className="error">{error}</div>}
       </div>

--- a/companion/mobile/src/screens/NotesScreen.tsx
+++ b/companion/mobile/src/screens/NotesScreen.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { Note } from '../lib/api';
+import { createNote, listNotes } from '../lib/api';
+import { ChevronLeftIcon, PlusIcon } from '../components/icons';
+
+// Notes: list the owner's notes/checklists, with a quick add (title + body).
+export default function NotesScreen({ conn, onBack }: { conn: Connection; onBack: () => void }) {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    listNotes(conn)
+      .then(setNotes)
+      .catch(() => setError('Could not load your notes.'))
+      .finally(() => setLoading(false));
+  }, [conn]);
+
+  useEffect(refresh, [refresh]);
+
+  async function save() {
+    if (!title.trim() && !content.trim()) return;
+    setSaving(true);
+    try {
+      await createNote(conn, { title: title.trim(), content: content.trim() });
+      setTitle('');
+      setContent('');
+      setAdding(false);
+      refresh();
+    } catch {
+      setError('Could not save the note.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="screen detail">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <span className="status-pill">Notes</span>
+        <button className="ghost" onClick={() => setAdding((a) => !a)} type="button" aria-label="New note">
+          <PlusIcon size={22} />
+        </button>
+      </header>
+
+      {adding && (
+        <div className="compose-body" style={{ flex: 'none' }}>
+          <label className="field">
+            <span>Title</span>
+            <input
+              className="note-input"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Note title"
+            />
+          </label>
+          <label className="field">
+            <span>Note</span>
+            <textarea value={content} onChange={(e) => setContent(e.target.value)} placeholder="Write..." />
+          </label>
+          <button className="stop send" onClick={save} type="button" disabled={saving}>
+            {saving ? 'Saving...' : 'Save note'}
+          </button>
+        </div>
+      )}
+
+      <div className="detail-body">
+        {error && <div className="error">{error}</div>}
+        {loading && <div className="muted pad">Loading...</div>}
+        {!loading && !error && notes.length === 0 && <div className="muted pad">No notes yet.</div>}
+        {notes.map((n) => (
+          <div key={n.id} className="note-card">
+            <div className="note-title">
+              {n.pinned ? '* ' : ''}
+              {n.title || '(untitled)'}
+            </div>
+            {n.items && n.items.length > 0 ? (
+              <ul className="note-items">
+                {n.items.map((it, i) => (
+                  <li key={i} className={it.checked ? 'done' : ''}>
+                    {it.checked ? '[x] ' : '[ ] '}
+                    {it.text}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              n.content && <p className="note-body">{n.content}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/PairScreen.tsx
+++ b/companion/mobile/src/screens/PairScreen.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import type { Connection } from '../lib/connection';
+import { normalizeBaseUrl, saveConnection } from '../lib/connection';
+import { ping } from '../lib/api';
+import { BrandMark } from '../components/icons';
+
+// First-run screen: point the app at your Odysseus and paste the pairing token.
+// Generate the token on the PC at  <server>/api/companion/pair  (admin only).
+// A QR scanner is a planned follow-up -- the pairing payload is already JSON
+// {v, host, port, token}, so scanning can prefill both fields.
+export default function PairScreen({ onPaired }: { onPaired: (c: Connection) => void }) {
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function connect() {
+    setError(null);
+    const baseUrl = normalizeBaseUrl(url);
+    if (!baseUrl || !token.trim()) {
+      setError('Enter your server address and a pairing token.');
+      return;
+    }
+    const conn: Connection = { baseUrl, token: token.trim() };
+    setBusy(true);
+    try {
+      const res = await ping(conn); // validates host + token in one round-trip
+      conn.name = res.name;
+      await saveConnection(conn);
+      onPaired(conn);
+    } catch (e) {
+      setError(
+        'Could not reach the server with that token. Check the address, that ' +
+          'the token is current, and that your phone can reach the PC.',
+      );
+      console.warn('pair failed', e);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="screen pair">
+      <div className="brand">
+        <BrandMark size={30} />
+        <span>Odysseus</span>
+      </div>
+      <p className="muted">Pair this phone with your PC to use it as a remote.</p>
+
+      <label className="field">
+        <span>Server address</span>
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="192.168.1.50:7000"
+          autoCapitalize="none"
+          autoCorrect="off"
+          inputMode="url"
+        />
+      </label>
+
+      <label className="field">
+        <span>Pairing token</span>
+        <input
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="ody_..."
+          autoCapitalize="none"
+          autoCorrect="off"
+        />
+      </label>
+
+      {error && <div className="error">{error}</div>}
+
+      <button className="primary" onClick={connect} disabled={busy} type="button">
+        {busy ? 'Connecting...' : 'Connect'}
+      </button>
+
+      <p className="hint">
+        Generate a token on the PC at <code>/api/companion/pair</code> (admin).
+        For access away from home, put your PC and phone on a private tunnel
+        (e.g. Tailscale) and pair with that address.
+      </p>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/PairScreen.tsx
+++ b/companion/mobile/src/screens/PairScreen.tsx
@@ -1,28 +1,23 @@
 import { useState } from 'react';
 import type { Connection } from '../lib/connection';
-import { normalizeBaseUrl, saveConnection } from '../lib/connection';
+import { normalizeBaseUrl, parsePairingPayload, saveConnection } from '../lib/connection';
 import { ping } from '../lib/api';
-import { BrandMark } from '../components/icons';
+import { BrandMark, QrIcon } from '../components/icons';
+import QrScanner from '../components/QrScanner';
 
-// First-run screen: point the app at your Odysseus and paste the pairing token.
-// Generate the token on the PC at  <server>/api/companion/pair  (admin only).
-// A QR scanner is a planned follow-up -- the pairing payload is already JSON
-// {v, host, port, token}, so scanning can prefill both fields.
+// First-run screen: point the app at your Odysseus and pair. Scan the QR on the
+// PC's  <server>/api/companion/pair  page (admin only), or enter the address and
+// token by hand. The pairing payload is JSON {v, host, port, token}.
 export default function PairScreen({ onPaired }: { onPaired: (c: Connection) => void }) {
   const [url, setUrl] = useState('');
   const [token, setToken] = useState('');
   const [busy, setBusy] = useState(false);
+  const [scanning, setScanning] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function connect() {
-    setError(null);
-    const baseUrl = normalizeBaseUrl(url);
-    if (!baseUrl || !token.trim()) {
-      setError('Enter your server address and a pairing token.');
-      return;
-    }
-    const conn: Connection = { baseUrl, token: token.trim() };
+  async function connectWith(conn: Connection) {
     setBusy(true);
+    setError(null);
     try {
       const res = await ping(conn); // validates host + token in one round-trip
       conn.name = res.name;
@@ -39,6 +34,32 @@ export default function PairScreen({ onPaired }: { onPaired: (c: Connection) => 
     }
   }
 
+  function connect() {
+    const baseUrl = normalizeBaseUrl(url);
+    if (!baseUrl || !token.trim()) {
+      setError('Enter your server address and a pairing token.');
+      return;
+    }
+    connectWith({ baseUrl, token: token.trim() });
+  }
+
+  function onScan(text: string) {
+    setScanning(false);
+    const parsed = parsePairingPayload(text);
+    if (!parsed) {
+      setError('That QR code is not an Odysseus pairing code.');
+      return;
+    }
+    // Prefill the fields too, so a failed ping leaves something to edit.
+    setUrl(parsed.baseUrl);
+    setToken(parsed.token);
+    connectWith(parsed);
+  }
+
+  if (scanning) {
+    return <QrScanner onResult={onScan} onClose={() => setScanning(false)} />;
+  }
+
   return (
     <div className="screen pair">
       <div className="brand">
@@ -46,6 +67,14 @@ export default function PairScreen({ onPaired }: { onPaired: (c: Connection) => 
         <span>Odysseus</span>
       </div>
       <p className="muted">Pair this phone with your PC to use it as a remote.</p>
+
+      <button className="primary scan" onClick={() => setScanning(true)} type="button" disabled={busy}>
+        <QrIcon size={20} />
+        <span>Scan pairing code</span>
+      </button>
+      <div className="or-divider">
+        <span>or enter manually</span>
+      </div>
 
       <label className="field">
         <span>Server address</span>
@@ -77,7 +106,7 @@ export default function PairScreen({ onPaired }: { onPaired: (c: Connection) => 
       </button>
 
       <p className="hint">
-        Generate a token on the PC at <code>/api/companion/pair</code> (admin).
+        Generate a pairing code on the PC at <code>/api/companion/pair</code> (admin).
         For access away from home, put your PC and phone on a private tunnel
         (e.g. Tailscale) and pair with that address.
       </p>

--- a/companion/mobile/src/screens/SearchScreen.tsx
+++ b/companion/mobile/src/screens/SearchScreen.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { SearchHit } from '../lib/api';
+import { searchChats } from '../lib/api';
+import { ChevronLeftIcon, SearchIcon } from '../components/icons';
+
+// Search across the owner's chat history. Debounced; tapping a hit opens that
+// session.
+export default function SearchScreen({
+  conn,
+  onBack,
+  onOpen,
+}: {
+  conn: Connection;
+  onBack: () => void;
+  onOpen: (sessionId: string) => void;
+}) {
+  const [q, setQ] = useState('');
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const term = q.trim();
+    if (!term) {
+      setHits([]);
+      setSearched(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const t = setTimeout(() => {
+      searchChats(conn, term)
+        .then((r) => {
+          setHits(r);
+          setSearched(true);
+        })
+        .catch(() => setSearched(true))
+        .finally(() => setLoading(false));
+    }, 300);
+    return () => clearTimeout(t);
+  }, [q, conn]);
+
+  return (
+    <div className="screen detail">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <div className="search-field">
+          <SearchIcon size={16} />
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search your chats"
+            autoCapitalize="none"
+            autoCorrect="off"
+            inputMode="search"
+          />
+        </div>
+      </header>
+      <div className="detail-body">
+        {loading && <div className="muted pad">Searching...</div>}
+        {!loading && searched && hits.length === 0 && <div className="muted pad">No matches.</div>}
+        {!loading && !searched && (
+          <div className="muted pad">Type to search your past conversations.</div>
+        )}
+        {hits.map((h, i) => (
+          <button key={i} className="row search-hit" onClick={() => onOpen(h.session_id)} type="button">
+            <span className="row-main">
+              <span className="row-title">{h.session_name || 'Untitled'}</span>
+              <span className="search-snippet">
+                <span className="search-role">{h.role}</span>
+                {h.content_snippet}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -22,6 +22,7 @@ import {
 } from '../components/Attachments';
 import { FileIcon } from '../components/icons';
 import FsBrowser from '../components/FsBrowser';
+import VoiceButton from '../components/VoiceButton';
 
 // A chat message plus, for the optimistic bubble of a just-sent turn, local
 // preview URLs for any images attached (server history is text-only).
@@ -349,6 +350,12 @@ export default function SessionScreen({
           disabled={isLive}
         />
         <PcFilesButton onClick={() => setShowBrowser(true)} disabled={isLive} />
+        <VoiceButton
+          conn={conn}
+          disabled={isLive}
+          onText={(t) => setDraft((d) => (d ? d + ' ' + t : t))}
+          onError={setSendError}
+        />
         <textarea
           className="composer-input"
           value={draft}

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -16,9 +16,11 @@ import ToolToggles from '../components/ToolToggles';
 import {
   AttachButton,
   AttachPreviews,
+  AuthImage,
   PcFilesButton,
   type Pending,
 } from '../components/Attachments';
+import { FileIcon } from '../components/icons';
 import FsBrowser from '../components/FsBrowser';
 
 // A chat message plus, for the optimistic bubble of a just-sent turn, local
@@ -277,6 +279,22 @@ export default function SessionScreen({
               <div className="msg-images">
                 {m.images.map((src, j) => (
                   <img key={j} src={src} alt="attachment" />
+                ))}
+              </div>
+            )}
+            {m.attachments && m.attachments.length > 0 && (
+              <div className="attach-previews">
+                {m.attachments.map((a) => (
+                  <div className="thumb" key={a.id}>
+                    {a.mime.startsWith('image/') ? (
+                      <AuthImage conn={conn} id={a.id} alt={a.name} />
+                    ) : (
+                      <span className="thumb-file">
+                        <FileIcon size={18} />
+                        <span className="thumb-name">{a.name}</span>
+                      </span>
+                    )}
+                  </div>
                 ))}
               </div>
             )}

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Connection } from '../lib/connection';
-import type { ChatMsg, ModelOption, StreamEvent } from '../lib/api';
-import { getMessages, listModels, sendMessage, stopSession, streamSession } from '../lib/api';
+import type { ChatMsg, ChatOptions, ModelOption, StreamEvent } from '../lib/api';
+import { DEFAULT_OPTIONS, getMessages, listModels, sendMessage, stopSession, streamSession } from '../lib/api';
 import { splitThinking } from '../lib/thinking';
 import { ChevronLeftIcon } from '../components/icons';
+import ToolToggles from '../components/ToolToggles';
 
 type Stream = 'loading' | 'connecting' | 'live' | 'done' | 'inactive' | 'error';
 
@@ -32,6 +33,7 @@ export default function SessionScreen({
   const [models, setModels] = useState<ModelOption[]>([]);
   const [picked, setPicked] = useState(0);
   const [draft, setDraft] = useState('');
+  const [options, setOptions] = useState<ChatOptions>(DEFAULT_OPTIONS);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   // Bumped after a successful send to re-run the subscribe effect on the new run.
@@ -169,6 +171,7 @@ export default function SessionScreen({
         message: text,
         endpointId: model?.endpointId,
         model: model?.model,
+        options,
       });
       setRawAnswer('');
       setFlaggedThink('');
@@ -250,6 +253,8 @@ export default function SessionScreen({
       </div>
 
       {sendError && <div className="error">{sendError}</div>}
+
+      <ToolToggles value={options} onChange={setOptions} disabled={isLive} />
 
       <form
         className="composer"

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -1,18 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Connection } from '../lib/connection';
-import type { StreamEvent } from '../lib/api';
-import { stopSession, streamSession } from '../lib/api';
+import type { ChatMsg, StreamEvent } from '../lib/api';
+import { getMessages, stopSession, streamSession } from '../lib/api';
 import { splitThinking } from '../lib/thinking';
 import { ChevronLeftIcon } from '../components/icons';
 
-// The remote-control detail view: connect to a session's live SSE, render the
-// streaming answer, surface tool/status events, and offer a Stop button. Opening
-// mid-run replays everything so far (the server buffers it), then streams live.
-//
-// Reasoning models stream their chain-of-thought two ways: flagged
-// (delta + thinking:true, from Odysseus' llm_core) or inline (<think>...</think>
-// in the normal text). We collect both into a collapsible "Thinking" block,
-// matching the desktop UI, and keep the answer itself clean.
+type Stream = 'loading' | 'connecting' | 'live' | 'done' | 'inactive' | 'error';
+
+// Session view. Loads the saved conversation first (so ANY session opens, not
+// just one with a live run), then attaches the live SSE on top: if a run is
+// active its output streams into an in-progress assistant bubble; if not, we
+// just show the saved messages. Reasoning models' chain-of-thought shows in a
+// collapsible "Thinking" block while live (it's stripped from saved messages,
+// same as the desktop).
 export default function SessionScreen({
   conn,
   sessionId,
@@ -22,70 +22,104 @@ export default function SessionScreen({
   sessionId: string;
   onBack: () => void;
 }) {
-  // rawAnswer = non-flagged stream (may contain inline <think> tags);
-  // flaggedThink = deltas the server flagged thinking:true.
+  const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [rawAnswer, setRawAnswer] = useState('');
   const [flaggedThink, setFlaggedThink] = useState('');
-  const [status, setStatus] = useState<'connecting' | 'live' | 'done' | 'error'>(
-    'connecting',
-  );
+  const [stream, setStream] = useState<Stream>('loading');
   const [statusLine, setStatusLine] = useState<string | null>(null);
   const [stopping, setStopping] = useState(false);
   const [thinkOpen, setThinkOpen] = useState(true);
   const bodyRef = useRef<HTMLDivElement>(null);
+  const hasHistory = useRef(false);
 
   const { answer, thinking } = useMemo(() => {
     const split = splitThinking(rawAnswer);
     return { answer: split.answer, thinking: (flaggedThink + split.thinking).trim() };
   }, [rawAnswer, flaggedThink]);
 
-  // Once a real answer starts arriving, fold the thinking away (like the PC).
   useEffect(() => {
     if (answer.trim()) setThinkOpen(false);
   }, [answer]);
 
   useEffect(() => {
     const ctrl = new AbortController();
+    let cancelled = false;
+    setMessages([]);
     setRawAnswer('');
     setFlaggedThink('');
-    setStatus('connecting');
+    setStream('loading');
     setThinkOpen(true);
+    hasHistory.current = false;
 
-    streamSession(
-      conn,
-      sessionId,
-      (ev: StreamEvent) => {
-        if (ev.kind === 'delta') {
-          setStatus('live');
-          if (ev.thinking) setFlaggedThink((t) => t + ev.text);
-          else setRawAnswer((t) => t + ev.text);
-        } else if (ev.kind === 'event') {
-          if (ev.type === 'tool_start') setStatusLine(`Running ${String(ev.raw.tool ?? 'tool')}...`);
-          else if (ev.type === 'tool_output' || ev.type === 'model_info') setStatusLine(null);
-        } else if (ev.kind === 'done') {
-          setStatus('done');
-          setStatusLine(null);
-        }
-      },
-      {
-        signal: ctrl.signal,
-        onClose: () => setStatus((s) => (s === 'live' || s === 'connecting' ? 'done' : s)),
-        onError: () => setStatus('error'),
-      },
-    );
+    // 1. Saved conversation first.
+    getMessages(conn, sessionId)
+      .then((m) => {
+        if (cancelled) return;
+        setMessages(m);
+        hasHistory.current = m.length > 0;
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (cancelled) return;
+        // 2. Attach the live stream (no-op if the run already finished).
+        setStream((s) => (s === 'loading' ? 'connecting' : s));
+        streamSession(
+          conn,
+          sessionId,
+          (ev: StreamEvent) => {
+            if (ev.kind === 'delta') {
+              setStream('live');
+              if (ev.thinking) setFlaggedThink((t) => t + ev.text);
+              else setRawAnswer((t) => t + ev.text);
+            } else if (ev.kind === 'event') {
+              if (ev.type === 'tool_start') setStatusLine(`Running ${String(ev.raw.tool ?? 'tool')}...`);
+              else if (ev.type === 'tool_output' || ev.type === 'model_info') setStatusLine(null);
+            } else if (ev.kind === 'done') {
+              setStatusLine(null);
+              finishRun();
+            }
+          },
+          {
+            signal: ctrl.signal,
+            onClose: () => setStream((s) => (s === 'live' || s === 'connecting' ? 'done' : s)),
+            // A failed stream just means no live run -- not an error if we have
+            // the saved conversation to show.
+            onError: () => setStream(hasHistory.current ? 'inactive' : 'error'),
+          },
+        );
+      });
 
-    return () => ctrl.abort(); // leaving the screen detaches; the run keeps going
+    // When a live run completes, the server has saved the assistant message;
+    // re-fetch so it lands as a normal bubble, then drop the live buffers.
+    async function finishRun() {
+      setStream('done');
+      try {
+        const m = await getMessages(conn, sessionId);
+        if (!cancelled) setMessages(m);
+      } catch {
+        /* keep what we have */
+      }
+      if (!cancelled) {
+        setRawAnswer('');
+        setFlaggedThink('');
+      }
+    }
+
+    return () => {
+      cancelled = true;
+      ctrl.abort(); // leaving detaches; the run keeps going server-side
+    };
   }, [conn, sessionId]);
 
   useEffect(() => {
     bodyRef.current?.scrollTo({ top: bodyRef.current.scrollHeight });
-  }, [answer, thinking, thinkOpen, statusLine]);
+  }, [messages, answer, thinking, thinkOpen, statusLine]);
 
   async function onStop() {
     setStopping(true);
     try {
       await stopSession(conn, sessionId);
-      setStatus('done');
+      setStream('done');
     } catch (e) {
       console.warn('stop failed', e);
     } finally {
@@ -93,7 +127,9 @@ export default function SessionScreen({
     }
   }
 
-  const hasOutput = Boolean(answer.trim() || thinking);
+  const isLive = stream === 'live' || stream === 'connecting';
+  const liveBlock = Boolean(answer.trim() || thinking);
+  const empty = stream !== 'loading' && messages.length === 0 && !liveBlock;
 
   return (
     <div className="screen detail">
@@ -101,40 +137,49 @@ export default function SessionScreen({
         <button className="ghost" onClick={onBack} type="button" aria-label="Back">
           <ChevronLeftIcon size={24} />
         </button>
-        <span className={'status-pill ' + status}>{status}</span>
-        <button
-          className="stop"
-          onClick={onStop}
-          type="button"
-          disabled={stopping || status === 'done'}
-        >
-          {stopping ? 'Stopping...' : 'Stop'}
-        </button>
+        <span className={'status-pill ' + stream}>{stream}</span>
+        {isLive && (
+          <button className="stop" onClick={onStop} type="button" disabled={stopping}>
+            {stopping ? 'Stopping...' : 'Stop'}
+          </button>
+        )}
       </header>
 
       <div className="detail-body" ref={bodyRef}>
-        {thinking && (
-          <div className="think">
-            <button
-              className="think-head"
-              type="button"
-              onClick={() => setThinkOpen((o) => !o)}
-            >
-              <span className={'think-caret' + (thinkOpen ? ' open' : '')}>&gt;</span>
-              <span>Thinking</span>
-              {status === 'live' && !answer.trim() && <span className="think-live">...</span>}
-            </button>
-            {thinkOpen && <pre className="think-text">{thinking}</pre>}
+        {messages.map((m, i) => (
+          <div key={i} className={'msg msg-' + m.role}>
+            <div className="msg-role">{m.role}</div>
+            <pre className="msg-text">{m.content}</pre>
+          </div>
+        ))}
+
+        {liveBlock && (
+          <div className="msg msg-assistant">
+            <div className="msg-role">assistant</div>
+            {thinking && (
+              <div className="think">
+                <button
+                  className="think-head"
+                  type="button"
+                  onClick={() => setThinkOpen((o) => !o)}
+                >
+                  <span className={'think-caret' + (thinkOpen ? ' open' : '')}>&gt;</span>
+                  <span>Thinking</span>
+                  {isLive && !answer.trim() && <span className="think-live">...</span>}
+                </button>
+                {thinkOpen && <pre className="think-text">{thinking}</pre>}
+              </div>
+            )}
+            {answer.trim() && <pre className="msg-text">{answer}</pre>}
           </div>
         )}
 
-        {answer.trim() && <pre className="stream-text">{answer}</pre>}
-
-        {!hasOutput && (
+        {stream === 'loading' && <div className="muted pad">Loading...</div>}
+        {empty && (
           <div className="muted pad">
-            {status === 'error'
-              ? 'Could not open the stream. The session may not be running.'
-              : 'Waiting for output...'}
+            {stream === 'error'
+              ? 'Could not load this session.'
+              : 'No messages yet.'}
           </div>
         )}
         {statusLine && <div className="tool-line">{statusLine}</div>}

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -13,7 +13,13 @@ import {
 import { splitThinking } from '../lib/thinking';
 import { ChevronLeftIcon } from '../components/icons';
 import ToolToggles from '../components/ToolToggles';
-import { AttachButton, AttachPreviews, type PendingFile } from '../components/Attachments';
+import {
+  AttachButton,
+  AttachPreviews,
+  PcFilesButton,
+  type Pending,
+} from '../components/Attachments';
+import FsBrowser from '../components/FsBrowser';
 
 // A chat message plus, for the optimistic bubble of a just-sent turn, local
 // preview URLs for any images attached (server history is text-only).
@@ -47,7 +53,8 @@ export default function SessionScreen({
   const [picked, setPicked] = useState(0);
   const [draft, setDraft] = useState('');
   const [options, setOptions] = useState<ChatOptions>(DEFAULT_OPTIONS);
-  const [pending, setPending] = useState<PendingFile[]>([]);
+  const [pending, setPending] = useState<Pending[]>([]);
+  const [showBrowser, setShowBrowser] = useState(false);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   // Bumped after a successful send to re-run the subscribe effect on the new run.
@@ -173,7 +180,8 @@ export default function SessionScreen({
 
   function removeAttachment(i: number) {
     setPending((p) => {
-      URL.revokeObjectURL(p[i]?.url);
+      const item = p[i];
+      if (item?.kind === 'local') URL.revokeObjectURL(item.url);
       return p.filter((_, j) => j !== i);
     });
   }
@@ -186,15 +194,18 @@ export default function SessionScreen({
     setSendError(null);
     const queued = pending;
     try {
-      // Upload any attachments first so we can pass their ids with the turn.
-      let attachments: string[] = [];
-      if (queued.length) {
-        const up = await uploadFiles(conn, queued.map((p) => p.file));
-        attachments = up.map((a) => a.id);
+      // Local files upload now; PC files already carry an attachment id.
+      const locals = queued.filter((p) => p.kind === 'local');
+      let attachments = queued.filter((p) => p.kind === 'remote').map((p) => p.id);
+      if (locals.length) {
+        const up = await uploadFiles(conn, locals.map((p) => (p as { file: File }).file));
+        attachments = [...up.map((a) => a.id), ...attachments];
       }
-      // Optimistically show the user's turn (with image previews); the run will
-      // stream the reply. The object URLs stay valid for this bubble.
-      const images = queued.filter((p) => p.file.type.startsWith('image/')).map((p) => p.url);
+      // Optimistically show the user's turn (local image previews stay valid for
+      // this bubble); the run will stream the reply.
+      const images = locals
+        .filter((p) => (p as { file: File }).file.type.startsWith('image/'))
+        .map((p) => (p as { url: string }).url);
       setMessages((m) => [...m, { role: 'user', content: text, images }]);
       setDraft('');
       setPending([]);
@@ -219,6 +230,18 @@ export default function SessionScreen({
   const isLive = stream === 'live' || stream === 'connecting' || sending;
   const liveBlock = Boolean(answer.trim() || thinking);
   const empty = stream !== 'loading' && messages.length === 0 && !liveBlock;
+
+  if (showBrowser) {
+    return (
+      <FsBrowser
+        conn={conn}
+        onClose={() => setShowBrowser(false)}
+        onPick={(att) =>
+          setPending((p) => [...p, { kind: 'remote', id: att.id, name: att.name, mime: att.mime }])
+        }
+      />
+    );
+  }
 
   return (
     <div className="screen detail">
@@ -307,6 +330,7 @@ export default function SessionScreen({
           onPick={(picked) => setPending((p) => [...p, ...picked])}
           disabled={isLive}
         />
+        <PcFilesButton onClick={() => setShowBrowser(true)} disabled={isLive} />
         <textarea
           className="composer-input"
           value={draft}

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -1,10 +1,23 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Connection } from '../lib/connection';
 import type { ChatMsg, ChatOptions, ModelOption, StreamEvent } from '../lib/api';
-import { DEFAULT_OPTIONS, getMessages, listModels, sendMessage, stopSession, streamSession } from '../lib/api';
+import {
+  DEFAULT_OPTIONS,
+  getMessages,
+  listModels,
+  sendMessage,
+  stopSession,
+  streamSession,
+  uploadFiles,
+} from '../lib/api';
 import { splitThinking } from '../lib/thinking';
 import { ChevronLeftIcon } from '../components/icons';
 import ToolToggles from '../components/ToolToggles';
+import { AttachButton, AttachPreviews, type PendingFile } from '../components/Attachments';
+
+// A chat message plus, for the optimistic bubble of a just-sent turn, local
+// preview URLs for any images attached (server history is text-only).
+type LocalMsg = ChatMsg & { images?: string[] };
 
 type Stream = 'loading' | 'connecting' | 'live' | 'done' | 'inactive' | 'error';
 
@@ -23,7 +36,7 @@ export default function SessionScreen({
   sessionId: string;
   onBack: () => void;
 }) {
-  const [messages, setMessages] = useState<ChatMsg[]>([]);
+  const [messages, setMessages] = useState<LocalMsg[]>([]);
   const [rawAnswer, setRawAnswer] = useState('');
   const [flaggedThink, setFlaggedThink] = useState('');
   const [stream, setStream] = useState<Stream>('loading');
@@ -34,6 +47,7 @@ export default function SessionScreen({
   const [picked, setPicked] = useState(0);
   const [draft, setDraft] = useState('');
   const [options, setOptions] = useState<ChatOptions>(DEFAULT_OPTIONS);
+  const [pending, setPending] = useState<PendingFile[]>([]);
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   // Bumped after a successful send to re-run the subscribe effect on the new run.
@@ -157,21 +171,39 @@ export default function SessionScreen({
     }
   }
 
+  function removeAttachment(i: number) {
+    setPending((p) => {
+      URL.revokeObjectURL(p[i]?.url);
+      return p.filter((_, j) => j !== i);
+    });
+  }
+
   async function onSend() {
     const text = draft.trim();
     const model = models[picked];
-    if (!text || sending || isLive) return;
+    if ((!text && pending.length === 0) || sending || isLive) return;
     setSending(true);
     setSendError(null);
-    // Optimistically show the user's turn; the run will stream the reply.
-    setMessages((m) => [...m, { role: 'user', content: text }]);
-    setDraft('');
+    const queued = pending;
     try {
+      // Upload any attachments first so we can pass their ids with the turn.
+      let attachments: string[] = [];
+      if (queued.length) {
+        const up = await uploadFiles(conn, queued.map((p) => p.file));
+        attachments = up.map((a) => a.id);
+      }
+      // Optimistically show the user's turn (with image previews); the run will
+      // stream the reply. The object URLs stay valid for this bubble.
+      const images = queued.filter((p) => p.file.type.startsWith('image/')).map((p) => p.url);
+      setMessages((m) => [...m, { role: 'user', content: text, images }]);
+      setDraft('');
+      setPending([]);
       await sendMessage(conn, sessionId, {
         message: text,
         endpointId: model?.endpointId,
         model: model?.model,
         options,
+        attachments,
       });
       setRawAnswer('');
       setFlaggedThink('');
@@ -218,7 +250,14 @@ export default function SessionScreen({
         {messages.map((m, i) => (
           <div key={i} className={'msg msg-' + m.role}>
             <div className="msg-role">{m.role}</div>
-            <pre className="msg-text">{m.content}</pre>
+            {m.images && m.images.length > 0 && (
+              <div className="msg-images">
+                {m.images.map((src, j) => (
+                  <img key={j} src={src} alt="attachment" />
+                ))}
+              </div>
+            )}
+            {m.content && <pre className="msg-text">{m.content}</pre>}
           </div>
         ))}
 
@@ -255,6 +294,7 @@ export default function SessionScreen({
       {sendError && <div className="error">{sendError}</div>}
 
       <ToolToggles value={options} onChange={setOptions} disabled={isLive} />
+      <AttachPreviews pending={pending} onRemove={removeAttachment} disabled={isLive} />
 
       <form
         className="composer"
@@ -263,6 +303,10 @@ export default function SessionScreen({
           onSend();
         }}
       >
+        <AttachButton
+          onPick={(picked) => setPending((p) => [...p, ...picked])}
+          disabled={isLive}
+        />
         <textarea
           className="composer-input"
           value={draft}
@@ -282,7 +326,7 @@ export default function SessionScreen({
             {stopping ? '...' : 'Stop'}
           </button>
         ) : (
-          <button className="stop send" type="submit" disabled={!draft.trim()}>
+          <button className="stop send" type="submit" disabled={!draft.trim() && pending.length === 0}>
             Send
           </button>
         )}

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -1,18 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Connection } from '../lib/connection';
-import type { ChatMsg, StreamEvent } from '../lib/api';
-import { getMessages, stopSession, streamSession } from '../lib/api';
+import type { ChatMsg, ModelOption, StreamEvent } from '../lib/api';
+import { getMessages, listModels, sendMessage, stopSession, streamSession } from '../lib/api';
 import { splitThinking } from '../lib/thinking';
 import { ChevronLeftIcon } from '../components/icons';
 
 type Stream = 'loading' | 'connecting' | 'live' | 'done' | 'inactive' | 'error';
 
-// Session view. Loads the saved conversation first (so ANY session opens, not
-// just one with a live run), then attaches the live SSE on top: if a run is
-// active its output streams into an in-progress assistant bubble; if not, we
-// just show the saved messages. Reasoning models' chain-of-thought shows in a
-// collapsible "Thinking" block while live (it's stripped from saved messages,
-// same as the desktop).
+// Session view: a full conversation with a composer at the bottom, so the phone
+// can carry a chat as far as the desktop can. Loads the saved history first (so
+// ANY session opens, not just one with a live run), then attaches the live SSE
+// on top. Sending a follow-up posts to /message and re-attaches the stream.
+// The model picker in the header switches models mid-chat, like the desktop.
+// Reasoning models' chain-of-thought shows in a collapsible "Thinking" block.
 export default function SessionScreen({
   conn,
   sessionId,
@@ -29,8 +29,16 @@ export default function SessionScreen({
   const [statusLine, setStatusLine] = useState<string | null>(null);
   const [stopping, setStopping] = useState(false);
   const [thinkOpen, setThinkOpen] = useState(true);
+  const [models, setModels] = useState<ModelOption[]>([]);
+  const [picked, setPicked] = useState(0);
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  // Bumped after a successful send to re-run the subscribe effect on the new run.
+  const [runNonce, setRunNonce] = useState(0);
   const bodyRef = useRef<HTMLDivElement>(null);
   const hasHistory = useRef(false);
+  const sessionIdRef = useRef(sessionId);
 
   const { answer, thinking } = useMemo(() => {
     const split = splitThinking(rawAnswer);
@@ -41,22 +49,42 @@ export default function SessionScreen({
     if (answer.trim()) setThinkOpen(false);
   }, [answer]);
 
+  // Model options for the in-chat picker (same source as the new-chat screen).
+  useEffect(() => {
+    listModels(conn).then(setModels).catch(() => {});
+  }, [conn]);
+
   useEffect(() => {
     const ctrl = new AbortController();
     let cancelled = false;
-    setMessages([]);
+    // Only wipe the transcript when the session itself changes -- a follow-up
+    // (runNonce bump) keeps the bubbles already on screen.
+    const sessionChanged = sessionIdRef.current !== sessionId;
+    sessionIdRef.current = sessionId;
+    if (sessionChanged) {
+      setMessages([]);
+      hasHistory.current = false;
+    }
     setRawAnswer('');
     setFlaggedThink('');
+    setStatusLine(null);
     setStream('loading');
     setThinkOpen(true);
-    hasHistory.current = false;
 
     // 1. Saved conversation first.
     getMessages(conn, sessionId)
-      .then((m) => {
+      .then((h) => {
         if (cancelled) return;
-        setMessages(m);
-        hasHistory.current = m.length > 0;
+        setMessages(h.messages);
+        hasHistory.current = h.messages.length > 0;
+        // Default the picker to the session's current model the first time.
+        if (h.model) {
+          setModels((ms) => {
+            const i = ms.findIndex((m) => m.model === h.model);
+            if (i >= 0) setPicked(i);
+            return ms;
+          });
+        }
       })
       .catch(() => {})
       .finally(() => {
@@ -94,8 +122,8 @@ export default function SessionScreen({
     async function finishRun() {
       setStream('done');
       try {
-        const m = await getMessages(conn, sessionId);
-        if (!cancelled) setMessages(m);
+        const h = await getMessages(conn, sessionId);
+        if (!cancelled) setMessages(h.messages);
       } catch {
         /* keep what we have */
       }
@@ -109,7 +137,7 @@ export default function SessionScreen({
       cancelled = true;
       ctrl.abort(); // leaving detaches; the run keeps going server-side
     };
-  }, [conn, sessionId]);
+  }, [conn, sessionId, runNonce]);
 
   useEffect(() => {
     bodyRef.current?.scrollTo({ top: bodyRef.current.scrollHeight });
@@ -127,7 +155,33 @@ export default function SessionScreen({
     }
   }
 
-  const isLive = stream === 'live' || stream === 'connecting';
+  async function onSend() {
+    const text = draft.trim();
+    const model = models[picked];
+    if (!text || sending || isLive) return;
+    setSending(true);
+    setSendError(null);
+    // Optimistically show the user's turn; the run will stream the reply.
+    setMessages((m) => [...m, { role: 'user', content: text }]);
+    setDraft('');
+    try {
+      await sendMessage(conn, sessionId, {
+        message: text,
+        endpointId: model?.endpointId,
+        model: model?.model,
+      });
+      setRawAnswer('');
+      setFlaggedThink('');
+      setRunNonce((n) => n + 1); // re-attach the stream to the new run
+    } catch (e) {
+      setSendError('Could not send. Is the model reachable?');
+      console.warn('sendMessage failed', e);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  const isLive = stream === 'live' || stream === 'connecting' || sending;
   const liveBlock = Boolean(answer.trim() || thinking);
   const empty = stream !== 'loading' && messages.length === 0 && !liveBlock;
 
@@ -137,12 +191,24 @@ export default function SessionScreen({
         <button className="ghost" onClick={onBack} type="button" aria-label="Back">
           <ChevronLeftIcon size={24} />
         </button>
-        <span className={'status-pill ' + stream}>{stream}</span>
-        {isLive && (
-          <button className="stop" onClick={onStop} type="button" disabled={stopping}>
-            {stopping ? 'Stopping...' : 'Stop'}
-          </button>
-        )}
+        <select
+          className="model-select"
+          value={picked}
+          onChange={(e) => setPicked(Number(e.target.value))}
+          disabled={models.length === 0 || isLive}
+          aria-label="Model"
+        >
+          {models.length === 0 && <option>model</option>}
+          {models.map((m, i) => (
+            <option key={m.endpointId + m.model} value={i}>
+              {m.model}
+              {models.some((o) => o.model === m.model && o.endpointId !== m.endpointId)
+                ? ` (${m.endpointName})`
+                : ''}
+            </option>
+          ))}
+        </select>
+        <span className={'status-dot ' + stream} title={stream} aria-label={stream} />
       </header>
 
       <div className="detail-body" ref={bodyRef}>
@@ -177,13 +243,45 @@ export default function SessionScreen({
         {stream === 'loading' && <div className="muted pad">Loading...</div>}
         {empty && (
           <div className="muted pad">
-            {stream === 'error'
-              ? 'Could not load this session.'
-              : 'No messages yet.'}
+            {stream === 'error' ? 'Could not load this session.' : 'No messages yet.'}
           </div>
         )}
         {statusLine && <div className="tool-line">{statusLine}</div>}
       </div>
+
+      {sendError && <div className="error">{sendError}</div>}
+
+      <form
+        className="composer"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSend();
+        }}
+      >
+        <textarea
+          className="composer-input"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              onSend();
+            }
+          }}
+          placeholder={isLive ? 'Running...' : 'Message Odysseus...'}
+          rows={1}
+          disabled={isLive}
+        />
+        {isLive ? (
+          <button className="stop" onClick={onStop} type="button" disabled={stopping}>
+            {stopping ? '...' : 'Stop'}
+          </button>
+        ) : (
+          <button className="stop send" type="submit" disabled={!draft.trim()}>
+            Send
+          </button>
+        )}
+      </form>
     </div>
   );
 }

--- a/companion/mobile/src/screens/SessionScreen.tsx
+++ b/companion/mobile/src/screens/SessionScreen.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { StreamEvent } from '../lib/api';
+import { stopSession, streamSession } from '../lib/api';
+import { splitThinking } from '../lib/thinking';
+import { ChevronLeftIcon } from '../components/icons';
+
+// The remote-control detail view: connect to a session's live SSE, render the
+// streaming answer, surface tool/status events, and offer a Stop button. Opening
+// mid-run replays everything so far (the server buffers it), then streams live.
+//
+// Reasoning models stream their chain-of-thought two ways: flagged
+// (delta + thinking:true, from Odysseus' llm_core) or inline (<think>...</think>
+// in the normal text). We collect both into a collapsible "Thinking" block,
+// matching the desktop UI, and keep the answer itself clean.
+export default function SessionScreen({
+  conn,
+  sessionId,
+  onBack,
+}: {
+  conn: Connection;
+  sessionId: string;
+  onBack: () => void;
+}) {
+  // rawAnswer = non-flagged stream (may contain inline <think> tags);
+  // flaggedThink = deltas the server flagged thinking:true.
+  const [rawAnswer, setRawAnswer] = useState('');
+  const [flaggedThink, setFlaggedThink] = useState('');
+  const [status, setStatus] = useState<'connecting' | 'live' | 'done' | 'error'>(
+    'connecting',
+  );
+  const [statusLine, setStatusLine] = useState<string | null>(null);
+  const [stopping, setStopping] = useState(false);
+  const [thinkOpen, setThinkOpen] = useState(true);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const { answer, thinking } = useMemo(() => {
+    const split = splitThinking(rawAnswer);
+    return { answer: split.answer, thinking: (flaggedThink + split.thinking).trim() };
+  }, [rawAnswer, flaggedThink]);
+
+  // Once a real answer starts arriving, fold the thinking away (like the PC).
+  useEffect(() => {
+    if (answer.trim()) setThinkOpen(false);
+  }, [answer]);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setRawAnswer('');
+    setFlaggedThink('');
+    setStatus('connecting');
+    setThinkOpen(true);
+
+    streamSession(
+      conn,
+      sessionId,
+      (ev: StreamEvent) => {
+        if (ev.kind === 'delta') {
+          setStatus('live');
+          if (ev.thinking) setFlaggedThink((t) => t + ev.text);
+          else setRawAnswer((t) => t + ev.text);
+        } else if (ev.kind === 'event') {
+          if (ev.type === 'tool_start') setStatusLine(`Running ${String(ev.raw.tool ?? 'tool')}...`);
+          else if (ev.type === 'tool_output' || ev.type === 'model_info') setStatusLine(null);
+        } else if (ev.kind === 'done') {
+          setStatus('done');
+          setStatusLine(null);
+        }
+      },
+      {
+        signal: ctrl.signal,
+        onClose: () => setStatus((s) => (s === 'live' || s === 'connecting' ? 'done' : s)),
+        onError: () => setStatus('error'),
+      },
+    );
+
+    return () => ctrl.abort(); // leaving the screen detaches; the run keeps going
+  }, [conn, sessionId]);
+
+  useEffect(() => {
+    bodyRef.current?.scrollTo({ top: bodyRef.current.scrollHeight });
+  }, [answer, thinking, thinkOpen, statusLine]);
+
+  async function onStop() {
+    setStopping(true);
+    try {
+      await stopSession(conn, sessionId);
+      setStatus('done');
+    } catch (e) {
+      console.warn('stop failed', e);
+    } finally {
+      setStopping(false);
+    }
+  }
+
+  const hasOutput = Boolean(answer.trim() || thinking);
+
+  return (
+    <div className="screen detail">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <span className={'status-pill ' + status}>{status}</span>
+        <button
+          className="stop"
+          onClick={onStop}
+          type="button"
+          disabled={stopping || status === 'done'}
+        >
+          {stopping ? 'Stopping...' : 'Stop'}
+        </button>
+      </header>
+
+      <div className="detail-body" ref={bodyRef}>
+        {thinking && (
+          <div className="think">
+            <button
+              className="think-head"
+              type="button"
+              onClick={() => setThinkOpen((o) => !o)}
+            >
+              <span className={'think-caret' + (thinkOpen ? ' open' : '')}>&gt;</span>
+              <span>Thinking</span>
+              {status === 'live' && !answer.trim() && <span className="think-live">...</span>}
+            </button>
+            {thinkOpen && <pre className="think-text">{thinking}</pre>}
+          </div>
+        )}
+
+        {answer.trim() && <pre className="stream-text">{answer}</pre>}
+
+        {!hasOutput && (
+          <div className="muted pad">
+            {status === 'error'
+              ? 'Could not open the stream. The session may not be running.'
+              : 'Waiting for output...'}
+          </div>
+        )}
+        {statusLine && <div className="tool-line">{statusLine}</div>}
+      </div>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/SessionsScreen.tsx
+++ b/companion/mobile/src/screens/SessionsScreen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type { Connection } from '../lib/connection';
 import type { SessionRow } from '../lib/api';
 import { listSessions } from '../lib/api';
-import { RefreshIcon, ChevronRightIcon, PlusIcon } from '../components/icons';
+import { RefreshIcon, ChevronRightIcon, PlusIcon, SearchIcon } from '../components/icons';
 
 // The home tab: the owner's sessions, live ones first. Polls lightly so a run
 // that starts on the desktop shows up here without a manual refresh.
@@ -10,10 +10,12 @@ export default function SessionsScreen({
   conn,
   onOpen,
   onNew,
+  onSearch,
 }: {
   conn: Connection;
   onOpen: (id: string) => void;
   onNew: () => void;
+  onSearch: () => void;
 }) {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -42,6 +44,9 @@ export default function SessionsScreen({
       <header className="list-header">
         <h1>Sessions</h1>
         <div className="header-actions">
+          <button className="ghost" onClick={onSearch} type="button" aria-label="Search chats">
+            <SearchIcon size={20} />
+          </button>
           <button className="ghost" onClick={refresh} type="button" aria-label="Refresh">
             <RefreshIcon size={20} />
           </button>

--- a/companion/mobile/src/screens/SessionsScreen.tsx
+++ b/companion/mobile/src/screens/SessionsScreen.tsx
@@ -2,16 +2,18 @@ import { useCallback, useEffect, useState } from 'react';
 import type { Connection } from '../lib/connection';
 import type { SessionRow } from '../lib/api';
 import { listSessions } from '../lib/api';
-import { RefreshIcon, ChevronRightIcon } from '../components/icons';
+import { RefreshIcon, ChevronRightIcon, PlusIcon } from '../components/icons';
 
 // The home tab: the owner's sessions, live ones first. Polls lightly so a run
 // that starts on the desktop shows up here without a manual refresh.
 export default function SessionsScreen({
   conn,
   onOpen,
+  onNew,
 }: {
   conn: Connection;
   onOpen: (id: string) => void;
+  onNew: () => void;
 }) {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -39,9 +41,14 @@ export default function SessionsScreen({
     <div className="screen list">
       <header className="list-header">
         <h1>Sessions</h1>
-        <button className="ghost" onClick={refresh} type="button" aria-label="Refresh">
-          <RefreshIcon size={20} />
-        </button>
+        <div className="header-actions">
+          <button className="ghost" onClick={refresh} type="button" aria-label="Refresh">
+            <RefreshIcon size={20} />
+          </button>
+          <button className="ghost" onClick={onNew} type="button" aria-label="New chat">
+            <PlusIcon size={22} />
+          </button>
+        </div>
       </header>
 
       {error && <div className="error">{error}</div>}

--- a/companion/mobile/src/screens/SessionsScreen.tsx
+++ b/companion/mobile/src/screens/SessionsScreen.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { SessionRow } from '../lib/api';
+import { listSessions } from '../lib/api';
+import { RefreshIcon, ChevronRightIcon } from '../components/icons';
+
+// The home tab: the owner's sessions, live ones first. Polls lightly so a run
+// that starts on the desktop shows up here without a manual refresh.
+export default function SessionsScreen({
+  conn,
+  onOpen,
+}: {
+  conn: Connection;
+  onOpen: (id: string) => void;
+}) {
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      setSessions(await listSessions(conn));
+      setError(null);
+    } catch (e) {
+      setError('Lost contact with the server.');
+      console.warn('listSessions failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [conn]);
+
+  useEffect(() => {
+    refresh();
+    const t = setInterval(refresh, 5000);
+    return () => clearInterval(t);
+  }, [refresh]);
+
+  return (
+    <div className="screen list">
+      <header className="list-header">
+        <h1>Sessions</h1>
+        <button className="ghost" onClick={refresh} type="button" aria-label="Refresh">
+          <RefreshIcon size={20} />
+        </button>
+      </header>
+
+      {error && <div className="error">{error}</div>}
+      {loading && sessions.length === 0 && <div className="muted pad">Loading...</div>}
+      {!loading && sessions.length === 0 && !error && (
+        <div className="muted pad">No sessions yet. Start one on your PC.</div>
+      )}
+
+      <ul className="rows">
+        {sessions.map((s) => (
+          <li key={s.id}>
+            <button className="row" onClick={() => onOpen(s.id)} type="button">
+              <span className={'dot' + (s.active ? ' live' : '')} aria-hidden />
+              <span className="row-main">
+                <span className="row-title">{s.name || 'Untitled'}</span>
+                <span className="row-sub">
+                  <span>{s.model || 'unknown model'}</span>
+                  <span className="sep" />
+                  <span>{s.message_count} msg</span>
+                  {s.active && (
+                    <>
+                      <span className="sep" />
+                      <span>running</span>
+                    </>
+                  )}
+                </span>
+              </span>
+              <span className="chev">
+                <ChevronRightIcon size={20} />
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/SettingsScreen.tsx
+++ b/companion/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import { clearConnection } from '../lib/connection';
+import { ping, type PingResult } from '../lib/api';
+
+// Connection status + unpair. Future home for the notifications (silent/loud)
+// and remote-access toggles from the roadmap.
+export default function SettingsScreen({
+  conn,
+  onDisconnect,
+}: {
+  conn: Connection;
+  onDisconnect: () => void;
+}) {
+  const [info, setInfo] = useState<PingResult | null>(null);
+  const [reachable, setReachable] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    ping(conn)
+      .then((r) => {
+        setInfo(r);
+        setReachable(true);
+      })
+      .catch(() => setReachable(false));
+  }, [conn]);
+
+  async function disconnect() {
+    await clearConnection();
+    onDisconnect();
+  }
+
+  return (
+    <div className="screen list">
+      <header className="list-header">
+        <h1>Settings</h1>
+      </header>
+
+      <div className="card">
+        <div className="card-row">
+          <span className="muted">Server</span>
+          <span>{conn.name || conn.baseUrl}</span>
+        </div>
+        <div className="card-row">
+          <span className="muted">Address</span>
+          <span className="mono">{conn.baseUrl}</span>
+        </div>
+        <div className="card-row">
+          <span className="muted">Status</span>
+          <span>
+            {reachable === null
+              ? 'Checking...'
+              : reachable
+                ? `Connected${info ? ` (v${info.version})` : ''}`
+                : 'Unreachable'}
+          </span>
+        </div>
+      </div>
+
+      <button className="danger" onClick={disconnect} type="button">
+        Unpair this device
+      </button>
+    </div>
+  );
+}

--- a/companion/mobile/src/screens/TasksScreen.tsx
+++ b/companion/mobile/src/screens/TasksScreen.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Connection } from '../lib/connection';
+import type { TaskRow } from '../lib/api';
+import { listTasks, taskAction } from '../lib/api';
+import { ChevronLeftIcon, RefreshIcon } from '../components/icons';
+
+// Scheduled / automation tasks: status at a glance, with pause / resume / run.
+export default function TasksScreen({ conn, onBack }: { conn: Connection; onBack: () => void }) {
+  const [tasks, setTasks] = useState<TaskRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    listTasks(conn)
+      .then(setTasks)
+      .catch(() => setError('Could not load your tasks.'))
+      .finally(() => setLoading(false));
+  }, [conn]);
+
+  useEffect(refresh, [refresh]);
+
+  async function act(id: string, action: 'pause' | 'resume' | 'run') {
+    setBusy(id + action);
+    try {
+      await taskAction(conn, id, action);
+      refresh();
+    } catch {
+      setError(`Could not ${action} that task.`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="screen detail">
+      <header className="detail-header">
+        <button className="ghost" onClick={onBack} type="button" aria-label="Back">
+          <ChevronLeftIcon size={24} />
+        </button>
+        <span className="status-pill">Tasks</span>
+        <button className="ghost" onClick={refresh} type="button" aria-label="Refresh">
+          <RefreshIcon size={20} />
+        </button>
+      </header>
+      <div className="detail-body">
+        {error && <div className="error">{error}</div>}
+        {loading && <div className="muted pad">Loading...</div>}
+        {!loading && !error && tasks.length === 0 && <div className="muted pad">No tasks.</div>}
+        {tasks.map((t) => {
+          const paused = (t.status || '').toLowerCase() === 'paused';
+          return (
+            <div key={t.id} className="task-card">
+              <div className="task-head">
+                <span className={'dot' + (paused ? '' : ' live')} aria-hidden />
+                <span className="task-name">{t.name || t.action || '(task)'}</span>
+                <span className="task-status">{t.status || ''}</span>
+              </div>
+              <div className="task-meta">
+                {whenLabel(t)}
+              </div>
+              <div className="task-actions">
+                <button
+                  className="chip"
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() => act(t.id, paused ? 'resume' : 'pause')}
+                >
+                  {paused ? 'Resume' : 'Pause'}
+                </button>
+                <button
+                  className="chip"
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() => act(t.id, 'run')}
+                >
+                  {busy === t.id + 'run' ? 'Running...' : 'Run now'}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function whenLabel(t: TaskRow): string {
+  if (t.trigger_type && t.trigger_type !== 'schedule') return `Trigger: ${t.trigger_type}`;
+  if (t.next_run) {
+    const d = new Date(t.next_run);
+    if (!isNaN(d.getTime())) return `Next: ${d.toLocaleString()}`;
+  }
+  if (t.schedule) return `Schedule: ${t.schedule}`;
+  return t.task_type || '';
+}

--- a/companion/mobile/src/screens/ToolsScreen.tsx
+++ b/companion/mobile/src/screens/ToolsScreen.tsx
@@ -1,0 +1,45 @@
+import {
+  CalendarIcon,
+  CheckSquareIcon,
+  ChevronRightIcon,
+  MailIcon,
+  NoteIcon,
+} from '../components/icons';
+
+export type ToolName = 'email' | 'calendar' | 'notes' | 'tasks';
+
+// The Tools tab: a menu into each owner-scoped tool. Keeps the bottom nav small
+// (Sessions / Tools / Settings) while the tools live one tap in.
+export default function ToolsScreen({ onOpen }: { onOpen: (t: ToolName) => void }) {
+  const items: { key: ToolName; label: string; sub: string; icon: JSX.Element }[] = [
+    { key: 'email', label: 'Email', sub: 'Read and reply to your mail', icon: <MailIcon size={22} /> },
+    { key: 'calendar', label: 'Calendar', sub: 'Upcoming events', icon: <CalendarIcon size={22} /> },
+    { key: 'notes', label: 'Notes', sub: 'Notes and checklists', icon: <NoteIcon size={22} /> },
+    { key: 'tasks', label: 'Tasks', sub: 'Scheduled and automation tasks', icon: <CheckSquareIcon size={22} /> },
+  ];
+  return (
+    <div className="screen list">
+      <header className="list-header">
+        <h1>Tools</h1>
+      </header>
+      <ul className="rows">
+        {items.map((it) => (
+          <li key={it.key}>
+            <button className="row" onClick={() => onOpen(it.key)} type="button">
+              <span className="fs-icon">{it.icon}</span>
+              <span className="row-main">
+                <span className="row-title">{it.label}</span>
+                <span className="row-sub">
+                  <span>{it.sub}</span>
+                </span>
+              </span>
+              <span className="chev">
+                <ChevronRightIcon size={20} />
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -737,6 +737,56 @@ button {
   border-top: 1px solid var(--border);
   padding-top: 14px;
 }
+/* Rendered HTML email body. Constrain it to the screen and tame email markup so
+   it reads on a phone instead of dumping desktop-width tables/inline styles. */
+.email-html {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+  font-size: 14px;
+  line-height: 1.55;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.email-html img {
+  max-width: 100%;
+  height: auto;
+}
+.email-html table {
+  max-width: 100%;
+}
+.email-html a {
+  color: var(--accent);
+  word-break: break-word;
+}
+.email-html * {
+  max-width: 100%;
+  white-space: normal !important;
+}
+.email-ai-bar {
+  display: flex;
+  gap: 8px;
+  margin: 14px 0 4px;
+}
+.email-summary {
+  margin: 10px 0 4px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: rgba(0, 170, 255, 0.08);
+}
+.email-summary-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.email-summary p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
 .email-reply {
   display: inline-flex;
   align-items: center;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -694,6 +694,149 @@ button {
   opacity: 0.45;
 }
 
+/* --- Tools: email / calendar / notes / tasks --- */
+.email-row .row-main {
+  gap: 2px;
+}
+.email-subj {
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.email-when {
+  font-size: 11px;
+  color: var(--muted);
+  flex: none;
+  align-self: flex-start;
+}
+.email-subject {
+  font-size: 18px;
+  margin: 0 0 6px;
+}
+.email-from {
+  color: var(--fg);
+  font-size: 14px;
+}
+.email-date {
+  color: var(--muted);
+  font-size: 12px;
+  margin-bottom: 14px;
+}
+.email-body {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+.email-reply {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+}
+.note-input {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 16px;
+}
+.note-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.note-card,
+.task-card {
+  margin: 8px 4px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+}
+.note-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.note-body {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.note-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1.6;
+}
+.note-items li.done {
+  color: var(--muted);
+  text-decoration: line-through;
+}
+.task-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.task-name {
+  flex: 1;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-status {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.task-meta {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 6px 0 10px;
+}
+.task-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* Agenda (calendar) */
+.agenda-day {
+  margin: 6px 0 14px;
+}
+.agenda-date {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.agenda-event {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 8px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+.agenda-time {
+  font-size: 12px;
+  color: var(--muted);
+}
+.agenda-title {
+  font-size: 14px;
+}
+.agenda-loc {
+  grid-column: 2;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 /* --- Bottom nav --- */
 .bottom-nav {
   display: flex;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -25,6 +25,8 @@ body,
 #root {
   height: 100%;
   margin: 0;
+  /* Never let a stray wide child scroll the whole page sideways. */
+  overflow-x: hidden;
 }
 
 body {
@@ -52,6 +54,9 @@ body {
 
 .screen {
   flex: 1;
+  /* min-width:0 so a wide child (e.g. a long session/model name) can't push
+     this flex item past the viewport and get clipped off the right edge. */
+  min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -238,8 +243,12 @@ button {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
   font-size: 12px;
   color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .row-sub .sep {
   width: 3px;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -703,6 +703,51 @@ button {
   opacity: 0.45;
 }
 
+/* --- Search --- */
+.search-field {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 8px 12px;
+  color: var(--muted);
+}
+.search-field input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 15px;
+}
+.search-field input:focus {
+  outline: none;
+}
+.search-hit {
+  align-items: flex-start;
+}
+.search-snippet {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.search-role {
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  margin-right: 6px;
+}
+
 /* --- Tools: email / calendar / notes / tasks --- */
 .email-row .row-main {
   gap: 2px;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -452,6 +452,23 @@ button {
 .composer .stop {
   flex: none;
 }
+/* Voice dictation mic: pulses red while recording, dims while transcribing. */
+.voice-recording {
+  color: var(--red);
+  animation: voice-pulse 1.1s ease-in-out infinite;
+}
+.voice-working {
+  opacity: 0.5;
+}
+@keyframes voice-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
 .stream-text {
   white-space: pre-wrap;
   word-break: break-word;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -288,12 +288,85 @@ button {
 .stop:disabled {
   opacity: 0.45;
 }
+/* In-chat model picker, sized to fill the header between back and status. */
+.model-select {
+  flex: 1;
+  min-width: 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 13px;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.model-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.model-select:disabled {
+  opacity: 0.7;
+}
+/* Compact run-state indicator (replaces the wordy pill now the header holds
+   the model picker). */
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--border);
+  flex: none;
+}
+.status-dot.live,
+.status-dot.connecting {
+  background: var(--green);
+  box-shadow: 0 0 0 4px rgba(80, 250, 123, 0.18);
+}
+.status-dot.error {
+  background: var(--red);
+}
+
 .detail-body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding: 16px;
+}
+
+/* Composer pinned at the bottom of the conversation. */
+.composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 12px calc(10px + var(--safe-bottom));
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+.composer-input {
+  flex: 1;
+  min-width: 0;
+  max-height: 140px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 16px;
+  line-height: 1.4;
+  resize: none;
+}
+.composer-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.composer-input:disabled {
+  opacity: 0.6;
+}
+.composer .stop {
+  flex: none;
 }
 .stream-text {
   white-space: pre-wrap;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -483,6 +483,80 @@ button {
   border-radius: 10px;
   padding: 10px 12px;
 }
+.msg-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.msg-images img {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+/* --- Attachments (picker, thumbnails) --- */
+.attach {
+  flex: none;
+  align-self: flex-end;
+  padding-bottom: 10px;
+}
+.compose-attach {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.compose-attach .toggles {
+  padding: 0;
+}
+.attach-previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 12px 0;
+}
+.thumb {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  overflow: hidden;
+}
+.thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.thumb-file {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 4px;
+  font-size: 10px;
+  color: var(--muted);
+  word-break: break-word;
+  text-align: center;
+}
+.thumb-x {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+}
 
 /* --- Compose (new chat) --- */
 .compose-body {

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -530,6 +530,22 @@ button {
   height: 100%;
   object-fit: cover;
 }
+.att-loading {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--panel), var(--border), var(--panel));
+  background-size: 200% 100%;
+  animation: att-shimmer 1.1s ease-in-out infinite;
+}
+@keyframes att-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
 .thumb-file {
   display: flex;
   flex-direction: column;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -137,6 +137,53 @@ button {
   color: var(--muted);
   line-height: 1.5;
 }
+.primary.scan {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.or-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 18px 0 2px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.or-divider::before,
+.or-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* --- QR scanner --- */
+.qr-viewport {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: #000;
+  overflow: hidden;
+}
+.qr-viewport video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.qr-frame {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 62vw;
+  max-width: 280px;
+  aspect-ratio: 1;
+  transform: translate(-50%, -50%);
+  border: 2px solid var(--accent);
+  border-radius: 16px;
+  box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.45);
+}
 .hint code {
   background: var(--panel);
   padding: 1px 5px;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -1,0 +1,381 @@
+/* Tokens mirror the web app's dark theme (static/style.css) so the companion
+   looks like part of Odysseus, not a separate app. */
+:root {
+  --bg: #282c34;
+  --fg: #9cdef2;
+  --panel: #111;
+  --border: #355a66;
+  --red: #e06c75;
+  --green: #50fa7b;
+  --warn: #f0ad4e;
+  --accent: #00aaff;
+  --muted: #888;
+  --nav-h: 64px;
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-top: env(safe-area-inset-top, 0px);
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  /* Fira Code is the web app's primary UI font; fall back to the platform
+     monospace until the font is bundled into the native build. */
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 15px;
+  overscroll-behavior: none;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.app-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+}
+
+.screen {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding-top: var(--safe-top);
+}
+
+.center {
+  align-items: center;
+  justify-content: center;
+}
+
+.muted {
+  color: var(--muted);
+}
+.pad {
+  padding: 24px;
+}
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+}
+.error {
+  margin: 12px 20px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(224, 108, 117, 0.14);
+  color: var(--red);
+  font-size: 14px;
+}
+
+/* --- Pairing --- */
+.pair {
+  padding: calc(var(--safe-top) + 56px) 24px 24px;
+  gap: 6px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 26px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 18px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.field input {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  color: var(--fg);
+  font-size: 16px;
+}
+.field input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+button {
+  font-family: inherit;
+}
+.primary {
+  margin-top: 22px;
+  background: var(--accent);
+  color: var(--panel);
+  border: none;
+  border-radius: 12px;
+  padding: 15px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.primary:disabled {
+  opacity: 0.6;
+}
+.hint {
+  margin-top: 18px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.hint code {
+  background: var(--panel);
+  padding: 1px 5px;
+  border-radius: 5px;
+}
+
+/* --- List screens --- */
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 10px;
+}
+.list-header h1 {
+  font-size: 22px;
+  margin: 0;
+}
+.rows {
+  list-style: none;
+  margin: 0;
+  padding: 0 12px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+  margin: 8px 0;
+  color: var(--fg);
+  text-align: left;
+}
+.row-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.row-title {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.row-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.row-sub .sep {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--muted);
+  flex: none;
+}
+.chev {
+  display: inline-flex;
+  color: var(--muted);
+}
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--border);
+  flex: none;
+}
+.dot.live {
+  background: var(--green);
+  box-shadow: 0 0 0 4px rgba(80, 250, 123, 0.18);
+}
+
+.card {
+  margin: 8px 16px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 6px 16px;
+}
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+.card-row:last-child {
+  border-bottom: none;
+}
+.danger {
+  margin: 18px 16px;
+  background: transparent;
+  color: var(--red);
+  border: 1px solid rgba(224, 108, 117, 0.4);
+  border-radius: 12px;
+  padding: 14px;
+  font-size: 15px;
+}
+.ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  padding: 6px 10px;
+}
+
+/* --- Session detail / stream --- */
+.detail {
+  height: 100%;
+}
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.status-pill {
+  flex: 1;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+.status-pill.live {
+  color: var(--green);
+}
+.status-pill.error {
+  color: var(--red);
+}
+.stop {
+  background: var(--red);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+}
+.stop:disabled {
+  opacity: 0.45;
+}
+.detail-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 16px;
+}
+.stream-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 0;
+}
+.tool-line {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--accent);
+}
+
+/* Reasoning / chain-of-thought, shown dimmed and collapsible like the desktop. */
+.think {
+  margin-bottom: 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(53, 90, 102, 0.12);
+}
+.think-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  padding: 10px 12px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.think-caret {
+  display: inline-block;
+  transition: transform 0.12s ease;
+  font-weight: 700;
+}
+.think-caret.open {
+  transform: rotate(90deg);
+}
+.think-live {
+  letter-spacing: 0;
+  color: var(--accent);
+}
+.think-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  padding: 0 12px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+/* --- Bottom nav --- */
+.bottom-nav {
+  display: flex;
+  height: calc(var(--nav-h) + var(--safe-bottom));
+  padding-bottom: var(--safe-bottom);
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+.nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+}
+.nav-item.active {
+  color: var(--accent);
+}
+.nav-icon {
+  display: inline-flex;
+}
+.nav-label {
+  font-size: 11px;
+}

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -351,6 +351,85 @@ button {
   color: var(--muted);
 }
 
+/* --- Conversation bubbles --- */
+.header-actions {
+  display: flex;
+  gap: 2px;
+}
+.msg {
+  margin-bottom: 16px;
+}
+.msg-role {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 5px;
+}
+.msg-assistant .msg-role {
+  color: var(--accent);
+}
+.msg-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+}
+.msg-user .msg-text {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+/* --- Compose (new chat) --- */
+.compose-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+.compose .field {
+  margin-top: 0;
+}
+.field.grow {
+  flex: 1;
+  min-height: 0;
+}
+.field select,
+.field textarea {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  color: var(--fg);
+  font-size: 16px;
+  font-family: inherit;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.field textarea {
+  flex: 1;
+  min-height: 120px;
+  resize: none;
+  line-height: 1.5;
+}
+.field select:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.stop.send {
+  background: var(--accent);
+  color: var(--panel);
+}
+.stop.send:disabled {
+  opacity: 0.45;
+}
+
 /* --- Bottom nav --- */
 .bottom-nav {
   display: flex;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -335,6 +335,34 @@ button {
   padding: 16px;
 }
 
+/* Capability chips (Agent / Web / Terminal), shared by the composer and the
+   new-chat screen. Highlight in the accent colour when active. */
+.toggles {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px 0;
+  flex-wrap: wrap;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 7px 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.chip.active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(0, 170, 255, 0.12);
+}
+.chip:disabled {
+  opacity: 0.5;
+}
+
 /* Composer pinned at the bottom of the conversation. */
 .composer {
   display: flex;

--- a/companion/mobile/src/styles.css
+++ b/companion/mobile/src/styles.css
@@ -532,15 +532,41 @@ button {
 }
 .thumb-file {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 4px;
   width: 100%;
   height: 100%;
   padding: 4px;
-  font-size: 10px;
+  font-size: 9px;
   color: var(--muted);
-  word-break: break-word;
   text-align: center;
+}
+.thumb-name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* --- PC file browser --- */
+.fs-path {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fs-rows {
+  flex: 1;
+}
+.fs-icon {
+  display: inline-flex;
+  color: var(--muted);
+  flex: none;
 }
 .thumb-x {
   position: absolute;

--- a/companion/mobile/src/vite-env.d.ts
+++ b/companion/mobile/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/companion/mobile/tsconfig.json
+++ b/companion/mobile/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/companion/mobile/tsconfig.node.json
+++ b/companion/mobile/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/companion/mobile/vite.config.ts
+++ b/companion/mobile/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// In the browser during `npm run dev`, requests to a different host (your PC's
+// LAN IP) are blocked by CORS unless the server allows your dev origin. To avoid
+// touching the server config, set VITE_PROXY_TARGET to your Odysseus URL and the
+// app will call relative `/api/...` paths that Vite proxies for you.
+//   VITE_PROXY_TARGET=http://192.168.1.50:7000 npm run dev
+// In the packaged Capacitor app there is no dev server, so the app talks to the
+// paired base URL directly (see src/lib/connection.ts).
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const target = env.VITE_PROXY_TARGET;
+  return {
+    plugins: [react()],
+    server: target
+      ? { proxy: { '/api': { target, changeOrigin: true } } }
+      : {},
+  };
+});

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -18,7 +18,7 @@ on a GET would be unsafe (Lax cookies ride top-level GET navigations), so GET
 
 import html
 
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, File, HTTPException, Request, Response, UploadFile
 from fastapi.responses import HTMLResponse, StreamingResponse
 
 from core.middleware import require_admin
@@ -38,6 +38,15 @@ def token_owner(request: Request) -> str | None:
     if getattr(request.state, "api_token", False):
         return getattr(request.state, "api_token_owner", None)
     return get_current_user(request)
+
+
+def _require_owner(request: Request) -> str:
+    """Resolve the token's real owner or 401. Shared by the tool-proxy endpoints
+    (email/calendar/notes/tasks)."""
+    owner = token_owner(request)
+    if not owner:
+        raise HTTPException(401, "Could not resolve an owner for this token")
+    return owner
 
 
 def owner_can_see(row_owner, owner) -> bool:
@@ -156,6 +165,38 @@ async def _fire_chat_run(
         raise
     except Exception as e:
         raise HTTPException(502, f"could not start the run: {e}")
+
+
+async def _proxy_internal(request: Request, owner: str, method: str, path: str,
+                          *, params=None, json_body=None) -> Response:
+    """Call an existing in-app route AS `owner` and pass its response straight
+    back to the phone.
+
+    Loopback to 127.0.0.1 with the internal-tool header + X-Odysseus-Owner --
+    the SAME owner-impersonation the agent tool layer uses (app.py AuthMiddleware
+    maps it to request.state.current_user "for notes/calendar/etc."). This lets
+    the companion reuse the desktop's owner-scoped email/calendar/notes/tasks
+    routes without re-implementing them or widening the chat-scoped bearer
+    token. The phone never gets a generic proxy: each companion endpoint pins a
+    fixed internal path, so only the intended actions are reachable.
+    """
+    import httpx
+
+    from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN
+
+    port = request.url.port or _pairing.default_port()
+    url = f"http://127.0.0.1:{port}{path}"
+    headers = {INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN, "X-Odysseus-Owner": owner}
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(45.0)) as client:
+            resp = await client.request(method, url, params=params, json=json_body, headers=headers)
+    except Exception as e:
+        raise HTTPException(502, f"internal request failed: {e}")
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type", "application/json"),
+    )
 
 
 def _resolve_endpoint_url(owner, endpoint_id: str):
@@ -717,6 +758,112 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
 
         _verify_session_owner(request, session_id, _resolve_session_manager(session_manager))
         return {"stopped": agent_runs.stop(session_id)}
+
+    # ---------------------------------------------------------------- #
+    # Tools: thin owner-impersonating proxies over the desktop's existing
+    # owner-scoped routes (see _proxy_internal). Each pins a fixed path.
+    # ---------------------------------------------------------------- #
+    @router.get("/email/accounts")
+    async def email_accounts(request: Request):
+        return await _proxy_internal(request, _require_owner(request), "GET", "/api/email/accounts")
+
+    @router.get("/email/list")
+    async def email_list(
+        request: Request,
+        folder: str = "INBOX",
+        limit: int = 50,
+        offset: int = 0,
+        filter: str = "all",
+        account_id: str | None = None,
+    ):
+        params = {"folder": folder, "limit": limit, "offset": offset, "filter": filter}
+        if account_id:
+            params["account_id"] = account_id
+        return await _proxy_internal(request, _require_owner(request), "GET", "/api/email/list", params=params)
+
+    @router.get("/email/read/{uid}")
+    async def email_read(request: Request, uid: str, folder: str = "INBOX", account_id: str | None = None):
+        params = {"folder": folder}
+        if account_id:
+            params["account_id"] = account_id
+        return await _proxy_internal(
+            request, _require_owner(request), "GET", f"/api/email/read/{uid}", params=params
+        )
+
+    @router.post("/email/{uid}/flag")
+    async def email_flag(request: Request, uid: str, action: str, folder: str = "INBOX", account_id: str | None = None):
+        """Mark read/unread or archive. `action` is mark-read|mark-unread|archive."""
+        if action not in ("mark-read", "mark-unread", "archive"):
+            raise HTTPException(400, "unknown action")
+        params = {"folder": folder}
+        if account_id:
+            params["account_id"] = account_id
+        return await _proxy_internal(
+            request, _require_owner(request), "POST", f"/api/email/{action}/{uid}", params=params
+        )
+
+    @router.post("/email/send")
+    async def email_send(request: Request):
+        owner = _require_owner(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_internal(request, owner, "POST", "/api/email/send", json_body=body)
+
+    @router.post("/email/ai-reply")
+    async def email_ai_reply(request: Request):
+        owner = _require_owner(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_internal(request, owner, "POST", "/api/email/ai-reply", json_body=body)
+
+    @router.get("/calendar/calendars")
+    async def calendar_calendars(request: Request):
+        return await _proxy_internal(request, _require_owner(request), "GET", "/api/calendar/calendars")
+
+    @router.get("/calendar/events")
+    async def calendar_events(request: Request, start: str, end: str, calendar: str = ""):
+        params = {"start": start, "end": end}
+        if calendar:
+            params["calendar"] = calendar
+        return await _proxy_internal(request, _require_owner(request), "GET", "/api/calendar/events", params=params)
+
+    @router.get("/notes")
+    async def notes_list(request: Request, archived: bool | None = None, label: str | None = None):
+        params = {}
+        if archived is not None:
+            params["archived"] = str(archived).lower()
+        if label:
+            params["label"] = label
+        return await _proxy_internal(request, _require_owner(request), "GET", "/api/notes", params=params)
+
+    @router.post("/notes")
+    async def notes_create(request: Request):
+        owner = _require_owner(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_internal(request, owner, "POST", "/api/notes", json_body=body)
+
+    @router.get("/tasks")
+    async def tasks_list(request: Request, status: str | None = None):
+        params = {}
+        if status:
+            params["status"] = status
+        return await _proxy_internal(request, _require_owner(request), "GET", "/api/tasks", params=params)
+
+    @router.post("/tasks/{task_id}/{action}")
+    async def tasks_action(request: Request, task_id: str, action: str):
+        """Pause, resume, or run a scheduled task."""
+        if action not in ("pause", "resume", "run"):
+            raise HTTPException(400, "unknown action")
+        return await _proxy_internal(
+            request, _require_owner(request), "POST", f"/api/tasks/{task_id}/{action}"
+        )
 
     @router.get("/pair")
     def pair_page(request: Request):

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -106,16 +106,22 @@ def _chat_run_options(body: dict) -> dict:
         live tool in agent mode (allow_web_search);
       - terminal (bash) is an agent-only tool, so enabling it implies agent mode.
     Anything omitted/false leaves the run as a plain chat, same as before."""
-    agent = bool(body.get("agent"))
-    web = bool(body.get("web"))
-    terminal = bool(body.get("terminal"))
-    if terminal:
-        agent = True
-    extra = {"mode": "agent" if agent else "chat"}
-    if web:
-        extra["allow_web_search" if agent else "use_web"] = "true"
-    if terminal:
-        extra["allow_bash"] = "true"
+    # Deep research is a self-contained mode: it forces chat mode and runs the
+    # research pipeline (which does its own searching), so it overrides the agent
+    # tool flags. Mirrors the desktop's research-toggle (static/js/chat.js).
+    if bool(body.get("research")):
+        extra = {"mode": "chat", "use_research": "true"}
+    else:
+        agent = bool(body.get("agent"))
+        web = bool(body.get("web"))
+        terminal = bool(body.get("terminal"))
+        if terminal:
+            agent = True
+        extra = {"mode": "agent" if agent else "chat"}
+        if web:
+            extra["allow_web_search" if agent else "use_web"] = "true"
+        if terminal:
+            extra["allow_bash"] = "true"
     # Attachment ids from POST /api/companion/upload; chat_stream parses this as
     # a JSON list and resolves each id owner-scoped.
     atts = body.get("attachments")

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -778,6 +778,33 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
             request, owner, "GET", "/api/search", params={"q": q, "limit": limit}
         )
 
+    @router.post("/stt/transcribe")
+    async def stt_transcribe(request: Request, file: UploadFile = File(...)):
+        """Transcribe a voice recording to text (phone dictation). Stateless --
+        no owner data -- so it just loopbacks the audio to the desktop's STT
+        service via the internal-tool header. Returns the server's {text} (or its
+        503 when STT is in browser mode / not configured)."""
+        import httpx
+
+        from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN
+
+        _require_owner(request)
+        audio = await file.read()
+        port = request.url.port or _pairing.default_port()
+        url = f"http://127.0.0.1:{port}/api/stt/transcribe"
+        headers = {INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN}
+        files = {"file": (file.filename or "audio.webm", audio, file.content_type or "audio/webm")}
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+                resp = await client.post(url, files=files, headers=headers)
+        except Exception as e:
+            raise HTTPException(502, f"transcription request failed: {e}")
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=resp.headers.get("content-type", "application/json"),
+        )
+
     # ---------------------------------------------------------------- #
     # Tools: thin owner-impersonating proxies over the desktop's existing
     # owner-scoped routes (see _proxy_internal). Each pins a fixed path.

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -967,6 +967,34 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
         qr_ok = bool(qr and qr.startswith("data:image/png;base64,"))
 
         if (request.query_params.get("format") or "").lower() == "json":
+            import ipaddress
+
+            def _host_kind(ip: str) -> str:
+                """local = private LAN; tailscale = the 100.64.0.0/10 tailnet
+                range (reachable from anywhere); other = anything else."""
+                try:
+                    addr = ipaddress.ip_address(ip)
+                except ValueError:
+                    return "other"
+                if addr in ipaddress.ip_network("100.64.0.0/10"):
+                    return "tailscale"
+                if addr.is_private:
+                    return "local"
+                return "other"
+
+            # One QR per candidate address (all carry the SAME minted token), so
+            # the desktop can offer "this network" vs "anywhere (tunnel)".
+            options = []
+            for h in hosts:
+                pl = _pairing.pairing_payload(h, port, raw_token)
+                q = _pairing.pairing_qr_png_data_uri(pl)
+                options.append({
+                    "kind": _host_kind(h),
+                    "host": h,
+                    "port": port,
+                    "payload": pl,
+                    "qr": q if (q and q.startswith("data:image/png;base64,")) else None,
+                })
             return {
                 "host": host,
                 "port": port,
@@ -975,6 +1003,7 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
                 "hosts": hosts,
                 "payload": payload,
                 "qr": qr if qr_ok else None,
+                "options": options,
             }
 
         import json as _json

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -820,6 +820,15 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
             body = {}
         return await _proxy_internal(request, owner, "POST", "/api/email/ai-reply", json_body=body)
 
+    @router.post("/email/summarize")
+    async def email_summarize(request: Request):
+        owner = _require_owner(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_internal(request, owner, "POST", "/api/email/summarize", json_body=body)
+
     @router.get("/calendar/calendars")
     async def calendar_calendars(request: Request):
         return await _proxy_internal(request, _require_owner(request), "GET", "/api/calendar/calendars")

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -759,6 +759,19 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
         _verify_session_owner(request, session_id, _resolve_session_manager(session_manager))
         return {"stopped": agent_runs.stop(session_id)}
 
+    @router.get("/search")
+    async def search_chats(request: Request, q: str = "", limit: int = 25):
+        """Search the owner's chat history (subject to owner impersonation, so it
+        scopes to the real owner, not the sandbox "api" user). Proxies the
+        desktop's GET /api/search; returns [{session_id, session_name, role,
+        content_snippet, timestamp}]."""
+        owner = _require_owner(request)
+        if not q.strip():
+            return []
+        return await _proxy_internal(
+            request, owner, "GET", "/api/search", params={"q": q, "limit": limit}
+        )
+
     # ---------------------------------------------------------------- #
     # Tools: thin owner-impersonating proxies over the desktop's existing
     # owner-scoped routes (see _proxy_internal). Each pins a fixed path.

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -223,6 +223,111 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         out.sort(key=lambda s: not s["active"])
         return {"sessions": out}
 
+    @router.post("/sessions")
+    async def start_session(request: Request):
+        """Start a NEW chat from the phone and return its session id.
+
+        Creates an owner-scoped session, then kicks off the SAME detached run the
+        desktop uses by making an internal loopback POST to /api/chat_stream. That
+        handler calls agent_runs.start BEFORE it streams, so by the time we get
+        response headers the run is registered and self-draining -- we close the
+        loopback immediately (closing an SSE never stops a detached run) and the
+        phone watches via /sessions/{id}/stream. We reuse the real chat pipeline
+        (models, tools, reasoning, message saving) rather than duplicate it; no
+        new LLM logic lives here.
+
+        Body (JSON): {message, endpoint_id, model}. endpoint_id/model come from
+        /api/companion/models. Owner-scoped: the session is owned by the token's
+        real owner, so it shows in the caller's list and passes ownership checks.
+        """
+        import uuid as _uuid
+
+        import httpx
+
+        owner = token_owner(request)
+        if not owner:
+            raise HTTPException(401, "Could not resolve an owner for this token")
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        message = (body.get("message") or "").strip()
+        model = (body.get("model") or "").strip()
+        endpoint_id = (body.get("endpoint_id") or "").strip()
+        if not message:
+            raise HTTPException(400, "message is required")
+        if not endpoint_id or not model:
+            raise HTTPException(400, "endpoint_id and model are required")
+
+        # Resolve the endpoint to a chat URL, owner-scoped (own or shared rows).
+        from core.database import SessionLocal, ModelEndpoint
+        from src.endpoint_resolver import build_chat_url, normalize_base
+        db = SessionLocal()
+        try:
+            ep = db.query(ModelEndpoint).filter(
+                ModelEndpoint.id == endpoint_id,
+                ModelEndpoint.is_enabled == True,  # noqa: E712
+            ).first()
+            if ep is None or not owner_can_see(ep.owner, owner):
+                raise HTTPException(404, "Model endpoint not found")
+            endpoint_url = build_chat_url(normalize_base(ep.base_url))
+        finally:
+            db.close()
+
+        # Create the (empty) session first; chat_stream adds the user message.
+        sm = _resolve_session_manager(session_manager)
+        sid = str(_uuid.uuid4())
+        name = (message[:40] or "New chat").strip()
+        sm.create_session(sid, name, endpoint_url, model, owner=owner)
+
+        # Internal-tool loopback: trusted because it originates from 127.0.0.1
+        # with no proxy headers; X-Odysseus-Owner attributes the run to the owner.
+        from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN
+        port = request.url.port or _pairing.default_port()
+        url = f"http://127.0.0.1:{port}/api/chat_stream"
+        headers = {INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN, "X-Odysseus-Owner": owner}
+        data = {"message": message, "session": sid}
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+                # Opening the stream sends the request and waits for headers; that
+                # is enough to guarantee the run started. We never read the body.
+                async with client.stream("POST", url, data=data, headers=headers) as resp:
+                    if resp.status_code >= 400:
+                        raise HTTPException(502, f"chat_stream returned {resp.status_code}")
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(502, f"could not start the run: {e}")
+
+        return {"session_id": sid, "name": name}
+
+    @router.get("/sessions/{session_id}/messages")
+    def session_messages(request: Request, session_id: str):
+        """Saved conversation for one session, so the phone can open ANY session
+        -- not only one with a live run. Owner-checked. Returns user/assistant
+        turns; reasoning is already stripped from saved messages (same as the
+        desktop), so this is the finished answer text."""
+        from routes.session_routes import _verify_session_owner, _content_to_text
+
+        sm = _resolve_session_manager(session_manager)
+        _verify_session_owner(request, session_id, sm)
+        try:
+            sess = sm.get_session(session_id)
+        except KeyError:
+            raise HTTPException(404, "Session not found")
+
+        out = []
+        for m in getattr(sess, "history", []) or []:
+            role = getattr(m, "role", None)
+            if role not in ("user", "assistant"):
+                continue
+            content = getattr(m, "content", "")
+            if not isinstance(content, str):
+                content = _content_to_text(content)
+            out.append({"role": role, "content": content})
+        return {"messages": out}
+
     @router.get("/sessions/{session_id}/stream")
     async def stream_session(request: Request, session_id: str):
         """Live SSE for one session -- the phone's "watch what it's doing" view.

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -18,7 +18,7 @@ on a GET would be unsafe (Lax cookies ride top-level GET navigations), so GET
 
 import html
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse, StreamingResponse
 
 from core.middleware import require_admin
@@ -107,7 +107,18 @@ def _chat_run_options(body: dict) -> dict:
         extra["allow_web_search" if agent else "use_web"] = "true"
     if terminal:
         extra["allow_bash"] = "true"
+    # Attachment ids from POST /api/companion/upload; chat_stream parses this as
+    # a JSON list and resolves each id owner-scoped.
+    atts = body.get("attachments")
+    if isinstance(atts, list) and atts:
+        import json as _json
+        extra["attachments"] = _json.dumps([str(a) for a in atts])
     return extra
+
+
+def _has_attachments(body: dict) -> bool:
+    atts = body.get("attachments")
+    return isinstance(atts, list) and len(atts) > 0
 
 
 async def _fire_chat_run(
@@ -208,7 +219,7 @@ def mint_pairing_token(owner: str, invalidate=None) -> tuple[str, str]:
     return token_id, raw_token
 
 
-def setup_companion_routes(session_manager=None) -> APIRouter:
+def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRouter:
     router = APIRouter(prefix="/api/companion", tags=["companion"])
 
     @router.get("/ping")
@@ -287,6 +298,61 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
             db.close()
         return {"endpoints": out}
 
+    @router.post("/upload")
+    async def upload(request: Request, files: list[UploadFile] = File(...)):
+        """Accept files from the phone (camera/gallery) and return attachment ids
+        to hand to a chat send (POST /sessions or /sessions/{id}/message).
+
+        Owner-stamped with the token's REAL owner, not the sandbox "api" user --
+        chat_handler resolves attachment ids with an exact owner match (no admin
+        shortcut on that path), so an upload owned by "api" would be invisible to
+        the owner's session. Mirrors the stock /api/upload route (same handler,
+        same per-IP concurrency guard); we just attribute it to the right owner
+        and scope it under the companion prefix so the phone can reach it with a
+        bearer token. Files are served back via the existing /api/upload/{id}.
+        """
+        import time
+
+        from src.upload_handler import count_recent_uploads
+
+        owner = token_owner(request)
+        if not owner:
+            raise HTTPException(401, "Could not resolve an owner for this token")
+        if upload_handler is None:
+            raise HTTPException(503, "Uploads are not available on this server")
+        if not files:
+            raise HTTPException(400, "No files uploaded")
+
+        client_ip = request.client.host if request.client else "unknown"
+        recent = count_recent_uploads(
+            upload_handler.upload_rate_log.get(client_ip, []), time.time()
+        )
+        if recent >= upload_handler.max_concurrent_uploads:
+            raise HTTPException(
+                429,
+                f"Maximum concurrent uploads ({upload_handler.max_concurrent_uploads}) exceeded",
+            )
+
+        out = []
+        for u in files:
+            try:
+                meta = upload_handler.save_upload(u, client_ip, owner=owner)
+                out.append({
+                    "id": meta["id"],
+                    "name": meta["name"],
+                    "mime": meta["mime"],
+                    "size": meta["size"],
+                    "width": meta.get("width"),
+                    "height": meta.get("height"),
+                })
+            except HTTPException:
+                raise
+            except Exception:
+                continue
+        if not out:
+            raise HTTPException(500, "All file uploads failed")
+        return {"files": out}
+
     @router.get("/sessions")
     def list_sessions(request: Request):
         """The caller's own sessions, annotated with live run state.
@@ -358,7 +424,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         message = (body.get("message") or "").strip()
         model = (body.get("model") or "").strip()
         endpoint_id = (body.get("endpoint_id") or "").strip()
-        if not message:
+        if not message and not _has_attachments(body):
             raise HTTPException(400, "message is required")
         if not endpoint_id or not model:
             raise HTTPException(400, "endpoint_id and model are required")
@@ -369,7 +435,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         # Create the (empty) session first; chat_stream adds the user message.
         sm = _resolve_session_manager(session_manager)
         sid = str(_uuid.uuid4())
-        name = (message[:40] or "New chat").strip()
+        name = (message[:40] or "Photo").strip()
         sm.create_session(sid, name, endpoint_url, model, owner=owner)
 
         await _fire_chat_run(request, owner, sid, message, _chat_run_options(body))
@@ -436,7 +502,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         except Exception:
             body = {}
         message = (body.get("message") or "").strip()
-        if not message:
+        if not message and not _has_attachments(body):
             raise HTTPException(400, "message is required")
 
         # Optional mid-chat model switch (the in-chat picker). Both must be given.

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -89,7 +89,30 @@ def session_summary(sess, active: bool, status, public_model=None) -> dict:
     }
 
 
-async def _fire_chat_run(request: Request, owner: str, sid: str, message: str) -> None:
+def _chat_run_options(body: dict) -> dict:
+    """Translate the phone's capability toggles into chat_stream form fields,
+    mirroring the desktop's static/js/chat.js:
+      - agent mode is the master switch that gives the model tools;
+      - web search is a pre-search augmentation in chat mode (use_web) and a
+        live tool in agent mode (allow_web_search);
+      - terminal (bash) is an agent-only tool, so enabling it implies agent mode.
+    Anything omitted/false leaves the run as a plain chat, same as before."""
+    agent = bool(body.get("agent"))
+    web = bool(body.get("web"))
+    terminal = bool(body.get("terminal"))
+    if terminal:
+        agent = True
+    extra = {"mode": "agent" if agent else "chat"}
+    if web:
+        extra["allow_web_search" if agent else "use_web"] = "true"
+    if terminal:
+        extra["allow_bash"] = "true"
+    return extra
+
+
+async def _fire_chat_run(
+    request: Request, owner: str, sid: str, message: str, extra: dict | None = None
+) -> None:
     """Kick off the detached chat run for `sid` and return once it's registered.
 
     Internal loopback to /api/chat_stream -- the SAME path the desktop uses, so
@@ -109,6 +132,8 @@ async def _fire_chat_run(request: Request, owner: str, sid: str, message: str) -
     url = f"http://127.0.0.1:{port}/api/chat_stream"
     headers = {INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN, "X-Odysseus-Owner": owner}
     data = {"message": message, "session": sid}
+    if extra:
+        data.update(extra)
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
             # Opening the stream sends the request and waits for headers; that is
@@ -347,7 +372,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         name = (message[:40] or "New chat").strip()
         sm.create_session(sid, name, endpoint_url, model, owner=owner)
 
-        await _fire_chat_run(request, owner, sid, message)
+        await _fire_chat_run(request, owner, sid, message, _chat_run_options(body))
         return {"session_id": sid, "name": name}
 
     @router.get("/sessions/{session_id}/messages")
@@ -423,7 +448,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         if not getattr(sess, "model", "").strip():
             raise HTTPException(400, "This session has no model selected")
 
-        await _fire_chat_run(request, owner, session_id, message)
+        await _fire_chat_run(request, owner, session_id, message, _chat_run_options(body))
         return {"ok": True}
 
     @router.get("/sessions/{session_id}/stream")

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -353,6 +353,57 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
             raise HTTPException(500, "All file uploads failed")
         return {"files": out}
 
+    @router.get("/upload/{file_id}")
+    def download_attachment(request: Request, file_id: str, thumb: int = 0):
+        """Serve an attachment owner-checked for the token's REAL owner.
+
+        The stock /api/upload/{id} resolves the caller via get_current_user,
+        which for a bearer token is the sandbox "api" user -- so the owner check
+        there 404s a phone request. Here we resolve with token_owner and reuse
+        upload_handler.resolve_upload (the same owner-aware lookup the chat path
+        uses). `?thumb=1` returns a small cached JPEG for images so the chat
+        history isn't pulling full-resolution photos to show them tiny.
+        """
+        import os
+
+        from fastapi.responses import FileResponse
+
+        owner = token_owner(request)
+        if not owner:
+            raise HTTPException(401, "Could not resolve an owner for this token")
+        if upload_handler is None:
+            raise HTTPException(503, "Uploads are not available on this server")
+
+        info = upload_handler.resolve_upload(file_id, owner=owner)
+        if not info:
+            raise HTTPException(404, "File not found")
+        path = info["path"]
+        mime = info.get("mime") or "application/octet-stream"
+        headers = {"X-Content-Type-Options": "nosniff"}
+
+        if thumb and mime.startswith("image/"):
+            try:
+                from PIL import Image, ImageOps
+
+                root = os.path.dirname(path)
+                thumb_dir = os.path.join(getattr(upload_handler, "upload_dir", root), ".thumbs")
+                os.makedirs(thumb_dir, exist_ok=True)
+                thumb_path = os.path.join(thumb_dir, file_id + ".jpg")
+                if (not os.path.exists(thumb_path)
+                        or os.path.getmtime(thumb_path) < os.path.getmtime(path)):
+                    im = ImageOps.exif_transpose(Image.open(path))
+                    im.thumbnail((320, 320))
+                    if im.mode not in ("RGB", "L"):
+                        im = im.convert("RGB")
+                    im.save(thumb_path, "JPEG", quality=80)
+                return FileResponse(thumb_path, media_type="image/jpeg", headers=headers)
+            except Exception:
+                pass  # fall back to the full image
+
+        return FileResponse(
+            path, media_type=mime, filename=info.get("name") or file_id, headers=headers
+        )
+
     @router.get("/fs/browse")
     def fs_browse(request: Request, path: str = ""):
         """Browse the PC filesystem so the phone can pick a file to attach.
@@ -571,7 +622,19 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
             content = getattr(m, "content", "")
             if not isinstance(content, str):
                 content = _content_to_text(content)
-            out.append({"role": role, "content": content})
+            row = {"role": role, "content": content}
+            # Surface attachments saved on the user turn so the phone can render
+            # the actual thumbnails (via GET /api/companion/upload/{id}) instead
+            # of the "[Image: name]" text the model sees.
+            meta = getattr(m, "metadata", None) or {}
+            atts = meta.get("attachments")
+            if isinstance(atts, list) and atts:
+                row["attachments"] = [
+                    {"id": a.get("id"), "name": a.get("name") or a.get("id"), "mime": a.get("mime", "")}
+                    for a in atts
+                    if isinstance(a, dict) and a.get("id")
+                ]
+            out.append(row)
         # model/name let the phone default its in-chat model picker and title
         # without a second round-trip to the sessions list.
         return {"messages": out, "model": getattr(sess, "model", "") or "", "name": sess.name}

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -18,8 +18,8 @@ on a GET would be unsafe (Lax cookies ride top-level GET navigations), so GET
 
 import html
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
 
 from core.middleware import require_admin
 from src.auth_helpers import get_current_user
@@ -52,6 +52,43 @@ def owner_can_see(row_owner, owner) -> bool:
     return row_owner is None or row_owner == owner
 
 
+_fallback_session_manager = None
+
+
+def _resolve_session_manager(injected):
+    """Use the app-shared SessionManager when wired in (so the live in-memory
+    sessions match the owner's desktop UI), falling back to a lazily-built one
+    for standalone/test contexts that call setup_companion_routes() with no
+    args. Kept module-level so it can be monkeypatched in tests."""
+    global _fallback_session_manager
+    if injected is not None:
+        return injected
+    if _fallback_session_manager is None:
+        from core.session_manager import SessionManager
+        _fallback_session_manager = SessionManager()
+    return _fallback_session_manager
+
+
+def session_summary(sess, active: bool, status, public_model=None) -> dict:
+    """Shape one session row for a companion client. Pure so it's unit-testable.
+
+    `active`/`status` come from agent_runs (is_active/get_status) so the phone
+    knows which sessions are still generating and can reconnect to the live
+    stream without a probe request. `public_model` lets the caller blank a
+    blind-compare session's real model (issue #1285); defaults to the stored
+    model.
+    """
+    return {
+        "id": sess.id,
+        "name": sess.name,
+        "model": sess.model if public_model is None else public_model,
+        "message_count": getattr(sess, "message_count", 0) or 0,
+        "is_important": bool(getattr(sess, "is_important", False)),
+        "active": bool(active),
+        "status": status,
+    }
+
+
 def mint_pairing_token(owner: str, invalidate=None) -> tuple[str, str]:
     """Mint a pairing token AND invalidate the auth middleware's in-memory token
     cache, so the new token is accepted on the very next request without a server
@@ -66,7 +103,7 @@ def mint_pairing_token(owner: str, invalidate=None) -> tuple[str, str]:
     return token_id, raw_token
 
 
-def setup_companion_routes() -> APIRouter:
+def setup_companion_routes(session_manager=None) -> APIRouter:
     router = APIRouter(prefix="/api/companion", tags=["companion"])
 
     @router.get("/ping")
@@ -144,6 +181,78 @@ def setup_companion_routes() -> APIRouter:
         finally:
             db.close()
         return {"endpoints": out}
+
+    @router.get("/sessions")
+    def list_sessions(request: Request):
+        """The caller's own sessions, annotated with live run state.
+
+        Owner-scoped via token_owner: a paired phone sees exactly the sessions
+        the owner sees on the desktop UI -- never another user's. An unresolved
+        owner (no cookie user, ownerless token) gets an EMPTY list, never the
+        global set -- session_manager.get_sessions_for_user(None) returns ALL
+        sessions, so we must not pass None through.
+
+        Each row carries agent_runs is_active/get_status so the client knows
+        which sessions are still generating and can reconnect to
+        /sessions/{id}/stream without a probe request. Read-only; accepts a
+        cookie session or a chat-scoped bearer token (same as /info, /models).
+        """
+        from src import agent_runs
+        from routes.session_routes import _public_model, _HIDDEN_SYSTEM_SESSION_NAMES
+
+        owner = token_owner(request)
+        if not owner:
+            return {"sessions": []}
+
+        sm = _resolve_session_manager(session_manager)
+        out = []
+        for sess in sm.get_sessions_for_user(owner).values():
+            if getattr(sess, "archived", False):
+                continue
+            name = (sess.name or "").strip()
+            if name in ("Nobody", "Incognito") or name in _HIDDEN_SYSTEM_SESSION_NAMES:
+                continue
+            out.append(session_summary(
+                sess,
+                agent_runs.is_active(sess.id),
+                agent_runs.get_status(sess.id),
+                public_model=_public_model(sess.name, sess.model),
+            ))
+        # Live runs first so the phone surfaces in-flight work at the top; the
+        # client is free to re-sort.
+        out.sort(key=lambda s: not s["active"])
+        return {"sessions": out}
+
+    @router.get("/sessions/{session_id}/stream")
+    async def stream_session(request: Request, session_id: str):
+        """Live SSE for one session -- the phone's "watch what it's doing" view.
+
+        Thin wrapper over the SAME detached-run machinery the desktop UI uses
+        (agent_runs.subscribe replays the buffer so far, then streams live), so
+        a phone that connects mid-run picks up where it is, and disconnecting
+        does NOT stop the run. Owner-checked via _verify_session_owner (which
+        resolves the bearer token's real owner), so a paired phone can only
+        watch its own sessions. 404 if no run is active for this session.
+        """
+        from src import agent_runs
+        from routes.session_routes import _verify_session_owner
+
+        _verify_session_owner(request, session_id, _resolve_session_manager(session_manager))
+        if not agent_runs.is_active(session_id):
+            raise HTTPException(404, "No active run for this session")
+        return StreamingResponse(agent_runs.subscribe(session_id), media_type="text/event-stream")
+
+    @router.post("/sessions/{session_id}/stop")
+    async def stop_session(request: Request, session_id: str):
+        """The phone's Stop/interrupt button. Cancels the detached run server-
+        side (closing the SSE alone does not, by design). Owner-checked the same
+        way as the stream. Returns {stopped: bool} -- false if nothing was
+        running, which the client can treat as already-stopped."""
+        from src import agent_runs
+        from routes.session_routes import _verify_session_owner
+
+        _verify_session_owner(request, session_id, _resolve_session_manager(session_manager))
+        return {"stopped": agent_runs.stop(session_id)}
 
     @router.get("/pair")
     def pair_page(request: Request):

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -353,6 +353,113 @@ def setup_companion_routes(session_manager=None, upload_handler=None) -> APIRout
             raise HTTPException(500, "All file uploads failed")
         return {"files": out}
 
+    @router.get("/fs/browse")
+    def fs_browse(request: Request, path: str = ""):
+        """Browse the PC filesystem so the phone can pick a file to attach.
+
+        ADMIN-ONLY, the same gate as /api/workspace/browse: enumerating the host
+        filesystem is sensitive, so a non-admin (or an ownerless token) is
+        refused. Unlike workspace browse this lists files too, not just dirs.
+        Hidden entries and symlinked dirs are skipped; paths are canonicalised so
+        the client navigates real directories.
+        """
+        import os
+
+        from src.tool_security import owner_is_admin_or_single_user
+
+        owner = token_owner(request)
+        if not owner_is_admin_or_single_user(owner):
+            raise HTTPException(403, "File browsing is admin-only")
+
+        target = os.path.realpath(os.path.expanduser(path.strip() or "~"))
+        if not os.path.isdir(target):
+            target = os.path.realpath(os.path.expanduser("~"))
+
+        dirs, files = [], []
+        try:
+            with os.scandir(target) as it:
+                for entry in it:
+                    try:
+                        if entry.name.startswith("."):
+                            continue
+                        child = os.path.join(target, entry.name)
+                        if entry.is_dir(follow_symlinks=False):
+                            dirs.append({"name": entry.name, "path": child})
+                        elif entry.is_file(follow_symlinks=False):
+                            try:
+                                size = entry.stat(follow_symlinks=False).st_size
+                            except OSError:
+                                size = 0
+                            files.append({"name": entry.name, "path": child, "size": size})
+                    except OSError:
+                        continue
+        except (PermissionError, OSError):
+            pass
+
+        parent = os.path.dirname(target)
+        return {
+            "path": target,
+            "parent": parent if parent and parent != target else None,
+            "dirs": sorted(dirs, key=lambda d: d["name"].lower()),
+            "files": sorted(files, key=lambda f: f["name"].lower()),
+        }
+
+    @router.post("/fs/attach")
+    async def fs_attach(request: Request):
+        """Copy a PC file (picked via /fs/browse) into a normal attachment so it
+        flows through the SAME owner-checked pipeline as a phone upload. Returns
+        the attachment id for a chat send. ADMIN-ONLY, owner-stamped.
+
+        Reuses upload_handler.save_upload (size/type validation, dedup,
+        thumbnails) by wrapping the local file in a minimal UploadFile-like shim
+        -- save_upload only reads .file and .filename.
+        """
+        import os
+
+        from src.tool_security import owner_is_admin_or_single_user
+
+        owner = token_owner(request)
+        if not owner:
+            raise HTTPException(401, "Could not resolve an owner for this token")
+        if not owner_is_admin_or_single_user(owner):
+            raise HTTPException(403, "File access is admin-only")
+        if upload_handler is None:
+            raise HTTPException(503, "Uploads are not available on this server")
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        raw = (body.get("path") or "").strip()
+        if not raw:
+            raise HTTPException(400, "path is required")
+        path = os.path.realpath(os.path.expanduser(raw))
+        if not os.path.isfile(path):
+            raise HTTPException(404, "File not found")
+
+        class _LocalUpload:
+            def __init__(self, p):
+                self.filename = os.path.basename(p)
+                self.file = open(p, "rb")
+
+        client_ip = request.client.host if request.client else "unknown"
+        up = _LocalUpload(path)
+        try:
+            meta = upload_handler.save_upload(up, client_ip, owner=owner)
+        finally:
+            try:
+                up.file.close()
+            except Exception:
+                pass
+        return {
+            "id": meta["id"],
+            "name": meta["name"],
+            "mime": meta["mime"],
+            "size": meta["size"],
+            "width": meta.get("width"),
+            "height": meta.get("height"),
+        }
+
     @router.get("/sessions")
     def list_sessions(request: Request):
         """The caller's own sessions, annotated with live run state.

--- a/companion/routes.py
+++ b/companion/routes.py
@@ -89,6 +89,86 @@ def session_summary(sess, active: bool, status, public_model=None) -> dict:
     }
 
 
+async def _fire_chat_run(request: Request, owner: str, sid: str, message: str) -> None:
+    """Kick off the detached chat run for `sid` and return once it's registered.
+
+    Internal loopback to /api/chat_stream -- the SAME path the desktop uses, so
+    the run reuses the real pipeline (models, tools, reasoning, message saving)
+    and is owned by `owner` (stamped via X-Odysseus-Owner). chat_stream calls
+    agent_runs.start before it streams, so by the time response headers arrive
+    the run is detached and self-draining; we close the loopback immediately
+    (closing an SSE never stops a detached run) and the phone watches via
+    /sessions/{id}/stream. Shared by start_session (new chat) and send_message
+    (follow-up turn) so both go through identical machinery.
+    """
+    import httpx
+
+    from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN
+
+    port = request.url.port or _pairing.default_port()
+    url = f"http://127.0.0.1:{port}/api/chat_stream"
+    headers = {INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN, "X-Odysseus-Owner": owner}
+    data = {"message": message, "session": sid}
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+            # Opening the stream sends the request and waits for headers; that is
+            # enough to guarantee the run started. We never read the body.
+            async with client.stream("POST", url, data=data, headers=headers) as resp:
+                if resp.status_code >= 400:
+                    raise HTTPException(502, f"chat_stream returned {resp.status_code}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(502, f"could not start the run: {e}")
+
+
+def _resolve_endpoint_url(owner, endpoint_id: str):
+    """Resolve an owner-visible, enabled endpoint id to (chat_url, base_url,
+    api_key). 404s if the endpoint is missing or owned by someone else. Shared
+    by the new-chat and model-switch paths."""
+    from core.database import SessionLocal, ModelEndpoint
+    from src.endpoint_resolver import build_chat_url, normalize_base
+
+    db = SessionLocal()
+    try:
+        ep = db.query(ModelEndpoint).filter(
+            ModelEndpoint.id == endpoint_id,
+            ModelEndpoint.is_enabled == True,  # noqa: E712
+        ).first()
+        if ep is None or not owner_can_see(ep.owner, owner):
+            raise HTTPException(404, "Model endpoint not found")
+        return build_chat_url(normalize_base(ep.base_url)), (ep.base_url or ""), (ep.api_key or "")
+    finally:
+        db.close()
+
+
+def _switch_session_model(session, sid: str, owner, endpoint_id: str, model: str) -> None:
+    """Switch a session's model/endpoint mid-conversation, mirroring the desktop
+    PATCH /session/{sid} path: resolve the endpoint owner-scoped, then update
+    model + endpoint_url + auth headers both in memory and in the DB row so the
+    next run (and the desktop UI) use the new model."""
+    from datetime import datetime
+
+    from core.database import Session as DbSession, SessionLocal
+    from src.endpoint_resolver import build_headers
+
+    chat_url, base_url, api_key = _resolve_endpoint_url(owner, endpoint_id)
+    session.model = model
+    session.endpoint_url = chat_url
+    session.headers = build_headers(api_key, base_url) if api_key else {}
+    db = SessionLocal()
+    try:
+        db_session = db.query(DbSession).filter(DbSession.id == sid).first()
+        if db_session:
+            db_session.model = model
+            db_session.endpoint_url = chat_url
+            db_session.headers = session.headers or {}
+            db_session.updated_at = datetime.utcnow()
+            db.commit()
+    finally:
+        db.close()
+
+
 def mint_pairing_token(owner: str, invalidate=None) -> tuple[str, str]:
     """Mint a pairing token AND invalidate the auth middleware's in-memory token
     cache, so the new token is accepted on the very next request without a server
@@ -242,8 +322,6 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         """
         import uuid as _uuid
 
-        import httpx
-
         owner = token_owner(request)
         if not owner:
             raise HTTPException(401, "Could not resolve an owner for this token")
@@ -261,19 +339,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
             raise HTTPException(400, "endpoint_id and model are required")
 
         # Resolve the endpoint to a chat URL, owner-scoped (own or shared rows).
-        from core.database import SessionLocal, ModelEndpoint
-        from src.endpoint_resolver import build_chat_url, normalize_base
-        db = SessionLocal()
-        try:
-            ep = db.query(ModelEndpoint).filter(
-                ModelEndpoint.id == endpoint_id,
-                ModelEndpoint.is_enabled == True,  # noqa: E712
-            ).first()
-            if ep is None or not owner_can_see(ep.owner, owner):
-                raise HTTPException(404, "Model endpoint not found")
-            endpoint_url = build_chat_url(normalize_base(ep.base_url))
-        finally:
-            db.close()
+        endpoint_url, _, _ = _resolve_endpoint_url(owner, endpoint_id)
 
         # Create the (empty) session first; chat_stream adds the user message.
         sm = _resolve_session_manager(session_manager)
@@ -281,25 +347,7 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
         name = (message[:40] or "New chat").strip()
         sm.create_session(sid, name, endpoint_url, model, owner=owner)
 
-        # Internal-tool loopback: trusted because it originates from 127.0.0.1
-        # with no proxy headers; X-Odysseus-Owner attributes the run to the owner.
-        from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN
-        port = request.url.port or _pairing.default_port()
-        url = f"http://127.0.0.1:{port}/api/chat_stream"
-        headers = {INTERNAL_TOOL_HEADER: INTERNAL_TOOL_TOKEN, "X-Odysseus-Owner": owner}
-        data = {"message": message, "session": sid}
-        try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
-                # Opening the stream sends the request and waits for headers; that
-                # is enough to guarantee the run started. We never read the body.
-                async with client.stream("POST", url, data=data, headers=headers) as resp:
-                    if resp.status_code >= 400:
-                        raise HTTPException(502, f"chat_stream returned {resp.status_code}")
-        except HTTPException:
-            raise
-        except Exception as e:
-            raise HTTPException(502, f"could not start the run: {e}")
-
+        await _fire_chat_run(request, owner, sid, message)
         return {"session_id": sid, "name": name}
 
     @router.get("/sessions/{session_id}/messages")
@@ -326,7 +374,57 @@ def setup_companion_routes(session_manager=None) -> APIRouter:
             if not isinstance(content, str):
                 content = _content_to_text(content)
             out.append({"role": role, "content": content})
-        return {"messages": out}
+        # model/name let the phone default its in-chat model picker and title
+        # without a second round-trip to the sessions list.
+        return {"messages": out, "model": getattr(sess, "model", "") or "", "name": sess.name}
+
+    @router.post("/sessions/{session_id}/message")
+    async def send_message(request: Request, session_id: str):
+        """Send a follow-up turn into an EXISTING session from the phone.
+
+        Same internal-loopback machinery as POST /sessions (new chat), but the
+        session already exists, so we just verify ownership, optionally switch
+        the model (body endpoint_id+model -- the phone's in-chat model picker,
+        mirroring the desktop), refuse if a run is already in flight, then fire
+        the detached run. The phone re-attaches to /sessions/{id}/stream to watch
+        it. Owner-checked; no new LLM logic.
+        """
+        from src import agent_runs
+        from routes.session_routes import _verify_session_owner
+
+        owner = token_owner(request)
+        if not owner:
+            raise HTTPException(401, "Could not resolve an owner for this token")
+
+        sm = _resolve_session_manager(session_manager)
+        _verify_session_owner(request, session_id, sm)
+        try:
+            sess = sm.get_session(session_id)
+        except KeyError:
+            raise HTTPException(404, "Session not found")
+
+        if agent_runs.is_active(session_id):
+            raise HTTPException(409, "A run is already in progress for this session")
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        message = (body.get("message") or "").strip()
+        if not message:
+            raise HTTPException(400, "message is required")
+
+        # Optional mid-chat model switch (the in-chat picker). Both must be given.
+        model = (body.get("model") or "").strip()
+        endpoint_id = (body.get("endpoint_id") or "").strip()
+        if model and endpoint_id and model != getattr(sess, "model", ""):
+            _switch_session_model(sess, session_id, owner, endpoint_id, model)
+
+        if not getattr(sess, "model", "").strip():
+            raise HTTPException(400, "This session has no model selected")
+
+        await _fire_chat_run(request, owner, session_id, message)
+        return {"ok": True}
 
     @router.get("/sessions/{session_id}/stream")
     async def stream_session(request: Request, session_id: str):

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -17,6 +17,15 @@ INTERNAL_TOOL_TOKEN = os.environ.get("ODYSSEUS_INTERNAL_TOKEN") or secrets.token
 INTERNAL_TOOL_HEADER = "X-Odysseus-Internal-Token"
 
 
+def is_cors_preflight(method: str, headers) -> bool:
+    """True for a genuine CORS preflight: an OPTIONS request carrying the
+    Access-Control-Request-Method header. Such requests are credential-less by
+    design and must reach CORSMiddleware to be answered -- gating them on auth
+    401s the preflight and breaks every cross-origin browser/WebView client
+    (e.g. the companion app). Pure so it can be unit-tested without the app."""
+    return method == "OPTIONS" and "access-control-request-method" in headers
+
+
 def require_admin(request: Request):
     """Raise 403 if the current user isn't an admin.
     Allows access when auth is explicitly disabled, or when the request carries

--- a/static/index.html
+++ b/static/index.html
@@ -903,6 +903,16 @@
           <span id="assistant-notif-dot" class="sidebar-notif-dot" style="display:none"></span>
         </div>
 
+        <div class="list-item" id="tool-companion-btn">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            style="flex-shrink:0;opacity:0.5;">
+            <rect x="5" y="2" width="14" height="20" rx="2" ry="2"/>
+            <path d="M12 18h.01"/>
+          </svg>
+          <span class="grow">Companion app</span>
+        </div>
+
         <div class="list-item" id="tool-theme-btn">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
             stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -2316,6 +2326,7 @@
 <script type="module" src="/static/js/settings.js"></script>
 <script type="module" src="/static/js/admin.js"></script>
 <script type="module" src="/static/js/assistant.js"></script>
+<script type="module" src="/static/js/companion.js"></script>
 <script type="module" src="/static/app.js"></script>  <!-- app.js must be LAST -->
 <script type="module" src="/static/js/init.js"></script>
 <script type="module" src="/static/js/a11y.js"></script>

--- a/static/js/companion.js
+++ b/static/js/companion.js
@@ -3,9 +3,17 @@
 // chat-scoped token via POST /api/companion/pair (admin-only, cookie auth) and
 // renders it as a self-contained overlay -- intentionally NOT wired into the
 // draggable modal/tile manager, so it stays simple and can't break that system.
+//
+// Two modes via a toggle: "This network" (LAN address) and "Anywhere" (a
+// Tailscale/tunnel address). The Anywhere tab shows a risk walkthrough the user
+// must read and Continue past before the remote QR is revealed.
 
 const BTN_ID = 'tool-companion-btn';
 const OVERLAY_ID = 'companion-pair-overlay';
+
+let pairData = null; // last fetched pairing payload
+let tab = 'local'; // 'local' | 'remote'
+let remoteAck = false; // user clicked Continue on the risk screen
 
 function close() {
   document.getElementById(OVERLAY_ID)?.remove();
@@ -14,6 +22,18 @@ function close() {
 
 function onKey(e) {
   if (e.key === 'Escape') close();
+}
+
+function pickLocal() {
+  const o = pairData && pairData.options;
+  if (!o || !o.length) return null;
+  return o.find((x) => x.kind === 'local') || o[0];
+}
+
+function pickRemote() {
+  const o = pairData && pairData.options;
+  if (!o) return null;
+  return o.find((x) => x.kind === 'tailscale') || o.find((x) => x.kind === 'other') || null;
 }
 
 function field(label, value) {
@@ -46,37 +66,117 @@ function field(label, value) {
   return row;
 }
 
-function render(body, data) {
-  body.innerHTML = '';
-
-  if (data.qr) {
+function renderOption(body, opt, hintText) {
+  if (opt && opt.qr) {
     const img = document.createElement('img');
     img.className = 'companion-qr';
     img.alt = 'Pairing QR code';
-    img.src = data.qr; // server-built data:image/png;base64 URI
+    img.src = opt.qr;
     body.appendChild(img);
   }
-
   const hint = document.createElement('p');
   hint.className = 'companion-hint';
-  hint.textContent = data.qr
-    ? 'Scan this in the Odysseus app (Pair -> Scan pairing code), or enter the details below.'
-    : 'Enter these in the Odysseus app to pair.';
+  hint.textContent = hintText;
   body.appendChild(hint);
-
-  body.appendChild(field('Server', `${data.host}:${data.port}`));
-  body.appendChild(field('Pairing token', data.token));
-
+  if (opt) {
+    body.appendChild(field('Server', `${opt.host}:${opt.port}`));
+  }
+  body.appendChild(field('Pairing token', pairData.token));
   const note = document.createElement('p');
   note.className = 'companion-note';
   note.textContent =
-    'One-time code, shown once. Revoke it anytime under Settings -> API tokens. ' +
-    'Phone and PC must reach each other (same network, or a private tunnel).';
+    'One-time code, shown once. Revoke it anytime under Settings -> API tokens.';
   body.appendChild(note);
+}
+
+function renderRisk(body) {
+  const h = document.createElement('div');
+  h.className = 'companion-risk';
+  h.innerHTML =
+    '<p class="companion-risk-title">Before you pair for access anywhere</p>' +
+    '<ul class="companion-risk-list">' +
+    '<li>The pairing token grants chat and tool access to this PC (including files and the terminal when those are enabled). Treat it like a password.</li>' +
+    '<li>Anyone who has the token <em>and</em> can reach your tunnel could control Odysseus. If a phone is lost, revoke the token under Settings -> API tokens.</li>' +
+    '<li>Use a private tunnel such as Tailscale or Cloudflare Tunnel. Do NOT forward router ports or expose Odysseus directly to the internet.</li>' +
+    '<li>Only pair devices you trust.</li>' +
+    '</ul>';
+  body.appendChild(h);
+  const btn = document.createElement('button');
+  btn.className = 'companion-continue';
+  btn.type = 'button';
+  btn.textContent = 'I understand - continue';
+  btn.addEventListener('click', () => {
+    remoteAck = true;
+    paint(body.parentElement.querySelector('.companion-body') || body);
+  });
+  body.appendChild(btn);
+}
+
+function renderNoTunnel(body) {
+  const d = document.createElement('div');
+  d.className = 'companion-risk';
+  d.innerHTML =
+    '<p class="companion-risk-title">No tunnel address detected</p>' +
+    '<p class="companion-hint" style="text-align:left">To reach Odysseus from any network:</p>' +
+    '<ul class="companion-risk-list">' +
+    '<li>Install <strong>Tailscale</strong> on this PC and your phone, signed into the same account (free for personal use; private and encrypted).</li>' +
+    '<li>Reopen this dialog - your Tailscale address will appear here with its own QR.</li>' +
+    '</ul>' +
+    '<p class="companion-note">You can still pair manually in the app with your tunnel address and the token below.</p>';
+  body.appendChild(d);
+  body.appendChild(field('Pairing token', pairData.token));
+}
+
+function segButton(label, active, onClick) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'companion-seg-btn' + (active ? ' active' : '');
+  b.textContent = label;
+  b.addEventListener('click', onClick);
+  return b;
+}
+
+function paint(body) {
+  body.innerHTML = '';
+  const seg = document.createElement('div');
+  seg.className = 'companion-seg';
+  seg.appendChild(
+    segButton('This network', tab === 'local', () => {
+      tab = 'local';
+      paint(body);
+    }),
+  );
+  seg.appendChild(
+    segButton('Anywhere', tab === 'remote', () => {
+      tab = 'remote';
+      paint(body);
+    }),
+  );
+  body.appendChild(seg);
+
+  if (tab === 'local') {
+    renderOption(
+      body,
+      pickLocal(),
+      'Scan in the Odysseus app (Pair -> Scan pairing code), or enter the details below. Works on this Wi-Fi.',
+    );
+  } else if (!remoteAck) {
+    renderRisk(body);
+  } else {
+    const remote = pickRemote();
+    if (remote && remote.qr) {
+      renderOption(body, remote, 'Use this from any network (it works at home too). Keep your tunnel running.');
+    } else {
+      renderNoTunnel(body);
+    }
+  }
 }
 
 async function open() {
   close();
+  tab = 'local';
+  remoteAck = false;
+  pairData = null;
   const overlay = document.createElement('div');
   overlay.className = 'companion-overlay';
   overlay.id = OVERLAY_ID;
@@ -97,7 +197,8 @@ async function open() {
   try {
     const resp = await fetch('/api/companion/pair?format=json', { method: 'POST' });
     if (!resp.ok) throw new Error('HTTP ' + resp.status);
-    render(body, await resp.json());
+    pairData = await resp.json();
+    paint(body);
   } catch (e) {
     body.innerHTML =
       '<p class="companion-err">Could not generate a pairing code. ' +

--- a/static/js/companion.js
+++ b/static/js/companion.js
@@ -1,0 +1,110 @@
+// Companion app pairing: Tools -> "Companion app" opens a QR (and manual
+// details) so a phone running the Odysseus companion can pair. Mints a fresh
+// chat-scoped token via POST /api/companion/pair (admin-only, cookie auth) and
+// renders it as a self-contained overlay -- intentionally NOT wired into the
+// draggable modal/tile manager, so it stays simple and can't break that system.
+
+const BTN_ID = 'tool-companion-btn';
+const OVERLAY_ID = 'companion-pair-overlay';
+
+function close() {
+  document.getElementById(OVERLAY_ID)?.remove();
+  document.removeEventListener('keydown', onKey);
+}
+
+function onKey(e) {
+  if (e.key === 'Escape') close();
+}
+
+function field(label, value) {
+  const row = document.createElement('div');
+  row.className = 'companion-field';
+  const wrap = document.createElement('div');
+  wrap.style.minWidth = '0';
+  const lab = document.createElement('div');
+  lab.className = 'companion-field-label';
+  lab.textContent = label;
+  const code = document.createElement('code');
+  code.textContent = value;
+  wrap.appendChild(lab);
+  wrap.appendChild(code);
+  const copy = document.createElement('button');
+  copy.className = 'companion-copy';
+  copy.type = 'button';
+  copy.textContent = 'Copy';
+  copy.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      copy.textContent = 'Copied';
+      setTimeout(() => (copy.textContent = 'Copy'), 1500);
+    } catch {
+      /* clipboard blocked; user can select manually */
+    }
+  });
+  row.appendChild(wrap);
+  row.appendChild(copy);
+  return row;
+}
+
+function render(body, data) {
+  body.innerHTML = '';
+
+  if (data.qr) {
+    const img = document.createElement('img');
+    img.className = 'companion-qr';
+    img.alt = 'Pairing QR code';
+    img.src = data.qr; // server-built data:image/png;base64 URI
+    body.appendChild(img);
+  }
+
+  const hint = document.createElement('p');
+  hint.className = 'companion-hint';
+  hint.textContent = data.qr
+    ? 'Scan this in the Odysseus app (Pair -> Scan pairing code), or enter the details below.'
+    : 'Enter these in the Odysseus app to pair.';
+  body.appendChild(hint);
+
+  body.appendChild(field('Server', `${data.host}:${data.port}`));
+  body.appendChild(field('Pairing token', data.token));
+
+  const note = document.createElement('p');
+  note.className = 'companion-note';
+  note.textContent =
+    'One-time code, shown once. Revoke it anytime under Settings -> API tokens. ' +
+    'Phone and PC must reach each other (same network, or a private tunnel).';
+  body.appendChild(note);
+}
+
+async function open() {
+  close();
+  const overlay = document.createElement('div');
+  overlay.className = 'companion-overlay';
+  overlay.id = OVERLAY_ID;
+  overlay.innerHTML =
+    '<div class="companion-card" role="dialog" aria-label="Companion app" aria-modal="true">' +
+    '<div class="companion-head"><h4>Companion app</h4>' +
+    '<button class="companion-close" type="button" aria-label="Close">&#x2716;</button></div>' +
+    '<div class="companion-body"><p class="companion-hint">Generating pairing code...</p></div>' +
+    '</div>';
+  document.body.appendChild(overlay);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
+  overlay.querySelector('.companion-close').addEventListener('click', close);
+  document.addEventListener('keydown', onKey);
+
+  const body = overlay.querySelector('.companion-body');
+  try {
+    const resp = await fetch('/api/companion/pair?format=json', { method: 'POST' });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    render(body, await resp.json());
+  } catch (e) {
+    body.innerHTML =
+      '<p class="companion-err">Could not generate a pairing code. ' +
+      'Pairing is admin-only -- make sure you are signed in as an admin.</p>';
+    console.warn('companion pair failed', e);
+  }
+}
+
+const btn = document.getElementById(BTN_ID);
+if (btn) btn.addEventListener('click', open);

--- a/static/style.css
+++ b/static/style.css
@@ -36505,3 +36505,55 @@ body.theme-frosted .modal {
   font-size: 12px;
   cursor: pointer;
 }
+.companion-seg {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: 14px;
+  background: var(--bg, #282c34);
+  border: 1px solid var(--border, #355a66);
+  border-radius: 10px;
+}
+.companion-seg-btn {
+  flex: 1;
+  background: none;
+  border: none;
+  border-radius: 7px;
+  padding: 8px 10px;
+  color: var(--muted, #888);
+  font-size: 13px;
+  cursor: pointer;
+}
+.companion-seg-btn.active {
+  background: var(--accent, #00aaff);
+  color: #00121f;
+  font-weight: 600;
+}
+.companion-risk {
+  text-align: left;
+}
+.companion-risk-title {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--warn, #f0ad4e);
+}
+.companion-risk-list {
+  margin: 0 0 14px;
+  padding-left: 18px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--fg, #9cdef2);
+}
+.companion-risk-list li { margin-bottom: 7px; }
+.companion-continue {
+  width: 100%;
+  background: var(--accent, #00aaff);
+  color: #00121f;
+  border: none;
+  border-radius: 8px;
+  padding: 11px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -36423,3 +36423,85 @@ body.theme-frosted .modal {
    the input beside it (.confirm-btn won't stretch on its own). */
 .ask-user-other-send { flex-shrink: 0; white-space: nowrap; min-height: 39px; }
 .ask-user-other-send:disabled { opacity: 0.5; cursor: default; }
+
+/* --- Companion app pairing overlay (Tools -> Companion app) --- */
+.companion-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+}
+.companion-card {
+  width: 100%;
+  max-width: 380px;
+  background: var(--panel, #111);
+  border: 1px solid var(--border, #355a66);
+  border-radius: 14px;
+  color: var(--fg, #9cdef2);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+.companion-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border, #355a66);
+}
+.companion-head h4 { margin: 0; font-size: 15px; }
+.companion-close {
+  background: none;
+  border: none;
+  color: var(--muted, #888);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+.companion-body { padding: 18px; text-align: center; }
+.companion-qr {
+  width: 230px;
+  height: 230px;
+  max-width: 100%;
+  background: #fff;
+  border-radius: 10px;
+  padding: 8px;
+  box-sizing: border-box;
+}
+.companion-hint { color: var(--muted, #888); font-size: 13px; margin: 12px 0 4px; line-height: 1.5; }
+.companion-note { color: var(--muted, #888); font-size: 11px; margin: 12px 0 0; line-height: 1.5; }
+.companion-err { color: var(--red, #e06c75); font-size: 13px; margin: 8px 0; }
+.companion-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: space-between;
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: var(--bg, #282c34);
+  border: 1px solid var(--border, #355a66);
+  border-radius: 8px;
+  text-align: left;
+}
+.companion-field-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted, #888);
+  margin-bottom: 2px;
+}
+.companion-field code { font-size: 12px; word-break: break-all; color: var(--fg, #9cdef2); }
+.companion-copy {
+  flex-shrink: 0;
+  background: var(--accent, #00aaff);
+  color: #00121f;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}

--- a/tests/test_companion_chat_options.py
+++ b/tests/test_companion_chat_options.py
@@ -1,0 +1,79 @@
+"""Unit tests for the companion chat-option translator.
+
+`_chat_run_options` maps the phone's per-turn toggles ({agent, web, terminal,
+research} + attachments) onto the exact chat_stream form fields, mirroring the
+desktop's static/js/chat.js. These are pure dict-in/dict-out helpers, so we test
+them directly (same style as tests/test_companion_readonly.py).
+"""
+
+import json
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# companion.routes only touches core.database lazily inside handlers, but stub it
+# so importing the module is robust regardless of collection order.
+if "core.database" not in sys.modules:
+    _db = types.ModuleType("core.database")
+    _db.SessionLocal = MagicMock()
+    _db.ModelEndpoint = MagicMock()
+    sys.modules["core.database"] = _db
+
+from companion.routes import _chat_run_options, _has_attachments
+
+
+def test_plain_chat_is_the_default():
+    assert _chat_run_options({}) == {"mode": "chat"}
+
+
+def test_agent_mode_sets_agent():
+    assert _chat_run_options({"agent": True}) == {"mode": "agent"}
+
+
+def test_terminal_implies_agent_and_allows_bash():
+    out = _chat_run_options({"terminal": True})
+    assert out["mode"] == "agent"
+    assert out["allow_bash"] == "true"
+
+
+def test_web_is_presearch_in_chat_mode():
+    out = _chat_run_options({"web": True})
+    assert out["mode"] == "chat"
+    assert out["use_web"] == "true"
+    assert "allow_web_search" not in out
+
+
+def test_web_is_a_tool_in_agent_mode():
+    out = _chat_run_options({"agent": True, "web": True})
+    assert out["mode"] == "agent"
+    assert out["allow_web_search"] == "true"
+    assert "use_web" not in out
+
+
+def test_research_overrides_agent_tools():
+    out = _chat_run_options({"research": True, "agent": True, "terminal": True, "web": True})
+    assert out["mode"] == "chat"
+    assert out["use_research"] == "true"
+    # research is self-contained: no agent tool flags leak through
+    assert "allow_bash" not in out
+    assert "allow_web_search" not in out
+
+
+def test_attachments_serialized_as_json_list():
+    out = _chat_run_options({"attachments": ["a.png", "b.pdf"]})
+    assert json.loads(out["attachments"]) == ["a.png", "b.pdf"]
+
+
+def test_attachments_ignored_when_empty_or_wrong_type():
+    assert "attachments" not in _chat_run_options({"attachments": []})
+    assert "attachments" not in _chat_run_options({"attachments": "nope"})
+
+
+def test_has_attachments():
+    assert _has_attachments({"attachments": ["x"]}) is True
+    assert _has_attachments({"attachments": []}) is False
+    assert _has_attachments({}) is False
+    assert _has_attachments({"attachments": "x"}) is False

--- a/tests/test_companion_cors_preflight.py
+++ b/tests/test_companion_cors_preflight.py
@@ -1,0 +1,30 @@
+"""Regression test for the CORS-preflight auth bypass.
+
+AuthMiddleware is the outermost middleware, so it used to 401 the credential-less
+OPTIONS preflight before CORSMiddleware could answer it -- which blocked every
+cross-origin browser/WebView client (the companion app) before the real request
+was sent. The fix lets a genuine preflight through; `is_cors_preflight` is the
+pure predicate it uses. Guard it so the bypass can't silently regress.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.middleware import is_cors_preflight
+
+
+def test_genuine_preflight_is_detected():
+    assert is_cors_preflight("OPTIONS", {"access-control-request-method": "POST"}) is True
+
+
+def test_options_without_acrm_header_is_not_a_preflight():
+    # A bare OPTIONS (no Access-Control-Request-Method) must NOT bypass auth.
+    assert is_cors_preflight("OPTIONS", {}) is False
+
+
+def test_real_methods_are_never_preflight():
+    headers = {"access-control-request-method": "POST"}
+    for method in ("GET", "POST", "PUT", "DELETE", "PATCH"):
+        assert is_cors_preflight(method, headers) is False


### PR DESCRIPTION
## Summary

Adds an **additive mobile companion** for Odysseus: a small, owner-scoped
`/api/companion/*` bridge plus a Capacitor + React + TS thin client
(`companion/mobile/`) that ships as a mobile web build and an installable
Android APK. The phone does no AI work — it pairs with the server (a chat-scoped,
revocable token via QR or manual entry) and acts as a remote: list/open any
session, start chats and follow-ups, switch model mid-chat, see reasoning, toggle
agent / web / terminal / deep-research, attach images (from the phone or a PC
file), search chat history, dictate by voice, and read/act on email (incl. AI
summary/reply/send), calendar, notes and tasks. Nothing in the existing chat/LLM
pipeline changes; the tool endpoints reuse the *existing* owner-impersonating
internal loopback rather than reimplementing anything. Also fixes a real bug: the
auth middleware 401'd CORS preflight (OPTIONS) before CORSMiddleware could answer
it, which blocked every cross-origin browser/WebView client.

Built with AI assistance (Claude Code — see the `Co-Authored-By` trailers), and
filed issue-first per CONTRIBUTING (#3244). Happy to split into smaller PRs (a
suggested split is at the bottom).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #3244

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue) — CORS preflight 401
- [x] New feature (non-breaking — adds new behaviour) — the companion bridge + app
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Server + companion API:

1. Run the server: `uvicorn app:app --host 0.0.0.0 --port 7000` (an admin user
   configured).
2. Mint a pairing token: in the desktop UI open **Tools → Companion app** (or
   `POST /api/companion/pair?format=json` with an admin cookie). You get a QR +
   `server:port` + token.
3. Companion API smoke test with the token:
   - `curl -H "Authorization: Bearer ody_…" http://<host>:7000/api/companion/ping` → `{"ok":true,...}`
   - `…/api/companion/sessions` lists only that owner's sessions.
   - `POST …/api/companion/sessions` `{"message","endpoint_id","model"}` starts a
     run; `GET …/sessions/{id}/stream` streams it; `…/search?q=…` finds messages.
4. Run the app: `cd companion/mobile && npm install && npm run build`, then either
   `npm run preview -- --host` (mobile web) or build the APK (see
   `companion/mobile/README.md`). Pair by scanning the QR; verify list/open
   session, start a chat, attach an image, and the tools (email/calendar/notes/
   tasks).

Automated checks:

- `pytest tests/test_companion_readonly.py tests/test_companion_pairing.py tests/test_companion_chat_options.py tests/test_companion_cors_preflight.py` → **43 passed**.
- `python -m py_compile app.py companion/*.py core/middleware.py` → OK.
- `cd companion/mobile && npm run build` → OK.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** — to be attached by the submitter (pairing,
  a live chat with the reasoning block, the Tools menu, an email with AI
  summary; mobile screenshots).
- [x] **Style match**: reuses existing CSS variables, button/card/border classes,
  inline Lucide-style SVG icons (no Unicode emoji), Fira Code, dark default; the
  new mobile app mirrors the desktop tokens. No new color/spacing primitives.
- [x] **No new component patterns** — extends existing list/modal/icon idioms.
- [ ] **I am not an LLM agent submitting a bulk PR.** — Disclosing honestly: this
  was built with AI assistance (Claude Code), but it is not a bulk auto-generated
  PR — it's a single cohesive, human-directed, tested feature, filed issue-first
  (#3244) per CONTRIBUTING. Leaving this box unticked rather than misrepresent;
  please judge on the issue + the diff and let me know if you'd like it split.

### Screenshots / clips
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/8e44cc0c-5902-463f-8001-b3337573be5c" />
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/929e867d-9108-4542-9232-bb6d3c9ae80a" />
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/b00fa870-41ec-436b-aef5-fad01f1daabb" />
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/bc239cf9-2574-4108-a0af-220a23f869a5" />
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/2e6651d9-4ab5-4eae-a9ab-c443410c716a" />
<img width="720" height="1560" alt="image" src="https://github.com/user-attachments/assets/130df3e4-c479-47d7-8d15-470ee968d9f0" />




<!-- submitter to drag in phone screenshots here -->

---

## Suggested split (if you prefer smaller PRs)

1. `/api/companion/*` core (ping/info/models/sessions/stream/stop) + the app
   shell + pairing + the CORS-preflight fix.
2. Attachments (phone + PC file) + history thumbnails.
3. Tools proxies (email/calendar/notes/tasks) + search.
4. Voice + deep-research toggles + the desktop pairing entry.
