### PR TITLE
fix(cookbook): resume interrupted HF downloads

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -132,6 +132,56 @@ def _shell_path(p: str) -> str:
     return '"' + p + '"'
 
 
+def _is_hf_hub_cache_dir(path: str | None) -> bool:
+    if not path:
+        return False
+    norm = path.rstrip("/").replace("\\", "/")
+    return norm == "~/.cache/huggingface/hub" or norm.endswith("/.cache/huggingface/hub")
+
+
+def _hf_download_target(repo_id: str, local_dir: str | None) -> dict[str, str | None]:
+    """Resolve Cookbook's download target into HF cache/local-dir arguments.
+
+    A configured download directory normally means "put this model in a
+    per-model flat folder". The Hugging Face hub cache itself is the exception:
+    passing ``--local-dir`` inside ``.../.cache/huggingface/hub`` creates a
+    local-dir layout under the cache and confuses later scans/resumes. In that
+    case, use the normal hub cache layout via cache_dir/--cache-dir instead.
+    """
+    if not local_dir:
+        return {"cache_dir": None, "local_dir": None}
+    if _is_hf_hub_cache_dir(local_dir):
+        return {"cache_dir": local_dir, "local_dir": None}
+    short = repo_id.split("/")[-1] if "/" in repo_id else repo_id
+    return {"cache_dir": None, "local_dir": local_dir.rstrip("/") + "/" + short}
+
+
+def _hf_download_retry_bash_lines(command: str, *, stdin_redirect: bool = False,
+                                  attempts: int = 5, sleep_seconds: int = 30) -> list[str]:
+    """Build bash lines that retry an HF download command and let HF resume.
+
+    ``hf download`` and ``snapshot_download`` resume from existing
+    ``.incomplete`` blobs when invoked with the same cache/local directory. The
+    wrapper treats transient transport failures as retryable by rerunning the
+    exact same command after a short delay.
+    """
+    run_cmd = f"{command} < /dev/null" if stdin_redirect else command
+    return [
+        "_odysseus_hf_attempt=1",
+        f"_odysseus_hf_max={int(attempts)}",
+        "while true; do",
+        '  echo "[odysseus] HF download attempt ${_odysseus_hf_attempt}/${_odysseus_hf_max}"',
+        f"  {run_cmd}",
+        "  _ec=$?",
+        "  if [ $_ec -eq 0 ]; then break; fi",
+        "  if [ $_odysseus_hf_attempt -ge $_odysseus_hf_max ]; then break; fi",
+        '  echo "[odysseus] Download failed/interrupted (exit $_ec). Sleeping, then resuming from the existing cache..."',
+        "  _odysseus_hf_attempt=$((_odysseus_hf_attempt + 1))",
+        f"  sleep {int(sleep_seconds)}",
+        "done",
+    ]
+
+
 def _local_tooling_path_export(executable: str) -> str:
     """Bash line prepending the running interpreter's bin dir to PATH.
 

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -48,7 +48,7 @@ from routes.cookbook_helpers import (
     _append_vllm_linux_preflight_lines, _ollama_bind_from_cmd, _pip_install_fallback_chain,
     _pip_install_no_cache, _user_shell_path_bootstrap, _venv_safe_local_pip_install_cmd,
     _append_pip_install_runner_lines,
-    _diagnose_serve_output, run_ssh_command_async,
+    _diagnose_serve_output, _hf_download_retry_bash_lines, _hf_download_target, run_ssh_command_async,
     ModelDownloadRequest, ServeRequest,
 )
 
@@ -297,13 +297,19 @@ def setup_cookbook_routes() -> APIRouter:
         session_id = f"cookbook-{uuid.uuid4().hex[:8]}"
         wrapper_script = TMUX_LOG_DIR / f"{session_id}.sh"
 
-        # When a download directory is set, target a per-model subfolder under it
-        # (<dir>/<name>) so the flat-directory cache scan lists it as its own
-        # model. Without it, hf/snapshot_download falls back to the HF cache.
-        _dl_short = req.repo_id.split("/")[-1] if "/" in req.repo_id else req.repo_id
-        _dl_base = (req.local_dir.rstrip("/") + "/" + _dl_short) if req.local_dir else None
-        _dl_shell = _shell_path(_dl_base) if _dl_base else None      # for hf CLI / bash
-        _dl_pyarg = (", local_dir=os.path.expanduser(" + repr(_dl_base) + ")") if _dl_base else ""
+        # Custom download dirs become per-model local-dir folders. If the
+        # selected dir is the HF hub cache itself, use cache_dir instead so HF
+        # keeps the normal models--org--repo/snapshots layout and resumes cleanly.
+        _dl_target = _hf_download_target(req.repo_id, req.local_dir)
+        _dl_local = _dl_target["local_dir"]
+        _dl_cache = _dl_target["cache_dir"]
+        _dl_shell_local = _shell_path(_dl_local) if _dl_local else None
+        _dl_shell_cache = _shell_path(_dl_cache) if _dl_cache else None
+        _dl_pyarg = ""
+        if _dl_cache:
+            _dl_pyarg = ", cache_dir=os.path.expanduser(" + repr(_dl_cache) + ")"
+        elif _dl_local:
+            _dl_pyarg = ", local_dir=os.path.expanduser(" + repr(_dl_local) + ")"
 
         # Build the hf download command. Redirection to suppress the interactive
         # "update available? [Y/n]" prompt is added per-platform further down
@@ -311,8 +317,10 @@ def setup_cookbook_routes() -> APIRouter:
         hf_cmd = f"hf download {req.repo_id}"
         if req.include:
             hf_cmd += f" --include '{req.include}'"
-        if _dl_shell:
-            hf_cmd += f" --local-dir {_dl_shell}"
+        if _dl_shell_cache:
+            hf_cmd += f" --cache-dir {_dl_shell_cache}"
+        elif _dl_shell_local:
+            hf_cmd += f" --local-dir {_dl_shell_local}"
 
         # Build the shell wrapper — runs hf download directly in tmux (which is a TTY)
         # No script/tee needed — we'll use tmux capture-pane to read output
@@ -451,8 +459,7 @@ def setup_cookbook_routes() -> APIRouter:
             runner_lines.append(_HF_TOKEN_STATUS_SNIPPET)
             # Try hf CLI first, fall back to Python huggingface_hub, then auto-install
             runner_lines.append('if command -v hf &>/dev/null; then')
-            # < /dev/null suppresses interactive "update available? [Y/n]" prompt
-            runner_lines.append(f'  {hf_cmd} < /dev/null')
+            runner_lines.extend("  " + line for line in _hf_download_retry_bash_lines(hf_cmd, stdin_redirect=True))
             runner_lines.append('elif python3 -c "import huggingface_hub" 2>/dev/null; then')
             runner_lines.append('  echo "hf CLI not found, using Python huggingface_hub..."')
             runner_lines.append(f'  python3 -c "import os; from huggingface_hub import snapshot_download; snapshot_download(\'{req.repo_id}\'{_dl_pyarg}, max_workers={4 if req.disable_hf_transfer else 8})"')
@@ -500,8 +507,7 @@ def setup_cookbook_routes() -> APIRouter:
                 lines.append(hf_cmd)
                 lines.append('_ec=$?; if [ $_ec -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $_ec)"; fi')
             else:
-                # < /dev/null suppresses interactive "update available? [Y/n]" prompt
-                lines.append(f"{hf_cmd} < /dev/null")
+                lines.extend(_hf_download_retry_bash_lines(hf_cmd, stdin_redirect=True))
                 lines.append('_ec=$?; if [ $_ec -eq 0 ]; then echo ""; echo "DOWNLOAD_OK"; else echo ""; echo "DOWNLOAD_FAILED (exit $_ec)"; fi')
                 lines.append(f"rm -f '{wrapper_script}'")
                 lines.append('exec "${SHELL:-/bin/bash}"')

--- a/static/js/cookbookDownload.js
+++ b/static/js/cookbookDownload.js
@@ -120,7 +120,13 @@ export function _buildDownloadCmd(model, backend) {
       // Reflect the server's download target in the preview (matches the real
       // download path built server-side). '' = default HF cache.
       const _dlDir = (_serverByVal?.(_envState.remoteServerKey || _envState.remoteHost || '') || {}).downloadDir || '';
-      const _localDirArg = _dlDir ? `, local_dir=os.path.expanduser('${_dlDir.replace(/\/$/, '')}/${repo.split('/').pop()}')` : '';
+      const _dlNorm = _dlDir.replace(/\/$/, '');
+      const _isHubCache = _dlNorm === '~/.cache/huggingface/hub' || _dlNorm.endsWith('/.cache/huggingface/hub');
+      const _downloadDirArg = _dlDir
+        ? (_isHubCache
+          ? `, cache_dir=os.path.expanduser('${_dlNorm}')`
+          : `, local_dir=os.path.expanduser('${_dlNorm}/${repo.split('/').pop()}')`)
+        : '';
       const _py = _isWindows() ? 'python' : 'python3';
       cmd = `${_py} -u -c "
 import sys, time, os
@@ -171,7 +177,7 @@ from huggingface_hub import snapshot_download
 repo='${repo}'
 print(f'START {repo}',flush=True)
 try:
- path=snapshot_download(repo${includeArg}${_localDirArg})
+ path=snapshot_download(repo${includeArg}${_downloadDirArg})
  print(f'DONE {path}',flush=True)
 except Exception as e:
  print(f'ERROR {e}',file=sys.stderr,flush=True);sys.exit(1)

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -15,6 +15,8 @@ from routes.cookbook_helpers import (
     _llama_cpp_rebuild_cmd,
     _append_vllm_linux_preflight_lines,
     _local_tooling_path_export,
+    _hf_download_retry_bash_lines,
+    _hf_download_target,
     _pip_install_attempt,
     _pip_install_fallback_chain,
     _ollama_bind_from_cmd,
@@ -142,6 +144,40 @@ def test_local_tooling_path_export_preserves_spaces_and_expands_path():
     line = _local_tooling_path_export("/Users/John Smith/.venv/bin/python3")
     assert line == 'export PATH="/Users/John Smith/.venv/bin:$PATH"'
     assert line.endswith(':$PATH"')  # $PATH stays expandable in double quotes
+
+
+def test_hf_download_target_uses_cache_dir_for_hub_cache():
+    target = _hf_download_target("cyankiwi/Qwen3.5-9B-AWQ-BF16-INT4", "/app/.cache/huggingface/hub")
+
+    assert target == {
+        "cache_dir": "/app/.cache/huggingface/hub",
+        "local_dir": None,
+    }
+
+
+def test_hf_download_target_keeps_custom_dirs_as_per_model_local_dir():
+    target = _hf_download_target("cyankiwi/Nemotron-Cascade-8B-AWQ-4bit", "/models")
+
+    assert target == {
+        "cache_dir": None,
+        "local_dir": "/models/Nemotron-Cascade-8B-AWQ-4bit",
+    }
+
+
+def test_hf_download_retry_loop_reruns_same_command_for_resume():
+    script = "\n".join(
+        _hf_download_retry_bash_lines(
+            'hf download cyankiwi/Qwen3.5-9B-AWQ-BF16-INT4 --cache-dir "/app/.cache/huggingface/hub"',
+            stdin_redirect=True,
+            attempts=3,
+            sleep_seconds=5,
+        )
+    )
+
+    assert "_odysseus_hf_max=3" in script
+    assert 'hf download cyankiwi/Qwen3.5-9B-AWQ-BF16-INT4 --cache-dir "/app/.cache/huggingface/hub" < /dev/null' in script
+    assert "Sleeping, then resuming from the existing cache" in script
+    assert "sleep 5" in script
 
 
 def test_pip_install_fallback_chain_prefers_venv_safe_install():


### PR DESCRIPTION
## Summary

- Use the normal Hugging Face hub cache layout when Cookbook's selected download directory is already an HF hub cache (for example `/app/.cache/huggingface/hub`) instead of creating a `--local-dir <hub>/<model>` folder inside it.
- Wrap POSIX `hf download` runs in a retry loop that reruns the same command after transient failures, letting Hugging Face resume from existing `.incomplete` blobs.
- Keep custom non-cache download directories working as per-model `local_dir` folders.
- Update the Cookbook download command preview so it shows `cache_dir=...` for hub-cache destinations.

## Linked Issue

Fixes #2722

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure a Cookbook server download directory as `/app/.cache/huggingface/hub` or another path ending in `.cache/huggingface/hub`.
2. Start a Hugging Face model download from Cookbook and confirm the generated command uses `--cache-dir <hub>` instead of `--local-dir <hub>/<model>`.
3. Interrupt a large download with a transient network failure or kill the HF process once; restart the task and confirm it retries/resumes from existing `.incomplete` cache files.
4. Configure a custom non-cache download directory such as `/models` and confirm Cookbook still uses a per-model `local_dir` folder there.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual rendering changes. The only frontend change updates the Cookbook command preview text to match the backend download target.

### Screenshots / clips

Not applicable; no visual layout changes.

## Local Checks

- `python3 -m py_compile routes/cookbook_routes.py routes/cookbook_helpers.py tests/test_cookbook_helpers.py`
- `node --check static/js/cookbookDownload.js`
- `git diff --check`
- Direct helper behavior assertions with import stubs for the thin local Python environment.
- Source assertions that backend uses `_hf_download_target(...)`, `--cache-dir`, and `_hf_download_retry_bash_lines(...)`.

Not run locally:

- Full `tests/test_cookbook_helpers.py` under pytest. The available temp pytest environment lacks SQLAlchemy; collection fails before this test file runs while importing `core.database`.
- Full Docker/app run and real multi-GB HF download, because this local environment is not configured with Docker/HF cache credentials for that reproduction.