### PR TITLE
fix(macos): start ChromaDB in start-macos.sh so tool calling works

### DIFF
--- a/start-macos.sh
+++ b/start-macos.sh
@@ -188,20 +188,26 @@ fi
 # the tool index never initializes and tool/MCP calling silently degrades.
 # Skip if one is already reachable, or if CHROMADB_HOST points at a remote host.
 CHROMA_PID=""
-CHROMA_HOST="${CHROMADB_HOST:-localhost}"
+CHROMA_HOST="${CHROMADB_HOST:-localhost}"   # what the app connects to
 CHROMA_PORT="${CHROMADB_PORT:-8100}"
-CHROMA_PROBE_HOST="$CHROMA_HOST"
-[ "$CHROMA_PROBE_HOST" = "0.0.0.0" ] && CHROMA_PROBE_HOST="127.0.0.1"
+# Bind + probe on IPv4 loopback. The app connects to "localhost", which Python
+# resolves to 127.0.0.1; binding chroma to the literal "localhost" can land on
+# IPv6 ::1 instead, leaving the app unable to reach it. Pin both to 127.0.0.1.
 CHROMA_BIN="$(dirname "$VENV_PY")/chroma"
-if (exec 3<>"/dev/tcp/$CHROMA_PROBE_HOST/$CHROMA_PORT") 2>/dev/null; then
-    echo "▶ ChromaDB already running on $CHROMA_HOST:$CHROMA_PORT - using it."
-elif [ "$CHROMA_HOST" != "localhost" ] && [ "$CHROMA_HOST" != "127.0.0.1" ]; then
+case "$CHROMA_HOST" in
+    localhost|127.0.0.1) CHROMA_BIND="127.0.0.1" ;;
+    0.0.0.0)             CHROMA_BIND="0.0.0.0" ;;
+    *)                   CHROMA_BIND="" ;;   # remote host - don't start locally
+esac
+if (exec 3<>"/dev/tcp/127.0.0.1/$CHROMA_PORT") 2>/dev/null; then
+    echo "▶ ChromaDB already running on 127.0.0.1:$CHROMA_PORT - using it."
+elif [ -z "$CHROMA_BIND" ]; then
     echo "▶ CHROMADB_HOST=$CHROMA_HOST is remote - not starting a local ChromaDB."
 elif [ -x "$CHROMA_BIN" ]; then
     CHROMA_LOG="${TMPDIR:-/tmp}/odysseus-chromadb.log"
-    echo "▶ Starting ChromaDB in the background on $CHROMA_HOST:$CHROMA_PORT…"
+    echo "▶ Starting ChromaDB in the background on $CHROMA_BIND:$CHROMA_PORT…"
     echo "  logging to $CHROMA_LOG"
-    nohup "$CHROMA_BIN" run --host "$CHROMA_HOST" --port "$CHROMA_PORT" --path "$PWD/data/chroma" >"$CHROMA_LOG" 2>&1 &
+    nohup "$CHROMA_BIN" run --host "$CHROMA_BIND" --port "$CHROMA_PORT" --path "$PWD/data/chroma" >"$CHROMA_LOG" 2>&1 &
     CHROMA_PID=$!
 else
     echo "▶ ChromaDB CLI not found in venv; skipping (tool index will be degraded)."

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -182,6 +182,31 @@ else
     echo "▶ Non-ARM macOS detected; skipping Apfel server bootstrap."
 fi
 
+# ChromaDB bootstrap (#3297). The tool index + vector RAG need ChromaDB
+# (default localhost:8100). The macOS native path intentionally avoids Docker,
+# and chromadb ships in the venv, so start a local server ourselves -- otherwise
+# the tool index never initializes and tool/MCP calling silently degrades.
+# Skip if one is already reachable, or if CHROMADB_HOST points at a remote host.
+CHROMA_PID=""
+CHROMA_HOST="${CHROMADB_HOST:-localhost}"
+CHROMA_PORT="${CHROMADB_PORT:-8100}"
+CHROMA_PROBE_HOST="$CHROMA_HOST"
+[ "$CHROMA_PROBE_HOST" = "0.0.0.0" ] && CHROMA_PROBE_HOST="127.0.0.1"
+CHROMA_BIN="$(dirname "$VENV_PY")/chroma"
+if (exec 3<>"/dev/tcp/$CHROMA_PROBE_HOST/$CHROMA_PORT") 2>/dev/null; then
+    echo "▶ ChromaDB already running on $CHROMA_HOST:$CHROMA_PORT - using it."
+elif [ "$CHROMA_HOST" != "localhost" ] && [ "$CHROMA_HOST" != "127.0.0.1" ]; then
+    echo "▶ CHROMADB_HOST=$CHROMA_HOST is remote - not starting a local ChromaDB."
+elif [ -x "$CHROMA_BIN" ]; then
+    CHROMA_LOG="${TMPDIR:-/tmp}/odysseus-chromadb.log"
+    echo "▶ Starting ChromaDB in the background on $CHROMA_HOST:$CHROMA_PORT…"
+    echo "  logging to $CHROMA_LOG"
+    nohup "$CHROMA_BIN" run --host "$CHROMA_HOST" --port "$CHROMA_PORT" --path "$PWD/data/chroma" >"$CHROMA_LOG" 2>&1 &
+    CHROMA_PID=$!
+else
+    echo "▶ ChromaDB CLI not found in venv; skipping (tool index will be degraded)."
+fi
+
 # 5. Launch. Bind to loopback by default; opt into LAN/Tailscale with
 #    ODYSSEUS_HOST=0.0.0.0.
 URL_HOST="$HOST"
