### PR TITLE
fix: agent loop-breaker no longer aborts legitimate tool batches

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -2231,7 +2231,12 @@ async def stream_agent_loop(
             _stuck_rounds += 1
         else:
             _stuck_rounds = 0
-        _runaway = next((t for t, n in _tool_type_counts.items() if n >= 15), None)
+        # Runaway backstop: only flag when the model is actually
+        # repeating (stuck_rounds > 0), not when it makes many distinct
+        # calls to the same tool (e.g. creating 18 calendar events).
+        _runaway = None
+        if _stuck_rounds > 0:
+            _runaway = next((t for t, n in _tool_type_counts.items() if n >= 15), None)
         if _stuck_rounds >= 4 or _runaway:
             reason = (f"calling {_runaway} over and over" if _runaway
                       else "repeating the same tool calls without new progress")


### PR DESCRIPTION
## Summary

The runaway backstop was counting all calls to a tool type (e.g. 18 distinct `manage_calendar` calls for creating 18 events) as a stuck loop and aborting. Now only triggers when the model is actually repeating the same calls (`_stuck_rounds > 0`), not when it makes many distinct calls to the same tool in a batch.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3185

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus in Agent mode
2. Ask the agent to create ~18 calendar events in one request (e.g. "add these birthdays as all-day events: Alice 14.03, Bob 27.08, ...")
3. The agent should complete all 18 events without the loop-breaker tripping
4. Verify that actual loops (same call repeated 15+ times) still get caught

## Visual / UI changes

No visual changes.