### PR TITLE
test: mark first slow tests from duration evidence

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -74,7 +74,14 @@ python3 tests/run_focus.py --area services --fast --durations 25 --durations-min
 
 The `slow` marker is opt-in. Mark a test `slow` only with duration evidence
 (from `--durations`), not by guessing - see the fast-lane policy in
-`TESTING_STANDARD.md`.
+`TESTING_STANDARD.md`. `--fast` is for quick reviewer feedback and must not
+replace the full suite before merge. A `slow` mark only excludes a test from the
+fast lane; the test stays runnable directly, e.g.:
+
+```bash
+python3 -m pytest tests/test_auth_config_lock_concurrency.py
+python3 -m pytest -m slow
+```
 
 ## Core principles
 

--- a/tests/test_auth_config_lock_concurrency.py
+++ b/tests/test_auth_config_lock_concurrency.py
@@ -25,6 +25,7 @@ def _fresh_auth_manager(tmp_path):
 class TestConcurrentCreateUser:
     """Concurrent create_user calls must not lose accounts."""
 
+    @pytest.mark.slow
     def test_parallel_creates_no_lost_users(self, tmp_path):
         mgr = _fresh_auth_manager(tmp_path)
         num_users = 50
@@ -63,6 +64,7 @@ class TestConcurrentCreateUser:
 class TestConcurrentDeleteUser:
     """Concurrent deletes must not corrupt state."""
 
+    @pytest.mark.slow
     def test_parallel_deletes_no_corruption(self, tmp_path):
         mgr = _fresh_auth_manager(tmp_path)
         mgr.create_user("admin", "adminpw", is_admin=True)
@@ -90,6 +92,7 @@ class TestConcurrentDeleteUser:
 class TestConcurrentRenameUser:
     """Concurrent renames must not lose or duplicate users."""
 
+    @pytest.mark.slow
     def test_parallel_renames_no_lost_users(self, tmp_path):
         mgr = _fresh_auth_manager(tmp_path)
         mgr.create_user("admin", "adminpw", is_admin=True)
@@ -115,6 +118,7 @@ class TestConcurrentRenameUser:
 class TestConcurrentMixedOperations:
     """Mixed create/delete/rename at the same time."""
 
+    @pytest.mark.slow
     def test_mixed_operations_no_corruption(self, tmp_path):
         mgr = _fresh_auth_manager(tmp_path)
         mgr.create_user("admin", "adminpw", is_admin=True)
@@ -161,6 +165,7 @@ class TestConcurrentMixedOperations:
 class TestDiskConsistency:
     """Verify auth.json is never in a corrupt state during concurrent writes."""
 
+    @pytest.mark.slow
     def test_file_always_valid_json_during_concurrent_ops(self, tmp_path):
         mgr = _fresh_auth_manager(tmp_path)
         mgr.create_user("admin", "adminpw", is_admin=True)

--- a/tests/test_run_focus.py
+++ b/tests/test_run_focus.py
@@ -7,7 +7,9 @@ injected fake executor so no pytest subprocess is ever spawned.
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -351,3 +353,47 @@ def test_durations_min_with_durations_is_allowed():
         "--durations=25",
         "--durations-min=0.05",
     ]]
