### PR TITLE
fix(calendar): extend list_events default range from 14 to 30 days

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2205,7 +2205,7 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
                 if end_raw:
                     end_dt = _parse_dt(end_raw)
                 else:
-                    end_dt = start_dt + timedelta(days=14)
+                    end_dt = start_dt + timedelta(days=30)
             except ValueError as e:
                 return {"error": f"Invalid date format: {e}", "exit_code": 1}
 

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -546,7 +546,7 @@ FUNCTION_TOOL_SCHEMAS = [
                     "calendar_href": {"type": "string", "description": "Specific calendar URL (optional; defaults to first calendar)"},
                     "calendar": {"type": "string", "description": "Filter list_events by calendar name or href"},
                     "start": {"type": "string", "description": "list_events range start (ISO datetime); defaults to today. Prefer start; backend also accepts start_date, range_start, from, dtstart, since."},
-                    "end": {"type": "string", "description": "list_events range end (ISO datetime); defaults to +14 days. Prefer end; backend also accepts end_date, range_end, to, dtend, until."},
+                    "end": {"type": "string", "description": "list_events range end (ISO datetime); defaults to +30 days. Prefer end; backend also accepts end_date, range_end, to, dtend, until."},
                     "event_type": {"type": "string", "description": "Tag / category for the event. Common values: work, personal, health, travel, meal, social, admin, other. Aliases accepted: tag, category, type."},
                     "importance": {"type": "string", "enum": ["low", "normal", "high", "critical"], "description": "Priority level (defaults to 'normal')"},
                     "reminder_minutes": {"type": "integer", "description": "For create_event: create an Odysseus reminder this many minutes before the event, e.g. 5 for 'reminder 5 min before'."},


### PR DESCRIPTION
## Summary

- \`manage_calendar\` with \`action: list_events\` defaulted to a 14-day window when no \`end\` date was provided
- A user asking the agent for \"events next month\" would silently get only two weeks of results — events beyond day 14 were invisible with no error or warning
- Root cause: hardcoded \`timedelta(days=14)\` in \`src/tool_implementations.py\` line 2208; schema description repeated this value so models were told to expect the 14-day behaviour

## Fix

- Changed default from \`timedelta(days=14)\` to \`timedelta(days=30)\` — covers a full calendar month without requiring the caller to pass an explicit end date
- Updated the tool schema \`end\` field description from \"defaults to +14 days\" to \"defaults to +30 days\" so the model receives accurate documentation

## Target branch

- [x] This PR targets **\`dev\`**, not \`main\`.

## Linked Issue

Fixes #3240

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets \`dev\`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus: \`python -m uvicorn app:app --host 127.0.0.1 --port 7000\`
2. Open a new chat in agent mode
3. Add a calendar event 3–4 weeks from today
4. Ask the agent: \"Are there any events on my calendar next month?\"
5. **Before this fix**: the agent reports no events (14-day window misses anything past day 14)
6. **After this fix**: the agent finds and reports the event (30-day window covers the full month)