### PR TITLE
feat(models): add Perplexity provider via OpenAI Responses API adapter

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -284,6 +284,7 @@ _HOST_TO_CURATED = (
     ("googleapis.com", "google"),
     ("x.ai", "xai"),
     ("openrouter.ai", "openrouter"),
+    ("perplexity.ai", "openrouter"),  # multi-model gateway: show full catalog
     ("ollama.com", "ollama"),
     ("opencode.ai/zen/go", "opencode-go"),
     ("opencode.ai/zen", "opencode-zen"),

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -171,6 +171,8 @@ def build_chat_url(base: str) -> str:
         return _anthropic_api_root(base) + "/v1/messages"
     if provider == "ollama":
         return _ollama_api_root(base) + "/chat"
+    if provider == "perplexity":
+        return base + "/responses"
     return base + "/chat/completions"
 
 

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -420,6 +420,8 @@ def _detect_provider(url: str) -> str:
         return "opencode-zen"
     if _host_match(url, "openrouter.ai"):
         return "openrouter"
+    if _host_match(url, "perplexity.ai"):
+        return "perplexity"
     if _host_match(url, "groq.com"):
         return "groq"
     from src.copilot import is_copilot_base
@@ -457,6 +459,7 @@ def _provider_label(url: str) -> str:
     if _host_match(url, "openrouter.ai"): return "OpenRouter"
     if _host_match(url, "opencode.ai/zen/go"): return "OpenCode Go"
     if _host_match(url, "opencode.ai/zen"): return "OpenCode Zen"
+    if _host_match(url, "perplexity.ai"): return "Perplexity"
     if _host_match(url, "groq.com"): return "Groq"
     from src.copilot import is_copilot_base
     if is_copilot_base(url): return "GitHub Copilot"
@@ -1178,6 +1181,13 @@ async def llm_call_async(
             model, messages_copy, temperature, max_tokens,
             stream=False, num_ctx=get_context_length(url, model),
         )
+    elif provider == "perplexity":
+        from src.openai_responses import build_responses_payload
+        target_url = url
+        h = _provider_headers(provider, headers)
+        payload = build_responses_payload(
+            model, messages_copy, temperature, max_tokens, stream=False, max_steps=1,
+        )
     else:
         target_url = url
         h = _provider_headers(provider, headers)
@@ -1226,6 +1236,9 @@ async def llm_call_async(
                     response = _parse_anthropic_response(data)
                 elif provider == "ollama":
                     response = _parse_ollama_response(data)
+                elif provider == "perplexity":
+                    from src.openai_responses import parse_responses_output
+                    response = parse_responses_output(data)
                 else:
                     msg = data["choices"][0]["message"]
                     response = msg.get("content") or msg.get("reasoning_content") or ""
@@ -1289,6 +1302,14 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         payload = _build_ollama_payload(
             model, messages_copy, temperature, max_tokens,
             stream=True, tools=tools, num_ctx=get_context_length(url, model),
+        )
+    elif provider == "perplexity":
+        from src.openai_responses import build_responses_payload
+        target_url = url
+        h = _provider_headers(provider, headers)
+        payload = build_responses_payload(
+            model, messages_copy, temperature, max_tokens,
+            stream=True, tools=tools, max_steps=1,
         )
     else:
         target_url = url
@@ -1487,6 +1508,57 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             yield f'event: error\ndata: {json.dumps({"error": "Network error", "status": 502})}\n\n'
         except Exception as e:
             logger.error(f"Anthropic stream error: {e}")
+            yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
+        return
+
+    # ── Perplexity / OpenAI Responses API streaming ──
+    if provider == "perplexity":
+        from src.openai_responses import ResponsesStreamTranslator
+        translator = ResponsesStreamTranslator()
+        try:
+            client = _get_http_client()
+            async with client.stream('POST', target_url, json=payload, headers=h, timeout=stream_timeout) as r:
+                _clear_host_dead(target_url)
+                if r.status_code != 200:
+                    raw = (await r.aread()).decode(errors="replace")
+                    friendly = _format_upstream_error(r.status_code, raw, target_url)
+                    yield f'event: error\ndata: {json.dumps({"status": r.status_code, "text": friendly, "raw": raw[:500]})}\n\n'
+                    return
+                async for line in r.aiter_lines():
+                    # JSON payload carries its own `type`; the `event:` line is redundant.
+                    if not line or not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if not data:
+                        continue
+                    if data == "[DONE]":
+                        for chunk in translator.flush():
+                            yield chunk
+                        return
+                    if not data.startswith("{"):
+                        continue
+                    try:
+                        ev = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    for chunk in translator.feed(ev):
+                        yield chunk
+                        if chunk == "data: [DONE]\n\n" or chunk.startswith("event: error"):
+                            return
+                # Stream closed with no terminal event.
+                for chunk in translator.flush():
+                    yield chunk
+        except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+            _cooled = _mark_host_dead(target_url)
+            _tail = f" — host cooled for {DEAD_HOST_COOLDOWN:.0f}s" if _cooled else " — transient, will retry"
+            logger.warning(f"Perplexity stream connect to {target_url} failed: {e}{_tail}")
+            yield f'event: error\ndata: {json.dumps({"error": f"Cannot reach {_host_key(target_url)}", "status": 503})}\n\n'
+        except httpx.ReadTimeout:
+            yield f'event: error\ndata: {json.dumps({"error": "Read timeout", "status": 504})}\n\n'
+        except httpx.NetworkError:
+            yield f'event: error\ndata: {json.dumps({"error": "Network error", "status": 502})}\n\n'
+        except Exception as e:
+            logger.error(f"Perplexity stream error: {e}")
             yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
         return
 

--- a/src/openai_responses.py
+++ b/src/openai_responses.py
@@ -1,0 +1,301 @@
+"""OpenAI Responses API adapter (POST /v1/responses).
+
+Pure protocol helpers mapping Odysseus's Chat-Completions-shaped messages to the
+Responses wire format (`input`/`output`, named SSE events, flattened tools) and
+translating Responses SSE back into the internal stream contract. First used by
+Perplexity's Agent API; `max_steps` is its extension (1 = single-shot).
+Transport (the HTTP loop) stays in `llm_core`.
+"""
+import copy
+import json
+from typing import Dict, List, Optional
+
+
+def _delta_event(text: str, *, thinking: bool = False) -> str:
+    payload = {"delta": text}
+    if thinking:
+        payload["thinking"] = True
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _responses_content_parts(content) -> List[Dict]:
+    """OpenAI message content → Responses input parts (text + image)."""
+    if isinstance(content, str):
+        return [{"type": "input_text", "text": content}]
+    if not isinstance(content, list):
+        return [{"type": "input_text", "text": "" if content is None else str(content)}]
+    parts: List[Dict] = []
+    for block in content:
+        if not isinstance(block, dict):
+            parts.append({"type": "input_text", "text": str(block)})
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            parts.append({"type": "input_text", "text": block.get("text", "")})
+        elif btype == "image_url":
+            url = (block.get("image_url") or {}).get("url", "")
+            if url.startswith("data:"):
+                try:
+                    header, b64_data = url.split(",", 1)
+                    media_type = header.split(";")[0].replace("data:", "")
+                except (ValueError, IndexError):
+                    continue
+                parts.append({"type": "input_image",
+                              "source": {"type": "base64", "media_type": media_type, "data": b64_data}})
+            elif url:
+                parts.append({"type": "input_image", "source": {"type": "url", "url": url}})
+    return parts
+
+
+def sanitize_responses_schema(node):
+    """Repair schema shapes Perplexity's Responses validator rejects: objects
+    need `properties`, typeless leaves need a `type`. Mutates in place.
+    """
+    if isinstance(node, dict):
+        _composition = ("anyOf", "oneOf", "allOf", "$ref", "enum", "const")
+        if "properties" in node and "type" not in node:
+            node["type"] = "object"
+        if node.get("type") == "object" and "properties" not in node:
+            node["properties"] = {}
+        if ("type" not in node and "properties" not in node
+                and not any(k in node for k in _composition)):
+            node["type"] = "string"
+        for key in ("properties", "$defs", "definitions"):
+            sub = node.get(key)
+            if isinstance(sub, dict):
+                for v in sub.values():
+                    sanitize_responses_schema(v)
+        for key in ("items", "additionalProperties", "contains", "not"):
+            if isinstance(node.get(key), dict):
+                sanitize_responses_schema(node[key])
+        for key in ("anyOf", "oneOf", "allOf", "prefixItems"):
+            if isinstance(node.get(key), list):
+                for v in node[key]:
+                    sanitize_responses_schema(v)
+    elif isinstance(node, list):
+        for v in node:
+            sanitize_responses_schema(v)
+    return node
+
+
+def responses_tools(tools) -> List[Dict]:
+    """Flatten Chat-Completions function tools to the Responses shape
+    (deep-copied + sanitized; `strict=False` since our schemas aren't closed).
+    """
+    out: List[Dict] = []
+    for t in tools or []:
+        if not isinstance(t, dict) or t.get("type") != "function":
+            continue
+        fn = t.get("function") or {}
+        params = copy.deepcopy(fn.get("parameters")) or {"type": "object", "properties": {}}
+        sanitize_responses_schema(params)
+        out.append({
+            "type": "function",
+            "name": fn.get("name", ""),
+            "description": fn.get("description", ""),
+            "parameters": params,
+            "strict": False,
+        })
+    return out
+
+
+def build_responses_payload(model, messages, temperature, max_tokens,
+                            *, stream=False, tools=None, max_steps=None) -> Dict:
+    """Build a Responses request from OpenAI-style messages: system →
+    `instructions`, assistant `tool_calls` → `function_call`, role:tool →
+    `function_call_output`.
+    """
+    instructions_parts: List[str] = []
+    input_items: List[Dict] = []
+    for m in messages:
+        role = m.get("role")
+        if role == "system":
+            instructions_parts.append(m.get("content") or "")
+        elif role == "tool":
+            input_items.append({
+                "type": "function_call_output",
+                "call_id": m.get("tool_call_id", ""),
+                "output": m.get("content") or "",
+            })
+        elif role == "assistant" and isinstance(m.get("tool_calls"), list):
+            if m.get("content"):
+                input_items.append({
+                    "type": "message", "role": "assistant",
+                    "content": [{"type": "output_text", "text": m["content"]}],
+                })
+            for tc in m["tool_calls"]:
+                fn = tc.get("function") or {}
+                input_items.append({
+                    "type": "function_call",
+                    "call_id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "arguments": fn.get("arguments") or "{}",
+                })
+        elif role == "assistant":
+            text = m.get("content")
+            if isinstance(text, list):
+                text = "".join(b.get("text", "") for b in text
+                               if isinstance(b, dict) and b.get("type") in ("text", "output_text"))
+            input_items.append({
+                "type": "message", "role": "assistant",
+                "content": [{"type": "output_text", "text": text or ""}],
+            })
+        else:
+            input_items.append({
+                "type": "message", "role": role or "user",
+                "content": _responses_content_parts(m.get("content")),
+            })
+
+    payload: Dict = {"model": model, "input": input_items}
+    instructions = "\n\n".join(p for p in instructions_parts if p)
+    if instructions:
+        payload["instructions"] = instructions
+    if temperature is not None:
+        payload["temperature"] = temperature
+    if max_tokens and max_tokens > 0:
+        payload["max_output_tokens"] = max_tokens
+    if stream:
+        payload["stream"] = True
+    tools_payload = responses_tools(tools)
+    if tools_payload:
+        payload["tools"] = tools_payload
+    if max_steps is not None:
+        payload["max_steps"] = max_steps
+    return payload
+
+
+def parse_responses_output(data: dict) -> str:
+    """Concatenate assistant text from a non-streaming `output` array."""
+    chunks: List[str] = []
+    for item in data.get("output") or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for part in item.get("content") or []:
+            if isinstance(part, dict) and part.get("type") == "output_text":
+                chunks.append(part.get("text") or "")
+    return "".join(chunks)
+
+
+def parse_responses_usage(obj: dict) -> Optional[Dict]:
+    """Extract {input_tokens, output_tokens} from a usage block, else None."""
+    usage = (obj or {}).get("usage") or {}
+    inp = usage.get("input_tokens")
+    out = usage.get("output_tokens")
+    if inp is None and out is None:
+        return None
+    return {"input_tokens": inp or 0, "output_tokens": out or 0}
+
+
+def _responses_calls_from_output(response: dict) -> List[Dict]:
+    """Completed function calls from `output` (fallback when args aren't streamed)."""
+    calls: List[Dict] = []
+    for item in (response or {}).get("output") or []:
+        if isinstance(item, dict) and item.get("type") == "function_call":
+            calls.append({
+                "id": item.get("call_id") or "",
+                "name": item.get("name") or "",
+                "arguments": item.get("arguments") or "",
+            })
+    return calls
+
+
+class ResponsesStreamTranslator:
+    """Translate Responses SSE events into Odysseus's internal stream chunks
+    (delta / thinking / tool_calls / usage / error / [DONE]).
+    """
+
+    def __init__(self):
+        self._calls: Dict[str, Dict] = {}   # item_id (fc_…) -> {id(call_id), name, arguments}
+        self._order: List[str] = []
+        self._reasoning_streamed = False
+        self._done = False
+
+    def _slot(self, item_id: str) -> Dict:
+        if item_id not in self._calls:
+            self._calls[item_id] = {"id": "", "name": "", "arguments": ""}
+            self._order.append(item_id)
+        return self._calls[item_id]
+
+    def feed(self, ev: dict) -> List[str]:
+        etype = ev.get("type", "")
+        out: List[str] = []
+        if etype == "response.output_text.delta":
+            d = ev.get("delta") or ""
+            if d:
+                out.append(_delta_event(d))
+        elif etype in ("response.reasoning_summary_text.delta", "response.reasoning_text.delta"):
+            d = ev.get("delta") or ""
+            if d:
+                self._reasoning_streamed = True
+                out.append(_delta_event(d, thinking=True))
+        elif etype == "response.output_item.added":
+            item = ev.get("item") or {}
+            if item.get("type") == "function_call":
+                slot = self._slot(ev.get("item_id") or item.get("id") or "")
+                slot["id"] = item.get("call_id") or slot["id"]
+                slot["name"] = item.get("name") or slot["name"]
+        elif etype == "response.function_call_arguments.delta":
+            slot = self._slot(ev.get("item_id") or "")
+            slot["arguments"] += ev.get("delta") or ""
+        elif etype == "response.function_call_arguments.done":
+            if ev.get("arguments") is not None:
+                self._slot(ev.get("item_id") or "")["arguments"] = ev.get("arguments")
+        elif etype == "response.output_item.done":
+            item = ev.get("item") or {}
+            itype = item.get("type")
+            if itype == "function_call":
+                slot = self._slot(ev.get("item_id") or item.get("id") or "")
+                slot["id"] = item.get("call_id") or slot["id"]
+                slot["name"] = item.get("name") or slot["name"]
+                if item.get("arguments") is not None:
+                    slot["arguments"] = item.get("arguments")
+            elif itype == "reasoning" and not self._reasoning_streamed:
+                text = self._reasoning_text(item)
+                if text:
+                    self._reasoning_streamed = True
+                    out.append(_delta_event(text, thinking=True))
+        elif etype in ("response.completed", "response.incomplete"):
+            out.extend(self._finish(ev.get("response") or {}))
+        elif etype in ("response.failed", "error") or isinstance(ev.get("error"), dict):
+            # Bare {"error": {...}} frame (no top-level type) — surface it, don't swallow.
+            out.append(self._error_event(ev))
+            self._done = True
+        return out
+
+    @staticmethod
+    def _reasoning_text(item: dict) -> str:
+        parts = item.get("summary") or item.get("content") or []
+        return "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+
+    def _finish(self, response: dict) -> List[str]:
+        if self._done:
+            return []
+        self._done = True
+        out: List[str] = []
+        calls = [
+            {"id": self._calls[i]["id"], "name": self._calls[i]["name"], "arguments": self._calls[i]["arguments"]}
+            for i in self._order
+        ]
+        if not calls:
+            calls = _responses_calls_from_output(response)
+        if calls:
+            out.append(f'data: {json.dumps({"type": "tool_calls", "calls": calls})}\n\n')
+        usage = parse_responses_usage(response)
+        if usage:
+            out.append(f'data: {json.dumps({"type": "usage", "data": usage})}\n\n')
+        out.append("data: [DONE]\n\n")
+        return out
+
+    @staticmethod
+    def _error_event(ev: dict) -> str:
+        err = (ev.get("response") or {}).get("error") or ev.get("error") or {}
+        msg = err.get("message") if isinstance(err, dict) else str(err)
+        code = err.get("code") if isinstance(err, dict) else None
+        status = code if isinstance(code, int) else 502
+        return f'event: error\ndata: {json.dumps({"error": msg or "Responses API error", "status": status})}\n\n'
+
+    def flush(self) -> List[str]:
+        """Finish a stream that closed with no explicit completed/failed event."""
+        if self._done:
+            return []
+        return self._finish({})

--- a/static/index.html
+++ b/static/index.html
@@ -2109,6 +2109,7 @@
                   <option value="https://api.deepseek.com/v1" data-logo="deepseek" selected>DeepSeek</option>
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>
                   <option value="https://openrouter.ai/api/v1" data-logo="openrouter">OpenRouter</option>
+                  <option value="https://api.perplexity.ai/v1" data-logo="perplexity">Perplexity</option>
                   <option value="https://ollama.com/api" data-logo="ollama">Ollama Cloud</option>
                   <option value="https://api.groq.com/openai/v1" data-logo="groq">Groq</option>
                   <option value="https://api.mistral.ai/v1" data-logo="mistral">Mistral</option>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -891,7 +891,7 @@ function initEndpointForm() {
       }
       const epType = el('adm-epType');
       if (epType) fd.append('model_type', epType.value);
-      if (provider.value && /openrouter\.ai|ollama\.com/i.test(provider.value)) fd.append('require_models', 'true');
+      if (provider.value && /openrouter\.ai|ollama\.com|perplexity\.ai/i.test(provider.value)) fd.append('require_models', 'true');
       else fd.append('skip_probe', 'false');
       const res = await fetch('/api/model-endpoints', { method: 'POST', body: fd, credentials: 'same-origin' });
       const d = await res.json();

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -48,6 +48,7 @@ const SETUP_PROVIDER_URLS = {
   deepseek: { name: 'DeepSeek', url: 'https://api.deepseek.com/v1' },
   openai: { name: 'OpenAI', url: 'https://api.openai.com/v1' },
   openrouter: { name: 'OpenRouter', url: 'https://openrouter.ai/api/v1' },
+  perplexity: { name: 'Perplexity', url: 'https://api.perplexity.ai/v1' },
   ollama: { name: 'Ollama Cloud', url: 'https://ollama.com/api' },
   xai: { name: 'xAI', url: 'https://api.x.ai/v1' },
   anthropic: { name: 'Anthropic', url: 'https://api.anthropic.com/v1' },
@@ -57,7 +58,7 @@ const SETUP_PROVIDER_URLS = {
   'opencode-zen': { name: 'OpenCode Zen', url: 'https://opencode.ai/zen/v1' },
   'opencode-go': { name: 'OpenCode Go', url: 'https://opencode.ai/zen/go/v1' },
 };
-const SETUP_PROVIDER_NAMES = ['deepseek', 'openai', 'openrouter', 'ollama', 'xai', 'anthropic', 'groq', 'gemini', 'opencode-zen', 'opencode-go'];
+const SETUP_PROVIDER_NAMES = ['deepseek', 'openai', 'openrouter', 'perplexity', 'ollama', 'xai', 'anthropic', 'groq', 'gemini', 'opencode-zen', 'opencode-go'];
 const SETUP_PROVIDER_HINT = SETUP_PROVIDER_NAMES.slice(0, -1).join(', ') + ', or ' + SETUP_PROVIDER_NAMES[SETUP_PROVIDER_NAMES.length - 1];
 const SETUP_LOCAL_ICON = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:5px;"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8"/><path d="M12 17v4"/></svg>';
 const SETUP_API_ICON = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-right:5px;"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>';

--- a/tests/test_perplexity_responses.py
+++ b/tests/test_perplexity_responses.py
@@ -1,0 +1,382 @@
+"""Tests for the OpenAI Responses API adapter (Perplexity Agent API).
+
+The Responses API uses `input`/`output` and named SSE events instead of Chat
+Completions' `messages`/`choices`. These cover the request builder, the
+non-streaming parsers, and the streaming translator that re-emits Odysseus's
+internal SSE format — plus a `stream_llm` integration over a canned SSE stream.
+"""
+import json
+import asyncio
+
+import pytest
+
+from src import llm_core
+from src.openai_responses import (
+    build_responses_payload,
+    parse_responses_output,
+    parse_responses_usage,
+    ResponsesStreamTranslator,
+    sanitize_responses_schema,
+    responses_tools,
+)
+
+
+# ── request builder ──
+
+class TestBuildResponsesPayload:
+    def test_basic_text(self):
+        p = build_responses_payload(
+            "openai/gpt-5.5",
+            [{"role": "user", "content": "hi"}],
+            0.7, 100, stream=False, max_steps=1,
+        )
+        assert p["model"] == "openai/gpt-5.5"
+        assert "messages" not in p
+        assert p["input"] == [
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+        ]
+        assert p["temperature"] == 0.7
+        assert p["max_output_tokens"] == 100
+        assert p["max_steps"] == 1
+        assert "stream" not in p  # stream=False omits the key
+
+    def test_system_becomes_instructions(self):
+        p = build_responses_payload(
+            "m",
+            [{"role": "system", "content": "be brief"},
+             {"role": "user", "content": "hi"}],
+            1.0, 0, stream=True,
+        )
+        assert p["instructions"] == "be brief"
+        assert all(i.get("role") != "system" for i in p["input"])
+        assert p["stream"] is True
+        assert "max_output_tokens" not in p  # max_tokens=0
+        assert "max_steps" not in p          # not provided
+
+    def test_tools_flattened_strict_false(self):
+        tools = [{"type": "function", "function": {
+            "name": "get_weather", "description": "w",
+            "parameters": {"type": "object", "properties": {"loc": {"type": "string"}}},
+        }}]
+        p = build_responses_payload("m", [{"role": "user", "content": "x"}], 0.5, 10, stream=True, tools=tools)
+        assert p["tools"] == [{
+            "type": "function",
+            "name": "get_weather",
+            "description": "w",
+            "parameters": {"type": "object", "properties": {"loc": {"type": "string"}}},
+            "strict": False,
+        }]
+
+    def test_assistant_tool_calls_round_trip(self):
+        msgs = [
+            {"role": "user", "content": "weather?"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "type": "function",
+                 "function": {"name": "get_weather", "arguments": '{"loc":"SF"}'}},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "72F"},
+        ]
+        items = build_responses_payload("m", msgs, 0.5, 10, stream=True)["input"]
+        fc = [i for i in items if i.get("type") == "function_call"]
+        fco = [i for i in items if i.get("type") == "function_call_output"]
+        # call_id must match on both sides or follow-up rounds 400
+        assert fc == [{"type": "function_call", "call_id": "call_1",
+                       "name": "get_weather", "arguments": '{"loc":"SF"}'}]
+        assert fco == [{"type": "function_call_output", "call_id": "call_1", "output": "72F"}]
+
+    def test_multimodal_image_data_uri(self):
+        msgs = [{"role": "user", "content": [
+            {"type": "text", "text": "what's this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]}]
+        parts = build_responses_payload("m", msgs, 0.5, 10, stream=False)["input"][0]["content"]
+        assert parts[0] == {"type": "input_text", "text": "what's this"}
+        assert parts[1] == {"type": "input_image",
+                            "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}
+
+
+# ── non-streaming parsers ──
+
+class TestParseResponses:
+    def test_output_text_concatenated(self):
+        data = {"output": [
+            {"type": "reasoning", "summary": [{"type": "summary_text", "text": "thinking"}]},
+            {"type": "message", "role": "assistant",
+             "content": [{"type": "output_text", "text": "Hello "},
+                         {"type": "output_text", "text": "world"}]},
+        ]}
+        assert parse_responses_output(data) == "Hello world"
+
+    def test_empty_output(self):
+        assert parse_responses_output({}) == ""
+        assert parse_responses_output({"output": []}) == ""
+
+    def test_usage(self):
+        assert parse_responses_usage({"usage": {"input_tokens": 10, "output_tokens": 5}}) == {
+            "input_tokens": 10, "output_tokens": 5}
+
+    def test_usage_missing(self):
+        assert parse_responses_usage({}) is None
+
+
+# ── streaming translator ──
+
+def _feed_all(translator, events):
+    out = []
+    for ev in events:
+        out.extend(translator.feed(ev))
+    out.extend(translator.flush())
+    return out
+
+
+def _parse_chunks(chunks):
+    """Internal SSE chunks → list of parsed JSON dicts (skipping [DONE])."""
+    objs = []
+    for c in chunks:
+        for ln in c.split("\n"):
+            ln = ln.strip()
+            if ln.startswith("data: ") and ln[6:] != "[DONE]":
+                try:
+                    objs.append(json.loads(ln[6:]))
+                except ValueError:
+                    pass
+    return objs
+
+
+class TestResponsesStreamTranslator:
+    def test_text_reasoning_usage(self):
+        events = [
+            {"type": "response.created"},
+            {"type": "response.reasoning_summary_text.delta", "delta": "think "},
+            {"type": "response.output_text.delta", "delta": "Hello "},
+            {"type": "response.output_text.delta", "delta": "world"},
+            {"type": "response.completed", "response": {"usage": {"input_tokens": 3, "output_tokens": 2}}},
+        ]
+        chunks = _feed_all(ResponsesStreamTranslator(), events)
+        assert chunks[-1] == "data: [DONE]\n\n"
+        objs = _parse_chunks(chunks)
+        assert {"delta": "think ", "thinking": True} in objs
+        assert {"delta": "Hello "} in objs
+        assert {"delta": "world"} in objs
+        assert {"type": "usage", "data": {"input_tokens": 3, "output_tokens": 2}} in objs
+
+    def test_function_call_streaming(self):
+        events = [
+            {"type": "response.output_item.added", "output_index": 0,
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "call_x", "name": "search", "arguments": ""}},
+            {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '{"q":'},
+            {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": '"cats"}'},
+            {"type": "response.function_call_arguments.done", "item_id": "fc_1", "arguments": '{"q":"cats"}'},
+            {"type": "response.output_item.done", "output_index": 0,
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "call_x",
+                      "name": "search", "arguments": '{"q":"cats"}'}},
+            {"type": "response.completed", "response": {"usage": {"input_tokens": 1, "output_tokens": 1}}},
+        ]
+        chunks = _feed_all(ResponsesStreamTranslator(), events)
+        tc = next(o for o in _parse_chunks(chunks) if o.get("type") == "tool_calls")
+        # id = call_id (round-trips to function_call.call_id next round)
+        assert tc["calls"] == [{"id": "call_x", "name": "search", "arguments": '{"q":"cats"}'}]
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+    def test_parallel_function_calls(self):
+        events = [
+            {"type": "response.output_item.added", "output_index": 0,
+             "item": {"type": "function_call", "id": "fc_1", "call_id": "call_a", "name": "f0"}},
+            {"type": "response.output_item.added", "output_index": 1,
+             "item": {"type": "function_call", "id": "fc_2", "call_id": "call_b", "name": "f1"}},
+            {"type": "response.function_call_arguments.delta", "item_id": "fc_1", "delta": "{}"},
+            {"type": "response.function_call_arguments.delta", "item_id": "fc_2", "delta": "{}"},
+            {"type": "response.completed", "response": {}},
+        ]
+        tc = next(o for o in _parse_chunks(_feed_all(ResponsesStreamTranslator(), events))
+                  if o.get("type") == "tool_calls")
+        by_id = {c["id"]: c for c in tc["calls"]}
+        assert set(by_id) == {"call_a", "call_b"}
+        assert by_id["call_a"]["name"] == "f0"
+        assert by_id["call_b"]["name"] == "f1"
+
+    def test_failed_emits_error_no_done(self):
+        t = ResponsesStreamTranslator()
+        chunks = []
+        for ev in [
+            {"type": "response.output_text.delta", "delta": "partial"},
+            {"type": "response.failed", "response": {"error": {"message": "model_error"}}},
+        ]:
+            chunks.extend(t.feed(ev))
+        chunks.extend(t.flush())   # must NOT append a [DONE] after a failure
+        joined = "".join(chunks)
+        assert "event: error" in joined
+        assert "model_error" in joined
+        assert "[DONE]" not in joined
+
+    def test_reasoning_block_without_deltas(self):
+        events = [
+            {"type": "response.output_item.done", "output_index": 0,
+             "item": {"type": "reasoning", "summary": [{"type": "summary_text", "text": "the plan"}]}},
+            {"type": "response.completed", "response": {}},
+        ]
+        objs = _parse_chunks(_feed_all(ResponsesStreamTranslator(), events))
+        assert {"delta": "the plan", "thinking": True} in objs
+
+    def test_calls_fallback_from_completed_output(self):
+        # No streamed arg deltas — calls live only in completed.output.
+        events = [
+            {"type": "response.completed", "response": {
+                "output": [{"type": "function_call", "call_id": "call_z", "name": "g", "arguments": "{}"}],
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            }},
+        ]
+        tc = next(o for o in _parse_chunks(_feed_all(ResponsesStreamTranslator(), events))
+                  if o.get("type") == "tool_calls")
+        assert tc["calls"] == [{"id": "call_z", "name": "g", "arguments": "{}"}]
+
+    def test_error_frame_surfaces_without_top_level_type(self):
+        # Perplexity's `error` SSE frame: {"error":{...}}, no top-level "type".
+        # Must surface as an error (not a silent empty reply) with no [DONE].
+        out = ResponsesStreamTranslator().feed(
+            {"error": {"message": "invalid request", "type": "invalid_request", "code": 400}})
+        joined = "".join(out)
+        assert joined.startswith("event: error")
+        assert "invalid request" in joined
+        assert json.loads(joined.split("data: ", 1)[1])["status"] == 400
+        assert "[DONE]" not in joined
+
+
+# ── tool-schema sanitization (Perplexity validator is stricter than OpenAI) ──
+
+class TestSchemaSanitizer:
+    def test_object_without_properties_gets_empty_props(self):
+        assert sanitize_responses_schema({"type": "object"})["properties"] == {}
+
+    def test_nested_freeform_object_fixed(self):
+        s = sanitize_responses_schema(
+            {"type": "object", "properties": {"body": {"type": "object", "description": "json"}}})
+        assert s["properties"]["body"]["properties"] == {}
+
+    def test_object_inside_array_items_fixed(self):
+        s = sanitize_responses_schema({"type": "array", "items": {"type": "object"}})
+        assert s["items"]["properties"] == {}
+
+    def test_typeless_property_gets_string_type(self):
+        s = sanitize_responses_schema(
+            {"type": "object", "properties": {"value": {"description": "any value"}}})
+        assert s["properties"]["value"]["type"] == "string"
+
+    def test_composition_node_not_forced_to_string(self):
+        node = sanitize_responses_schema({"anyOf": [{"type": "string"}, {"type": "number"}]})
+        assert "type" not in node  # anyOf preserved
+
+    def test_properties_without_type_becomes_object(self):
+        node = sanitize_responses_schema({"properties": {"a": {"type": "string"}}})
+        assert node["type"] == "object"
+
+    def test_responses_tools_flattens_and_sanitizes(self):
+        tools = [{"type": "function", "function": {
+            "name": "f", "description": "d",
+            "parameters": {"type": "object", "properties": {
+                "body": {"type": "object"}, "v": {"description": "x"}}}}}]
+        out = responses_tools(tools)
+        assert out[0]["name"] == "f" and out[0]["strict"] is False
+        props = out[0]["parameters"]["properties"]
+        assert props["body"]["properties"] == {} and props["v"]["type"] == "string"
+
+    def test_does_not_mutate_caller_schema(self):
+        original = {"type": "object", "properties": {"body": {"type": "object"}}}
+        responses_tools([{"type": "function", "function": {"name": "f", "parameters": original}}])
+        assert "properties" not in original["properties"]["body"]  # deep-copied
+
+
+# ── stream_llm integration over a canned Responses SSE stream ──
+
+class _FakeResp:
+    def __init__(self, lines, status=200):
+        self._lines = lines
+        self.status_code = status
+
+    async def aiter_lines(self):
+        for ln in self._lines:
+            yield ln
+
+    async def aread(self):
+        return b""
+
+
+class _FakeStreamCtx:
+    def __init__(self, lines, status):
+        self._lines, self._status = lines, status
+
+    async def __aenter__(self):
+        return _FakeResp(self._lines, self._status)
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeClient:
+    def __init__(self, lines, status=200):
+        self._lines, self._status = lines, status
+
+    def stream(self, method, url, **kw):
+        return _FakeStreamCtx(self._lines, self._status)
+
+
+def _drive(monkeypatch, lines, tools=None, status=200):
+    monkeypatch.setattr(llm_core, "_get_http_client", lambda: _FakeClient(lines, status))
+    monkeypatch.setattr(llm_core, "_is_host_dead", lambda u: False)
+    monkeypatch.setattr(llm_core, "note_model_activity", lambda *a, **k: None)
+    monkeypatch.setattr(llm_core, "_clear_host_dead", lambda *a, **k: None)
+
+    async def run():
+        chunks = []
+        async for chunk in llm_core.stream_llm(
+            "https://api.perplexity.ai/v1/responses",
+            "openai/gpt-5.5",
+            [{"role": "user", "content": "hi"}],
+            headers={"Authorization": "Bearer k"},
+            tools=tools,
+        ):
+            chunks.append(chunk)
+        return chunks
+
+    return asyncio.run(run())
+
+
+def _evt(etype, **fields):
+    return "data: " + json.dumps({"type": etype, **fields})
+
+
+def test_stream_llm_perplexity_text(monkeypatch):
+    lines = [
+        _evt("response.output_text.delta", delta="Hello"),
+        _evt("response.output_text.delta", delta=" world"),
+        _evt("response.completed", response={"usage": {"input_tokens": 2, "output_tokens": 2}}),
+    ]
+    chunks = _drive(monkeypatch, lines)
+    objs = _parse_chunks(chunks)
+    text = "".join(o["delta"] for o in objs if "delta" in o and not o.get("thinking"))
+    assert text == "Hello world"
+    assert {"type": "usage", "data": {"input_tokens": 2, "output_tokens": 2}} in objs
+    assert any("[DONE]" in c for c in chunks)
+
+
+def test_stream_llm_perplexity_tool_call(monkeypatch):
+    lines = [
+        _evt("response.output_item.added", output_index=0,
+             item={"type": "function_call", "id": "fc_1", "call_id": "call_x", "name": "search"}),
+        _evt("response.function_call_arguments.delta", item_id="fc_1", delta='{"q":"x"}'),
+        _evt("response.output_item.done", output_index=0,
+             item={"type": "function_call", "id": "fc_1", "call_id": "call_x",
+                   "name": "search", "arguments": '{"q":"x"}'}),
+        _evt("response.completed", response={"usage": {"input_tokens": 1, "output_tokens": 1}}),
+    ]
+    chunks = _drive(monkeypatch, lines,
+                    tools=[{"type": "function", "function": {"name": "search", "parameters": {}}}])
+    tc = next(o for o in _parse_chunks(chunks) if o.get("type") == "tool_calls")
+    assert tc["calls"] == [{"id": "call_x", "name": "search", "arguments": '{"q":"x"}'}]
+
+
+def test_stream_llm_perplexity_http_error(monkeypatch):
+    chunks = _drive(monkeypatch, ["irrelevant"], status=401)
+    joined = "".join(chunks)
+    assert "event: error" in joined
+    assert "[DONE]" not in joined

--- a/tests/test_provider_detection.py
+++ b/tests/test_provider_detection.py
@@ -48,6 +48,9 @@ class TestDetectProviderRealHosts:
     def test_openrouter(self):
         assert llm_core._detect_provider("https://openrouter.ai/api/v1") == "openrouter"
 
+    def test_perplexity(self):
+        assert llm_core._detect_provider("https://api.perplexity.ai/v1") == "perplexity"
+
     def test_groq_openai_compat_path(self):
         # Groq's base carries an /openai/v1 path; detection must still see the host.
         assert llm_core._detect_provider("https://api.groq.com/openai/v1") == "groq"
@@ -70,6 +73,9 @@ class TestDetectProviderRejectsSubstringFalsePositives:
 
     def test_lookalike_host(self):
         assert llm_core._detect_provider("https://anthropic.com.example/v1") == "openai"
+
+    def test_perplexity_lookalike_host(self):
+        assert llm_core._detect_provider("https://perplexity.ai.evil.com/v1") == "openai"
 
     def test_none_safe(self):
         assert llm_core._detect_provider(None) == "openai"

--- a/tests/test_provider_endpoints.py
+++ b/tests/test_provider_endpoints.py
@@ -47,6 +47,10 @@ PROVIDER_CASES = [
     ("openrouter", "https://openrouter.ai/api/v1",
      "https://openrouter.ai/api/v1/chat/completions",
      "https://openrouter.ai/api/v1/models"),
+    # Perplexity Agent API = OpenAI Responses API: chat → /responses, list → /models.
+    ("perplexity", "https://api.perplexity.ai/v1",
+     "https://api.perplexity.ai/v1/responses",
+     "https://api.perplexity.ai/v1/models"),
     ("groq", "https://api.groq.com/openai/v1",
      "https://api.groq.com/openai/v1/chat/completions",
      "https://api.groq.com/openai/v1/models"),
@@ -113,6 +117,8 @@ def test_headers_anthropic_without_key_still_sends_version():
     "https://api.deepseek.com",
     "https://api.groq.com/openai/v1",
     "https://generativelanguage.googleapis.com/v1beta/openai",
+    # Perplexity is plain Bearer — no attribution headers.
+    "https://api.perplexity.ai/v1",
 ])
 def test_headers_openai_style_use_bearer(base):
     h = er.build_headers("secret", base)

--- a/tests/test_providers_perplexity_logo_js.py
+++ b/tests/test_providers_perplexity_logo_js.py
@@ -1,0 +1,36 @@
+"""Pin the Perplexity provider logo + endpoint label.
+
+The Perplexity connector relies on the pre-existing `/perplexity|sonar/i` logo
+pattern and the `perplexity.ai` → "Perplexity" endpoint label. These guard
+against either being dropped, which would leave the new provider unbranded.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HELPER = _REPO / "static" / "js" / "providers.js"
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node not on PATH")
+
+
+def _eval(expr_js):
+    js = (
+        f"import {{ providerLogo, providerLabel }} from '{_HELPER.as_posix()}';"
+        f"console.log(JSON.stringify({expr_js}));"
+    )
+    p = subprocess.run(["node", "--input-type=module"], input=js,
+                       capture_output=True, text=True, cwd=str(_REPO), timeout=30)
+    assert p.returncode == 0, p.stderr
+    return json.loads(p.stdout.strip())
+
+
+def test_perplexity_models_get_a_logo():
+    assert _eval("providerLogo('perplexity/sonar') !== null") is True
+    assert _eval("providerLogo('sonar-pro') !== null") is True
+
+
+def test_perplexity_endpoint_label():
+    assert _eval("providerLabel('https://api.perplexity.ai/v1')") == "Perplexity"


### PR DESCRIPTION
## Summary

Adds **Perplexity** as an opt-in API model provider (`https://api.perplexity.ai/v1`), giving OpenRouter-style access to Perplexity's full multi-vendor catalog (`openai/*`, `anthropic/*`, `google/*`, `xai/*`, `nvidia/*`, `perplexity/*`) through a single API key. That catalog is only reachable via Perplexity's **Agent API**, which implements the standard **OpenAI Responses API** (`POST /v1/responses`) — not the classic Sonar `/chat/completions` (which exposes only the 4 `sonar` models). Odysseus didn't speak the Responses wire format (`input`/`output`, named SSE events, flattened tools), so this PR adds a small, self-contained **OpenAI Responses adapter** as its own module (`src/openai_responses.py`) and wires Perplexity through it. Configured like every other endpoint: pick it from the Add Models dropdown, paste a key, done. Existing Chat-Completions connectors are untouched — purely additive.

> Note on shape: issue #3021 / PR #3015 proposed Perplexity via classic chat-completions (`sonar-pro`). This PR instead targets the **Agent API (Responses)** because that's what unlocks the *full* multi-model catalog, not just the 4 sonar models. Happy to align if maintainers prefer the chat-completions shape.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #3021

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this implements #3021 (related: #3015 takes the chat-completions approach).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end against the live Perplexity API (catalog fetch + curation, streaming chat, reasoning, and native tool-calling through the agent loop).

## How to Test

**Unit tests** (no key needed):

```
pytest tests/test_perplexity_responses.py tests/test_provider_detection.py tests/test_provider_endpoints.py -q
```

Covers the request builder, the non-streaming parsers, the streaming translator (text / reasoning / tool calls / parallel calls / error frames), the schema sanitizer, and a `stream_llm` integration over a canned SSE stream. Full suite (`pytest -q`) is green.

**End-to-end** (needs a `PERPLEXITY_API_KEY`):

1. Run the app (`uvicorn app:app` or `docker compose up`).
2. **Settings → Add Models → API** → select **Perplexity** (the URL auto-fills `https://api.perplexity.ai/v1`), paste your key, save. The model list populates with the full catalog (`openai/*`, `anthropic/*`, `google/*`, `xai/*`, …).
3. Plain chat with e.g. `anthropic/claude-sonnet-4-6`: tokens stream, reasoning surfaces as thinking, usage/metrics appear.
4. Agent task that needs a tool (e.g. web search or file read) with a Perplexity-hosted model: a native tool call fires, executes, and a second round completes — confirming the `call_id` round-trips (no 400).
5. Negative: a bad key surfaces a friendly "Perplexity rejected…" error, no crash.

## Visual / UI changes

Minimal: adds one `<option value="https://api.perplexity.ai/v1">Perplexity</option>` to the existing Add-Models provider dropdown (reusing the existing `<option>`/`data-logo` pattern — the Perplexity logo + label already shipped), extends the `require_models` probe regex, and adds a `/setup perplexity` shortcut. No new CSS, colors, fonts, spacing, components, or emoji.

- [x] **Style match**: reuses existing dropdown-option styling and the already-present Perplexity logo/label; no new visual language introduced.
- [x] **No new component patterns.**

### Screenshots / clips

_Dropdown entry shown below (new "Perplexity" option in Add Models → API)._

<!-- screenshot to be attached -->
