### PR TITLE
ci(pr-checks): make title and description checks advisory, not blocking

### DIFF
--- a/.github/scripts/check-pr-description.js
+++ b/.github/scripts/check-pr-description.js
@@ -125,6 +125,7 @@ module.exports = async ({ github, context, core }) => {
     await swapLabel(prNum, 'ready for review', 'needs work');
   } else {
     await swapLabel(prNum, 'needs work', 'ready for review');
-    core.setFailed(`PR description has ${problems.length} issue(s) — see bot comment for details.`);
+    // Advisory only (per #2288): comment + label, but do not block merges.
+    core.warning(`PR description has ${problems.length} issue(s) — see bot comment for details.`);
   }
 };

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -46,7 +46,8 @@ jobs:
             // Conventional Commits: type(optional-scope)(optional !): summary
             const re = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([\w .\/-]+\))?!?: .+/;
             if (!re.test(title)) {
-              core.setFailed(
+              // Advisory only (per #2288): annotate, do not block merges.
+              core.warning(
                 `PR title is not in Conventional Commits format:\n  "${title}"\n\n` +
                 `Expected: type(scope): summary\n` +
                 `Example:  fix(search): handle empty query\n` +


### PR DESCRIPTION
## Summary

Makes the two "soft" PR-checks advisory instead of merge-blocking, per #2288 ("keep flaky/strict checks advisory until the policy is settled"):

- **Check PR title (Conventional Commits)** and **Check PR description** now call `core.warning` instead of `core.setFailed`. They still annotate the run, post the description bot-comment, and swap the `ready for review` / `needs work` label, but the jobs report success so they cannot block a merge even while listed as required checks.

Motivation: these two checks just blocked the maintainer's own revert PRs (#3437/#3438), which had a non-conventional title ("Revert ...") and a bare body. Style/governance nits should not hard-block; correctness checks should. Syntax (compileall), pytest, JS syntax, and the unmergeable-flag job are unchanged.

Follow-up (not in this PR): once the policy is settled, the title regex could also accept GitHub's default `Revert ...` prefix, and these can be dropped from the required-checks list in branch protection.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #2288 (CI baseline gate: advisory vs blocking split).

## Type of Change

- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. YAML parses, `node --check .github/scripts/check-pr-description.js` passes.
2. Open a PR with a non-conventional title and an empty body: the title + description checks now report success (with warning annotations + the bot comment), and the PR is mergeable on those grounds.

## Visual / UI changes

None - CI workflow + script only.
