### PR TITLE
Fix: CORS preflight 401'd by AuthMiddleware before CORSMiddleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ from core.constants import (
     REQUEST_TIMEOUT, OPENAI_API_KEY,
 )
 from core.database import SessionLocal, ApiToken
-from core.middleware import SecurityHeadersMiddleware
+from core.middleware import SecurityHeadersMiddleware, is_cors_preflight
 from core.auth import AuthManager
 from core.exceptions import (
     SessionNotFoundError, InvalidFileUploadError,
@@ -253,6 +253,15 @@ if AUTH_ENABLED:
     class AuthMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
             path = request.url.path
+            # A genuine CORS preflight (OPTIONS + Access-Control-Request-Method)
+            # carries no credentials by design and must reach CORSMiddleware to be
+            # answered. AuthMiddleware is the outermost middleware, so gating the
+            # preflight on auth 401s it before CORS can respond -- which blocks
+            # every cross-origin browser/WebView client before the real request
+            # is sent. Let real preflights through (only OPTIONS w/ the ACRM
+            # header; never a credentialed request).
+            if is_cors_preflight(request.method, request.headers):
+                return await call_next(request)
             if _is_auth_exempt(path):
                 return await call_next(request)
             # In-process internal-tool token bypass. Used by the agent

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -17,6 +17,15 @@ INTERNAL_TOOL_TOKEN = os.environ.get("ODYSSEUS_INTERNAL_TOKEN") or secrets.token
 INTERNAL_TOOL_HEADER = "X-Odysseus-Internal-Token"
 
 
+def is_cors_preflight(method: str, headers) -> bool:
+    """True for a genuine CORS preflight: an OPTIONS request carrying the
+    Access-Control-Request-Method header. Such requests are credential-less by
+    design and must reach CORSMiddleware to be answered -- gating them on auth
+    401s the preflight and breaks every cross-origin browser/WebView client.
+    Pure so it can be unit-tested without standing up the app."""
+    return method == "OPTIONS" and "access-control-request-method" in headers
+
+
 def require_admin(request: Request):
     """Raise 403 if the current user isn't an admin.
     Allows access when auth is explicitly disabled, or when the request carries

--- a/tests/test_cors_preflight.py
+++ b/tests/test_cors_preflight.py
@@ -1,0 +1,30 @@
+"""Regression test for the CORS-preflight auth bypass.
+
+AuthMiddleware is the outermost middleware, so it used to 401 the credential-less
+OPTIONS preflight before CORSMiddleware could answer it -- which blocks every
+cross-origin browser/WebView client before the real request is ever sent. The
+fix lets a genuine preflight through; `is_cors_preflight` is the pure predicate
+it uses. Guard it so the bypass can't silently regress.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.middleware import is_cors_preflight
+
+
+def test_genuine_preflight_is_detected():
+    assert is_cors_preflight("OPTIONS", {"access-control-request-method": "POST"}) is True
+
+
+def test_bare_options_is_not_a_preflight():
+    # OPTIONS without Access-Control-Request-Method must NOT bypass auth.
+    assert is_cors_preflight("OPTIONS", {}) is False
+
+
+def test_real_methods_are_never_preflight():
+    headers = {"access-control-request-method": "POST"}
+    for method in ("GET", "POST", "PUT", "DELETE", "PATCH"):
+        assert is_cors_preflight(method, headers) is False


### PR DESCRIPTION
## Summary

`AuthMiddleware` is the outermost middleware, so a credential-less **CORS
preflight** (`OPTIONS` + `Access-Control-Request-Method`) was rejected with
**401 before `CORSMiddleware` could answer it**. The browser/WebView then never
sends the real request — so every cross-origin client is blocked. This lets a
genuine preflight through at the top of `AuthMiddleware.dispatch` via a pure,
unit-tested predicate (`core.middleware.is_cors_preflight`). It matches *only*
`OPTIONS` carrying `Access-Control-Request-Method` (a credentialed request is
never matched) and does no data access.

Found while building the companion app (#3244); pulling it out as its own small,
mergeable fix per maintainer request. Built with AI assistance (see the
`Co-Authored-By` trailer).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Found via #3244

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run the server with auth on: `uvicorn app:app --host 0.0.0.0 --port 7000`.
2. Send a CORS preflight to any gated `/api/*` path:
   ```
   curl -i -X OPTIONS \
     -H "Origin: http://localhost" \
     -H "Access-Control-Request-Method: POST" \
     http://127.0.0.1:7000/api/sessions
   ```
   - **Before:** `401 Unauthorized`.
   - **After:** `200` (or `204`) with an `access-control-allow-origin` header.
3. A bare `OPTIONS` (no `Access-Control-Request-Method`) and all real methods
   still go through auth unchanged.

Verified locally: preflight returns `200` with
`access-control-allow-origin: http://localhost`.

Automated: `pytest tests/test_cors_preflight.py` -> 3 passed;
`python -m py_compile app.py core/middleware.py` -> OK.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI / visual changes — back-end middleware only (`app.py`,
`core/middleware.py`, one test). Not applicable.
