### PR TITLE
fix(chat): keep balanced trailing ')' when extracting URLs

### DIFF
--- a/src/chat_helpers.py
+++ b/src/chat_helpers.py
@@ -24,7 +24,14 @@ def extract_urls(text: str) -> List[str]:
     urls = re.findall(url_pattern, text)
     cleaned_urls = []
     for url in urls:
-        url = re.sub(r'[.,;:!?\)]+$', '', url)
+        # Strip trailing sentence punctuation, but keep a balanced ')' so URLs
+        # that legitimately end in one are preserved, e.g. the Wikipedia link
+        # ".../Python_(programming_language)". A ')' is only dropped when it is
+        # unbalanced (more ')' than '('), which is the prose-glued case such as
+        # "(see https://example.com)".
+        url = re.sub(r'[.,;:!?]+$', '', url)
+        while url.endswith(')') and url.count(')') > url.count('('):
+            url = re.sub(r'[.,;:!?]+$', '', url[:-1])
         cleaned_urls.append(url)
     return cleaned_urls
 

--- a/tests/test_extract_urls.py
+++ b/tests/test_extract_urls.py
@@ -1,0 +1,38 @@
+"""extract_urls must keep a *balanced* trailing ')' while still trimming
+prose-glued punctuation.
+
+The old cleanup stripped any trailing ')' unconditionally, which corrupted URLs
+that legitimately end in one (Wikipedia disambiguation links being the common
+case). The fix only drops an *unbalanced* ')'.
+"""
+from src.chat_helpers import extract_urls
+
+
+def test_keeps_balanced_trailing_paren():
+    text = "see https://en.wikipedia.org/wiki/Python_(programming_language)"
+    assert extract_urls(text) == [
+        "https://en.wikipedia.org/wiki/Python_(programming_language)"
+    ]
+
+
+def test_strips_unbalanced_trailing_paren_from_prose():
+    # The closing paren belongs to the sentence, not the URL.
+    assert extract_urls("(see https://example.com)") == ["https://example.com"]
+
+
+def test_strips_trailing_sentence_punctuation():
+    assert extract_urls("go to https://example.com.") == ["https://example.com"]
+    assert extract_urls("https://example.com, then continue") == [
+        "https://example.com"
+    ]
+
+
+def test_strips_trailing_punctuation_after_balanced_close():
+    # Keep the balanced ')' but drop the sentence period after it.
+    text = "ref https://en.wikipedia.org/wiki/Foo_(bar)."
+    assert extract_urls(text) == ["https://en.wikipedia.org/wiki/Foo_(bar)"]
+
+
+def test_nested_balanced_parens_preserved():
+    text = "https://example.com/a_(b_(c))"
+    assert extract_urls(text) == ["https://example.com/a_(b_(c))"]


### PR DESCRIPTION
## Summary

`extract_urls()` in `src/chat_helpers.py` stripped any trailing `)` from a matched URL via `re.sub(r'[.,;:!?\)]+$', '', url)`. Because `)` is part of a valid URL, this corrupts links that legitimately end in one — most commonly Wikipedia disambiguation URLs like `https://en.wikipedia.org/wiki/Python_(programming_language)`, which become `...Python_(programming_language` and 404 when the web/research tools fetch them. This PR keeps a *balanced* `)` while still trimming prose-glued punctuation.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3412

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

Strip trailing sentence punctuation as before, then only drop a `)` while it is *unbalanced* (more `)` than `(`):

```python
url = re.sub(r'[.,;:!?]+$', '', url)
while url.endswith(')') and url.count(')') > url.count('('):
    url = re.sub(r'[.,;:!?]+$', '', url[:-1])
```

A prose-glued `(see https://example.com)` still loses its closing paren; a balanced URL keeps it.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

```
python -m pytest tests/test_extract_urls.py -q     # 5 passed
python -m py_compile src/chat_helpers.py           # ok
```

The new tests cover: balanced trailing `)`, unbalanced/prose-glued `)`, trailing sentence punctuation, punctuation after a balanced `)`, and nested balanced parens. Quick manual check: `extract_urls("see https://en.wikipedia.org/wiki/Python_(programming_language)")` returns the URL intact instead of dropping the final `)`.

## Visual / UI changes

None — backend string handling only.
