### PR TITLE
fix(models): query v1 models for llama-server endpoints

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -857,7 +857,7 @@ def _ping_endpoint(base_url: str, api_key: str = None, timeout: float = 1.5) -> 
             and 400 <= result["status_code"] < 500
             and result["status_code"] not in (401, 403)
         ):
-            models_url = base.rstrip("/") + "/models"
+            models_url = build_models_url(base)
             try:
                 r2 = httpx.get(models_url, headers=headers, timeout=timeout, verify=llm_verify())
                 result2 = _result_from_response(r2)

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -184,7 +184,7 @@ def build_chat_url(base: str) -> str:
 
 def build_models_url(base: str) -> Optional[str]:
     """Return the provider-specific model-list endpoint URL for a base."""
-    base = resolve_url(base)
+    base = normalize_base(resolve_url(base))
     provider = _detect_provider(base)
     if provider == "anthropic":
         return _anthropic_api_root(base) + "/v1/models"

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -1042,7 +1042,9 @@ def list_model_ids(
         if provider == "ollama":
             models_url = _ollama_api_root(base_chat_url) + "/tags"
         else:
-            models_url = base_chat_url.replace("/chat/completions", "/models")
+            from src.endpoint_resolver import build_models_url
+
+            models_url = build_models_url(base_chat_url)
         r = httpx.get(models_url, headers=h, timeout=timeout)
         r.raise_for_status()
         data = r.json()

--- a/src/model_context.py
+++ b/src/model_context.py
@@ -297,7 +297,9 @@ def _query_context_length(endpoint_url: str, model: str) -> int:
             logger.info(f"Using known context window for {model}: {known}")
         return known or DEFAULT_CONTEXT
 
-    models_url = endpoint_url.replace("/chat/completions", "/models")
+    from src.endpoint_resolver import build_models_url
+
+    models_url = build_models_url(endpoint_url)
     try:
         r = httpx.get(models_url, timeout=REQUEST_TIMEOUT)
         if r.is_success:

--- a/tests/test_llama_server_models_url.py
+++ b/tests/test_llama_server_models_url.py
@@ -20,7 +20,7 @@ def test_build_models_url_accepts_v1_base_and_chat_url(monkeypatch):
 
 def test_llm_core_list_model_ids_queries_models_for_v1_base(monkeypatch):
     monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url)
-    monkeypatch.setattr(llm_core, "_configured_cached_model_ids", lambda url: [])
+    monkeypatch.setattr(llm_core, "_configured_cached_model_ids", lambda url, **kwargs: [])
     seen = []
 
     def fake_get(url, headers=None, timeout=None):

--- a/tests/test_llama_server_models_url.py
+++ b/tests/test_llama_server_models_url.py
@@ -1,0 +1,58 @@
+"""Regression coverage for llama-server style /v1 model-list endpoints (#3330)."""
+
+import httpx
+
+from src import endpoint_resolver, llm_core, model_context
+
+
+def test_build_models_url_accepts_v1_base_and_chat_url(monkeypatch):
+    monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url)
+
+    assert (
+        endpoint_resolver.build_models_url("http://127.0.0.1:8080/v1")
+        == "http://127.0.0.1:8080/v1/models"
+    )
+    assert (
+        endpoint_resolver.build_models_url("http://127.0.0.1:8080/v1/chat/completions")
+        == "http://127.0.0.1:8080/v1/models"
+    )
+
+
+def test_llm_core_list_model_ids_queries_models_for_v1_base(monkeypatch):
+    monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url)
+    monkeypatch.setattr(llm_core, "_configured_cached_model_ids", lambda url: [])
+    seen = []
+
+    def fake_get(url, headers=None, timeout=None):
+        seen.append(url)
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, json={"data": [{"id": "qwen3"}]}, request=request)
+
+    monkeypatch.setattr(llm_core.httpx, "get", fake_get)
+
+    assert llm_core.list_model_ids("http://127.0.0.1:8080/v1", timeout=1) == ["qwen3"]
+    assert seen == ["http://127.0.0.1:8080/v1/models"]
+
+
+def test_model_context_queries_models_for_v1_base(monkeypatch):
+    monkeypatch.setattr(endpoint_resolver, "resolve_url", lambda url: url)
+    seen = []
+
+    def fake_get(url, timeout=None):
+        seen.append(url)
+        request = httpx.Request("GET", url)
+        if url.endswith("/slots"):
+            return httpx.Response(404, request=request)
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "qwen3", "context_length": 32768}]},
+            request=request,
+        )
+
+    monkeypatch.setattr(model_context.httpx, "get", fake_get)
+
+    assert model_context._query_context_length("http://127.0.0.1:8080/v1", "qwen3") == 32768
+    assert seen == [
+        "http://127.0.0.1:8080/slots",
+        "http://127.0.0.1:8080/v1/models",
+    ]


### PR DESCRIPTION
## Summary

Fixes llama-server/OpenAI-compatible endpoints configured directly as `/v1` by routing model-list probes through the shared `build_models_url()` helper instead of deriving `/models` with ad hoc string replacement.

Before this, `src/model_context.py` and `src/llm_core.py` only replaced `/chat/completions` with `/models`, so a base like `http://host:8080/v1` could be queried as `GET /v1` instead of `GET /v1/models`. `_ping_endpoint` now also uses the same helper for its 404 fallback path, keeping the route probe aligned with the shared endpoint resolver.

The shared `build_models_url()` helper now normalizes already-expanded URLs first, so both `http://host:8080/v1` and `http://host:8080/v1/chat/completions` resolve to `http://host:8080/v1/models`.

Duplicate check: I checked #3330 and searched open PRs for the issue number and same llama-server/model-list URL area. I did not find an active PR fixing this `/v1` model-list derivation path.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3330

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Backend/provider-path note: I did not claim a manual llama-server run. I verified the affected model-list and context-probe paths with Docker-based mocked HTTP regression tests, without requiring a real llama-server instance.

A real llama-server manual run would still be useful confirmation from someone with that setup, but the regression test pins the URL construction bug reported in #3330.

## How to Test

From the repository root, run the focused Docker regression set:

    docker compose run --rm --no-deps --entrypoint python -e PYTHONDONTWRITEBYTECODE=1 --volume "${PWD}:/app" odysseus -m pytest -q -p no:cacheprovider tests/test_llama_server_models_url.py tests/test_endpoint_resolver.py tests/test_provider_endpoints.py tests/test_model_context.py tests/test_model_routes.py

Expected result: `233 passed`.

Optional syntax check:

    docker compose run --rm --no-deps --entrypoint python -e PYTHONDONTWRITEBYTECODE=1 --volume "${PWD}:/app" odysseus -m py_compile src/endpoint_resolver.py src/model_context.py src/llm_core.py routes/model_routes.py tests/test_llama_server_models_url.py

The new regression coverage verifies:

- `build_models_url("http://127.0.0.1:8080/v1")` returns `/v1/models`.
- `build_models_url("http://127.0.0.1:8080/v1/chat/completions")` also returns `/v1/models`.
- `llm_core.list_model_ids()` queries `/v1/models` for a llama-server-style `/v1` endpoint.
- `model_context._query_context_length()` queries `/v1/models` after the local `/slots` probe does not return context metadata.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - backend/provider URL handling and tests only. No UI rendering, CSS, HTML, SVG, or `static/js` files touched.

### Screenshots / clips

N/A - no visual/UI change. Verification is the Docker regression set listed above.