### PR TITLE
fix(chat): copy only the reply from the message copy button

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -863,6 +863,20 @@ export function stripToolBlocks(text) {
 }
 
 /**
+ * Plain-text payload for the message copy buttons: the reply as the renderer
+ * displays it — tool blocks and <think> reasoning stripped. dataset.raw keeps
+ * the full model output (chat.js even embeds the elapsed time into the
+ * <think> tag for reload persistence), so copying it verbatim leaks the
+ * thinking block (#3722). Falls back to the raw text when stripping leaves
+ * nothing (e.g. turns interrupted mid-thinking).
+ */
+export function copyMessageText(msgElement) {
+  const raw = msgElement.dataset.raw || msgElement.querySelector('.body')?.textContent || '';
+  const { content } = markdownModule.extractThinkingBlocks(stripToolBlocks(raw));
+  return content || raw;
+}
+
+/**
  * Build a collapsible sources box (used by both research and web search).
  */
 export function buildSourcesBox(sources, type, expanded) {
@@ -1372,7 +1386,7 @@ export function createMsgFooter(msgElement) {
     { id: 'copy', icon: COPY_ICON, title: 'Copy message', cls: 'footer-copy-btn', html: true, handler(e) {
       e.stopPropagation();
       const btn = e.currentTarget;
-      uiModule.copyToClipboard(msgElement.dataset.raw || msgElement.querySelector('.body')?.textContent || '');
+      uiModule.copyToClipboard(copyMessageText(msgElement));
       btn.innerHTML = CHECK_ICON;
       setTimeout(() => { btn.innerHTML = COPY_ICON; }, 1500);
     }},
@@ -2444,6 +2458,7 @@ const chatRenderer = {
   updateSessionCostUI,
   roleTimestamp,
   stripToolBlocks,
+  copyMessageText,
   safeToolScreenshotSrc,
   safeDisplayImageSrc,
   buildSourcesBox,

--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -380,7 +380,7 @@ function _slashFooter(msgEl) {
   copyBtn.innerHTML = _copySvg;
   copyBtn.onclick = (e) => {
     e.stopPropagation();
-    uiModule.copyToClipboard(msgEl.dataset.raw || msgEl.querySelector('.body')?.textContent || '');
+    uiModule.copyToClipboard(chatRenderer.copyMessageText(msgEl));
     copyBtn.innerHTML = _checkSvg;
     setTimeout(() => { copyBtn.innerHTML = _copySvg; }, 1500);
   };

--- a/tests/test_copy_message_strips_thinking_js.py
+++ b/tests/test_copy_message_strips_thinking_js.py
@@ -1,0 +1,160 @@
+"""Regression coverage for issue #3722 — the message copy button copied the
+full raw model output (``dataset.raw``), which still contains the
+``<think time="...">...</think>`` reasoning block that the renderer strips for
+display. Pasting therefore leaked the model's thinking, and the first heading
+after ``</think>`` lost its markdown formatting because it was glued to the
+closing tag.
+
+The fix adds chatRenderer.copyMessageText(), which mirrors the display
+pipeline (``stripToolBlocks()`` then ``extractThinkingBlocks()``), and routes
+both AI-message copy buttons (createMsgFooter and the slash-reply footer)
+through it. extractThinkingBlocks() behavior is pinned here under node
+(including on the payload from the issue report); the helper and handler
+wiring are guarded at the source level because chatRenderer.js pulls in
+browser globals and can't be imported under node (same approach as
+test_new_chat_clears_input.py).
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_HAS_NODE = shutil.which("node") is not None
+
+
+@pytest.fixture(scope="module")
+def node_available():
+    if not _HAS_NODE:
+        pytest.skip("node binary not on PATH")
+
+
+def _extract_thinking_blocks(text: str) -> dict:
+    """Run markdown.js extractThinkingBlocks(text) under node."""
+    script = textwrap.dedent(
+        r"""
+        import fs from 'node:fs';
+
+        globalThis.window = { location: { origin: 'http://localhost' }, katex: null };
+        globalThis.document = {
+          readyState: 'loading',
+          addEventListener() {},
+          createElement(tag) {
+            if (tag !== 'template') throw new Error(`unsupported element: ${tag}`);
+            return {
+              _html: '',
+              content: { querySelectorAll() { return []; } },
+              set innerHTML(value) { this._html = value; },
+              get innerHTML() { return this._html; },
+            };
+          },
+        };
+        globalThis.MutationObserver = class { observe() {} };
+
+        let source = fs.readFileSync('./static/js/markdown.js', 'utf8');
+        source = source.replace(
+          /import uiModule from ['"]\.\/ui\.js['"];/,
+          ''
+        );
+        source = source.replace(
+          /import \{ splitTableRow \} from ['"]\.\/markdown\/tableRow\.js['"];/,
+          `function splitTableRow(row) {
+            return (row || '').replace(/^\\s*\\|/, '').replace(/\\|\\s*$/, '').split('|').map(c => c.trim());
+          }`
+        );
+        const emojiSource = fs.readFileSync('./static/js/emojiShortcodes.js', 'utf8')
+          .replace(/^export default .*$/m, '')
+          .replace(/export const /g, 'const ')
+          .replace(/export function /g, 'function ');
+        source = source.replace(
+          /import \{ replaceEmojiShortcodes, hasEmojiShortcode \} from ['"]\.\/emojiShortcodes\.js['"];/,
+          () => emojiSource
+        );
+        source = source.replace(
+          /var escapeHtml = uiModule\.esc;/,
+          `var escapeHtml = (value) => String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');`
+        );
+
+        const moduleUrl = 'data:text/javascript;base64,' + Buffer.from(source).toString('base64');
+        const mod = await import(moduleUrl);
+        const input = JSON.parse(process.argv[1]);
+        console.log(JSON.stringify({ out: mod.extractThinkingBlocks(input) }));
+        """
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script, json.dumps(text)],
+        cwd=_REPO,
+        capture_output=True,
+        timeout=15,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed:\nSTDERR:\n{result.stderr}\nSTDOUT:\n{result.stdout}")
+    return json.loads(result.stdout.splitlines()[-1])["out"]
+
+
+def test_issue_payload_copy_text_excludes_thinking(node_available):
+    # Shape reported in #3722: timed think block glued to the reply heading.
+    raw = (
+        '<think time="24.5">\n'
+        "Here's a thinking process that leads to the desired summary:\n\n"
+        "6.  **Generate the Output.** (This matches the final provided response.)"
+        "</think>### Juxtaposition: Interweaving Cultural Norms in Lesson Design\n"
+        "The most effective lesson structure is created by deliberately juxtaposing."
+    )
+    out = _extract_thinking_blocks(raw)
+
+    assert out["content"].startswith("### Juxtaposition:"), out["content"]
+    assert "thinking process" not in out["content"]
+    assert "<think" not in out["content"]
+    assert out["thinkingTime"] == "24.5"
+
+
+def test_plain_reply_copy_text_is_unchanged(node_available):
+    raw = "### Heading\nJust a normal reply with no reasoning markup."
+    out = _extract_thinking_blocks(raw)
+    assert out["content"] == raw
+
+
+def test_thinking_only_message_yields_empty_content(node_available):
+    # The copy handler falls back to the raw text in this case so the button
+    # still copies something for turns interrupted mid-thinking.
+    out = _extract_thinking_blocks("<think>only reasoning, no reply yet</think>")
+    assert out["content"] == ""
+
+
+def _function_body(text: str, marker: str) -> str:
+    start = text.index(marker)
+    rest = text[start + len(marker):]
+    m = re.search(r"\nexport function |\nfunction ", rest)
+    return rest[: m.start()] if m else rest
+
+
+def test_copy_message_text_mirrors_display_pipeline():
+    text = (_REPO / "static/js/chatRenderer.js").read_text(encoding="utf-8")
+    body = _function_body(text, "export function copyMessageText")
+    # Mirrors the display path: tool blocks stripped, then thinking extracted.
+    assert "extractThinkingBlocks" in body
+    assert "stripToolBlocks" in body
+    assert "dataset.raw" in body
+
+
+def test_copy_handlers_route_through_copy_message_text():
+    for path, count in (("static/js/chatRenderer.js", 1), ("static/js/slashCommands.js", 1)):
+        text = (_REPO / path).read_text(encoding="utf-8")
+        assert text.count("copyToClipboard(copyMessageText(") + text.count(
+            "copyToClipboard(chatRenderer.copyMessageText("
+        ) == count, path
+        # The old behavior passed dataset.raw straight to the clipboard.
+        assert "copyToClipboard(msgElement.dataset.raw" not in text, path
+        assert "copyToClipboard(msgEl.dataset.raw" not in text, path


### PR DESCRIPTION
## Summary

The AI-message copy buttons copy `msgElement.dataset.raw`, which holds the model's full raw output — still containing the `<think time="...">…</think>` reasoning block (and any tool-call markup) that the renderer strips for display. Pasting therefore leaks the model's thinking, and the first heading after `</think>` loses its markdown formatting because it is glued to the closing tag (exactly the `### Juxtaposition` symptom in the report). This adds `chatRenderer.copyMessageText()`, which mirrors the display pipeline, and routes both copy buttons through it.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3722

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Root cause

`static/js/chatRenderer.js` → `createMsgFooter()` copy action (and the same pattern in the slash-reply footer in `static/js/slashCommands.js`) passed `dataset.raw` straight to `uiModule.copyToClipboard()`. `dataset.raw` is intentionally the unstripped accumulated stream (chat.js even embeds the elapsed time into the `<think>` tag for reload persistence), so everything the display path strips — `stripToolBlocks()` then `extractThinkingBlocks()` — was leaking into the clipboard.

## Fix

New `copyMessageText(msgElement)` helper in chatRenderer.js mirrors the display pipeline: `extractThinkingBlocks(stripToolBlocks(raw)).content`, falling back to the raw text when stripping leaves nothing (turns interrupted mid-thinking). Both AI-message copy handlers route through it (slashCommands.js already imports `chatRenderer`, so no new import). The user-message copy button (plain `.body` text, never had think blocks) and the interrupted-turn **Continue** flow (which intentionally reads `dataset.raw`) are unchanged.

## Tests

- New `tests/test_copy_message_strips_thinking_js.py`:
  - runs `extractThinkingBlocks()` under node on the payload shape from the issue (timed think block glued to a `###` heading) — asserts the copied content starts at the heading, contains no thinking, and preserves `thinkingTime`;
  - pins the no-think-markup case (content unchanged) and the thinking-only case (empty content → helper falls back to raw);
  - source-level guards that `copyMessageText()` mirrors the display pipeline and that both copy handlers route through it (chatRenderer.js pulls in browser globals and can't be imported under node — same approach as `tests/test_new_chat_clears_input.py`).
- `python -m pytest tests/test_*_js.py tests/test_chat_tool_screenshot_xss.py tests/test_new_chat_clears_input.py` → 140 passed.
- `node --check static/js/chatRenderer.js static/js/slashCommands.js` clean.

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start a chat with a thinking model (any backend that emits `<think>` blocks, e.g. the LM Studio setup from the issue) and send a prompt.
2. After the reply finishes, click the **copy** button under the AI message.
3. Paste anywhere: the clipboard contains only the visible reply — no `<think time="...">…</think>` block, no tool-call markup — and the first `###` heading pastes as a proper heading.
4. Same check on a slash-skill reply's copy button.
5. Quick no-app check: `.venv/bin/python -m pytest tests/test_copy_message_strips_thinking_js.py -q` (needs `node` on PATH).

## Scope / Follow-up

- The interrupted-turn **Continue** button keeps reading `dataset.raw` on purpose (the model needs its own unstripped tail to resume).
- Unrelated latent issue noticed while wiring this: `slashCommands.js` references `markdownModule` in its `renderMarkdown` reveal path without importing it (would throw if that option were used). Left untouched — separate concern.

## Visual / UI changes

None — the buttons' appearance and feedback animation are untouched; only the clipboard payload changes.