### PR TITLE
fix: skip malformed document tool call items

### DIFF
--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -1258,14 +1258,24 @@ def function_call_to_tool_block(name: str, arguments: str) -> Optional[ToolBlock
         content = "\n".join(parts)
     elif tool_type == "edit_document":
         blocks = []
-        for edit in args.get("edits", []):
+        edits = args.get("edits", [])
+        if not isinstance(edits, list):
+            edits = []
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
             blocks.append(
                 f'<<<FIND>>>\n{edit.get("find", "")}\n<<<REPLACE>>>\n{edit.get("replace", "")}\n<<<END>>>'
             )
         content = "\n".join(blocks)
     elif tool_type == "suggest_document":
         blocks = []
-        for s in args.get("suggestions", []):
+        suggestions = args.get("suggestions", [])
+        if not isinstance(suggestions, list):
+            suggestions = []
+        for s in suggestions:
+            if not isinstance(s, dict):
+                continue
             blocks.append(
                 f'<<<FIND>>>\n{s.get("find", "")}\n<<<SUGGEST>>>\n{s.get("replace", "")}\n<<<REASON>>>\n{s.get("reason", "")}\n<<<END>>>'
             )

--- a/tests/test_function_call_non_object_args.py
+++ b/tests/test_function_call_non_object_args.py
@@ -35,3 +35,27 @@ def test_non_object_arguments_do_not_crash(arguments):
     assert block is not None
     assert block.tool_type == "bash"
     assert block.content == ""
+
+
+def test_edit_document_skips_non_object_edit_items():
+    block = function_call_to_tool_block(
+        "edit_document",
+        '{"edits": ["bad", 42, null, {"find": "old", "replace": "new"}]}',
+    )
+
+    assert block is not None
+    assert block.tool_type == "edit_document"
+    assert block.content == "<<<FIND>>>\nold\n<<<REPLACE>>>\nnew\n<<<END>>>"
+
+
+def test_suggest_document_skips_non_object_suggestion_items():
+    block = function_call_to_tool_block(
+        "suggest_document",
+        '{"suggestions": ["bad", 42, null, {"find": "old", "replace": "new", "reason": "clearer"}]}',
+    )
+
+    assert block is not None
+    assert block.tool_type == "suggest_document"
+    assert block.content == (
+        "<<<FIND>>>\nold\n<<<SUGGEST>>>\nnew\n<<<REASON>>>\nclearer\n<<<END>>>"
+    )


### PR DESCRIPTION
## Summary

- Prevent malformed `edit_document` and `suggest_document` function-call list items from crashing `function_call_to_tool_block()`.
- Skip non-object `edits` / `suggestions` entries while preserving valid entries in the same tool call.
- Add focused regression coverage in the existing function-call argument parsing test file.

## Linked Issue

Fixes #2166

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `/private/tmp/mcp-use-python-content-venv/bin/python -m pytest tests/test_function_call_non_object_args.py -q` and confirm all tests pass.
2. Run `python3 -m py_compile src/tool_schemas.py tests/test_function_call_non_object_args.py` and confirm both files compile.
3. Run `git diff --check` and confirm there are no whitespace errors.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI or visual rendering changes. This only changes backend tool-call conversion and parser regression tests.

### Screenshots / clips

Not applicable; no UI or visual changes.

## Local Checks

- `/private/tmp/mcp-use-python-content-venv/bin/python -m pytest tests/test_function_call_non_object_args.py -q` — 7 passed.
- `python3 -m py_compile src/tool_schemas.py tests/test_function_call_non_object_args.py`
- `git diff --check`

Not run locally:

- Full app run (`docker compose up` / `uvicorn app:app`) because this is isolated function-call parsing with no UI surface.