### PR TITLE
fix: avoid double bcrypt on login

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -456,6 +456,22 @@ class AuthManager:
         self._save_sessions()
         return token
 
+    def create_session_for_user(self, username: str) -> Optional[str]:
+        """Issue a session token for an already-authenticated user without
+        re-checking the password. Use this when the caller has already
+        verified credentials (e.g. login route after verify_password + TOTP)."""
+        username = username.strip().lower()
+        if username not in self.users:
+            return None
+        token = secrets.token_hex(32)
+        with self._sessions_lock:
+            self._sessions[token] = {
+                "username": username,
+                "expiry": time.time() + TOKEN_TTL,
+            }
+        self._save_sessions()
+        return token
+
     def validate_token(self, token: Optional[str]) -> bool:
         if not token:
             return False

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -131,10 +131,10 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
                 return {"ok": False, "requires_totp": True, "username": username}
             if not auth_manager.totp_verify(username, body.totp_code):
                 raise HTTPException(401, "Invalid 2FA code")
-        # All checks passed — create session
-        token = await asyncio.to_thread(auth_manager.create_session, username, body.password)
+        # All checks passed — create session (password already verified above)
+        token = await asyncio.to_thread(auth_manager.create_session_for_user, username)
         if not token:
-            raise HTTPException(401, "Invalid credentials")
+            raise HTTPException(500, "Session creation failed")
         cookie_kwargs = dict(
             key=SESSION_COOKIE,
             value=token,


### PR DESCRIPTION
## What's in this

Fixes #3230 — every successful login was running bcrypt twice: once in the login route's `verify_password()` check, then again inside `create_session()`. This adds `create_session_for_user()` which issues a token without re-checking the password, cutting bcrypt calls from 2 to 1 per login.

## Files changed

- `core/auth.py` — added `create_session_for_user(username)` method
- `routes/auth_routes.py` — login route uses the new method after verify_password + TOTP

## Checks

- `python3 -m py_compile core/auth.py routes/auth_routes.py` — passes