### PR TITLE
fix(issue-template): ask bug reporters to validate against dev, not main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
           required: true
         - label: This is **not** a security vulnerability. (Vulnerabilities go to [GitHub Security Advisories](https://github.com/pewdiepie-archdaemon/odysseus/security/advisories/new) — see [SECURITY.md](https://github.com/pewdiepie-archdaemon/odysseus/blob/main/SECURITY.md).)
           required: true
-        - label: I am running the latest code from `main`.
+        - label: I am running the latest code from the `dev` branch (the default branch you get on clone, where fixes land first) and the bug still reproduces there. Please `git pull` the latest `dev` before filing.
           required: true
 
   - type: dropdown


### PR DESCRIPTION
## Summary

The bug-report template requires ticking "I am running the latest code from `main`", but per CONTRIBUTING the default branch on clone is `dev` (`main` is the curated release; fixes land on `dev` first). So reporters confirm a stale branch and bugs already fixed on `dev` get re-filed against `main` (e.g. #3401). Reword the prerequisite to require reproduction on the latest `dev`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #3401 (reporters tagging "latest main").

## Type of Change

- [x] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `python -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/bug_report.yml'))"` parses clean.
2. Open the New Issue -> Bug report form; the prerequisite now reads "running the latest code from the `dev` branch ... and the bug still reproduces there", instead of `main`.

## Visual / UI changes

None — issue-template YAML only.
