### PR TITLE
fix: prefer ddgs over deprecated duckduckgo-search

### DIFF
--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -415,10 +415,14 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
             return []
 
     try:
-        from duckduckgo_search import DDGS
+        from ddgs import DDGS
     except ImportError:
-        logger.warning("duckduckgo-search package not installed; using HTML fallback")
-        return _html_fallback()
+        try:
+            from duckduckgo_search import DDGS
+            logger.warning("duckduckgo-search is deprecated; install ddgs instead")
+        except ImportError:
+            logger.warning("Neither ddgs nor duckduckgo-search package installed; using HTML fallback")
+            return _html_fallback()
 
     timelimit = None
     if time_filter:


### PR DESCRIPTION
## What's in this

Fixes #3142 — `duckduckgo-search` has been renamed to `ddgs`. Now tries importing from `ddgs` first, falls back to `duckduckgo-search` with a deprecation warning, then HTML fallback.

## Files changed

- `services/search/providers.py` — try `ddgs` first, then `duckduckgo-search`, then HTML fallback

## Checks

- `python3 -m py_compile services/search/providers.py` — passes