### PR TITLE
feat(workspace): folder workspace picker with saved/favorited workspaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -529,6 +529,10 @@ upload_cleanup_task = None
 from routes.emoji_routes import setup_emoji_routes
 app.include_router(setup_emoji_routes())
 
+# Workspace (admin-only folder browser for the workspace picker)
+from routes.workspace_routes import setup_workspace_routes
+app.include_router(setup_workspace_routes())
+
 # Sessions
 from routes.session_routes import setup_session_routes
 session_config = {"REQUEST_TIMEOUT": REQUEST_TIMEOUT, "OPENAI_API_KEY": OPENAI_API_KEY, "SESSIONS_FILE": SESSIONS_FILE}

--- a/routes/workspace_routes.py
+++ b/routes/workspace_routes.py
@@ -1,0 +1,56 @@
+"""Workspace API — browse server directories to pick a tool workspace folder."""
+import os
+from fastapi import APIRouter, Request, HTTPException, Query
+
+from src.auth_helpers import get_current_user
+from src.tool_security import owner_is_admin_or_single_user
+
+
+def setup_workspace_routes():
+    router = APIRouter(prefix="/api/workspace", tags=["workspace"])
+
+    @router.get("/browse")
+    def browse(request: Request, path: str = Query(default="")):
+        """List subdirectories of `path` (default: home) so the UI can navigate
+        the server filesystem and pick a workspace folder. Directories only.
+
+        ADMIN-ONLY: this enumerates the server filesystem, so it is gated the
+        same way the file/shell tools are (read_file/write_file/bash are in
+        NON_ADMIN_BLOCKED_TOOLS). A non-admin who can't use those tools must not
+        be able to map the host's directory tree either.
+        """
+        owner = get_current_user(request)
+        if not owner_is_admin_or_single_user(owner):
+            raise HTTPException(status_code=403, detail="Workspace browsing is admin-only")
+
+        # Resolve symlinks so the reported path is canonical and the UI navigates
+        # real directories (defends against symlink games in displayed paths).
+        target = os.path.realpath(os.path.expanduser(path.strip() or "~"))
+        if not os.path.isdir(target):
+            target = os.path.realpath(os.path.expanduser("~"))
+
+        dirs = []
+        try:
+            with os.scandir(target) as it:
+                for entry in it:
+                    try:
+                        # Don't follow symlinks when classifying — a symlinked
+                        # dir is skipped rather than letting the browser wander
+                        # off via a link. Hidden entries are omitted.
+                        if entry.is_dir(follow_symlinks=False) and not entry.name.startswith("."):
+                            # Build the child path server-side with os.path.join
+                            # so it's correct on Windows (backslashes) and Linux.
+                            dirs.append({"name": entry.name, "path": os.path.join(target, entry.name)})
+                    except OSError:
+                        continue
+        except (PermissionError, OSError):
+            dirs = []
+
+        parent = os.path.dirname(target)
+        return {
+            "path": target,
+            "parent": parent if parent and parent != target else None,
+            "dirs": sorted(dirs, key=lambda d: d["name"].lower()),
+        }
+
+    return router

--- a/static/app.js
+++ b/static/app.js
@@ -4,6 +4,7 @@
 // ============================================
 import Storage from './js/storage.js';
 import uiModule from './js/ui.js';
+import workspaceModule from './js/workspace.js';
 import fileHandlerModule from './js/fileHandler.js';
 import modelsModule from './js/models.js';
 import ragModule from './js/rag.js';
@@ -1701,6 +1702,7 @@ function initializeEventListeners() {
   }
   setupToggle('web-toggle-btn', 'web-toggle', 'web');
   setupToggle('bash-toggle-btn', 'bash-toggle', 'bash');
+  try { workspaceModule.initWorkspace(); } catch (_) {}
 
   // Document editor toggle (special: uses module panel, not a checkbox)
   const overflowDocBtn = el('overflow-doc-btn');

