### PR TITLE
fix(caldav): skip the prune when any object fails to parse

### DIFF
--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -246,14 +246,13 @@ def _should_prune_window(seen_uids: set, parse_failed: bool) -> bool:
     """Whether the post-sync prune of vanished CalDAV events is safe to run.
 
     The prune deletes local ``origin=="caldav"`` rows in the window whose UID the
-    server did not just return. When ``seen_uids`` is empty that normally means
-    the calendar has no events in the window, so pruning is correct. But if the
-    server returned objects and every one failed to parse, ``seen_uids`` is empty
-    only because we could not read them — pruning would wipe the whole window.
-    Skip the prune in that case (no readable data + at least one parse failure).
+    server did not just return. Any parse failure (total or partial) makes
+    ``seen_uids`` an incomplete view of the server, so pruning against it can
+    delete events that still exist upstream but could not be read: a total
+    failure wipes the whole window, a partial failure deletes just the
+    unreadable ones. Only prune on a clean read. An empty ``seen_uids`` after a
+    clean read is a genuinely empty window, which is safe to prune.
     """
-    if seen_uids:
-        return True
     return not parse_failed
 
 
@@ -432,9 +431,11 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
                 # are prunable; locally-created events (agent / email triage / a
                 # UI event whose write-back failed) carry origin NULL and must
                 # never be deleted just because the server didn't return them.