@@ -224,7 +249,7 @@ fi
 # Setup is done — drop the setup-failure handler, and clean up the background
 # opener when the server exits or the user presses Ctrl+C.
 trap - ERR
-trap '[ -n "$POLLER_PID" ] && kill "$POLLER_PID" 2>/dev/null; [ -n "$APFEL_PID" ] && kill "$APFEL_PID" 2>/dev/null' EXIT INT TERM
+trap '[ -n "$POLLER_PID" ] && kill "$POLLER_PID" 2>/dev/null; [ -n "$APFEL_PID" ] && kill "$APFEL_PID" 2>/dev/null; [ -n "$CHROMA_PID" ] && kill "$CHROMA_PID" 2>/dev/null' EXIT INT TERM
 
 echo
 echo "▶ Starting Odysseus — it will open in your browser at $URL"

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -182,17 +182,15 @@ else
     echo "▶ Non-ARM macOS detected; skipping Apfel server bootstrap."
 fi
 
-# ChromaDB bootstrap (#3297). The tool index + vector RAG need ChromaDB
-# (default localhost:8100). The macOS native path intentionally avoids Docker,
-# and chromadb ships in the venv, so start a local server ourselves -- otherwise
-# the tool index never initializes and tool/MCP calling silently degrades.
-# Skip if one is already reachable, or if CHROMADB_HOST points at a remote host.
+# ChromaDB backs the tool index and vector RAG. chromadb ships in the venv, so
+# start a local server before launching. Skip when one is already reachable, or
+# when CHROMADB_HOST points at a remote host.
 CHROMA_PID=""
 CHROMA_HOST="${CHROMADB_HOST:-localhost}"   # what the app connects to
 CHROMA_PORT="${CHROMADB_PORT:-8100}"
-# Bind + probe on IPv4 loopback. The app connects to "localhost", which Python
-# resolves to 127.0.0.1; binding chroma to the literal "localhost" can land on
-# IPv6 ::1 instead, leaving the app unable to reach it. Pin both to 127.0.0.1.
+# Bind + probe on IPv4 loopback: the app's "localhost" resolves to 127.0.0.1,
+# but binding chroma to the literal "localhost" can land on IPv6 ::1, which the
+# app can't then reach. Pin both to 127.0.0.1.
 CHROMA_BIN="$(dirname "$VENV_PY")/chroma"
 case "$CHROMA_HOST" in
     localhost|127.0.0.1) CHROMA_BIND="127.0.0.1" ;;


### PR DESCRIPTION
## Summary

`start-macos.sh` provisions the venv and launches uvicorn but never starts ChromaDB. On native macOS installs (which intentionally avoid Docker), the tool index then fails to initialize and MCP/tool injection silently degrades - the agent reports its tools as unavailable. This starts a local ChromaDB from the venv before launching the app, mirroring the script's existing Apfel background-service pattern (background + PID + exit-trap cleanup).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3297

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate (the open issue is #3297; it has no linked PR).
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above - one file, `start-macos.sh`.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. On macOS (no Docker), ensure nothing is serving on ChromaDB's port (default 8100).
2. Run `./start-macos.sh`.
3. **Before this change:** logs show `ChromaDB is not reachable at localhost:8100` and `ToolIndex init failed (will retry ...)`; the agent has no file/MCP tools.
4. **After:** the script prints `Starting ChromaDB in the background on 127.0.0.1:8100`; app logs show `ChromaDB connected` and `Indexed N built-in tools`; tool/MCP calling works.
5. **Idempotent:** if a ChromaDB is already reachable on 8100 (e.g. a Docker one), the script prints `already running - using it` and does not start a second.
6. **Remote:** with `CHROMADB_HOST` set to a non-local host, the script prints `is remote - not starting a local ChromaDB`.
7. **Cleanup:** Ctrl+C stops the app and the spawned ChromaDB (exit/INT/TERM trap).

Checks run: `bash -n start-macos.sh` (clean); spawned `./venv/bin/chroma run --host 127.0.0.1 --port 8100 --path data/chroma` and confirmed `GET /api/v2/heartbeat` returns 200; confirmed the app's tool index initialized against it (`Indexed 67 built-in tools`).

## Visual / UI changes

N/A - shell launcher script only; no UI, CSS, HTML, SVG, or rendering changes.