### PR TITLE
fix(search): write cache under DATA_DIR, guard mkdir against read-only path

### DIFF
--- a/services/search/cache.py
+++ b/services/search/cache.py
@@ -6,17 +6,23 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict
 
+from core.constants import DATA_DIR
+
 logger = logging.getLogger(__name__)
 
 # Cache directories
-CACHE_DIR = Path(__file__).resolve().parent.parent / "cache"
+CACHE_DIR = Path(DATA_DIR) / "cache"
 SEARCH_CACHE_DIR = CACHE_DIR / "search"
 CONTENT_CACHE_DIR = CACHE_DIR / "content"
 CACHE_MAX_ENTRIES = 1000
 
-# Create cache directories
-SEARCH_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-CONTENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+# Create cache directories. Guarded so an unwritable path (e.g. a read-only
+# mount) degrades to no-disk-cache instead of crashing module import.
+try:
+    SEARCH_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    CONTENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+except OSError as _e:
+    logger.warning("Search cache directory unavailable (%s); disk cache disabled", _e)
 
 # Track cache size for LRU eviction
 search_cache_index: Dict[str, datetime] = {}


### PR DESCRIPTION
## Summary

`services/search/cache.py` set `CACHE_DIR = Path(__file__).resolve().parent.parent / "cache"` (i.e. `services/cache`, in the source tree) and called `mkdir(parents=True)` at import time with no guard. In Docker `services/` is part of the read-only image layer, so that mkdir fails at import (same root cause as the analytics fix in #2366). This moves the cache under `DATA_DIR/cache` (writable on both Docker and native) and wraps the directory creation so an unwritable path degrades to no-disk-cache instead of crashing module import.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3331.

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Verified with py_compile, import check (CACHE_DIR resolves under DATA_DIR), and the search/cache suite (347 passed).

## How to Test

1. `python -c "import services.search.cache as c; print(c.CACHE_DIR)"` shows a path under the data dir, not `services/cache`.
2. In Docker (read-only `services/`), the module imports without the previous mkdir crash; disk cache works against the mounted data volume.

## Visual / UI changes

N/A, backend path resolution only.
