### PR TITLE
ci(pr-checks): conventional-commit title check, unmergeable-PR flagging, pin actions by SHA

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -91,10 +91,6 @@ jobs:
               }
               if (!labels.includes(CONFLICT)) {
                 await github.rest.issues.addLabels({ ...repo, issue_number: number, labels: [CONFLICT] });
-                await github.rest.issues.createComment({
-                  ...repo, issue_number: number,
-                  body: "This PR conflicts with `dev` and can't be merged as-is, so I removed the `ready for review` label and added `merge conflict`. Please rebase on the latest `dev` and resolve the conflicts; the label clears once it's mergeable again.",
-                });
               }
             } else if (pr.mergeable === true) {
               if (labels.includes(CONFLICT)) {

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -15,14 +15,37 @@ jobs:
   check-description:
     name: Check PR description
     runs-on: ubuntu-latest
-    # Skip bots — they open PRs programmatically and have their own process.
+    # Skip bots: they open PRs programmatically and have their own process.
     if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ github.base_ref }}
           sparse-checkout: .github/scripts
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: return require('./.github/scripts/check-pr-description.js')({github, context, core})
+
+  check-title:
+    name: Check PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    # Skip bots: they open PRs programmatically and have their own process.
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const title = context.payload.pull_request.title || "";
+            // Conventional Commits: type(optional-scope)(optional !): summary
+            const re = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([\w .\/-]+\))?!?: .+/;
+            if (!re.test(title)) {
+              core.setFailed(
+                `PR title is not in Conventional Commits format:\n  "${title}"\n\n` +
+                `Expected: type(scope): summary\n` +
+                `Example:  fix(search): handle empty query\n` +
+                `Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.`
+              );
+            } else {
+              core.info(`PR title OK: ${title}`);
+            }

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -7,9 +7,13 @@ on:
 # pull_request_target runs in the base-repo context (has secrets).
 # The checkout below pins to the base branch so no fork code is executed.
 # The script only reads context.payload and calls the GitHub API.
+# Least privilege: contents:read for the base-ref checkout, pull-requests:read
+# for pulls.get (mergeability), issues:write for label + comment management
+# (PR labels and comments both go through the issues API).
 permissions:
+  contents: read
+  pull-requests: read
   issues: write
-  pull-requests: write
 
 jobs:
   check-description:

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -1,8 +1,8 @@
-name: ci / PR description check
+name: ci / PR checks
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 # pull_request_target runs in the base-repo context (has secrets).
 # The checkout below pins to the base branch so no fork code is executed.
@@ -48,4 +48,56 @@ jobs:
               );
             } else {
               core.info(`PR title OK: ${title}`);
+            }
+
+  check-mergeable:
+    name: Flag unmergeable PRs
+    runs-on: ubuntu-latest
+    # Skip bots: they open PRs programmatically and have their own process.
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const number = context.payload.pull_request.number;
+            const READY = "ready for review";
+            const CONFLICT = "merge conflict";
+
+            // Ensure the conflict label exists (red). Ignore if already present.
+            try {
+              await github.rest.issues.getLabel({ ...repo, name: CONFLICT });
+            } catch {
+              await github.rest.issues.createLabel({
+                ...repo, name: CONFLICT, color: "B60205",
+                description: "Conflicts with the base branch; needs a rebase before review.",
+              }).catch(() => {});
+            }
+
+            // mergeable is computed asynchronously and is often null right after
+            // an event, so poll a few times until GitHub has resolved it.
+            let pr = null;
+            for (let i = 0; i < 5; i++) {
+              const { data } = await github.rest.pulls.get({ ...repo, pull_number: number });
+              if (data.mergeable !== null) { pr = data; break; }
+              await new Promise(r => setTimeout(r, 3000));
+            }
+            if (!pr || pr.draft) return;
+            const labels = pr.labels.map(l => l.name);
+
+            if (pr.mergeable === false) {
+              if (labels.includes(READY)) {
+                await github.rest.issues.removeLabel({ ...repo, issue_number: number, name: READY }).catch(() => {});
+              }
+              if (!labels.includes(CONFLICT)) {
+                await github.rest.issues.addLabels({ ...repo, issue_number: number, labels: [CONFLICT] });
+                await github.rest.issues.createComment({
+                  ...repo, issue_number: number,
+                  body: "This PR conflicts with `dev` and can't be merged as-is, so I removed the `ready for review` label and added `merge conflict`. Please rebase on the latest `dev` and resolve the conflicts; the label clears once it's mergeable again.",
+                });
+              }
+            } else if (pr.mergeable === true) {
+              if (labels.includes(CONFLICT)) {
+                await github.rest.issues.removeLabel({ ...repo, issue_number: number, name: CONFLICT }).catch(() => {});
+              }
             }


### PR DESCRIPTION
## Summary

Extends the existing PR-meta workflow (`pr-description-check.yml`, renamed to "PR checks") with two jobs plus a security pin, keeping all PR-meta automation in one file instead of separate workflows:

1. **`check-title`** - fails the PR when its title is not Conventional Commits format (`type(scope): summary`), via an inline `github-script` regex. Types: `feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert`, optional scope and `!`. Pairs with the CONTRIBUTING guidance in #3335.
2. **`check-mergeable`** - on PR events, polls the PR's mergeable state (it's computed asynchronously) and, when it conflicts with the base, removes `ready for review`, adds a red `merge conflict` label (auto-created if missing). The label is the signal; no comment is posted. Clears `merge conflict` once the PR is mergeable again. (Folded in from the standalone #3338, which is now closed. No `push` trigger; a PR that goes stale from a base advance is re-checked on its next event.)
3. **Pin actions by SHA** - `actions/checkout` v6.0.3 and `actions/github-script` v9.0.0, replacing mutable `@v4`/`@v7`.

Bots and drafts are skipped. `ready_for_review` added to the trigger types (`labeled`/`unlabeled` intentionally excluded to avoid a self-trigger loop when the workflow adds the conflict label).

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #2288 (CI baseline gate). Complements the Conventional Commits guidance in #3335. Supersedes #3338.

## Type of Change

- [ ] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Validated the workflow YAML parses and both inline github-script bodies pass `node --check` (the mergeable script wrapped in an async function, since github-script runs it as one).

## How to Test

1. Workflow YAML parses; both inline scripts are syntactically valid.
2. Title regex accepts `fix(search): ...`, `feat: ...`, `chore!: ...`; rejects `Fix bug`, `WIP`.
3. After merge: a PR that conflicts with `dev` loses `ready for review`, gains `merge conflict`, on its next event; rebasing to clean clears `merge conflict`.

## Visual / UI changes

N/A, CI workflow only.
