### PR TITLE
fix(security): fail closed in /api/models auth gate on unexpected errors

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -1232,8 +1232,9 @@ def setup_model_routes(model_discovery):
                 raise HTTPException(401, "Not authenticated")
         except HTTPException:
             raise
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error('Auth gate error in GET /api/models, failing closed: %s', e)
+            raise HTTPException(status_code=500, detail='Internal error')
         # Admins see every endpoint (they manage the global pool); regular
         # users get the owner-scoped view.
         _is_admin = False

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
 from tests.helpers.import_state import clear_fake_endpoint_resolver_modules, preserve_import_state
 
@@ -1271,6 +1272,24 @@ def test_background_refresh_failure_keeps_existing_cached_models(monkeypatch):
     assert _wait_for(lambda: db.commits > 0)
     assert result["items"][0]["models"] == ["cached-model"]
     assert json.loads(ep.cached_models) == ["cached-model"]
+
+
+def test_api_models_auth_gate_fails_closed_on_unexpected_error(monkeypatch):
+    """A non-HTTPException raised while checking auth must yield 500, not a
+    silent pass-through that leaks the model list to an unauthenticated caller."""
+    router = model_routes.setup_model_routes(model_discovery=None)
+
+    monkeypatch.setattr(model_routes, "_auth_disabled", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(current_user=None),
+        app=SimpleNamespace(state=SimpleNamespace(auth_manager=SimpleNamespace(is_configured=True))),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _route_endpoint(router, "/api/models")(request)
+
+    assert exc.value.status_code == 500
 
 
 def test_llm_core_list_model_ids_uses_cached_configured_proxy(monkeypatch):


### PR DESCRIPTION
## Summary

`GET /api/models` swallowed any unexpected (non-`HTTPException`) error raised while checking whether the caller is authenticated, via a bare `except Exception: pass`. That means a broken `auth_manager`, an exception from `get_current_user`, or any other unforeseen failure in the auth check silently fell through to "treat as authenticated", handing the full model list to an anonymous caller instead of rejecting the request. This replaces that with an explicit fail-closed: any unexpected exception is logged and the endpoint returns HTTP 500.

## Linked Issue

Relates to #2348 (the auth-gate portion of it — the secret-file deny-list portion is being consolidated on #3158).

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Run `pytest tests/test_model_routes.py -k auth_gate -v` — the new `test_api_models_auth_gate_fails_closed_on_unexpected_error` test should pass (and the full `test_model_routes.py` suite remains green: 117 passed).
2. Manually: monkeypatch/break `auth_manager` (e.g. make `is_configured` raise) and call `GET /api/models` as an anonymous caller — the response should be HTTP 500 with `{"detail": "Internal error"}`, not HTTP 200 with the model list.

## Context

This was originally bundled with the secret-file deny-list in #2360. Per reviewer feedback there (the deny-list overlaps #3158 and should be consolidated there, while this auth-gate fix is an unrelated, single-purpose change), I'm splitting it out into its own focused PR. #2360 is being closed in favor of #3158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)