### PR TITLE
style(theme): add catpuccin themes

### DIFF
--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -35,6 +35,15 @@ export const THEMES = {
   catppuccin_mocha:      { bg:'#1e1e2e', fg:'#cdd6f4', panel:'#181825', border:'#6c7086', red:'#f38ba8' },
 };
 
+const THEME_DISPLAY_NAME_MAP = {
+  dark: 'original',
+  gpt: 'GPT',
+  catppuccin_latte: 'catppuccin latte',
+  catppuccin_frappe: 'catppuccin frappe',
+  catppuccin_macchiato: 'catppuccin macchiato',
+  catppuccin_mocha: 'catppuccin mocha',
+};
+
 const DEFAULT_THEME = 'dark';
 const LS_KEY = 'odysseus-theme';
 const CUSTOM_THEMES_KEY = 'odysseus-custom-themes';
@@ -642,7 +651,7 @@ export function initThemeUI() {
         <span style="background:${c.fg}"></span>
         <span style="background:${c.red}"></span>
       </div>
-      ${name === 'dark' ? 'original' : (name === 'gpt' ? 'GPT' : name)}
+      ${THEME_DISPLAY_NAME_MAP.hasOwnProperty(name) ? THEME_DISPLAY_NAME_MAP[name] : name}
     </div>
   `).join('');
 

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -29,6 +29,10 @@ export const THEMES = {
                             inputBg: '#2f2f2f' } },
   claude:     { bg:'#262624', fg:'#f5f4f0', panel:'#30302e', border:'#4a4a47', red:'#c6613f' },
   cute:       { bg:'#fff0f5', fg:'#d4608a', panel:'#fff8fa', border:'#f0c0d0', red:'#ff6b9d' },
+  catppuccin_latte:      { bg:'#eff1f5', fg:'#4c4f69', panel:'#e6e9ef', border:'#9ca0b0', red:'#d20f39' },
+  catppuccin_frappe:     { bg:'#303446', fg:'#c6d0f5', panel:'#292c3c', border:'#737994', red:'#e78284' },
+  catppuccin_macchiato:  { bg:'#24273a', fg:'#cad3f5', panel:'#1e2030', border:'#6e738d', red:'#ed8796' },
+  catppuccin_mocha:      { bg:'#1e1e2e', fg:'#cdd6f4', panel:'#181825', border:'#6c7086', red:'#f38ba8' },
 };
 
 const DEFAULT_THEME = 'dark';
@@ -58,6 +62,10 @@ const THEME_DEFAULT_PATTERN = {
   organs:     'rain',
   ume:        'petals',
   cute:       'sparkles',
+  catppuccin_latte:     'petals',
+  catppuccin_frappe:    'constellations',
+  catppuccin_macchiato: 'embers',
+  catppuccin_mocha:     'embers',
 };
 
 // Default effect colors for specific themes (overrides --fg)
@@ -66,6 +74,10 @@ const THEME_DEFAULT_EFFECT_COLOR = {
   organs:     '#451616',
   cute:       '#ff8cb8',
   ume:        '#f5a0c0',
+  catppuccin_latte:     '#fe640b',
+  catppuccin_frappe:    '#ef9f76',
+  catppuccin_macchiato: '#f5a97f',
+  catppuccin_mocha:     '#fab387',
 };
 
 // Default effect intensity (0..1) per theme. Any theme not listed defaults to 1.


### PR DESCRIPTION
## Summary

<!-- One paragraph: what changed and why. "Fixed bug" and "Added feature" are not summaries. -->
This PR adds four new default themes, based on the catppuccin color palettes.
As the catppuccin themes are usually named in the format "catppuccin <palette name>" the code to use a custom string, instead of the javascript property name, as the display name had to be reworked slightly.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->
Fixes: #3692

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
  - very minimal
- [ ] Documentation only
- [ ] CI / tooling / configuration
- [x] Style / theme change

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Open theme menu
2. Observe custom display names in "Default Themes" Panel
3. Observe four new themes (catppuccin latte, catppuccin frappe, catppuccin macchiato and catppuccin mocha) that have names with spaces

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<!-- Drag and drop images or a screen recording here. Required for any UI/visual change. -->

Catppuccin latte:
<img width="1920" height="1080" alt="1_catppuccin_latte" src="https://github.com/user-attachments/assets/17fc8e0f-9601-4441-b9ef-6fbcb5932296" />

Catppuccin frappe:
<img width="1920" height="1080" alt="2_catppuccin_frappe" src="https://github.com/user-attachments/assets/95d83a59-bbae-4f08-9d5f-a124f55c1e6a" />

Catppuccin macchiato:
<img width="1920" height="1080" alt="3_catppuccin_macchiato" src="https://github.com/user-attachments/assets/0c1b2d2f-5678-4424-af8c-2cc849c7f3a1" />

Catppuccin mocha:
<img width="1920" height="1080" alt="4_catppuccin_mocha" src="https://github.com/user-attachments/assets/e5926624-ff36-4f49-a06e-9f3bbe2d0210" />

Mobile layout test with custom display names:
<img width="1440" height="3040" alt="5_mobile_layout_test" src="https://github.com/user-attachments/assets/7a880afa-0b41-4c0c-a223-678ae561e09f" />
