### PR TITLE
chore(deps): migrate DuckDuckGo search to the maintained ddgs package

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -15,7 +15,9 @@ faster-whisper
 # DuckDuckGo as a search provider option.
 # Install if you want DDG in the search-provider dropdown.
 # Alternatives: SearXNG, Brave, Tavily, Serper, Google PSE.
-duckduckgo-search
+# `ddgs` is the maintained successor to `duckduckgo-search` (frozen Jul 2025);
+# the search provider still falls back to the old package name if it's present.
+ddgs
 
 # PDF form-filling feature (fillable AcroForm detection, field extraction,
 # value/annotation/signature stamping, page rendering for the form overlay).

--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -417,10 +417,17 @@ def duckduckgo_search(query: str, count: Optional[int] = None, time_filter: Opti
             return []
 
     try:
-        from duckduckgo_search import DDGS
+        # `ddgs` is the maintained successor to `duckduckgo-search` (which froze
+        # in Jul 2025). Prefer it; fall back to the old package name if only that
+        # is installed, then to the HTML scrape — so this can't regress an
+        # existing install.
+        from ddgs import DDGS
     except ImportError:
-        logger.warning("duckduckgo-search package not installed; using HTML fallback")
-        return _html_fallback()
+        try:
+            from duckduckgo_search import DDGS
+        except ImportError:
+            logger.warning("ddgs / duckduckgo-search not installed; using HTML fallback")
+            return _html_fallback()
 
     timelimit = None
     if time_filter:


### PR DESCRIPTION
## Summary
`duckduckgo-search` was frozen in Jul 2025 and renamed to `ddgs` by the same
maintainer; the frozen package stops getting DuckDuckGo anti-bot fixes. This
prefers `ddgs`, falls back to the old package name if only that is installed, then
to the HTML scrape — so an existing install can't regress. The `ddgs` API is a
drop-in: same `text(query, max_results=, timelimit=, safesearch=)` params, same
`{title, href, body}` results — verified live against the package.

## Target branch
- [x] This PR targets `dev`, not `main`.

## Linked Issue
Fixes #3696

## Type of Change
- [x] Refactor / cleanup (behaviour unchanged)

## Checklist
- [x] I searched open issues and PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified end-to-end (installed `ddgs`, confirmed `text()` params + `{title, href, body}` result shape + a live query returning results).

## How to Test
1. `pip install ddgs` (now in `requirements-optional.txt`).
2. In Settings, set the search provider to DuckDuckGo and run a search — results come back as before.
3. Fallback: with only `duckduckgo-search` installed (not `ddgs`), search still works — the import falls back to the old package name.

## Visual / UI changes
N/A — dependency + import change only; nothing renders.