-                # Skip the prune when the fetch returned objects we couldn't read
-                # (empty seen_uids from parse failures, not an empty calendar) —
-                # otherwise the isnot(None) branch deletes every windowed event.
+                # Skip the prune on any parse failure: seen_uids is then an
+                # incomplete view of the server, so pruning against it would
+                # delete events that still exist upstream but could not be read
+                # (the empty-seen_uids case wipes the whole window; a partial
+                # failure deletes just the unreadable rows).
                 if _should_prune_window(seen_uids, parse_failed):
                     stale = db.query(CalendarEvent).filter(
                         CalendarEvent.calendar_id == local_cal.id,

--- a/src/caldav_sync.py
+++ b/src/caldav_sync.py
@@ -242,6 +242,21 @@ def _build_dav_client(url: str, username: str, password: str):
     return client
 
 
+def _should_prune_window(seen_uids: set, parse_failed: bool) -> bool:
+    """Whether the post-sync prune of vanished CalDAV events is safe to run.
+
+    The prune deletes local ``origin=="caldav"`` rows in the window whose UID the
+    server did not just return. When ``seen_uids`` is empty that normally means
+    the calendar has no events in the window, so pruning is correct. But if the
+    server returned objects and every one failed to parse, ``seen_uids`` is empty
+    only because we could not read them — pruning would wipe the whole window.
+    Skip the prune in that case (no readable data + at least one parse failure).
+    """
+    if seen_uids:
+        return True
+    return not parse_failed
+
+
 def _sync_blocking(owner: str, url: str, username: str, password: str, account_id: str = "") -> dict:
     """The actual sync — synchronous, intended to run in a threadpool.
     Returns counts: {calendars, events, deleted, errors}."""
@@ -328,6 +343,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
                 # duplicate UIDs within the same batch are updated, not re-inserted
                 # (which would violate the UNIQUE constraint on commit).
                 pending: dict = {}
+                parse_failed = False
                 try:
                     objs = remote_cal.date_search(start=start, end=end, expand=False)
                 except Exception as e:
@@ -339,6 +355,7 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
                         ical = iCal.from_ical(obj.data)
                     except Exception as e:
                         result["errors"].append(f"{display_name}: parse failed ({e})")
+                        parse_failed = True
                         continue
 
                     for comp in ical.walk():
@@ -415,17 +432,21 @@ def _sync_blocking(owner: str, url: str, username: str, password: str, account_i
                 # are prunable; locally-created events (agent / email triage / a
                 # UI event whose write-back failed) carry origin NULL and must
                 # never be deleted just because the server didn't return them.
-                stale = db.query(CalendarEvent).filter(
-                    CalendarEvent.calendar_id == local_cal.id,
-                    CalendarEvent.origin == "caldav",
-                    CalendarEvent.dtstart >= start,
-                    CalendarEvent.dtstart <= end,
-                    ~CalendarEvent.uid.in_(seen_uids) if seen_uids else CalendarEvent.uid.isnot(None),
-                ).all()
-                for ev in stale:
-                    db.delete(ev)
-                result["deleted"] += len(stale)
-                db.commit()
+                # Skip the prune when the fetch returned objects we couldn't read
+                # (empty seen_uids from parse failures, not an empty calendar) —
+                # otherwise the isnot(None) branch deletes every windowed event.
+                if _should_prune_window(seen_uids, parse_failed):
+                    stale = db.query(CalendarEvent).filter(
+                        CalendarEvent.calendar_id == local_cal.id,
+                        CalendarEvent.origin == "caldav",
+                        CalendarEvent.dtstart >= start,
+                        CalendarEvent.dtstart <= end,
+                        ~CalendarEvent.uid.in_(seen_uids) if seen_uids else CalendarEvent.uid.isnot(None),
+                    ).all()
+                    for ev in stale:
+                        db.delete(ev)
+                    result["deleted"] += len(stale)
+                    db.commit()
             except Exception as e:
                 logger.exception("CalDAV sync failed for one calendar")
                 result["errors"].append(str(e)[:200])

--- a/tests/test_caldav_prune_parse_failure.py
+++ b/tests/test_caldav_prune_parse_failure.py
@@ -1,0 +1,27 @@
+"""CalDAV sync must not prune the whole window when it can't read the server.
+
+The prune deletes local caldav rows whose UID the server didn't return. When
+`seen_uids` is empty it falls back to `uid.isnot(None)` (match-all). That is
+correct when the calendar is genuinely empty, but catastrophic when the server
+returned objects and every one failed to parse — `seen_uids` is empty only
+because nothing could be read, so the match-all branch wipes every event in the
+window. `_should_prune_window` gates the prune on that distinction.
+"""
+from src.caldav_sync import _should_prune_window
+
+
+def test_prune_runs_when_calendar_genuinely_empty():
+    # No objects returned, no parse errors -> server really has nothing -> prune.
+    assert _should_prune_window(set(), parse_failed=False) is True
+
+
+def test_prune_skipped_when_all_objects_failed_to_parse():
+    # Objects came back but none parsed -> empty seen_uids is not "empty
+    # calendar" -> must NOT prune (would delete the whole window).
+    assert _should_prune_window(set(), parse_failed=True) is False
+
+
+def test_prune_runs_when_some_uids_seen_even_with_parse_errors():
+    # At least one event was read -> the normal ~uid.in_(seen) prune is safe.
+    assert _should_prune_window({"uid-a"}, parse_failed=True) is True
+    assert _should_prune_window({"uid-a"}, parse_failed=False) is True

--- a/tests/test_caldav_prune_parse_failure.py
+++ b/tests/test_caldav_prune_parse_failure.py
@@ -1,27 +1,37 @@
-"""CalDAV sync must not prune the whole window when it can't read the server.
+"""CalDAV sync must not prune the window when it can't fully read the server.
 
-The prune deletes local caldav rows whose UID the server didn't return. When
-`seen_uids` is empty it falls back to `uid.isnot(None)` (match-all). That is
-correct when the calendar is genuinely empty, but catastrophic when the server
-returned objects and every one failed to parse — `seen_uids` is empty only
-because nothing could be read, so the match-all branch wipes every event in the
-window. `_should_prune_window` gates the prune on that distinction.
+The prune deletes local caldav rows whose UID the server didn't return. `seen_uids`
+is built only from objects that parsed, so any parse failure (total or partial)
+makes it an incomplete view of the server:
+
+- total failure: `seen_uids` is empty and the prune falls back to `uid.isnot(None)`
+  (match-all), wiping every event in the window;
+- partial failure: the events that failed to parse are absent from `seen_uids`, so
+  `~uid.in_(seen_uids)` deletes those still-upstream events.
+
+`_should_prune_window` therefore only allows the prune on a clean read.
 """
 from src.caldav_sync import _should_prune_window
 
 
+def test_prune_runs_on_clean_read():
+    # Clean read with events -> the normal ~uid.in_(seen) prune is safe.
+    assert _should_prune_window({"uid-a", "uid-b"}, parse_failed=False) is True
+
+
 def test_prune_runs_when_calendar_genuinely_empty():
-    # No objects returned, no parse errors -> server really has nothing -> prune.
+    # Clean read, no objects -> genuinely empty window -> safe to prune.
     assert _should_prune_window(set(), parse_failed=False) is True
 
 
 def test_prune_skipped_when_all_objects_failed_to_parse():
-    # Objects came back but none parsed -> empty seen_uids is not "empty
+    # Every object failed -> empty seen_uids is "couldn't read", not "empty
     # calendar" -> must NOT prune (would delete the whole window).
     assert _should_prune_window(set(), parse_failed=True) is False
 
 
-def test_prune_runs_when_some_uids_seen_even_with_parse_errors():
-    # At least one event was read -> the normal ~uid.in_(seen) prune is safe.
-    assert _should_prune_window({"uid-a"}, parse_failed=True) is True
-    assert _should_prune_window({"uid-a"}, parse_failed=False) is True
+def test_prune_skipped_on_partial_parse_failure():
+    # Some objects parsed and at least one failed: seen_uids is incomplete, so
+    # pruning would delete the unparsed-but-still-upstream events. Skipping the
+    # prune keeps the local copy of the unparsed event instead of deleting it.
+    assert _should_prune_window({"parsed-uid"}, parse_failed=True) is False


### PR DESCRIPTION
## Summary

The CalDAV post-sync prune deletes local `origin=="caldav"` rows in the window whose UID the server didn't just return. `seen_uids` is built only from objects that parsed, so any parse failure makes it an incomplete view of the server. On a total failure `seen_uids` is empty and the prune falls back to `uid.isnot(None)` (match-all), wiping the window; on a partial failure the unparsed-but-still-upstream events are absent from `seen_uids` and get deleted by `~uid.in_(seen_uids)`. This skips the prune on any parse failure and only prunes on a clean read.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3449

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

```python
def _should_prune_window(seen_uids: set, parse_failed: bool) -> bool:
    # Any parse failure means seen_uids is an incomplete view of the server, so
    # pruning against it can delete events that exist upstream but couldn't be
    # read. Only prune on a clean read (an empty seen_uids there is a genuinely
    # empty window, which is safe to prune).
    return not parse_failed
```

Cases: total failure -> skip, partial failure -> skip, clean read (incl. empty calendar) -> prune. Tradeoff: one permanently-unparseable event pauses deletion mirroring until it is fixed, which is the safe direction (false-keep beats false-delete), matching the principle used in the memory-tidy fix. Supersedes #1306, which skipped the prune whenever `seen_uids` was empty and so stopped mirroring deletions on a genuinely empty calendar.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

```
python -m pytest tests/test_caldav_prune_parse_failure.py tests/test_caldav_sync_prune_local_events.py tests/test_caldav_sync_uid_scope.py -q   # 9 passed
python -m py_compile src/caldav_sync.py   # ok
```

Tests cover clean-read-prunes, genuinely-empty-prunes, total-failure-skips, and the partial-failure case (one object parses, one fails, so the prune is skipped and the unparsed event's local copy is kept). Existing caldav prune/uid-scope tests stay green.

## Visual / UI changes

None — backend sync logic only.
