### PR TITLE
fix(llm): remove max_output_tokens from ChatGPT Subscription payload

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -563,8 +563,9 @@ def _build_chatgpt_responses_payload(
     }
     if not _restricts_temperature(model):
         payload["temperature"] = temperature
-    if max_tokens and max_tokens > 0:
-        payload["max_output_tokens"] = max_tokens
+    # ChatGPT Subscription Codex API does not support max_output_tokens —
+    # passing it returns HTTP 400 "Unsupported parameter: max_output_tokens".
+    # Do not include it in the payload.
     return payload
 
 

--- a/tests/test_llm_core_temperature.py
+++ b/tests/test_llm_core_temperature.py
@@ -75,7 +75,10 @@ def test_normal_model_payload_keeps_temperature_above_one(monkeypatch):
     assert payload["temperature"] == 1.2
 
 
-def test_chatgpt_subscription_payload_uses_max_output_tokens():
+def test_chatgpt_subscription_payload_omits_max_output_tokens():
+    # ChatGPT Subscription Codex API does not support max_output_tokens —
+    # passing it returns HTTP 400 "Unsupported parameter: max_output_tokens".
+    # The payload should NOT include max_output_tokens regardless of max_tokens.
     payload = llm_core._build_chatgpt_responses_payload(
         "gpt-5.1-codex",
         [{"role": "user", "content": "Say OK"}],
@@ -83,10 +86,10 @@ def test_chatgpt_subscription_payload_uses_max_output_tokens():
         max_tokens=37,
     )
 
-    assert payload["max_output_tokens"] == 37
+    assert "max_output_tokens" not in payload
 
 
-def test_chatgpt_subscription_payload_omits_empty_max_output_tokens():
+def test_chatgpt_subscription_payload_omits_max_output_tokens_when_zero():
     payload = llm_core._build_chatgpt_responses_payload(
         "gpt-5.1-codex",
         [{"role": "user", "content": "Say OK"}],


### PR DESCRIPTION
## Summary

`_build_chatgpt_responses_payload()` was unconditionally adding `max_output_tokens` to every request sent to the ChatGPT Codex API. That API rejects the parameter with HTTP 400 "Unsupported parameter: max_output_tokens", which caused the Deep Research endpoint probe to fail immediately — blocking the entire research workflow for any ChatGPT Subscription model. The fix removes the two lines that conditionally set `payload["max_output_tokens"]`; the parameter is simply never sent and the API applies its own default limit.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3650

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Add a ChatGPT Subscription endpoint in Settings and select a `gpt-5.x-codex` model.
2. Open Deep Research and start a research task with that model.
3. **Before fix:** the probe returns HTTP 400 "Unsupported parameter: max_output_tokens" and research never starts.
4. **After fix:** the probe succeeds and research proceeds normally.
5. Run `pytest tests/test_llm_core_temperature.py` — all 26 tests pass, including the two renamed tests that now assert `max_output_tokens` is absent from the payload.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI changes — this fix is backend-only (`src/llm_core.py` and `tests/test_llm_core_temperature.py`).

Previous: 
<img width="1476" height="1428" alt="image" src="https://github.com/user-attachments/assets/30c8fd26-173a-41b5-a59f-888bd2615233" />

After: 
<img width="1322" height="986" alt="image" src="https://github.com/user-attachments/assets/115ea04e-00ad-4cf1-a82c-bc94d32ffcf8" />

