### PR TITLE
fix(cookbook): classify dead local dep installs from the runner log instead of branding them crashed

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -2856,6 +2856,32 @@ def setup_cookbook_routes() -> APIRouter:
                         except Exception:
                             pass
 
+            # Local macOS/Linux: the serve-runner tees into TMUX_LOG_DIR/<session>.log,
+            # which outlives the tmux session (same model as the Windows detached
+            # log). A fast pip dependency install can exit before any status poll
+            # captures the pane, so the live capture and the persisted output are
+            # both empty — and the dead-session HF-cache check below can never
+            # validate a pip package (its repo_id has no "/"). Without this
+            # fallback the task reports "stopped" and the UI downgrades a clean
+            # exit-0 install to "crashed".
+            local_log_task = False
+            if (
+                not is_alive
+                and not remote
+                and not IS_WINDOWS
+                and not full_snapshot
+                and task_type == "download"
+            ):
+                _log_path = TMUX_LOG_DIR / f"{session_id}.log"
+                try:
+                    if _log_path.exists():
+                        full_snapshot = _log_path.read_text(
+                            encoding="utf-8", errors="replace"
+                        ).strip()[-12000:]
+                        local_log_task = bool(full_snapshot)
+                except Exception:
+                    pass
+
             # Determine status. For the local-Windows detached model the log file
             # persists after the process exits, so a finished download still has a
             # snapshot to classify (DOWNLOAD_OK / exit marker) — evaluate it even
@@ -2872,7 +2898,7 @@ def setup_cookbook_routes() -> APIRouter:
                     or _download_cache_incomplete(_payload.get("repo_id") or model, remote, str(_tport or ""))
                 )
             )
