### PR TITLE
fix(settings): scrub camelCase secret keys

### DIFF
--- a/src/settings_scrub.py
+++ b/src/settings_scrub.py
@@ -12,6 +12,8 @@ tunnel / reverse proxy. Scrubbing is deep (recurses nested dicts/lists) and keye
 on secret-shaped names.
 """
 
+import re
+
 _SECRET_KEY_PATTERNS = (
     "_api_key", "_apikey", "_password", "_passwd", "_pass", "_pwd",
     "_secret", "_client_secret", "_token", "_access_token", "_refresh_token",
@@ -26,8 +28,16 @@ _SENSITIVE_KEY_EXACT = (
 )
 
 
+def _canonical_key_name(name: str) -> str:
+    """Normalize common JS-style key names so secret matching is style-agnostic."""
+    n = (name or "").replace("-", "_")
+    n = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", n)
+    n = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", n)
+    return n.lower()
+
+
 def is_secret_key(name: str) -> bool:
-    n = (name or "").lower()
+    n = _canonical_key_name(name)
     if n in _SECRET_KEY_ALLOW:
         return False
     if n in _SENSITIVE_KEY_EXACT:

--- a/tests/test_settings_scrub.py
+++ b/tests/test_settings_scrub.py
@@ -40,7 +40,8 @@ def test_secret_in_list_of_dicts_blanked():
 
 def test_non_secret_keys_preserved():
     s = {"keybinds": {"send": "Enter"}, "theme": "dark", "image_model": "x",
-         "default_endpoint_id": "ep1", "search_result_count": 5, "tts_enabled": True}
+         "default_endpoint_id": "ep1", "search_result_count": 5, "tts_enabled": True,
+         "tokenId": "public-id", "keyId": "public-key-id"}
     assert scrub_settings(s) == s  # untouched
 
 
@@ -69,6 +70,23 @@ def test_empty_and_nonstring_secret_values_untouched():
 def test_exact_name_matches():
     out = scrub_settings({"password": "p", "token": "t", "secret": "s", "apikey": "a", "key": "k"})
     assert all(v == "" for v in out.values()), out
+
+
+def test_camel_case_secret_keys_blanked():
+    out = scrub_settings({
+        "apiKey": "api-secret",
+        "accessToken": "access-secret",
+        "refreshToken": "refresh-secret",
+        "clientSecret": "client-secret",
+        "hfToken": "hf-secret",
+        "nested": {"privateKey": "private-secret"},
+    })
+    assert out["apiKey"] == ""
+    assert out["accessToken"] == ""
+    assert out["refreshToken"] == ""
+    assert out["clientSecret"] == ""
+    assert out["hfToken"] == ""
+    assert out["nested"]["privateKey"] == ""
 
 
 def test_non_object_settings_return_empty_mapping():


### PR DESCRIPTION
## Summary

JS-style camelCase keys (e.g. `apiKey`, `clientSecret`, `accessToken`, `privateKey`) stored in user settings were not recognized as secret keys during `/api/auth/settings` sanitization. This left sensitive keys unscrubbed when settings were returned to non-admin clients. This change canonicalizes key names to lower snake_case to enable style-agnostic secret key matching.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3714

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Add mock sensitive camelCase configuration keys to user settings, e.g. `{"apiKey": "supersecret", "nested": {"privateKey": "anothersecret"}}`.
2. Call `scrub_settings()` or hit `/api/auth/settings` without admin credentials.
3. Verify that these keys are successfully blanked out while non-sensitive keys like `tokenId` or `keyId` remain preserved.
4. Alternatively, run the updated test suite: `pytest tests/test_settings_scrub.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
