### PR TITLE
fix: block bash/python tools when auth is not configured

### DIFF
--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -162,14 +162,21 @@ def is_public_blocked_tool(tool_name: Optional[str]) -> bool:
 
 
 def owner_is_admin_or_single_user(owner: Optional[str]) -> bool:
-    """Return True for admins, or when auth is not configured yet."""
+    """Return True for admins, or when there is exactly one user (single-user
+    mode). When auth is not configured at all (no users yet), return False so
+    dangerous tools like bash/python are not accessible without authentication."""
     try:
         from core.auth import AuthManager
 
         auth = AuthManager()
         if not auth.is_configured:
+            return False
+        if auth.is_admin(owner):
             return True
-        return bool(owner and auth.is_admin(owner))
+        # Single-user mode: if there's only one user, treat them as admin
+        if owner and len(auth.users) == 1:
+            return True
+        return False
     except Exception as exc:
         logger.warning("Unable to evaluate owner admin status: %s", exc)
         return False


### PR DESCRIPTION
## Summary

When no users exist (pre-setup), `owner_is_admin_or_single_user()` was returning `True`, making bash and python tools accessible without any authentication. This is a pre-setup RCE vector. Now returns `False` when auth is not configured, and only returns `True` for single-user mode (exactly one user) or admins.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3201

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start a fresh Odysseus instance with no users (delete `data/auth.json` if it exists)
2. Without logging in, try to use bash/python tools via the API — they should be blocked
3. Create the first admin user via `/api/auth/setup`
4. Now bash/python tools should work for the admin user

## Visual / UI changes

No visual changes.