### PR TITLE
fix(auth): case-insensitive skill owner match on rename

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -391,7 +391,8 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
             skills_root = Path(SKILLS_DIR)
             if skills_root.is_dir():
                 _owner_re = re.compile(
-                    r'(?m)^(owner:\s*)' + re.escape(old_username) + r'\s*$'
+                    r'(?m)^(owner:\s*)' + re.escape(old_username) + r'\s*$',
+                    re.IGNORECASE,
                 )
                 for p in skills_root.rglob("SKILL.md"):
                     try:
@@ -406,12 +407,12 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
                     try:
                         usage = json.loads(usage_path.read_text(encoding="utf-8"))
                         if isinstance(usage, dict):
-                            prefix = old_username + "::"
                             new_usage = {}
                             changed = False
                             for k, v in usage.items():
-                                if k.startswith(prefix):
-                                    new_usage[new_username + "::" + k[len(prefix):]] = v
+                                owner_part, sep, skill_part = k.partition("::")
+                                if sep and owner_part.lower() == old_username:
+                                    new_usage[new_username + "::" + skill_part] = v
                                     changed = True
                                 else:
                                     new_usage[k] = v

--- a/tests/test_rename_user_owner_sync.py
+++ b/tests/test_rename_user_owner_sync.py
@@ -333,6 +333,37 @@ def test_rename_no_skills_dir_does_not_crash(rename_endpoint):
     assert res["ok"] is True
 
 
+def test_rename_skill_md_owner_case_insensitive(rename_endpoint):
+    """SKILL.md written with owner: Alice (mixed case) must be updated when
+    renaming alice — the regex was missing re.IGNORECASE."""
+    endpoint, _am, tmp_path = rename_endpoint
+
+    skill_dir = tmp_path / "skills" / "general" / "s"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(_SKILL_MD.format(owner="Alice"), encoding="utf-8")
+
+    asyncio.run(endpoint("alice", SimpleNamespace(username="alice2"), _request(tmp_path)))
+
+    assert "owner: alice2" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_rename_usage_keys_case_insensitive(rename_endpoint):
+    """_usage.json keys stored as Alice::skill-name must be migrated when
+    renaming alice — the old startswith check was not lowercasing."""
+    endpoint, _am, tmp_path = rename_endpoint
+
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir(parents=True)
+    usage = {"Alice::my-skill": {"uses": 5, "last_used": 999}}
+    (skills_root / "_usage.json").write_text(json.dumps(usage), encoding="utf-8")
+
+    asyncio.run(endpoint("alice", SimpleNamespace(username="alice2"), _request(tmp_path)))
+
+    updated = json.loads((skills_root / "_usage.json").read_text(encoding="utf-8"))
+    assert "alice2::my-skill" in updated
+    assert "Alice::my-skill" not in updated
+
+
 # ---------------------------------------------------------------------------
 # 5. P1 regression: rejected auth rename must not mutate file-backed stores
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The skill owner rename block added in #3397 used a case-sensitive regex and a case-sensitive `startswith` check against `old_username` (which is already lowercased). A SKILL.md written with `owner: Alice` was silently skipped when renaming `alice`, and `_usage.json` keys like `Alice::skill-name` were left unmigrated. Every other store in the same route (deep_research, memory.json) already does a `.lower()` comparison — skills slipped through.

Fix: add `re.IGNORECASE` to the frontmatter regex; switch the usage-key loop to `k.partition(::)` with `owner_part.lower() == old_username`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click Edit on this PR and change the base.

## Linked Issue

Fixes #3611

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Create a skill as user `Alice` so SKILL.md frontmatter has `owner: Alice`
2. Add `Alice::that-skill` entry to `data/skills/_usage.json`
3. Admin renames `alice` to `alice2`
4. Before: SKILL.md still says `owner: Alice`, usage key unchanged
5. After: SKILL.md updated to `owner: alice2`, usage key becomes `alice2::that-skill`

Or run the two new regression tests:
```
pytest tests/test_rename_user_owner_sync.py::test_rename_skill_md_owner_case_insensitive tests/test_rename_user_owner_sync.py::test_rename_usage_keys_case_insensitive -v
```