### PR TITLE
fix(hwfit): detect NVIDIA GPU on WSL and other minimal-PATH environments

### DIFF
--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -76,9 +76,10 @@ def _detect_nvidia():
     global _last_gpu_error
     _last_gpu_error = None
     out = _run(["nvidia-smi", "--query-gpu=memory.total,name", "--format=csv,noheader,nounits"])
-    # Remote fallback: a non-interactive SSH shell often has a minimal PATH
-    # that omits where nvidia-smi lives (/usr/bin, /usr/local/cuda/bin), so the
-    # first call silently returns nothing → "No GPU" on hosts that DO have GPUs.
+    # Fallback: a non-interactive shell (or WSL) often has a minimal PATH
+    # that omits where nvidia-smi lives (/usr/bin, /usr/local/cuda/bin,
+    # /usr/lib/wsl/lib), so the first call silently returns nothing →
+    # "No GPU" on machines that DO have GPUs.
     # Retry through a login shell with the common CUDA bin dirs on PATH.
     if not out and _remote_host:
         out = _run(
@@ -88,9 +89,16 @@ def _detect_nvidia():
     # Last resort: call nvidia-smi by absolute path. Some hosts have a login
     # shell that isn't bash (or a profile that errors), so the bash -lc retry
     # above still comes back empty even though the binary is right there.
-    if not out and _remote_host:
+    # Also handles WSL where nvidia-smi lives at /usr/lib/wsl/lib/ — a path
+    # that may not be in the server process's PATH.
+    if not out:
         for _p in ("/usr/bin/nvidia-smi", "/usr/local/bin/nvidia-smi", "/usr/local/cuda/bin/nvidia-smi", "/usr/lib/wsl/lib/nvidia-smi"):
-            out = _run(f"{_p} --query-gpu=memory.total,name --format=csv,noheader,nounits")
+            # Use list form so subprocess.run (local) resolves the absolute path
+            # correctly instead of treating the whole string as an executable name.
+            if _remote_host:
+                out = _run(f"{_p} --query-gpu=memory.total,name --format=csv,noheader,nounits")
+            else:
+                out = _run([_p, "--query-gpu=memory.total,name", "--format=csv,noheader,nounits"])
             if out:
                 break
     if not out:


### PR DESCRIPTION
## Summary

The Cookbook hardware detection reports "No GPU" on systems where `nvidia-smi` is not in the default `PATH` but is accessible via an absolute path. The most common case is WSL (Windows Subsystem for Linux), where `nvidia-smi` lives at `/usr/lib/wsl/lib/nvidia-smi`. The absolute-path fallback in `_detect_nvidia()` was gated on `_remote_host`, so it never ran for local detection. This fix removes the gate and corrects the argument format so `subprocess.run()` resolves the absolute path correctly.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3307

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start Odysseus with a restricted PATH that excludes `/usr/lib/wsl/lib` (or wherever `nvidia-smi` lives on your system):
   ```bash
   PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" python -m uvicorn app:app --host 127.0.0.1 --port 7000
   ```
2. Authenticate and call `GET /api/hwfit/system?fresh=true`:
   ```bash
   curl -s http://localhost:7000/api/auth/login -X POST -H "Content-Type: application/json" -d '{"username":"admin","password":"<your-password>"}' -c /tmp/cookies.txt
   curl -s -b /tmp/cookies.txt "http://localhost:7000/api/hwfit/system?fresh=true" | python3 -m json.tool
   ```
3. **Before fix** — response shows `"has_gpu": false` with `"backend": "cpu_x86"`.
4. **After fix** — response shows `"has_gpu": true` with the correct GPU name, VRAM, and `"backend": "cuda"`.

Alternatively, test directly from the Python shell:
```python
import os, sys; sys.path.insert(0, ".")
os.environ["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
from services.hwfit.hardware import detect_system
info = detect_system(fresh=True)
print("has_gpu:", info.get("has_gpu"), "| gpu_name:", info.get("gpu_name"), "| backend:", info.get("backend"))
```

## Visual / UI changes — REQUIRED if you touched anything that renders

> Not applicable — this change is backend-only (services/hwfit/hardware.py).

- [ ] Screenshot or short clip of the change in the running app, attached below.
- [ ] Style match: the change uses Odysseus's existing visual language.
- [ ] No new component patterns.
- [ ] I am not an LLM agent submitting a bulk PR.

### Screenshots / clips

N/A
