### PR TITLE
chore: add .pi/ to gitignore for local pi agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ research_data/
 
 # Internal dev/review notes — not for public repo
 dev-docs/
+.pi/
 # Windows-port working docs (local only, not for public repo)
 docs/windows-port/
 


### PR DESCRIPTION
Adds  to  so that local pi coding agent skills stay out of the repo.