### PR TITLE
fix(cookbook): restore Serve panel model interaction

### DIFF
--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -16,6 +16,7 @@ let _sshCmd;
 let _getPort;
 let _sshPrefix;
 let _getPlatform;
+let _serverByVal;
 let _isWindows;
 let _isMetal;
 let _buildEnvPrefix;
@@ -2307,6 +2308,7 @@ export function initServe(shared) {
   _getPort = shared._getPort;
   _sshPrefix = shared._sshPrefix;
   _getPlatform = shared._getPlatform;
+  _serverByVal = shared._serverByVal;
   _isWindows = shared._isWindows;
   _isMetal = shared._isMetal;
   _buildEnvPrefix = shared._buildEnvPrefix;

--- a/tests/test_cookbook_same_host_server_profiles_js.py
+++ b/tests/test_cookbook_same_host_server_profiles_js.py
@@ -40,6 +40,8 @@ def test_cookbook_submodules_resolve_visible_profile_selection():
     assert "_serverByVal?.(val)" in SERVE
     assert "_serverByVal?.(_es.remoteServerKey || _es.remoteHost || '')" in SERVE
     assert "_serverByVal?.(_envState.remoteServerKey || _probeHost)" in SERVE
+    assert "let _serverByVal;" in SERVE
+    assert "_serverByVal = shared._serverByVal;" in SERVE
 
 
 def test_running_tab_resolves_profile_key_not_first_host():


### PR DESCRIPTION
## Summary

Restores the Cookbook Serve tab model-card action by wiring the Serve module to the shared server-profile resolver it already uses. Without that injected helper, clicking a cached model or choosing Serve from the model action menu could throw before the serve configuration panel rendered.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3594  

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open Odysseus, go to Cookbook, then open the Serve tab.
2. Click a cached ready model card and confirm the serve configuration panel opens.
3. Open the model’s three-dot action menu, click Serve, and confirm the same serve configuration panel opens.
4. There should be no ReferenceError: _serverByVal is not defined error. 

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [ ] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Attach a screenshot or short clip showing the Serve tab after clicking a cached model card, with the serve configuration panel open.

## Notes

Added a test, so this would not be overridden by accident