### PR TITLE
fix(tools): use _INTERNAL_BASE in serve-session endpoint registration

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -2684,7 +2684,7 @@ async def _ensure_served_endpoint(
     try:
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
-                f"{_COOKBOOK_BASE}/api/model-endpoints",
+                f"{_INTERNAL_BASE}/api/model-endpoints",
                 data=payload,
                 headers=_internal_headers(),
             )


### PR DESCRIPTION
## Summary

`src/tool_implementations.py:2687` referenced `_COOKBOOK_BASE`, which #3322 (`76c1f42`) renamed to `_INTERNAL_BASE`. A later Cookbook commit (`fa8c93e`) reintroduced one call site with the old name, so `_ensure_served_endpoint` — the helper that registers a model endpoint for a running serve session — raised `NameError` on every call. The surrounding `try` swallows it, so endpoint registration silently never happens. This PR is the one-line rename to the current helper-derived base.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3669

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end (steps below).

## How to Test

1. On `dev`, start the app: `uvicorn app:app --port 7311`
2. Call the helper directly so it exercises the fixed line:
   ```bash
   APP_PORT=7311 python - <<'PY'
   import asyncio
   from src.tool_implementations import _ensure_served_endpoint
   print(asyncio.run(_ensure_served_endpoint(
       model="test/dummy", cmd="llama-server --port 9999", host=None)))
   PY
   ```
3. **Before this fix** the result is `{'added': False, ..., 'error': "name '_COOKBOOK_BASE' is not defined"}` — the NameError, caught and surfaced as the error string.
4. **With this fix** the POST goes through to the live app's `/api/model-endpoints` and you get a real HTTP response instead (an auth rejection when run outside the app process, or a registered endpoint when called from the agent in-process).
5. Static check: `pyflakes src/tool_implementations.py` no longer reports `undefined name '_COOKBOOK_BASE'`. Related suite: `pytest -k 'tool_implementation or cookbook or serve'` — 201 passed.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend-only one-line fix, nothing renders.
