### PR TITLE
docs(contributing): require constants/helpers over hardcoded paths and URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,8 @@ Don't hardcode values that the project already exposes through a constant or a h
 
 If you need a value that has no constant or helper yet, add one in the appropriate module (usually `core/constants.py` or `src/constants.py`) and import it, rather than repeating a literal across files.
 
+**Commits:** use [Conventional Commits](https://www.conventionalcommits.org), `type(scope): summary` (e.g. `fix(search): ...`, `feat(notes): ...`, `docs(contributing): ...`). Common types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`. Keep the subject short and imperative; put the "why" in the body when it isn't obvious.
+
 ## Issue Reports
 
 For bugs, include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,16 @@ Before submitting any change that affects what the app looks like — buttons, i
 
 If you are unsure whether a change is "visual," it is. Default to attaching a screenshot.
 
+## Code conventions
+
+Don't hardcode values that the project already exposes through a constant or a helper. Hardcoded literals drift out of sync, break on non-default deployments, and reintroduce bugs we've already fixed.
+
+- **Filesystem paths:** never build writable paths from `Path(__file__)...` into the source tree or hardcode `/app/...`. Use `DATA_DIR` (and the other path constants) from `core.constants`, e.g. `Path(DATA_DIR) / "logs" / "x.log"`. The source tree is read-only in Docker, and `/app/...` does not exist on native runs. Guard directory creation so an unwritable path degrades gracefully instead of crashing at import.
+- **Internal API / loopback URLs:** don't hardcode `http://localhost:7000`. Use `internal_api_base()` from `core.constants` (it honors `ODYSSEUS_INTERNAL_BASE` / `APP_PORT`).
+- **Ports, limits, model lists, and similar:** reuse the existing constant if one exists; if it doesn't and the value is used in more than one place, add a constant rather than copying the literal.
+
+If you need a value that has no constant or helper yet, add one in the appropriate module (usually `core/constants.py` or `src/constants.py`) and import it, rather than repeating a literal across files.
+
 ## Issue Reports
 
 For bugs, include:


### PR DESCRIPTION
## Summary

Adds a "Code conventions" section to `CONTRIBUTING.md` requiring contributors to use existing constants and helpers instead of hardcoding values. Covers filesystem paths (use `DATA_DIR` from `core.constants`, never `Path(__file__)...` into the source tree or `/app/...`, guard `mkdir`), internal/loopback URLs (use `internal_api_base()`, not `http://localhost:7000`), and the general rule to add a constant when a repeated literal has none, plus a Conventional Commits guideline for commit messages. This codifies the bug class behind the recent path/URL fixes (#2366, #2752, #3331) so it stops recurring.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3331.

## Type of Change

- [ ] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Documentation-only change; no code paths affected.

## How to Test

1. Read the new "Code conventions" section in `CONTRIBUTING.md` (between "Style and visual changes" and "Issue Reports").

## Visual / UI changes

N/A, documentation only.

## Note

The section references `internal_api_base()`, which is introduced in #3322 (open). If that hasn't merged yet, the helper reference is forward-looking but the convention stands.
