### PR TITLE
fix(security): don't grant tool access in the pre-setup window

### DIFF
--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional, Set
 
 logger = logging.getLogger(__name__)
+
+
+def _auth_intentionally_disabled() -> bool:
+    """True when the operator has explicitly turned auth off (AUTH_ENABLED=false).
+
+    This is the intentional single-user / local self-host mode. Mirrors the
+    AUTH_ENABLED parsing in app.py / core.middleware so the tool layer agrees
+    with the request layer on what "no auth" means.
+    """
+    return os.getenv("AUTH_ENABLED", "true").strip().lower() == "false"
 
 
 # Tools regular/public users must not execute directly. These either expose
@@ -162,13 +173,24 @@ def is_public_blocked_tool(tool_name: Optional[str]) -> bool:
 
 
 def owner_is_admin_or_single_user(owner: Optional[str]) -> bool:
-    """Return True for admins, or when auth is not configured yet."""
+    """Return True for admins, or in intentional single-user mode.
+
+    Single-user mode means the operator explicitly disabled auth
+    (``AUTH_ENABLED=false``) — the local/self-host default where the owner has
+    full access to their own box.
+
+    The pre-setup window (auth ENABLED but no admin created yet) is treated as
+    NON-admin: returning True there would hand server-execution tools
+    (``bash``/``python``) to any caller before setup completes. The auth
+    middleware already 401s ``/api/`` requests pre-setup, so this is
+    defense-in-depth for callers that bypass it (e.g. trusted loopback).
+    """
     try:
         from core.auth import AuthManager
 
         auth = AuthManager()
         if not auth.is_configured:
-            return True
+            return _auth_intentionally_disabled()
         return bool(owner and auth.is_admin(owner))
     except Exception as exc:
         logger.warning("Unable to evaluate owner admin status: %s", exc)

--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -3,20 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Optional, Set
 
 logger = logging.getLogger(__name__)
-
-
-def _auth_intentionally_disabled() -> bool:
-    """True when the operator has explicitly turned auth off (AUTH_ENABLED=false).
-
-    This is the intentional single-user / local self-host mode. Mirrors the
-    AUTH_ENABLED parsing in app.py / core.middleware so the tool layer agrees
-    with the request layer on what "no auth" means.
-    """
-    return os.getenv("AUTH_ENABLED", "true").strip().lower() == "false"
 
 
 # Tools regular/public users must not execute directly. These either expose
@@ -190,7 +179,9 @@ def owner_is_admin_or_single_user(owner: Optional[str]) -> bool:
 
         auth = AuthManager()
         if not auth.is_configured:
-            return _auth_intentionally_disabled()
+            from src.auth_helpers import _auth_disabled
+
+            return _auth_disabled()
         return bool(owner and auth.is_admin(owner))
     except Exception as exc:
         logger.warning("Unable to evaluate owner admin status: %s", exc)

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -647,6 +647,60 @@ def test_public_agent_policy_hides_sensitive_tools(monkeypatch):
     assert "manage_tasks" in blocked
 
 
+def test_presetup_does_not_grant_admin_tools_when_auth_enabled(monkeypatch):
+    """Pre-setup window: auth is enabled but no admin user exists yet.
+
+    This must NOT be treated as single-user/admin at the tool layer — the
+    server-execution tools (bash/python) stay blocked as defense-in-depth so
+    an unauthenticated caller that slips past the auth middleware (e.g. via a
+    loopback bypass) can't reach an RCE before setup completes.
+    """
+    monkeypatch.delenv("AUTH_ENABLED", raising=False)  # default: enabled
+    auth_mod = _install_core_auth_stub(monkeypatch)
+
+    class FakeAuth:
+        is_configured = False
+
+        def is_admin(self, username):
+            return False
+
+    monkeypatch.setattr(auth_mod, "AuthManager", lambda: FakeAuth())
+
+    from src.tool_security import (
+        blocked_tools_for_owner,
+        owner_is_admin_or_single_user,
+    )
+
+    assert owner_is_admin_or_single_user(None) is False
+    blocked = blocked_tools_for_owner(None)
+    assert "bash" in blocked
+    assert "python" in blocked
+
+
+def test_single_user_mode_keeps_full_tool_access_when_auth_disabled(monkeypatch):
+    """Intentional single-user mode (AUTH_ENABLED=false) keeps full tool
+    access even with no admin user — this is the default local/self-host UX
+    and must not regress."""
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    auth_mod = _install_core_auth_stub(monkeypatch)
+
+    class FakeAuth:
+        is_configured = False
+
+        def is_admin(self, username):
+            return False
+
+    monkeypatch.setattr(auth_mod, "AuthManager", lambda: FakeAuth())
+
+    from src.tool_security import (
+        blocked_tools_for_owner,
+        owner_is_admin_or_single_user,
+    )
+
+    assert owner_is_admin_or_single_user(None) is True
+    assert blocked_tools_for_owner(None) == set()
+
+
 @pytest.mark.asyncio
 async def test_webhook_tool_reuses_private_url_validation():
     class FakeDb:


### PR DESCRIPTION
## Summary

`owner_is_admin_or_single_user()` returned `True` whenever auth was not configured, which conflated two very different states: **intentional single-user mode** (operator set `AUTH_ENABLED=false`) and the **pre-setup window** (auth enabled, but no admin user created yet). In the pre-setup window `blocked_tools_for_owner()` returned an empty set, so server-execution tools (`bash`/`python`) and the other admin-only tools were ungated.

The auth middleware already 401s `/api/` requests pre-setup, but a caller that bypasses it (the trusted-loopback / internal-tool path) could reach those tools before setup completed. This change treats "not configured" as admin **only** when auth is intentionally disabled (`AUTH_ENABLED=false`), mirroring the `AUTH_ENABLED` parsing in `app.py` / `core/middleware.py`. Intentional single-user mode is preserved; the pre-setup window is now non-admin as defense-in-depth.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3201

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. *(Not checked — verified via the unit tests below rather than a full app run.)*

## How to Test

1. `PYTHONPATH=$PWD python -m pytest tests/test_review_regressions.py -k "presetup or single_user_mode" -v`
2. `test_presetup_does_not_grant_admin_tools_when_auth_enabled` — with `AUTH_ENABLED` unset (default on) and no admin user, `owner_is_admin_or_single_user(None)` is `False` and `blocked_tools_for_owner(None)` blocks `bash`/`python`.
3. `test_single_user_mode_keeps_full_tool_access_when_auth_disabled` — with `AUTH_ENABLED=false`, full tool access is preserved (empty blocked set).

No UI/visual changes — the Visual section is N/A.

---
<sub>Disclosure: prepared with the help of Claude Opus 4.8; reviewed and submitted by the author.</sub>
