### PR TITLE
fix(calanders): Removed/merged duplicate calender delete endpoints

### DIFF
--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -851,27 +851,26 @@ def setup_calendar_routes() -> APIRouter:
         from src.caldav_sync import sync_caldav
         return await sync_caldav(owner)
 
+
     @router.delete("/calendars/{cal_id}")
-    async def delete_calendar(cal_id: str, request: Request):
+    async def delete_calendar(request: Request, cal_id: str):
         owner = _require_user(request)
         db = SessionLocal()
         try:
-            cal = db.query(CalendarCal).filter(
-                CalendarCal.id == cal_id,
-                CalendarCal.owner == owner,
-            ).first()
-            if not cal:
-                raise HTTPException(404, "Calendar not found")
+            cal = _get_or_404_calendar(db, cal_id, owner)
+            db.query(CalendarEvent).filter(CalendarEvent.calendar_id == cal_id).delete()
             db.delete(cal)
             db.commit()
             return {"ok": True}
         except HTTPException:
             raise
         except Exception as e:
+            db.rollback()
             logger.error("Failed to delete calendar %s: %s", cal_id, e)
             raise HTTPException(500, "Failed to delete calendar")
         finally:
             db.close()
+
 
     @router.get("/calendars")
     async def list_calendars(request: Request):
@@ -1152,23 +1151,6 @@ def setup_calendar_routes() -> APIRouter:
         finally:
             db.close()
 
-    @router.delete("/calendars/{cal_id}")
-    async def delete_calendar(request: Request, cal_id: str):
-        owner = _require_user(request)
-        db = SessionLocal()
-        try:
-            cal = _get_or_404_calendar(db, cal_id, owner)
-            db.query(CalendarEvent).filter(CalendarEvent.calendar_id == cal_id).delete()
-            db.delete(cal)
-            db.commit()
-            return {"ok": True}
-        except HTTPException:
-            raise
-        except Exception as e:
-            db.rollback()
-            return {"error": str(e)}
-        finally:
-            db.close()
 
     # Hard cap on ICS upload (ICS_MAX_BYTES, default 10 MB). Loading the whole
     # file into memory is unavoidable with python-icalendar, so an unbounded

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -863,7 +863,7 @@ def setup_calendar_routes() -> APIRouter:
             db.commit()
             return {"ok": True}
         except HTTPException:
-            raise HTTPException(404, "Calendar not found")
+            raise
         except Exception as e:
             db.rollback()
             logger.error("Failed to delete calendar %s: %s", cal_id, e)

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -863,7 +863,7 @@ def setup_calendar_routes() -> APIRouter:
             db.commit()
             return {"ok": True}
         except HTTPException:
-            raise
+            raise HTTPException(404, "Calendar not found")
         except Exception as e:
             db.rollback()
             logger.error("Failed to delete calendar %s: %s", cal_id, e)


### PR DESCRIPTION
## Summary

@RaresEduard-Tudor reported there were 2 functions performing the same thing, I merged the two functions, kept the original logic of deleting the calender form the second, and the logging from the first.

## Target branch

- [X] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #

#3672

## Type of Change

- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->
1. launch the app
2. open calenders
3. add calender if not present already
4. delete calender

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI was touched.

### Screenshots / clips

No UI was touched.
