### PR TITLE
fix: add Esc key handlers to tour hints, assistant settings, voice recorder

### DIFF
--- a/static/js/assistant.js
+++ b/static/js/assistant.js
@@ -78,10 +78,15 @@ async function _runCheckInNow(taskId) {
 
 // ── Settings modal ─────────────────────────────────────────────────────────
 
+function _isModalHidden(modal) {
+  return !modal || modal.classList.contains('hidden') || modal.style.display === 'none';
+}
+
 function _closeModal() {
   if (_modalEl) {
     _modalEl.classList.add('hidden');
     _modalEl.style.display = '';
+    if (_modalEl._escCleanup) _modalEl._escCleanup();
   }
 }
 
@@ -108,6 +113,14 @@ function _ensureModalEl() {
   modal.addEventListener('click', (e) => {
     if (e.target === modal) _closeModal();
   });
+  const _escHandler = (e) => {
+    if (e.key === 'Escape' && !_isModalHidden(modal)) {
+      e.preventDefault();
+      _closeModal();
+    }
+  };
+  document.addEventListener('keydown', _escHandler);
+  modal._escCleanup = () => document.removeEventListener('keydown', _escHandler);
   _modalEl = modal;
   return modal;
 }

--- a/static/js/tourHints.js
+++ b/static/js/tourHints.js
@@ -114,14 +114,24 @@ function _show(modal) {
     pop.classList.add('tour-hint-in');
   });
 
-  const dismiss = () => {
+  const _escHandler = (e) => {
+    if (e.key === 'Escape' && pop.isConnected) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      _dismiss();
+    }
+  };
+  document.addEventListener('keydown', _escHandler, true);
+
+  const _dismiss = () => {
+    document.removeEventListener('keydown', _escHandler, true);
     pop.classList.add('tour-hint-out');
     setTimeout(() => pop.remove(), 280);
     _markSeen();
   };
-  pop.querySelector('.tour-hint-dismiss').addEventListener('click', dismiss);
+  pop.querySelector('.tour-hint-dismiss').addEventListener('click', _dismiss);
   // Auto-dismiss after 14s so it doesn't linger forever.
-  setTimeout(() => { if (pop.isConnected) dismiss(); }, 14000);
+  setTimeout(() => { if (pop.isConnected) _dismiss(); }, 14000);
 }
 
 function _watchModals() {

--- a/static/js/voiceRecorder.js
+++ b/static/js/voiceRecorder.js
@@ -268,6 +268,19 @@ export function getIsRecording() {
 export function init() {
   isRecording = false;
   refreshSttProvider();
+  _installEscHandler();
+}
+
+let _escHandlerInstalled = false;
+function _installEscHandler() {
+  if (_escHandlerInstalled) return;
+  _escHandlerInstalled = true;
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && isRecording) {
+      e.preventDefault();
+      stopRecording();
+    }
+  });
 }
 
 const voiceRecorderModule = {


### PR DESCRIPTION
## Summary

Add Esc key dismiss/close/stop handling to three UI modules that had no Esc support: tourHints.js (dismiss hint), assistant.js (close settings modal), voiceRecorder.js (stop active recording).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #845 (Esc handlers portion).

## Type of Change

- [x] Bug fix (non-breaking — adds missing keyboard accessibility)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus, open any tool modal (e.g. Calendar, Gallery) — the "drag to snap" hint appears. Press Esc → hint dismisses.
2. Open the Personal Assistant settings modal (gear icon in chat header when assistant session is active). Press Esc → modal closes.
3. Start a voice recording (click the microphone button on the send button). Press Esc → recording stops.

## Visual / UI changes

- [x] **Style match**: no visual changes, only keyboard event listeners added.
- [x] **No new component patterns.**

### Screenshots / clips

No visual changes.