### PR TITLE
fix(cookbook): locate cookbook_state.json via DATA_DIR, not hardcoded /app/data

### DIFF
--- a/routes/codex_routes.py
+++ b/routes/codex_routes.py
@@ -17,6 +17,7 @@ from fastapi.responses import StreamingResponse
 
 from src.auth_helpers import require_authenticated_request, require_user
 from src.tool_implementations import do_manage_notes
+from core.constants import DATA_DIR
 
 
 COOKBOOK_READ_SCOPES = {"cookbook:read", "cookbook:launch"}
@@ -425,7 +426,7 @@ def setup_codex_routes(
     def _read_cookbook_state() -> dict:
         from pathlib import Path as _Path
         import os as _os, json as _json
-        p = _Path(_os.environ.get("DATA_DIR", "data")) / "cookbook_state.json"
+        p = _Path(DATA_DIR) / "cookbook_state.json"
         if not p.exists():
             return {}
         try:
@@ -733,7 +734,7 @@ def setup_codex_routes(
         import time as _t, json as _json
         from core.atomic_io import atomic_write_json
         from pathlib import Path as _Path
-        cookbook_state_path = _Path("/app/data/cookbook_state.json")
+        cookbook_state_path = _Path(DATA_DIR) / "cookbook_state.json"
         try:
             state = _json.loads(cookbook_state_path.read_text(encoding="utf-8"))
         except Exception:

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -29,6 +29,7 @@ from core.platform_compat import (
     which_tool,
 )
 from routes.shell_routes import TMUX_LOG_DIR
+from core.constants import DATA_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ _HF_TOKEN_STATUS_SNIPPET = (
 
 def setup_cookbook_routes() -> APIRouter:
     router = APIRouter(tags=["cookbook"])
-    _cookbook_state_path = Path(os.environ.get("DATA_DIR", "data")) / "cookbook_state.json"
+    _cookbook_state_path = Path(DATA_DIR) / "cookbook_state.json"
 
     def _mask_secret(value: str) -> str:
         if not value:

--- a/src/builtin_actions.py
+++ b/src/builtin_actions.py
@@ -12,7 +12,7 @@ from typing import Tuple
 
 from src.auth_helpers import owner_filter
 from core.platform_compat import IS_WINDOWS, find_bash
-from core.constants import internal_api_base
+from core.constants import DATA_DIR, internal_api_base
 
 logger = logging.getLogger(__name__)
 
@@ -2043,7 +2043,7 @@ async def action_cookbook_serve(
     except Exception:
         end_after_min = 0
 
-    state_path = Path("/app/data/cookbook_state.json")
+    state_path = Path(DATA_DIR) / "cookbook_state.json"
     try:
         state = json.loads(state_path.read_text(encoding="utf-8")) if state_path.exists() else {}
     except Exception:

--- a/src/cookbook_serve_lifecycle.py
+++ b/src/cookbook_serve_lifecycle.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 
 import httpx
-from core.constants import internal_api_base
+from core.constants import DATA_DIR, internal_api_base
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ async def _stop_serve(session_id: str, remote_host: str = "", ssh_port: str = ""
 
 
 async def _tick() -> None:
-    state_path = Path("/app/data/cookbook_state.json")
+    state_path = Path(DATA_DIR) / "cookbook_state.json"
     if not state_path.exists():
         return
     try:

--- a/tests/test_cookbook_state_path.py
+++ b/tests/test_cookbook_state_path.py
@@ -1,0 +1,29 @@
+"""Guard: cookbook_state.json must be located via DATA_DIR, not hardcoded /app/data
+(which breaks native runs) or a relative os.environ fallback."""
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+FILES = [
+    "src/cookbook_serve_lifecycle.py",
+    "src/builtin_actions.py",
+    "routes/codex_routes.py",
+    "routes/cookbook_routes.py",
+]
+
+
+def test_no_hardcoded_app_data_cookbook_state():
+    for rel in FILES:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for ln in text.splitlines():
+            if ln.strip().startswith("#"):
+                continue
+            assert "/app/data/cookbook_state" not in ln, f"{rel}: hardcoded /app/data: {ln.strip()}"
+            assert 'os.environ.get("DATA_DIR"' not in ln, f"{rel}: relative DATA_DIR env fallback: {ln.strip()}"
+
+
+def test_cookbook_state_uses_datadir_constant():
+    # Each file that references cookbook_state.json should import the DATA_DIR constant.
+    for rel in FILES:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        if "cookbook_state.json" in text:
+            assert "from core.constants import DATA_DIR" in text, f"{rel}: missing DATA_DIR import"


### PR DESCRIPTION
## Summary

`cookbook_state.json` was located three different ways across the codebase: three call sites hardcoded `Path("/app/data/cookbook_state.json")`, and two used `os.environ.get("DATA_DIR", "data")`. The hardcoded `/app/data` only exists in Docker, so on a native run the real path is `<repo>/data`, the state file looks missing, and cookbook serve-state is silently ignored. The env-var form falls back to a relative `"data"` (DATA_DIR is never set as an env var). This routes all five through `core.constants.DATA_DIR` so the path is one consistent absolute location on both Docker and native.

Files: `src/cookbook_serve_lifecycle.py`, `src/builtin_actions.py`, `routes/codex_routes.py` (two refs), `routes/cookbook_routes.py`. Adds a guard test that none of them reintroduce the hardcoded `/app/data` or relative env fallback.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3331.

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Verified with py_compile, import checks, the new guard test, and the cookbook/serve suite (168 passed). All modules import with no circular-import issues.

## How to Test

1. `python -m pytest tests/test_cookbook_state_path.py -q` passes.
2. On a native (non-Docker) run, serve a model via Cookbook, then confirm the serve state persists and is read back (previously the `/app/data` path made it look absent).

## Visual / UI changes

N/A, backend path resolution only.
