### PR TITLE
feat: Kimi Code, hwfit search, provider logos, chat polish

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -233,6 +233,9 @@ _PROVIDER_CURATED = {
     "zai-coding": [
         "glm-5.1", "glm-5v-turbo", "glm-5-turbo", "glm-4.7", "glm-4.5-air",
     ],
+    "kimi-code": [
+        "kimi-for-coding",
+    ],
     "deepseek": [
         "deepseek-chat", "deepseek-reasoner",
     ],
@@ -302,6 +305,8 @@ def _match_provider_curated(base_url: str, provider: str) -> str:
     parsed = urlparse(base_url)
     if _host_match(base_url, "z.ai") and "/api/coding" in (parsed.path or ""):
         return "zai-coding"
+    if _host_match(base_url, "kimi.com") and "/coding" in (parsed.path or ""):
+        return "kimi-code"
     for domain, key in _HOST_TO_CURATED:
         if _host_match(base_url, domain):
             return key
@@ -681,6 +686,7 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
     """Probe a base URL's /models endpoint and return list of model IDs.
     For Anthropic, queries their /v1/models API, falling back to hardcoded list."""
     from src.endpoint_resolver import resolve_url
+    from src.llm_core import httpx_get_kimi_aware
     base = resolve_url(_normalize_base(base_url))
     if _detect_provider(base) == "chatgpt-subscription":
         from src.chatgpt_subscription import fetch_available_models
@@ -719,7 +725,7 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
         return list(fallback or [])
     headers = build_headers(api_key, base)
     try:
-        r = httpx.get(url, headers=headers, timeout=timeout, verify=llm_verify())
+        r = httpx_get_kimi_aware(url, headers, timeout=timeout, verify=llm_verify())
         r.raise_for_status()
         data = r.json()
         # OpenAI format: {"data": [{"id": "model-name"}]}
@@ -731,6 +737,11 @@ def _probe_endpoint(base_url: str, api_key: str = None, timeout: int = 5) -> Lis
             # Z.AI coding plan omits some working models from /models;
             # append curated-only entries for that endpoint only.
             if _host_match(base, "z.ai") and "/api/coding" in (urlparse(base).path or ""):
+                _ck = _match_provider_curated(base, None)
+                for _e in _PROVIDER_CURATED.get(_ck, []):
+                    if _e not in set(models) and not any(m.startswith(_e) for m in models):
+                        models.append(_e)
+            if _host_match(base, "kimi.com") and "/coding" in (urlparse(base).path or ""):
                 _ck = _match_provider_curated(base, None)
                 for _e in _PROVIDER_CURATED.get(_ck, []):
                     if _e not in set(models) and not any(m.startswith(_e) for m in models):

--- a/routes/webhook_routes.py
+++ b/routes/webhook_routes.py
@@ -198,6 +198,8 @@ def setup_webhook_routes(
         "opencode-go": "https://opencode.ai/zen/go/v1",
         "fireworks": "https://api.fireworks.ai/inference/v1",
         "venice": "https://api.venice.ai/api/v1",
+        "kimi-code": "https://api.kimi.com/coding/v1",
+        "kimicode": "https://api.kimi.com/coding/v1",
     }
 
     # Model prefix → provider mapping for auto-detection
@@ -210,6 +212,8 @@ def setup_webhook_routes(
         "mistral": "mistral",
         "llama": "groq",
         "mixtral": "groq",
+        "kimi-for-coding": "kimi-code",
+        "kimi": "kimi-code",
     }
 
     def _resolve_base_url(model: Optional[str], provider: Optional[str]) -> Optional[str]:

--- a/services/hwfit/data/hf_models.json
+++ b/services/hwfit/data/hf_models.json
@@ -4650,7 +4650,7 @@
   "min_ram_gb": 2.6,
   "recommended_ram_gb": 4.4,
   "min_vram_gb": 2.4,
-  "quantization": "Q4_K_M",
+  "quantization": "NVFP4",
   "context_length": 40960,
   "use_case": "General purpose text generation",
   "capabilities": [
@@ -6647,6 +6647,33 @@
   "gguf_sources": [
    {
     "repo": "unsloth/granite-3.3-8b-instruct-GGUF",
+    "provider": "unsloth"
+   }
+  ]
+ },
+ {
+  "name": "Qwen/Qwen3-8B",
+  "provider": "Alibaba",
+  "parameter_count": "8.2B",
+  "parameters_raw": 8190735360,
+  "min_ram_gb": 4.6,
+  "recommended_ram_gb": 7.6,
+  "min_vram_gb": 4.2,
+  "quantization": "Q4_K_M",
+  "context_length": 131072,
+  "use_case": "Instruction following, chat",
+  "capabilities": [
+   "tool_use"
+  ],
+  "pipeline_tag": "text-generation",
+  "architecture": "qwen3",
+  "hf_downloads": 1200000,
+  "hf_likes": 500,
+  "release_date": "2025-04-28",
+  "_discovered": true,
+  "gguf_sources": [
+   {
+    "repo": "unsloth/Qwen3-8B-GGUF",
     "provider": "unsloth"
    }
   ]

--- a/services/hwfit/fit.py
+++ b/services/hwfit/fit.py
@@ -517,6 +517,44 @@ SORT_KEYS = {
     "newest": lambda r: r.get("release_date") or "",
 }
 
+_SEARCH_VARIANT_SUFFIXES = (
+    "-instruct-reasoning", "-instruct", "-non-reasoning",
+    "-thinking", "-it", "-chat",
+)
+
+_DEEPSEEK_QWEN_DISTILL_RE = re.compile(r"deepseek-r1-\d{4}-qwen", re.IGNORECASE)
+
+
+def _search_needles(search: str) -> tuple[str, ...]:
+    """Expand common slug variants so qwen3-8b-instruct also matches qwen3-8b in HF ids."""
+    s = search.lower().strip()
+    if not s:
+        return ()
+    needles = [s]
+    for suffix in _SEARCH_VARIANT_SUFFIXES:
+        if s.endswith(suffix) and len(s) > len(suffix):
+            base = s[: -len(suffix)].rstrip("-")
+            if base and base not in needles:
+                needles.append(base)
+    return tuple(needles)
+
+
+def _model_matches_search(model: dict, search: str) -> bool:
+    needles = _search_needles(search)
+    if not needles:
+        return True
+    name = model.get("name", "").lower()
+    provider = model.get("provider", "").lower()
+    matched = any(n in name or n in provider for n in needles)
+    if not matched:
+        return False
+    # DeepSeek-R1-0528-Qwen3-8B embeds "qwen3-8b" as a distill suffix — not a
+    # Qwen catalog entry. Exclude unless the user is searching for DeepSeek.
+    if any(n.startswith("qwen") for n in needles) and "deepseek" not in search.lower():
+        if _DEEPSEEK_QWEN_DISTILL_RE.search(name):
+            return False
+    return True
+
 
 def rank_models(system, use_case=None, limit=50, search=None, sort="score", quant=None, target_context=None, fit_only=False):
     """Rank all models against detected hardware. Returns sorted list of fit results.
@@ -638,11 +676,8 @@ def rank_models(system, use_case=None, limit=50, search=None, sort="score", quan
             if quant in ("INT4", "INT8", "W4A16", "W8A8", "W8A16") and native_q != quant:
                 continue
 
-        if search:
-            name = m.get("name", "").lower()
-            provider = m.get("provider", "").lower()
-            if search.lower() not in name and search.lower() not in provider:
-                continue
+        if search and not _model_matches_search(m, search):
+            continue
 
         result = analyze_model(m, system, target_quant=quant, scoring_use_case=(use_case or "general"), target_context=target_context)
         if result is None:

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -15,7 +15,12 @@ import logging
 from typing import AsyncGenerator, List, Dict, Optional, Set
 from urllib.parse import urlparse
 
-from src.llm_core import stream_llm, stream_llm_with_fallback, _is_ollama_native_url
+from src.llm_core import (
+    stream_llm,
+    stream_llm_with_fallback,
+    _is_ollama_native_url,
+    _requires_reasoning_content_on_tool_calls,
+)
 from src.model_context import estimate_tokens
 from src.settings import get_setting
 from src.prompt_security import untrusted_context_message
@@ -239,7 +244,7 @@ Edit an EXISTING file by exact string replacement. PREFER this over bash (sed/ec
 <language>
 <content>
 ```
-Create a NEW document in the editor panel. Only use when the user explicitly asks for a new file/document. If a document is already open in the editor, the user's request "fix this", "add X", "change Y", etc. refers to THAT document — use edit_document, never create_document.""",
+Create a NEW document in the editor panel. Only use when the user explicitly asks for a new file/document. If a document is already open in the editor, the user's request "fix this", "add X", "change Y", etc. refers to THAT document — use edit_document, never create_document. For interactive apps/games/UIs the user should try in-browser, use language="html" — they can preview with the editor Run (▶) button; Python scripts run here but have no interactive stdin/GUI.""",
 
     "edit_document": """\
 ```edit_document
@@ -478,7 +483,7 @@ _API_HOSTS = frozenset([
     "api.deepseek.com", "deepseek.com",
     "api.together.xyz", "api.fireworks.ai",
     "api.perplexity.ai", "api.x.ai",
-    "ollama.com", "api.venice.ai",
+    "ollama.com", "api.venice.ai", "api.kimi.com",
     "api.githubcopilot.com",
     # Local OpenAI-compatible endpoints (llama.cpp, vLLM, LM Studio, etc.).
     # Without these, `_is_api_model` falls back to keyword sniffing on the
@@ -1163,6 +1168,7 @@ def _append_tool_results(
     used_native: bool,
     round_num: int,
     round_reasoning: str = "",
+    endpoint_url: str = "",
 ):
     """Append tool execution results back into the message history for the next LLM round.
 
@@ -1171,18 +1177,24 @@ def _append_tool_results(
     rejects follow-up requests in thinking mode that don't include the
     prior reasoning.
 
+    Kimi Code / Moonshot thinking models are stricter: every assistant message
+    that carries tool_calls must retain its reasoning_content across rounds.
+
     NOTE: it is NOT universally ignored. Nemotron's chat template re-injects
     EVERY prior `reasoning_content` as a <think> block, and this agent loop is
     trimmed only once (before the loop), so across rounds the reasoning piles
     up unbounded — bloating context and feeding the model its own prior
     reasoning, which reinforces repetition/looping. So keep reasoning_content
     on the MOST RECENT assistant turn only: enough for DeepSeek continuity,
-    without the per-round accumulation.
+    without the per-round accumulation — except for Kimi/Moonshot, which
+    requires the full history.
     """
-    # Strip reasoning_content from earlier assistant turns; only the newest keeps it.
-    for _m in messages:
-        if _m.get("role") == "assistant":
-            _m.pop("reasoning_content", None)
+    preserve_all_reasoning = _requires_reasoning_content_on_tool_calls(endpoint_url)
+    if not preserve_all_reasoning:
+        # Strip reasoning_content from earlier assistant turns; only the newest keeps it.
+        for _m in messages:
+            if _m.get("role") == "assistant":
+                _m.pop("reasoning_content", None)
     if used_native and native_tool_calls:
         assistant_msg = {"role": "assistant"}
         # When the model emitted ONLY tool calls (no prose), content must be
@@ -1195,6 +1207,8 @@ def _append_tool_results(
         assistant_msg["content"] = round_response if round_response.strip() else None
         if round_reasoning:
             assistant_msg["reasoning_content"] = round_reasoning
+        elif preserve_all_reasoning:
+            assistant_msg["reasoning_content"] = ""
         assistant_msg["tool_calls"] = [
             {
                 "id": tc.get("id", f"call_{round_num}_{j}"),
@@ -2614,7 +2628,7 @@ async def stream_agent_loop(
         # Feed results back to LLM for next round
         _append_tool_results(messages, round_response, native_tool_calls,
                              tool_results, tool_result_texts, used_native, round_num,
-                             round_reasoning=round_reasoning)
+                             round_reasoning=round_reasoning, endpoint_url=endpoint_url)
 
         # Emit agent_step event
         yield (

--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -12,7 +12,7 @@ from typing import Optional, Tuple, Dict
 from urllib.parse import urlparse, urlunparse
 
 from core.database import SessionLocal, ModelEndpoint
-from src.llm_core import _detect_provider, _host_match, _ollama_api_root
+from src.llm_core import _detect_provider, _host_match, _is_kimi_code_url, KIMI_CODE_USER_AGENT, _ollama_api_root
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +215,8 @@ def build_headers(api_key: Optional[str], base: str) -> Dict[str, str]:
     if provider == "openrouter":
         headers.setdefault("HTTP-Referer", "https://github.com/pewdiepie-archdaemon/odysseus")
         headers.setdefault("X-OpenRouter-Title", "Odysseus")
+    if _is_kimi_code_url(base):
+        headers.setdefault("User-Agent", KIMI_CODE_USER_AGENT)
     return headers
 
 

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -405,6 +405,156 @@ def _host_match(url: str, *domains: str) -> bool:
     return any(host == d or host.endswith("." + d) for d in domains)
 
 
+# Kimi Code subscription keys (api.kimi.com/coding/v1) require a whitelisted
+# coding-agent User-Agent; otherwise the API returns 403 access_terminated_error.
+# Tried in order; first success is cached per base URL for later requests.
+KIMI_CODE_USER_AGENTS: tuple[str, ...] = (
+    "claude-code/0.1.0",
+    "claude-code/1.0.0",
+    "KimiCLI/1.0",
+    "Kilo-Code/1.0",
+    "Roo-Code/1.0",
+    "Cursor/1.0",
+)
+KIMI_CODE_USER_AGENT = KIMI_CODE_USER_AGENTS[0]
+_kimi_code_ua_cache: dict[str, str] = {}
+
+
+def _is_kimi_code_url(url: str) -> bool:
+    if not url or not _host_match(url, "kimi.com"):
+        return False
+    try:
+        return "/coding" in (urlparse(url).path or "")
+    except Exception:
+        return False
+
+
+def _requires_reasoning_content_on_tool_calls(url: str) -> bool:
+    """Kimi Code / Moonshot thinking models require reasoning_content on every
+    assistant message that carries tool_calls during multi-turn tool use."""
+    if not url:
+        return False
+    if _is_kimi_code_url(url):
+        return True
+    return _host_match(url, "moonshot")
+
+
+def _kimi_code_base_key(url: str) -> str:
+    """Normalize a Kimi Code chat/models URL to its OpenAI base (.../coding/v1)."""
+    parsed = urlparse(url)
+    path = (parsed.path or "").rstrip("/")
+    for suffix in ("/chat/completions", "/models", "/completions"):
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+    path = path.rstrip("/") or "/coding/v1"
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def _is_kimi_code_access_denied(status: int, body: bytes | str) -> bool:
+    if status != 403:
+        return False
+    text = body.decode("utf-8", errors="replace") if isinstance(body, bytes) else (body or "")
+    lower = text.lower()
+    return (
+        "access_terminated_error" in lower
+        or "coding agents" in lower
+        or "only available for coding" in lower
+    )
+
+
+def _kimi_code_ua_candidates(url: str) -> list[str]:
+    if not _is_kimi_code_url(url):
+        return []
+    base_key = _kimi_code_base_key(url)
+    cached = _kimi_code_ua_cache.get(base_key)
+    if cached:
+        return [cached] + [ua for ua in KIMI_CODE_USER_AGENTS if ua != cached]
+    return list(KIMI_CODE_USER_AGENTS)
+
+
+def _remember_kimi_code_user_agent(url: str, user_agent: str) -> None:
+    _kimi_code_ua_cache[_kimi_code_base_key(url)] = user_agent
+
+
+def apply_kimi_code_headers(headers: Optional[Dict], url: str) -> Dict[str, str]:
+    """Pick a Kimi Code User-Agent (cached probe when possible)."""
+    h = dict(headers or {})
+    if not _is_kimi_code_url(url):
+        return h
+    base_key = _kimi_code_base_key(url)
+    cached = _kimi_code_ua_cache.get(base_key)
+    if cached:
+        h["User-Agent"] = cached
+        return h
+    models_url = base_key.rstrip("/") + "/models"
+    from src.tls_overrides import llm_verify
+    for ua in KIMI_CODE_USER_AGENTS:
+        trial = dict(h)
+        trial["User-Agent"] = ua
+        try:
+            r = httpx.get(models_url, headers=trial, timeout=8, verify=llm_verify())
+        except Exception:
+            continue
+        if _is_kimi_code_access_denied(r.status_code, r.content):
+            logger.debug("Kimi Code rejected User-Agent %s (403), trying next", ua)
+            continue
+        if r.status_code < 400:
+            _remember_kimi_code_user_agent(url, ua)
+            h["User-Agent"] = ua
+            return h
+        break
+    h.setdefault("User-Agent", KIMI_CODE_USER_AGENT)
+    return h
+
+
+def httpx_get_kimi_aware(url: str, headers: Optional[Dict], **kwargs):
+    h = apply_kimi_code_headers(headers, url)
+    if not _is_kimi_code_url(url):
+        return httpx.get(url, headers=h, **kwargs)
+    last = None
+    for ua in _kimi_code_ua_candidates(url):
+        trial = dict(h)
+        trial["User-Agent"] = ua
+        last = httpx.get(url, headers=trial, **kwargs)
+        if not _is_kimi_code_access_denied(last.status_code, last.content):
+            if last.status_code < 400:
+                _remember_kimi_code_user_agent(url, ua)
+            return last
+    return last
+
+
+def httpx_post_kimi_aware(url: str, headers: Optional[Dict], **kwargs):
+    h = apply_kimi_code_headers(headers, url)
+    if not _is_kimi_code_url(url):
+        return httpx.post(url, headers=h, **kwargs)
+    last = None
+    for ua in _kimi_code_ua_candidates(url):
+        trial = dict(h)
+        trial["User-Agent"] = ua
+        last = httpx.post(url, headers=trial, **kwargs)
+        if not _is_kimi_code_access_denied(last.status_code, last.content):
+            if last.status_code < 400:
+                _remember_kimi_code_user_agent(url, ua)
+            return last
+    return last
+
+
+async def httpx_post_kimi_aware_async(client, url: str, headers: Optional[Dict], **kwargs):
+    h = apply_kimi_code_headers(headers, url)
+    if not _is_kimi_code_url(url):
+        return await client.post(url, headers=h, **kwargs)
+    last = None
+    for ua in _kimi_code_ua_candidates(url):
+        trial = dict(h)
+        trial["User-Agent"] = ua
+        last = await client.post(url, headers=trial, **kwargs)
+        if not _is_kimi_code_access_denied(last.status_code, last.content):
+            if last.status_code < 400:
+                _remember_kimi_code_user_agent(url, ua)
+            return last
+    return last
+
+
 def _detect_provider(url: str) -> str:
     """Detect the API provider from a configured endpoint URL.
 
@@ -474,6 +624,12 @@ def _provider_label(url: str) -> str:
     if _host_match(url, "googleapis.com"): return "Google"
     if _host_match(url, "together.xyz", "together.ai"): return "Together"
     if _host_match(url, "fireworks.ai"): return "Fireworks"
+    if _host_match(url, "kimi.com"):
+        try:
+            if "/coding" in (urlparse(url).path or ""):
+                return "Kimi Code"
+        except Exception:
+            pass
     if _is_ollama_native_url(url): return "Ollama"
     try:
         host = (urlparse(url).hostname or "").lower()
@@ -1043,7 +1199,7 @@ def list_model_ids(
             models_url = _ollama_api_root(base_chat_url) + "/tags"
         else:
             models_url = base_chat_url.replace("/chat/completions", "/models")
-        r = httpx.get(models_url, headers=h, timeout=timeout)
+        r = httpx_get_kimi_aware(models_url, h, timeout=timeout)
         r.raise_for_status()
         data = r.json()
         model_ids = [m.get("id") for m in (data.get("data") or []) if m.get("id")]
@@ -1151,7 +1307,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
             payload[tok_key] = max_tokens
     try:
         note_model_activity(target_url, model)
-        r = httpx.post(target_url, headers=h, json=payload, timeout=timeout)
+        r = httpx_post_kimi_aware(target_url, h, json=payload, timeout=timeout)
     except Exception as e:
         raise HTTPException(502, f"POST {target_url} failed: {e}")
     if not r.is_success:
@@ -1354,7 +1510,7 @@ async def llm_call_async(
         try:
             note_model_activity(target_url, model)
             client = _get_http_client()
-            r = await client.post(target_url, headers=h, json=payload, timeout=call_timeout)
+            r = await httpx_post_kimi_aware_async(client, target_url, h, json=payload, timeout=call_timeout)
             duration = time.time() - start
             if not r.is_success:
                 friendly = _format_upstream_error(r.status_code, r.text, target_url)
@@ -1742,6 +1898,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             events.append(_stream_delta_event(part))
         return events
 
+    h = apply_kimi_code_headers(h, target_url)
     try:
         client = _get_http_client()
         async with client.stream('POST', target_url, json=payload, headers=h, timeout=stream_timeout) as r:

--- a/src/teacher_escalation.py
+++ b/src/teacher_escalation.py
@@ -42,7 +42,7 @@ _SOTA_HOSTS = frozenset({
     "api.together.xyz", "api.fireworks.ai",
     "api.perplexity.ai", "api.x.ai",
     "generativelanguage.googleapis.com", "api.groq.com",
-    "openrouter.ai", "ollama.com", "api.venice.ai",
+    "openrouter.ai", "ollama.com", "api.venice.ai", "api.kimi.com",
 })
 
 

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -9,6 +9,7 @@ import settingsModule from './settings.js';
 import spinnerModule from './spinner.js';
 import { bindMenuDismiss } from './escMenuStack.js';
 import { matchModelKey } from './model/matchKey.js';
+import { modelDisplayName } from './modelAliases.js';
 
 const SEARCH_ICON = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>';
 const REPORT_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>';
@@ -521,7 +522,7 @@ const IMAGE_PRICING = {
 export function shortModel(name) {
   if (!name) return '...';
   if (typeof name !== 'string') name = String(name);
-  let short = name.split('/').pop();
+  let short = name.includes('/') ? modelDisplayName(name) : modelDisplayName(name, name);
   // Strip .gguf extension
   short = short.replace(/\.gguf$/i, '');
   // Strip quantization suffixes (Q4_K_M, Q8_0, etc.) and shard numbers
@@ -860,6 +861,36 @@ export function stripToolBlocks(text) {
   cleaned = cleaned.replace(TOOL_NARRATION_RE, '');
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
   return cleaned.trim();
+}
+
+/** Human-readable agent tool name for thread headers (live + restored). */
+export function agentToolLabel(toolName) {
+  const lower = String(toolName || '').toLowerCase();
+  const labels = {
+    web_search: 'Web Search',
+    bash: 'Terminal',
+    python: 'Python',
+    create_document: 'Write Document',
+    update_document: 'Write Document',
+    read_document: 'Read Document',
+    edit_file: 'Edit File',
+    read_file: 'Read File',
+    write_file: 'Write File',
+    list_files: 'Browse Files',
+    image_gen: 'Generate Image',
+    generate_image: 'Generate Image',
+    manage_memory: 'Memory',
+    save_memory: 'Memory',
+    search_memory: 'Memory',
+    manage_session: 'Sessions',
+    deep_research: 'Deep Research',
+    list_models: 'Models',
+    ui_control: 'UI Control',
+  };
+  if (labels[lower]) return labels[lower];
+  return String(toolName || 'tool')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 /**
@@ -2087,7 +2118,8 @@ export function addMessage(role, content, modelName, metadata) {
             node.className = 'agent-thread-node' + (ok ? '' : ' error');
             // Hide the raw JSON command when a diff says it better (same as live).
             const evCmdHtml = (ev.command && !(ev.diff && ev.diff.text)) ? `<pre class="agent-thread-cmd">${esc(ev.command)}</pre>` : '';
-            node.innerHTML = `<div class="agent-thread-dot"></div><div class="agent-thread-header"><span class="agent-thread-icon">${ok ? '\u2713' : '\u2717'}</span><span class="agent-thread-tool">${esc(ev.tool)}</span><span class="agent-thread-status">${ok ? 'done' : 'failed'}</span><span class="agent-thread-chevron">\u25B6</span></div><div class="agent-thread-content">${evCmdHtml}${outHtml}${evDiffHtml}</div>`;
+            const evToolLabel = agentToolLabel(ev.tool);
+            node.innerHTML = `<div class="agent-thread-dot"></div><div class="agent-thread-header"><span class="agent-thread-icon">${ok ? '\u2713' : '\u2717'}</span><span class="agent-thread-tool">${esc(evToolLabel)}</span><span class="agent-thread-status">${ok ? 'done' : 'failed'}</span><span class="agent-thread-chevron">\u25B6</span></div><div class="agent-thread-content">${evCmdHtml}${outHtml}${evDiffHtml}</div>`;
             // Click handling is delegated globally \u2014 see chat.js init.
             threadWrap.appendChild(node);
           }

--- a/static/js/modalManager.js
+++ b/static/js/modalManager.js
@@ -1281,10 +1281,10 @@ export function restore(id) {
 }
 
 /**
- * If the modal is currently MINIMIZED, restore it and return true.
- * Otherwise return false so the caller falls through to its own
- * open/close handling. We deliberately do NOT minimize on toggle —
- * that's the `_` button's job, not the rail/sidebar button's job.
+ * Sidebar / rail toggle for a registered modal:
+ *   - minimized → restore, return true
+ *   - visible   → close, return true
+ *   - otherwise → return false so the caller opens it
  */
 export function toggle(id) {
   const s = _state.get(id);
@@ -1292,6 +1292,12 @@ export function toggle(id) {
   const modal = document.getElementById(id);
   if (!modal) { _state.delete(id); return false; }
   if (s.isMinimized) return restore(id);
+  const visible = !modal.classList.contains('hidden')
+    && getComputedStyle(modal).display !== 'none';
+  if (visible) {
+    close(id);
+    return true;
+  }
   return false;
 }
 

--- a/static/js/modelAliases.js
+++ b/static/js/modelAliases.js
@@ -1,0 +1,32 @@
+// Shared per-browser display labels for model IDs (localStorage only).
+import Storage from './storage.js';
+
+export const MODEL_ALIASES_KEY = 'odysseus-model-aliases';
+
+export function loadModelAliases() {
+  return Storage.getJSON(MODEL_ALIASES_KEY, {});
+}
+
+export function modelBaseName(mid, fallback) {
+  const raw = fallback || mid || '';
+  return String(raw).split('/').pop();
+}
+
+export function modelDisplayName(mid, fallback) {
+  if (!mid) return modelBaseName('', fallback);
+  const alias = loadModelAliases()[mid];
+  return alias || modelBaseName(mid, fallback);
+}
+
+export function saveModelAlias(mid, name) {
+  if (!mid) return;
+  const aliases = loadModelAliases();
+  const trimmed = (name || '').trim();
+  const base = modelBaseName(mid);
+  if (trimmed && trimmed !== base) aliases[mid] = trimmed;
+  else delete aliases[mid];
+  Storage.setJSON(MODEL_ALIASES_KEY, aliases);
+  try {
+    document.dispatchEvent(new CustomEvent('odysseus:model-alias-changed', { detail: { mid, name: trimmed || base } }));
+  } catch { /* non-DOM contexts */ }
+}

--- a/static/js/providers.js
+++ b/static/js/providers.js
@@ -89,11 +89,88 @@ const _PROVIDERS = [
     '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></svg>'],
 ];
 
+// HF org slug -> brand key used for logo lookup (checked before regex on full id).
+const _HF_ORG_BRAND = {
+  'deepseek-ai': 'deepseek',
+  'qwen': 'qwen',
+  'meta-llama': 'meta',
+  'google': 'google',
+  'mistralai': 'mistral',
+  'microsoft': 'microsoft',
+  'nvidia': 'nvidia',
+  'zhipuai': 'zhipu',
+  'moonshotai': 'kimi',
+  'nousresearch': 'nous',
+  'allenai': 'meta',
+};
+
+const _BRAND_PROBE = {
+  deepseek: 'deepseek-r1',
+  qwen: 'qwen3-8b',
+  meta: 'meta-llama',
+  google: 'gemma-2',
+  mistral: 'mixtral',
+  openai: 'gpt-4',
+  microsoft: 'phi-3',
+  nvidia: 'nvidia-nemotron',
+  zhipu: 'glm-4',
+  kimi: 'kimi-k2',
+  nous: 'nous-hermes',
+};
+
+const _BRAND_SVG = (() => {
+  const out = {};
+  for (const [brand, probe] of Object.entries(_BRAND_PROBE)) {
+    for (const [re, svg] of _PROVIDERS) {
+      if (re.test(probe)) {
+        out[brand] = svg;
+        break;
+      }
+    }
+  }
+  return out;
+})();
+
+function _logoForBrand(brand) {
+  return brand ? (_BRAND_SVG[brand] || null) : null;
+}
+
+function _brandFromShortName(short) {
+  if (!short) return null;
+  if (/^DeepSeek-/i.test(short)) return 'deepseek';
+  if (/^Qwen/i.test(short)) return 'qwen';
+  if (/^Llama-/i.test(short) || /^Meta-/i.test(short)) return 'meta';
+  if (/^gemma-/i.test(short)) return 'google';
+  if (/^Mistral|^Mixtral|^Ministral/i.test(short)) return 'mistral';
+  if (/^Phi-/i.test(short)) return 'microsoft';
+  if (/^glm-/i.test(short)) return 'zhipu';
+  if (/^kimi-/i.test(short)) return 'kimi';
+  if (/Nemotron/i.test(short)) return 'nvidia';
+  return null;
+}
+
 // Returns an SVG string for the given model ID, or null if no match
 export function providerLogo(modelId) {
   if (!modelId) return null;
+  const id = String(modelId);
+  const slash = id.indexOf('/');
+  const org = slash >= 0 ? id.slice(0, slash).toLowerCase() : '';
+  const short = slash >= 0 ? id.slice(slash + 1) : id;
+
+  // Quant/publisher forks (nvidia/Qwen3-8B-NVFP4) keep the base model family icon.
+  const familyBrand = _brandFromShortName(short);
+  if (familyBrand) {
+    const svg = _logoForBrand(familyBrand);
+    if (svg) return svg;
+  }
+
+  if (org && _HF_ORG_BRAND[org]) {
+    const svg = _logoForBrand(_HF_ORG_BRAND[org]);
+    if (svg) return svg;
+  }
+
   for (const [re, svg] of _PROVIDERS) {
-    if (re.test(modelId)) return svg;
+    if (re.test(id)) return svg;
   }
   return null;
 }
@@ -119,6 +196,7 @@ const _ENDPOINT_LABELS = [
   [/(^|\.)fireworks\.ai$/i, "Fireworks"],
   [/(^|\.)perplexity\.ai$/i, "Perplexity"],
   [/(^|\.)x\.ai$/i, "xAI"],
+  [/(^|\.)kimi\.com$/i, "Kimi Code"],
 ];
 
 /**

--- a/static/js/slashAutocomplete.js
+++ b/static/js/slashAutocomplete.js
@@ -23,6 +23,13 @@ const PROMOTED_ALIASES = new Set([
   'memories','forget',
 ]);
 
+// Top-level command aliases that deserve their own row in the popup
+// (e.g. /docs → library, not buried as a secondary alias on /library).
+const PROMOTED_CMD_ALIASES = {
+  docs: 'library',
+  documents: 'library',
+};
+
 function _flatten() {
   const out = [];
   const seen = new Set();
@@ -58,7 +65,23 @@ function _flatten() {
     }
   }
 
-  // 2. Promoted legacy aliases (/new, /clear, /web …) as convenient short rows
+  // 2. Promoted top-level aliases (/docs, /documents …)
+  for (const [alias, parent] of Object.entries(PROMOTED_CMD_ALIASES)) {
+    const tok = `/${alias}`;
+    if (seen.has(tok)) continue;
+    const def = COMMANDS[parent];
+    if (!def?.handler || def.hidden) continue;
+    seen.add(tok);
+    out.push({
+      token: tok,
+      aliases: [],
+      category: def.category || '',
+      help: def.help || '',
+      usage: tok,
+    });
+  }
+
+  // 3. Promoted legacy aliases (/new, /clear, /web …) as convenient short rows
   if (LEGACY_ALIASES) {
     for (const [alias, { parent, sub }] of Object.entries(LEGACY_ALIASES)) {
       if (!PROMOTED_ALIASES.has(alias)) continue;

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -343,6 +343,64 @@ class TestAppendToolResultsNativeContent:
         assert "tool output" in messages[1]["content"]
 
 
+class TestAppendToolResultsKimiReasoning:
+    """Kimi Code rejects multi-turn tool calls when prior assistant tool_call
+    messages lose their reasoning_content field."""
+
+    def _native(self):
+        return [{"id": "call_1", "name": "write_file", "arguments": "{}"}]
+
+    def test_kimi_preserves_prior_reasoning_on_tool_calls(self):
+        messages = [{
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "round 1 thinking",
+            "tool_calls": [{
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        }, {
+            "role": "tool",
+            "tool_call_id": "call_0",
+            "content": "file contents",
+        }]
+        _append_tool_results(
+            messages, "", self._native(), [{}], ["ok"],
+            used_native=True, round_num=2,
+            round_reasoning="round 2 thinking",
+            endpoint_url="https://api.kimi.com/coding/v1/chat/completions",
+        )
+        first = messages[0]
+        second = messages[2]
+        assert first["reasoning_content"] == "round 1 thinking"
+        assert second["reasoning_content"] == "round 2 thinking"
+
+    def test_non_kimi_still_strips_prior_reasoning(self):
+        messages = [{
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "old reasoning",
+            "tool_calls": [{
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }],
+        }, {
+            "role": "tool",
+            "tool_call_id": "call_0",
+            "content": "file contents",
+        }]
+        _append_tool_results(
+            messages, "", self._native(), [{}], ["ok"],
+            used_native=True, round_num=2,
+            round_reasoning="new reasoning",
+            endpoint_url="https://api.openai.com/v1/chat/completions",
+        )
+        assert "reasoning_content" not in messages[0]
+        assert messages[2]["reasoning_content"] == "new reasoning"
+
+
 class TestAppendToolResultsThoughtSignature:
     """Gemini 3 returns an opaque thought_signature (in extra_content) with each
     function call and rejects the follow-up turn with HTTP 400 unless it is

--- a/tests/test_hwfit_search.py
+++ b/tests/test_hwfit_search.py
@@ -1,0 +1,16 @@
+from services.hwfit.fit import _model_matches_search, rank_models
+
+
+def test_aa_slug_search_strips_instruct_suffix():
+    model = {"name": "Qwen/Qwen3-8B-AWQ", "provider": "Alibaba"}
+    assert _model_matches_search(model, "qwen3-8b-instruct") is True
+    assert _model_matches_search(model, "qwen3-8b") is True
+    assert _model_matches_search(model, "llama-3") is False
+
+
+def test_rank_models_finds_qwen3_8b_via_aa_slug():
+    system = {"has_gpu": True, "gpu_vram_gb": 24, "ram_gb": 32, "backend": "cuda"}
+    results = rank_models(system, search="qwen3-8b-instruct", limit=900)
+    names = {r["name"] for r in results}
+    assert "Qwen/Qwen3-8B" in names
+    assert "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B" not in names

--- a/tests/test_kimi_code_hosts.py
+++ b/tests/test_kimi_code_hosts.py
@@ -1,0 +1,32 @@
+"""Kimi Code host-allowlist behavior (follow-up to provider support).
+
+Kimi Code (https://api.kimi.com/coding/v1) is a subscription, OpenAI-compatible
+cloud API with native tool-calling. These tests pin the three host-list integrations:
+  - agent loop sends native tool schemas to Kimi Code (not fenced-block parsing),
+  - teacher escalation treats Kimi Code as SOTA (loop OFF, no added latency).
+"""
+from src import agent_loop, teacher_escalation
+
+
+class TestAgentToolHosts:
+    def test_kimi_code_in_api_hosts(self):
+        assert "api.kimi.com" in agent_loop._API_HOSTS
+
+    def test_kimi_code_url_matches_api_host(self):
+        url = "https://api.kimi.com/coding/v1/chat/completions"
+        assert any(h in url for h in agent_loop._API_HOSTS)
+
+    def test_unknown_host_not_matched(self):
+        url = "https://example.invalid/v1/chat/completions"
+        assert not any(h in url for h in agent_loop._API_HOSTS)
+
+
+class TestTeacherEscalationSota:
+    def test_kimi_code_is_sota_not_self_hosted(self):
+        assert teacher_escalation.is_self_hosted("https://api.kimi.com/coding/v1/chat/completions") is False
+
+    def test_known_cloud_still_sota(self):
+        assert teacher_escalation.is_self_hosted("https://api.openai.com/v1") is False
+
+    def test_local_endpoint_still_self_hosted(self):
+        assert teacher_escalation.is_self_hosted("http://localhost:8000/v1") is True

--- a/tests/test_kimi_code_user_agent.py
+++ b/tests/test_kimi_code_user_agent.py
@@ -1,0 +1,69 @@
+"""Kimi Code User-Agent fallback list and 403 detection."""
+from src.llm_core import (
+    KIMI_CODE_USER_AGENTS,
+    KIMI_CODE_USER_AGENT,
+    _is_kimi_code_access_denied,
+    _is_kimi_code_url,
+    _kimi_code_base_key,
+    _kimi_code_ua_cache,
+    _kimi_code_ua_candidates,
+    _remember_kimi_code_user_agent,
+    httpx_post_kimi_aware,
+)
+
+
+class TestKimiCodeUserAgents:
+    def test_default_is_first_fallback(self):
+        assert KIMI_CODE_USER_AGENT == KIMI_CODE_USER_AGENTS[0]
+
+    def test_multiple_fallbacks_configured(self):
+        assert len(KIMI_CODE_USER_AGENTS) >= 3
+        assert "KimiCLI/1.0" in KIMI_CODE_USER_AGENTS
+
+    def test_detects_coding_agent_403(self):
+        body = '{"error":{"message":"only available for Coding Agents","type":"access_terminated_error"}}'
+        assert _is_kimi_code_access_denied(403, body) is True
+
+    def test_non_403_not_access_denied(self):
+        assert _is_kimi_code_access_denied(401, "unauthorized") is False
+
+    def test_ua_candidates_prefers_cache(self):
+        _kimi_code_ua_cache.clear()
+        url = "https://api.kimi.com/coding/v1/chat/completions"
+        _remember_kimi_code_user_agent(url, "Kilo-Code/1.0")
+        candidates = _kimi_code_ua_candidates(url)
+        assert candidates[0] == "Kilo-Code/1.0"
+        assert len(candidates) == len(KIMI_CODE_USER_AGENTS)
+        _kimi_code_ua_cache.clear()
+
+    def test_non_kimi_url_has_no_candidates(self):
+        assert _kimi_code_ua_candidates("https://api.openai.com/v1") == []
+
+    def test_base_key_normalizes_chat_url(self):
+        assert _kimi_code_base_key("https://api.kimi.com/coding/v1/chat/completions") == (
+            "https://api.kimi.com/coding/v1"
+        )
+
+    def test_post_retries_next_user_agent_on_403(self, monkeypatch):
+        _kimi_code_ua_cache.clear()
+        calls = []
+
+        class _Resp:
+            def __init__(self, status, text=""):
+                self.status_code = status
+                self.content = text.encode()
+                self.text = text
+
+        def fake_post(url, headers=None, **kwargs):
+            calls.append(headers.get("User-Agent"))
+            if headers.get("User-Agent") == KIMI_CODE_USER_AGENTS[0]:
+                return _Resp(403, '{"error":{"type":"access_terminated_error"}}')
+            return _Resp(200, "{}")
+
+        monkeypatch.setattr("src.llm_core.httpx.post", fake_post)
+        url = "https://api.kimi.com/coding/v1/chat/completions"
+        r = httpx_post_kimi_aware(url, {"Authorization": "Bearer x"}, json={})
+        assert r.status_code == 200
+        assert calls[0] == KIMI_CODE_USER_AGENTS[0]
+        assert calls[1] == KIMI_CODE_USER_AGENTS[1]
+        _kimi_code_ua_cache.clear()

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -184,6 +184,9 @@ class TestMatchProviderCurated:
     def test_ollama_url(self):
         assert _match_provider_curated("https://ollama.com/api", "openai") == "ollama"
 
+    def test_kimi_code_url(self):
+        assert _match_provider_curated("https://api.kimi.com/coding/v1", "openai") == "kimi-code"
+
     def test_no_url_match_returns_provider(self):
         assert _match_provider_curated("https://localhost:1234", "openai") == "openai"
 
@@ -209,6 +212,12 @@ class TestCurateModels:
         curated, extra = _curate_models(models, "unknown_provider")
         assert curated == models
         assert extra == []
+
+    def test_kimi_code_partitions(self):
+        models = ["kimi-for-coding", "other-model"]
+        curated, extra = _curate_models(models, "kimi-code")
+        assert "kimi-for-coding" in curated
+        assert "other-model" in extra
 
     def test_curated_sorted_by_priority(self):
         models = ["gpt-4o-mini", "gpt-4o", "o3"]

--- a/tests/test_providers_mixtral_logo_js.py
+++ b/tests/test_providers_mixtral_logo_js.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node not on PA
 
 def _has_logo(model):
     js = (
-        f"import {{ providerLogo }} from '{_HELPER.as_posix()}';"
+        "import { providerLogo } from './static/js/providers.js';"
         f"console.log(JSON.stringify(providerLogo({json.dumps(model)}) !== null));"
     )
     p = subprocess.run(["node", "--input-type=module"], input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30)
@@ -34,3 +34,29 @@ def test_mixtral_ministral_get_a_logo():
 
 def test_unknown_vendor_has_no_logo():
     assert _has_logo("totally-unknown-model-xyz") is False
+
+
+def test_deepseek_distill_does_not_get_qwen_logo():
+    deepseek = _has_logo("deepseek-ai/DeepSeek-R1-0528-Qwen3-8B")
+    qwen = _has_logo("Qwen/Qwen3-8B")
+    assert deepseek is True
+    assert qwen is True
+    js = (
+        "import { providerLogo } from './static/js/providers.js';"
+        "const ds = providerLogo('deepseek-ai/DeepSeek-R1-0528-Qwen3-8B');"
+        "const qw = providerLogo('Qwen/Qwen3-8B');"
+        "const nq = providerLogo('nvidia/Qwen3-8B-NVFP4');"
+        "console.log(JSON.stringify({"
+        "  same: ds === qw,"
+        "  nvidiaForkUsesQwen: nq === qw,"
+        "  ds: !!ds, qw: !!qw, nq: !!nq"
+        "}));"
+    )
+    p = subprocess.run(["node", "--input-type=module"], input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30)
+    assert p.returncode == 0, p.stderr
+    payload = json.loads(p.stdout.strip())
+    assert payload["ds"] is True
+    assert payload["qw"] is True
+    assert payload["nq"] is True
+    assert payload["same"] is False
+    assert payload["nvidiaForkUsesQwen"] is True


### PR DESCRIPTION
## Summary

Scoped contribution from personal fork after rebase onto `upstream/dev`. Adds hwfit search alias expansion, provider logo disambiguation, Kimi Code provider routing, chat slash/agent tool label polish, and modal toggle-close.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3118

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)
- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open Cookbook → Scan tab.
2. Search `qwen3-8b-instruct` — should find `Qwen/Qwen3-8B` without also surfacing DeepSeek-R1 distill forks.
3. Search `deepseek-r1-0528` — should find the canonical DeepSeek release only.
4. Scan a quant fork (e.g. `solidrust/gemma-2-9b-it-AWQ`) — provider logo should match the base model org (Google), not the quant publisher.
5. Add Kimi Code endpoint in Settings; verify chat/agent tool calls preserve `reasoning_content`.
6. In chat, type `/` to see `/docs` autocomplete, and verify agent tool labels render via `agentToolLabel()`.
7. Verify sidebar modal toggle closes on second click (`modalManager.js`).

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

**Cookbook Scan:** Provider logo disambiguation correctly identifies Google as the base organization for the `solidrust/gemma` quant fork.
<img width=1140 height=401 alt=image src=https://github.com/user-attachments/assets/4b6dcc08-56a2-4483-b0ea-6b066c62e40b />

**Chat:** Slash command autocomplete menu
<img width=907 height=739 alt=image src=https://github.com/user-attachments/assets/650eeb4e-7d07-496f-91e3-40ed6636d5f8 />