### PR TITLE
fix(agent): nudge intent-without-action stalls in non-English conversations

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -2063,13 +2063,54 @@ async def stream_agent_loop(
     # no tool_calls. The intent is sincere but the function call gets dropped.
     # Match the common phrasings + an action verb that maps to an available
     # tool, so we don't nudge on harmless transitional text like "let me
-    # know what you think".
+    # know what you think". The model mirrors the user's language (#3668),
+    # so the same announce-then-stall shape is matched for Swedish /
+    # Norwegian / Danish, German (verb-final: a bounded object gap before
+    # the infinitive), Spanish, and French as well — otherwise non-English
+    # conversations stall silently instead of getting the nudge.
     _INTENT_RE = re.compile(
-        r"(?:^|\n)\s*(?:let me|i'?ll|i will|going to|let's)\s+"
-        r"(?:tail|check|investigate|look at|see|tail|read|fetch|inspect|"
+        r"(?:^|\n)\s*"
+        r"(?:"
+        # English: intent prefix + action verb
+        r"(?:let me|i'?ll|i will|going to|let's)\s+"
+        r"(?:tail|check|investigate|look at|see|read|fetch|inspect|"
         r"verify|diagnose|examine|debug|capture|grab|pull|view|run|call|"
         r"trigger|launch|start|kick off|stop|kill|restart|adopt|serve|"
-        r"register|adopt|list|search|find|query|hit|ping|test)"
+        r"register|list|search|find|query|hit|ping|test)"
+        r"|"
+        # Swedish / Norwegian / Danish: prefix + optional adverb + verb
+        r"(?:låt (?:mig|oss)|jag ska|jag kommer att|jag tänker|nu ska (?:jag|vi)|"
+        r"la (?:meg|oss)|jeg skal|jeg kommer til å|nå skal (?:jeg|vi)|"
+        r"lad (?:mig|os)|jeg vil|nu vil (?:jeg|vi))\s+"
+        r"(?:nu\s+|nå\s+|først\s+|snabbt\s+|raskt\s+|lige\s+|bare\s+)?"
+        r"(?:kolla|kontrollera|undersöka?|titta|läsa|hämta|inspektera|"
+        r"verifiera|diagnostisera|granska|felsöka?|köra?|anropa|starta(?: om)?|"
+        r"stoppa|lista|söka?|hitta|testa|pinga?|"
+        r"sjekke|tjekke|kontrollere|undersøke|undersøge|se på|lese|læse|hente|"
+        r"inspisere|verifisere|diagnostisere|granske|feilsøke|fejlsøge|"
+        r"kjøre|køre|kalle|kalde|starte(?: om)?|genstarte|stoppe|liste|"
+        r"søke|søge|finne|finde|teste|pinge)"
+        r"|"
+        # German: prefix + bounded object gap + infinitive (verb-final)
+        r"(?:lass(?:t)? (?:mich|uns)|ich werde|jetzt werde ich)\s+"
+        r"(?:[^.\n]{0,80}?\s+)?"
+        r"(?:prüfen|überprüfen|untersuchen|ansehen|anschauen|lesen|holen|"
+        r"abrufen|inspizieren|verifizieren|diagnostizieren|debuggen|checken|"
+        r"ausführen|aufrufen|starten|neu starten|neustarten|stoppen|"
+        r"auflisten|suchen|finden|testen|pingen)"
+        r"|"
+        # Spanish: prefix + action verb
+        r"(?:déjame|dejame|déjenme|dejenme|voy a|vamos a)\s+"
+        r"(?:revisar|comprobar|verificar|investigar|mirar|leer|buscar|obtener|"
+        r"inspeccionar|diagnosticar|depurar|examinar|ejecutar|correr|lanzar|"
+        r"iniciar|reiniciar|detener|parar|listar|encontrar|consultar|probar)"
+        r"|"
+        # French: prefix + action verb
+        r"(?:laisse[- ]moi|laissez[- ]moi|je vais|on va)\s+"
+        r"(?:vérifier|examiner|enquêter|regarder|lire|récupérer|chercher|"
+        r"inspecter|valider|diagnostiquer|déboguer|exécuter|lancer|démarrer|"
+        r"redémarrer|arrêter|lister|trouver|tester|interroger|consulter)"
+        r")"
         r"\b[^.\n]{0,140}",
         re.IGNORECASE,
     )

--- a/tests/test_intent_nudge_non_english.py
+++ b/tests/test_intent_nudge_non_english.py
@@ -1,0 +1,186 @@
+"""Issue #3668 — the intent-without-action supervisor (`_INTENT_RE` in
+src/agent_loop.py) only recognizes English intent phrasings ("let me …",
+"I'll …"). When the agent converses in another language, the model announces
+its next action in that language (e.g. Swedish "Låt mig kolla loggarna"),
+emits no tool call, the regex doesn't match, and the loop exits via the
+"no tools — done" path: the agent stalls silently mid-task instead of getting
+the "you said you would X — call the actual tool now" nudge.
+
+These tests drive the real `stream_agent_loop` with a fake LLM stream (same
+harness shape as tests/test_fenced_example_not_executed_for_native_models.py).
+The observable contract: a short announce-only round must trigger the nudge,
+which forces a second LLM round. Without the nudge the loop breaks after one
+round. We assert on the number of LLM rounds and on the `agent_step` event the
+nudge emits.
+
+The non-English cases fail against current dev and pass with the fix; the
+English and guard cases pin existing behavior so the fix cannot regress it.
+"""
+import asyncio
+import json
+
+import src.agent_loop as al
+
+
+def _collect(gen):
+    async def _run():
+        return [c async for c in gen]
+    return asyncio.run(_run())
+
+
+def _events(chunks):
+    out = []
+    for c in chunks:
+        if c.startswith("data: ") and not c.startswith("data: [DONE]"):
+            try:
+                out.append(json.loads(c[6:]))
+            except Exception:
+                pass
+    return out
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(al, "get_setting", lambda key, default=None: default, raising=False)
+    monkeypatch.setattr(al, "get_mcp_manager", lambda: None, raising=False)
+    monkeypatch.setattr(al, "estimate_tokens", lambda *a, **k: 10, raising=False)
+
+    async def _fake_exec(block, *a, **k):
+        return ("bash", {"output": "ok", "exit_code": 0})
+    monkeypatch.setattr(al, "execute_tool_block", _fake_exec, raising=False)
+
+
+def _run_announce_only_round(monkeypatch, announce_text, user_text):
+    """Round 1 streams `announce_text` with no tool calls; any later round
+    answers plainly. Returns (number of LLM rounds, parsed SSE events)."""
+    call_count = {"n": 0}
+
+    async def _fake_stream(_candidates, messages, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            yield f'data: {json.dumps({"delta": announce_text})}\n\n'
+        else:
+            yield f'data: {json.dumps({"delta": "All done, here is your answer."})}\n\n'
+        yield "data: [DONE]\n\n"
+
+    monkeypatch.setattr(al, "stream_llm_with_fallback", _fake_stream, raising=False)
+
+    gen = al.stream_agent_loop(
+        "https://api.openai.com/v1", "gpt-4o",
+        [{"role": "user", "content": user_text}],
+        max_rounds=4,
+        relevant_tools={"bash"},
+    )
+    events = _events(_collect(gen))
+    return call_count["n"], events
+
+
+# ---------------------------------------------------------------------------
+# Existing behavior pin: English announce-only round gets the nudge.
+# ---------------------------------------------------------------------------
+def test_english_announce_only_round_is_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, events = _run_announce_only_round(
+        monkeypatch,
+        "Let me check the logs to see the error.",
+        "The build fails, please investigate.",
+    )
+    assert rounds == 2, "English intent phrase must trigger the nudge and a second round"
+    assert any(e.get("type") == "agent_step" for e in events), events
+
+
+# ---------------------------------------------------------------------------
+# Issue #3668 repro: the same announce-only stall in other languages must be
+# nudged too. Each of these fails on current dev (loop ends after 1 round).
+# ---------------------------------------------------------------------------
+def test_swedish_announce_only_round_is_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, events = _run_announce_only_round(
+        monkeypatch,
+        "Låt mig kolla loggarna för att se felet.",
+        "Bygget misslyckas, kan du undersöka?",
+    )
+    assert rounds == 2, "Swedish intent phrase must trigger the nudge and a second round"
+    assert any(e.get("type") == "agent_step" for e in events), events
+
+
+def test_norwegian_announce_only_round_is_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, events = _run_announce_only_round(
+        monkeypatch,
+        "La meg sjekke loggene for å se feilen.",
+        "Bygget feiler, kan du undersøke?",
+    )
+    assert rounds == 2, "Norwegian intent phrase must trigger the nudge and a second round"
+    assert any(e.get("type") == "agent_step" for e in events), events
+
+
+def test_german_announce_only_round_is_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, events = _run_announce_only_round(
+        monkeypatch,
+        "Lass mich die Logs prüfen, um den Fehler zu sehen.",
+        "Der Build schlägt fehl, bitte untersuchen.",
+    )
+    assert rounds == 2, "German intent phrase must trigger the nudge and a second round"
+    assert any(e.get("type") == "agent_step" for e in events), events
+
+
+def test_spanish_announce_only_round_is_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, events = _run_announce_only_round(
+        monkeypatch,
+        "Déjame revisar los registros para ver el error.",
+        "La compilación falla, por favor investiga.",
+    )
+    assert rounds == 2, "Spanish intent phrase must trigger the nudge and a second round"
+    assert any(e.get("type") == "agent_step" for e in events), events
+
+
+def test_french_announce_only_round_is_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, events = _run_announce_only_round(
+        monkeypatch,
+        "Laisse-moi vérifier les journaux pour voir l'erreur.",
+        "La compilation échoue, peux-tu enquêter ?",
+    )
+    assert rounds == 2, "French intent phrase must trigger the nudge and a second round"
+    assert any(e.get("type") == "agent_step" for e in events), events
+
+
+# ---------------------------------------------------------------------------
+# Guards: harmless phrasings must NOT be nudged — neither the English
+# "let me know" escape nor its non-English equivalents, nor long answers.
+# ---------------------------------------------------------------------------
+def test_let_me_know_is_not_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, _ = _run_announce_only_round(
+        monkeypatch,
+        "That's everything.\nLet me know what you think.",
+        "Thanks for the help.",
+    )
+    assert rounds == 1, "'let me know' must not trigger the nudge"
+
+
+def test_swedish_let_me_know_equivalent_is_not_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    rounds, _ = _run_announce_only_round(
+        monkeypatch,
+        "Det var allt.\nLåt mig veta vad du tycker.",
+        "Tack för hjälpen.",
+    )
+    assert rounds == 1, "Swedish 'låt mig veta' must not trigger the nudge"
+
+
+def test_long_answer_containing_intent_phrase_is_not_nudged(monkeypatch):
+    _patch_common(monkeypatch)
+    long_answer = (
+        "Låt mig kolla loggarna är vad jag normalt skulle säga, men här är "
+        "istället en full genomgång av felet och hur du löser det själv. "
+        + "Detaljer. " * 60
+    )
+    rounds, _ = _run_announce_only_round(
+        monkeypatch,
+        long_answer,
+        "Bygget misslyckas, kan du undersöka?",
+    )
+    assert rounds == 1, "long answers (>=400 chars) must never be nudged"


### PR DESCRIPTION
## Summary

The intent-without-action supervisor in `stream_agent_loop` (`_INTENT_RE`, src/agent_loop.py) only matched English intent phrasings ("let me …", "i'll …", "going to …") and English action verbs. Models mirror the user's language, so when a non-English conversation hits the announce-then-stall pattern (e.g. Swedish "Låt mig kolla loggarna", Norwegian "La meg sjekke loggene") with no tool call, `_looks_like_promise` never fires and the loop exits through the no-tools break: the agent stalls silently mid-task and only resumes on the next user message. This PR extends `_INTENT_RE` with the same announce shape for Swedish, Norwegian, Danish, German, Spanish, and French, leaving every existing gate unchanged (line-start anchor, <400 chars, no code fence, `_MAX_INTENT_NUDGES` cap, `guide_only`).

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3668

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

`_INTENT_RE` keeps the original prefix + action-verb shape per language group:

- Swedish / Norwegian / Danish: `låt mig|jag ska|la meg|jeg skal|lad mig|…` + optional adverb (`nu|nå|først|…`) + verb (`kolla|sjekke|tjekke|undersöka|…`). "Låt mig veta" / "la meg vite" (let me know) stay unmatched because `veta`/`vite` are not in the verb lists.
- German is verb-final ("lass mich die Logs **prüfen**"), so its branch allows a bounded object gap before the infinitive: `(?:lass(?:t)? (?:mich|uns)|ich werde|…)\s+(?:[^.\n]{0,80}?\s+)?(?:prüfen|untersuchen|…)`.
- Spanish (`déjame|voy a|…`) and French (`laisse-moi|je vais|…`) follow the English adjacent-verb shape.

Worst case on a false match is one polite system nudge and one extra round, capped at `_MAX_INTENT_NUDGES = 2`.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Note on the last box: I rebuilt and ran the app (`docker compose up -d --build`) with this change and exercised agent mode in Norwegian end-to-end against a local Ollama endpoint (tool call executed, turn completed normally). A genuine model announce-stall can't be forced on demand in a live session, so the nudge behavior itself is verified by the regression tests below, which drive the real `stream_agent_loop`.

## How to Test

```
python -m pytest tests/test_intent_nudge_non_english.py -q   # 9 passed
python -m pytest tests/test_agent_loop.py tests/test_fenced_example_not_executed_for_native_models.py tests/test_agent_rounds_exhausted.py -q   # 67 passed
python -m py_compile src/agent_loop.py                       # ok
```

The new tests drive the real `stream_agent_loop` with a fake LLM stream (same harness shape as tests/test_fenced_example_not_executed_for_native_models.py). An announce-only round in Swedish/Norwegian/German/Spanish/French must trigger the nudge and a second LLM round; "let me know" (and Swedish "låt mig veta") and long answers must not. The five non-English cases fail on current `dev` without the src/agent_loop.py change and pass with it; the English case pins existing behavior.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend agent-loop logic and tests only. No CSS, HTML, SVG, or `static/js/` files changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no visual styling changes.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

This is a single-purpose, AI-assisted fix following the issue-first flow: root cause and deterministic repro were confirmed and posted on #3668 before opening this PR.

### Screenshots / clips

N/A — no visual rendering changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
