### PR TITLE
feat(workspace): add git workflow backend APIs

### DIFF
--- a/app.py
+++ b/app.py
@@ -522,6 +522,8 @@ app.include_router(setup_emoji_routes())
 
 from routes.workspace_routes import setup_workspace_routes
 app.include_router(setup_workspace_routes())
+from routes.workspace_git_routes import setup_workspace_git_routes
+app.include_router(setup_workspace_git_routes())
 
 # Sessions
 from routes.session_routes import setup_session_routes

--- a/routes/workspace_git_routes.py
+++ b/routes/workspace_git_routes.py
@@ -78,6 +78,16 @@ def _resolve_commit_model(session_id: str | None, owner: str | None):
             sm = get_session_manager()
             sess = sm.get_session(session_id) if sm else None
             if sess and getattr(sess, "model", None):
+                # Refresh the session's auth exactly like the chat path does.
+                # Session-backed providers (ChatGPT Subscription, Copilot, …) keep
+                # a short-lived bearer that is re-resolved per request and never
+                # persisted to the session, so reading sess.headers alone yields no
+                # token and the model call goes out unauthorized (401).
+                try:
+                    from routes.chat_helpers import resolve_session_auth
+                    resolve_session_auth(sess, session_id, owner)
+                except Exception:
+                    pass
                 return (
                     getattr(sess, "endpoint_url", None) or None,
                     sess.model,

--- a/routes/workspace_git_routes.py
+++ b/routes/workspace_git_routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Body, Query, Request
 from fastapi.responses import JSONResponse
 
 from src.auth_helpers import get_current_user
+from src.task_endpoint import resolve_task_endpoint
 from src.tool_security import owner_is_admin_or_single_user
 from src.workspace_git import (
     GitWorkspaceError,
@@ -60,6 +61,95 @@ def _body_list(body: dict[str, Any], key: str) -> list[str]:
 
 def _hunk_id(body: dict[str, Any]) -> str:
     return str(body.get("hunkId") or body.get("hunk_id") or "")
+
+
+# ── AI commit-message generation ────────────────────────────────────────────
+_COMMIT_MSG_MAX_DIFF = 12000
+
+
+def _resolve_commit_model(session_id: str | None, owner: str | None):
+    """(endpoint_url, model, headers) for the message. Prefer the exact model/
+    endpoint/key of the chat session the user has selected; fall back to the
+    configured background-task endpoint when no session model is available."""
+    if session_id:
+        try:
+            from src.ai_interaction import get_session_manager
+            sm = get_session_manager()
+            sess = sm.get_session(session_id) if sm else None
+            if sess and getattr(sess, "model", None):
+                return (
+                    getattr(sess, "endpoint_url", None) or None,
+                    sess.model,
+                    getattr(sess, "headers", None) or None,
+                )
+        except Exception:
+            pass
+    return resolve_task_endpoint(owner=owner)
+
+
+def _clean_commit_text(raw: str) -> str:
+    text = raw or ""
+    try:
+        from src.text_helpers import strip_think
+        text = strip_think(text, prose=False, prompt_echo=False)
+    except Exception:
+        pass
+    text = (text or "").strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    if len(text) >= 2 and text[0] in "\"'" and text[-1] == text[0]:
+        text = text[1:-1].strip()
+    return text
+
+
+def _generate_commit_message(workspace: str | None, session_id: str | None, owner: str | None) -> dict[str, Any]:
+    # Prefer the staged diff; fall back to the full working-tree diff.
+    diff = git_diff(workspace, None, True)
+    patch = (diff.get("patch") or "").strip()
+    scope = "staged"
+    if not patch:
+        diff = git_diff(workspace, None, False)
+        patch = (diff.get("patch") or "").strip()
+        scope = "uncommitted"
+    if not patch:
+        raise GitWorkspaceError("no_changes", "No changes to describe")
+    truncated = bool(diff.get("truncated")) or len(patch) > _COMMIT_MSG_MAX_DIFF
+    if len(patch) > _COMMIT_MSG_MAX_DIFF:
+        patch = patch[:_COMMIT_MSG_MAX_DIFF]
+
+    url, model, headers = _resolve_commit_model(session_id, owner)
+    if not model:
+        raise GitWorkspaceError("llm_failed", "No model is available to generate a message")
+
+    system = (
+        "You write clear git commit messages. Return ONLY the commit message: a "
+        "concise imperative subject line (<= 72 chars), optionally followed by a "
+        "blank line and a short body. No markdown, no code fences, no surrounding "
+        "quotes, no preamble."
+    )
+    note = "\n\n[diff truncated]" if truncated else ""
+    user = f"Write a commit message for these {scope} changes:\n\n{patch}{note}"
+    try:
+        from src.llm_core import llm_call
+        raw = llm_call(
+            url, model,
+            [{"role": "system", "content": system}, {"role": "user", "content": user}],
+            temperature=0.3, max_tokens=512, headers=headers or None, timeout=30,
+        )
+    except GitWorkspaceError:
+        raise
+    except Exception as exc:  # provider/network failure
+        raise GitWorkspaceError("llm_failed", f"Model call failed: {exc}")
+
+    message = _clean_commit_text(raw)
+    if not message:
+        raise GitWorkspaceError("llm_failed", "The model returned an empty message")
+    return {"ok": True, "message": message, "model": model, "truncated": truncated}
 
 
 def setup_workspace_git_routes() -> APIRouter:
@@ -127,6 +217,19 @@ def setup_workspace_git_routes() -> APIRouter:
     @router.post("/branch/create")
     def branch_create(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
         return _run(request, git_create_branch, body.get("workspace"), body.get("branch"))
+
+    @router.post("/commit-message")
+    def commit_message(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        blocked = _authorized(request)
+        if blocked is not None:
+            return blocked
+        owner = get_current_user(request)
+        session_id = body.get("sessionId") or body.get("session_id")
+        try:
+            return _generate_commit_message(body.get("workspace"), session_id, owner)
+        except GitWorkspaceError as exc:
+            status = 403 if exc.code == "not_authorized" else 400
+            return _error(status, exc.code, exc.message)
 
     @router.post("/fetch")
     def fetch(request: Request, body: dict[str, Any] = Body(default_factory=dict)):

--- a/routes/workspace_git_routes.py
+++ b/routes/workspace_git_routes.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from fastapi import APIRouter, Body, Query, Request
+from fastapi.responses import JSONResponse
+
+from src.auth_helpers import get_current_user
+from src.tool_security import owner_is_admin_or_single_user
+from src.workspace_git import (
+    GitWorkspaceError,
+    git_blame,
+    git_branches,
+    git_checkout,
+    git_clone,
+    git_commit,
+    git_commit_selected,
+    git_conflicts,
+    git_diff,
+    git_discard,
+    git_history,
+    git_init,
+    git_remote_action,
+    git_resolve_conflict,
+    git_stage,
+    git_stage_hunk,
+    git_status,
+    git_unstage,
+    git_unstage_hunk,
+)
+
+
+def _error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse({"ok": False, "error": message, "code": code}, status_code=status_code)
+
+
+def _authorized(request: Request) -> JSONResponse | None:
+    owner = get_current_user(request)
+    if not owner_is_admin_or_single_user(owner):
+        return _error(403, "not_authorized", "Workspace Git APIs are admin-only")
+    return None
+
+
+def _run(request: Request, func: Callable[..., dict[str, Any]], *args: Any, **kwargs: Any):
+    blocked = _authorized(request)
+    if blocked is not None:
+        return blocked
+    try:
+        return func(*args, **kwargs)
+    except GitWorkspaceError as exc:
+        status = 403 if exc.code == "not_authorized" else 400
+        return _error(status, exc.code, exc.message)
+
+
+def _body_list(body: dict[str, Any], key: str) -> list[str]:
+    value = body.get(key)
+    return value if isinstance(value, list) else []
+
+
+def _hunk_id(body: dict[str, Any]) -> str:
+    return str(body.get("hunkId") or body.get("hunk_id") or "")
+
+
+def setup_workspace_git_routes() -> APIRouter:
+    router = APIRouter(prefix="/api/workspace/git", tags=["workspace-git"])
+
+    @router.get("/status")
+    def status(request: Request, workspace: str | None = Query(default=None)):
+        return _run(request, git_status, workspace)
+
+    @router.get("/diff")
+    def diff(
+        request: Request,
+        workspace: str | None = Query(default=None),
+        path: str | None = Query(default=None),
+        staged: bool = Query(default=False),
+    ):
+        return _run(request, git_diff, workspace, path, staged)
+
+    @router.post("/stage")
+    def stage(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_stage, body.get("workspace"), _body_list(body, "paths"))
+
+    @router.post("/unstage")
+    def unstage(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_unstage, body.get("workspace"), _body_list(body, "paths"))
+
+    @router.post("/discard")
+    def discard(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(
+            request,
+            git_discard,
+            body.get("workspace"),
+            _body_list(body, "paths"),
+            bool(body.get("confirmConflict") or body.get("confirm_conflict")),
+        )
+
+    @router.post("/hunks/stage")
+    def stage_hunk(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_stage_hunk, body.get("workspace"), body.get("path"), _hunk_id(body))
+
+    @router.post("/hunks/unstage")
+    def unstage_hunk(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_unstage_hunk, body.get("workspace"), body.get("path"), _hunk_id(body))
+
+    @router.post("/commit")
+    def commit(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_commit, body.get("workspace"), body.get("message"))
+
+    @router.post("/commit-selected")
+    def commit_selected(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_commit_selected, body.get("workspace"), _body_list(body, "paths"), body.get("message"))
+
+    @router.get("/branches")
+    def branches(request: Request, workspace: str | None = Query(default=None)):
+        return _run(request, git_branches, workspace)
+
+    @router.post("/checkout")
+    def checkout(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_checkout, body.get("workspace"), body.get("branch"), stash=False)
+
+    @router.post("/checkout-stash")
+    def checkout_stash(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_checkout, body.get("workspace"), body.get("branch"), stash=True)
+
+    @router.post("/fetch")
+    def fetch(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_remote_action, body.get("workspace"), "fetch")
+
+    @router.post("/pull")
+    def pull(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_remote_action, body.get("workspace"), "pull")
+
+    @router.post("/push")
+    def push(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_remote_action, body.get("workspace"), "push")
+
+    @router.post("/init")
+    def init(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_init, body.get("workspace"))
+
+    @router.post("/clone")
+    def clone(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_clone, body.get("workspace"), body.get("url"), body.get("target"), body.get("name"))
+
+    @router.get("/history")
+    def history(
+        request: Request,
+        workspace: str | None = Query(default=None),
+        path: str | None = Query(default=None),
+        limit: int = Query(default=50),
+    ):
+        return _run(request, git_history, workspace, path, limit)
+
+    @router.get("/blame")
+    def blame(request: Request, workspace: str | None = Query(default=None), path: str | None = Query(default=None)):
+        return _run(request, git_blame, workspace, path)
+
+    @router.get("/conflicts")
+    def conflicts(request: Request, workspace: str | None = Query(default=None)):
+        return _run(request, git_conflicts, workspace)
+
+    @router.post("/conflict/resolve")
+    def resolve_conflict(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        blocked = _authorized(request)
+        if blocked is not None:
+            return blocked
+        if "content" not in body or not isinstance(body.get("content"), str):
+            return _error(400, "invalid_request", "content must be provided as text")
+        try:
+            return git_resolve_conflict(body.get("workspace"), body.get("path"), body.get("content"))
+        except GitWorkspaceError as exc:
+            status = 403 if exc.code == "not_authorized" else 400
+            return _error(status, exc.code, exc.message)
+
+    return router

--- a/routes/workspace_git_routes.py
+++ b/routes/workspace_git_routes.py
@@ -16,6 +16,7 @@ from src.workspace_git import (
     git_commit,
     git_commit_selected,
     git_conflicts,
+    git_create_branch,
     git_diff,
     git_discard,
     git_history,
@@ -122,6 +123,10 @@ def setup_workspace_git_routes() -> APIRouter:
     @router.post("/checkout-stash")
     def checkout_stash(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
         return _run(request, git_checkout, body.get("workspace"), body.get("branch"), stash=True)
+
+    @router.post("/branch/create")
+    def branch_create(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        return _run(request, git_create_branch, body.get("workspace"), body.get("branch"))
 
     @router.post("/fetch")
     def fetch(request: Request, body: dict[str, Any] = Body(default_factory=dict)):

--- a/routes/workspace_git_routes.py
+++ b/routes/workspace_git_routes.py
@@ -16,6 +16,7 @@ from src.workspace_git import (
     git_clone,
     git_commit,
     git_commit_selected,
+    git_commit_stat,
     git_conflicts,
     git_create_branch,
     git_diff,
@@ -259,6 +260,14 @@ def setup_workspace_git_routes() -> APIRouter:
         limit: int = Query(default=50),
     ):
         return _run(request, git_history, workspace, path, limit)
+
+    @router.get("/commit")
+    def commit_stat(
+        request: Request,
+        workspace: str | None = Query(default=None),
+        sha: str | None = Query(default=None),
+    ):
+        return _run(request, git_commit_stat, workspace, sha)
 
     @router.get("/blame")
     def blame(request: Request, workspace: str | None = Query(default=None), path: str | None = Query(default=None)):

--- a/routes/workspace_routes.py
+++ b/routes/workspace_routes.py
@@ -9,6 +9,7 @@ from src.auth_helpers import get_current_user
 from src.tool_security import owner_is_admin_or_single_user
 from src.workspace_git import (
     GitWorkspaceError,
+    delete_workspace_file,
     list_workspace_files,
     read_workspace_file,
     save_workspace_file,
@@ -100,6 +101,16 @@ def setup_workspace_routes():
             return _workspace_error(400, "invalid_request", "content must be provided as text")
         try:
             return save_workspace_file(body.get("workspace"), body.get("path") or "", body.get("content"))
+        except GitWorkspaceError as exc:
+            return _workspace_error(400, exc.code, exc.message)
+
+    @router.post("/file/delete")
+    def file_delete(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        blocked = _require_workspace_admin(request)
+        if blocked is not None:
+            return blocked
+        try:
+            return delete_workspace_file(body.get("workspace"), body.get("path") or "")
         except GitWorkspaceError as exc:
             return _workspace_error(400, exc.code, exc.message)
 

--- a/routes/workspace_routes.py
+++ b/routes/workspace_routes.py
@@ -1,9 +1,39 @@
-"""Workspace API — browse server directories to pick a tool workspace folder."""
+"""Workspace API — browse and edit files in a selected tool workspace."""
 import os
-from fastapi import APIRouter, Request, HTTPException, Query
+from typing import Any
+
+from fastapi import APIRouter, Body, Request, HTTPException, Query
+from fastapi.responses import JSONResponse
 
 from src.auth_helpers import get_current_user
 from src.tool_security import owner_is_admin_or_single_user
+from src.workspace_git import (
+    GitWorkspaceError,
+    list_workspace_files,
+    read_workspace_file,
+    save_workspace_file,
+)
+
+
+def _workspace_error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse({"ok": False, "error": message, "code": code}, status_code=status_code)
+
+
+def _require_workspace_admin(request: Request) -> JSONResponse | None:
+    owner = get_current_user(request)
+    if not owner_is_admin_or_single_user(owner):
+        return _workspace_error(403, "not_authorized", "Workspace APIs are admin-only")
+    return None
+
+
+def _run_workspace(request: Request, func, *args):
+    blocked = _require_workspace_admin(request)
+    if blocked is not None:
+        return blocked
+    try:
+        return func(*args)
+    except GitWorkspaceError as exc:
+        return _workspace_error(400, exc.code, exc.message)
 
 
 def setup_workspace_routes():
@@ -52,5 +82,25 @@ def setup_workspace_routes():
             "parent": parent if parent and parent != target else None,
             "dirs": sorted(dirs, key=lambda d: d["name"].lower()),
         }
+
+    @router.get("/files")
+    def files(request: Request, workspace: str | None = Query(default=None), path: str = Query(default="")):
+        return _run_workspace(request, list_workspace_files, workspace, path)
+
+    @router.get("/file")
+    def file(request: Request, workspace: str | None = Query(default=None), path: str = Query(default="")):
+        return _run_workspace(request, read_workspace_file, workspace, path)
+
+    @router.post("/file/save")
+    def file_save(request: Request, body: dict[str, Any] = Body(default_factory=dict)):
+        blocked = _require_workspace_admin(request)
+        if blocked is not None:
+            return blocked
+        if "content" not in body or not isinstance(body.get("content"), str):
+            return _workspace_error(400, "invalid_request", "content must be provided as text")
+        try:
+            return save_workspace_file(body.get("workspace"), body.get("path") or "", body.get("content"))
+        except GitWorkspaceError as exc:
+            return _workspace_error(400, exc.code, exc.message)
 
     return router

--- a/src/workspace_git.py
+++ b/src/workspace_git.py
@@ -658,6 +658,47 @@ def _is_dirty(ctx: RepoContext) -> bool:
     return bool(git_run(ctx.repo_root, ["status", "--porcelain"], check=False).stdout.strip())
 
 
+# Auto-stashes created during branch switches are tagged with this prefix so we
+# only ever pop our own (never the user's manual `git stash`). The stash's git
+# subject is "On <source-branch>: odysseus-branch-switch ...", which lets us key
+# a parked change-set to the branch it was made on and restore it on return.
+_AUTOSTASH_PREFIX = "odysseus-branch-switch"
+
+
+def _autostash_entries(repo_root: str) -> list[dict[str, str]]:
+    """Our branch-switch stashes, each as {ref, branch} where branch is the
+    source branch the stash was created on (parsed from the 'On <branch>:' subject)."""
+    result = git_run(repo_root, ["stash", "list", "--format=%gd%x00%gs"], check=False)
+    if result.returncode != 0:
+        return []
+    entries: list[dict[str, str]] = []
+    for line in result.stdout.splitlines():
+        ref, sep, subject = line.partition("\x00")
+        if not sep or not subject.startswith("On "):
+            continue
+        head, sep2, message = subject[3:].partition(": ")
+        if not sep2 or not message.startswith(_AUTOSTASH_PREFIX):
+            continue
+        entries.append({"ref": ref, "branch": head.strip()})
+    return entries
+
+
+def _restore_autostash(repo_root: str, branch: str) -> dict[str, bool]:
+    """Pop the parked change-set for `branch` (the branch just checked out), if
+    one exists and the worktree is clean. Only touches our tagged stashes."""
+    if bool(git_run(repo_root, ["status", "--porcelain"], check=False).stdout.strip()):
+        return {"restored": False}
+    for item in _autostash_entries(repo_root):
+        if item["branch"] != branch:
+            continue
+        result = git_run(repo_root, ["stash", "pop", "--index", item["ref"]], check=False)
+        if result.returncode == 0:
+            return {"restored": True}
+        # Conflict on restore: leave the stash in place for manual recovery.
+        return {"restored": False, "restore_failed": True}
+    return {"restored": False}
+
+
 def git_checkout(workspace: str, branch: str, *, stash: bool = False) -> dict[str, Any]:
     ctx = repo_context(workspace)
     _require_repo_root_workspace(ctx)
@@ -670,10 +711,31 @@ def git_checkout(workspace: str, branch: str, *, stash: bool = False) -> dict[st
         if _is_dirty(ctx):
             if not stash:
                 raise GitWorkspaceError("dirty_worktree", "worktree has uncommitted changes")
-            git_run(ctx.repo_root, ["stash", "push", "-u", "-m", "Odysseus checkout stash"])
-            stashed = True
-        git_run(ctx.repo_root, ["checkout", branch])
-    return {"ok": True, "branch": branch, "stashed": stashed}
+            # Park dirty changes tagged to the CURRENT branch so returning here
+            # later restores them (per-branch auto-stash).
+            current = git_run(ctx.repo_root, ["branch", "--show-current"], check=False).stdout.strip()
+            result = git_run(ctx.repo_root, ["stash", "push", "-u", "-m", f"{_AUTOSTASH_PREFIX} to {branch}"])
+            stashed = "No local changes to save" not in (result.stdout + result.stderr)
+            try:
+                git_run(ctx.repo_root, ["checkout", branch])
+            except GitWorkspaceError:
+                # Roll back the stash so the user's changes are never stranded.
+                still_here = git_run(ctx.repo_root, ["branch", "--show-current"], check=False).stdout.strip()
+                if stashed and current == still_here:
+                    git_run(ctx.repo_root, ["stash", "pop", "--index", "stash@{0}"], check=False)
+                raise
+        else:
+            git_run(ctx.repo_root, ["checkout", branch])
+        # Whether we arrived clean or after parking, restore this branch's
+        # previously-parked changes if any.
+        restored = _restore_autostash(ctx.repo_root, branch)
+    return {
+        "ok": True,
+        "branch": branch,
+        "stashed": stashed,
+        "restored": bool(restored.get("restored")),
+        "restoreFailed": bool(restored.get("restore_failed")),
+    }
 
 
 def git_create_branch(workspace: str, branch: str) -> dict[str, Any]:

--- a/src/workspace_git.py
+++ b/src/workspace_git.py
@@ -830,20 +830,62 @@ def git_clone(workspace: str | None, url: str, target: str | None = None, name: 
     return {"ok": True, "path": os.path.realpath(dest)}
 
 
+def _git_remotes(ctx: RepoContext) -> set[str]:
+    result = git_run(ctx.repo_root, ["remote"], check=False)
+    if result.returncode != 0:
+        return set()
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _parse_refs(decoration: str, remotes: set[str]) -> list[dict[str, Any]]:
+    """Turn a `--decorate=short` `%D` string into typed ref objects so the
+    frontend never has to string-parse decorations. Ref names cannot contain a
+    space, so splitting on ", " is unambiguous."""
+    refs: list[dict[str, Any]] = []
+    for raw in (decoration or "").strip().split(", "):
+        name = raw.strip()
+        if not name:
+            continue
+        if name.startswith("HEAD -> "):
+            refs.append({"name": name[len("HEAD -> "):].strip(), "type": "head", "current": True})
+        elif name == "HEAD":
+            refs.append({"name": "HEAD", "type": "head", "current": True})
+        elif name.startswith("tag: "):
+            refs.append({"name": name[len("tag: "):].strip(), "type": "tag", "current": False})
+        else:
+            remote = name.split("/", 1)[0] in remotes
+            refs.append({"name": name, "type": "remote" if remote else "local", "current": False})
+    return refs
+
+
 def git_history(workspace: str, path: str | None = None, limit: int = 50) -> dict[str, Any]:
     ctx = repo_context(workspace)
     limit = max(1, min(int(limit or 50), 200))
-    args = ["log", f"-n{limit}", "--date=iso-strict", "--pretty=format:%H%x1f%an%x1f%ae%x1f%ad%x1f%s"]
+    fmt = "%H%x1f%P%x1f%D%x1f%an%x1f%ae%x1f%ad%x1f%s"
+    args = ["log", f"-n{limit}", "--date-order", "--decorate=short", "--date=iso-strict", f"--pretty=format:{fmt}"]
     if path:
+        # File scope stays linear on the current branch (single file).
         args.extend(["--", _repo_rel(ctx, path)])
-    elif ctx.prefix:
-        args.extend(["--", ctx.prefix])
+    else:
+        # Repo scope draws every local + remote ref as a lane.
+        args.append("--all")
+        if ctx.prefix:
+            args.extend(["--", ctx.prefix])
     result = git_run(ctx.repo_root, args)
+    remotes = _git_remotes(ctx)
     commits = []
     for line in result.stdout.splitlines():
         parts = line.split("\x1f")
-        if len(parts) == 5:
-            commits.append({"sha": parts[0], "author": parts[1], "email": parts[2], "date": parts[3], "message": parts[4]})
+        if len(parts) == 7:
+            commits.append({
+                "sha": parts[0],
+                "parents": parts[1].split(),
+                "refs": _parse_refs(parts[2], remotes),
+                "author": parts[3],
+                "email": parts[4],
+                "date": parts[5],
+                "message": parts[6],
+            })
     return {"ok": True, "commits": commits}
 
 

--- a/src/workspace_git.py
+++ b/src/workspace_git.py
@@ -182,6 +182,32 @@ def save_workspace_file(workspace: str, path: str, content: str) -> dict[str, An
     return {"ok": True, "path": workspace_rel(base, target), "size": stat.st_size, "mtime": stat.st_mtime}
 
 
+def delete_workspace_file(workspace: str, path: str) -> dict[str, Any]:
+    """Delete a file (or, recursively, a folder) inside the workspace. Path
+    safety is inherited from resolve_workspace_path: traversal, sensitive paths,
+    and forbidden components (.git, node_modules, …) are rejected, and the
+    workspace root itself can never be removed."""
+    base = resolve_workspace(workspace)
+    if not str(path or "").strip():
+        raise GitWorkspaceError("invalid_request", "path is required")
+    target = resolve_workspace_path(base, path, must_exist=True)
+    if _norm(target) == _norm(base):
+        raise GitWorkspaceError("outside_workspace", "cannot delete the workspace root")
+    rel = workspace_rel(base, target)
+    try:
+        if os.path.islink(target) or os.path.isfile(target):
+            os.remove(target)
+        elif os.path.isdir(target):
+            shutil.rmtree(target)
+        else:
+            raise GitWorkspaceError("invalid_request", "path is not a file or directory")
+    except GitWorkspaceError:
+        raise
+    except OSError as exc:
+        raise GitWorkspaceError("git_failed", str(exc)) from exc
+    return {"ok": True, "path": rel}
+
+
 def _git_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     env = {}
     for key, value in os.environ.items():

--- a/src/workspace_git.py
+++ b/src/workspace_git.py
@@ -889,6 +889,61 @@ def git_history(workspace: str, path: str | None = None, limit: int = 50) -> dic
     return {"ok": True, "commits": commits}
 
 
+_COMMIT_SHA_RE = re.compile(r"[0-9a-fA-F]{4,40}")
+
+
+def _numstat_count(value: str) -> int | None:
+    """A numstat column is a decimal count, or '-' for a binary file."""
+    return int(value) if value.isdigit() else None
+
+
+def git_commit_stat(workspace: str, sha: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    candidate = (sha or "").strip()
+    if not _COMMIT_SHA_RE.fullmatch(candidate):
+        raise GitWorkspaceError("git_failed", "invalid commit id")
+    verify = git_run(ctx.repo_root, ["rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"], check=False)
+    resolved = verify.stdout.strip()
+    if verify.returncode != 0 or not resolved:
+        raise GitWorkspaceError("git_failed", "unknown commit")
+    # An RS (\x1e) terminates the header so a multi-line body never collides with
+    # the numstat block that follows; fields inside the header split on US (\x1f).
+    fmt = "%H%x1f%P%x1f%an%x1f%ae%x1f%ad%x1f%s%x1f%b%x1e"
+    result = git_run(ctx.repo_root, ["show", "--no-color", "--numstat", f"--format={fmt}", resolved, "--"])
+    header, _, rest = result.stdout.partition("\x1e")
+    fields = header.split("\x1f")
+    if len(fields) != 7:
+        raise GitWorkspaceError("git_failed", "could not read commit")
+    files: list[dict[str, Any]] = []
+    additions = 0
+    deletions = 0
+    for line in rest.splitlines():
+        if "\t" not in line:
+            continue
+        ins_raw, del_raw, path = line.split("\t", 2)
+        insertions = _numstat_count(ins_raw)
+        removed = _numstat_count(del_raw)
+        additions += insertions or 0
+        deletions += removed or 0
+        files.append({"path": path, "insertions": insertions, "deletions": removed})
+    return {
+        "ok": True,
+        "commit": {
+            "sha": fields[0],
+            "parents": fields[1].split(),
+            "author": fields[2],
+            "email": fields[3],
+            "date": fields[4],
+            "subject": fields[5],
+            "body": fields[6].rstrip("\n"),
+            "files": files,
+            "fileCount": len(files),
+            "additions": additions,
+            "deletions": deletions,
+        },
+    }
+
+
 def git_blame(workspace: str, path: str) -> dict[str, Any]:
     file_info = read_workspace_file(workspace, path)
     if file_info.get("binary"):

--- a/src/workspace_git.py
+++ b/src/workspace_git.py
@@ -1,0 +1,828 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.tool_execution import _is_sensitive_path
+
+
+GIT_TIMEOUT_SECONDS = 30
+TEXT_PREVIEW_LIMIT = 512 * 1024
+SKIPPED_DIRS = {".git", "node_modules", ".venv", "__pycache__"}
+MAX_STATUS_FILES = 1000
+MAX_DIFF_BYTES = 2 * 1024 * 1024
+MAX_BLAME_BYTES = 1024 * 1024
+MAX_CONFLICT_SCAN_FILES = 2000
+_MUTATION_LOCKS: dict[str, threading.Lock] = {}
+_MUTATION_LOCKS_GUARD = threading.Lock()
+
+
+class GitWorkspaceError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class RepoContext:
+    workspace: str
+    repo_root: str
+    prefix: str
+
+
+def _norm(path: str) -> str:
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _has_forbidden_component(path: str) -> bool:
+    return any(part in SKIPPED_DIRS for part in Path(path).parts)
+
+
+def resolve_workspace(workspace: str | None) -> str:
+    if workspace is None or not str(workspace).strip():
+        raise GitWorkspaceError("invalid_workspace", "workspace is required")
+    resolved = os.path.realpath(os.path.expanduser(str(workspace).strip()))
+    if not os.path.isdir(resolved):
+        raise GitWorkspaceError("invalid_workspace", "workspace must be an existing directory")
+    if _is_sensitive_path(resolved):
+        raise GitWorkspaceError("outside_workspace", "workspace is sensitive")
+    return resolved
+
+
+def resolve_workspace_path(
+    workspace: str,
+    path: str | None,
+    *,
+    must_exist: bool = False,
+    allow_absolute: bool = False,
+) -> str:
+    base = resolve_workspace(workspace)
+    rel = "" if path is None else str(path).strip()
+    if os.path.isabs(rel) and not allow_absolute:
+        raise GitWorkspaceError("outside_workspace", "path must be workspace-relative")
+    expanded = os.path.expanduser(rel)
+    candidate = expanded if os.path.isabs(expanded) else os.path.join(base, expanded)
+    resolved = os.path.realpath(candidate)
+    if _is_sensitive_path(resolved):
+        raise GitWorkspaceError("outside_workspace", "path is sensitive")
+    rel_to_base = os.path.relpath(resolved, base)
+    if rel_to_base != "." and _has_forbidden_component(rel_to_base):
+        raise GitWorkspaceError("outside_workspace", "path is not editable")
+    if resolved != base:
+        try:
+            if os.path.commonpath([_norm(resolved), _norm(base)]) != _norm(base):
+                raise ValueError
+        except ValueError as exc:
+            raise GitWorkspaceError("outside_workspace", "path is outside the workspace") from exc
+    if must_exist and not os.path.exists(resolved):
+        raise GitWorkspaceError("outside_workspace", "path does not exist")
+    return resolved
+
+
+def workspace_rel(workspace: str, absolute: str) -> str:
+    rel = os.path.relpath(os.path.realpath(absolute), resolve_workspace(workspace))
+    return "" if rel == "." else rel.replace(os.sep, "/")
+
+
+def _is_binary_sample(data: bytes) -> bool:
+    return b"\x00" in data
+
+
+def list_workspace_files(workspace: str, path: str | None = "") -> dict[str, Any]:
+    base = resolve_workspace(workspace)
+    target = resolve_workspace_path(base, path or "", must_exist=True)
+    if not os.path.isdir(target):
+        raise GitWorkspaceError("invalid_workspace", "path must be a directory")
+    dirs: list[dict[str, Any]] = []
+    files: list[dict[str, Any]] = []
+    try:
+        entries = list(os.scandir(target))
+    except OSError as exc:
+        raise GitWorkspaceError("invalid_workspace", str(exc)) from exc
+    for entry in entries:
+        if entry.name.startswith(".") or entry.name in SKIPPED_DIRS:
+            continue
+        try:
+            stat = entry.stat(follow_symlinks=False)
+            rel = workspace_rel(base, os.path.join(target, entry.name))
+            item = {"name": entry.name, "path": rel, "mtime": stat.st_mtime}
+            if entry.is_dir(follow_symlinks=False):
+                dirs.append(item)
+            elif entry.is_file(follow_symlinks=False):
+                item["size"] = stat.st_size
+                files.append(item)
+        except OSError:
+            continue
+    dirs.sort(key=lambda d: d["name"].lower())
+    files.sort(key=lambda f: f["name"].lower())
+    parent_abs = os.path.dirname(target)
+    parent = None if _norm(parent_abs) == _norm(base) or _norm(target) == _norm(base) else workspace_rel(base, parent_abs)
+    return {
+        "ok": True,
+        "workspace": base,
+        "path": workspace_rel(base, target),
+        "parent": parent,
+        "dirs": dirs,
+        "files": files,
+    }
+
+
+def read_workspace_file(workspace: str, path: str) -> dict[str, Any]:
+    base = resolve_workspace(workspace)
+    target = resolve_workspace_path(base, path, must_exist=True)
+    if not os.path.isfile(target):
+        raise GitWorkspaceError("outside_workspace", "path must be a file")
+    stat = os.stat(target)
+    with open(target, "rb") as fh:
+        sample = fh.read(TEXT_PREVIEW_LIMIT + 1)
+    binary = _is_binary_sample(sample)
+    out = {
+        "ok": True,
+        "path": workspace_rel(base, target),
+        "size": stat.st_size,
+        "mtime": stat.st_mtime,
+        "binary": binary,
+        "editable": not binary,
+    }
+    if not binary:
+        out["content"] = sample[:TEXT_PREVIEW_LIMIT].decode("utf-8", errors="replace")
+    return out
+
+
+def save_workspace_file(workspace: str, path: str, content: str) -> dict[str, Any]:
+    if not isinstance(content, str):
+        raise GitWorkspaceError("binary_file", "content must be text")
+    base = resolve_workspace(workspace)
+    if not str(path or "").strip():
+        raise GitWorkspaceError("invalid_request", "path is required")
+    target = resolve_workspace_path(base, path, must_exist=False)
+    parent = os.path.dirname(target)
+    if not os.path.isdir(parent):
+        raise GitWorkspaceError("outside_workspace", "parent directory does not exist")
+    encoded = content.encode("utf-8")
+    if _is_binary_sample(encoded):
+        raise GitWorkspaceError("binary_file", "content must be text")
+    try:
+        with open(target, "w", encoding="utf-8", newline="") as fh:
+            fh.write(content)
+        stat = os.stat(target)
+    except IsADirectoryError as exc:
+        raise GitWorkspaceError("invalid_request", "path must be a file") from exc
+    except OSError as exc:
+        raise GitWorkspaceError("git_failed", str(exc)) from exc
+    return {"ok": True, "path": workspace_rel(base, target), "size": stat.st_size, "mtime": stat.st_mtime}
+
+
+def _git_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {}
+    for key, value in os.environ.items():
+        if key in {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_CONFIG"}:
+            continue
+        if key.startswith("GIT_CONFIG_"):
+            continue
+        env[key] = value
+    hardened = {
+        "GIT_CONFIG_COUNT": "3",
+        "GIT_CONFIG_KEY_0": "protocol.ext.allow",
+        "GIT_CONFIG_VALUE_0": "never",
+        "GIT_CONFIG_KEY_1": "core.hooksPath",
+        "GIT_CONFIG_VALUE_1": os.devnull,
+        "GIT_CONFIG_KEY_2": "diff.external",
+        "GIT_CONFIG_VALUE_2": "",
+    }
+    env.update(hardened)
+    if extra:
+        offset = int(env["GIT_CONFIG_COUNT"])
+        config_items = [(k, v) for k, v in extra.items() if k.startswith("GIT_CONFIG_KEY_")]
+        if config_items:
+            raise GitWorkspaceError("git_failed", "internal git config override is not supported")
+        env.update(extra)
+        if "GIT_INDEX_FILE" in extra:
+            env["GIT_CONFIG_COUNT"] = str(offset)
+    return env
+
+
+def _raw_git_run(repo_root: str, args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    if shutil.which("git") is None:
+        raise GitWorkspaceError("missing_git", "git is not installed")
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            shell=False,
+            env=_git_env(env),
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise GitWorkspaceError("missing_git", "git is not installed") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GitWorkspaceError("git_failed", "git command timed out") from exc
+
+
+def _reject_unsafe_git_config(repo_root: str) -> None:
+    result = _raw_git_run(repo_root, ["config", "--local", "--get-regexp", r"^(filter\..*\.(clean|process)|core\.fsmonitor|core\.sshcommand)$"])
+    if result.returncode == 0 and result.stdout.strip():
+        raise GitWorkspaceError("git_failed", "unsafe git config blocks this operation")
+
+
+def git_run(repo_root: str, args: list[str], *, check: bool = True, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    result = _raw_git_run(repo_root, args, env=env)
+    if check and result.returncode != 0:
+        stderr = (result.stderr or result.stdout or "git command failed").strip()
+        code = "merge_conflict" if "conflict" in stderr.lower() else "git_failed"
+        raise GitWorkspaceError(code, stderr)
+    return result
+
+
+def repo_context(workspace: str) -> RepoContext:
+    ws = resolve_workspace(workspace)
+    result = git_run(ws, ["rev-parse", "--show-toplevel"], check=False)
+    if result.returncode != 0:
+        raise GitWorkspaceError("not_git_repo", "workspace is not inside a git repository")
+    root = os.path.realpath(result.stdout.strip())
+    try:
+        if os.path.commonpath([_norm(ws), _norm(root)]) != _norm(root):
+            raise ValueError
+    except ValueError as exc:
+        raise GitWorkspaceError("outside_workspace", "repository is outside workspace") from exc
+    prefix = os.path.relpath(ws, root)
+    return RepoContext(workspace=ws, repo_root=root, prefix="" if prefix == "." else prefix.replace(os.sep, "/"))
+
+
+def _repo_rel(ctx: RepoContext, workspace_path: str) -> str:
+    resolved = resolve_workspace_path(ctx.workspace, workspace_path, must_exist=False)
+    rel = os.path.relpath(resolved, ctx.repo_root).replace(os.sep, "/")
+    if rel in {"", "."} or rel.startswith("../"):
+        raise GitWorkspaceError("outside_workspace", "path must be a workspace-relative file path")
+    return rel
+
+
+def _workspace_pathspec(ctx: RepoContext) -> list[str]:
+    return [ctx.prefix] if ctx.prefix else []
+
+
+def _to_workspace_rel(ctx: RepoContext, repo_path: str | None) -> str | None:
+    if repo_path is None:
+        return None
+    clean = repo_path.replace("\\", "/")
+    if not ctx.prefix:
+        return clean
+    prefix = ctx.prefix.rstrip("/") + "/"
+    if clean == ctx.prefix:
+        return ""
+    if clean.startswith(prefix):
+        return clean[len(prefix):]
+    return clean
+
+
+def _validate_paths(ctx: RepoContext, paths: list[str] | None) -> list[str]:
+    if not paths:
+        raise GitWorkspaceError("outside_workspace", "at least one path is required")
+    rels = []
+    for path in paths:
+        if not isinstance(path, str) or not path.strip() or path.strip() in {".", "./"}:
+            raise GitWorkspaceError("outside_workspace", "path must be a workspace-relative file path")
+        rels.append(_repo_rel(ctx, path))
+    return rels
+
+
+def _require_repo_root_workspace(ctx: RepoContext) -> None:
+    if ctx.prefix:
+        raise GitWorkspaceError("outside_workspace", "operation requires the repository root workspace")
+
+
+def _to_workspace_paths(ctx: RepoContext, rels: list[str]) -> list[str]:
+    return [path for path in (_to_workspace_rel(ctx, rel) for rel in rels) if path is not None]
+
+
+def _mutation_lock(repo_root: str) -> threading.Lock:
+    key = os.path.realpath(repo_root)
+    with _MUTATION_LOCKS_GUARD:
+        return _MUTATION_LOCKS.setdefault(key, threading.Lock())
+
+
+def _porcelain_kind(value: str) -> str | None:
+    return {
+        ".": None,
+        "M": "modified",
+        "A": "added",
+        "D": "deleted",
+        "R": "renamed",
+        "C": "copied",
+        "U": "unmerged",
+        "?": "untracked",
+        "!": "ignored",
+    }.get(value, value.lower() if value and value != "." else None)
+
+
+def git_status(workspace: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    branch = git_run(ctx.repo_root, ["branch", "--show-current"], check=False).stdout.strip()
+    upstream = git_run(ctx.repo_root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], check=False)
+    upstream_name = upstream.stdout.strip() if upstream.returncode == 0 else None
+    ahead = behind = 0
+    if upstream_name:
+        counts = git_run(ctx.repo_root, ["rev-list", "--left-right", "--count", f"{upstream_name}...HEAD"], check=False)
+        if counts.returncode == 0:
+            parts = counts.stdout.strip().split()
+            if len(parts) == 2:
+                behind, ahead = int(parts[0]), int(parts[1])
+
+    args = ["status", "--porcelain=v2", "--branch", "--untracked-files=all"]
+    pathspec = _workspace_pathspec(ctx)
+    if pathspec:
+        args.extend(["--", *pathspec])
+    result = git_run(ctx.repo_root, args)
+    files: list[dict[str, Any]] = []
+    truncated = False
+    for line in result.stdout.splitlines():
+        if len(files) >= MAX_STATUS_FILES:
+            truncated = True
+            break
+        if not line or line.startswith("#") or line.startswith("!"):
+            continue
+        if line.startswith("? "):
+            files.append({"path": _to_workspace_rel(ctx, line[2:]), "index": None, "worktree": "untracked", "raw": "??"})
+            continue
+        parts = line.split(" ")
+        if line.startswith("1 ") and len(parts) >= 9:
+            xy = parts[1]
+            files.append({"path": _to_workspace_rel(ctx, " ".join(parts[8:])), "index": _porcelain_kind(xy[0]), "worktree": _porcelain_kind(xy[1]), "raw": xy})
+        elif line.startswith("2 ") and len(parts) >= 10:
+            xy = parts[1]
+            path_field = " ".join(parts[9:])
+            new_path, _, old_path = path_field.partition("\t")
+            files.append({
+                "path": _to_workspace_rel(ctx, new_path),
+                "origPath": _to_workspace_rel(ctx, old_path) if old_path else None,
+                "index": _porcelain_kind(xy[0]),
+                "worktree": _porcelain_kind(xy[1]),
+                "raw": xy,
+            })
+        elif line.startswith("u ") and len(parts) >= 11:
+            files.append({"path": _to_workspace_rel(ctx, " ".join(parts[10:])), "index": "unmerged", "worktree": "unmerged", "raw": parts[1]})
+    return {
+        "ok": True,
+        "workspace": ctx.workspace,
+        "repoRoot": ctx.repo_root,
+        "branch": branch,
+        "upstream": upstream_name,
+        "ahead": ahead,
+        "behind": behind,
+        "files": files,
+        "truncated": truncated,
+    }
+
+
+_DIFF_HEADER_RE = re.compile(r"^diff --git a/(.*?) b/(.*)$")
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def _hunk_id(path: str, header: str, index: int) -> str:
+    digest = hashlib.sha1(f"{path}\0{index}\0{header}".encode("utf-8")).hexdigest()[:16]
+    return f"{path}:{digest}"
+
+
+def _parse_diff(patch: str) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    current_hunk: dict[str, Any] | None = None
+    hunk_index = 0
+    for line in patch.splitlines():
+        m = _DIFF_HEADER_RE.match(line)
+        if m:
+            current = {"path": m.group(2), "oldPath": m.group(1), "hunks": []}
+            files.append(current)
+            current_hunk = None
+            hunk_index = 0
+            continue
+        if current is None:
+            continue
+        hm = _HUNK_RE.match(line)
+        if hm:
+            hunk_index += 1
+            current_hunk = {
+                "id": _hunk_id(current["path"], line, hunk_index),
+                "header": line,
+                "oldStart": int(hm.group(1)),
+                "oldLines": int(hm.group(2) or "1"),
+                "newStart": int(hm.group(3)),
+                "newLines": int(hm.group(4) or "1"),
+                "lines": [],
+            }
+            current["hunks"].append(current_hunk)
+            continue
+        if current_hunk is not None:
+            current_hunk["lines"].append(line)
+    return files
+
+
+def git_diff(workspace: str, path: str | None = None, staged: bool = False) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    args = ["diff", "--patch", "--find-renames", "--no-ext-diff", "--no-textconv"]
+    if staged:
+        args.append("--cached")
+    if path:
+        args.extend(["--", _repo_rel(ctx, path)])
+    elif ctx.prefix:
+        args.extend(["--", ctx.prefix])
+    result = git_run(ctx.repo_root, args)
+    patch = result.stdout
+    truncated = False
+    if len(patch.encode("utf-8", errors="replace")) > MAX_DIFF_BYTES:
+        patch = patch.encode("utf-8", errors="replace")[:MAX_DIFF_BYTES].decode("utf-8", errors="replace")
+        truncated = True
+    files = _parse_diff(patch)
+    for file_info in files:
+        file_info["path"] = _to_workspace_rel(ctx, file_info.get("path"))
+        file_info["oldPath"] = _to_workspace_rel(ctx, file_info.get("oldPath"))
+    return {"ok": True, "workspace": ctx.workspace, "staged": staged, "patch": patch, "files": files, "truncated": truncated}
+
+
+def git_stage(workspace: str, paths: list[str]) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    rels = _validate_paths(ctx, paths)
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        git_run(ctx.repo_root, ["add", "--", *rels])
+    return {"ok": True, "paths": _to_workspace_paths(ctx, rels)}
+
+
+def git_unstage(workspace: str, paths: list[str]) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    rels = _validate_paths(ctx, paths)
+    with _mutation_lock(ctx.repo_root):
+        result = git_run(ctx.repo_root, ["restore", "--staged", "--", *rels], check=False)
+        if result.returncode != 0:
+            git_run(ctx.repo_root, ["rm", "--cached", "-r", "--ignore-unmatch", "--", *rels], check=False)
+    return {"ok": True, "paths": _to_workspace_paths(ctx, rels)}
+
+
+def _has_unmerged(ctx: RepoContext, rels: list[str]) -> bool:
+    result = git_run(ctx.repo_root, ["diff", "--name-only", "--diff-filter=U", "--", *rels], check=False)
+    return bool(result.stdout.strip())
+
+
+def _is_head_tracked(ctx: RepoContext, rel: str) -> bool:
+    result = git_run(ctx.repo_root, ["ls-tree", "-r", "--name-only", "HEAD", "--", rel], check=False)
+    return result.returncode == 0 and rel in result.stdout.splitlines()
+
+
+def git_discard(workspace: str, paths: list[str], confirm_conflict: bool = False) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    rels = _validate_paths(ctx, paths)
+    with _mutation_lock(ctx.repo_root):
+        if _has_unmerged(ctx, rels) and not confirm_conflict:
+            raise GitWorkspaceError("merge_conflict", "discarding conflicted files requires confirmation")
+        tracked = []
+        untracked = []
+        for rel in rels:
+            (tracked if _is_head_tracked(ctx, rel) else untracked).append(rel)
+        if tracked:
+            unstaged = git_run(ctx.repo_root, ["restore", "--staged", "--", *tracked], check=False)
+            if unstaged.returncode != 0:
+                git_run(ctx.repo_root, ["rm", "--cached", "-r", "--ignore-unmatch", "--", *tracked], check=False)
+            head_tracked = [
+                rel for rel in tracked
+                if git_run(ctx.repo_root, ["ls-files", "--error-unmatch", "--", rel], check=False).returncode == 0
+            ]
+            if head_tracked:
+                restored = git_run(ctx.repo_root, ["restore", "--worktree", "--", *head_tracked], check=False)
+                if restored.returncode != 0:
+                    raise GitWorkspaceError("git_failed", (restored.stderr or restored.stdout).strip())
+            untracked.extend(rel for rel in tracked if rel not in head_tracked)
+        for rel in untracked:
+            git_run(ctx.repo_root, ["rm", "--cached", "-r", "--ignore-unmatch", "--", rel], check=False)
+            abs_path = os.path.realpath(os.path.join(ctx.repo_root, rel))
+            if os.path.exists(abs_path):
+                if os.path.isfile(abs_path) or os.path.islink(abs_path):
+                    os.remove(abs_path)
+                elif os.path.isdir(abs_path):
+                    shutil.rmtree(abs_path)
+    return {"ok": True, "paths": _to_workspace_paths(ctx, rels)}
+
+
+def _select_hunk_patch(workspace: str, path: str, hunk_id: str, *, staged: bool) -> str:
+    diff = git_diff(workspace, path=path, staged=staged)
+    patch_lines = diff["patch"].splitlines()
+    for file_info in diff["files"]:
+        for hunk in file_info["hunks"]:
+            if hunk["id"] == hunk_id:
+                ctx = repo_context(workspace)
+                repo_old = f"{ctx.prefix}/{file_info['oldPath']}" if ctx.prefix and file_info["oldPath"] else file_info["oldPath"]
+                repo_new = f"{ctx.prefix}/{file_info['path']}" if ctx.prefix and file_info["path"] else file_info["path"]
+                start = next(i for i, line in enumerate(patch_lines) if line == f"diff --git a/{repo_old} b/{repo_new}")
+                hunk_start = next(i for i in range(start, len(patch_lines)) if patch_lines[i] == hunk["header"])
+                hunk_end = hunk_start + 1
+                while hunk_end < len(patch_lines) and not patch_lines[hunk_end].startswith(("@@ ", "diff --git ")):
+                    hunk_end += 1
+                headers = patch_lines[start:hunk_start]
+                return "\n".join(headers + patch_lines[hunk_start:hunk_end]) + "\n"
+    raise GitWorkspaceError("git_failed", "hunk no longer exists")
+
+
+def git_stage_hunk(workspace: str, path: str, hunk_id: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    _repo_rel(ctx, path)
+    patch = _select_hunk_patch(workspace, path, hunk_id, staged=False)
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        if shutil.which("git") is None:
+            raise GitWorkspaceError("missing_git", "git is not installed")
+        try:
+            result = subprocess.run(
+                ["git", "apply", "--cached", "--unidiff-zero", "-"],
+                cwd=ctx.repo_root,
+                input=patch,
+                text=True,
+                capture_output=True,
+                timeout=GIT_TIMEOUT_SECONDS,
+                env=_git_env(),
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise GitWorkspaceError("missing_git", "git is not installed") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise GitWorkspaceError("git_failed", "git command timed out") from exc
+        if result.returncode != 0:
+            raise GitWorkspaceError("git_failed", (result.stderr or result.stdout).strip())
+    return {"ok": True, "path": path, "hunkId": hunk_id}
+
+
+def git_unstage_hunk(workspace: str, path: str, hunk_id: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    _repo_rel(ctx, path)
+    patch = _select_hunk_patch(workspace, path, hunk_id, staged=True)
+    with _mutation_lock(ctx.repo_root):
+        if shutil.which("git") is None:
+            raise GitWorkspaceError("missing_git", "git is not installed")
+        try:
+            result = subprocess.run(
+                ["git", "apply", "--cached", "--reverse", "--unidiff-zero", "-"],
+                cwd=ctx.repo_root,
+                input=patch,
+                text=True,
+                capture_output=True,
+                timeout=GIT_TIMEOUT_SECONDS,
+                env=_git_env(),
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise GitWorkspaceError("missing_git", "git is not installed") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise GitWorkspaceError("git_failed", "git command timed out") from exc
+        if result.returncode != 0:
+            raise GitWorkspaceError("git_failed", (result.stderr or result.stdout).strip())
+    return {"ok": True, "path": path, "hunkId": hunk_id}
+
+
+def _ensure_message(message: str | None) -> str:
+    msg = (message or "").strip()
+    if not msg:
+        raise GitWorkspaceError("git_failed", "commit message is required")
+    return msg
+
+
+def git_commit(workspace: str, message: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    with _mutation_lock(ctx.repo_root):
+        if ctx.prefix:
+            staged = git_run(ctx.repo_root, ["diff", "--cached", "--name-only"]).stdout.splitlines()
+            prefix = ctx.prefix.rstrip("/") + "/"
+            outside = [path for path in staged if path != ctx.prefix and not path.startswith(prefix)]
+            if outside:
+                raise GitWorkspaceError("outside_workspace", "staged changes outside the workspace cannot be committed")
+        git_run(ctx.repo_root, ["commit", "-m", _ensure_message(message)])
+        sha = git_run(ctx.repo_root, ["rev-parse", "HEAD"]).stdout.strip()
+    return {"ok": True, "commit": sha}
+
+
+def git_commit_selected(workspace: str, paths: list[str], message: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    rels = _validate_paths(ctx, paths)
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        index_path = git_run(ctx.repo_root, ["rev-parse", "--git-path", "index"]).stdout.strip()
+        if not os.path.isabs(index_path):
+            index_path = os.path.join(ctx.repo_root, index_path)
+        with tempfile.NamedTemporaryFile(prefix="odysseus-git-index-", delete=False) as tmp:
+            tmp_index = tmp.name
+        try:
+            if os.path.exists(index_path):
+                shutil.copy2(index_path, tmp_index)
+            else:
+                os.remove(tmp_index)
+            env = {"GIT_INDEX_FILE": tmp_index}
+            git_run(ctx.repo_root, ["add", "-A", "--", *rels], env=env)
+            git_run(ctx.repo_root, ["commit", "-m", _ensure_message(message), "--", *rels], env=env)
+            sha = git_run(ctx.repo_root, ["rev-parse", "HEAD"]).stdout.strip()
+            git_run(ctx.repo_root, ["reset", "-q", "HEAD", "--", *rels])
+        finally:
+            try:
+                os.remove(tmp_index)
+            except OSError:
+                pass
+    return {"ok": True, "commit": sha, "paths": _to_workspace_paths(ctx, rels)}
+
+
+def git_branches(workspace: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    current = git_run(ctx.repo_root, ["branch", "--show-current"], check=False).stdout.strip()
+    local = []
+    lines = git_run(ctx.repo_root, ["for-each-ref", "--format=%(refname:short)|%(upstream:short)", "refs/heads"]).stdout.splitlines()
+    for line in lines:
+        name, _, upstream = line.partition("|")
+        ahead = behind = 0
+        if upstream:
+            counts = git_run(ctx.repo_root, ["rev-list", "--left-right", "--count", f"{upstream}...{name}"], check=False)
+            if counts.returncode == 0 and len(counts.stdout.split()) == 2:
+                behind, ahead = map(int, counts.stdout.split())
+        local.append({"name": name, "current": name == current, "upstream": upstream or None, "ahead": ahead, "behind": behind})
+    remotes = [{"name": line.strip()} for line in git_run(ctx.repo_root, ["branch", "-r", "--format=%(refname:short)"], check=False).stdout.splitlines() if line.strip()]
+    return {"ok": True, "current": current, "local": local, "remote": remotes}
+
+
+def _is_dirty(ctx: RepoContext) -> bool:
+    return bool(git_run(ctx.repo_root, ["status", "--porcelain"], check=False).stdout.strip())
+
+
+def git_checkout(workspace: str, branch: str, *, stash: bool = False) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    _require_repo_root_workspace(ctx)
+    branch = (branch or "").strip()
+    if not branch:
+        raise GitWorkspaceError("git_failed", "branch is required")
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        stashed = False
+        if _is_dirty(ctx):
+            if not stash:
+                raise GitWorkspaceError("dirty_worktree", "worktree has uncommitted changes")
+            git_run(ctx.repo_root, ["stash", "push", "-u", "-m", "Odysseus checkout stash"])
+            stashed = True
+        git_run(ctx.repo_root, ["checkout", branch])
+    return {"ok": True, "branch": branch, "stashed": stashed}
+
+
+def git_remote_action(workspace: str, action: str) -> dict[str, Any]:
+    if action not in {"fetch", "pull", "push"}:
+        raise GitWorkspaceError("git_failed", "unknown remote action")
+    ctx = repo_context(workspace)
+    _require_repo_root_workspace(ctx)
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        result = git_run(ctx.repo_root, [action], check=False)
+        if result.returncode != 0:
+            message = (result.stderr or result.stdout).strip()
+            code = "merge_conflict" if "conflict" in message.lower() else "git_failed"
+            raise GitWorkspaceError(code, message)
+    return {"ok": True, "output": (result.stdout or result.stderr).strip()}
+
+
+def git_init(workspace: str) -> dict[str, Any]:
+    ws = resolve_workspace(workspace)
+    with _mutation_lock(ws):
+        git_run(ws, ["init"])
+    return {"ok": True, "workspace": ws}
+
+
+def _inside_docker() -> bool:
+    if os.path.exists("/.dockerenv"):
+        return True
+    try:
+        return "docker" in Path("/proc/1/cgroup").read_text(errors="ignore") or "kubepods" in Path("/proc/1/cgroup").read_text(errors="ignore")
+    except OSError:
+        return False
+
+
+def default_clone_parent() -> str:
+    return "/app/data/workspaces" if _inside_docker() else os.path.expanduser("~/odysseus-workspaces")
+
+
+def git_clone(workspace: str | None, url: str, target: str | None = None, name: str | None = None) -> dict[str, Any]:
+    url = (url or "").strip()
+    if not url:
+        raise GitWorkspaceError("git_failed", "clone url is required")
+    if name and (os.path.basename(name) != name or name in {".", ".."}):
+        raise GitWorkspaceError("outside_workspace", "unsafe target name")
+    if target:
+        if not workspace:
+            raise GitWorkspaceError("invalid_workspace", "workspace is required when target is supplied")
+        parent = resolve_workspace_path(resolve_workspace(workspace), target, must_exist=False, allow_absolute=True)
+    else:
+        parent = os.path.realpath(default_clone_parent())
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError as exc:
+        raise GitWorkspaceError("git_failed", str(exc)) from exc
+    inferred_name = os.path.splitext(os.path.basename(url.rstrip("/")))[0] or "repository"
+    if not name and (os.path.basename(inferred_name) != inferred_name or inferred_name in {".", ".."}):
+        raise GitWorkspaceError("outside_workspace", "unsafe target name")
+    dest = os.path.join(parent, name or inferred_name)
+    dest = os.path.realpath(dest)
+    try:
+        if os.path.commonpath([_norm(dest), _norm(parent)]) != _norm(parent):
+            raise ValueError
+    except ValueError as exc:
+        raise GitWorkspaceError("outside_workspace", "clone target is outside parent") from exc
+    try:
+        with _mutation_lock(parent):
+            git_run(parent, ["clone", url, dest])
+    except OSError as exc:
+        raise GitWorkspaceError("git_failed", str(exc)) from exc
+    return {"ok": True, "path": os.path.realpath(dest)}
+
+
+def git_history(workspace: str, path: str | None = None, limit: int = 50) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    limit = max(1, min(int(limit or 50), 200))
+    args = ["log", f"-n{limit}", "--date=iso-strict", "--pretty=format:%H%x1f%an%x1f%ae%x1f%ad%x1f%s"]
+    if path:
+        args.extend(["--", _repo_rel(ctx, path)])
+    elif ctx.prefix:
+        args.extend(["--", ctx.prefix])
+    result = git_run(ctx.repo_root, args)
+    commits = []
+    for line in result.stdout.splitlines():
+        parts = line.split("\x1f")
+        if len(parts) == 5:
+            commits.append({"sha": parts[0], "author": parts[1], "email": parts[2], "date": parts[3], "message": parts[4]})
+    return {"ok": True, "commits": commits}
+
+
+def git_blame(workspace: str, path: str) -> dict[str, Any]:
+    file_info = read_workspace_file(workspace, path)
+    if file_info.get("binary"):
+        raise GitWorkspaceError("binary_file", "blame is only available for text files")
+    if int(file_info.get("size") or 0) > MAX_BLAME_BYTES:
+        raise GitWorkspaceError("git_failed", "file is too large to blame")
+    ctx = repo_context(workspace)
+    rel = _repo_rel(ctx, path)
+    result = git_run(ctx.repo_root, ["blame", "--line-porcelain", "--", rel])
+    lines = []
+    current: dict[str, Any] = {}
+    for line in result.stdout.splitlines():
+        if re.match(r"^[0-9a-f]{40} ", line):
+            current = {"sha": line.split()[0]}
+        elif line.startswith("author "):
+            current["author"] = line[7:]
+        elif line.startswith("\t"):
+            current["text"] = line[1:]
+            lines.append(current)
+    return {"ok": True, "path": _to_workspace_rel(ctx, rel), "lines": lines}
+
+
+def _contains_conflict_markers(text: str) -> bool:
+    return "<<<<<<<" in text or "=======" in text or ">>>>>>>" in text
+
+
+def git_conflicts(workspace: str) -> dict[str, Any]:
+    ctx = repo_context(workspace)
+    args = ["diff", "--name-only", "--diff-filter=U"]
+    if ctx.prefix:
+        args.extend(["--", ctx.prefix])
+    result = git_run(ctx.repo_root, args, check=False)
+    paths = set(_to_workspace_rel(ctx, p) for p in result.stdout.splitlines() if p.strip())
+    scanned = 0
+    truncated = False
+    for root, dirs, files in os.walk(ctx.workspace):
+        dirs[:] = [d for d in dirs if d not in SKIPPED_DIRS and not d.startswith(".")]
+        for filename in files:
+            if scanned >= MAX_CONFLICT_SCAN_FILES:
+                truncated = True
+                break
+            scanned += 1
+            abs_path = os.path.join(root, filename)
+            try:
+                with open(abs_path, "r", encoding="utf-8", errors="ignore") as fh:
+                    if _contains_conflict_markers(fh.read(TEXT_PREVIEW_LIMIT)):
+                        paths.add(workspace_rel(ctx.workspace, abs_path))
+            except OSError:
+                continue
+        if truncated:
+            break
+    return {"ok": True, "files": [{"path": p} for p in sorted(paths)], "truncated": truncated}
+
+
+def git_resolve_conflict(workspace: str, path: str, content: str) -> dict[str, Any]:
+    if _contains_conflict_markers(content):
+        raise GitWorkspaceError("merge_conflict", "conflict markers remain")
+    saved = save_workspace_file(workspace, path, content)
+    ctx = repo_context(workspace)
+    rel = _repo_rel(ctx, path)
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        git_run(ctx.repo_root, ["add", "--", rel])
+    return {"ok": True, "path": saved["path"]}

--- a/src/workspace_git.py
+++ b/src/workspace_git.py
@@ -676,6 +676,29 @@ def git_checkout(workspace: str, branch: str, *, stash: bool = False) -> dict[st
     return {"ok": True, "branch": branch, "stashed": stashed}
 
 
+def git_create_branch(workspace: str, branch: str) -> dict[str, Any]:
+    """Create a new branch and switch to it. `git checkout -b` carries any
+    uncommitted changes onto the new branch (normal git behaviour), so no stash
+    is needed here. Rejects unsafe/duplicate names with a clean error."""
+    ctx = repo_context(workspace)
+    _require_repo_root_workspace(ctx)
+    branch = (branch or "").strip()
+    if not branch:
+        raise GitWorkspaceError("git_failed", "branch name is required")
+    # Reject leading '-' (option injection) before any name reaches git.
+    if branch.startswith("-"):
+        raise GitWorkspaceError("git_failed", f"invalid branch name: {branch}")
+    if git_run(ctx.repo_root, ["check-ref-format", "--branch", branch], check=False).returncode != 0:
+        raise GitWorkspaceError("git_failed", f"invalid branch name: {branch}")
+    with _mutation_lock(ctx.repo_root):
+        _reject_unsafe_git_config(ctx.repo_root)
+        exists = git_run(ctx.repo_root, ["rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"], check=False)
+        if exists.returncode == 0:
+            raise GitWorkspaceError("git_failed", f"branch already exists: {branch}")
+        git_run(ctx.repo_root, ["checkout", "-b", branch])
+    return {"ok": True, "branch": branch, "created": True}
+
+
 def git_remote_action(workspace: str, action: str) -> dict[str, Any]:
     if action not in {"fetch", "pull", "push"}:
         raise GitWorkspaceError("git_failed", "unknown remote action")
@@ -784,8 +807,21 @@ def git_blame(workspace: str, path: str) -> dict[str, Any]:
     return {"ok": True, "path": _to_workspace_rel(ctx, rel), "lines": lines}
 
 
+# Match a real git conflict-marker line: exactly seven marker characters at the
+# start of a line, optionally followed by a label (e.g. "<<<<<<< HEAD"). Anchoring
+# and the exact-7 length keep legitimate content from false-positiving — an 8+ char
+# "========" underline or a long "====" rule is not a marker — while still catching
+# every marker git emits. The "|||||||" alternative is the diff3/zdiff3 base
+# separator, so resolutions in that conflict style cannot slip a leaked base
+# section past validation and get staged.
+_CONFLICT_MARKER_RE = re.compile(
+    r"^(?:<{7}|\|{7}|={7}|>{7})(?:[ \t].*)?$",
+    re.MULTILINE,
+)
+
+
 def _contains_conflict_markers(text: str) -> bool:
-    return "<<<<<<<" in text or "=======" in text or ">>>>>>>" in text
+    return bool(_CONFLICT_MARKER_RE.search(text))
 
 
 def git_conflicts(workspace: str) -> dict[str, Any]:

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -59,6 +59,7 @@ def test_all_workspace_file_and_git_endpoints_reject_non_admin_owner(monkeypatch
         ("/api/workspace/git/diff", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/branches", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/history", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/commit", {"workspace": str(tmp_path), "sha": "abcdef"}),
         ("/api/workspace/git/blame", {"workspace": str(tmp_path), "path": "x"}),
         ("/api/workspace/git/conflicts", {"workspace": str(tmp_path)}),
     ]
@@ -954,3 +955,65 @@ def test_git_history_repo_scope_surfaces_all_branches(monkeypatch, tmp_path):
     for commit in file_history["commits"]:
         assert isinstance(commit["parents"], list)
         assert isinstance(commit["refs"], list)
+
+
+def _commit_with_changes(repo):
+    """Second commit changing a text file, adding a text file and a binary file.
+    Returns the new commit sha."""
+    (repo / "f.txt").write_text("a\nb\nc\n", encoding="utf-8")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "base")
+
+    (repo / "f.txt").write_text("a\nB\nc\nd\n", encoding="utf-8")
+    (repo / "new.txt").write_text("new\n", encoding="utf-8")
+    (repo / "image.bin").write_bytes(b"\x00\x01\x02bin")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "subject line", "-m", "body one\nbody two")
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_commit_stat_endpoint_returns_changed_files(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    head_sha = _commit_with_changes(repo)
+
+    response = client.get("/api/workspace/git/commit", params={"workspace": str(repo), "sha": head_sha})
+    assert response.status_code == 200
+    commit = response.json()["commit"]
+
+    assert commit["sha"] == head_sha
+    assert commit["subject"] == "subject line"
+    assert commit["body"].splitlines() == ["body one", "body two"]
+    assert len(commit["parents"]) == 1
+    assert commit["fileCount"] == 3
+    assert commit["additions"] == 3   # f.txt +2, new.txt +1
+    assert commit["deletions"] == 1   # f.txt -1
+
+    files = {entry["path"]: entry for entry in commit["files"]}
+    assert files["f.txt"]["insertions"] == 2 and files["f.txt"]["deletions"] == 1
+    assert files["new.txt"]["insertions"] == 1 and files["new.txt"]["deletions"] == 0
+    # Binary files report no line counts.
+    assert files["image.bin"]["insertions"] is None and files["image.bin"]["deletions"] is None
+
+
+def test_commit_stat_endpoint_accepts_abbreviated_sha(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    head_sha = _commit_with_changes(repo)
+
+    response = client.get("/api/workspace/git/commit", params={"workspace": str(repo), "sha": head_sha[:8]})
+    assert response.status_code == 200
+    assert response.json()["commit"]["sha"] == head_sha
+
+
+def test_commit_stat_endpoint_rejects_invalid_sha(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    _commit_with_changes(repo)
+
+    for bad in ["zzz", "; rm -rf /", "../../etc/passwd", "HEAD", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"]:
+        response = client.get("/api/workspace/git/commit", params={"workspace": str(repo), "sha": bad})
+        assert response.status_code == 400, f"expected rejection for {bad!r}"
+        body = response.json()
+        assert body["ok"] is False
+        assert body["code"]

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -74,6 +74,7 @@ def test_all_workspace_file_and_git_endpoints_reject_non_admin_owner(monkeypatch
         ("/api/workspace/git/checkout", {"workspace": str(tmp_path), "branch": "main"}),
         ("/api/workspace/git/checkout-stash", {"workspace": str(tmp_path), "branch": "main"}),
         ("/api/workspace/git/branch/create", {"workspace": str(tmp_path), "branch": "feature"}),
+        ("/api/workspace/git/commit-message", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/fetch", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/pull", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/push", {"workspace": str(tmp_path)}),
@@ -423,6 +424,74 @@ def test_git_commit_branches_and_local_remote_actions(monkeypatch, tmp_path):
     assert client.post("/api/workspace/git/fetch", json={"workspace": str(repo)}).status_code == 200
     assert client.post("/api/workspace/git/pull", json={"workspace": str(repo)}).status_code == 200
     assert client.post("/api/workspace/git/push", json={"workspace": str(repo)}).status_code == 200
+
+
+def test_generate_commit_message(monkeypatch, tmp_path):
+    import routes.workspace_git_routes as wgr
+    import src.llm_core as llm_core
+
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+    # Staged change to describe.
+    (repo / "file.txt").write_text("base\nhello world\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+
+    # Resolve to a fake model + stub the LLM so no provider is hit.
+    monkeypatch.setattr(wgr, "resolve_task_endpoint", lambda *a, **k: ("http://fake", "test-model", {}))
+    captured = {}
+
+    def _fake_llm(url, model, messages, **kwargs):
+        captured["model"] = model
+        captured["prompt"] = messages[-1]["content"]
+        return "feat: add hello world line\n\nAppend a greeting to file.txt."
+
+    monkeypatch.setattr(llm_core, "llm_call", _fake_llm)
+
+    resp = client.post("/api/workspace/git/commit-message", json={"workspace": str(repo)})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["message"].startswith("feat: add hello world line")
+    # The staged diff was fed to the model.
+    assert "hello world" in captured["prompt"]
+    assert captured["model"] == "test-model"
+
+    # Clean tree -> nothing to describe -> clean error.
+    _git(repo, "commit", "-m", "done")
+    empty = client.post("/api/workspace/git/commit-message", json={"workspace": str(repo)})
+    assert empty.status_code == 400
+    assert empty.json()["code"] in ("git_failed", "no_changes")
+
+
+def test_git_checkout_stash_restores_per_branch(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "other")
+    start = _git(repo, "branch", "--show-current").stdout.strip()
+
+    # Uncommitted WIP on the starting branch.
+    (repo / "file.txt").write_text("base\nWIP-on-start\n", encoding="utf-8")
+
+    # Switch away: WIP is auto-parked, target arrives clean.
+    away = client.post("/api/workspace/git/checkout-stash", json={"workspace": str(repo), "branch": "other"})
+    assert away.status_code == 200
+    assert away.json()["stashed"] is True
+    assert "WIP-on-start" not in (repo / "file.txt").read_text(encoding="utf-8")
+
+    # Switch back: the branch's parked WIP is restored.
+    back = client.post("/api/workspace/git/checkout-stash", json={"workspace": str(repo), "branch": start})
+    assert back.status_code == 200
+    assert back.json()["restored"] is True
+    assert "WIP-on-start" in (repo / "file.txt").read_text(encoding="utf-8")
+
+    # The auto-stash is consumed (not left lingering).
+    assert "odysseus-branch-switch" not in _git(repo, "stash", "list").stdout
 
 
 def test_git_create_branch(monkeypatch, tmp_path):

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -73,6 +73,7 @@ def test_all_workspace_file_and_git_endpoints_reject_non_admin_owner(monkeypatch
         ("/api/workspace/git/commit-selected", {"workspace": str(tmp_path), "paths": ["x"], "message": "m"}),
         ("/api/workspace/git/checkout", {"workspace": str(tmp_path), "branch": "main"}),
         ("/api/workspace/git/checkout-stash", {"workspace": str(tmp_path), "branch": "main"}),
+        ("/api/workspace/git/branch/create", {"workspace": str(tmp_path), "branch": "feature"}),
         ("/api/workspace/git/fetch", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/pull", {"workspace": str(tmp_path)}),
         ("/api/workspace/git/push", {"workspace": str(tmp_path)}),
@@ -424,6 +425,42 @@ def test_git_commit_branches_and_local_remote_actions(monkeypatch, tmp_path):
     assert client.post("/api/workspace/git/push", json={"workspace": str(repo)}).status_code == 200
 
 
+def test_git_create_branch(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+
+    created = client.post("/api/workspace/git/branch/create", json={"workspace": str(repo), "branch": "feature-x"})
+    assert created.status_code == 200
+    assert created.json()["branch"] == "feature-x"
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "feature-x"
+
+    # Creating an existing branch is rejected.
+    dup = client.post("/api/workspace/git/branch/create", json={"workspace": str(repo), "branch": "feature-x"})
+    assert dup.status_code == 400
+    assert dup.json()["code"] == "git_failed"
+
+    # Invalid names are rejected before reaching the worktree.
+    for bad in ("bad name", "-x", "foo..bar"):
+        resp = client.post("/api/workspace/git/branch/create", json={"workspace": str(repo), "branch": bad})
+        assert resp.status_code == 400, bad
+
+
+def test_git_create_branch_rejects_nested_workspace(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    workspace = repo / "sub"
+    workspace.mkdir()
+    (workspace / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    resp = client.post("/api/workspace/git/branch/create", json={"workspace": str(workspace), "branch": "feature"})
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "outside_workspace"
+
+
 def test_git_commit_staged_changes(monkeypatch, tmp_path):
     client = _client(monkeypatch)
     repo = _init_repo(tmp_path / "repo")
@@ -722,3 +759,43 @@ def test_missing_git_returns_stable_error(monkeypatch, tmp_path):
 
     assert response.status_code == 400
     assert response.json()["code"] == "missing_git"
+
+
+def test_conflict_marker_detection_covers_diff3_and_is_anchored():
+    import src.workspace_git as workspace_git
+
+    detect = workspace_git._contains_conflict_markers
+
+    # Standard merge-style markers (with and without labels).
+    assert detect("a\n<<<<<<< HEAD\nx\n=======\ny\n>>>>>>> branch\nb\n")
+    assert detect("<<<<<<<\nx\n=======\ny\n>>>>>>>\n")
+    # diff3/zdiff3 base separator must be treated as a remaining marker so a
+    # leaked base section cannot pass validation and get staged.
+    assert detect("ours\n||||||| merged common ancestors\nbase\n=======\ntheirs\n")
+    assert detect("clean\n||||||| base\nstuff\n")
+    assert not detect("resolved\n")
+    # Exact-7-char anchoring: an 8+ char underline / long rule / inline text is NOT
+    # a conflict marker.
+    assert not detect("Title\n========\n\nbody text\n")  # 8 '=' (reST underline)
+    assert not detect("section\n====================\nbody\n")  # long rule
+    assert not detect("the operator <<<<<<< is documented inline\n")  # mid-line
+
+
+def test_resolve_conflict_rejects_leaked_diff3_base(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "f.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "base")
+
+    # Content that still carries a diff3 base separator must be rejected, not staged.
+    leaked = client.post(
+        "/api/workspace/git/conflict/resolve",
+        json={
+            "workspace": str(repo),
+            "path": "f.txt",
+            "content": "ours\n||||||| merged common ancestors\nbase\n",
+        },
+    )
+    assert leaked.status_code == 400
+    assert leaked.json()["code"] == "merge_conflict"

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -868,3 +868,89 @@ def test_resolve_conflict_rejects_leaked_diff3_base(monkeypatch, tmp_path):
     )
     assert leaked.status_code == 400
     assert leaked.json()["code"] == "merge_conflict"
+
+
+def _history_topology(repo, tmp_path):
+    """Build a repo with a tag, a feature branch, a merge commit and a
+    remote-tracking ref, returning (default_branch, base_sha)."""
+    (repo / "f.txt").write_text("a\n", encoding="utf-8")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "tag", "v1.0")
+    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    main = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "f.txt").write_text("a\nb\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "feature work")
+
+    _git(repo, "checkout", main)
+    (repo / "g.txt").write_text("c\n", encoding="utf-8")
+    _git(repo, "add", "g.txt")
+    _git(repo, "commit", "-m", "main work")
+    _git(repo, "merge", "--no-ff", "feature", "-m", "merge feature")
+
+    # A remote-tracking ref plus a registered remote so it types as "remote".
+    _git(repo, "update-ref", f"refs/remotes/origin/{main}", main)
+    _git(repo, "remote", "add", "origin", str(tmp_path / "fake-remote"))
+    return main, base_sha
+
+
+def test_git_history_includes_parents_and_typed_refs(monkeypatch, tmp_path):
+    import src.workspace_git as workspace_git
+
+    repo = _init_repo(tmp_path / "repo")
+    main, base_sha = _history_topology(repo, tmp_path)
+
+    history = workspace_git.git_history(str(repo))
+    commits = history["commits"]
+    assert commits, "expected commits under repo scope"
+
+    for commit in commits:
+        assert isinstance(commit["parents"], list)
+        assert isinstance(commit["refs"], list)
+        for ref in commit["refs"]:
+            assert set(ref) == {"name", "type", "current"}
+            assert ref["type"] in {"head", "local", "remote", "tag"}
+
+    by_sha = {commit["sha"]: commit for commit in commits}
+
+    merge = next(commit for commit in commits if commit["message"] == "merge feature")
+    assert len(merge["parents"]) == 2
+    assert all(parent in by_sha for parent in merge["parents"])
+
+    base = by_sha[base_sha]
+    assert base["parents"] == []
+    assert any(ref["type"] == "tag" and ref["name"] == "v1.0" for ref in base["refs"])
+
+    all_refs = [ref for commit in commits for ref in commit["refs"]]
+    assert any(ref["type"] == "head" and ref["current"] and ref["name"] == main for ref in all_refs)
+    assert any(ref["type"] == "remote" and ref["name"] == f"origin/{main}" for ref in all_refs)
+    assert any(ref["type"] == "local" and ref["name"] == "feature" for ref in all_refs)
+
+
+def test_git_history_repo_scope_surfaces_all_branches(monkeypatch, tmp_path):
+    """Repo scope uses --all, so a branch not reachable from HEAD still appears."""
+    import src.workspace_git as workspace_git
+
+    repo = _init_repo(tmp_path / "repo")
+    main, _ = _history_topology(repo, tmp_path)
+
+    # An orphan-ish side branch whose tip is not on the current branch.
+    _git(repo, "checkout", "-b", "sidebar")
+    (repo / "side.txt").write_text("side\n", encoding="utf-8")
+    _git(repo, "add", "side.txt")
+    _git(repo, "commit", "-m", "side commit")
+    _git(repo, "checkout", main)
+
+    repo_messages = [commit["message"] for commit in workspace_git.git_history(str(repo))["commits"]]
+    assert "side commit" in repo_messages
+
+    # File scope stays linear on the current branch and omits the side branch.
+    file_history = workspace_git.git_history(str(repo), path="f.txt")
+    file_messages = [commit["message"] for commit in file_history["commits"]]
+    assert "side commit" not in file_messages
+    assert "base" in file_messages
+    for commit in file_history["commits"]:
+        assert isinstance(commit["parents"], list)
+        assert isinstance(commit["refs"], list)

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -1017,3 +1017,63 @@ def test_commit_stat_endpoint_rejects_invalid_sha(monkeypatch, tmp_path):
         body = response.json()
         assert body["ok"] is False
         assert body["code"]
+
+
+def test_commit_message_refreshes_session_auth_like_chat(monkeypatch, tmp_path):
+    """A ChatGPT-Subscription chat session stores no persisted bearer (it is
+    short-lived and re-resolved per request). Commit-message generation must
+    refresh the session's auth the same way the chat path does, otherwise the
+    model call goes out unauthorized (the codex endpoint returns 401)."""
+    import routes.workspace_git_routes as wgr
+    import routes.chat_helpers as chat_helpers
+    import src.ai_interaction as ai_interaction
+    import src.llm_core as llm_core
+
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "f.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "base")
+    # A staged change to describe.
+    (repo / "f.txt").write_text("base\nchanged\n", encoding="utf-8")
+    _git(repo, "add", "f.txt")
+
+    # Fake ChatGPT-Subscription session: model + codex endpoint, but NO persisted
+    # bearer (mirrors how the chat path keeps the token request-local).
+    class _Sess:
+        model = "gpt-5-codex"
+        endpoint_url = "https://chatgpt.com/backend-api/codex"
+        headers: dict = {}
+
+    sess = _Sess()
+
+    class _SM:
+        def get_session(self, _sid):
+            return sess
+
+    monkeypatch.setattr(ai_interaction, "get_session_manager", lambda: _SM())
+
+    # Stand in for the per-request bearer refresh the chat path performs.
+    def _fake_resolve_session_auth(s, session_id, owner=None):
+        s.headers = {"Authorization": "Bearer fresh-token"}
+
+    monkeypatch.setattr(chat_helpers, "resolve_session_auth", _fake_resolve_session_auth)
+
+    captured = {}
+
+    def _fake_llm(url, model, messages, **kwargs):
+        captured["model"] = model
+        captured["headers"] = kwargs.get("headers")
+        return "feat: append a changed line"
+
+    monkeypatch.setattr(llm_core, "llm_call", _fake_llm)
+
+    resp = client.post(
+        "/api/workspace/git/commit-message",
+        json={"workspace": str(repo), "sessionId": "sess-1"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["model"] == "gpt-5-codex"
+    # The fresh, request-local bearer must reach the model call.
+    assert captured["headers"], "no auth headers were sent to the model"
+    assert captured["headers"].get("Authorization") == "Bearer fresh-token"

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -1,0 +1,724 @@
+import os
+import subprocess
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _git(repo, *args, check=True):
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result
+
+
+def _init_repo(path):
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init")
+    _git(path, "config", "user.email", "tests@example.test")
+    _git(path, "config", "user.name", "Workspace Tests")
+    return path
+
+
+def _client(monkeypatch, *, admin=True):
+    import routes.workspace_routes as workspace_routes
+    import routes.workspace_git_routes as workspace_git_routes
+
+    monkeypatch.setattr(workspace_routes, "get_current_user", lambda request: "alice")
+    monkeypatch.setattr(workspace_routes, "owner_is_admin_or_single_user", lambda owner: admin)
+    monkeypatch.setattr(workspace_git_routes, "get_current_user", lambda request: "alice")
+    monkeypatch.setattr(workspace_git_routes, "owner_is_admin_or_single_user", lambda owner: admin)
+
+    app = FastAPI()
+    app.include_router(workspace_routes.setup_workspace_routes())
+    app.include_router(workspace_git_routes.setup_workspace_git_routes())
+    return TestClient(app)
+
+
+def test_git_routes_reject_non_admin_owner(monkeypatch, tmp_path):
+    client = _client(monkeypatch, admin=False)
+
+    response = client.get("/api/workspace/git/status", params={"workspace": str(tmp_path)})
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "not_authorized"
+
+
+def test_all_workspace_file_and_git_endpoints_reject_non_admin_owner(monkeypatch, tmp_path):
+    client = _client(monkeypatch, admin=False)
+    get_endpoints = [
+        ("/api/workspace/files", {"workspace": str(tmp_path)}),
+        ("/api/workspace/file", {"workspace": str(tmp_path), "path": "x"}),
+        ("/api/workspace/git/status", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/diff", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/branches", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/history", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/blame", {"workspace": str(tmp_path), "path": "x"}),
+        ("/api/workspace/git/conflicts", {"workspace": str(tmp_path)}),
+    ]
+    post_endpoints = [
+        ("/api/workspace/file/save", {"workspace": str(tmp_path), "path": "x", "content": ""}),
+        ("/api/workspace/git/stage", {"workspace": str(tmp_path), "paths": ["x"]}),
+        ("/api/workspace/git/unstage", {"workspace": str(tmp_path), "paths": ["x"]}),
+        ("/api/workspace/git/discard", {"workspace": str(tmp_path), "paths": ["x"]}),
+        ("/api/workspace/git/hunks/stage", {"workspace": str(tmp_path), "path": "x", "hunkId": "h"}),
+        ("/api/workspace/git/hunks/unstage", {"workspace": str(tmp_path), "path": "x", "hunkId": "h"}),
+        ("/api/workspace/git/commit", {"workspace": str(tmp_path), "message": "m"}),
+        ("/api/workspace/git/commit-selected", {"workspace": str(tmp_path), "paths": ["x"], "message": "m"}),
+        ("/api/workspace/git/checkout", {"workspace": str(tmp_path), "branch": "main"}),
+        ("/api/workspace/git/checkout-stash", {"workspace": str(tmp_path), "branch": "main"}),
+        ("/api/workspace/git/fetch", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/pull", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/push", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/init", {"workspace": str(tmp_path)}),
+        ("/api/workspace/git/clone", {"workspace": str(tmp_path), "url": str(tmp_path), "name": "x"}),
+        ("/api/workspace/git/conflict/resolve", {"workspace": str(tmp_path), "path": "x", "content": ""}),
+    ]
+
+    for path, params in get_endpoints:
+        response = client.get(path, params=params)
+        assert response.status_code == 403, path
+        assert response.json()["code"] == "not_authorized"
+    for path, body in post_endpoints:
+        response = client.post(path, json=body)
+        assert response.status_code == 403, path
+        assert response.json()["code"] == "not_authorized"
+
+
+def test_git_routes_reject_missing_or_invalid_workspace(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+
+    missing = client.get("/api/workspace/git/status")
+    invalid = client.get("/api/workspace/git/status", params={"workspace": str(tmp_path / "missing")})
+
+    assert missing.status_code == 400
+    assert missing.json()["code"] == "invalid_workspace"
+    assert invalid.status_code == 400
+    assert invalid.json()["code"] == "invalid_workspace"
+
+
+def test_git_status_rejects_non_git_workspace(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+
+    response = client.get("/api/workspace/git/status", params={"workspace": str(tmp_path)})
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "not_git_repo"
+
+
+def test_workspace_file_list_read_save_and_rejections(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    (tmp_path / "b-dir").mkdir()
+    (tmp_path / "a-dir").mkdir()
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "z.txt").write_text("z", encoding="utf-8")
+    (tmp_path / "A.txt").write_text("hello", encoding="utf-8")
+    (tmp_path / "bin.dat").write_bytes(b"a\x00b")
+    (tmp_path / ".ssh").mkdir()
+
+    listed = client.get("/api/workspace/files", params={"workspace": str(tmp_path), "path": ""})
+    assert listed.status_code == 200
+    body = listed.json()
+    assert [d["name"] for d in body["dirs"]] == ["a-dir", "b-dir"]
+    assert [f["name"] for f in body["files"]] == ["A.txt", "bin.dat", "z.txt"]
+
+    read_text = client.get("/api/workspace/file", params={"workspace": str(tmp_path), "path": "A.txt"})
+    assert read_text.json()["content"] == "hello"
+    assert read_text.json()["binary"] is False
+    assert read_text.json()["editable"] is True
+
+    read_binary = client.get("/api/workspace/file", params={"workspace": str(tmp_path), "path": "bin.dat"})
+    assert read_binary.json()["binary"] is True
+    assert read_binary.json()["editable"] is False
+    assert "content" not in read_binary.json()
+
+    saved = client.post(
+        "/api/workspace/file/save",
+        json={"workspace": str(tmp_path), "path": "A.txt", "content": "updated"},
+    )
+    assert saved.status_code == 200
+    assert (tmp_path / "A.txt").read_text(encoding="utf-8") == "updated"
+
+    traversal = client.get("/api/workspace/file", params={"workspace": str(tmp_path), "path": "../x"})
+    sensitive = client.post(
+        "/api/workspace/file/save",
+        json={"workspace": str(tmp_path), "path": ".ssh/authorized_keys", "content": "x"},
+    )
+    new_parent = client.post(
+        "/api/workspace/file/save",
+        json={"workspace": str(tmp_path), "path": "new/child.txt", "content": "x"},
+    )
+    assert traversal.status_code == 400
+    assert traversal.json()["code"] == "outside_workspace"
+    assert sensitive.status_code == 400
+    assert sensitive.json()["code"] == "outside_workspace"
+    assert new_parent.status_code == 400
+    assert new_parent.json()["code"] == "outside_workspace"
+
+
+def test_workspace_file_apis_reject_git_metadata_and_malformed_body(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "safe.txt").write_text("safe\n", encoding="utf-8")
+
+    read_git = client.get("/api/workspace/file", params={"workspace": str(repo), "path": ".git/config"})
+    write_git = client.post(
+        "/api/workspace/file/save",
+        json={"workspace": str(repo), "path": ".git/hooks/pre-commit", "content": "#!/bin/sh\nexit 1\n"},
+    )
+    missing_content = client.post(
+        "/api/workspace/file/save",
+        json={"workspace": str(repo), "path": "safe.txt"},
+    )
+
+    assert read_git.status_code == 400
+    assert read_git.json()["code"] == "outside_workspace"
+    assert write_git.status_code == 400
+    assert write_git.json()["code"] == "outside_workspace"
+    assert missing_content.status_code == 400
+    assert missing_content.json()["code"] == "invalid_request"
+    assert (repo / "safe.txt").read_text(encoding="utf-8") == "safe\n"
+
+
+def test_git_status_and_diff_cover_common_file_states(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    (repo / "delete-me.txt").write_text("gone\n", encoding="utf-8")
+    (repo / "old-name.txt").write_text("rename\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+
+    (repo / "tracked.txt").write_text("base\nchanged\n", encoding="utf-8")
+    (repo / "new.txt").write_text("new\n", encoding="utf-8")
+    (repo / "delete-me.txt").unlink()
+    _git(repo, "mv", "old-name.txt", "new-name.txt")
+    (repo / "ignored.txt").write_text("ignored\n", encoding="utf-8")
+    _git(repo, "add", "new.txt", "new-name.txt")
+
+    status = client.get("/api/workspace/git/status", params={"workspace": str(repo)}).json()
+    by_path = {item["path"]: item for item in status["files"]}
+    assert by_path["tracked.txt"]["worktree"] == "modified"
+    assert by_path["new.txt"]["index"] == "added"
+    assert by_path["delete-me.txt"]["worktree"] == "deleted"
+    assert by_path["new-name.txt"]["index"] == "renamed"
+    assert "ignored.txt" not in by_path
+
+    diff = client.get(
+        "/api/workspace/git/diff",
+        params={"workspace": str(repo), "path": "tracked.txt"},
+    ).json()
+    assert diff["files"][0]["path"] == "tracked.txt"
+    assert diff["files"][0]["hunks"]
+    assert "+changed" in diff["patch"]
+
+
+def test_git_status_and_diff_are_bounded_to_selected_workspace(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    workspace = repo / "workspace"
+    workspace.mkdir()
+    (workspace / "visible.txt").write_text("base\n", encoding="utf-8")
+    (repo / "secret.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+
+    (workspace / "visible.txt").write_text("base\nvisible\n", encoding="utf-8")
+    (repo / "secret.txt").write_text("base\nsecret\n", encoding="utf-8")
+
+    status = client.get("/api/workspace/git/status", params={"workspace": str(workspace)}).json()
+    assert [item["path"] for item in status["files"]] == ["visible.txt"]
+
+    diff = client.get("/api/workspace/git/diff", params={"workspace": str(workspace)}).json()
+    assert "visible" in diff["patch"]
+    assert "secret" not in diff["patch"]
+    assert diff["files"][0]["path"] == "visible.txt"
+
+
+def test_git_mutation_responses_use_workspace_relative_paths(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    workspace = repo / "workspace"
+    workspace.mkdir()
+    (workspace / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    (workspace / "file.txt").write_text("changed\n", encoding="utf-8")
+
+    staged = client.post("/api/workspace/git/stage", json={"workspace": str(workspace), "paths": ["file.txt"]})
+    selected = client.post(
+        "/api/workspace/git/commit-selected",
+        json={"workspace": str(workspace), "paths": ["file.txt"], "message": "selected"},
+    )
+    blame = client.get("/api/workspace/git/blame", params={"workspace": str(workspace), "path": "file.txt"})
+
+    assert staged.status_code == 200
+    assert staged.json()["paths"] == ["file.txt"]
+    assert selected.status_code == 200
+    assert selected.json()["paths"] == ["file.txt"]
+    assert blame.status_code == 200
+    assert blame.json()["path"] == "file.txt"
+
+
+def test_git_rejects_absolute_blank_and_root_pathspecs(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+
+    absolute = client.post("/api/workspace/git/stage", json={"workspace": str(repo), "paths": [str(repo / "file.txt")]})
+    blank = client.post("/api/workspace/git/stage", json={"workspace": str(repo), "paths": [""]})
+    root = client.post("/api/workspace/git/discard", json={"workspace": str(repo), "paths": ["."]})
+
+    assert absolute.status_code == 400
+    assert absolute.json()["code"] == "outside_workspace"
+    assert blank.status_code == 400
+    assert blank.json()["code"] == "outside_workspace"
+    assert root.status_code == 400
+    assert root.json()["code"] == "outside_workspace"
+
+
+def test_git_stage_unstage_discard_and_hunk_operations(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+
+    (repo / "file.txt").write_text("ONE\ntwo\nTHREE\n", encoding="utf-8")
+    diff = client.get(
+        "/api/workspace/git/diff",
+        params={"workspace": str(repo), "path": "file.txt"},
+    ).json()
+    hunk_id = diff["files"][0]["hunks"][0]["id"]
+
+    staged_hunk = client.post(
+        "/api/workspace/git/hunks/stage",
+        json={"workspace": str(repo), "path": "file.txt", "hunkId": hunk_id},
+    )
+    assert staged_hunk.status_code == 200
+    assert client.get("/api/workspace/git/diff", params={"workspace": str(repo), "staged": True}).json()["files"]
+
+    unstaged_hunk = client.post(
+        "/api/workspace/git/hunks/unstage",
+        json={"workspace": str(repo), "path": "file.txt", "hunkId": hunk_id},
+    )
+    assert unstaged_hunk.status_code == 200
+
+    assert client.post("/api/workspace/git/stage", json={"workspace": str(repo), "paths": ["file.txt"]}).status_code == 200
+    assert client.post("/api/workspace/git/unstage", json={"workspace": str(repo), "paths": ["file.txt"]}).status_code == 200
+    assert client.post("/api/workspace/git/discard", json={"workspace": str(repo), "paths": ["file.txt"]}).status_code == 200
+    assert (repo / "file.txt").read_text(encoding="utf-8") == "one\ntwo\nthree\n"
+
+    traversal = client.post("/api/workspace/git/stage", json={"workspace": str(repo), "paths": ["../escape"]})
+    assert traversal.status_code == 400
+    assert traversal.json()["code"] == "outside_workspace"
+
+
+def test_git_stage_rejects_clean_filter_config(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "config", "filter.bad.clean", "sh -c 'echo pwned > should-not-run'")
+    _git(repo, "config", "filter.bad.smudge", "cat")
+    (repo / ".gitattributes").write_text("*.txt filter=bad\n", encoding="utf-8")
+    (repo / "file.txt").write_text("content\n", encoding="utf-8")
+
+    response = client.post("/api/workspace/git/stage", json={"workspace": str(repo), "paths": ["file.txt"]})
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "git_failed"
+    assert "unsafe git config" in response.json()["error"]
+    assert not (repo / "should-not-run").exists()
+
+
+def test_git_discard_removes_staged_additions_and_restores_staged_deletions(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "delete-me.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "delete-me.txt")
+    _git(repo, "commit", "-m", "base")
+
+    (repo / "new.txt").write_text("new\n", encoding="utf-8")
+    _git(repo, "add", "new.txt")
+    add_response = client.post("/api/workspace/git/discard", json={"workspace": str(repo), "paths": ["new.txt"]})
+    assert add_response.status_code == 200
+    assert not (repo / "new.txt").exists()
+    assert "new.txt" not in _git(repo, "diff", "--cached", "--name-only").stdout
+
+    (repo / "delete-me.txt").unlink()
+    _git(repo, "add", "delete-me.txt")
+    delete_response = client.post("/api/workspace/git/discard", json={"workspace": str(repo), "paths": ["delete-me.txt"]})
+    assert delete_response.status_code == 200
+    assert (repo / "delete-me.txt").read_text(encoding="utf-8") == "base\n"
+    assert "delete-me.txt" not in _git(repo, "diff", "--cached", "--name-only").stdout
+
+
+def test_git_discard_reports_tracked_restore_failure(monkeypatch, tmp_path):
+    import subprocess
+    import src.workspace_git as workspace_git
+
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+
+    real_git_run = workspace_git.git_run
+
+    def failing_restore(repo_root, args, *, check=True, env=None):
+        if args[:2] == ["restore", "--worktree"]:
+            return subprocess.CompletedProcess(["git", *args], 1, "", "restore failed")
+        return real_git_run(repo_root, args, check=check, env=env)
+
+    monkeypatch.setattr(workspace_git, "git_run", failing_restore)
+
+    response = client.post("/api/workspace/git/discard", json={"workspace": str(repo), "paths": ["file.txt"]})
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "git_failed"
+
+
+def test_git_commit_branches_and_local_remote_actions(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    remote = tmp_path / "remote.git"
+    _git(tmp_path, "init", "--bare", str(remote))
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "remote", "add", "origin", str(remote))
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "push", "-u", "origin", "master")
+
+    (repo / "file.txt").write_text("base\nnext\n", encoding="utf-8")
+    committed = client.post("/api/workspace/git/commit-selected", json={
+        "workspace": str(repo),
+        "paths": ["file.txt"],
+        "message": "selected",
+    })
+    assert committed.status_code == 200
+    assert committed.json()["commit"]
+
+    branches = client.get("/api/workspace/git/branches", params={"workspace": str(repo)}).json()
+    assert branches["current"]
+    assert any(branch["name"] == "master" for branch in branches["local"])
+
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    blocked = client.post("/api/workspace/git/checkout", json={"workspace": str(repo), "branch": "master"})
+    assert blocked.status_code == 400
+    assert blocked.json()["code"] == "dirty_worktree"
+    stashed = client.post("/api/workspace/git/checkout-stash", json={"workspace": str(repo), "branch": "master"})
+    assert stashed.status_code == 200
+
+    assert client.post("/api/workspace/git/fetch", json={"workspace": str(repo)}).status_code == 200
+    assert client.post("/api/workspace/git/pull", json={"workspace": str(repo)}).status_code == 200
+    assert client.post("/api/workspace/git/push", json={"workspace": str(repo)}).status_code == 200
+
+
+def test_git_commit_staged_changes(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+
+    response = client.post("/api/workspace/git/commit", json={"workspace": str(repo), "message": "normal commit"})
+
+    assert response.status_code == 200
+    assert response.json()["commit"]
+    assert _git(repo, "show", "--name-only", "--format=", "HEAD").stdout.splitlines() == ["file.txt"]
+
+
+def test_repo_wide_mutations_reject_nested_workspace(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    workspace = repo / "workspace"
+    workspace.mkdir()
+    (workspace / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+
+    for endpoint, body in [
+        ("/api/workspace/git/checkout", {"workspace": str(workspace), "branch": "master"}),
+        ("/api/workspace/git/checkout-stash", {"workspace": str(workspace), "branch": "master"}),
+        ("/api/workspace/git/fetch", {"workspace": str(workspace)}),
+        ("/api/workspace/git/pull", {"workspace": str(workspace)}),
+        ("/api/workspace/git/push", {"workspace": str(workspace)}),
+    ]:
+        response = client.post(endpoint, json=body)
+        assert response.status_code == 400, endpoint
+        assert response.json()["code"] == "outside_workspace"
+
+
+def test_git_status_and_branches_report_upstream_ahead_behind(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    remote = tmp_path / "remote.git"
+    _git(tmp_path, "init", "--bare", str(remote))
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "remote", "add", "origin", str(remote))
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "push", "-u", "origin", "master")
+
+    (repo / "ahead.txt").write_text("ahead\n", encoding="utf-8")
+    _git(repo, "add", "ahead.txt")
+    _git(repo, "commit", "-m", "ahead")
+    other = tmp_path / "other"
+    _git(tmp_path, "clone", str(remote), str(other))
+    _git(other, "config", "user.email", "tests@example.test")
+    _git(other, "config", "user.name", "Workspace Tests")
+    (other / "behind.txt").write_text("behind\n", encoding="utf-8")
+    _git(other, "add", "behind.txt")
+    _git(other, "commit", "-m", "behind")
+    _git(other, "push")
+    _git(repo, "fetch")
+
+    status = client.get("/api/workspace/git/status", params={"workspace": str(repo)}).json()
+    assert status["upstream"] == "origin/master"
+    assert status["ahead"] == 1
+    assert status["behind"] == 1
+
+    branches = client.get("/api/workspace/git/branches", params={"workspace": str(repo)}).json()
+    master = next(branch for branch in branches["local"] if branch["name"] == "master")
+    assert master["upstream"] == "origin/master"
+    assert master["ahead"] == 1
+    assert master["behind"] == 1
+    assert any(branch["name"] == "origin/master" for branch in branches["remote"])
+
+
+def test_selected_commit_preserves_unrelated_staged_changes(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "selected.txt").write_text("base\n", encoding="utf-8")
+    (repo / "staged.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+
+    (repo / "selected.txt").write_text("selected\n", encoding="utf-8")
+    (repo / "staged.txt").write_text("staged\n", encoding="utf-8")
+    _git(repo, "add", "staged.txt")
+
+    response = client.post("/api/workspace/git/commit-selected", json={
+        "workspace": str(repo),
+        "paths": ["selected.txt"],
+        "message": "selected only",
+    })
+
+    assert response.status_code == 200
+    committed = _git(repo, "show", "--name-only", "--format=", "HEAD").stdout.splitlines()
+    assert committed == ["selected.txt"]
+    assert "staged.txt" in _git(repo, "diff", "--cached", "--name-only").stdout.splitlines()
+
+
+def test_selected_commit_failure_does_not_stage_selected_paths(monkeypatch, tmp_path):
+    import src.workspace_git as workspace_git
+
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "selected.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "selected.txt")
+    _git(repo, "commit", "-m", "base")
+    real_git_run = workspace_git.git_run
+
+    def failing_commit(repo_root, args, *, check=True, env=None):
+        if args and args[0] == "commit":
+            raise workspace_git.GitWorkspaceError("git_failed", "simulated commit failure")
+        return real_git_run(repo_root, args, check=check, env=env)
+
+    monkeypatch.setattr(workspace_git, "git_run", failing_commit)
+
+    (repo / "selected.txt").write_text("changed\n", encoding="utf-8")
+    response = client.post("/api/workspace/git/commit-selected", json={
+        "workspace": str(repo),
+        "paths": ["selected.txt"],
+        "message": "blocked",
+    })
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "git_failed"
+    assert _git(repo, "diff", "--cached", "--name-only").stdout == ""
+
+
+def test_initial_selected_commit(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "first.txt").write_text("first\n", encoding="utf-8")
+
+    response = client.post("/api/workspace/git/commit-selected", json={
+        "workspace": str(repo),
+        "paths": ["first.txt"],
+        "message": "initial selected",
+    })
+
+    assert response.status_code == 200
+    assert _git(repo, "show", "--name-only", "--format=", "HEAD").stdout.splitlines() == ["first.txt"]
+
+
+def test_selected_commit_can_commit_deletions(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "deleted.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "deleted.txt")
+    _git(repo, "commit", "-m", "base")
+    (repo / "deleted.txt").unlink()
+
+    response = client.post("/api/workspace/git/commit-selected", json={
+        "workspace": str(repo),
+        "paths": ["deleted.txt"],
+        "message": "delete selected",
+    })
+
+    assert response.status_code == 200
+    assert _git(repo, "show", "--name-status", "--format=", "HEAD").stdout.splitlines() == ["D\tdeleted.txt"]
+
+
+def test_git_init_clone_history_blame_and_conflict_resolution(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+
+    init_target = tmp_path / "init-target"
+    init_target.mkdir()
+    init_response = client.post("/api/workspace/git/init", json={"workspace": str(init_target)})
+    assert init_response.status_code == 200
+    assert (init_target / ".git").is_dir()
+
+    source = _init_repo(tmp_path / "source")
+    (source / "file.txt").write_text("line one\nline two\n", encoding="utf-8")
+    _git(source, "add", "file.txt")
+    _git(source, "commit", "-m", "base")
+
+    clone_parent = tmp_path / "clones"
+    clone = client.post("/api/workspace/git/clone", json={
+        "workspace": str(tmp_path),
+        "url": str(source),
+        "target": str(clone_parent),
+        "name": "safe-clone",
+    })
+    assert clone.status_code == 200
+    clone_path = clone.json()["path"]
+    assert os.path.isdir(os.path.join(clone_path, ".git"))
+
+    unsafe = client.post("/api/workspace/git/clone", json={
+        "workspace": str(tmp_path),
+        "url": str(source),
+        "target": str(clone_parent),
+        "name": "../bad",
+    })
+    assert unsafe.status_code == 400
+    assert unsafe.json()["code"] == "outside_workspace"
+
+    no_workspace_target = client.post("/api/workspace/git/clone", json={
+        "url": str(source),
+        "target": str(tmp_path / "anywhere"),
+        "name": "clone",
+    })
+    assert no_workspace_target.status_code == 400
+    assert no_workspace_target.json()["code"] == "invalid_workspace"
+
+    history = client.get("/api/workspace/git/history", params={"workspace": clone_path}).json()
+    assert history["commits"][0]["message"] == "base"
+    file_history = client.get(
+        "/api/workspace/git/history",
+        params={"workspace": clone_path, "path": "file.txt"},
+    ).json()
+    assert file_history["commits"]
+    blame = client.get("/api/workspace/git/blame", params={"workspace": clone_path, "path": "file.txt"}).json()
+    assert blame["lines"][0]["text"] == "line one"
+
+    conflict_repo = _init_repo(tmp_path / "conflict")
+    (conflict_repo / "conflict.txt").write_text("base\n", encoding="utf-8")
+    _git(conflict_repo, "add", "conflict.txt")
+    _git(conflict_repo, "commit", "-m", "base")
+    _git(conflict_repo, "checkout", "-b", "left")
+    (conflict_repo / "conflict.txt").write_text("left\n", encoding="utf-8")
+    _git(conflict_repo, "commit", "-am", "left")
+    _git(conflict_repo, "checkout", "master")
+    _git(conflict_repo, "checkout", "-b", "right")
+    (conflict_repo / "conflict.txt").write_text("right\n", encoding="utf-8")
+    _git(conflict_repo, "commit", "-am", "right")
+    _git(conflict_repo, "merge", "left", check=False)
+
+    discard_blocked = client.post(
+        "/api/workspace/git/discard",
+        json={"workspace": str(conflict_repo), "paths": ["conflict.txt"]},
+    )
+    assert discard_blocked.status_code == 400
+    assert discard_blocked.json()["code"] == "merge_conflict"
+
+    conflicts = client.get("/api/workspace/git/conflicts", params={"workspace": str(conflict_repo)}).json()
+    assert conflicts["files"][0]["path"] == "conflict.txt"
+
+    unresolved = client.post("/api/workspace/git/conflict/resolve", json={
+        "workspace": str(conflict_repo),
+        "path": "conflict.txt",
+        "content": "<<<<<<< HEAD\nx\n=======\ny\n>>>>>>> other\n",
+    })
+    assert unresolved.status_code == 400
+    assert unresolved.json()["code"] == "merge_conflict"
+    resolved = client.post("/api/workspace/git/conflict/resolve", json={
+        "workspace": str(conflict_repo),
+        "path": "conflict.txt",
+        "content": "resolved\n",
+    })
+    assert resolved.status_code == 200
+    assert not client.get("/api/workspace/git/conflicts", params={"workspace": str(conflict_repo)}).json()["files"]
+
+
+def test_clone_default_parent_and_binary_blame_rejection(monkeypatch, tmp_path):
+    import src.workspace_git as workspace_git
+
+    client = _client(monkeypatch)
+    source = _init_repo(tmp_path / "source")
+    (source / "file.txt").write_text("content\n", encoding="utf-8")
+    _git(source, "add", "file.txt")
+    _git(source, "commit", "-m", "base")
+
+    default_parent = tmp_path / "default-clones"
+    monkeypatch.setattr(workspace_git, "default_clone_parent", lambda: str(default_parent))
+    clone = client.post("/api/workspace/git/clone", json={"url": str(source)})
+
+    assert clone.status_code == 200
+    assert clone.json()["path"] == os.path.join(str(default_parent), "source")
+    assert os.path.isdir(os.path.join(clone.json()["path"], ".git"))
+
+    (source / "bin.dat").write_bytes(b"a\x00b")
+    _git(source, "add", "bin.dat")
+    _git(source, "commit", "-m", "binary")
+    rejected = client.get("/api/workspace/git/blame", params={"workspace": str(source), "path": "bin.dat"})
+    assert rejected.status_code == 400
+    assert rejected.json()["code"] == "binary_file"
+
+
+def test_default_clone_parent_uses_docker_or_home(monkeypatch):
+    import src.workspace_git as workspace_git
+
+    monkeypatch.setattr(workspace_git.os.path, "exists", lambda path: path == "/.dockerenv")
+    assert workspace_git.default_clone_parent() == "/app/data/workspaces"
+
+    monkeypatch.setattr(workspace_git.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(workspace_git.Path, "read_text", lambda self, errors=None: "0::/docker/abc")
+    assert workspace_git.default_clone_parent() == "/app/data/workspaces"
+
+    monkeypatch.setattr(workspace_git.Path, "read_text", lambda self, errors=None: "")
+    assert workspace_git.default_clone_parent().endswith("odysseus-workspaces")
+
+
+def test_missing_git_returns_stable_error(monkeypatch, tmp_path):
+    import src.workspace_git as workspace_git
+
+    client = _client(monkeypatch)
+    _init_repo(tmp_path / "repo")
+    monkeypatch.setattr(workspace_git.shutil, "which", lambda name: None)
+
+    response = client.get("/api/workspace/git/status", params={"workspace": str(tmp_path / "repo")})
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "missing_git"

--- a/tests/test_workspace_git_backend.py
+++ b/tests/test_workspace_git_backend.py
@@ -1077,3 +1077,44 @@ def test_commit_message_refreshes_session_auth_like_chat(monkeypatch, tmp_path):
     # The fresh, request-local bearer must reach the model call.
     assert captured["headers"], "no auth headers were sent to the model"
     assert captured["headers"].get("Authorization") == "Bearer fresh-token"
+
+
+def test_delete_workspace_file_and_folder_and_rejections(monkeypatch, tmp_path):
+    client = _client(monkeypatch)
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "gone.txt").write_text("gone\n", encoding="utf-8")
+    (repo / "keep.txt").write_text("keep\n", encoding="utf-8")
+    _git(repo, "add", "keep.txt")
+    _git(repo, "commit", "-m", "base")  # keep.txt is tracked
+    sub = repo / "sub"
+    sub.mkdir()
+    (sub / "inner.txt").write_text("inner\n", encoding="utf-8")
+
+    # Untracked file.
+    resp = client.post("/api/workspace/file/delete", json={"workspace": str(repo), "path": "gone.txt"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    assert not (repo / "gone.txt").exists()
+
+    # Tracked file (same code path; shows up as a git deletion afterward).
+    resp = client.post("/api/workspace/file/delete", json={"workspace": str(repo), "path": "keep.txt"})
+    assert resp.status_code == 200
+    assert not (repo / "keep.txt").exists()
+
+    # Folder, recursively.
+    resp = client.post("/api/workspace/file/delete", json={"workspace": str(repo), "path": "sub"})
+    assert resp.status_code == 200
+    assert not sub.exists()
+
+    # Rejections: traversal, forbidden .git component, missing path, workspace root.
+    for bad in ["../escape.txt", ".git/config", "missing.txt", "", "."]:
+        r = client.post("/api/workspace/file/delete", json={"workspace": str(repo), "path": bad})
+        assert r.status_code == 400, f"{bad!r} should be rejected"
+        assert r.json()["ok"] is False
+
+
+def test_delete_file_is_admin_only(monkeypatch, tmp_path):
+    client = _client(monkeypatch, admin=False)
+    r = client.post("/api/workspace/file/delete", json={"workspace": str(tmp_path), "path": "x"})
+    assert r.status_code == 403
+    assert r.json()["code"] == "not_authorized"


### PR DESCRIPTION
## Summary

Adds the backend foundation for workspace source-control workflows: workspace-confined `/api/workspace/git/*` endpoints for status, diff/stage/unstage/discard, hunk operations, commits, branch switching/creation, remote actions, init/clone, history, commit file stats, blame, and conflict resolution. It also adds workspace file delete support and a focused backend regression suite.

This is intentionally backend-only. The current UI keeps behaving as it does today; the panel UI that consumes these endpoints will be submitted separately so the backend API and safety boundary can be reviewed first.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #2451

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Review scope

- `routes/workspace_git_routes.py` — authenticated workspace git API routes.
- `src/workspace_git.py` — path confinement, git command execution, mutation locking, and git workflow helpers.
- `tests/test_workspace_git_backend.py` — backend coverage for auth gating, path rejection, file operations, status/diff, staging, commits, branches, remotes, history, blame, and conflict handling.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the branch starts successfully. Type-checks and unit tests are not enough.

## How to Test

I ran:

```bash
uv run python -m py_compile app.py routes/workspace_git_routes.py routes/workspace_routes.py src/workspace_git.py tests/test_workspace_git_backend.py
uv run pytest tests/test_workspace_git_backend.py -q
```

Result:

```text
40 passed, 2 warnings
```

I also started the app locally and confirmed it served requests:

```bash
uv run python -m uvicorn app:app --host 127.0.0.1 --port 7017
curl -sS -o /tmp/odysseus-root-check.txt -w 'HTTP %{http_code}\n' http://127.0.0.1:7017/
# HTTP 302
```

The 302 is the expected auth redirect from `/` on a local authenticated app instance.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — this PR does not touch CSS, HTML, SVG, or `static/js`, and it does not change rendered UI components.

### Screenshots / clips

N/A — backend/API only.
