### PR TITLE
revert: remove model-picker remove-from-recent button (#2894)

### DIFF
--- a/static/js/modelPicker.js
+++ b/static/js/modelPicker.js
@@ -35,11 +35,6 @@ function _pushRecent(mid) {
   next.unshift(mid);
   _saveList(RECENT_KEY, next.slice(0, RECENT_MAX));
 }
-function _removeRecent(mid) {
-  if (!mid) return;
-  const next = _loadRecent().filter(x => x !== mid);
-  _saveList(RECENT_KEY, next);
-}
 function _loadFavorites() { return _loadList(FAVORITES_KEY); }
 function _toggleFavorite(mid) {
   const favs = _loadFavorites();
@@ -309,7 +304,7 @@ function _initModelPickerDropdown() {
       empty.textContent = text;
       listEl.appendChild(empty);
     }
-    function _addRow(m, onRemove) {
+    function _addRow(m) {
       const row = document.createElement('div');
       row.className = 'model-switch-item';
       if (m.stale) {
@@ -381,20 +376,6 @@ function _initModelPickerDropdown() {
       });
       row.appendChild(favDot);
 
-      // Remove-from-recent button (shown only for Recent section items).
-      if (onRemove) {
-        const rmBtn = document.createElement('button');
-        rmBtn.type = 'button';
-        rmBtn.className = 'mp-remove-dot';
-        rmBtn.textContent = '×';
-        rmBtn.title = 'Remove from recent';
-        rmBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          onRemove();
-        });
-        row.appendChild(rmBtn);
-      }
-
       row.addEventListener('click', () => _pick(m));
       listEl.appendChild(row);
     }
@@ -411,7 +392,8 @@ function _initModelPickerDropdown() {
       return;
     }
 
-    // ── Browse mode: sections in order: Favorites → Recent (big catalogs only) → All / Providers ──
+    // ── Browse mode: Favorites (manual) + Recent (auto), with dedupe. ──
+    // Rules:
     //   1. Never list the same model twice in the dropdown. Favorites
     //      win over Recent (if you favorited it, that's where it
     //      belongs — Recent shouldn't show it again as duplicate).
@@ -436,13 +418,7 @@ function _initModelPickerDropdown() {
         .slice(0, RECENT_MAX);
       if (recentModels.length) {
         _addSection('Recent');
-        recentModels.forEach(m => {
-          shown.add(m.mid);
-          _addRow(m, () => {
-            _removeRecent(m.mid);
-            _populate('');
-          });
-        });
+        recentModels.forEach(m => { shown.add(m.mid); _addRow(m); });
       }
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -2940,34 +2940,6 @@ body.bg-pattern-sparkles {
       45% { text-shadow: 0 0 10px color-mix(in srgb, var(--accent, var(--red)) 60%, transparent); }
       100% { text-shadow: 0 0 0 color-mix(in srgb, var(--accent, var(--red)) 0%, transparent); }
     }
-    /* Inline remove-from-recent button — only shown on Recent rows. */
-    .model-picker-list .mp-remove-dot {
-      flex: 0 0 auto;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 24px;
-      height: 24px;
-      margin: -4px -4px -4px 2px;
-      padding: 0;
-      border: none;
-      background: transparent;
-      cursor: pointer;
-      color: color-mix(in srgb, var(--fg) 28%, transparent);
-      font-family: inherit;
-      font-size: 15px;
-      line-height: 1;
-      transition: color 0.15s ease, opacity 0.15s ease, transform 0.12s ease;
-      -webkit-tap-highlight-color: transparent;
-    }
-    .model-picker-list .mp-remove-dot:hover {
-      color: var(--red, #ff5555);
-      transform: scale(1.1);
-    }
-    .model-picker-list .mp-remove-dot:focus-visible {
-      outline: none;
-      color: var(--red, #ff5555);
-    }
     /* First-run hint when a large catalog has no Recent/Favorites yet. */
     .model-picker-list .mp-empty-hint {
       flex-direction: column;


### PR DESCRIPTION
## Summary

Reverts #2894 (the remove-from-recent `×` button on model-picker Recent rows), per the maintainer's post-merge note on that PR: the button does not work reliably in the current picker, and an always-present per-row control adds clutter to an already-dense picker for a low-value (localStorage-only) action.

Clean `git revert` of 2a422c0 (no conflicts). Removes the `×` button JS in `modelPicker.js` and its CSS in `style.css`; nothing else depends on it. If recent-list management is wanted later, it should live behind an overflow/menu or a settings/reset affordance rather than a row control.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Reverts #2894 (maintainer recommendation in that PR's thread).

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `node --check static/js/modelPicker.js` passes.
2. Open the chat-box model picker: Recent rows no longer show the `×` remove control; recent list still populates and selecting still works.

## Visual / UI changes

Removes a UI control (the per-row `×` on Recent rows). No new styling; net removal of the button and its CSS. Restores the picker to its pre-#2894 appearance.
