### PR TITLE
fix: default allow_bash to user privilege when not explicitly set

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -612,7 +612,10 @@ def setup_chat_routes(
         finally:
             _doc_db.close()
 
-        # Build disabled-tools set from frontend toggles + user privileges
+        # Build disabled-tools set from frontend toggles + user privileges.
+        # allow_bash/allow_web_search come from the frontend toggle; when not
+        # explicitly set (None), default based on the user's privilege so
+        # admin/single-user installs aren't silently blocked.
         disabled_tools = set()
         if str(allow_bash).lower() != "true":
             disabled_tools.add("bash")
@@ -635,6 +638,10 @@ def setup_chat_routes(
         if _user and hasattr(request.app.state, 'auth_manager') and request.app.state.auth_manager:
             _privs = request.app.state.auth_manager.get_privileges(_user)
         if _privs:
+            # If the frontend didn't explicitly set allow_bash (None), default
+            # to the user's can_use_bash privilege instead of always blocking.
+            if allow_bash is None and _privs.get("can_use_bash", False):
+                disabled_tools.discard("bash")
             if not _privs.get("can_use_bash", True):
                 disabled_tools.update({"bash", "python", "read_file", "write_file"})
             if not _privs.get("can_use_browser", True):


### PR DESCRIPTION
## Summary

When the frontend doesn't send `allow_bash` (None), bash was always disabled because `str(None).lower() != "true"`. This meant admin users and API callers couldn't use bash unless they manually toggled the shell icon. Now defaults to the user's `can_use_bash` privilege when not explicitly set.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3229

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Log in as an admin user (who has `can_use_bash: true`)
2. Send a chat message asking the agent to run a shell command, without toggling the shell icon on
3. The agent should be able to execute shell commands
4. Repeat with a non-admin user who has `can_use_bash: false` — bash should remain blocked

## Visual / UI changes

No visual changes.