### PR TITLE
fix: markdown tables scroll horizontally on narrow screens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -7723,6 +7723,10 @@ button.hamburger {
   margin: 0.5em 0;
   font-size: 0.9em;
   width: auto;
+  max-width: 100%;
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 .msg th {
   background: color-mix(in srgb, var(--fg) 7%, transparent);


### PR DESCRIPTION
## Summary

Markdown tables in chat messages were collapsing into unreadable single-character columns on narrow/mobile screens. Added `overflow-x: auto`, `display: block`, and `max-width: 100%` to `.msg table` so tables scroll horizontally instead of collapsing.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3199

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus, open a chat
2. Ask the model to generate a markdown table with several columns (e.g. "compare these features in a table")
3. Resize the browser to mobile width (~375px) or use device emulation
4. The table should scroll horizontally within the message bubble instead of collapsing columns to single characters

## Visual / UI changes — REQUIRED

- [x] **Screenshot or short clip**: see issue #3199 for before/after screenshots
- [x] **Style match**: uses existing CSS, no new variables or classes introduced
- [x] **No new component patterns**: extends existing `.msg table` rule

### Screenshots / clips

See issue #3199 — the "after" state shows tables scrolling horizontally on mobile instead of collapsing.