### PR TITLE
fix(contacts): tolerate non-string body in /api/contacts/import

### DIFF
--- a/routes/contacts_routes.py
+++ b/routes/contacts_routes.py
@@ -729,8 +729,11 @@ def setup_contacts_routes():
     @router.post("/import")
     async def import_vcf(data: dict, _admin: str = Depends(require_admin)):
         """Import contacts from .vcf or CSV. Body: {"vcf": "..."} or {"csv": "..."}."""
-        text = data.get("vcf") or data.get("text") or ""
-        csv_text = data.get("csv") or ""
+        # Coerce defensively: a non-string vcf/text/csv (e.g. a number or list
+        # in the JSON body) would otherwise reach .strip() and 500 with an
+        # AttributeError instead of degrading to a clean "no data" response.
+        text = str(data.get("vcf") or data.get("text") or "")
+        csv_text = str(data.get("csv") or "")
         if text.strip():
             if "BEGIN:VCARD" not in text.upper():
                 return {"success": False, "error": "No vCard data found"}

--- a/tests/test_contacts_import_nonstring.py
+++ b/tests/test_contacts_import_nonstring.py
@@ -1,0 +1,39 @@
+"""POST /api/contacts/import must not 500 on a non-string vcf/text/csv value.
+
+`text = data.get("vcf") or ... or ""` left a non-string value (e.g. a number)
+in place, so the next `text.strip()` raised AttributeError -> HTTP 500. The
+handler now coerces with str() and degrades to a structured "no data" response.
+"""
+import asyncio
+
+from routes.contacts_routes import setup_contacts_routes
+
+
+def _import_handler():
+    router = setup_contacts_routes()
+    for route in router.routes:
+        if getattr(route, "path", "").endswith("/import") and "POST" in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError("import route not found")
+
+
+def _call(data):
+    handler = _import_handler()
+    return asyncio.run(handler(data=data, _admin="admin"))
+
+
+def test_non_string_vcf_degrades_cleanly():
+    resp = _call({"vcf": 123})
+    assert resp["success"] is False
+    assert "error" in resp
+
+
+def test_non_string_csv_degrades_cleanly():
+    resp = _call({"csv": ["a", "b"]})
+    assert resp["success"] is False
+
+
+def test_empty_body_reports_no_data():
+    resp = _call({})
+    assert resp["success"] is False
+    assert resp["error"] == "No contact data found"


### PR DESCRIPTION
## Summary

`import_vcf` built `text = data.get("vcf") or data.get("text") or ""`, so a non-string JSON value (a number, list, etc.) stayed in place and the next `text.strip()` raised AttributeError, returning HTTP 500. This coerces `vcf`/`text`/`csv` with `str()` so non-string input degrades to the existing structured "no data" response.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3633

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

```python
text = str(data.get("vcf") or data.get("text") or "")
csv_text = str(data.get("csv") or "")
```

Matches the file's existing `str()` convention for request fields.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) and this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace churn.

## How to Test

```
python -m pytest tests/test_contacts_import_nonstring.py -q   # 3 passed
python -m py_compile routes/contacts_routes.py               # ok
```

Tests: non-string `vcf`, non-string `csv`, and empty body all return a structured response instead of raising.

## Visual / UI changes

None, backend route only.
