### PR TITLE
fix(windowDrag): disable duplicate top-edge fullscreen snap

### DIFF
--- a/static/js/windowDrag.js
+++ b/static/js/windowDrag.js
@@ -61,7 +61,7 @@ export function makeWindowDraggable(modal, options = {}) {
   const fsClass = options.fsClass || null;
   const onEnterFullscreen = options.onEnterFullscreen || null;
   const onExitFullscreen = options.onExitFullscreen || null;
-  const enableFullscreen = options.enableFullscreen !== false && !!onEnterFullscreen;
+  const enableFullscreen = false;
   const onDragEnd = options.onDragEnd || null;
   const onDragStart = options.onDragStart || null;
   const skipSelector = options.skipSelector || 'button, input, select';


### PR DESCRIPTION
## Summary
`windowDrag.js` maintained its own top-edge fullscreen system (`cy <= SNAP_PX` → `_enterFs()`)
independently of the `tileManager.js` snap zones, causing duplicate and unexpected fullscreen
behavior when dragging a minimized window chip toward the top of the screen. Fixed by hardcoding
`enableFullscreen` to `false` in `windowDrag.js`, making `tileManager.js` the single source of
truth for fullscreen snap behavior.

## Target branch
- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue
Fixes #3492

## Type of Change
- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist
- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test
1. Open any window modal (calendar, tasks, email, etc.) and minimize it to the dock chip.
2. On desktop (viewport > 768px), drag the chip toward the top of the screen and release near the top edge.
3. Verify the window snaps to fullscreen exactly once with no duplicate or unexpected behavior.

## Visual / UI changes — REQUIRED if you touched anything that renders
**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**
- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips
before fix
https://github.com/user-attachments/assets/b7b681e1-ee75-47b5-8a14-54f5a470c580
after fix
https://github.com/user-attachments/assets/9acfcfa2-704f-462b-8237-d2bddd7cdd8d

