### PR TITLE
fix(research): stabilize web search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,7 @@ docs/windows-port/
 
 # Local config
 compound.config.json
+config/local_model_router.json
+.tools/gitleaks/gitleaks
 *.error.log
 _scratch/

--- a/core/database.py
+++ b/core/database.py
@@ -5,8 +5,7 @@ from datetime import datetime, timezone
 from sqlalchemy import event, create_engine, Column, String, Text, Boolean, DateTime, Integer, ForeignKey, JSON, Index, func, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.types import TypeDecorator
-from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy.orm import relationship, sessionmaker, backref
+from sqlalchemy.orm import declarative_base, declared_attr, relationship, sessionmaker, backref
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/services/search/core.py
+++ b/services/search/core.py
@@ -32,6 +32,7 @@ from .providers import (
     _get_search_settings,
     _get_provider_key,
     _get_result_count,
+    get_provider_availability,
 )
 from .content import (
     fetch_webpage_content,
@@ -175,6 +176,13 @@ def searxng_search_results(query: str, count: int = 10, time_filter: str = None)
 
     results: List[dict] = []
     for provider_name in provider_chain:
+        availability = get_provider_availability(provider_name)
+        if not availability.ok:
+            detail = f" ({availability.detail})" if availability.detail else ""
+            logger.warning(
+                f"Skipping {provider_name} search: {availability.reason}{detail}"
+            )
+            continue
         for attempt in range(2):
             try:
                 logger.info(f"Attempting {provider_name} search (attempt {attempt + 1})")
@@ -281,6 +289,15 @@ def comprehensive_web_search(
     search_results = []
     provider_attempts = {}
     for provider_name in provider_chain:
+        availability = get_provider_availability(provider_name)
+        if not availability.ok:
+            detail = f" ({availability.detail})" if availability.detail else ""
+            provider_attempts[provider_name] = f"{availability.reason}{detail}"
+            logger.warning(
+                f"Comprehensive search: skipping {provider_name}: "
+                f"{availability.reason}{detail}"
+            )
+            continue
         last_err = None
         empty = False
         for attempt in range(2):

--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -3,6 +3,9 @@
 import json
 import logging
 import os
+import time
+import warnings
+from dataclasses import dataclass
 from typing import List, Optional
 from urllib.parse import urljoin, urlparse, parse_qs
 
@@ -16,6 +19,7 @@ from .query import build_enhanced_query
 logger = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT = 20
+DDG_RETRY_DELAY_SECONDS = 0.35
 
 # Provider registry — maps setting value to (label, needs_key, needs_url)
 PROVIDER_INFO = {
@@ -27,6 +31,119 @@ PROVIDER_INFO = {
     "serper":   ("Serper",            True,  False),
     "disabled": ("Disabled",          False, False),
 }
+
+
+@dataclass(frozen=True)
+class ProviderPolicy:
+    name: str
+    label: str
+    required_settings: tuple[str, ...] = ()
+    query_concurrency: str = "parallel"
+    fallback_concurrency: int = 4
+    status_when_empty: str = "empty"
+
+
+@dataclass(frozen=True)
+class ProviderAvailability:
+    provider: str
+    ok: bool
+    reason: str = "ok"
+    detail: str = ""
+
+
+_PROVIDER_POLICIES = {
+    "searxng": ProviderPolicy(
+        name="searxng",
+        label="SearXNG",
+        query_concurrency="parallel",
+        fallback_concurrency=2,
+        status_when_empty="searxng returned no results",
+    ),
+    "brave": ProviderPolicy(
+        name="brave",
+        label="Brave Search",
+        required_settings=("brave_api_key",),
+        query_concurrency="parallel",
+        fallback_concurrency=4,
+        status_when_empty="brave returned no results",
+    ),
+    "duckduckgo": ProviderPolicy(
+        name="duckduckgo",
+        label="DuckDuckGo",
+        query_concurrency="sequential",
+        fallback_concurrency=1,
+        status_when_empty="duckduckgo returned no results after retry and HTML fallback",
+    ),
+    "google_pse": ProviderPolicy(
+        name="google_pse",
+        label="Google PSE",
+        required_settings=("google_pse_key", "google_pse_cx"),
+        query_concurrency="parallel",
+        fallback_concurrency=4,
+        status_when_empty="google_pse returned no results",
+    ),
+    "tavily": ProviderPolicy(
+        name="tavily",
+        label="Tavily",
+        required_settings=("tavily_api_key",),
+        query_concurrency="parallel",
+        fallback_concurrency=4,
+        status_when_empty="tavily returned no results",
+    ),
+    "serper": ProviderPolicy(
+        name="serper",
+        label="Serper",
+        required_settings=("serper_api_key",),
+        query_concurrency="parallel",
+        fallback_concurrency=4,
+        status_when_empty="serper returned no results",
+    ),
+}
+
+
+def get_provider_policy(provider: str) -> ProviderPolicy:
+    """Return provider capability metadata for research/search orchestration."""
+    if provider in _PROVIDER_POLICIES:
+        return _PROVIDER_POLICIES[provider]
+    label, needs_key, _needs_url = PROVIDER_INFO.get(provider, (provider or "unknown", False, False))
+    required = (f"{provider}_api_key",) if needs_key and provider else ()
+    return ProviderPolicy(
+        name=provider,
+        label=label,
+        required_settings=required,
+        status_when_empty=f"{provider} returned no results" if provider else "provider returned no results",
+    )
+
+
+def _provider_config_value(provider: str, field: str) -> str:
+    settings = _get_search_settings()
+    if field.endswith("_api_key") or field.endswith("_key"):
+        return _get_provider_key(provider)
+    if field == "google_pse_cx":
+        return (settings.get("google_pse_cx") or "").strip() or os.environ.get("GOOGLE_PSE_CX", "").strip()
+    if field == "search_url":
+        return _get_search_instance()
+    return (settings.get(field) or "").strip()
+
+
+def get_provider_availability(provider: str) -> ProviderAvailability:
+    """Return whether provider has required local config, without exposing secrets."""
+    if provider == "disabled":
+        return ProviderAvailability(provider=provider, ok=False, reason="disabled", detail="search provider is disabled")
+
+    policy = get_provider_policy(provider)
+    missing = [
+        field for field in policy.required_settings
+        if not _provider_config_value(provider, field)
+    ]
+    if missing:
+        return ProviderAvailability(
+            provider=provider,
+            ok=False,
+            reason="missing_config",
+            detail="missing required setting(s): " + ", ".join(missing),
+        )
+    return ProviderAvailability(provider=provider, ok=True)
 
 
 # ── Settings helpers ──
@@ -381,34 +498,106 @@ def _resolve_ddg_redirect(raw: str) -> str:
     return resolved
 
 
+def _is_duckduckgo_rename_warning(warning: warnings.WarningMessage) -> bool:
+    message = str(warning.message)
+    return (
+        issubclass(warning.category, RuntimeWarning)
+        and "duckduckgo_search" in message
+        and "ddgs" in message
+    )
+
+
+def _build_ddgs_client(DDGS):
+    with warnings.catch_warnings(record=True) as caught:
+        ddgs = DDGS()
+    for warning in caught:
+        if _is_duckduckgo_rename_warning(warning):
+            continue
+        warnings.warn(
+            warning.message,
+            warning.category,
+            stacklevel=2,
+        )
+    return ddgs
+
+
 def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = None) -> List[dict]:
     """Search using DuckDuckGo via the duckduckgo-search library. No API key needed."""
 
     def _html_fallback() -> List[dict]:
-        try:
-            response = httpx.get(
-                "https://html.duckduckgo.com/html/",
-                params={"q": query, "kp": _safesearch_for("duckduckgo_html")},
-                headers={"User-Agent": "Mozilla/5.0"},
-                timeout=REQUEST_TIMEOUT,
-            )
-            response.raise_for_status()
-            soup = BeautifulSoup(response.text, "html.parser")
+        def _link_result(link, snippet: str = "") -> Optional[dict]:
+            url = _resolve_ddg_redirect(link.get("href", ""))
+            if not url:
+                return None
+            parsed = urlparse(url)
+            if parsed.scheme not in {"http", "https"}:
+                return None
+            title = link.get_text(" ", strip=True)
+            if not title:
+                return None
+            return {"title": title, "url": url, "snippet": snippet}
+
+        def _parse_html_results(html: str) -> List[dict]:
+            soup = BeautifulSoup(html, "html.parser")
             parsed = []
             for result in soup.select(".result")[:count]:
                 link = result.select_one(".result__a")
                 if not link:
                     continue
-                url = _resolve_ddg_redirect(link.get("href", ""))
-                if not url:
-                    continue
                 snippet_el = result.select_one(".result__snippet")
-                parsed.append({
-                    "title": link.get_text(" ", strip=True),
-                    "url": url,
-                    "snippet": snippet_el.get_text(" ", strip=True) if snippet_el else "",
-                })
-            logger.info(f"DuckDuckGo HTML search returned {len(parsed)} results")
+                item = _link_result(
+                    link,
+                    snippet_el.get_text(" ", strip=True) if snippet_el else "",
+                )
+                if item:
+                    parsed.append(item)
+            return parsed
+
+        def _parse_lite_results(html: str) -> List[dict]:
+            soup = BeautifulSoup(html, "html.parser")
+            parsed = []
+            seen = set()
+            for link in soup.select("a"):
+                item = _link_result(link)
+                if not item or item["url"] in seen:
+                    continue
+                seen.add(item["url"])
+                parsed.append(item)
+                if len(parsed) >= count:
+                    break
+            return parsed
+
+        try:
+            data = {"q": query, "kp": _safesearch_for("duckduckgo_html")}
+            response = httpx.post(
+                "https://html.duckduckgo.com/html/",
+                data=data,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=REQUEST_TIMEOUT,
+                follow_redirects=True,
+            )
+            response.raise_for_status()
+            parsed = _parse_html_results(response.text)
+            logger.info(
+                f"DuckDuckGo HTML search returned {len(parsed)} results "
+                f"(status {getattr(response, 'status_code', 'unknown')})"
+            )
+            if parsed:
+                return parsed
+
+            lite_response = httpx.post(
+                "https://lite.duckduckgo.com/lite/",
+                data=data,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=REQUEST_TIMEOUT,
+                follow_redirects=True,
+            )
+            lite_response.raise_for_status()
+            parsed = _parse_lite_results(lite_response.text)
+            logger.info(
+                f"DuckDuckGo Lite search returned {len(parsed)} results "
+                f"(status {getattr(lite_response, 'status_code', 'unknown')})"
+            )
             return parsed
         except Exception as e:
             logger.warning(f"DuckDuckGo HTML search failed: {e}")
@@ -425,8 +614,8 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
         time_map = {"day": "d", "week": "w", "month": "m", "year": "y"}
         timelimit = time_map.get(time_filter)
 
-    try:
-        ddgs = DDGS()
+    def _library_search_once() -> List[dict]:
+        ddgs = _build_ddgs_client(DDGS)
         raw = ddgs.text(
             query,
             max_results=count,
@@ -443,8 +632,23 @@ def duckduckgo_search(query: str, count: int = 10, time_filter: Optional[str] = 
                 "url": url,
                 "snippet": item.get("body", ""),
             })
-        logger.info(f"DuckDuckGo search returned {len(results)} results")
-        return results or _html_fallback()
+        return results
+
+    try:
+        for attempt in range(2):
+            results = _library_search_once()
+            logger.info(
+                f"DuckDuckGo search returned {len(results)} results "
+                f"(attempt {attempt + 1})"
+            )
+            if results:
+                return results
+            if attempt == 0:
+                logger.info("DuckDuckGo returned 0 results; retrying once before HTML fallback")
+                if DDG_RETRY_DELAY_SECONDS > 0:
+                    time.sleep(DDG_RETRY_DELAY_SECONDS)
+        logger.warning("DuckDuckGo returned 0 results after retry; using HTML fallback")
+        return _html_fallback()
     except Exception as e:
         logger.warning(f"DuckDuckGo search failed: {e}")
         return _html_fallback()

--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -22,6 +22,28 @@ from src.prompt_security import untrusted_context_message
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_provider_diagnostic(value) -> str:
+    text = str(value or "")
+    replacements = [
+        (r"(?i)([?&]key=)[^&\s,;]+", r"\1[redacted]"),
+        (r"(?i)(api[_-]?key=)[^&\s,;]+", r"\1[redacted]"),
+        (r"(?i)(token=)[^&\s,;]+", r"\1[redacted]"),
+        (r"(?i)(secret=)[^&\s,;]+", r"\1[redacted]"),
+        (r"(?i)(authorization:\s*(?:bearer|basic)\s+)[^\s,;]+", r"\1[redacted]"),
+        (r"(?i)(x-api-key:\s*)[^\s,;]+", r"\1[redacted]"),
+        (r"\bsk-[A-Za-z0-9._-]+\b", "[redacted]"),
+    ]
+    for pattern, replacement in replacements:
+        text = re.sub(pattern, replacement, text)
+    return text
+
+
+def _default_provider_empty_reason(provider: str) -> str:
+    if provider == "duckduckgo":
+        return "duckduckgo returned no results after retry and HTML fallback"
+    return f"{provider} returned no results"
+
+
 def current_date_context() -> str:
     """Preamble that grounds query-generation/planning LLMs in the real current
     date. Without it the model falls back to its training-cutoff year and emits
@@ -108,16 +130,18 @@ You are deciding whether a research report is comprehensive enough.
 **Current report:**
 {report}
 
-**Rounds completed:** {round_num} of {max_rounds}
+**Rounds completed:** {round_num}
+**Round safety cap:** {max_rounds}
 
 Based on the report so far, do we have enough information to answer the question \
 comprehensively?  Consider:
 - Are the key aspects of the question addressed?
 - Are there obvious gaps or unanswered sub-questions?
 - Is the evidence sufficient and from multiple sources?
+- Would another round likely add important new evidence, or mostly repeat what we know?
 
-If rounds completed is well below the target, prefer continuing unless the \
-report is already exhaustive.
+Treat the safety cap as an upper bound, not a target. Stop when the report is \
+comprehensive enough; continue only when there are specific important gaps.
 
 Reply with ONLY "YES" or "NO" followed by a brief one-sentence reason.
 Example: "YES — The report covers all major aspects with evidence from multiple sources."
@@ -232,7 +256,11 @@ class DeepResearcher:
         self._start_time: float = 0
         self.queries_used: Set[str] = set()
         self.urls_fetched: Set[str] = set()
+        self.url_candidates_seen: Set[str] = set()
+        self.fetch_attempt_count: int = 0
+        self.successful_extractions: int = 0
         self.round_count: int = 0
+        self.stop_reason: Optional[str] = None
         # Track which search providers actually returned results during the
         # run, in arrival order — surfaced in the visual report so users can
         # see whether searxng / brave / tavily etc. carried the work.
@@ -240,6 +268,7 @@ class DeepResearcher:
         self.findings: List[Dict] = []
         self.evolving_report: str = ""
         self.research_plan: str = ""
+        self._provider_fallback_semaphores: Dict[str, asyncio.Semaphore] = {}
 
     def cancel(self):
         """Request cooperative cancellation of the research loop."""
@@ -264,7 +293,17 @@ class DeepResearcher:
             prior_urls: URLs already visited (won't be re-fetched).
         """
         self._start_time = time.time()
+        self.round_count = 0
+        self.stop_reason = None
+        self.queries_used.clear()
+        self.urls_fetched.clear()
+        self.url_candidates_seen.clear()
+        self.fetch_attempt_count = 0
+        self.providers_used.clear()
+        self._provider_fallback_semaphores.clear()
+        self._last_search_error = None
         findings: List[Dict] = list(prior_findings) if prior_findings else []
+        self.successful_extractions = len(findings)
         report = prior_report or ""
 
         # PLAN: Analyze the question and create a research strategy
@@ -284,15 +323,17 @@ class DeepResearcher:
 
         if prior_urls:
             self.urls_fetched.update(prior_urls)
+            self.url_candidates_seen.update(prior_urls)
         self.findings = findings  # expose for handler
         consecutive_empty_rounds = 0
 
         for round_num in range(1, self.max_rounds + 1):
-            self.round_count = round_num
             if self._cancelled:
+                self.stop_reason = "cancelled"
                 logger.info(f"Research cancelled after {round_num - 1} rounds")
                 break
-            if self._time_exceeded():
+            if not self._has_round_budget():
+                self.stop_reason = "time_budget"
                 logger.info(f"Time limit reached after {round_num - 1} rounds")
                 break
 
@@ -302,9 +343,15 @@ class DeepResearcher:
             # THINK: generate queries
             queries = await self._generate_queries(question, report, round_num)
             if not queries:
+                self.stop_reason = "no_queries"
                 logger.warning(f"Round {round_num}: no queries generated, stopping")
                 break
+            if self._remaining_time() < self._minimum_phase_budget():
+                self.stop_reason = "time_budget"
+                logger.info(f"Time budget too low to search round {round_num}")
+                break
 
+            self.round_count = round_num
             self._emit(phase="searching", round=round_num, queries=len(queries),
                        query_preview=queries[0] if queries else "",
                        total_sources=len(self.urls_fetched))
@@ -323,8 +370,9 @@ class DeepResearcher:
                 consecutive_empty_rounds += 1
                 logger.info(f"Round {round_num}: no new findings ({consecutive_empty_rounds} consecutive empty)")
                 if consecutive_empty_rounds >= self.max_empty_rounds:
+                    self.stop_reason = "search_unavailable"
                     logger.warning(f"Search appears to be down — {self.max_empty_rounds} consecutive rounds with no results")
-                    err_detail = getattr(self, '_last_search_error', 'unknown error')
+                    err_detail = getattr(self, '_last_search_error', None) or 'unknown error'
                     self._emit(phase="error", message=f"Search engine unavailable: {err_detail}")
                     if not findings:
                         return (
@@ -336,6 +384,10 @@ class DeepResearcher:
 
             # SYNTHESIZE
             if findings:
+                if self._remaining_time() < self._minimum_phase_budget():
+                    self.stop_reason = "time_budget"
+                    logger.info(f"Time budget too low to synthesize after round {round_num}")
+                    break
                 self._emit(phase="analyzing", round=round_num,
                            total_sources=len(self.urls_fetched),
                            total_findings=len(findings))
@@ -345,8 +397,14 @@ class DeepResearcher:
             if round_num >= self.min_rounds:
                 should_stop = await self._should_stop(question, report, round_num)
                 if should_stop:
+                    self.stop_reason = "llm_stop"
                     logger.info(f"LLM decided to stop after round {round_num}")
                     break
+        else:
+            self.stop_reason = "max_rounds"
+
+        if self.stop_reason is None:
+            self.stop_reason = "max_rounds" if self.round_count >= self.max_rounds else "time_budget"
 
         # FINAL REPORT
         self._emit(phase="writing", total_sources=len(self.urls_fetched),
@@ -365,11 +423,17 @@ class DeepResearcher:
             return "No information could be gathered for this question."
 
         self.evolving_report = report  # preserve pre-synthesis report
-        final = await self._final_report(question, report)
+        if self._remaining_time() < self._minimum_final_report_budget():
+            if self.stop_reason is None:
+                self.stop_reason = "time_budget"
+            logger.info("Time budget too low for final report generation; returning evolving report")
+            final = report
+        else:
+            final = await self._final_report(question, report)
         elapsed = time.time() - self._start_time
         logger.info(
             f"Research complete: {self.round_count} rounds, "
-            f"{len(findings)} findings, {len(self.urls_fetched)} URLs, "
+            f"{len(findings)} findings, {self.successful_extractions} analyzed URLs, "
             f"{elapsed:.1f}s"
         )
         return final
@@ -508,12 +572,23 @@ class DeepResearcher:
         """Search each query and extract relevant info from top results."""
         all_findings: List[Dict] = []
 
-        # Search all queries in parallel
-        search_tasks = [self._search(q) for q in queries]
-        search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
+        if self._should_search_queries_sequentially():
+            search_results = []
+            for query in queries:
+                if self._cancelled or self._time_exceeded():
+                    break
+                try:
+                    search_results.append(await self._search(query))
+                except Exception as e:
+                    search_results.append(e)
+        else:
+            # Search all queries in parallel
+            search_tasks = [self._search(q) for q in queries]
+            search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
 
         # Collect URLs to fetch from all search results
         urls_to_fetch = []
+        round_url_cap = max(0, self.max_urls_per_round * len(queries))
         for result in search_results:
             if isinstance(result, Exception):
                 logger.warning(f"Search error: {result}")
@@ -522,11 +597,15 @@ class DeepResearcher:
                 continue
             for r in result:
                 url = r.get("url", "")
-                if url and url not in self.urls_fetched:
-                    urls_to_fetch.append(r)
-                    self.urls_fetched.add(url)
-                if len(urls_to_fetch) >= self.max_urls_per_round * len(queries):
-                    break
+                if not url:
+                    continue
+                self.url_candidates_seen.add(url)
+                if url in self.urls_fetched:
+                    continue
+                if len(urls_to_fetch) >= round_url_cap:
+                    continue
+                urls_to_fetch.append(r)
+                self.urls_fetched.add(url)
 
         if self._cancelled or self._time_exceeded():
             return all_findings
@@ -541,6 +620,7 @@ class DeepResearcher:
                 return await self._fetch_and_extract(result["url"], question, result.get("title", ""))
 
         extract_tasks = [_bounded_extract(r) for r in urls_to_fetch]
+        self.fetch_attempt_count += len(urls_to_fetch)
         results_gathered = await asyncio.gather(*extract_tasks, return_exceptions=True)
 
         for result in results_gathered:
@@ -549,8 +629,82 @@ class DeepResearcher:
                 continue
             if result:
                 all_findings.append(result)
+                self.successful_extractions += 1
 
         return all_findings
+
+    def _search_provider_chain(self) -> List[str]:
+        try:
+            from src.search.providers import _get_search_settings
+            from src.search.core import _build_provider_chain
+
+            settings = _get_search_settings()
+            provider = (self.search_provider_override or "").strip()
+            if not provider:
+                provider = (settings.get("research_search_provider") or "").strip()
+            if not provider:
+                provider = settings.get("search_provider", "searxng")
+            if provider == "disabled":
+                return ["disabled"]
+            return _build_provider_chain(provider)
+        except Exception as e:
+            logger.debug(f"Could not resolve research search provider chain: {e}")
+            return []
+
+    def _should_search_queries_sequentially(self) -> bool:
+        chain = self._search_provider_chain()
+        if not chain:
+            return False
+        try:
+            from src.search.providers import (
+                get_provider_availability,
+                get_provider_policy,
+            )
+
+            effective_provider = chain[0]
+            for provider in chain:
+                availability = get_provider_availability(provider)
+                if availability.ok:
+                    effective_provider = provider
+                    break
+            return get_provider_policy(effective_provider).query_concurrency == "sequential"
+        except Exception as e:
+            logger.debug(f"Could not resolve research search concurrency policy: {e}")
+            return chain == ["duckduckgo"]
+
+    def _provider_fallback_semaphore(self, provider: str, limit: int) -> asyncio.Semaphore:
+        semaphores = getattr(self, "_provider_fallback_semaphores", None)
+        if semaphores is None:
+            semaphores = {}
+            self._provider_fallback_semaphores = semaphores
+        key = f"{provider}:{max(1, int(limit or 1))}"
+        if key not in semaphores:
+            semaphores[key] = asyncio.Semaphore(max(1, int(limit or 1)))
+        return semaphores[key]
+
+    async def _call_search_provider(
+        self,
+        call_provider,
+        provider: str,
+        query: str,
+        count: int,
+        *,
+        is_fallback: bool,
+    ) -> List[Dict]:
+        if not is_fallback:
+            return await asyncio.to_thread(call_provider, provider, query, count)
+
+        try:
+            from src.search.providers import get_provider_policy
+
+            policy = get_provider_policy(provider)
+            limit = max(1, int(policy.fallback_concurrency or 1))
+        except Exception:
+            limit = 1 if provider == "duckduckgo" else 4
+
+        semaphore = self._provider_fallback_semaphore(provider, limit)
+        async with semaphore:
+            return await asyncio.to_thread(call_provider, provider, query, count)
 
     async def _search(self, query: str) -> List[Dict]:
         """Run a search query using the configured research search provider."""
@@ -572,18 +726,47 @@ class DeepResearcher:
             # Try primary provider, then fallbacks
             chain = _build_provider_chain(provider)
             raised = False
-            for prov in chain:
+            attempts = []
+            for idx, prov in enumerate(chain):
                 try:
-                    results = await asyncio.to_thread(_call_provider, prov, query, 10)
+                    from src.search.providers import get_provider_availability
+
+                    availability = get_provider_availability(prov)
+                    if not availability.ok:
+                        attempts.append(
+                            f"{prov}: {availability.reason}"
+                            + (f" ({availability.detail})" if availability.detail else "")
+                        )
+                        self._last_search_error = attempts[-1]
+                        continue
+                except Exception:
+                    pass
+
+                try:
+                    results = await self._call_search_provider(
+                        _call_provider,
+                        prov,
+                        query,
+                        10,
+                        is_fallback=idx > 0,
+                    )
                     if results:
                         logger.info(f"Research search: {prov} returned {len(results)} results")
                         if prov not in self.providers_used:
                             self.providers_used.append(prov)
                         return results
+                    try:
+                        from src.search.providers import get_provider_policy
+
+                        empty_reason = get_provider_policy(prov).status_when_empty
+                    except Exception:
+                        empty_reason = _default_provider_empty_reason(prov)
+                    attempts.append(empty_reason if len(chain) == 1 else f"{prov}: {empty_reason}")
                 except Exception as e:
                     raised = True
-                    logger.warning(f"Research search: {prov} failed: {e}")
-                    self._last_search_error = f"{prov}: {e}"
+                    safe_error = _sanitize_provider_diagnostic(e)
+                    logger.warning(f"Research search: {prov} failed: {safe_error}")
+                    self._last_search_error = f"{prov}: {safe_error}"
             # Every provider ran but none returned results. If none of them
             # raised, record an actionable reason here — otherwise this empty
             # path leaves `_last_search_error` unset and the caller surfaces a
@@ -591,10 +774,13 @@ class DeepResearcher:
             # case where the service is reachable but all its engines fail, so
             # each provider returns [] without throwing.
             if not raised:
-                self._last_search_error = (
-                    f"no results from search provider(s): "
-                    f"{', '.join(chain) if chain else provider}"
-                )
+                if attempts:
+                    self._last_search_error = "; ".join(attempts)
+                else:
+                    provider_names = ", ".join(chain) if chain else provider
+                    self._last_search_error = (
+                        f"no results from search provider(s): {provider_names}"
+                    )
             return []
         except Exception as e:
             logger.error(f"Search failed for '{query}': {e}")
@@ -791,6 +977,31 @@ class DeepResearcher:
     def _time_exceeded(self) -> bool:
         return (time.time() - self._start_time) > self.max_time
 
+    def _remaining_time(self) -> float:
+        if not self._start_time:
+            return float(self.max_time)
+        return max(0.0, float(self.max_time) - (time.time() - self._start_time))
+
+    def _time_budget_reserve(self, cap_seconds: float) -> float:
+        max_time = max(0.0, float(self.max_time or 0))
+        if max_time <= 0:
+            return 0.0
+        return min(float(cap_seconds), max_time / 2.0)
+
+    def _minimum_phase_budget(self) -> float:
+        return self._time_budget_reserve(15.0)
+
+    def _minimum_round_budget(self) -> float:
+        return self._time_budget_reserve(30.0)
+
+    def _minimum_final_report_budget(self) -> float:
+        return self._time_budget_reserve(30.0)
+
+    def _has_round_budget(self) -> bool:
+        if self._time_exceeded():
+            return False
+        return self._remaining_time() >= self._minimum_round_budget()
+
     # _strip_think_tags removed — use research_utils.strip_thinking()
 
     @staticmethod
@@ -914,8 +1125,11 @@ class DeepResearcher:
             "Duration": f"{elapsed:.1f}s",
             "Rounds": self.round_count,
             "Queries": len(self.queries_used),
-            "URLs": len(self.urls_fetched),
+            "URLs": self.successful_extractions,
             "Model": self.llm_model,
+            "Stop Reason": self.stop_reason or "max_rounds",
+            "URL Candidates": len(self.url_candidates_seen),
+            "Fetch Attempts": self.fetch_attempt_count,
         }
         if self.providers_used:
             stats["Search"] = ", ".join(self.providers_used)

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -652,8 +652,8 @@ class ResearchHandler:
             logger.info(f"Visual report generated for {session_id}")
             return html_content
         except Exception as e:
-            logger.error(f"Failed to generate visual report: {e}")
-            return None
+            logger.error(f"Failed to generate visual report: {e}", exc_info=True)
+            raise
 
     def hide_image(self, session_id: str, image_url: str) -> bool:
         """Add image_url to the persisted hidden_images list for a research."""
@@ -790,12 +790,15 @@ class ResearchHandler:
                 maximum=3600,
             )
 
+            effective_max_rounds = max_rounds if max_rounds and max_rounds > 0 else 20
+            effective_min_rounds = min(2, effective_max_rounds)
+
             researcher = DeepResearcher(
                 llm_endpoint=llm_endpoint,
                 llm_model=llm_model,
                 llm_headers=llm_headers,
-                max_rounds=max_rounds,
-                min_rounds=max(2, max_rounds - 2),
+                max_rounds=effective_max_rounds,
+                min_rounds=effective_min_rounds,
                 max_time=max_time,
                 max_report_tokens=_max_report_tokens,
                 extraction_timeout=_extraction_timeout,

--- a/tests/test_deep_research_extraction_controls.py
+++ b/tests/test_deep_research_extraction_controls.py
@@ -1,12 +1,15 @@
 import asyncio
 import json
 import sys
+import threading
 import time
 import types
 
 import pytest
 
 from src.deep_research import DeepResearcher
+from services.search import core as search_core
+from services.search import providers as search_providers
 
 
 class _ControlledResearcher(DeepResearcher):
@@ -43,6 +46,172 @@ async def test_search_and_extract_respects_extraction_concurrency():
 
     assert len(findings) == 8
     assert researcher.max_active == 2
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_only_research_searches_sequentially(monkeypatch):
+    providers_mod = types.ModuleType("src.search.providers")
+    providers_mod._get_search_settings = lambda: {
+        "search_provider": "duckduckgo",
+        "search_fallback_chain": ["duckduckgo"],
+    }
+    core_mod = types.ModuleType("src.search.core")
+    core_mod._build_provider_chain = lambda provider: ["duckduckgo"]
+    monkeypatch.setitem(sys.modules, "src.search.providers", providers_mod)
+    monkeypatch.setitem(sys.modules, "src.search.core", core_mod)
+
+    class _DuckDuckGoResearcher(DeepResearcher):
+        def __init__(self):
+            super().__init__(
+                llm_endpoint="http://local.test/v1/chat/completions",
+                llm_model="local-model",
+                search_provider="duckduckgo",
+                extraction_concurrency=2,
+                max_urls_per_round=2,
+            )
+            self.active_searches = 0
+            self.max_active_searches = 0
+            self.search_events = []
+            self.active_extracts = 0
+            self.max_active_extracts = 0
+
+        async def _search(self, query):
+            self.search_events.append(f"start:{query}")
+            self.active_searches += 1
+            self.max_active_searches = max(self.max_active_searches, self.active_searches)
+            await asyncio.sleep(0.01)
+            self.active_searches -= 1
+            self.search_events.append(f"end:{query}")
+            return [
+                {"url": f"https://example.test/{query}/{i}", "title": f"{query}-{i}"}
+                for i in range(2)
+            ]
+
+        async def _fetch_and_extract(self, url, question, title):
+            self.active_extracts += 1
+            self.max_active_extracts = max(self.max_active_extracts, self.active_extracts)
+            await asyncio.sleep(0.01)
+            self.active_extracts -= 1
+            return {"url": url, "title": title, "summary": "ok"}
+
+    researcher = _DuckDuckGoResearcher()
+    researcher._start_time = time.time()
+
+    findings = await researcher._search_and_extract(["a", "b", "c"], "question")
+
+    assert len(findings) == 6
+    assert researcher.max_active_searches == 1
+    assert researcher.search_events == [
+        "start:a", "end:a",
+        "start:b", "end:b",
+        "start:c", "end:c",
+    ]
+    assert researcher.max_active_extracts == 2
+
+
+@pytest.mark.asyncio
+async def test_api_primary_duckduckgo_fallback_is_bounded(monkeypatch):
+    chain = ["google_pse", "duckduckgo"]
+    monkeypatch.setattr(
+        search_providers,
+        "_get_search_settings",
+        lambda: {"search_provider": "google_pse", "search_fallback_chain": chain},
+    )
+    monkeypatch.setattr(search_core, "_build_provider_chain", lambda provider: list(chain))
+
+    lock = threading.Lock()
+    active_duckduckgo = 0
+    max_active_duckduckgo = 0
+
+    def fake_call_provider(provider, query, count, time_filter=None):
+        nonlocal active_duckduckgo, max_active_duckduckgo
+        if provider == "google_pse":
+            return []
+        if provider == "duckduckgo":
+            with lock:
+                active_duckduckgo += 1
+                max_active_duckduckgo = max(max_active_duckduckgo, active_duckduckgo)
+            time.sleep(0.02)
+            with lock:
+                active_duckduckgo -= 1
+            return [{"url": f"https://example.test/{query}", "title": query}]
+        return []
+
+    monkeypatch.setattr(search_core, "_call_provider", fake_call_provider)
+
+    class _FallbackResearcher(DeepResearcher):
+        async def _fetch_and_extract(self, url, question, title):
+            return {"url": url, "title": title, "summary": "ok"}
+
+    researcher = _FallbackResearcher(
+        llm_endpoint="http://local.test/v1/chat/completions",
+        llm_model="local-model",
+        search_provider="google_pse",
+        max_urls_per_round=1,
+        extraction_concurrency=3,
+    )
+    researcher._start_time = time.time()
+
+    findings = await researcher._search_and_extract(["a", "b", "c"], "question")
+
+    assert len(findings) == 3
+    assert researcher.providers_used == ["duckduckgo"]
+    assert max_active_duckduckgo == 1
+
+
+@pytest.mark.asyncio
+async def test_api_primary_remains_parallel_with_duckduckgo_fallback(monkeypatch):
+    chain = ["google_pse", "duckduckgo"]
+    monkeypatch.setattr(
+        search_providers,
+        "_get_search_settings",
+        lambda: {
+            "search_provider": "google_pse",
+            "search_fallback_chain": chain,
+            "google_pse_key": "test-key",
+            "google_pse_cx": "test-cx",
+        },
+    )
+    monkeypatch.setattr(search_core, "_build_provider_chain", lambda provider: list(chain))
+
+    lock = threading.Lock()
+    active_google = 0
+    max_active_google = 0
+
+    def fake_call_provider(provider, query, count, time_filter=None):
+        nonlocal active_google, max_active_google
+        if provider == "google_pse":
+            with lock:
+                active_google += 1
+                max_active_google = max(max_active_google, active_google)
+            time.sleep(0.02)
+            with lock:
+                active_google -= 1
+            return [{"url": f"https://google.example/{query}", "title": query}]
+        if provider == "duckduckgo":
+            raise AssertionError("DuckDuckGo fallback should not run when API primary succeeds")
+        return []
+
+    monkeypatch.setattr(search_core, "_call_provider", fake_call_provider)
+
+    class _ApiResearcher(DeepResearcher):
+        async def _fetch_and_extract(self, url, question, title):
+            return {"url": url, "title": title, "summary": "ok"}
+
+    researcher = _ApiResearcher(
+        llm_endpoint="http://local.test/v1/chat/completions",
+        llm_model="local-model",
+        search_provider="google_pse",
+        max_urls_per_round=1,
+        extraction_concurrency=3,
+    )
+    researcher._start_time = time.time()
+
+    findings = await researcher._search_and_extract(["a", "b", "c"], "question")
+
+    assert len(findings) == 3
+    assert researcher.providers_used == ["google_pse"]
+    assert max_active_google > 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_deep_research_loop_optimization.py
+++ b/tests/test_deep_research_loop_optimization.py
@@ -1,0 +1,211 @@
+import asyncio
+import time
+
+import pytest
+
+import src.deep_research as deep_research
+from src.deep_research import DeepResearcher
+from src.research_handler import ResearchHandler
+
+
+class _LoopResearcher(DeepResearcher):
+    def __init__(self, **kwargs):
+        self.stop_after_round = kwargs.pop("stop_after_round", None)
+        self.timeout_on_check = kwargs.pop("timeout_on_check", None)
+        super().__init__(
+            llm_endpoint="http://local.test/v1/chat/completions",
+            llm_model="local-model",
+            **kwargs,
+        )
+        self.time_checks = 0
+
+    async def _create_plan(self, question):
+        return "plan"
+
+    async def _classify_category(self, question):
+        return None
+
+    async def _generate_queries(self, question, report, round_num):
+        if round_num == 1:
+            queries = [f"broad {i}" for i in range(4)]
+        else:
+            queries = [f"followup {round_num}-{i}" for i in range(3)]
+        self.queries_used.update(queries)
+        return queries
+
+    async def _search_and_extract(self, queries, question):
+        return [{"url": f"https://example.test/{len(self.findings)}", "summary": "ok"}]
+
+    async def _synthesize(self, question, findings, current_report):
+        return "updated report"
+
+    async def _should_stop(self, question, report, round_num):
+        return self.stop_after_round == round_num
+
+    async def _final_report(self, question, report):
+        return f"final: {report}"
+
+    def _time_exceeded(self):
+        self.time_checks += 1
+        return self.timeout_on_check == self.time_checks
+
+
+def test_stop_prompt_treats_max_rounds_as_safety_cap_not_target():
+    assert "safety cap" in deep_research.STOP_PROMPT.lower()
+    assert "below the target" not in deep_research.STOP_PROMPT.lower()
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_stops_after_llm_says_enough_at_round_two():
+    researcher = _LoopResearcher(max_rounds=20, min_rounds=2, stop_after_round=2)
+
+    report = await researcher.research("question")
+    stats = researcher.get_stats()
+
+    assert report == "final: updated report"
+    assert stats["Rounds"] == 2
+    assert stats["Queries"] == 7
+    assert stats["Stop Reason"] == "llm_stop"
+
+
+@pytest.mark.asyncio
+async def test_timeout_before_next_round_does_not_increment_round_count():
+    researcher = _LoopResearcher(max_rounds=20, min_rounds=2, timeout_on_check=3)
+
+    await researcher.research("question")
+    stats = researcher.get_stats()
+
+    assert stats["Rounds"] == 2
+    assert stats["Queries"] == 7
+    assert stats["Stop Reason"] == "time_budget"
+
+
+@pytest.mark.asyncio
+async def test_short_direct_time_budget_can_still_enter_first_round():
+    researcher = _LoopResearcher(
+        max_rounds=1,
+        min_rounds=1,
+        max_time=1,
+        stop_after_round=1,
+    )
+
+    report = await researcher.research("question")
+    stats = researcher.get_stats()
+
+    assert report == "final: updated report"
+    assert stats["Rounds"] == 1
+    assert stats["Stop Reason"] == "llm_stop"
+
+
+@pytest.mark.asyncio
+async def test_research_resets_run_scoped_provider_state_when_reused():
+    researcher = _LoopResearcher(max_rounds=1, min_rounds=1, stop_after_round=1)
+    researcher.providers_used = ["duckduckgo"]
+    researcher._last_search_error = "old provider error"
+
+    await researcher.research("question")
+
+    assert researcher.providers_used == []
+    assert getattr(researcher, "_last_search_error", None) is None
+
+
+@pytest.mark.asyncio
+async def test_search_and_extract_global_url_cap_and_success_stats():
+    class _UrlAccountingResearcher(DeepResearcher):
+        def __init__(self):
+            super().__init__(
+                llm_endpoint="http://local.test/v1/chat/completions",
+                llm_model="local-model",
+                max_urls_per_round=2,
+                extraction_concurrency=4,
+            )
+            self.fetch_attempt_urls = []
+
+        async def _search(self, query):
+            return [
+                {"url": f"https://example.test/{query}/{i}", "title": f"{query}-{i}"}
+                for i in range(4)
+            ]
+
+        async def _fetch_and_extract(self, url, question, title):
+            self.fetch_attempt_urls.append(url)
+            if url.endswith("/3"):
+                return None
+            return {"url": url, "title": title, "summary": "ok"}
+
+    researcher = _UrlAccountingResearcher()
+    researcher._start_time = time.time()
+
+    findings = await researcher._search_and_extract(["a", "b"], "question")
+    stats = researcher.get_stats()
+
+    assert len(researcher.fetch_attempt_urls) == 4
+    assert len(findings) == 3
+    assert stats["URL Candidates"] == 8
+    assert stats["Fetch Attempts"] == 4
+    assert stats["URLs"] == 3
+
+
+def test_call_research_service_auto_rounds_uses_safety_cap_and_min_two(monkeypatch):
+    captured = {}
+
+    class _FakeResearcher:
+        findings = []
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def research(self, *args, **kwargs):
+            return "report"
+
+        def get_stats(self):
+            return {"Duration": "1.0s", "Rounds": 2, "Queries": 7, "URLs": 3}
+
+    monkeypatch.setattr(ResearchHandler, "_probe_endpoint", lambda *a, **k: _async_none())
+    monkeypatch.setattr(deep_research, "DeepResearcher", _FakeResearcher)
+
+    handler = ResearchHandler.__new__(ResearchHandler)
+    result = asyncio.run(handler.call_research_service(
+        "question",
+        "http://local.test/v1/chat/completions",
+        "local-model",
+        max_rounds=0,
+    ))
+
+    assert "report" in result
+    assert captured["max_rounds"] == 20
+    assert captured["min_rounds"] == 2
+
+
+def test_call_research_service_explicit_one_round_sets_min_one(monkeypatch):
+    captured = {}
+
+    class _FakeResearcher:
+        findings = []
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def research(self, *args, **kwargs):
+            return "report"
+
+        def get_stats(self):
+            return {"Duration": "1.0s", "Rounds": 1, "Queries": 4, "URLs": 3}
+
+    monkeypatch.setattr(ResearchHandler, "_probe_endpoint", lambda *a, **k: _async_none())
+    monkeypatch.setattr(deep_research, "DeepResearcher", _FakeResearcher)
+
+    handler = ResearchHandler.__new__(ResearchHandler)
+    asyncio.run(handler.call_research_service(
+        "question",
+        "http://local.test/v1/chat/completions",
+        "local-model",
+        max_rounds=1,
+    ))
+
+    assert captured["max_rounds"] == 1
+    assert captured["min_rounds"] == 1
+
+
+async def _async_none():
+    return None

--- a/tests/test_deep_research_search_error.py
+++ b/tests/test_deep_research_search_error.py
@@ -15,6 +15,27 @@ import asyncio
 import sys
 import types
 
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("raw", "secret"),
+    [
+        ("api_key=sk-live-secret", "sk-live-secret"),
+        ("https://api.example.test/search?key=AIzaSySecretValue&cx=test", "AIzaSySecretValue"),
+        ("Authorization: Bearer bearer-secret", "bearer-secret"),
+        ("Authorization: Basic basic-secret", "basic-secret"),
+        ("x-api-key: header-secret", "header-secret"),
+    ],
+)
+def test_sanitize_provider_diagnostic_redacts_common_secret_shapes(raw, secret):
+    from src.deep_research import _sanitize_provider_diagnostic
+
+    sanitized = _sanitize_provider_diagnostic(raw)
+
+    assert secret not in sanitized
+    assert "[redacted]" in sanitized
+
 
 def _make_researcher():
     # Build the object without running the heavy __init__ (which wires up an
@@ -55,6 +76,20 @@ def test_empty_results_without_exception_record_reason(monkeypatch):
     assert "searxng" in err
 
 
+def test_duckduckgo_empty_results_report_retry_and_html_fallback(monkeypatch):
+    _install_search_fakes(
+        monkeypatch,
+        chain=["duckduckgo"],
+        call_provider=lambda prov, query, n: [],
+    )
+    r = _make_researcher()
+    results = asyncio.run(r._search("anything"))
+
+    assert results == []
+    err = getattr(r, "_last_search_error", None)
+    assert err == "duckduckgo returned no results after retry and HTML fallback"
+
+
 def test_provider_exception_is_still_surfaced(monkeypatch):
     # A provider that raises must keep surfacing its own error unchanged.
     def _boom(prov, query, n):
@@ -69,6 +104,40 @@ def test_provider_exception_is_still_surfaced(monkeypatch):
     assert err and "connection refused" in err
     # The raise path, not the empty-results path.
     assert "no results" not in err
+
+
+def test_provider_exception_diagnostic_redacts_key_like_values(monkeypatch):
+    def _boom(prov, query, n):
+        raise RuntimeError("provider rejected api_key=sk-live-secret for request")
+
+    _install_search_fakes(monkeypatch, chain=["brave"], call_provider=_boom)
+    r = _make_researcher()
+    results = asyncio.run(r._search("anything"))
+
+    assert results == []
+    err = getattr(r, "_last_search_error", None)
+    assert err
+    assert "provider rejected" in err
+    assert "sk-live-secret" not in err
+    assert "[redacted]" in err
+
+
+def test_provider_exception_diagnostic_redacts_url_key_parameters(monkeypatch):
+    def _boom(prov, query, n):
+        raise RuntimeError(
+            "Google PSE failed for https://www.googleapis.com/customsearch/v1"
+            "?key=AIzaSySecretValue&cx=test-cx"
+        )
+
+    _install_search_fakes(monkeypatch, chain=["google_pse"], call_provider=_boom)
+    r = _make_researcher()
+    results = asyncio.run(r._search("anything"))
+
+    assert results == []
+    err = getattr(r, "_last_search_error", None)
+    assert err
+    assert "key=[redacted]" in err
+    assert "AIzaSySecretValue" not in err
 
 
 def test_results_are_returned_and_provider_recorded(monkeypatch):

--- a/tests/test_research_handler_path_confinement.py
+++ b/tests/test_research_handler_path_confinement.py
@@ -59,6 +59,27 @@ def test_handler_disk_read_methods_reject_invalid_ids(tmp_path, monkeypatch):
     assert handler.get_report_html("../escape") is None
 
 
+def test_get_report_html_propagates_generation_errors(tmp_path, monkeypatch):
+    data_dir = tmp_path / "deep_research"
+    data_dir.mkdir()
+    (data_dir / "rp-abc123.json").write_text(
+        json.dumps({"query": "q", "result": "## Report", "owner": "alice"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(research_handler, "RESEARCH_DATA_DIR", data_dir)
+
+    import src.visual_report as visual_report
+
+    def fail_generate_visual_report(**_kwargs):
+        raise RuntimeError("renderer missing dependency")
+
+    monkeypatch.setattr(visual_report, "generate_visual_report", fail_generate_visual_report)
+    handler = _handler()
+
+    with pytest.raises(RuntimeError, match="renderer missing dependency"):
+        handler.get_report_html("rp-abc123")
+
+
 def test_handler_mutations_reject_invalid_ids_without_touching_outside_files(tmp_path, monkeypatch):
     outside = tmp_path / "escape.json"
     outside.write_text(json.dumps({"result": "secret", "hidden_images": ["x"]}), encoding="utf-8")

--- a/tests/test_research_owner_scope_routes.py
+++ b/tests/test_research_owner_scope_routes.py
@@ -91,6 +91,24 @@ def test_report_rejects_null_owner_before_generating_html(tmp_path, monkeypatch)
     handler.get_report_html.assert_not_called()
 
 
+def test_report_generation_error_returns_500(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data" / "deep_research"
+    _write_research(data_dir, "alice-report", owner="alice", result="alice report")
+
+    handler = _research_handler()
+    handler.get_report_html.side_effect = RuntimeError("renderer missing dependency")
+    router = setup_research_routes(handler)
+    target = _route(router, "/api/research/report/{session_id}", "GET")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(target(session_id="alice-report", request=_request("alice")))
+
+    assert exc.value.status_code == 500
+    assert "Report generation failed: renderer missing dependency" == exc.value.detail
+    handler.get_report_html.assert_called_once_with("alice-report")
+
+
 def test_archive_rejects_cross_owner_without_mutating_report(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     data_dir = tmp_path / "data" / "deep_research"

--- a/tests/test_service_search_provider_guards.py
+++ b/tests/test_service_search_provider_guards.py
@@ -5,8 +5,81 @@ behavior at the single implementation point.
 """
 
 import sys
+import types
+import warnings
+
+import pytest
 
 from services.search import providers
+
+
+def test_provider_policy_covers_search_providers():
+    for provider_name in providers.PROVIDER_INFO:
+        if provider_name == "disabled":
+            continue
+
+        policy = providers.get_provider_policy(provider_name)
+
+        assert policy.name == provider_name
+        assert policy.label
+        assert policy.status_when_empty
+        assert policy.query_concurrency in {"parallel", "sequential"}
+        assert policy.fallback_concurrency >= 1
+
+    google_policy = providers.get_provider_policy("google_pse")
+    assert "google_pse_key" in google_policy.required_settings
+    assert "google_pse_cx" in google_policy.required_settings
+
+
+def test_provider_availability_reports_missing_config_without_secret(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-google-secret")
+    monkeypatch.setenv("GOOGLE_PSE_CX", "")
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {
+        "google_pse_key": "",
+        "google_pse_cx": "",
+        "search_api_key": "",
+    })
+
+    status = providers.get_provider_availability("google_pse")
+
+    assert status.ok is False
+    assert status.reason == "missing_config"
+    assert "google_pse_cx" in status.detail
+    assert "sk-google-secret" not in status.detail
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "search_fn", "settings", "env_names"),
+    [
+        ("brave", providers.brave_search, {}, ("DATA_BRAVE_API_KEY",)),
+        ("google_pse", providers.google_pse_search, {"google_pse_key": "test-key"}, ("GOOGLE_API_KEY", "GOOGLE_PSE_CX")),
+        ("tavily", providers.tavily_search, {}, ("TAVILY_API_KEY",)),
+        ("serper", providers.serper_search, {}, ("SERPER_API_KEY",)),
+    ],
+)
+def test_missing_config_does_not_call_provider_network(
+    monkeypatch, provider_name, search_fn, settings, env_names
+):
+    for env_name in env_names:
+        monkeypatch.delenv(env_name, raising=False)
+    base_settings = {
+        "search_api_key": "",
+        "brave_api_key": "",
+        "google_pse_key": "",
+        "google_pse_cx": "",
+        "tavily_api_key": "",
+        "serper_api_key": "",
+    }
+    base_settings.update(settings)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: base_settings)
+
+    def fail_network(*args, **kwargs):
+        raise AssertionError(f"{provider_name} should not call network with missing config")
+
+    monkeypatch.setattr(providers.httpx, "get", fail_network)
+    monkeypatch.setattr(providers.httpx, "post", fail_network)
+
+    assert search_fn("odysseus", count=1) == []
 
 
 def test_service_safesearch_values_match_provider_contract(monkeypatch):
@@ -86,15 +159,193 @@ def test_service_ddg_html_fallback_sends_safesearch(monkeypatch):
         def raise_for_status(self):
             return None
 
-    def fake_get(url, **kwargs):
-        seen["params"] = kwargs["params"]
+    def fake_post(url, **kwargs):
+        seen["url"] = url
+        seen["data"] = kwargs["data"]
         return _Response()
 
     monkeypatch.setitem(sys.modules, "duckduckgo_search", None)
     monkeypatch.setattr(providers, "_get_search_settings", lambda: {"search_safesearch": "off"})
-    monkeypatch.setattr(providers.httpx, "get", fake_get)
+    monkeypatch.setattr(providers.httpx, "post", fake_post)
 
     results = providers.duckduckgo_search("odysseus", count=1)
 
-    assert seen["params"]["kp"] == "-2"
+    assert seen["url"] == "https://html.duckduckgo.com/html/"
+    assert seen["data"]["kp"] == "-2"
     assert results[0]["url"].startswith("https://notduckduckgo.com/")
+
+
+def test_duckduckgo_html_fallback_parses_lite_results_when_html_empty(monkeypatch):
+    calls = []
+    challenge_html = """
+    <html><body>
+      <p>Unfortunately, bots use DuckDuckGo too.</p>
+    </body></html>
+    """
+    lite_html = """
+    <html><body>
+      <a href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fresult">
+        Lite Result
+      </a>
+    </body></html>
+    """
+
+    class _Response:
+        def __init__(self, text):
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+    def fake_post(url, **kwargs):
+        calls.append((url, kwargs))
+        if "html.duckduckgo.com" in url:
+            return _Response(challenge_html)
+        return _Response(lite_html)
+
+    monkeypatch.setitem(sys.modules, "duckduckgo_search", None)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {"search_safesearch": "strict"})
+    monkeypatch.setattr(providers.httpx, "post", fake_post)
+
+    results = providers.duckduckgo_search("long generated query", count=1)
+
+    assert [r["url"] for r in results] == ["https://example.com/result"]
+    assert [url for url, _ in calls] == [
+        "https://html.duckduckgo.com/html/",
+        "https://lite.duckduckgo.com/lite/",
+    ]
+
+
+def _install_fake_ddgs(monkeypatch, text_impl, *, constructor_warning: str = ""):
+    fake_mod = types.ModuleType("duckduckgo_search")
+
+    class _FakeDDGS:
+        def __init__(self):
+            if constructor_warning:
+                warnings.warn(constructor_warning, RuntimeWarning, stacklevel=2)
+
+        def text(self, *args, **kwargs):
+            return text_impl(*args, **kwargs)
+
+    fake_mod.DDGS = _FakeDDGS
+    monkeypatch.setitem(sys.modules, "duckduckgo_search", fake_mod)
+
+
+def _html_response(url="https://html.example/result"):
+    html = f"""
+    <html><body>
+      <div class="result">
+        <a class="result__a" href="{url}">HTML Result</a>
+        <a class="result__snippet">HTML snippet</a>
+      </div>
+    </body></html>
+    """
+
+    class _Response:
+        text = html
+
+        def raise_for_status(self):
+            return None
+
+    return _Response()
+
+
+def test_duckduckgo_retries_library_before_html_fallback(monkeypatch):
+    calls = []
+    html_calls = []
+
+    def fake_text(*args, **kwargs):
+        calls.append((args, kwargs))
+        if len(calls) == 1:
+            return []
+        return [{
+            "title": "Retry Result",
+            "href": "https://example.com/retry",
+            "body": "retry snippet",
+        }]
+
+    def fake_post(*args, **kwargs):
+        html_calls.append((args, kwargs))
+        return _html_response()
+
+    _install_fake_ddgs(monkeypatch, fake_text)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {"search_safesearch": "strict"})
+    monkeypatch.setattr(providers, "DDG_RETRY_DELAY_SECONDS", 0, raising=False)
+    monkeypatch.setattr(providers.httpx, "post", fake_post)
+
+    results = providers.duckduckgo_search("odysseus", count=1)
+
+    assert [r["url"] for r in results] == ["https://example.com/retry"]
+    assert len(calls) == 2
+    assert html_calls == []
+
+
+def test_duckduckgo_suppresses_known_package_rename_warning(monkeypatch):
+    def fake_text(*args, **kwargs):
+        return [{
+            "title": "Result",
+            "href": "https://example.com/result",
+            "body": "snippet",
+        }]
+
+    _install_fake_ddgs(
+        monkeypatch,
+        fake_text,
+        constructor_warning="This package (`duckduckgo_search`) has been renamed to `ddgs`!",
+    )
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {"search_safesearch": "strict"})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        results = providers.duckduckgo_search("odysseus", count=1)
+
+    assert [r["url"] for r in results] == ["https://example.com/result"]
+    assert not [
+        warning for warning in caught
+        if "duckduckgo_search" in str(warning.message)
+    ]
+
+
+def test_duckduckgo_uses_html_fallback_after_empty_retries(monkeypatch):
+    calls = []
+    html_calls = []
+
+    def fake_text(*args, **kwargs):
+        calls.append((args, kwargs))
+        return []
+
+    def fake_post(*args, **kwargs):
+        html_calls.append((args, kwargs))
+        return _html_response("https://example.com/html")
+
+    _install_fake_ddgs(monkeypatch, fake_text)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {"search_safesearch": "strict"})
+    monkeypatch.setattr(providers, "DDG_RETRY_DELAY_SECONDS", 0, raising=False)
+    monkeypatch.setattr(providers.httpx, "post", fake_post)
+
+    results = providers.duckduckgo_search("odysseus", count=1)
+
+    assert [r["url"] for r in results] == ["https://example.com/html"]
+    assert len(calls) == 2
+    assert len(html_calls) == 1
+
+
+def test_duckduckgo_still_uses_html_fallback_after_library_error(monkeypatch):
+    html_calls = []
+
+    def fake_text(*args, **kwargs):
+        raise RuntimeError("ddg library down")
+
+    def fake_post(*args, **kwargs):
+        html_calls.append((args, kwargs))
+        return _html_response("https://example.com/html-error")
+
+    _install_fake_ddgs(monkeypatch, fake_text)
+    monkeypatch.setattr(providers, "_get_search_settings", lambda: {"search_safesearch": "strict"})
+    monkeypatch.setattr(providers, "DDG_RETRY_DELAY_SECONDS", 0, raising=False)
+    monkeypatch.setattr(providers.httpx, "post", fake_post)
+
+    results = providers.duckduckgo_search("odysseus", count=1)
+
+    assert [r["url"] for r in results] == ["https://example.com/html-error"]
+    assert len(html_calls) == 1


### PR DESCRIPTION
## Summary

Stabilizes Deep Research web search by making provider behavior explicit, keeping DuckDuckGo reliable under no-key usage, and making run stats/report failures more truthful.

This also adds focused regression coverage, modernizes the SQLAlchemy declarative base import, and pins pytest-asyncio loop scope to remove local test-config noise.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Part of #344

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] Manual app acceptance was verified on phone/laptop, and a local live DuckDuckGo provider smoke test was run.

## Duplicate Search Notes

I found related PR #421, but it is not a duplicate: #421 targets `main` and focuses on DuckDuckGo redirect/fetch handling, while this PR targets `dev` and covers provider availability, provider-aware search concurrency, DuckDuckGo retry/fallback behavior, Deep Research round accounting, URL stats, diagnostic redaction, and visual-report error propagation.

## How to Test

1. Run:
   `.venv/bin/python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest tests/test_deep_research_extraction_controls.py tests/test_deep_research_search_error.py tests/test_deep_research_loop_optimization.py tests/test_research_service.py tests/test_research_owner_scope_routes.py tests/test_research_handler_path_confinement.py tests/test_service_search_provider_guards.py tests/test_search_config_no_key_leak.py tests/test_search_config_provider_key.py tests/test_search_provider_json.py tests/test_ddg_redirect_resolution.py tests/test_security_regressions.py -q`
2. Run:
   `.venv/bin/python -m pytest -q`
3. Run Gitleaks on the staged diff:
   `./.tools/gitleaks/gitleaks git --staged --redact --no-banner --no-color`
4. Manual smoke: configure DuckDuckGo as the search provider and start a Deep Research job. Confirm it searches for real time, analyzes URLs, and opens the visual report.

## Verification Performed

- Focused suite: 171 passed in 0.81s.
- Full suite: 2621 passed, 1 skipped.
- Gitleaks staged scan: no leaks found.
- Live DuckDuckGo smoke returned 1 result for `OpenAI official website`.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI rendering changes.
