### PR TITLE
fix(test): tolerate owner kwarg in compaction summary mock (green dev)

### DIFF
--- a/tests/test_compaction_summary_failure.py
+++ b/tests/test_compaction_summary_failure.py
@@ -48,7 +48,7 @@ class TestCompactionSummaryFailure:
         cc.get_context_length = lambda url, model: context_length
         cc.estimate_tokens = lambda msgs: 10000  # well over the threshold
         cc.llm_call_async = _boom
-        cc.resolve_endpoint = lambda which: (None, None, None)
+        cc.resolve_endpoint = lambda *a, **k: (None, None, None)
         cc._update_session_history = lambda *a, **k: None
         try:
             return asyncio.run(


### PR DESCRIPTION
## Summary

Fixes a merge-order test regression on `dev`. #2996 changed `context_compactor` to call `resolve_endpoint("utility", owner=owner)`, but the mock in `tests/test_compaction_summary_failure.py` (added by #2174) stubbed `resolve_endpoint` as `lambda which: ...`, which rejects the new `owner` kwarg with `TypeError`. Each PR passed alone; together on `dev` the two compaction tests fail and the pytest job goes red. Widens the mock to `lambda *a, **k: ...` so it tolerates the owner kwarg.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes the `dev` pytest regression introduced by the #2174 + #2996 interaction.

## Type of Change

- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Ran `python -m pytest -q` locally: 2574 passed, 1 skipped, 0 failed (the 2 previously-failing compaction tests now pass).

## How to Test

1. `python -m pytest tests/test_compaction_summary_failure.py -q` passes (was 2 failed with `TypeError: ... unexpected keyword argument 'owner'`).
2. Full `python -m pytest -q` is green.

## Visual / UI changes

N/A, test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
