### PR TITLE
fix(notes): handle time-first due_date phrases in parse_due_for_user

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -258,6 +258,17 @@ def parse_due_for_user(s: str) -> str:
         if t is not None:
             return base.replace(hour=t[0], minute=t[1]).isoformat()
 
+    # Time-first: "3pm today", "11pm today", "9am tomorrow"
+    m = _re.match(r'^(.+?)\s+(today|tonight|tomorrow|tmrw|yesterday)$', lower)
+    if m:
+        time_part, word = m.group(1).strip(), m.group(2)
+        base = today
+        if word in ("tomorrow", "tmrw"): base = today + _td(days=1)
+        elif word == "yesterday":        base = today - _td(days=1)
+        t = _parse_time(time_part)
+        if t is not None:
+            return base.replace(hour=t[0], minute=t[1]).isoformat()
+
     m = _re.match(r'^in\s+(\d+)\s*(hour|hr|minute|min|day)s?\s*$', lower)
     if m:
         n = int(m.group(1)); unit = m.group(2)

--- a/tests/test_parse_due_time_first.py
+++ b/tests/test_parse_due_time_first.py
@@ -1,0 +1,63 @@
+"""Regression: parse_due_for_user must handle time-first phrasings.
+
+The tool schema and tool_index both advertise '11pm today' as a valid
+due_date example. The parser's natural-language branch only matched
+day-first format ('today at 11pm'), so time-first strings like '3pm today'
+raised ValueError, fell back to the raw string, and the ISO-only reminder
+scanner never fired the note. Fixes #3302.
+"""
+from datetime import datetime, timezone
+
+import routes.calendar_routes as calendar_routes
+from src.user_time import clear_user_time_context, set_user_tz_name, set_user_tz_offset
+
+
+class _FixedNow(datetime):
+    """Freeze server clock at 2026-06-07T10:00:00 UTC for deterministic tests."""
+    @classmethod
+    def now(cls, tz=None):
+        value = datetime(2026, 6, 7, 10, 0, 0, tzinfo=timezone.utc)
+        if tz is not None:
+            return value.astimezone(tz)
+        return value.replace(tzinfo=None)
+
+
+def setup_function():
+    clear_user_time_context()
+    set_user_tz_offset(0)
+    set_user_tz_name("UTC")
+
+
+def teardown_function():
+    clear_user_time_context()
+
+
+def test_time_first_today(monkeypatch):
+    monkeypatch.setattr(calendar_routes, "datetime", _FixedNow)
+    result = calendar_routes.parse_due_for_user("3pm today")
+    assert result.startswith("2026-06-07T15:00:00")
+
+
+def test_time_first_today_11pm(monkeypatch):
+    monkeypatch.setattr(calendar_routes, "datetime", _FixedNow)
+    result = calendar_routes.parse_due_for_user("11pm today")
+    assert result.startswith("2026-06-07T23:00:00")
+
+
+def test_time_first_tomorrow(monkeypatch):
+    monkeypatch.setattr(calendar_routes, "datetime", _FixedNow)
+    result = calendar_routes.parse_due_for_user("9am tomorrow")
+    assert result.startswith("2026-06-08T09:00:00")
+
+
+def test_time_first_with_minutes(monkeypatch):
+    monkeypatch.setattr(calendar_routes, "datetime", _FixedNow)
+    result = calendar_routes.parse_due_for_user("2:30pm tomorrow")
+    assert result.startswith("2026-06-08T14:30:00")
+
+
+def test_day_first_still_works(monkeypatch):
+    """Existing day-first format must not regress."""
+    monkeypatch.setattr(calendar_routes, "datetime", _FixedNow)
+    result = calendar_routes.parse_due_for_user("today at 3pm")
+    assert result.startswith("2026-06-07T15:00:00")


### PR DESCRIPTION
## Summary

`parse_due_for_user` only matched day-first natural-language dates like `'today at 3pm'`. Time-first phrasings like `'3pm today'` or `'11pm today'` — which the tool schema, tool_index, and tool_implementations all advertise as valid `due_date` examples — fell through every branch and either raised `ValueError` or hit the legacy `_parse_dt` fallback which couldn't parse them either. `do_manage_notes` catches the exception and falls back to storing the raw string verbatim. The ISO-only reminder scanner (`action_ping_notes`) then never sees the note as due, so the reminder silently never fires.

The fix adds a single time-first regex branch in `parse_due_for_user` immediately after the existing day-first branch:

```python
# Time-first: "3pm today", "11pm today", "9am tomorrow"
m = _re.match(r'^(.+?)\s+(today|tonight|tomorrow|tmrw|yesterday)$', lower)
if m:
    time_part, word = m.group(1).strip(), m.group(2)
    ...
```

The existing day-first parsing path is unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3302

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (PR #3299 fixes the doc examples only; this PR fixes the parser itself. Different files, complementary fixes.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start Odysseus and open a chat session.
2. Ask the assistant: *"remind me at 3 PM today about the standup"*.
3. The agent calls `manage_notes` with `due_date: "3pm today"`.
4. Check the created note via the Notes panel — the `due_date` should be an ISO timestamp (e.g. `2026-06-07T15:00:00+00:00`), not the raw string `"3pm today"`.
5. Repeat with `"11pm today"` and `"9am tomorrow"` — both should store ISO timestamps.
6. Verify day-first format still works: ask *"remind me today at 3pm"* — should also store ISO correctly.

**Automated:** `pytest tests/test_parse_due_time_first.py` — 5 tests covering `3pm today`, `11pm today`, `9am tomorrow`, `2:30pm tomorrow`, and a day-first regression check. All pass.