### PR TITLE
fix(tools): gate web_search/web_fetch behind explicit intent, not always-available

### DIFF
--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -30,7 +30,12 @@ logger = logging.getLogger(__name__)
 # Tools that are ALWAYS included regardless of retrieval results.
 # These are the most commonly needed and should never be missing.
 ALWAYS_AVAILABLE = frozenset({
-    "bash", "python", "web_search", "web_fetch",
+    "bash", "python",
+    # NOTE: web_search / web_fetch are intentionally NOT here. They are
+    # exposed only on explicit search/current-info/URL intent (see the web
+    # entry in _KEYWORD_HINTS and _URL_RE in get_tools_for_query), so a
+    # trivial agent-mode prompt like "test" / "yo" no longer surfaces or
+    # triggers SearXNG web search (regression from #2684, per maintainer note).
     # File tools: read AND write/edit. An agent with disk access should always
     # be able to change files, not just read them — otherwise a bare "edit X"
     # request can miss write_file/edit_file (RAG-only) and the model wrongly
@@ -357,7 +362,21 @@ class ToolIndex:
     )
 
     # Keyword hints: if the query mentions these words, force-include the tools.
+    # A literal URL or bare domain in the prompt signals the user wants a
+    # specific page fetched (e.g. 'check example.com', 'open https://...').
+    _URL_RE = re.compile(
+        r"\bhttps?://|\bwww\.|\b[\w-]+\.(?:com|org|net|io|dev|ai|app|gov|edu|co)\b",
+        re.IGNORECASE,
+    )
+
     _KEYWORD_HINTS = {
+        # Web lookup intent — surface the web tools only when the user is
+        # actually asking to search / get current info / open a URL.
+        frozenset({"search", "google", "look up", "lookup", "search for",
+                   "latest", "news", "weather", "web", "online",
+                   "internet", "fetch", "website", "web search",
+                   "current price", "stock price", "what's new"}):
+            {"web_search", "web_fetch"},
         # NOTE: "tell" was removed from this set. It fired on any "tell me ..."
         # request (e.g. "visit <url> and tell me the title"), force-including the
         # whole email toolset and crowding out the relevant tools — the model then
@@ -516,6 +535,9 @@ class ToolIndex:
         # the agent can actually create the cron job instead of fumbling.
         if self._SCHEDULE_RE.search(ql):
             base.add("manage_tasks")
+        # A URL/domain in the prompt = the user named a page to read.
+        if self._URL_RE.search(ql):
+            base.update({"web_fetch", "web_search"})
         return base
 
 

--- a/tests/test_web_tools_intent.py
+++ b/tests/test_web_tools_intent.py
@@ -1,0 +1,40 @@
+"""web_search/web_fetch must not be ambient — only on search/current/URL intent (#2684).
+
+Regression: they were in ALWAYS_AVAILABLE, so a trivial agent-mode prompt
+('test', 'yo') surfaced/triggered SearXNG web search. They are now exposed
+only via the web keyword hint or a URL in the prompt.
+"""
+from src.tool_index import ToolIndex, ALWAYS_AVAILABLE
+
+
+def _tools_for(query: str) -> set:
+    # Bypass the embedding-backed __init__; get_tools_for_query only needs
+    # retrieve() + the class-level hint tables.
+    idx = object.__new__(ToolIndex)
+    idx.retrieve = lambda q, k=8: set()
+    return idx.get_tools_for_query(query)
+
+
+def test_web_tools_not_always_available():
+    assert "web_search" not in ALWAYS_AVAILABLE
+    assert "web_fetch" not in ALWAYS_AVAILABLE
+
+
+def test_trivial_prompt_has_no_web_tools():
+    for q in ("test", "yo", "hello", "thanks"):
+        tools = _tools_for(q)
+        assert "web_search" not in tools, q
+        assert "web_fetch" not in tools, q
+
+
+def test_search_intent_surfaces_web_search():
+    for q in ("search for the latest python release",
+              "what's the latest news on mars",
+              "look up the current weather"):
+        assert "web_search" in _tools_for(q), q
+
+
+def test_url_in_prompt_surfaces_web_fetch():
+    for q in ("check example.com", "open https://news.ycombinator.com", "read www.python.org"):
+        tools = _tools_for(q)
+        assert "web_fetch" in tools, q


### PR DESCRIPTION
## Summary

Addresses the maintainer regression note on #2684: `web_search` / `web_fetch` were in `ALWAYS_AVAILABLE`, so they were offered to the agent on every prompt. In agent mode a trivial prompt (`test`, `yo`) could surface or trigger SearXNG web search instead of just answering.

Fix (the maintainer's recommended approach): stop treating the web tools as ambient always-available, and expose them only on explicit search / current-info / URL intent.

- Removed `web_search` / `web_fetch` from `ALWAYS_AVAILABLE`.
- Added a web-lookup keyword hint to `_KEYWORD_HINTS` (search, google, look up, latest, news, weather, web, online, internet, fetch, website, current/stock price, what's new) that force-includes both web tools.
- Added `_URL_RE`: a literal URL or bare domain in the prompt (`example.com`, `https://...`, `www....`) force-includes `web_fetch` + `web_search`, since the user named a page to read.

Net: a casual prompt no longer offers web tools; an explicit search or URL still does. The web toggle (`allow_web_search`) still gates whether they are allowed at all on top of this.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #2684 (regression from that PR, per the maintainer's post-merge note).

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `python -m pytest tests/test_web_tools_intent.py` — covers: trivial prompts (`test`/`yo`) surface no web tools; search-intent prompts include `web_search`; a URL in the prompt includes `web_fetch`.
2. Manual: agent mode, web toggle on, send `test` — the model should answer normally with no `web_search` call. Send "what's the latest news on X" or "open example.com" — web tools are offered.

## Visual / UI changes

None — tool-selection logic only.
