### PR TITLE
fix: port main-only fixes to dev (#2761 sharpen auth, #2762 doc version 404)

### DIFF
--- a/routes/document_routes.py
+++ b/routes/document_routes.py
@@ -664,8 +664,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         try:
             # Verify ownership before listing versions
             doc = db.query(Document).filter(Document.id == doc_id).first()
-            if doc:
-                _verify_doc_owner(db, doc, user)
+            if not doc:
+                raise HTTPException(404, "Document not found")
+            _verify_doc_owner(db, doc, user)
             versions = db.query(DocumentVersion).filter(
                 DocumentVersion.document_id == doc_id
             ).order_by(DocumentVersion.version_number.desc()).all()
@@ -688,8 +689,9 @@ def setup_document_routes(session_manager, upload_handler=None) -> APIRouter:
         try:
             # Verify ownership
             doc = db.query(Document).filter(Document.id == doc_id).first()
-            if doc:
-                _verify_doc_owner(db, doc, user)
+            if not doc:
+                raise HTTPException(404, "Document not found")
+            _verify_doc_owner(db, doc, user)
             ver = db.query(DocumentVersion).filter(
                 DocumentVersion.document_id == doc_id,
                 DocumentVersion.version_number == num,

--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -1385,6 +1385,7 @@ def setup_gallery_routes() -> APIRouter:
     @router.post("/api/image/sharpen")
     async def sharpen_image(request: Request):
         """Apply unsharp-mask sharpening to an image."""
+        require_privilege(request, "can_generate_images")
         body = await request.json()
         image_b64 = body.get("image")
         amount = body.get("amount", 50) / 100.0


### PR DESCRIPTION
## Summary

Ports two fixes that were merged directly to `main` (bypassing `dev`) back into `dev`, so they are not silently reverted at the next release fast-forward and so `dev` is not running without them. Cherry-picked with original authorship preserved (@ErnestHysa): #2761 adds the missing `require_privilege(request, "can_generate_images")` gate to `/api/image/sharpen` (currently unauthenticated on `dev`), and #2762 adds 404 guards to the document `list_versions` / `get_version` endpoints (only `restore_version` had one on `dev`). The other two main-only commits (#2764 task-chain owner check, #2765 caldav owner-in-hash) are already present in `dev` via equivalent PRs, so they are intentionally excluded.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Ports #2761 and #2762 to `dev`.

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Verified via `python -m py_compile` on both files and code inspection. These are straight cherry-picks of fixes already validated on `main` via #2761 / #2762.

## How to Test

1. `python -m py_compile routes/gallery_routes.py routes/document_routes.py` passes.
2. POST `/api/image/sharpen` without the `can_generate_images` privilege is now rejected (was unauthenticated on `dev`).
3. GET `/api/document/{bad_id}/versions` and `/api/document/{bad_id}/version/{n}` now return 404 instead of an empty or incorrect response.

## Visual / UI changes

N/A, backend only (route auth gate + 404 guards). Nothing renders.

## Note for maintainers

Both fixes landed on `main` directly, bypassing the dev-first flow. Flagging so it can be reinforced; otherwise main-only hotfixes get reverted whenever `main` is fast-forwarded from `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