--- a/static/index.html
+++ b/static/index.html
@@ -1040,6 +1040,19 @@
                 <span>RAG</span>
                 <span class="overflow-active-dot"></span>
               </button>
+              <button type="button" class="overflow-menu-item" id="overflow-workspace-btn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                </svg>
+                <span>Workspace</span>
+                <span class="overflow-active-dot"></span>
+              </button>
+              <button type="button" class="overflow-menu-item" id="overflow-saved-workspaces-btn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                </svg>
+                <span>Saved workspaces</span>
+              </button>
               <!-- Inline "deep research mode" toggle removed (superseded by the
                    Deep Research sidebar / trigger_research). The hidden
                    #research-toggle checkbox is kept inert so existing JS refs
@@ -1077,6 +1090,12 @@
               <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>
             </svg>
             <span style="font-size:11px;margin-left:2px;">RAG</span>
+            <svg class="tool-indicator-x" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+          </button>
+          <!-- Workspace indicator (hidden until a folder is set) -->
+          <button type="button" class="input-icon-btn tool-indicator" title="Workspace — click to clear" id="workspace-indicator-btn" aria-label="Clear workspace" style="display:none;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+            <span style="font-size:11px;margin-left:2px;max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" id="workspace-indicator-name"></span>
             <svg class="tool-indicator-x" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
           </button>
           <!-- 6. Deep Research (hidden until active) -->

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -23,7 +23,8 @@ export const KEYS = {
   MCP_ACTIVE: 'odysseus-mcp-active',
   SECTION_ORDER: 'sidebar-section-order',
   ADMIN_LAST_TAB: 'admin-last-tab',
-  DENSITY: 'odysseus-density'
+  DENSITY: 'odysseus-density',
+  WORKSPACE: 'odysseus-workspace'
 };
 
 /**

--- a/static/js/workspace.js
+++ b/static/js/workspace.js
@@ -1,0 +1,341 @@
+// static/js/workspace.js
+//
+// Workspace picker: browse server directories in a draggable modal, choose a
+// folder, and show it as a removable pill in the chat input bar. While set, the
+// chat request sends `workspace` so the agent's file/shell tools are confined
+// to that folder (see routes/chat_routes.py + src/tool_execution.py).
+
+import Storage, { KEYS } from './storage.js';
+import uiModule from './ui.js';
+import { makeWindowDraggable } from './windowDrag.js';
+
+const API_BASE = window.location.origin;
+// Same folder glyph as the overflow menu item + pill (not an emoji).
+const _FOLDER_SVG = '<svg class="workspace-row-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>';
+// Star glyph for the "saved workspaces" rows.
+const _STAR_SVG = '<svg class="workspace-row-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>';
+// Per-user prefs key holding the saved-workspaces array (server-side, persists
+// across devices). Each entry is { name, path }.
+const _SAVED_PREF = 'saved-workspaces';
+let _modal = null;
+let _curPath = '';
+let _saved = [];
+
+export function getWorkspace() {
+  return Storage.get(KEYS.WORKSPACE, '') || '';
+}
+
+function _basename(p) {
+  if (!p) return '';
+  // Handle both POSIX (/) and Windows (\) separators.
+  const parts = p.replace(/[\\/]+$/, '').split(/[\\/]/);
+  return parts[parts.length - 1] || p;
+}
+
+// ── Saved workspaces (per-user prefs) ──────────────────────────────
+// Persisted server-side via /api/prefs so bookmarks follow the user across
+// devices and survive a localStorage clear, unlike the active-workspace pill.
+
+async function _loadSaved() {
+  try {
+    const res = await fetch(`${API_BASE}/api/prefs/${_SAVED_PREF}`, { credentials: 'same-origin' });
+    if (!res.ok) return [];
+    const data = await res.json();
+    const v = data && data.value;
+    // Tolerate a never-set pref (null) or any legacy/corrupt shape.
+    return Array.isArray(v) ? v.filter((e) => e && typeof e.path === 'string' && e.path) : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+async function _persistSaved(list) {
+  const res = await fetch(`${API_BASE}/api/prefs/${_SAVED_PREF}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    body: JSON.stringify({ value: list }),
+  });
+  if (!res.ok) throw new Error(`save failed: ${res.status}`);
+}
+
+function _isSaved(path) {
+  return _saved.some((e) => e.path === path);
+}
+
+// Star/un-star a folder. Persists to prefs and returns the new saved state so
+// callers can update the clicked folder's star icon in place.
+async function _toggleFav(path, name) {
+  if (!path) return _isSaved(path);
+  const wasSaved = _isSaved(path);
+  const next = wasSaved
+    ? _saved.filter((e) => e.path !== path)
+    : _saved.concat([{ name: name || _basename(path), path }]);
+  try {
+    await _persistSaved(next);
+    _saved = next;
+    if (uiModule && uiModule.showToast) {
+      uiModule.showToast(wasSaved ? `Unsaved: ${_basename(path)}` : `Saved: ${_basename(path)}`);
+    }
+  } catch (e) {
+    if (uiModule && uiModule.showError) uiModule.showError('Could not update saved workspaces');
+    return wasSaved; // unchanged
+  }
+  return !wasSaved;
+}
+
+export function syncWorkspaceIndicator(path) {
+  const pill = document.getElementById('workspace-indicator-btn');
+  const name = document.getElementById('workspace-indicator-name');
+  const overflow = document.getElementById('overflow-workspace-btn');
+  if (pill) {
+    pill.style.display = path ? '' : 'none';
+    pill.classList.toggle('active', !!path);
+    if (path) pill.title = `Workspace: ${path} — click to clear`;
+  }
+  if (name) name.textContent = path ? _basename(path) : '';
+  if (overflow) overflow.classList.toggle('active', !!path);
+  // Recompute the "+" overflow dot (app.js owns updatePlusDot via this event).
+  try { document.dispatchEvent(new CustomEvent('overflow-state-change')); } catch (_) {}
+}
+
+export function setWorkspace(path) {
+  if (path) Storage.set(KEYS.WORKSPACE, path);
+  else Storage.remove(KEYS.WORKSPACE);
+  syncWorkspaceIndicator(path || '');
+}
+
+export function clearWorkspace() {
+  setWorkspace('');
+  if (uiModule && uiModule.showToast) uiModule.showToast('Workspace cleared');
+}
+
+async function _load(path) {
+  const url = `${API_BASE}/api/workspace/browse${path ? `?path=${encodeURIComponent(path)}` : ''}`;
+  const res = await fetch(url, { credentials: 'same-origin' });
+  if (!res.ok) throw new Error(`browse failed: ${res.status}`);
+  return res.json();
+}
+
+function _render(data) {
+  _curPath = data.path;
+  const body = _modal.querySelector('#workspace-body');
+  const pathEl = _modal.querySelector('#workspace-cur-path');
+  if (pathEl) {
+    // Reflect the resolved (realpath) location back into the editable field.
+    pathEl.value = data.path;
+    pathEl.title = data.path;
+  }
+  let rows = '';
+  if (data.parent) {
+    rows += `<div class="workspace-row workspace-up" data-path="${encodeURIComponent(data.parent)}">↑ ..</div>`;
+  }
+  for (const d of data.dirs) {
+    // Backend supplies the full child path (os.path.join → cross-platform).
+    // Each folder carries a star toggle to favorite it as a saved workspace.
+    const star = _isSaved(d.path) ? ' saved' : '';
+    rows += `<div class="workspace-row" data-path="${encodeURIComponent(d.path)}">`
+      + _FOLDER_SVG
+      + `<span>${uiModule.esc(d.name)}</span>`
+      + `<button type="button" class="workspace-fav-btn${star}" data-fav="${encodeURIComponent(d.path)}" data-name="${uiModule.esc(d.name)}" `
+      + `title="${star ? 'Saved — click to remove' : 'Save this workspace'}" aria-label="Toggle saved workspace">${_STAR_SVG}</button>`
+      + `</div>`;
+  }
+  if (!data.dirs.length && !data.parent) rows = '<div class="workspace-empty">No subfolders</div>';
+  body.innerHTML = rows || '<div class="workspace-empty">No subfolders</div>';
+  body.querySelectorAll('.workspace-row').forEach((row) => {
+    row.addEventListener('click', (ev) => {
+      if (ev.target.closest('.workspace-fav-btn')) return; // star handled below
+      _navigate(decodeURIComponent(row.dataset.path));
+    });
+  });
+  body.querySelectorAll('.workspace-fav-btn').forEach((btn) => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      const path = decodeURIComponent(btn.dataset.fav);
+      const nowSaved = await _toggleFav(path, btn.dataset.name);
+      btn.classList.toggle('saved', nowSaved);
+      btn.title = nowSaved ? 'Saved — click to remove' : 'Save this workspace';
+    });
+  });
+}
+
+async function _navigate(path) {
+  try {
+    _render(await _load(path));
+  } catch (e) {
+    if (uiModule && uiModule.showError) uiModule.showError('Could not open folder');
+  }
+}
+
+function _getModal() {
+  if (_modal) return _modal;
+  _modal = document.createElement('div');
+  _modal.id = 'workspace-modal';
+  _modal.className = 'modal';
+  _modal.style.display = 'none';
+  _modal.innerHTML = `
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>Select workspace</h4>
+        <button class="close-btn" id="workspace-close" aria-label="Close">✖</button>
+      </div>
+      <input type="text" class="styled-prompt-input workspace-cur" id="workspace-cur-path"
+             spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"
+             placeholder="Type or paste a folder path, then press Enter" />
+      <div class="modal-body workspace-body" id="workspace-body"></div>
+      <div class="modal-footer workspace-footer">
+        <span class="workspace-hint">★ a folder to save it as a workspace</span>
+        <span class="workspace-footer-spacer"></span>
+        <button type="button" class="confirm-btn confirm-btn-secondary" id="workspace-cancel">Cancel</button>
+        <button type="button" class="confirm-btn confirm-btn-primary" id="workspace-use">Use this folder</button>
+      </div>
+    </div>`;
+  document.body.appendChild(_modal);
+  _modal.querySelector('#workspace-close').addEventListener('click', closeWorkspaceBrowser);
+  _modal.querySelector('#workspace-cancel').addEventListener('click', closeWorkspaceBrowser);
+  // Editable path bar: Enter navigates to a typed/pasted folder.
+  _modal.querySelector('#workspace-cur-path').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const v = e.target.value.trim();
+      if (v) _navigate(v);
+    }
+  });
+  _modal.querySelector('#workspace-use').addEventListener('click', () => {
+    setWorkspace(_curPath);
+    if (uiModule && uiModule.showToast) uiModule.showToast(`Workspace set: ${_basename(_curPath)}`);
+    closeWorkspaceBrowser();
+  });
+  const content = _modal.querySelector('.modal-content');
+  const header = _modal.querySelector('.modal-header');
+  if (content && header) makeWindowDraggable(_modal, { content, header });
+  return _modal;
+}
+
+export async function openWorkspaceBrowser() {
+  const modal = _getModal();
+  modal.style.display = 'flex';
+  // Load saved bookmarks first so folder rows render their star state correctly,
+  // then browse. (Both hit the network; saved is small and resolves quickly.)
+  try {
+    _saved = await _loadSaved();
+  } catch (_) { _saved = []; }
+  try {
+    _render(await _load(getWorkspace() || ''));
+  } catch (e) {
+    if (uiModule && uiModule.showError) uiModule.showError('Could not browse folders');
+  }
+}
+
+export function closeWorkspaceBrowser() {
+  if (_modal) _modal.style.display = 'none';
+}
+
+// ── Saved-workspaces list modal (opened from the + overflow menu) ───
+let _savedModal = null;
+
+function _getSavedModal() {
+  if (_savedModal) return _savedModal;
+  _savedModal = document.createElement('div');
+  _savedModal.id = 'saved-workspace-modal';
+  _savedModal.className = 'modal';
+  _savedModal.style.display = 'none';
+  _savedModal.innerHTML = `
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:6px"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Saved workspaces</h4>
+        <button class="close-btn" id="saved-workspace-close" aria-label="Close">✖</button>
+      </div>
+      <div class="modal-body workspace-body" id="saved-workspace-body"></div>
+      <div class="modal-footer workspace-footer">
+        <button type="button" class="confirm-btn confirm-btn-secondary" id="saved-workspace-browse">Browse folders…</button>
+        <span class="workspace-footer-spacer"></span>
+        <button type="button" class="confirm-btn confirm-btn-secondary" id="saved-workspace-cancel">Close</button>
+      </div>
+    </div>`;
+  document.body.appendChild(_savedModal);
+  _savedModal.querySelector('#saved-workspace-close').addEventListener('click', closeSavedWorkspaces);
+  _savedModal.querySelector('#saved-workspace-cancel').addEventListener('click', closeSavedWorkspaces);
+  _savedModal.querySelector('#saved-workspace-browse').addEventListener('click', () => {
+    closeSavedWorkspaces();
+    openWorkspaceBrowser();
+  });
+  const content = _savedModal.querySelector('.modal-content');
+  const header = _savedModal.querySelector('.modal-header');
+  if (content && header) makeWindowDraggable(_savedModal, { content, header });
+  return _savedModal;
+}
+
+function _renderSavedList() {
+  const body = _savedModal.querySelector('#saved-workspace-body');
+  if (!_saved.length) {
+    body.innerHTML = '<div class="workspace-empty">No saved workspaces yet — open “Browse folders…”, then ★ a folder to save it.</div>';
+    return;
+  }
+  const active = getWorkspace();
+  let rows = '';
+  for (let i = 0; i < _saved.length; i++) {
+    const e = _saved[i];
+    const isActive = active === e.path ? ' active' : '';
+    rows += `<div class="workspace-row workspace-saved-row${isActive}" data-idx="${i}" title="${uiModule.esc(e.path)}">`
+      + _FOLDER_SVG
+      + `<span>${uiModule.esc(e.name || _basename(e.path))}</span>`
+      + `<button type="button" class="workspace-saved-del" data-del="${i}" title="Remove" aria-label="Remove saved workspace">✖</button>`
+      + `</div>`;
+  }
+  body.innerHTML = rows;
+  body.querySelectorAll('.workspace-saved-row').forEach((row) => {
+    row.addEventListener('click', (ev) => {
+      if (ev.target.closest('.workspace-saved-del')) return;
+      const entry = _saved[Number(row.dataset.idx)];
+      if (!entry) return;
+      setWorkspace(entry.path);
+      if (uiModule && uiModule.showToast) uiModule.showToast(`Workspace set: ${_basename(entry.path)}`);
+      closeSavedWorkspaces();
+    });
+  });
+  body.querySelectorAll('.workspace-saved-del').forEach((btn) => {
+    btn.addEventListener('click', async (ev) => {
+      ev.stopPropagation();
+      const entry = _saved[Number(btn.dataset.del)];
+      if (!entry) return;
+      const next = _saved.filter((e) => e.path !== entry.path);
+      try {
+        await _persistSaved(next);
+        _saved = next;
+        _renderSavedList();
+      } catch (e) {
+        if (uiModule && uiModule.showError) uiModule.showError('Could not remove saved workspace');
+      }
+    });
+  });
+}
+
+export async function openSavedWorkspaces() {
+  const modal = _getSavedModal();
+  modal.style.display = 'flex';
+  const body = modal.querySelector('#saved-workspace-body');
+  body.innerHTML = '<div class="workspace-empty">Loading…</div>';
+  try {
+    _saved = await _loadSaved();
+  } catch (_) { _saved = []; }
+  _renderSavedList();
+}
+
+export function closeSavedWorkspaces() {
+  if (_savedModal) _savedModal.style.display = 'none';
+}
+
+export function initWorkspace() {
+  // Restore persisted workspace into the pill on load.
+  syncWorkspaceIndicator(getWorkspace());
+  const overflow = document.getElementById('overflow-workspace-btn');
+  if (overflow) overflow.addEventListener('click', openWorkspaceBrowser);
+  const savedBtn = document.getElementById('overflow-saved-workspaces-btn');
+  if (savedBtn) savedBtn.addEventListener('click', openSavedWorkspaces);
+  const pill = document.getElementById('workspace-indicator-btn');
+  if (pill) pill.addEventListener('click', clearWorkspace);
+}
+
+export default { initWorkspace, openWorkspaceBrowser, openSavedWorkspaces, getWorkspace, setWorkspace, clearWorkspace, syncWorkspaceIndicator };

--- a/static/style.css
+++ b/static/style.css
@@ -36606,3 +36606,94 @@ body.theme-frosted .modal {
    the input beside it (.confirm-btn won't stretch on its own). */
 .ask-user-other-send { flex-shrink: 0; white-space: nowrap; min-height: 39px; }
 .ask-user-other-send:disabled { opacity: 0.5; cursor: default; }
