### PR TITLE
feat: add Claude CLI provider (subscription quota, no API key)

### DIFF
--- a/src/claude_cli_provider.py
+++ b/src/claude_cli_provider.py
@@ -1,0 +1,217 @@
+"""
+Acqua OS -- Claude CLI provider
+================================
+Routes LLM calls through the ``claude`` CLI subprocess instead of the
+Anthropic REST API.  Uses Micah's Claude Max subscription (zero API cost,
+zero API key required).
+
+Configure an endpoint in the Acqua OS UI:
+  URL:    claude-cli://local
+  Model:  claude-sonnet-4-5   (or any Claude model you have access to)
+  API Key: (leave blank)
+
+Billing guardrail: if ANTHROPIC_API_KEY is present in the environment,
+this module raises an error and refuses to run -- preventing any accidental
+paid-API charges.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+from typing import AsyncIterator, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# ---- Constants ---------------------------------------------------------------
+
+# The endpoint URL that triggers this provider in Odysseus endpoint config.
+CLAUDE_CLI_URL = "claude-cli://local"
+
+# Model list served to the UI when this endpoint is selected.
+CLAUDE_CLI_MODELS: List[str] = [
+    "claude-sonnet-4-5",
+    "claude-opus-4",
+    "claude-haiku-4",
+    "claude-sonnet-4-5-20250929",
+    "claude-opus-4-20250514",
+    "claude-haiku-4-20250514",
+]
+
+# Default CLI timeout (seconds).  Override with CLAUDE_CLI_TIMEOUT env var.
+_CLI_TIMEOUT: int = int(os.environ.get("CLAUDE_CLI_TIMEOUT", "120"))
+
+# ---- Helpers -----------------------------------------------------------------
+
+def _guardrail() -> None:
+    """Refuse to proceed if ANTHROPIC_API_KEY is set in the environment.
+
+    Having that variable set is the only way to accidentally start billing
+    against the paid REST API.  If someone sets it, we hard-fail here rather
+    than silently ignore it.
+    """
+    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        msg = (
+            "ANTHROPIC_API_KEY is set in the environment. "
+            "Acqua OS uses the Claude CLI (subscription quota), NOT the paid API. "
+            "Unset ANTHROPIC_API_KEY to proceed."
+        )
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+
+def _extract_system_and_user(messages: List[Dict]) -> "tuple[str, str]":
+    """Pull system prompt and last user message out of an OpenAI-style list.
+
+    Returns (system_prompt, user_message).  Multimodal content blocks are
+    flattened to text.  The *last* user message is used (matches how Odysseus
+    calls the upstream for most single-turn completions).
+    """
+    system_parts: List[str] = []
+    user_msg: str = ""
+    for m in messages:
+        role = m.get("role", "")
+        content = m.get("content") or ""
+        if isinstance(content, list):
+            # Flatten multimodal blocks -- extract text parts only
+            content = " ".join(
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+        if role == "system":
+            system_parts.append(content)
+        elif role == "user":
+            user_msg = content  # keep the last user message
+    return "\n\n".join(system_parts), user_msg
+
+
+# ---- Sync call ---------------------------------------------------------------
+
+def call_claude_cli(messages: List[Dict], model: str = "claude-sonnet-4-5") -> str:
+    """Synchronous Claude CLI call.  Blocks until the response is complete.
+
+    Args:
+        messages: OpenAI-style message list (system / user / assistant roles).
+        model:    Claude model slug, e.g. ``"claude-sonnet-4-5"``.
+
+    Returns:
+        The assistant's response text.
+
+    Raises:
+        RuntimeError: on timeout, non-zero exit, or CLI error response.
+    """
+    _guardrail()
+    system_prompt, user_message = _extract_system_and_user(messages)
+    if not user_message:
+        raise ValueError("No user message found in messages list")
+
+    args = ["claude", "--print", "--model", model, "--output-format", "json"]
+    if system_prompt:
+        args += ["--append-system-prompt", system_prompt]
+
+    logger.debug("claude-cli [sync]: %s", " ".join(args[:4]))
+    try:
+        result = subprocess.run(
+            args,
+            input=user_message,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT,
+            shell=True,  # needed on Windows where claude is claude.cmd
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"claude CLI timed out after {_CLI_TIMEOUT}s")
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude CLI exited {result.returncode}: {result.stderr[:500]}"
+        )
+
+    try:
+        wrapper = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Failed to parse claude CLI JSON output: {exc}\n"
+            f"stdout head: {result.stdout[:300]}"
+        )
+
+    if wrapper.get("is_error"):
+        raise RuntimeError(f"claude CLI returned error: {wrapper.get('result', '')}")
+
+    text = (wrapper.get("result") or "").strip()
+    cost = wrapper.get("total_cost_usd") or 0
+    usage = wrapper.get("usage") or {}
+    logger.debug(
+        "claude-cli [sync]: done -- cost=$%.4f  in=%d  out=%d",
+        cost,
+        usage.get("input_tokens", 0),
+        usage.get("output_tokens", 0),
+    )
+    return text
+
+
+# ---- Async call --------------------------------------------------------------
+
+async def call_claude_cli_async(
+    messages: List[Dict], model: str = "claude-sonnet-4-5"
+) -> str:
+    """Async Claude CLI call.
+
+    Runs the synchronous ``call_claude_cli`` in a thread pool so that the
+    event loop stays unblocked during the subprocess wait.  This also keeps
+    Windows compatibility -- ``claude`` is usually ``claude.cmd`` on Windows,
+    which only works with ``shell=True``; the sync call already handles that.
+
+    Args:
+        messages: OpenAI-style message list.
+        model:    Claude model slug.
+
+    Returns:
+        The assistant's response text.
+    """
+    # asyncio.to_thread requires Python 3.9+; fall back to run_in_executor
+    try:
+        return await asyncio.to_thread(call_claude_cli, messages, model=model)
+    except AttributeError:
+        loop = asyncio.get_event_loop()
+        import functools
+        return await loop.run_in_executor(
+            None, functools.partial(call_claude_cli, messages, model=model)
+        )
+
+
+# ---- Streaming (pseudo-stream) -----------------------------------------------
+
+async def stream_claude_cli(
+    messages: List[Dict], model: str = "claude-sonnet-4-5"
+) -> AsyncIterator[str]:
+    """Yield Odysseus-compatible SSE chunks from a Claude CLI response.
+
+    The CLI does not stream natively -- we run the full call and emit the
+    result paragraph-by-paragraph so the UI renders progressively rather than
+    waiting for one giant chunk.
+
+    Yields:
+        SSE strings: ``data: {"delta": "..."}\\n\\n`` or
+        ``event: error\\ndata: {...}\\n\\n`` or
+        ``data: [DONE]\\n\\n``.
+    """
+    try:
+        text = await call_claude_cli_async(messages, model=model)
+    except RuntimeError as exc:
+        yield f'event: error\ndata: {json.dumps({"error": str(exc), "status": 502})}\n\n'
+        return
+
+    # Yield paragraph by paragraph for a progressive-render feel
+    paragraphs = text.split("\n\n")
+    for i, para in enumerate(paragraphs):
+        if not para:
+            continue
+        chunk = para if i == 0 else "\n\n" + para
+        yield f'data: {json.dumps({"delta": chunk})}\n\n'
+
+    yield "data: [DONE]\n\n"

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -259,6 +259,15 @@ ANTHROPIC_MODELS = [
     "claude-haiku-4-20250514", "claude-haiku-4", "claude-haiku-3-5-20241022", "claude-haiku-3-5",
 ]
 
+# ── Acqua OS — Claude CLI provider (subscription quota, zero API cost) ───────
+from src.claude_cli_provider import (
+    call_claude_cli,
+    call_claude_cli_async,
+    stream_claude_cli,
+    CLAUDE_CLI_URL,
+    CLAUDE_CLI_MODELS,
+)
+
 
 def _is_ollama_native_url(url: str) -> bool:
     """Return True for native Ollama API URLs, including Ollama Cloud."""
@@ -416,6 +425,8 @@ def _detect_provider(url: str) -> str:
     """
     if _is_ollama_native_url(url):
         return "ollama"
