### PR TITLE
revert: remove supports_tools toggle from local endpoint UI (#3195)

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -432,8 +432,7 @@ async function loadEndpoints() {
               ${ep.is_enabled ? '' : '<span class="admin-badge admin-badge-off">disabled</span>'}
               ${hasModels ? '<span style="font-size:10px;opacity:0.4;">Click to manage models</span>' : ''}
             </div>
-            <div class="admin-ep-actions">
-              ${_isLocalEndpoint(ep.base_url) ? '<select class="admin-tools-select" data-adm-tools-select="' + ep.id + '" title="Native tool calling mode. Auto = use heuristic (fenced blocks for Ollama /v1). On = always use native function calling. Off = always use fenced blocks."><option value="auto"' + (ep.supports_tools !== true && ep.supports_tools !== false ? ' selected' : '') + '>Tools: Auto</option><option value="true"' + (ep.supports_tools === true ? ' selected' : '') + '>Tools: On</option><option value="false"' + (ep.supports_tools === false ? ' selected' : '') + '>Tools: Off</option></select>' : ''}
+            <div style="display:flex;gap:4px;align-items:center;">
               <button class="admin-btn-sm" data-adm-toggle-ep="${ep.id}">${ep.is_enabled ? 'Disable' : 'Enable'}</button>
               <button class="admin-btn-delete" data-adm-del-ep="${ep.id}" data-adm-ep-online="${ep.online ? '1' : '0'}">Delete</button>
               ${hasModels ? '<svg class="admin-user-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.3;transition:transform 0.2s,opacity 0.2s;"><polyline points="6 9 12 15 18 9"/></svg>' : ''}
@@ -477,22 +476,6 @@ async function loadEndpoints() {
     };
     queryAll('[data-adm-toggle-ep]').forEach(btn => {
       btn.addEventListener('click', async (e) => { e.stopPropagation(); await fetch(`/api/model-endpoints/${btn.dataset.admToggleEp}`, { method: 'PATCH' }); loadEndpoints(); });
-    });
-    queryAll('[data-adm-tools-select]').forEach(sel => {
-      sel.addEventListener('change', async (e) => {
-        e.stopPropagation();
-        const epId = sel.dataset.admToolsSelect;
-        const val = sel.value;
-        const body = {};
-        if (val === 'auto') body.supports_tools = null;
-        else body.supports_tools = val === 'true';
-        await fetch(`/api/model-endpoints/${epId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        });
-        loadEndpoints();
-      });
     });
     queryAll('[data-adm-copy-url]').forEach(btn => {
       btn.addEventListener('click', (e) => {

--- a/static/style.css
+++ b/static/style.css
@@ -14154,22 +14154,6 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
   background: var(--border);
   border-color: var(--red);
 }
-.admin-tools-select {
-  padding: 3px 6px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--panel);
-  color: var(--fg);
-  cursor: pointer;
-  font-size: 11px;
-  font-family: inherit;
-  height: 26px;
-  min-width: 90px;
-}
-.admin-tools-select:hover {
-  background: var(--border);
-  border-color: var(--red);
-}
 .admin-spinner {
   display: inline-block;
   width: 12px;
@@ -14285,7 +14269,6 @@ body:has(.doc-version-panel:not(.hidden)) .hamburger-btn {
 .admin-ep-actions {
   display: flex;
   gap: 4px;
-  align-items: center;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary

Reverts #3195 (the Tools Auto/On/Off dropdown on local-endpoint rows in the admin UI), per the maintainer's post-merge note: the control is unnecessary in the current UI and makes model setup harder to reason about.

Clean `git revert` of 7b68413 (no conflicts), removing the dropdown from `admin.js` and its CSS from `style.css`. Nothing else depends on it.

Note: the maintainer also raised a deeper, separate concern, that added/served models can end up with tools forced on from model-name guessing, and that local/Ollama/Cookbook endpoints should default to Auto/unknown unless there is explicit proof in the serve command (e.g. `--enable-auto-tool-choice`) or a deliberate advanced opt-in. That behavioral change is out of scope for this revert and should be a focused follow-up; this PR only removes the UI control.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Reverts #3195 (maintainer recommendation in that PR's thread).

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `node --check static/js/admin.js` passes.
2. In Settings -> Model Endpoints, local-endpoint rows no longer show the Tools Auto/On/Off dropdown; Disable/Delete still work.

## Visual / UI changes

Removes the Tools dropdown control from local-endpoint rows; net removal of markup + CSS, restoring the row to its pre-#3195 appearance. No new styling.
