### PR TITLE
fix: gallery null-owner read bypass when auth is enabled

### DIFF
--- a/routes/gallery_helpers.py
+++ b/routes/gallery_helpers.py
@@ -129,8 +129,21 @@ def _owner_filter(q, user):
     must too — otherwise the tag/model filter sidebars come back empty and the
     tag-cleanup endpoints (clear-user-tags, clear-ai-tags, dedupe-tags)
     silently affect zero rows in the most common self-hosted deployment.
+
+    When auth IS enabled, a None user means unauthenticated — block rather
+    than leak every user's images (issue #3148).
     """
     if user is None:
+        # Distinguish "auth disabled" (single-user, show all) from
+        # "auth enabled but unauthenticated" (block).
+        try:
+            from core.auth import AuthManager
+            if AuthManager().is_configured:
+                # Auth is on and user is None → unauthenticated. Return
+                # an empty result set rather than leaking all images.
+                return q.filter(False)
+        except Exception:
+            pass
         return q
     return q.filter(GalleryImage.owner == user)
 


### PR DESCRIPTION
## Summary

When auth is enabled but the user is unauthenticated, `get_current_user` returns `None`. `_owner_filter` was treating this as "show everything", leaking every user's images to unauthenticated requests. Now checks if auth is configured — if so, returns an empty result set for unauthenticated requests.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3148

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus with auth enabled and multiple users
2. Without logging in, try to access gallery images via the API
3. Should return empty results (not other users' images)
4. Log in as a user — should see only that user's images
5. With auth disabled (single-user mode) — should still show all images

## Visual / UI changes

No visual changes.