### PR TITLE
fix: increase request timeout for local endpoints (llama.cpp)

### DIFF
--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -1105,6 +1105,7 @@ async def do_list_models(content: str, session_id: Optional[str] = None, owner: 
     from src.database import SessionLocal, ModelEndpoint
     from src.llm_core import _detect_provider, ANTHROPIC_MODELS
     from src.auth_helpers import owner_filter
+    from src.model_context import _is_local_endpoint, LOCAL_REQUEST_TIMEOUT
 
     keyword = content.strip().lower() if content.strip() else None
 
@@ -1130,7 +1131,8 @@ async def do_list_models(content: str, session_id: Optional[str] = None, owner: 
                 model_ids = list(ANTHROPIC_MODELS)
             else:
                 try:
-                    r = httpx.get(build_models_url(base), headers=headers, timeout=5)
+                    timeout = LOCAL_REQUEST_TIMEOUT if _is_local_endpoint(str(ep.base_url)) else 5
+                    r = httpx.get(build_models_url(base), headers=headers, timeout=timeout)
                     r.raise_for_status()
                     data = r.json()
                     model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]

--- a/src/model_context.py
+++ b/src/model_context.py
@@ -82,6 +82,7 @@ def _is_local_endpoint(url: str) -> bool:
 # ---------------------------------------------------------------------------
 DEFAULT_CONTEXT = 128000
 REQUEST_TIMEOUT = 5
+LOCAL_REQUEST_TIMEOUT = 30  # local llama.cpp can be slow on consumer hardware
 
 # Known context windows for major API models (used as fallback when /models
 # endpoint doesn't report context_length).
@@ -276,7 +277,7 @@ def _query_context_length(endpoint_url: str, model: str) -> int:
     if _is_local_endpoint(endpoint_url):
         try:
             base = endpoint_url.split("/v1")[0] if "/v1" in endpoint_url else endpoint_url.rsplit("/", 1)[0]
-            r = httpx.get(f"{base}/slots", timeout=REQUEST_TIMEOUT)
+            r = httpx.get(f"{base}/slots", timeout=LOCAL_REQUEST_TIMEOUT)
             if r.is_success:
                 slots = r.json()
                 if isinstance(slots, list) and slots:
@@ -299,7 +300,8 @@ def _query_context_length(endpoint_url: str, model: str) -> int:
 
     models_url = endpoint_url.replace("/chat/completions", "/models")
     try:
-        r = httpx.get(models_url, timeout=REQUEST_TIMEOUT)
+        timeout = LOCAL_REQUEST_TIMEOUT if _is_local_endpoint(endpoint_url) else REQUEST_TIMEOUT
+        r = httpx.get(models_url, timeout=timeout)
         if r.is_success:
             data = r.json()
             models_list = data.get("data") or []


### PR DESCRIPTION
## Summary

Local llama.cpp servers on consumer hardware can take 10–15 seconds to respond (e.g., prompt evaluation on CPU), but Odysseus uses a hard-coded 5-second `REQUEST_TIMEOUT` for all endpoints. This causes working local servers to be marked "offline" and cancels in-flight requests. The fix adds a separate `LOCAL_REQUEST_TIMEOUT = 30` used only for localhost/127.0.0.1 endpoints, keeping the existing 5-second timeout for remote APIs.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3401

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Set up a local llama.cpp server (or any OpenAI-compatible endpoint on localhost).
2. In Odysseus, add it as a model endpoint (e.g. `http://localhost:8080`).
3. Before this patch: the `/slots` health check and `/models` listing time out after 5 seconds, marking the endpoint "offline".
4. After this patch: local endpoints use a 30-second timeout, so llama.cpp servers on slower hardware respond correctly.
5. Remote endpoints (non-localhost) still use the existing 5-second timeout — verify that no regression occurs with a remote API.