+    if url == CLAUDE_CLI_URL or url.startswith("claude-cli://"):
+        return "claude-cli"
     if _host_match(url, "anthropic.com"):
         return "anthropic"
     if _host_match(url, "opencode.ai/zen/go"):
@@ -1033,6 +1044,8 @@ def list_model_ids(
     if cached:
         return cached
     provider = _detect_provider(base_chat_url)
+    if provider == "claude-cli":
+        return list(CLAUDE_CLI_MODELS)
     if provider == "anthropic":
         return list(ANTHROPIC_MODELS)
     try:
@@ -1123,6 +1136,15 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
     if cached_response:
         logger.debug(f"Returning cached response for key: {cache_key}")
         return cached_response
+
+    # ── Acqua OS Claude CLI (subscription quota, no API key) ─────────────────
+    if provider == "claude-cli":
+        try:
+            response = call_claude_cli(messages_copy, model=model)
+            _set_cached_response(cache_key, response)
+            return response
+        except RuntimeError as e:
+            raise HTTPException(502, f"Claude CLI error: {e}")
 
     if provider == "anthropic":
         target_url = _normalize_anthropic_url(url)
@@ -1312,6 +1334,15 @@ async def llm_call_async(
         response = "".join(parts)
         _set_cached_response(cache_key, response)
         return response
+
+    # ── Acqua OS Claude CLI (subscription quota, no API key) ─────────────────
+    if provider == "claude-cli":
+        try:
+            response = await call_claude_cli_async(messages_copy, model=model)
+            _set_cached_response(cache_key, response)
+            return response
+        except RuntimeError as e:
+            raise HTTPException(502, f"Claude CLI error: {e}")
 
     if provider == "anthropic":
         target_url = _normalize_anthropic_url(url)
@@ -1595,6 +1626,12 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         except Exception as e:
             logger.error(f"Ollama stream error: {e}")
             yield f'event: error\ndata: {json.dumps({"error": str(e), "status": 502})}\n\n'
+        return
+
+    # ── Acqua OS Claude CLI streaming (pseudo-stream, subscription quota) ──────
+    if provider == "claude-cli":
+        async for chunk in stream_claude_cli(messages_copy, model=model):
+            yield chunk
         return
 
     # ── Anthropic streaming ──

--- a/static/index.html
+++ b/static/index.html
@@ -2105,6 +2105,7 @@
                 </div>
                 <select id="adm-epProvider" style="display:none">
                   <option value="">Custom URL</option>
+                  <option value="claude-cli://local" data-logo="claude" data-no-key="true">Claude CLI (Subscription)</option>
                   <option value="https://api.anthropic.com" data-logo="anthropic">Anthropic</option>
                   <option value="https://api.deepseek.com/v1" data-logo="deepseek" selected>DeepSeek</option>
                   <option value="https://api.openai.com/v1" data-logo="openai">OpenAI</option>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -741,16 +741,20 @@ function initEndpointForm() {
         msg.className = '';
       }
     } else {
-      urlInput.placeholder = 'Base URL or pick provider';
-      urlInput.readOnly = false;
+      // Claude CLI and similar no-key providers: disable API key field
+      const _opt = _selectedProviderOption();
+      const isNoKey = _opt && _opt.dataset && _opt.dataset.noKey === 'true';
+      urlInput.placeholder = isNoKey ? 'claude-cli://local (set automatically)' : 'Base URL or pick provider';
+      urlInput.readOnly = isNoKey;
       if (apiKey) {
-        apiKey.placeholder = 'API key';
-        apiKey.disabled = false;
+        apiKey.placeholder = isNoKey ? 'No API key needed — uses Claude CLI' : 'API key';
+        apiKey.disabled = isNoKey;
+        if (isNoKey) apiKey.value = '';
       }
       if (testBtn) {
-        testBtn.disabled = false;
-        testBtn.style.opacity = '';
-        testBtn.style.cursor = '';
+        testBtn.disabled = isNoKey;
+        testBtn.style.opacity = isNoKey ? '0.45' : '';
+        testBtn.style.cursor = isNoKey ? 'not-allowed' : '';
       }
       if (addBtn) {
         addBtn.disabled = false;
@@ -759,8 +763,8 @@ function initEndpointForm() {
         addBtn.style.display = '';
       }
       if (msg) {
-        msg.textContent = '';
-        msg.className = '';
+        msg.textContent = isNoKey ? 'Runs locally via claude CLI (your subscription, no API charges).' : '';
+        msg.className = isNoKey ? 'adm-ep-inline-msg adm-ep-ok' : '';
       }
       if (!deviceAuthPolling && status) status.textContent = '';
     }

--- a/static/js/providers.js
+++ b/static/js/providers.js
@@ -3,6 +3,10 @@
 // All SVGs use viewBox="0 0 24 24" fill="currentColor"
 
 const _PROVIDERS = [
+  // Claude CLI / Anthropic — matches "claude" model names AND the "claude-cli" data-logo tag
+  [/claude-cli/i,
+    '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"/></svg>'],
+
   // Ollama
   [/ollama|:11434/i,
     '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.5c-3.1 0-5.65 2.43-5.86 5.48A6.62 6.62 0 0 0 3 13.62C3 18 6.8 21.5 12 21.5s9-3.5 9-7.88a6.62 6.62 0 0 0-3.14-5.64C17.65 4.93 15.1 2.5 12 2.5Zm-2.7 8.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm5.4 0a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm-5.15 5.15c.75.7 1.55 1.04 2.45 1.04s1.7-.34 2.45-1.04c.26-.24.66-.23.9.03.24.26.23.66-.03.9-.98.91-2.08 1.37-3.32 1.37s-2.34-.46-3.32-1.37a.64.64 0 0 1-.03-.9.64.64 0 0 1 .9-.03Z"/></svg>'],
@@ -89,7 +93,7 @@ const _PROVIDERS = [
     '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></svg>'],
 ];
 
-// Returns an SVG string for the given model ID, or null if no match
+// Returns an SVG string for the given model ID or endpoint URL, or null if no match
 export function providerLogo(modelId) {
   if (!modelId) return null;
   for (const [re, svg] of _PROVIDERS) {
@@ -128,6 +132,8 @@ const _ENDPOINT_LABELS = [
  */
 export function providerLabel(endpointUrl) {
   if (!endpointUrl || typeof endpointUrl !== "string") return null;
+  // Claude CLI (Acqua OS subscription provider) — special scheme, not an HTTP URL.
+  if (endpointUrl.startsWith("claude-cli://")) return "Claude CLI";
   let host;
   try {
     host = new URL(endpointUrl).hostname;


### PR DESCRIPTION
Adds a new `claude-cli` provider that routes all LLM calls through the `claude` CLI subprocess (Micah's Claude Max subscription) instead of the Anthropic REST API.  Zero API cost, no ANTHROPIC_API_KEY required.

- src/claude_cli_provider.py  -- new module: sync/async/streaming call functions, billing guardrail, Windows shell compat
- src/llm_core.py             -- detect `claude-cli://local` URL;
  early-return in all 3 call paths (sync, async, stream)
- static/index.html           -- add "Claude CLI (Subscription)" option
  to provider dropdown with data-no-key=true
- static/js/admin.js          -- hide API key field, show helper msg
  when claude-cli provider is selected
- static/js/providers.js      -- add claude-cli icon + label detection

Configure in UI: URL = claude-cli://local, leave API key blank.
Billing guardrail: process refuses to start if ANTHROPIC_API_KEY is set.

## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->

## Target branch

- [ ] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [ ] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [ ] This PR targets `dev`
- [ ] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1.
2.
3.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->