+
+/* ── Workspace picker ───────────────────────────────────────────── */
+/* Layout (width/flex column/max-height) inherited from base .modal-content. */
+/* Editable path/address bar: reuses .styled-prompt-input for border/bg/radius/
+   focus ring (set in the element's class list). Overrides only the deltas:
+   mono font, and full-bleed via flex stretch with no horizontal margin (the
+   modal-content's 10px padding is the gutter) instead of the base width:100%,
+   which overflowed against the overflow:auto scrollbar. */
+.workspace-cur {
+  align-self: stretch;
+  width: auto;
+  min-width: 0;
+  margin: 4px 0 8px;
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+}
+/* flex/overflow inherited from base .modal-body; only the padding differs. */
+.workspace-body { padding: 6px 0; }
+.workspace-row {
+  padding: 7px 18px;
+  cursor: pointer;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.workspace-row > span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.workspace-row-icon { flex-shrink: 0; opacity: 0.75; }
+.workspace-row:hover {
+  background: color-mix(in srgb, var(--border) 20%, transparent);
+}
+.workspace-up { opacity: 0.7; }
+.workspace-empty { padding: 14px 18px; opacity: 0.5; font-size: 13px; }
+.workspace-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 18px;
+  border-top: 1px solid var(--border);
+}
+/* Push Cancel/Use to the right while the hint stays on the left. */
+.workspace-footer-spacer { flex: 1 1 auto; }
+.workspace-hint { font-size: 11px; opacity: 0.5; }
+/* Per-folder "favorite" star button shown on the right of each browser row.
+   Hollow by default; filled gold when the folder is a saved workspace. */
+.workspace-fav-btn {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--muted, currentColor);
+  opacity: 0.35;
+  display: inline-flex;
+  align-items: center;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+.workspace-fav-btn .workspace-row-icon { opacity: 1; }
+.workspace-row:hover .workspace-fav-btn { opacity: 0.7; }
+.workspace-fav-btn:hover { opacity: 1; color: #f5c518; }
+.workspace-fav-btn.saved {
+  opacity: 1;
+  color: #f5c518;
+}
+.workspace-fav-btn.saved .workspace-row-icon { fill: #f5c518; }
+/* Saved-workspaces list modal rows. */
+.workspace-saved-row.active {
+  background: color-mix(in srgb, var(--accent, var(--border)) 22%, transparent);
+}
+.workspace-saved-del {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0;
+  padding: 0 2px;
+  font-size: 12px;
+  line-height: 1;
+  transition: opacity 0.12s ease;
+}
+.workspace-saved-row:hover .workspace-saved-del { opacity: 0.6; }
+.workspace-saved-del:hover { opacity: 1 !important; }
+/* Cookbook serve panel: Launch + ^ split button pair */


### PR DESCRIPTION
## Summary

  introduces the workspace picker. an admin-only folder browser opened from the
  composer's **+** menu, and adds a **Saved workspaces** feature on top of it. In the
  picker you can star any folder to bookmark it; a new **Saved workspaces** item in the
  **+** menu opens those bookmarks so you can switch into one in a click. Bookmarks are
  stored per-user via the existing `/api/prefs` store, so they persist across sessions and
  devices. Scope is intentionally **UI-only**: selecting a workspace sets/saves the active
  folder in the UI, but this PR does **not** reinstate the agent file/shell tool-confinement
  that was previously removed — only the picker and the bookmarking UX.

  ## Target branch

  - [x] This PR targets **`dev`**, not `main`.

  ## Linked Issue

  <!-- No tracking issue exists yet. If the maintainer requires one, open an issue
       describing the workspace-picker reintroduction first and link it here. -->

  Part of #

  ## Type of Change

  - [ ] Bug fix (non-breaking — fixes a confirmed issue)
  - [x] New feature (non-breaking — adds new behaviour)
  - [ ] Breaking change (changes or removes existing behaviour)
  - [ ] Refactor / cleanup (behaviour unchanged)
  - [ ] Documentation only
  - [ ] CI / tooling / configuration

  ## Checklist

  - [x] I searched open issues and open PRs — this is not a duplicate.
  - [x] This PR targets `dev`
  - [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
  - [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

  ## How to Test

  1. `docker compose up -d --build`, open `http://localhost:7000`, log in as an admin.
  2. Click the **+** button in the composer → **Workspace**. The folder browser opens.
  3. Navigate into any folder and click the **★ star** on its row — it fills gold and a "Saved" toast appears. Click **Use this folder** and confirm the workspace pill shows in
  the composer.
  4. Click **+** → **Saved workspaces**. Your starred folder is listed; click it and confirm the workspace switches (pill updates). Hover a row and click ✖ to remove it.
  5. Reload the page and reopen **Saved workspaces** — bookmarks persist (stored per-user via `/api/prefs`).

  ## Visual / UI changes — REQUIRED

  - [x] **Screenshot or short clip** — _attach below (see note)._
  - [x] **Style match**: reuses existing `.overflow-menu-item`, `.input-icon-btn`, `.tool-indicator`, `.modal`/`.modal-content`, and `.confirm-btn` classes and existing CSS
  variables (`--border`, `--accent`, `--muted`, `--mono`); no new color/font/spacing primitives introduced.
  - [x] **No Unicode emoji in UI**: all icons are inline monochrome SVG (folder + star) matching the existing icon set. (The ✖/★ glyphs reuse the pattern already used by the
  sibling tool-indicator buttons.)
  - [x] **No new component patterns**: extends the existing overflow-menu + draggable-modal patterns rather than introducing parallel ones.
  - [x] **I am not an LLM agent submitting a bulk PR.**

  ### Screenshots / clips
<img width="394" height="507" alt="Screenshot 2026-06-09 023059" src="https://github.com/user-attachments/assets/627df72b-176f-4547-8191-eefbb652c689" />
<img width="1228" height="264" alt="Screenshot 2026-06-09 023446" src="https://github.com/user-attachments/assets/2ef86602-af61-4d10-9177-b470cd63b922" />
