### PR TITLE
fix: stop calendar from collapsing sidebar on open

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -71,7 +71,6 @@ let _escHandler = null;
 let _modal = null;
 
 let _dragUid = null;
-let _sidebarWasOpen = false;
 let _slideDir = 0;  // -1 = prev, +1 = next, 0 = none
 
 // (Single undo stack lives at `_calUndoStack` further below; this used to
@@ -543,28 +542,6 @@ async function _createEventReminder(ev, dueDate) {
     }
   } catch (e) {
     if (uiModule.showError) uiModule.showError('Failed to create reminder');
-  }
-}
-
-// ── Sidebar collapse ──
-
-function _collapseSidebar() {
-  const sb = document.getElementById('sidebar');
-  if (sb && !sb.classList.contains('hidden')) {
-    // Only remember the prior state on desktop. On mobile the sidebar is an
-    // overlay that the user intentionally swipes/taps away when the tool
-    // opens — popping it back on close is unwanted.
-    if (window.innerWidth >= 700) _sidebarWasOpen = true;
-    sb.classList.add('hidden');
-    if (window.syncRailSide) window.syncRailSide();
-  }
-}
-
-function _restoreSidebar() {
-  if (_sidebarWasOpen) {
-    const sb = document.getElementById('sidebar');
-    if (sb) { sb.classList.remove('hidden'); if (window.syncRailSide) window.syncRailSide(); }
-    _sidebarWasOpen = false;
   }
 }
 
@@ -3271,7 +3248,6 @@ function openCalendar() {
   }
   _open = true;
   if (_todayCount() > 0) { _markBadgeSeen(); _updateBadge(); }
-  _collapseSidebar();
   const modal = _getModal();
   // Clean up any leftover state from a previous swipe-dismiss
   modal.classList.remove('hidden', 'modal-minimized');
@@ -3353,7 +3329,6 @@ let _highlightEventUid = null;
 
 function _doCloseCalendar() {
   _open = false;
-  _restoreSidebar();
   if (_modal) {
     _modal.style.display = 'none';
     _modal.classList.add('hidden');


### PR DESCRIPTION
## Summary

Calendar was the only tool that collapsed the sidebar on open and restored it on close. This made it inconsistent with every other tool (Brain, Compare, Cookbook, Gallery, Notes, Tasks, Theme, Settings). Removed the `_collapseSidebar()`/`_restoreSidebar()` calls so calendar behaves like the rest of the app.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3123

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus, make sure the sidebar is expanded
2. Click the Calendar button in the sidebar — the sidebar should stay expanded
3. Close the calendar — the sidebar should remain expanded
4. Compare with other tools (Brain, Cookbook, Gallery, etc.) — all should behave the same way

## Visual / UI changes

- [x] **Style match**: no CSS changes, only removed JS sidebar manipulation
- [x] **No new component patterns**

### Screenshots / clips

See issue #3123 for before/after screen recordings.