### PR TITLE
feat(linux): add native desktop launcher suite

### DIFF
--- a/contrib/linux/icon.svg
+++ b/contrib/linux/icon.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 32 32" width="256" height="256" aria-hidden="true">
+  <path d="M16 4L16 22L6 22Z" fill="#e06c75"></path>
+  
+  <path d="M16 8L16 22L24 22Z" fill="#9b565e"></path>
+  
+  <path d="M4 24Q10 20 16 24Q22 28 28 24" stroke="#9b565e" stroke-width="2.5" fill="none" stroke-linecap="round"></path>
+</svg>

--- a/contrib/linux/install.sh
+++ b/contrib/linux/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+APPS_DIR="$HOME/.local/share/applications"
+ICONS_DIR="$HOME/.local/share/icons"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" || exit 1
+
+# ensure XDG target directories exist
+mkdir -p "$APPS_DIR"
+mkdir -p "$ICONS_DIR"
+
+# copy the custom icon to local system icon pool (default colors from webpage)
+cp "$SCRIPT_DIR/icon.svg" "$ICONS_DIR/odysseus.svg"
+
+# ensure launch script is executable
+chmod +x "$SCRIPT_DIR/launch.sh"
+
+# generate the customized application shortcut desktop file
+cat << INNER_EOF > "$APPS_DIR/odysseus.desktop"
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Odysseus
+Comment=Your own AI Workspace, running on your hardware
+Exec=$SCRIPT_DIR/launch.sh
+Icon=odysseus
+Terminal=true
+Categories=Development;IDE;
+INNER_EOF
+
+echo "[o] You can now launch Odysseus from your system's launcher."

--- a/contrib/linux/launch.sh
+++ b/contrib/linux/launch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# dynamically locate the repository root folder relative to this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" || exit 1
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)" || exit 1
+
+cd "$REPO_DIR" || exit 1
+
+# detect and activate uv or standard venv if present
+if [ -d ".venv" ]; then
+    # shellcheck source=/dev/null
+    source .venv/bin/activate
+elif [ -d "venv" ]; then
+    # shellcheck source=/dev/null
+    source venv/bin/activate
+fi
+
+# run setup configuration checks
+python setup.py
+
+# spin up background process to launch the web instance
+(sleep 1.5 && xdg-open http://127.0.0.1:7000) &
+
+# run core application server
+python -m uvicorn app:app --host 127.0.0.1 --port 7000


### PR DESCRIPTION
## Summary
Add an isolated contrib/linux/ directory containing a path-independent launcher wrapper, an automated desktop menu shortcut installer conforming to XDG specifications, and a high-resolution vector logo matched to the Odysseus color palette (for the desktop entry).
﻿
## Target branch
- [x] This PR targets **`dev`**, not `main`.
﻿
## Linked Issue
Part of #2475
﻿
## Type of Change
- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration
﻿
## Checklist
- [x] I searched open issues and open PRs — this is not a duplicate (this is the implementation for #2475).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.
﻿
## How to Test
1. `cd` into `odysseus/contrib/linux`
2. Run `install.sh`
3. Launch Odysseus from your system's launcher.
4. Verify if the desktop entry displays properly.
