### PR TITLE
style(settings): Align appearance 'Reset All' button padding

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1820,7 +1820,7 @@
               </label>
             </div>
           </div>
-          <div style="text-align:right;padding:0 4px;">
+          <div style="text-align:right;padding:0 4px;padding-bottom:6px;">
             <button type="button" class="admin-btn-sm" id="set-uiVisResetBtn" style="opacity:0.5;">Reset All</button>
           </div>
         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -1820,7 +1820,7 @@
               </label>
             </div>
           </div>
-          <div style="text-align:right;padding:0 4px;padding-bottom:6px;">
+          <div style="text-align:right;padding:0 4px 6px 4px;">
             <button type="button" class="admin-btn-sm" id="set-uiVisResetBtn" style="opacity:0.5;">Reset All</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Aligned 'Reset All' button  in settings/appearance to follow the base style

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

<!-- Every PR should be linked to an issue.
     Use one of:  Fixes #NNN  |  Part of #NNN  |  Closes #NNN  -->

Fixes #3752

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

<!-- Step-by-step instructions a reviewer can follow to verify this works.
     Do not leave this empty — a PR without test steps will be sent back. -->

1. Pull the branch and rebuild: `docker-compose up -d --build`
2. Open the dev instance of web-application in the browser
3. Navigate to the Settings icon at the bottom of the sidebar
4. In the opened Settings window navigate to the Appearance tab

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips
Before:
<img width="723" height="165" alt="Screenshot_20260610_114320" src="https://github.com/user-attachments/assets/9fc9646a-12a1-4152-9db5-01f66ceef2ac" />
<img width="338" height="244" alt="image" src="https://github.com/user-attachments/assets/66732bdd-4342-45b7-8447-8a9137458238" />

After:
<img width="721" height="188" alt="Screenshot_20260610_112930" src="https://github.com/user-attachments/assets/6776d0fc-219a-47c4-9da2-796e25dcd233" />
<img width="334" height="292" alt="Screenshot_20260610_112919" src="https://github.com/user-attachments/assets/799c91bd-a166-4ef9-ad32-c17228fe840d" />



