### PR TITLE
fix: quote kernels repair package spec

### DIFF
--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -406,7 +406,7 @@ export const ERROR_PATTERNS = [
       { label: 'Repair kernel package', action: () => {
         const _vp = (_envState.env === 'venv' && _envState.envPath)
           ? `${_envState.envPath.replace(/\/+$/, '')}/bin/python3` : 'python3';
-        _launchServeTask('repair-kernels', 'pip-update', `${_vp} -m pip install --user --break-system-packages kernels<0.15`);
+        _launchServeTask('repair-kernels', 'pip-update', `${_vp} -m pip install --user --break-system-packages "kernels<0.15"`);
       }},
       { label: 'Open Dependencies', action: () => _openCookbookDependencies('sglang') },
     ],

--- a/tests/test_cookbook_diagnosis_js.py
+++ b/tests/test_cookbook_diagnosis_js.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DIAGNOSIS_JS = ROOT / "static" / "js" / "cookbook-diagnosis.js"
+
+
+def test_repair_kernels_pip_spec_is_shell_quoted():
+    source = DIAGNOSIS_JS.read_text(encoding="utf-8")
+
+    assert '"kernels<0.15"' in source
+    assert " --break-system-packages kernels<0.15" not in source


### PR DESCRIPTION
## Summary

Fix the Cookbook diagnosis action for the vLLM/Transformers `kernels` mismatch so the generated repair command quotes the `kernels<0.15` package spec. Without quotes, the shell treats `<0.15` as input redirection and the repair task exits with `0.15: No such file or directory` before pip runs.

This keeps the existing repair intent unchanged and only makes the generated shell command valid.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #191

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Trigger a Cookbook serve failure matching `Either a revision or a version must be specified`, `transformers.integrations.hub_kernels`, or `kernels/layer`.
2. Click **Repair kernel package**.
3. Confirm the Running task command contains `"kernels<0.15"` and no longer exits with `0.15: No such file or directory` before pip starts.
4. Automated check: run `/private/tmp/mcp-use-python-content-venv/bin/python -m pytest tests/test_cookbook_diagnosis_js.py -q`.
5. Syntax check: run `node --check static/js/cookbook-diagnosis.js`.

## Local Checks

- `/private/tmp/mcp-use-python-content-venv/bin/python -m pytest tests/test_cookbook_diagnosis_js.py -q` — 1 passed.
- `python3 -m py_compile tests/test_cookbook_diagnosis_js.py` — passed.
- `node --check static/js/cookbook-diagnosis.js` — passed.
- `git diff --check` — passed.

Not run locally:

- `tests/test_cookbook_error_feedback.py`; the available local test environment fails during collection with `ModuleNotFoundError: No module named 'sqlalchemy.engine'; 'sqlalchemy' is not a package` before reaching these changes.
- Full app run; this is a narrowly scoped generated-command fix and I do not have the affected vLLM/kernels environment here.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual or rendering changes. This only changes the command launched by an existing diagnosis button and adds a regression test for the generated JS source.