-            if is_alive or (local_win_task and full_snapshot):
+            if is_alive or ((local_win_task or local_log_task) and full_snapshot):
                 lower = full_snapshot.lower()
                 exit_match = re.search(r"=== process exited with code\s+(-?\d+)", full_snapshot, re.I)
                 has_exit = exit_match is not None

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -3532,12 +3532,18 @@ async function _pollBackgroundStatus() {
         // dead-session check inspects). Recover "done" from the retained output's
         // exit-0 sentinel so a clean install isn't downgraded to crashed.
         const depDone = !!task.payload?._dep && _depInstallSucceeded(task.output);
+        // A dep install with NO retained output is genuinely unknown — a fast
+        // install (everything already satisfied) can exit before the first
+        // status poll ever captures the pane, and on remote hosts the backend
+        // can't read the runner log either. Keep "stopped" instead of
+        // inventing "crashed".
+        const depNoEvidence = !!task.payload?._dep && !String(task.output || '').trim();
         const nextStatus = live.status === 'completed'
           ? 'done'
           : (live.status === 'error'
             ? 'error'
             : (live.status === 'stopped'
-                ? (depDone ? 'done' : (task.type === 'download' ? 'crashed' : 'stopped'))
+                ? (depDone ? 'done' : (task.type === 'download' && !depNoEvidence ? 'crashed' : 'stopped'))
                 : null));
         if (nextStatus && task.status !== nextStatus) {
           updates.status = nextStatus;

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -74,7 +74,32 @@ def test_background_poll_recovers_done_for_stopped_dependency_install():
     source = _read("static/js/cookbookRunning.js")
 
     assert "const depDone = !!task.payload?._dep && _depInstallSucceeded(task.output);" in source
-    assert "depDone ? 'done' : (task.type === 'download' ? 'crashed' : 'stopped')" in source
+    assert "depDone ? 'done' : (task.type === 'download' && !depNoEvidence ? 'crashed' : 'stopped')" in source
+
+
+def test_background_poll_keeps_stopped_for_evidence_free_dependency_install():
+    """A dep install with no retained output is unknown, not crashed: a fast
+    install (everything already satisfied) can exit before the first status
+    poll captures the pane, and on remote hosts the backend can't read the
+    runner log either. "stopped" must not be downgraded to "crashed" then."""
+    source = _read("static/js/cookbookRunning.js")
+
+    assert "const depNoEvidence = !!task.payload?._dep && !String(task.output || '').trim();" in source
+
+
+def test_backend_dead_local_session_falls_back_to_runner_log():
+    """The local (non-Windows) serve-runner tees into TMUX_LOG_DIR/<session>.log,
+    which outlives the tmux session. When a download task's session is already
+    gone and no output was ever captured, the status endpoint must classify
+    from that log (DOWNLOAD_OK / exit-0 marker) instead of reporting "stopped"
+    — the HF-cache check can never validate a pip package (no "/" in repo_id),
+    so a clean dependency install ended up branded as crashed."""
+    source = _read("routes/cookbook_routes.py")
+
+    assert 'local_log_task = False' in source
+    assert '_log_path = TMUX_LOG_DIR / f"{session_id}.log"' in source
+    assert 'local_log_task = bool(full_snapshot)' in source
+    assert 'if is_alive or ((local_win_task or local_log_task) and full_snapshot):' in source
 
 
 def test_dependency_install_payload_keeps_env_path_for_refresh():


### PR DESCRIPTION
## Summary

A pip dependency install that finishes quickly (easiest repro: the package is already installed, so pip exits 0 in ~2-5 s) is deterministically branded **crashed** on local macOS/Linux servers, even though the runner log ends with `DOWNLOAD_OK` and `=== Process exited with code 0 ===`. The session exits before the first status poll ever captures the pane, so the task's retained output is empty; the backend's dead-session path then only consults the HF cache check (`_download_cache_complete`), which can never validate a pip package (no `/` in its id) and ignores the persistent runner log — it reports `"stopped"`, and the frontend reconciler downgrades evidence-free stopped downloads to `"crashed"`. This PR makes the backend classify dead local sessions from the runner log at `TMUX_LOG_DIR/<session>.log` (the same model the local-Windows path already uses, #620), and makes the frontend keep `"stopped"` rather than inventing `"crashed"` when a dep install has no retained evidence either way (covers remote hosts, where the log is not locally readable).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3772

Related: #1262 / PR #1315 covered the same symptom but only when the retained output held the exit-0 sentinel — an empty output (install faster than the first poll) still crashed; #620 introduced the persistent-log classification this reuses. Not the same as #3734 (genuine `basicsr` build failure, exit code 1 — the crashed badge is accurate there).

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end (see How to Test; verified against a real stuck `pip realesrgan` task whose log classifies as `completed` with this change).

## How to Test

1. On a local macOS/Linux install, open Cookbook -> Dependencies and install a package that is **already installed** (e.g. `realesrgan`). pip exits 0 in a few seconds — before this fix, the Running-tab card flips to "crashed" on the next background poll; the persisted task in `data/cookbook_state.json` shows `status: "crashed"` with an empty `output`.
2. With this fix, the next `/api/cookbook/tasks/status` poll reads `/tmp/odysseus-tmux/<session>.log`, sees `DOWNLOAD_OK` / `=== Process exited with code 0 ===`, reports `completed`, and the card shows "finished". An already-mislabeled crashed task self-corrects the same way (empty retained output -> log fallback), no manual cleanup needed.
3. Negative path: a genuinely failing install (non-zero exit in the log) still classifies as `error`, and a remote dep install with no evidence now reads "stopped" instead of "crashed".
4. `venv/bin/python -m pytest tests/ -k cookbook` — 110 passed (includes 2 new regression tests in `tests/test_cookbook_dependency_completion_regression.py`).

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual changes — the `static/js/cookbookRunning.js` edit only changes which *existing* status value the reconciler picks (`stopped` vs `crashed`); badge rendering, styles, and components are untouched.

---
*This was written via Claude and verified by a human.*
