### PR TITLE
fix(research): Include visited research URLs in final report sources …

### DIFF
--- a/src/deep_research.py
+++ b/src/deep_research.py
@@ -238,6 +238,7 @@ class DeepResearcher:
         # see whether searxng / brave / tavily etc. carried the work.
         self.providers_used: List[str] = []
         self.findings: List[Dict] = []
+        self.visited_urls: List[Dict] = []
         self.evolving_report: str = ""
         self.research_plan: str = ""
 
@@ -525,6 +526,10 @@ class DeepResearcher:
                 if url and url not in self.urls_fetched:
                     urls_to_fetch.append(r)
                     self.urls_fetched.add(url)
+                    self.visited_urls.append({
+                        "url": url,
+                        "title": r.get("title", "") or url
+                    })
                 if len(urls_to_fetch) >= self.max_urls_per_round * len(queries):
                     break
 

--- a/src/research_handler.py
+++ b/src/research_handler.py
@@ -349,9 +349,11 @@ class ResearchHandler:
                     entry["status"] = "done"
                     self._save_result(session_id, entry)
                     try:
-                        sources = self._extract_sources(researcher.findings) if researcher.findings else []
-                        findings = self._extract_raw_findings(researcher.findings) if researcher.findings else []
-                        _guarded_complete(session_id, entry["result"], sources, findings)
+                        visited = getattr(researcher, "visited_urls", [])
+                        findings = researcher.findings or []
+                        sources = self._extract_sources(findings, visited)
+                        findings_extracted = self._extract_raw_findings(findings)
+                        _guarded_complete(session_id, entry["result"], sources, findings_extracted)
                     except Exception as e:
                         logger.warning(f"on_complete callback failed in timeout branch: {e}")
                 else:
@@ -373,9 +375,11 @@ class ResearchHandler:
                     entry["status"] = "done"
                     self._save_result(session_id, entry)
                     try:
-                        sources = self._extract_sources(researcher.findings) if researcher.findings else []
-                        findings = self._extract_raw_findings(researcher.findings) if researcher.findings else []
-                        _guarded_complete(session_id, entry["result"], sources, findings)
+                        visited = getattr(researcher, "visited_urls", [])
+                        findings = researcher.findings or []
+                        sources = self._extract_sources(findings, visited)
+                        findings_extracted = self._extract_raw_findings(findings)
+                        _guarded_complete(session_id, entry["result"], sources, findings_extracted)
                     except Exception as cb_err:
                         logger.warning(f"on_complete callback failed in error branch: {cb_err}")
                     on_progress({"phase": "warning", "message": f"Research finished with errors — partial results saved ({_elapsed:.0f}s elapsed)"})
@@ -464,8 +468,11 @@ class ResearchHandler:
             if entry.get("sources"):
                 return entry["sources"]
             researcher = entry.get("researcher")
-            if researcher and researcher.findings:
-                return self._extract_sources(researcher.findings)
+            if researcher:
+                visited = getattr(researcher, "visited_urls", [])
+                findings = researcher.findings or []
+                if findings or visited:
+                    return self._extract_sources(findings, visited)
         # Check disk
         path = _research_json_path(session_id)
         if path is None:
@@ -498,23 +505,34 @@ class ResearchHandler:
         return None
 
     @staticmethod
-    def _extract_sources(findings: list) -> list:
-        """Extract deduplicated [{url, title}] from findings, filtering low-quality ones."""
+    def _extract_sources(findings: list, visited_urls: list = None) -> list:
+        """Extract deduplicated [{url, title, image}] from findings and visited_urls."""
         seen = set()
         sources = []
-        for f in findings:
-            if not isinstance(f, dict):
-                continue
-            url = f.get("url", "")
-            title = f.get("title", "") or url
-            summary = f.get("summary", "") or f.get("evidence", "")
-            if url and url not in seen and not is_low_quality(summary):
-                seen.add(url)
-                entry = {"url": url, "title": title}
-                og_img = f.get("og_image", "")
-                if og_img:
-                    entry["image"] = og_img
-                sources.append(entry)
+        if findings:
+            for f in findings:
+                if not isinstance(f, dict):
+                    continue
+                url = f.get("url", "")
+                title = f.get("title", "") or url
+                if url and url not in seen:
+                    seen.add(url)
+                    entry = {"url": url, "title": title}
+                    og_img = f.get("og_image", "")
+                    if og_img:
+                        entry["image"] = og_img
+                    sources.append(entry)
+                
+        if visited_urls:
+            for v in visited_urls:
+                if not isinstance(v, dict):
+                    continue
+                url = v.get("url", "")
+                title = v.get("title", "") or url
+                if url and url not in seen:
+                    seen.add(url)
+                    sources.append({"url": url, "title": title})
+                    
         return sources
 
     @staticmethod
@@ -585,9 +603,13 @@ class ResearchHandler:
             sources = []
             raw_findings = []
             researcher = entry.get("researcher")
-            if researcher and researcher.findings:
-                sources = self._extract_sources(researcher.findings)
-                raw_findings = self._extract_raw_findings(researcher.findings)
+            if researcher:
+                visited = getattr(researcher, "visited_urls", [])
+                findings = researcher.findings or []
+                if findings or visited:
+                    sources = self._extract_sources(findings, visited)
+                if findings:
+                    raw_findings = self._extract_raw_findings(findings)
             entry["sources"] = sources
 
             data = {

--- a/src/task_scheduler.py
+++ b/src/task_scheduler.py
@@ -1776,12 +1776,13 @@ class TaskScheduler:
         try:
             RESEARCH_DATA_DIR.mkdir(parents=True, exist_ok=True)
             findings = getattr(researcher, "findings", []) or []
+            visited = getattr(researcher, "visited_urls", [])
             payload = {
                 "query": task.prompt or task.name or "Scheduled research",
                 "status": "done",
                 "result": report,
                 "raw_report": strip_thinking(report or ""),
-                "sources": ResearchHandler._extract_sources(findings),
+                "sources": ResearchHandler._extract_sources(findings, visited),
                 "raw_findings": ResearchHandler._extract_raw_findings(findings),
                 "stats": stats,
                 "category": "scheduled",


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Deep Research final report only displayed a filtered subset of the URLs visited (only those yielding high-quality extractions). To align the displayed sources with the total "URLs Analyzed" statistic and provide full transparency into the engine's background work, the research engine now captures every URL it attempts to process in a new `visited_urls` list. This list is merged directly into the final "Sources" output, displaying the full breadth of the research sweep while retaining rich thumbnail metadata for successfully scraped links.

*(Note: The scheduled research path in `task_scheduler.py` was also updated to include visited URLs in its persistence.)*

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3054

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Start the Odysseus application (e.g., `powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1` or `uvicorn app:app`).
2. Open the UI, toggle "Deep Research", and run a query (e.g., "What are the latest updates on Python 3.14?").
3. Wait for the engine to complete its loops and generate the final report.
4. Scroll to the very bottom, expand the "Sources" accordion, and verify that the number of listed URLs matches the "URLs Analyzed" metric in the stats block above.

## Visual / UI changes — REQUIRED if you touched anything that renders

*(This PR only modifies backend data extraction, no CSS/HTML/UI components were changed, but confirming compliance below:)*

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

N/A
