### PR TITLE
fix(sessions): use owner_filter for list_sessions queries when auth disabled

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -11,7 +11,7 @@ from core.session_manager import SessionManager
 from core.models import ChatMessage
 from src.request_models import SessionResponse
 from core.database import Session as DbSession, SessionLocal, Document, GalleryImage, utcnow_naive
-from src.auth_helpers import get_current_user, effective_user, _auth_disabled
+from src.auth_helpers import get_current_user, effective_user, _auth_disabled, owner_filter
 from src.session_actions import is_session_recently_active
 
 
@@ -258,7 +258,9 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             last_msg_map = {}
             mode_map = {}
             msg_count_map = {}
-            rows = db.query(DbSession.id, DbSession.folder, DbSession.total_input_tokens, DbSession.total_output_tokens, DbSession.is_important, DbSession.created_at, DbSession.updated_at, DbSession.last_message_at, DbSession.mode, DbSession.message_count).filter(DbSession.archived == False, DbSession.owner == user).all()
+            q = db.query(DbSession.id, DbSession.folder, DbSession.total_input_tokens, DbSession.total_output_tokens, DbSession.is_important, DbSession.created_at, DbSession.updated_at, DbSession.last_message_at, DbSession.mode, DbSession.message_count).filter(DbSession.archived == False)
+            q = owner_filter(q, DbSession, user)
+            rows = q.all()
             for row in rows:
                 folder_map[row.id] = row.folder
                 token_map[row.id] = (row.total_input_tokens or 0) + (row.total_output_tokens or 0)
@@ -277,17 +279,19 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
             # Sessions with active documents that have content
             from sqlalchemy import func
             doc_session_ids = set(
-                r[0] for r in db.query(Document.session_id)
-                .filter(Document.is_active == True,
-                        Document.current_content != None,
-                        func.trim(Document.current_content) != "",
-                        Document.owner == user)
+                r[0] for r in owner_filter(
+                    db.query(Document.session_id)
+                    .filter(Document.is_active == True,
+                            Document.current_content != None,
+                            func.trim(Document.current_content) != ""),
+                    Document, user)
                 .distinct().all()
             )
             img_session_ids = set(
-                r[0] for r in db.query(GalleryImage.session_id)
-                .filter(GalleryImage.session_id != None,
-                        GalleryImage.owner == user)
+                r[0] for r in owner_filter(
+                    db.query(GalleryImage.session_id)
+                    .filter(GalleryImage.session_id != None),
+                    GalleryImage, user)
                 .distinct().all()
             )
         finally:


### PR DESCRIPTION
## Summary

`list_sessions` builds three enrichment queries with direct `Column == user` comparisons. When `AUTH_ENABLED=false`, `effective_user()` returns `None`, which SQLAlchemy translates to `WHERE owner IS NULL` — returning only rows with a null owner. Sessions that carry an explicit owner (created while auth was enabled) go completely invisible. Same flaw on the `Document` and `GalleryImage` sub-queries, hiding the active-document badge and gallery badge counts.

The codebase already has `owner_filter(query, model_cls, user)` in `src.auth_helpers` for exactly this case — it is a no-op when `user` is falsy, so all rows come through in single-user mode. Replaced all three direct comparisons with `owner_filter()`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3620

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run with `AUTH_ENABLED=true`, create a few sessions as any user (they get an explicit owner stored in the DB).
2. Stop the server, set `AUTH_ENABLED=false`, restart.
3. `GET /api/sessions` — before this fix: empty list; after: all sessions returned.
4. Open the chat sidebar — sessions are visible again.
5. To verify the badge fixes: create a session with an uploaded document and a gallery image while auth is enabled, then disable auth and confirm the active-document badge and gallery badge counts appear correctly on the sidebar.