### PR TITLE
feat(chat): promote /docs and /documents in slash autocomplete

### DIFF
--- a/static/js/slashAutocomplete.js
+++ b/static/js/slashAutocomplete.js
@@ -23,6 +23,13 @@ const PROMOTED_ALIASES = new Set([
   'memories','forget',
 ]);
 
+// Top-level command aliases that deserve their own row in the popup
+// (e.g. /docs → library, not buried as a secondary alias on /library).
+const PROMOTED_CMD_ALIASES = {
+  docs: 'library',
+  documents: 'library',
+};
+
 function _flatten() {
   const out = [];
   const seen = new Set();
@@ -58,7 +65,23 @@ function _flatten() {
     }
   }
 
-  // 2. Promoted legacy aliases (/new, /clear, /web …) as convenient short rows
+  // 2. Promoted top-level aliases (/docs, /documents …)
+  for (const [alias, parent] of Object.entries(PROMOTED_CMD_ALIASES)) {
+    const tok = `/${alias}`;
+    if (seen.has(tok)) continue;
+    const def = COMMANDS[parent];
+    if (!def?.handler || def.hidden) continue;
+    seen.add(tok);
+    out.push({
+      token: tok,
+      aliases: [],
+      category: def.category || '',
+      help: def.help || '',
+      usage: tok,
+    });
+  }
+
+  // 3. Promoted legacy aliases (/new, /clear, /web …) as convenient short rows
   if (LEGACY_ALIASES) {
     for (const [alias, { parent, sub }] of Object.entries(LEGACY_ALIASES)) {
       if (!PROMOTED_ALIASES.has(alias)) continue;


### PR DESCRIPTION
## Summary

Promotes `/docs` and `/documents` as first-class rows in the slash-command autocomplete menu, mapping to the library command instead of hiding them as secondary aliases on `/library`.

## Target branch

- [x] This PR targets **dev**, not main.

## Linked Issue

None

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets dev
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (docker compose up or uvicorn app:app) and verified the change works end-to-end.

## How to Test

1. In chat, type `/` and confirm `/docs` and `/documents` appear as their own autocomplete suggestions.
2. Select `/docs` and verify it runs the library command.

## Visual / UI changes

- [x] Screenshot or short clip attached below.
- [x] Style match: uses existing autocomplete popup styling.

### Screenshots / clips

**Chat:** Slash command autocomplete menu
<img width=907 height=739 alt=image src=https://github.com/user-attachments/assets/650eeb4e-7d07-496f-91e3-40ed6636d5f8/>