### PR TITLE
fix(embeddings): fall back to default cache dir when FASTEMBED_CACHE_PATH is empty

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -55,7 +55,13 @@ MEMORY_VECTORS_DIR = os.path.join(DATA_DIR, "memory_vectors")
 
 # Paths with an intentional dedicated env override, defaulting under DATA_DIR.
 MAIL_ATTACHMENTS_DIR = os.getenv("ODYSSEUS_MAIL_ATTACHMENTS_DIR", os.path.join(DATA_DIR, "mail-attachments"))
-FASTEMBED_CACHE_DIR = os.getenv("FASTEMBED_CACHE_PATH", os.path.join(DATA_DIR, "fastembed_cache"))
+# `or` (not os.getenv's default arg) so a PRESENT-but-EMPTY value falls back to
+# the default. docker-compose.yml injects `FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}`,
+# which sets the var to "" when the host hasn't defined it. os.getenv(name, default)
+# only returns the default when the var is ABSENT, so the empty string would win →
+# os.makedirs("") raises [Errno 2] No such file or directory: '' → FastEmbed fails to
+# init and all vector features (RAG, semantic memory, tool index) silently degrade.
+FASTEMBED_CACHE_DIR = os.getenv("FASTEMBED_CACHE_PATH") or os.path.join(DATA_DIR, "fastembed_cache")
 
 # Agent tool output limits (single source of truth — imported by tool_execution.py,
 # tool_implementations.py, agent_tools.py, and any other module that needs them)

--- a/tests/test_fastembed_cache_path.py
+++ b/tests/test_fastembed_cache_path.py
@@ -1,0 +1,69 @@
+"""Regression: FASTEMBED_CACHE_DIR must tolerate a PRESENT-but-EMPTY
+FASTEMBED_CACHE_PATH.
+
+docker-compose.yml injects ``FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}``,
+which sets the variable to ``""`` when the host has not defined it. The old
+``os.getenv("FASTEMBED_CACHE_PATH", default)`` only used the default when the
+variable was ABSENT, so an empty value made ``FASTEMBED_CACHE_DIR == ""`` →
+``os.makedirs("")`` raised ``[Errno 2] No such file or directory: ''`` →
+FastEmbed failed to initialise and every vector feature (RAG, semantic memory,
+tool index) silently degraded on the default Docker stack.
+
+These tests pin the fix: empty is treated like absent → use the DATA_DIR
+default, while an explicit non-empty override is still honoured.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import src.constants as constants
+
+
+def _reload_with(monkeypatch, value):
+    """Reload src.constants with FASTEMBED_CACHE_PATH set to ``value`` (or
+    removed when ``value`` is None) and return the reloaded module."""
+    if value is None:
+        monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+    else:
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", value)
+    return importlib.reload(constants)
+
+
+def _restore(monkeypatch):
+    """Return the module to its env-default state so reloading it here does
+    not leak a test-specific FASTEMBED_CACHE_DIR into other tests."""
+    monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+    importlib.reload(constants)
+
+
+def test_empty_fastembed_cache_path_falls_back_to_default(monkeypatch):
+    """The bug: an empty FASTEMBED_CACHE_PATH (exactly what Docker injects)
+    must fall back to the DATA_DIR default, never the empty string."""
+    try:
+        mod = _reload_with(monkeypatch, "")
+        assert mod.FASTEMBED_CACHE_DIR, "empty env must not yield an empty path"
+        assert mod.FASTEMBED_CACHE_DIR == os.path.join(mod.DATA_DIR, "fastembed_cache")
+    finally:
+        _restore(monkeypatch)
+
+
+def test_unset_fastembed_cache_path_uses_default(monkeypatch):
+    """Sanity: an absent variable also resolves to the default."""
+    try:
+        mod = _reload_with(monkeypatch, None)
+        assert mod.FASTEMBED_CACHE_DIR == os.path.join(mod.DATA_DIR, "fastembed_cache")
+    finally:
+        _restore(monkeypatch)
+
+
+def test_explicit_fastembed_cache_path_is_respected(monkeypatch):
+    """A real explicit override must still win — the fix only changes the
+    empty-value handling, not the documented FASTEMBED_CACHE_PATH override."""
+    custom = os.path.join("custom", "fastembed-cache")
+    try:
+        mod = _reload_with(monkeypatch, custom)
+        assert mod.FASTEMBED_CACHE_DIR == custom
+    finally:
+        _restore(monkeypatch)


### PR DESCRIPTION
## Summary

FastEmbed fails to initialise on the default Docker stack because the container receives an **empty** `FASTEMBED_CACHE_PATH`, which becomes an empty cache directory and crashes `os.makedirs("")`. As a result `VectorRAG`, semantic memory (`MemoryVectorStore`), and the tool index all silently fall back to keyword-only mode. This change treats an empty value the same as an unset one, so the default path applies and vector features work out of the box in Docker.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Closes #3433

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. On a fresh checkout with **no** `FASTEMBED_CACHE_PATH` set on the host, run `docker compose up -d --build`.
2. `docker compose logs odysseus | grep -E "FastEmbed|embedding lanes|No such file"`
3. **Before this fix:** logs show `FastEmbed init failed: [Errno 2] No such file or directory: ''`, and `VectorRAG` / `MemoryVectorStore` / `ToolIndex` report `No embedding lanes available`.
4. **With this fix:** logs show `FastEmbed loaded model=sentence-transformers/all-MiniLM-L6-v2`, then `VectorRAG ready`, `MemoryVectorStore ready`, and `ToolIndex initialized (lanes=['fastembed'])`.
5. Unit test: `python -m pytest tests/test_fastembed_cache_path.py -v` → 3 passed (covers empty / unset / explicit `FASTEMBED_CACHE_PATH`).

Verified on Docker Desktop (Windows 11): rebuilt the image with the empty `FASTEMBED_CACHE_PATH=""` still injected by compose, and all vector subsystems initialised healthy.

## Root cause / fix detail

`docker-compose.yml` injects `FASTEMBED_CACHE_PATH=${FASTEMBED_CACHE_PATH:-}` (empty when the host hasn't set it). `src/constants.py` used `os.getenv("FASTEMBED_CACHE_PATH", default)`, and `os.getenv` only returns the default when the variable is **absent** — so the empty string won → `FASTEMBED_CACHE_DIR = ""` → `os.makedirs("")` → `[Errno 2] No such file or directory: ''`. Native `uvicorn` runs are unaffected (the variable is absent there), which is why it only surfaces under Docker.

```diff
-FASTEMBED_CACHE_DIR = os.getenv("FASTEMBED_CACHE_PATH", os.path.join(DATA_DIR, "fastembed_cache"))
+FASTEMBED_CACHE_DIR = os.getenv("FASTEMBED_CACHE_PATH") or os.path.join(DATA_DIR, "fastembed_cache")
```

`MAIL_ATTACHMENTS_DIR` (the line above) shares the same `os.getenv(name, default)` pattern, but `docker-compose.yml` doesn't inject that variable, so it isn't currently triggered. Left as-is to keep this PR minimal.

## Visual / UI changes

N/A — backend only. This PR changes one constant in `src/constants.py` plus a new test file; nothing that renders to the DOM, so no screenshots apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
