### PR TITLE
fix(codenav): resolve code-nav paths under active workspace

### DIFF
--- a/src/agent_tools/filesystem_tools.py
+++ b/src/agent_tools/filesystem_tools.py
@@ -229,7 +229,7 @@ class LsTool:
         else:
             raw_path = _s.split("\n", 1)[0].strip()
         try:
-            root = _resolve_search_root(raw_path)
+            root = _resolve_search_root(raw_path, workspace=workspace)
         except ValueError as e:
             return {"error": f"ls: {e}", "exit_code": 1}
 
@@ -287,7 +287,7 @@ class GlobTool:
         if not pattern:
             return {"error": "glob: pattern is required", "exit_code": 1}
         try:
-            root = _resolve_search_root(str(args.get("path", "")))
+            root = _resolve_search_root(str(args.get("path", "")), workspace=workspace)
         except ValueError as e:
             return {"error": f"glob: {e}", "exit_code": 1}
 
@@ -352,7 +352,7 @@ class GrepTool:
             max_hits = _CODENAV_MAX_HITS
         max_hits = max(1, min(max_hits, _CODENAV_MAX_HITS))
         try:
-            root = _resolve_search_root(str(args.get("path", "")))
+            root = _resolve_search_root(str(args.get("path", "")), workspace=workspace)
         except ValueError as e:
             return {"error": f"grep: {e}", "exit_code": 1}
 

--- a/src/tool_execution.py
+++ b/src/tool_execution.py
@@ -214,13 +214,17 @@ def get_mcp_manager():
 
 
 
-def _resolve_search_root(raw_path: str) -> str:
+def _resolve_search_root(raw_path: str, workspace: Optional[str] = None) -> str:
     """Resolve + confine a code-nav path (grep/glob/ls).
 
     An empty path defaults to the agent's primary root (project data dir) and a
     supplied path is confined by the global allowlist + sensitive-file policy.
+    When a workspace is active, relative paths and the empty path resolve under
+    that workspace instead, matching read_file/write_file/edit_file behavior.
     """
     raw = (raw_path or "").strip()
+    if workspace:
+        return _resolve_tool_path_in_workspace(workspace, raw or ".")
     if not raw:
         roots = _tool_path_roots()
         return roots[0] if roots else os.path.realpath(".")
@@ -635,7 +639,9 @@ async def execute_tool_block(
         # Code-navigation tools — no MCP server; run the direct implementation.
         first_line = content.split(chr(10))[0][:80]
         desc = f"{tool}: {first_line}"
-        result = await _direct_fallback(tool, content, progress_cb=progress_cb) \
+        result = await _direct_fallback(
+            tool, content, progress_cb=progress_cb, workspace=workspace
+        ) \
             or {"error": f"{tool}: execution failed", "exit_code": 1}
     elif tool == "create_document":
         title = content.split("\n")[0].strip()[:60]

--- a/tests/test_code_nav_tools.py
+++ b/tests/test_code_nav_tools.py
@@ -14,6 +14,10 @@ def _run(tool, content):
     return asyncio.run(_direct_fallback(tool, content))
 
 
+def _run_workspace(tool, content, workspace):
+    return asyncio.run(_direct_fallback(tool, content, workspace=workspace))
+
+
 @pytest.fixture
 def repo():
     # Built under /tmp, which is on the default tool-path allowlist.
@@ -31,6 +35,22 @@ def repo():
         os.mkdir(g)
         with open(os.path.join(g, "config"), "w") as f:
             f.write("needle in git\n")
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+@pytest.fixture
+def home_workspace():
+    # Keep this outside the default data/tmp tool roots so workspace-aware
+    # resolution is the only way code-nav tools can reach it.
+    root = tempfile.mkdtemp(
+        dir=os.path.expanduser("~"),
+        prefix=".odysseus_codenav_workspace_",
+    )
+    try:
+        with open(os.path.join(root, "agent_marker.py"), "w") as f:
+            f.write("# workspace needle\n")
         yield root
     finally:
         shutil.rmtree(root, ignore_errors=True)
@@ -88,6 +108,16 @@ def test_grep_python_fallback_when_no_rg(repo, monkeypatch):
     assert ".git/config" not in r["output"]
 
 
+def test_grep_searches_active_workspace_relative_path(home_workspace):
+    r = _run_workspace(
+        "grep",
+        '{"pattern": "workspace needle", "path": "."}',
+        workspace=home_workspace,
+    )
+    assert r["exit_code"] == 0
+    assert "agent_marker.py:1:" in r["output"]
+
+
 # ── glob ──────────────────────────────────────────────────────────────────
 
 def test_glob_py(repo):
@@ -107,6 +137,16 @@ def test_glob_requires_pattern(repo):
     assert r["exit_code"] == 1
 
 
+def test_glob_searches_active_workspace_relative_path(home_workspace):
+    r = _run_workspace(
+        "glob",
+        '{"pattern": "*.py", "path": "."}',
+        workspace=home_workspace,
+    )
+    assert r["exit_code"] == 0
+    assert "agent_marker.py" in r["output"]
+
+
 # ── ls ────────────────────────────────────────────────────────────────────
 
 def test_ls_lists_entries(repo):
@@ -121,6 +161,12 @@ def test_ls_path_outside_rejected(repo):
     r = _run("ls", '{"path": "/etc"}')
     assert r["exit_code"] == 1
     assert "outside the allowed roots" in r["error"]
+
+
+def test_ls_defaults_to_active_workspace(home_workspace):
+    r = _run_workspace("ls", "{}", workspace=home_workspace)
+    assert r["exit_code"] == 0
+    assert "agent_marker.py" in r["output"]
 
 
 # ── read_file line range ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When a workspace is active, code-navigation tools (`grep`, `glob`, `ls`) resolved empty/relative paths against the agent's primary project data directory rather than the active workspace directory. This made files inside the workspace unreachable or incorrectly scoped. This change propagates the `workspace` parameter to code-nav tools and uses `_resolve_tool_path_in_workspace` to resolve empty/relative paths.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3715

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Create a workspace separate from the main project data directory and add unique source files inside it (e.g. `agent_marker.py`).
2. Run code-nav tools (`grep`, `glob`, or `ls`) with an active workspace session using empty or relative paths.
3. Verify that they correctly resolve inside the active workspace directory instead of failing with an out-of-bounds error or querying the global data directory.
4. Run the updated tests: `pytest tests/test_code_nav_tools.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
