### PR TITLE
fix(cookbook): use COOKBOOK_STATE_FILE constant for state path

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request, Depends
 
 from src.auth_helpers import require_user
+from src.constants import COOKBOOK_STATE_FILE
 from pydantic import BaseModel
 
 from core.middleware import require_admin
@@ -54,7 +55,7 @@ _HF_TOKEN_STATUS_SNIPPET = (
 
 def setup_cookbook_routes() -> APIRouter:
     router = APIRouter(tags=["cookbook"])
-    _cookbook_state_path = Path(os.environ.get("DATA_DIR", "data")) / "cookbook_state.json"
+    _cookbook_state_path = Path(COOKBOOK_STATE_FILE)
 
     def _mask_secret(value: str) -> str:
         if not value:


### PR DESCRIPTION
## Summary

`cookbook_routes.py` derived its state file path as `Path(os.environ.get("DATA_DIR", "data")) / "cookbook_state.json"`. The application's env var is `ODYSSEUS_DATA_DIR`, not `DATA_DIR` — and `ODYSSEUS_DATA_DIR` is read exactly once, in `src/constants.py`, which already exports `COOKBOOK_STATE_FILE`. When `ODYSSEUS_DATA_DIR` is set (Docker, custom installs), the old code never saw it: `DATA_DIR` was almost certainly unset, so the path fell back to `data/cookbook_state.json` relative to CWD while every other persistent file resolved under the custom data directory. Cookbook state was silently read from and written to the wrong location.

Fixed by importing and using `COOKBOOK_STATE_FILE` from `src.constants`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3621

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Set `ODYSSEUS_DATA_DIR=/tmp/ody-data` and start the server.
2. Open the Cookbook tab, configure an HF token or toggle any cookbook state, save.
3. Before fix: `ls data/cookbook_state.json` — file appears in CWD `data/`; `ls /tmp/ody-data/cookbook_state.json` — missing.
4. After fix: `ls /tmp/ody-data/cookbook_state.json` — file is in the correct data directory.
5. Restart with `ODYSSEUS_DATA_DIR` still set — cookbook state is restored correctly from the right path.