### PR TITLE
feat: disambiguate provider logos for quant forks

### DIFF
--- a/static/js/providers.js
+++ b/static/js/providers.js
@@ -89,11 +89,88 @@ const _PROVIDERS = [
     '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></svg>'],
 ];
 
+// HF org slug -> brand key used for logo lookup (checked before regex on full id).
+const _HF_ORG_BRAND = {
+  'deepseek-ai': 'deepseek',
+  'qwen': 'qwen',
+  'meta-llama': 'meta',
+  'google': 'google',
+  'mistralai': 'mistral',
+  'microsoft': 'microsoft',
+  'nvidia': 'nvidia',
+  'zhipuai': 'zhipu',
+  'moonshotai': 'kimi',
+  'nousresearch': 'nous',
+  'allenai': 'meta',
+};
+
+const _BRAND_PROBE = {
+  deepseek: 'deepseek-r1',
+  qwen: 'qwen3-8b',
+  meta: 'meta-llama',
+  google: 'gemma-2',
+  mistral: 'mixtral',
+  openai: 'gpt-4',
+  microsoft: 'phi-3',
+  nvidia: 'nvidia-nemotron',
+  zhipu: 'glm-4',
+  kimi: 'kimi-k2',
+  nous: 'nous-hermes',
+};
+
+const _BRAND_SVG = (() => {
+  const out = {};
+  for (const [brand, probe] of Object.entries(_BRAND_PROBE)) {
+    for (const [re, svg] of _PROVIDERS) {
+      if (re.test(probe)) {
+        out[brand] = svg;
+        break;
+      }
+    }
+  }
+  return out;
+})();
+
+function _logoForBrand(brand) {
+  return brand ? (_BRAND_SVG[brand] || null) : null;
+}
+
+function _brandFromShortName(short) {
+  if (!short) return null;
+  if (/^DeepSeek-/i.test(short)) return 'deepseek';
+  if (/^Qwen/i.test(short)) return 'qwen';
+  if (/^Llama-/i.test(short) || /^Meta-/i.test(short)) return 'meta';
+  if (/^gemma-/i.test(short)) return 'google';
+  if (/^Mistral|^Mixtral|^Ministral/i.test(short)) return 'mistral';
+  if (/^Phi-/i.test(short)) return 'microsoft';
+  if (/^glm-/i.test(short)) return 'zhipu';
+  if (/^kimi-/i.test(short)) return 'kimi';
+  if (/Nemotron/i.test(short)) return 'nvidia';
+  return null;
+}
+
 // Returns an SVG string for the given model ID, or null if no match
 export function providerLogo(modelId) {
   if (!modelId) return null;
+  const id = String(modelId);
+  const slash = id.indexOf('/');
+  const org = slash >= 0 ? id.slice(0, slash).toLowerCase() : '';
+  const short = slash >= 0 ? id.slice(slash + 1) : id;
+
+  // Quant/publisher forks (nvidia/Qwen3-8B-NVFP4) keep the base model family icon.
+  const familyBrand = _brandFromShortName(short);
+  if (familyBrand) {
+    const svg = _logoForBrand(familyBrand);
+    if (svg) return svg;
+  }
+
+  if (org && _HF_ORG_BRAND[org]) {
+    const svg = _logoForBrand(_HF_ORG_BRAND[org]);
+    if (svg) return svg;
+  }
+
   for (const [re, svg] of _PROVIDERS) {
-    if (re.test(modelId)) return svg;
+    if (re.test(id)) return svg;
   }
   return null;
 }
@@ -119,6 +196,7 @@ const _ENDPOINT_LABELS = [
   [/(^|\.)fireworks\.ai$/i, "Fireworks"],
   [/(^|\.)perplexity\.ai$/i, "Perplexity"],
   [/(^|\.)x\.ai$/i, "xAI"],
+  [/(^|\.)kimi\.com$/i, "Kimi Code"],
 ];
 
 /**

--- a/tests/test_providers_mixtral_logo_js.py
+++ b/tests/test_providers_mixtral_logo_js.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node not on PA
 
 def _has_logo(model):
     js = (
-        f"import {{ providerLogo }} from '{_HELPER.as_posix()}';"
+        "import { providerLogo } from './static/js/providers.js';"
         f"console.log(JSON.stringify(providerLogo({json.dumps(model)}) !== null));"
     )
     p = subprocess.run(["node", "--input-type=module"], input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30)
@@ -34,3 +34,29 @@ def test_mixtral_ministral_get_a_logo():
 
 def test_unknown_vendor_has_no_logo():
     assert _has_logo("totally-unknown-model-xyz") is False
+
+
+def test_deepseek_distill_does_not_get_qwen_logo():
+    deepseek = _has_logo("deepseek-ai/DeepSeek-R1-0528-Qwen3-8B")
+    qwen = _has_logo("Qwen/Qwen3-8B")
+    assert deepseek is True
+    assert qwen is True
+    js = (
+        "import { providerLogo } from './static/js/providers.js';"
+        "const ds = providerLogo('deepseek-ai/DeepSeek-R1-0528-Qwen3-8B');"
+        "const qw = providerLogo('Qwen/Qwen3-8B');"
+        "const nq = providerLogo('nvidia/Qwen3-8B-NVFP4');"
+        "console.log(JSON.stringify({"
+        "  same: ds === qw,"
+        "  nvidiaForkUsesQwen: nq === qw,"
+        "  ds: !!ds, qw: !!qw, nq: !!nq"
+        "}));"
+    )
+    p = subprocess.run(["node", "--input-type=module"], input=js, capture_output=True, text=True, cwd=str(_REPO), timeout=30)
+    assert p.returncode == 0, p.stderr
+    payload = json.loads(p.stdout.strip())
+    assert payload["ds"] is True
+    assert payload["qw"] is True
+    assert payload["nq"] is True
+    assert payload["same"] is False
+    assert payload["nvidiaForkUsesQwen"] is True


### PR DESCRIPTION
## Summary

Improves provider logo resolution in the UI so that quant forks (e.g. `solidrust/gemma`) display their base model organization's logo (Google) instead of showing a missing logo or the quant publisher's logo.

## Target branch

- [x] This PR targets **dev**, not main.

## Linked Issue

Related to #3098

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets dev
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (docker compose up or uvicorn app:app) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open Cookbook → Scan tab.
2. Scan a quant fork (e.g. `solidrust/gemma-2-9b-it-AWQ`).
3. Verify that the provider logo matches the base model organization (Google), not the quant publisher.
4. Run the test suite: `pytest tests/test_providers_mixtral_logo_js.py`

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: the change uses Odysseus's existing visual language.

### Screenshots / clips

**Cookbook Scan:** Provider logo disambiguation correctly identifies Google as the base organization for the `solidrust/gemma` quant fork.
<img width="1140" height="401" alt="image" src="https://github.com/user-attachments/assets/4b6dcc08-56a2-4483-b0ea-6b066c62e40b/">