### PR TITLE
fix(hwfit): tolerate non-numeric gpu_count in /api/hwfit/models

### DIFF
--- a/routes/hwfit_routes.py
+++ b/routes/hwfit_routes.py
@@ -177,8 +177,14 @@ def setup_hwfit_routes():
             system["gpu_name"] = g["name"]
             system["active_group"] = {**g, "use_count": n}
 
-        if gpu_count != "":
-            n = int(gpu_count)
+        # Parse the optional count defensively (matches the gpu_group guard
+        # above): a non-numeric query param previously raised ValueError ->
+        # HTTP 500. A malformed value is ignored, same as omitting it.
+        try:
+            n = int(gpu_count) if gpu_count != "" else None
+        except ValueError:
+            n = None
+        if n is not None:
             if n == 0:
                 # RAM-only mode: rank against system memory, offload allowed.
                 system["has_gpu"] = False

--- a/tests/test_hwfit_gpu_count_nonnumeric.py
+++ b/tests/test_hwfit_gpu_count_nonnumeric.py
@@ -1,0 +1,28 @@
+"""GET /api/hwfit/models must not 500 on a non-numeric gpu_count.
+
+The handler did `n = int(gpu_count)` with no guard, so `?gpu_count=abc` (or any
+non-integer) raised ValueError -> HTTP 500. A malformed count is now ignored,
+matching how the neighbouring gpu_group param is already parsed.
+"""
+from routes.hwfit_routes import setup_hwfit_routes
+
+
+def _get_models():
+    router = setup_hwfit_routes()
+    for route in router.routes:
+        if getattr(route, "path", "").endswith("/models") and "GET" in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError("hwfit /models route not found")
+
+
+def test_non_numeric_gpu_count_does_not_raise():
+    handler = _get_models()
+    # Previously raised ValueError (HTTP 500); now degrades to a normal ranking.
+    result = handler(gpu_count="abc")
+    assert isinstance(result, dict)
+
+
+def test_numeric_gpu_count_still_accepted():
+    handler = _get_models()
+    result = handler(gpu_count="0")
+    assert isinstance(result, dict)

--- a/tests/test_hwfit_gpu_count_nonnumeric.py
+++ b/tests/test_hwfit_gpu_count_nonnumeric.py
@@ -26,3 +26,13 @@ def test_numeric_gpu_count_still_accepted():
     handler = _get_models()
     result = handler(gpu_count="0")
     assert isinstance(result, dict)
+
+
+def test_non_numeric_manual_gpu_count_does_not_raise():
+    # manual_gpu_count is the other count param on this endpoint (the hardware
+    # simulator in _apply_manual_hardware). A non-numeric value must also degrade
+    # (default to 1) rather than 500, so the endpoint's count parsing is fully
+    # covered.
+    handler = _get_models()
+    result = handler(manual_mode="gpu", manual_gpu_count="abc")
+    assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

`GET /api/hwfit/models` did `n = int(gpu_count)` with no guard, so a non-numeric query param like `?gpu_count=abc` raised ValueError and returned HTTP 500. This parses it defensively, mirroring the `gpu_group` guard a few lines above: a malformed value is ignored, exactly like omitting the param.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3634

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

```python
try:
    n = int(gpu_count) if gpu_count != "" else None
except ValueError:
    n = None
if n is not None:
    ...   # existing 0 / grp / uniform-split branches, unchanged
elif grp:
    ...   # existing "no explicit count" branch
```

A malformed count now falls through to the existing "no explicit count" path.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) and this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace churn.

## How to Test

```
python -m pytest tests/test_hwfit_gpu_count_nonnumeric.py -q   # 2 passed
python -m py_compile routes/hwfit_routes.py                    # ok
```

Tests: a non-numeric `gpu_count` returns a ranking instead of raising; a numeric value is still accepted. Verified it raises ValueError against current `dev`.

## Visual / UI changes

None, backend only.
