### PR TITLE
revert: remove supports_tools toggle from local endpoint UI (#3195)

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -432,8 +432,7 @@ async function loadEndpoints() {
               ${ep.is_enabled ? '' : '<span class="admin-badge admin-badge-off">disabled</span>'}
               ${hasModels ? '<span style="font-size:10px;opacity:0.4;">Click to manage models</span>' : ''}
             </div>
-            <div class="admin-ep-actions">
-              ${_isLocalEndpoint(ep.base_url) ? '<select class="admin-tools-select" data-adm-tools-select="' + ep.id + '" title="Native tool calling mode. Auto = use heuristic (fenced blocks for Ollama /v1). On = always use native function calling. Off = always use fenced blocks."><option value="auto"' + (ep.supports_tools !== true && ep.supports_tools !== false ? ' selected' : '') + '>Tools: Auto</option><option value="true"' + (ep.supports_tools === true ? ' selected' : '') + '>Tools: On</option><option value="false"' + (ep.supports_tools === false ? ' selected' : '') + '>Tools: Off</option></select>' : ''}
+            <div style="display:flex;gap:4px;align-items:center;">
               <button class="admin-btn-sm" data-adm-toggle-ep="${ep.id}">${ep.is_enabled ? 'Disable' : 'Enable'}</button>
               <button class="admin-btn-delete" data-adm-del-ep="${ep.id}" data-adm-ep-online="${ep.online ? '1' : '0'}">Delete</button>
               ${hasModels ? '<svg class="admin-user-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;transition:transform 0.2s,opacity 0.2s;"><polyline points="6 9 12 15 18 9"/></svg>' : ''}
@@ -477,22 +476,6 @@ async function loadEndpoints() {
     };
     queryAll('[data-adm-toggle-ep]').forEach(btn => {
       btn.addEventListener('click', async (e) => { e.stopPropagation(); await fetch(`/api/model-endpoints/${btn.dataset.admToggleEp}`, { method: 'PATCH' }); loadEndpoints(); });
-    });
-    queryAll('[data-adm-tools-select]').forEach(sel => {
-      sel.addEventListener('change', async (e) => {
-        e.stopPropagation();
-        const epId = sel.dataset.admToolsSelect;
-        const val = sel.value;
-        const body = {};
-        if (val === 'auto') body.supports_tools = null;
-        else body.supports_tools = val === 'true';
-        await fetch(`/api/model-endpoints/${epId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        });
-        loadEndpoints();
-      });
     });
     queryAll('[data-adm-copy-url]').forEach(btn => {
       btn.addEventListener('click', (e) => {

--- a/static/style.css
+++ b/static/style.css
@@ -14154,22 +14154,6 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
   background: var(--border);
   border-color: var(--red);
 }
-.admin-tools-select {
-  padding: 3px 6px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--panel);
-  color: var(--fg);
-  cursor: pointer;
-  font-size: 11px;
-  font-family: inherit;
-  height: 26px;
-  min-width: 90px;
-}
-.admin-tools-select:hover {
-  background: var(--border);
-  border-color: var(--red);
-}
 .admin-spinner {
   display: inline-block;
   width: 12px;
@@ -14285,7 +14269,6 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
 .admin-ep-actions {
   display: flex;
   gap: 4px;
-  align-items: center;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary

Reverts #3195 / commit `7b68413`, which exposed a Tools Auto/On/Off control for local model endpoints in the admin endpoint list.

## Why

This adds another visible control to an already dense endpoint UI, and makes added/local model behavior harder to reason about while agent/tool support is still being stabilized.

Endpoint tool support should stay conservative for now:

- no extra endpoint-row Tools control
- no forced tools-on default for local/Ollama endpoints
- tool support should only become explicit through a tested advanced flow or clear launch configuration such as `--enable-auto-tool-choice`

## Scope

- Removes the local endpoint Tools selector from `static/js/admin.js`.
- Removes the associated `.admin-tools-select` CSS.
- Leaves backend `supports_tools` storage/API behavior untouched.

## Testing

Not run. Direct revert of the UI addition.

## Linked Issue

Reverts #3195 (maintainer recommendation in that PR thread).

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`

## How to Test

1. `node --check` passes on the touched JS, and the reverted control no longer appears in the UI while the surrounding rows still work.