+
+
+# --- fast lane deselects evidence-backed slow tests (real collection) -------
+
+# Node names in tests/test_auth_config_lock_concurrency.py: the single unmarked
+# fast test, and the five @pytest.mark.slow tests the fast lane must exclude.
+_FAST_AUTH_CONCURRENCY_TEST = "test_parallel_creates_same_username_only_one_wins"
+_SLOW_AUTH_CONCURRENCY_TESTS = (
+    "test_parallel_creates_no_lost_users",
+    "test_parallel_deletes_no_corruption",
+    "test_parallel_renames_no_lost_users",
+    "test_mixed_operations_no_corruption",
+    "test_file_always_valid_json_during_concurrent_ops",
+)
+
+
+def test_fast_lane_collects_only_unmarked_auth_concurrency_test():
+    """`--fast` collection drops the marked slow tests but keeps the fast one.
+
+    Unlike the other tests here, this runs a real `--collect-only` so it proves
+    the `slow` markers actually deselect during collection, not just that the
+    command is built with `not slow`.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "tests/run_focus.py",
+            "--fast",
+            "--",
+            "--collect-only",
+            "-q",
+            "tests/test_auth_config_lock_concurrency.py",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    collected = result.stdout
+
+    assert _FAST_AUTH_CONCURRENCY_TEST in collected
+    for slow_test in _SLOW_AUTH_CONCURRENCY_TESTS:
+        assert slow_test not in collected, f"slow test was not deselected: {slow_test}"


### PR DESCRIPTION
## Summary

Marks the first duration-backed slow tests and adds focused coverage proving the fast lane excludes them.

This PR:

- adds `@pytest.mark.slow` to the 5 auth config concurrency tests identified by duration evidence
- keeps the remaining auth concurrency test unmarked because it was not part of the slow evidence
- adds focused `run_focus.py` coverage for the fast-lane exclusion behavior
- documents the slow-marker rule in the existing fast-lane README section

This is intentionally limited to the first evidence-backed slow-marker slice. It does not broaden slow markers to borderline tests, change CI behavior, move test files, or change production behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #3699

Part of #2523

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [x] Documentation
- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

For this test-tooling PR, "end-to-end" means the slow marker selection, direct slow-test execution, inverse marker selection, fast-lane collect-only behavior, and focused `run_focus.py` coverage were validated. This PR does not change app runtime behavior, routes, UI, or user-facing behavior.

## How to Test

Compile changed test files:

- `.venv/bin/python -m py_compile tests/test_auth_config_lock_concurrency.py tests/test_run_focus.py`

Focused runner test validation:

- `.venv/bin/python -m pytest -q tests/test_run_focus.py`

Auth concurrency marker validation:

- `.venv/bin/python -m pytest -q tests/test_auth_config_lock_concurrency.py`
- `.venv/bin/python -m pytest -q -m slow tests/test_auth_config_lock_concurrency.py`
- `.venv/bin/python -m pytest -q -m "not slow" tests/test_auth_config_lock_concurrency.py`

Fast-lane collect-only checks:

- `.venv/bin/python tests/run_focus.py --fast -- --collect-only -q tests/test_auth_config_lock_concurrency.py`
- `.venv/bin/python tests/run_focus.py --fast -- --collect-only -q`

Diff hygiene:

- `git diff --check`

Local results:

- compile check: passed
- `tests/test_run_focus.py`: passed
- auth concurrency file: 6 passed, 1 warning
- slow selection: 5 passed, 1 deselected, 1 warning
- not-slow selection: 1 passed, 5 deselected, 1 warning
- target fast collect-only: 1/6 tests collected, 5 deselected
- full fast collect-only: 3058/3063 tests collected, 5 deselected
- `git diff --check`: passed

## Context

This follows the test-hardening roadmap after:

- #3491 - taxonomy markers
- #3556 - focused test selection runner
- #3659 - fast lane and duration visibility
- #3685 - fake DB / SessionLocal helper audit and pilot

The duration audit found one clearly safe first group: auth config concurrency tests that consistently dominate the duration report.

Duration evidence:

```text
9.43s call     tests/test_auth_config_lock_concurrency.py::TestConcurrentCreateUser::test_parallel_creates_no_lost_users
9.20s call     tests/test_auth_config_lock_concurrency.py::TestDiskConsistency::test_file_always_valid_json_during_concurrent_ops
7.45s call     tests/test_auth_config_lock_concurrency.py::TestConcurrentMixedOperations::test_mixed_operations_no_corruption
5.64s call     tests/test_auth_config_lock_concurrency.py::TestConcurrentDeleteUser::test_parallel_deletes_no_corruption
3.79s call     tests/test_auth_config_lock_concurrency.py::TestConcurrentRenameUser::test_parallel_renames_no_lost_users
```

Tests intentionally left unmarked:

- `TestConcurrentCreateUser::test_parallel_creates_same_username_only_one_wins`

That test was not part of the slow evidence, so the PR uses individual function markers instead of marking the whole file.

## Safety details

This PR does not:

- change production code
- change CI workflows
- move tests
- change assertions
- skip or xfail tests
- mark borderline 1-second tests
- mark the whole file slow
- touch `tests/conftest.py`
- touch `tests/_taxonomy.py`
- introduce new test infrastructure
- change app runtime behavior

The fast lane now excludes only the 5 evidence-backed slow tests. The marked tests remain runnable directly, through `-m slow`, and through normal pytest runs.

## Visual / UI changes - REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like - buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM - needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language.
- [ ] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

N/A: no UI, CSS, HTML, SVG, or rendering files changed.

### Screenshots / clips

N/A - no visual or UI changes.
