### PR TITLE
fix(cookbook): serve panel content unreachable when model card is expanded

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15475,6 +15475,9 @@ body:not(.email-doc-split-active) #email-lib-modal.email-lib-fullscreen:not(.mod
     height: auto !important;
   }
 }
+#cookbook-modal .hwfit-cached-list {
+  flex-shrink: 0;
+}
 .memory-toolbar {
   transition: opacity 0.12s ease, max-height 0.2s ease;
   max-height: 120px;


### PR DESCRIPTION
## Summary

When the Cookbook modal is at a reduced height, the serve configuration panel (Extra args, Launch button) becomes unreachable. `.hwfit-cached-list` is a flex child with default `flex-shrink: 1` and no minimum height constraint, so the flex container compresses it below its content height. The panel is pushed out of view with nothing to scroll to it. Reproduces on the default Serve tab and when a model card is expanded.

Fix: `flex-shrink: 0` on `#cookbook-modal .hwfit-cached-list` keeps the list at its full content height so the panel stays reachable at any modal size. Three-line CSS change scoped to the cookbook modal.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3385

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. Run the app with `docker compose up --build`.
2. Open the Cookbook modal and go to the Serve tab.
3. Resize the browser window to a short height so the modal is constrained vertically.
4. Confirm the Extra args field and Launch button are reachable by scrolling.
5. Click a model card to expand it and confirm the full configuration panel remains reachable.

## Visual / UI changes

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no new CSS variables, colors, fonts, or spacing units introduced. Single property added using no values.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

Before (panel clipped at reduced height, Extra args and Launch unreachable):

<img width="616" height="372" alt="WindowsTerminal_7eiX9UTj2N" src="https://github.com/user-attachments/assets/695bb130-f08d-4f1d-9adb-0830e1a7431b" />

After (model expanded, full panel reachable):

<img width="614" height="371" alt="WindowsTerminal_zlKyFjY5W5" src="https://github.com/user-attachments/assets/ffe79dc7-126d-4808-b12c-224f3de4153e" />