### PR TITLE
fix(llm): Properly detect remote Ollama bare URLs as native endpoints…

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -270,8 +270,10 @@ def _is_ollama_native_url(url: str) -> bool:
     path = (parsed.path or "").rstrip("/")
     if _host_match(url, "ollama.com"):
         return True
+    if path.startswith("/v1"):
+        return False
     local_ollama_host = host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"} or parsed.port == 11434
-    return local_ollama_host and (path == "/api" or path.startswith("/api/"))
+    return local_ollama_host and (path == "" or path == "/api" or path.startswith("/api/"))
 
 
 def _ollama_api_root(url: str) -> str:
@@ -287,6 +289,8 @@ def _ollama_api_root(url: str) -> str:
         return url[: -len("/generate")]
     if path.endswith("/api"):
         return url
+    if path == "":
+        return url + "/api"
     if _host_match(url, "ollama.com"):
         root = f"{parsed.scheme}://{parsed.netloc}" if parsed.scheme and parsed.netloc else "https://ollama.com"
         return root.rstrip("/") + "/api"

--- a/tests/test_endpoint_resolver.py
+++ b/tests/test_endpoint_resolver.py
@@ -61,7 +61,11 @@ def _detect_provider(url: str) -> str:
     parsed = urlparse(url or "")
     host = parsed.hostname or ""
     path = (parsed.path or "").rstrip("/")
-    if host.endswith("ollama.com") or (parsed.port == 11434 and (path == "/api" or path.startswith("/api/"))):
+    if host.endswith("ollama.com"):
+        return "ollama"
+    if path.startswith("/v1"):
+        pass # OpenAI compat
+    elif (parsed.port == 11434 or host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}) and (path == "" or path == "/api" or path.startswith("/api/")):
         return "ollama"
     if "anthropic.com" in (url or ""):
         return "anthropic"
@@ -75,6 +79,8 @@ def _ollama_api_root(base: str) -> str:
     path = (parsed.path or "").rstrip("/")
     if path.endswith("/api"):
         return base
+    if path == "":
+        return base + "/api"
     if host.endswith("ollama.com"):
         return f"{parsed.scheme}://{parsed.netloc}/api"
     return base
@@ -155,6 +161,12 @@ class TestBuildChatUrl:
 
     def test_ollama_cloud_root_adds_api(self):
         assert build_chat_url("https://ollama.com") == "https://ollama.com/api/chat"
+
+    def test_ollama_bare_url_adds_api(self):
+        assert build_chat_url("http://nas:11434") == "http://nas:11434/api/chat"
+
+    def test_ollama_v1_preserves_openai_compat(self):
+        assert build_chat_url("http://nas:11434/v1") == "http://nas:11434/v1/chat/completions"
 
 
 class TestBuildModelsUrl:


### PR DESCRIPTION
fix(llm): Properly detect remote Ollama bare URLs as native endpoints (fixes #3252)

## Summary

This fixes an issue where remote Ollama instances hosted over a LAN using a bare URL (e.g., `http://nas:11434` without a `/api` or `/v1` suffix) were improperly falling back to the `openai` provider classification. As a result, utility tasks (like memory "tidy") would fail with a 404 error because the application attempted to append `/chat/completions` instead of `/api/chat` or `/v1/chat/completions`. This PR adds an explicitly empty-path check to `_is_ollama_native_url` and `_ollama_api_root` to correctly identify and build native endpoints for these URLs, while still fully preserving OpenAI compatibility for paths explicitly starting with `/v1`. Pure-function test helpers have also been synced and new unit tests added.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3252

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Set up a remote or LAN Ollama endpoint in Settings -> Model Endpoints using a bare URL (e.g., `http://YOUR_LAN_IP:11434` with **no** `/v1` or `/api` suffix).
2. Assign this endpoint as your Utility endpoint (or leave utility blank so it falls back to this as default).
3. Navigate to the "Brain" tab and click "Tidy" to trigger a memory consolidation utility task.
4. Verify the task completes successfully instead of returning an HTTP 404 "check the terminal" error.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A - Backend routing fix only, no UI changes.
