### PR TITLE
fix: prevent DNS rebinding SSRF in webpage content fetcher

### DIFF
--- a/services/search/content.py
+++ b/services/search/content.py
@@ -89,18 +89,57 @@ def _public_http_url(url: str) -> bool:
         return False
 
 
+def _resolve_and_validate_ip(url: str) -> str:
+    """Resolve the hostname to an IP, validate it is public, and return
+    the IP. Raises if the URL is private/invalid. This is the single
+    DNS resolution point — the returned IP is pinned for the actual
+    HTTP connection to prevent DNS rebinding."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").strip()
+    if not host:
+        raise httpx.RequestError("No hostname in URL", request=httpx.Request("GET", url))
+    addrs = _resolve_hostname_ips(host)
+    if not addrs:
+        raise httpx.RequestError(f"DNS resolution failed for {host}", request=httpx.Request("GET", url))
+    # All resolved addresses must be public
+    for addr in addrs:
+        if _is_private_address(addr):
+            raise httpx.RequestError(f"Blocked private/internal IP for {host}: {addr}", request=httpx.Request("GET", url))
+    return str(addrs[0])
+
+
 def _get_public_url(url: str, headers: dict, timeout: int, max_redirects: int = 5) -> httpx.Response:
     current = url
     for _ in range(max_redirects + 1):
         if not _public_http_url(current):
             raise httpx.RequestError("Blocked private/internal URL", request=httpx.Request("GET", current))
-        response = httpx.get(current, headers=headers, timeout=timeout, follow_redirects=False)
+        # Pin the IP before connecting to prevent DNS rebinding.
+        # Resolve once, validate, then connect directly to the IP with
+        # the original Host header so the server still sees the right name.
+        pinned_ip = _resolve_and_validate_ip(current)
+        parsed = urlparse(current)
+        host = parsed.hostname or ""
+        port = parsed.port
+        scheme = parsed.scheme or "http"
+        # Build URL with pinned IP
+        netloc = f"{pinned_ip}:{port}" if port else pinned_ip
+        pinned_url = f"{scheme}://{netloc}{parsed.path or '/'}"
+        if parsed.query:
+            pinned_url += f"?{parsed.query}"
+        response = httpx.get(
+            pinned_url,
+            headers={**headers, "Host": host},
+            timeout=timeout,
+            follow_redirects=False,
+        )
         if response.status_code not in (301, 302, 303, 307, 308):
             return response
         location = response.headers.get("location")
         if not location:
             return response
-        current = urljoin(str(response.url), location)
+        # Use the original (pre-IP) URL as the base for resolving relative
+        # redirects, so the next iteration's hostname resolution works.
+        current = urljoin(current, location)
     raise httpx.RequestError("Too many redirects", request=httpx.Request("GET", current))
 
 # PDF extraction (optional dependency)

--- a/services/search/content.py
+++ b/services/search/content.py
@@ -108,37 +108,56 @@ def _resolve_and_validate_ip(url: str) -> str:
     return str(addrs[0])
 
 
+class _PinnedIPTransport(httpx.HTTPTransport):
+    """httpx transport that resolves the hostname once, validates the IP
+    is public, then connects directly to that IP while preserving the
+    original hostname for TLS SNI and the Host header. This prevents
+    DNS rebinding attacks where the DNS response changes between
+    validation and connection."""
+
+    def __init__(self, resolved_ip: str, sni_hostname: str, *args, **kwargs):
+        self._resolved_ip = resolved_ip
+        self._sni_hostname = sni_hostname
+        super().__init__(*args, **kwargs)
+
+    def handle_request(self, request):
+        # Rewrite the URL to use the pinned IP, but keep the original
+        # hostname in the Host header and as the TLS SNI target.
+        original_url = request.url
+        rebuilt = original_url.copy_with(host=self._resolved_ip)
+        request.url = rebuilt
+        request.headers["Host"] = self._sni_hostname
+        # Set SNI hostname for TLS so the server presents the right cert.
+        # httpcore reads 'sni_hostname' from request.extensions.
+        if request.extensions is None:
+            request.extensions = {}
+        request.extensions["sni_hostname"] = self._sni_hostname
+        return super().handle_request(request)
+
+
 def _get_public_url(url: str, headers: dict, timeout: int, max_redirects: int = 5) -> httpx.Response:
     current = url
     for _ in range(max_redirects + 1):
         if not _public_http_url(current):
             raise httpx.RequestError("Blocked private/internal URL", request=httpx.Request("GET", current))
         # Pin the IP before connecting to prevent DNS rebinding.
-        # Resolve once, validate, then connect directly to the IP with
-        # the original Host header so the server still sees the right name.
+        # Resolve once, validate, then connect directly to the pinned IP
+        # while preserving the original hostname for TLS SNI and Host header.
         pinned_ip = _resolve_and_validate_ip(current)
         parsed = urlparse(current)
         host = parsed.hostname or ""
-        port = parsed.port
-        scheme = parsed.scheme or "http"
-        # Build URL with pinned IP
-        netloc = f"{pinned_ip}:{port}" if port else pinned_ip
-        pinned_url = f"{scheme}://{netloc}{parsed.path or '/'}"
-        if parsed.query:
-            pinned_url += f"?{parsed.query}"
-        response = httpx.get(
-            pinned_url,
-            headers={**headers, "Host": host},
-            timeout=timeout,
-            follow_redirects=False,
-        )
+        transport = _PinnedIPTransport(pinned_ip, host)
+        with httpx.Client(transport=transport, timeout=timeout) as _client:
+            response = _client.get(
+                current,
+                headers=headers,
+                follow_redirects=False,
+            )
         if response.status_code not in (301, 302, 303, 307, 308):
             return response
         location = response.headers.get("location")
         if not location:
             return response
-        # Use the original (pre-IP) URL as the base for resolving relative
-        # redirects, so the next iteration's hostname resolution works.
         current = urljoin(current, location)
     raise httpx.RequestError("Too many redirects", request=httpx.Request("GET", current))
 


### PR DESCRIPTION
## Summary

The webpage content fetcher resolved DNS twice (once for validation in `_public_http_url`, once for connection in `httpx.get`), creating a TOCTOU window exploitable via DNS rebinding. An attacker-controlled domain could initially resolve to a public IP (passing validation), then switch to a private IP (e.g. `169.254.169.254`) for the actual connection.

Fix: resolve DNS once, validate the IP is public, then connect directly to the pinned IP using a custom httpx transport that preserves the original hostname for TLS SNI (`sni_hostname` in request extensions) and the Host header. This eliminates the TOCTOU window while keeping HTTPS working.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3200

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed security issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus with web search enabled
2. Ask the agent to fetch a webpage (e.g. "fetch https://example.com") — should work for both HTTP and HTTPS
3. Verify HTTPS pages fetch correctly (TLS cert validation passes) — the `sni_hostname` extension ensures the TLS handshake presents the original domain
4. The `_public_http_url` check still blocks obviously private URLs (localhost, .local, RFC 1918 addresses)
5. `python3 -m py_compile services/search/content.py` passes

## Visual / UI changes

No visual changes.