### PR TITLE
fix: Docker healthchecks for all services + dependency checks in /api/health

### DIFF
--- a/app.py
+++ b/app.py
@@ -730,8 +730,50 @@ async def get_version():
     return {"version": APP_VERSION}
 
 @app.get("/api/health")
-async def health_check() -> Dict[str, str]:
-    return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
+async def health_check() -> Dict[str, object]:
+    import httpx as _httpx
+    checks: Dict[str, object] = {}
+    overall = "healthy"
+
+    # Database connectivity
+    try:
+        from core.database import SessionLocal as _SL
+        _db = _SL()
+        try:
+            _db.execute("SELECT 1")
+            checks["database"] = {"status": "ok"}
+        finally:
+            _db.close()
+    except Exception as e:
+        checks["database"] = {"status": "error", "detail": str(e)}
+        overall = "degraded"
+
+    # ChromaDB heartbeat
+    try:
+        _chroma_host = os.getenv("CHROMADB_HOST", "chromadb")
+        _chroma_port = os.getenv("CHROMADB_PORT", "8000")
+        async with _httpx.AsyncClient(timeout=5.0) as _c:
+            _r = await _c.get(f"http://{_chroma_host}:{_chroma_port}/api/v1/heartbeat")
+            _r.raise_for_status()
+            checks["chromadb"] = {"status": "ok"}
+    except Exception as e:
+        checks["chromadb"] = {"status": "error", "detail": str(e)}
+        overall = "degraded"
+
+    # SearXNG reachability
+    try:
+        _searxng = os.getenv("SEARXNG_INSTANCE", "http://searxng:8080")
+        async with _httpx.AsyncClient(timeout=5.0) as _c:
+            _r = await _c.get(_searxng + "/", allow_redirects=False)
+            # 200 or 302 (redirect to search page) both mean alive
+            if _r.status_code not in (200, 301, 302):
+                raise Exception(f"HTTP {_r.status_code}")
+            checks["searxng"] = {"status": "ok"}
+    except Exception as e:
+        checks["searxng"] = {"status": "error", "detail": str(e)}
+        overall = "degraded"
+
+    return {"status": overall, "timestamp": datetime.utcnow().isoformat(), "checks": checks}
 
 @app.get("/api/runtime")
 async def runtime_info() -> Dict[str, object]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,13 @@ services:
       searxng:
         condition: service_healthy
       chromadb:
-        condition: service_started
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:7000/api/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   chromadb:
@@ -51,6 +57,12 @@ services:
       - chromadb-data:/chroma/chroma
     environment:
       - ANONYMIZED_TELEMETRY=FALSE
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/heartbeat', timeout=5)\""]
+      interval: 10s
+      timeout: 6s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   searxng:
@@ -93,6 +105,12 @@ services:
       - ntfy-cache:/var/cache/ntfy
     environment:
       - NTFY_BASE_URL=${NTFY_BASE_URL:-http://localhost:8091}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/v1/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

Add Docker healthchecks to all 4 services (chromadb, searxng, odysseus, ntfy) and enhance `/api/health` to check downstream dependencies (database, ChromaDB heartbeat, SearXNG reachability). Returns `"healthy"` or `"degraded"` with per-service status. Upgrades chromadb dependency from `service_started` to `service_healthy` so odysseus waits for ChromaDB to be ready.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #845 (Docker healthchecks + /api/health portion).

## Type of Change

- [x] New feature (non-breaking — adds healthcheck infrastructure)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I verified the change with `docker compose config` (valid config) and `python3 -m py_compile app.py` (passes).

## How to Test

1. Run `docker compose up -d --build`
2. Run `docker compose ps` — all 4 containers should show `healthy` status after startup
3. Run `curl http://localhost:7000/api/health` — should return `{"status": "healthy", "checks": {"database": {"status": "ok"}, "chromadb": {"status": "ok"}, "searxng": {"status": "ok"}}}`
4. Stop chromadb: `docker compose stop chromadb`, then `curl http://localhost:7000/api/health` — should return `"status": "degraded"` with chromadb showing error

## Visual / UI changes

No visual changes.