### PR TITLE
fix(agent): match non-English keywords in tool-RAG domain classifier

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -765,31 +765,47 @@ def _classify_agent_request(messages: List[Dict], last_user: str) -> Dict[str, o
     def has(*patterns: str) -> bool:
         return any(re.search(p, q) for p in patterns)
 
-    if has(r"\b(cookbook|serve|serving|served|launch|start|preset|vllm|sglang|llama\.?cpp|ollama|download|downloading|pull|cached models?|running models?|model servers?|models? (?:are )?running|what models?|model picker|gpu box|kierkegaard|odysseus|ajax|qwen|gemma|llama|mistral|minimax)\b"):
+    # Domain keywords are matched in English plus, where phrasing differs,
+    # Swedish / Norwegian / Danish / German / Spanish / French / Italian —
+    # models
+    # mirror the user's language, and a request that matches no domain is
+    # flagged low_signal, which skips tool retrieval entirely (#3668
+    # follow-up). Each language line sticks to high-precision nouns/verbs;
+    # chosen so they do not collide with common English words.
+    if has(r"\b(cookbook|serve|serving|served|launch|start|preset|vllm|sglang|llama\.?cpp|ollama|download|downloading|pull|cached models?|running models?|model servers?|models? (?:are )?running|what models?|model picker|gpu box|kierkegaard|odysseus|ajax|qwen|gemma|llama|mistral|minimax)\b",
+           r"\b(last ned|hent ned|ladda ner|hämta hem|herunterladen|descarga\w*|télécharge\w*|scarica\w*|modell(?:e|en|er|ene|erna|o|i)?|modelo\w*|modèle\w*)\b"):
         domains.add("cookbook")
-    if has(r"\b(emails?|mails?|gmail|inbox|reply|forward|cc|bcc|send email|compose email|draft email|message chris|message him|message her)\b"):
+    if has(r"\b(emails?|mails?|gmail|inbox|reply|forward|cc|bcc|send email|compose email|draft email|message chris|message him|message her)\b",
+           r"\b(e-?post\w*|innboks\w*|inkorg\w*|indbakke\w*|posteingang\w*|mejl\w*|correos?|courriels?|boîte de réception|bandeja de entrada|posta in arrivo)\b"):
         domains.add("email")
-    if has(r"\b(note|todo|to-do|checklist|task list|remind me|reminder|buy|pickup|pick up)\b"):
+    if has(r"\b(note|todo|to-do|checklist|task list|remind me|reminder|buy|pickup|pick up)\b",
+           r"\b(notat\w*|anteckning\w*|notiz(?!ie)\w*|huskeliste\w*|gjøremål\w*|påminn\w*|påmind\w*|erinnerung\w*|recordatorio\w*|recuérdame|rappel\w*|rappelle-moi|aufgabenliste\w*|tareas?|tâches?|promemoria\w*|ricordami|notas?)\b"):
         domains.add("notes_calendar_tasks")
     if has(r"\b(every day|every morning|every evening|recurring|automatically|cron|scheduled task|background task)\b"):
         domains.add("notes_calendar_tasks")
-    if has(r"\b(calendar|event|meeting|appointment|schedule)\b"):
+    if has(r"\b(calendar|event|meeting|appointment|schedule)\b",
+           r"\b(kalender\w*|calendario\w*|calendrier\w*|møte\w*|möte\w*|termin(?!a[lt])\w*|avtale\w*|citas?|rendez-vous|reunión\w*|réunion\w*|appuntament\w*|riunion\w*)\b"):
         domains.add("notes_calendar_tasks")
-    if has(r"\b(documents?|docs?|draft|compose|poem|story|essay|outline|letter|edit|rewrite|proofread|suggest|feedback|review this|make a file)\b"):
+    if has(r"\b(documents?|docs?|draft|compose|poem|story|essay|outline|letter|edit|rewrite|proofread|suggest|feedback|review this|make a file)\b",
+           r"\b(dokument\w*|utkast\w*|udkast\w*|entwurf\w*|borrador\w*|brouillon\w*|dikt|gedicht\w*|poemas?|poèmes?|essä\w*|aufsatz\w*|ensayos?|documento\w*|bozza\w*)\b"):
         domains.add("documents")
-    if "notes_calendar_tasks" not in domains and has(r"\bwrite\b"):
+    if "notes_calendar_tasks" not in domains and has(r"\b(write|skriv\w*|schreib\w*|escrib\w*|écri\w*|rédige\w*|scriv\w*)\b"):
         domains.add("documents")
-    if has(r"\b(search|web|google|look up|latest|news|current|weather|forecast|stock price|price of|website|url|https?://|www\.)\b"):
+    if has(r"\b(search|web|google|look up|latest|news|current|weather|forecast|stock price|price of|website|url|https?://|www\.)\b",
+           r"\b(søk\w*|sök\w*|suche\w*|busca\w*|cherche\w*|recherche\w*|nettet|nätet|wetter\w*|väder\w*|vejr\w*|været|værmelding\w*|météo|meteo|nyhet\w*|nachricht\w*|noticias?|actualités?|cerca\w*|notizie)\b"):
         domains.add("web")
     if has(r"\b(research|deep dive|investigate|look into)\b"):
         domains.add("web")
-    if has(r"\b(open|show|toggle|turn on|turn off|disable|enable|switch model|change model|settings|theme|panel)\b"):
+    if has(r"\b(open|show|toggle|turn on|turn off|disable|enable|switch model|change model|settings|theme|panel)\b",
+           r"\b(åpn\w*|öppn\w*|åbn\w*|öffn\w*|abre|abrir|ouvre\w*|ouvrir|apri|slå på|slå av|skru på|skru av|stäng av|sätt på|schalte\w*|aktiver\w*|deaktiver\w*|désactive\w*)\b"):
         domains.add("ui")
     if has(r"\b(session|chat history|rename chat|delete chat|archive chat|fork chat|list chats)\b"):
         domains.add("sessions")
-    if has(r"\b(file|folder|directory|repo|git|grep|find in files|read file|edit file|shell|terminal|bash|python)\b"):
+    if has(r"\b(file|folder|directory|repo|git|grep|find in files|read file|edit file|shell|terminal|bash|python)\b",
+           r"\b(fil(?:er|en|ene|erna|a)?|mappe\w*|mapp(?:en|ar|er)?|ordner\w*|datei\w*|carpeta\w*|dossiers?|fichier\w*|archivos?|cartell\w*|katalog\w*|verzeichnis\w*)\b"):
         domains.add("files")
-    if has(r"\b(endpoint|api token|mcp|webhook|preference|configure|config|setting)\b"):
+    if has(r"\b(endpoint|api token|mcp|webhook|preference|configure|config|setting)\b",
+           r"\b(innstilling\w*|inställning\w*|indstilling\w*|einstellung\w*|ajustes?|configuración\w*|configura\w*|paramètres?|konfigur\w*|impostazion\w*)\b"):
         domains.add("settings")
 
     low_signal = not continuation and not domains

--- a/tests/test_tool_rag_multilingual_domains.py
+++ b/tests/test_tool_rag_multilingual_domains.py
@@ -1,0 +1,164 @@
+"""The tool-RAG domain classifier (`_classify_agent_request` in
+src/agent_loop.py) only matched English keywords, so a non-English agent
+request matched no domain, was flagged `low_signal=True`, and tool retrieval
+was skipped entirely: the model received only the always-available tools
+(manage_memory, ask_user, update_plan) and told the user it could not do the
+task. Live repro (Norwegian, agent mode):
+
+    [agent-intent] latest='Vis meg de fem siste e-postene i innboksen min.'
+        continuation=False low_signal=True domains=[] ...
+    [tool-rag] Low-signal agent message; skipping retrieval and using
+        always-available tools only
+    [agent-intent] selected_tools=['ask_user', 'manage_memory', 'update_plan']
+
+while the English "Show me the five latest emails in my inbox." classified
+domains=['email', 'ui', 'web'] and was offered every email tool.
+
+The classifier is deterministic string matching (no embeddings / no DB), so it
+can be exercised directly. The non-English cases fail on current dev and pass
+with the multilingual keyword extension; the English cases pin existing
+behavior, and smalltalk must stay low-signal in every language.
+"""
+import pytest
+
+from src.agent_loop import _classify_agent_request
+
+
+def _classify(text):
+    return _classify_agent_request([{"role": "user", "content": text}], text)
+
+
+# ---------------------------------------------------------------------------
+# Non-English requests must classify into the same domain as their English
+# equivalent and must NOT be low-signal (which would skip tool retrieval).
+# Languages: Swedish / Norwegian / Danish / German / Spanish / French /
+# Italian (the live repro in #3766 was Italian).
+# ---------------------------------------------------------------------------
+NON_ENGLISH_DOMAIN_CASES = [
+    # email — the live-repro phrasing first
+    ("Vis meg de fem siste e-postene i innboksen min.", "email"),
+    ("Visa de senaste mejlen i min inkorg.", "email"),
+    ("Vis de seneste mails i min indbakke.", "email"),
+    ("Zeig mir den Posteingang.", "email"),
+    ("Muéstrame los últimos correos.", "email"),
+    ("Montre-moi les derniers courriels dans ma boîte de réception.", "email"),
+    # notes / calendar / tasks
+    ("Lag et notat om dette.", "notes_calendar_tasks"),
+    ("Skapa en anteckning om mötet.", "notes_calendar_tasks"),
+    ("Erstell eine Notiz und eine Erinnerung für morgen.", "notes_calendar_tasks"),
+    ("Crea un recordatorio para mañana.", "notes_calendar_tasks"),
+    ("Ajoute un rappel pour demain.", "notes_calendar_tasks"),
+    ("Legg det inn i kalenderen min.", "notes_calendar_tasks"),
+    # documents
+    ("Lag et dokument med et utkast til talen.", "documents"),
+    ("Skriv en dikt om havet.", "documents"),
+    ("Schreib einen Entwurf für den Brief.", "documents"),
+    ("Escribe un borrador del informe.", "documents"),
+    ("Écris un brouillon de la lettre.", "documents"),
+    # web
+    ("Søk på nettet etter dagens nyheter.", "web"),
+    ("Sök på nätet efter senaste nyheterna.", "web"),
+    ("Such im Internet nach den Nachrichten.", "web"),
+    ("Busca en internet las noticias de hoy.", "web"),
+    ("Cherche sur internet la météo.", "web"),
+    ("Hvordan blir været i morgen?", "web"),
+    # files
+    ("Vis meg filene i mappen.", "files"),
+    ("Visa filerna i mappen.", "files"),
+    ("Zeig mir die Dateien im Ordner.", "files"),
+    ("Muéstrame los archivos de la carpeta.", "files"),
+    ("Montre-moi les fichiers dans le dossier.", "files"),
+    # settings
+    ("Endre innstillingene for varsler.", "settings"),
+    ("Ändra inställningarna för aviseringar.", "settings"),
+    ("Ändere die Einstellungen für Benachrichtigungen.", "settings"),
+    ("Cambia la configuración de las notificaciones.", "settings"),
+    ("Modifie les paramètres des notifications.", "settings"),
+    # ui
+    ("Åpne gallerivisningen.", "ui"),
+    ("Öppna panelen.", "ui"),
+    ("Öffne das Panel.", "ui"),
+    ("Abre el panel.", "ui"),
+    ("Ouvre le panneau.", "ui"),
+    # cookbook
+    ("Last ned modellen til maskinen min.", "cookbook"),
+    ("Ladda ner modellen.", "cookbook"),
+    ("Lade das Modell herunter.", "cookbook"),
+    ("Descarga el modelo.", "cookbook"),
+    ("Télécharge le modèle.", "cookbook"),
+    # Italian (live repro language in #3766)
+    ("Mostrami la posta in arrivo.", "email"),
+    ("Crea un promemoria per domani.", "notes_calendar_tasks"),
+    ("Aggiungi l'appuntamento al calendario.", "notes_calendar_tasks"),
+    ("Scrivi una bozza della lettera.", "documents"),
+    ("Cerca su internet le notizie di oggi.", "web"),
+    ("Mostrami i file nella cartella.", "files"),
+    ("Cambia le impostazioni delle notifiche.", "settings"),
+    ("Apri il pannello.", "ui"),
+    ("Scarica il modello.", "cookbook"),
+]
+
+
+@pytest.mark.parametrize("text,domain", NON_ENGLISH_DOMAIN_CASES)
+def test_non_english_request_gets_domain_and_is_not_low_signal(text, domain):
+    intent = _classify(text)
+    assert domain in intent["domains"], (
+        f"expected {domain!r} for {text!r}, got {sorted(intent['domains'])}"
+    )
+    assert intent["low_signal"] is False, f"must not be low_signal: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# English behavior is pinned: same phrasings as before classify identically.
+# ---------------------------------------------------------------------------
+ENGLISH_PINNED_CASES = [
+    ("Show me the five latest emails in my inbox.", "email"),
+    ("Create a note about this.", "notes_calendar_tasks"),
+    ("Write a poem about the sea.", "documents"),
+    ("Search the web for today's news.", "web"),
+    ("Show me the files in the folder.", "files"),
+    ("Configure the email endpoint.", "settings"),
+    ("Download the model.", "cookbook"),
+]
+
+
+@pytest.mark.parametrize("text,domain", ENGLISH_PINNED_CASES)
+def test_english_request_classification_pinned(text, domain):
+    intent = _classify(text)
+    assert domain in intent["domains"], (
+        f"expected {domain!r} for {text!r}, got {sorted(intent['domains'])}"
+    )
+    assert intent["low_signal"] is False
+
+
+# ---------------------------------------------------------------------------
+# Smalltalk stays low-signal in every language: no domain keywords, no
+# retrieval. The fix widens keyword coverage, it must not make every
+# non-English message a domain hit.
+# ---------------------------------------------------------------------------
+SMALLTALK_CASES = [
+    "Hei, hvordan går det med deg i dag?",
+    "Hej, hur mår du idag?",
+    "Hallo, wie geht es dir heute?",
+    "Hola, ¿cómo estás hoy?",
+    "Salut, comment ça va aujourd'hui ?",
+    "Hello, how are you today?",
+]
+
+
+# ---------------------------------------------------------------------------
+# Cross-language collision guard: Italian "notizie" (news) must not trip the
+# German "Notiz" (note) keyword — found in live testing.
+# ---------------------------------------------------------------------------
+def test_italian_news_request_is_web_only_not_notes():
+    intent = _classify("Cerca su internet le notizie di oggi.")
+    assert intent["domains"] == {"web"}, sorted(intent["domains"])
+
+
+@pytest.mark.parametrize("text", SMALLTALK_CASES)
+def test_smalltalk_stays_low_signal(text):
+    intent = _classify(text)
+    assert intent["domains"] == set(), (
+        f"smalltalk must match no domain: {text!r} -> {sorted(intent['domains'])}"
+    )
+    assert intent["low_signal"] is True


### PR DESCRIPTION
## Summary

The tool-RAG domain classifier `_classify_agent_request` (src/agent_loop.py) only matched English keywords, so a non-English agent request matched no domain, was flagged `low_signal`, and tool retrieval was skipped entirely (`low_signal = not continuation and not domains`; the low-signal branch pins the tool set to `ALWAYS_AVAILABLE`). Live repro: Norwegian "Vis meg de fem siste e-postene i innboksen min." got only `ask_user`/`manage_memory`/`update_plan` and the agent told the user to "check your email client or webmail provider directly", while the English phrasing was offered every email tool. This PR extends each domain regex (email, notes/calendar/tasks, documents, web, ui, files, settings, cookbook) with high-precision Swedish/Norwegian/Danish/German/Spanish/French/Italian keywords. Gating semantics, ordering, and English behavior are unchanged; smalltalk stays low-signal in every language.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3713
Fixes #3766 (same bug reported from the Italian side; Italian is covered)

Related: #3605/#3606 (missing `images` domain in the same classifier — intentionally not touched here; it should get the same multilingual treatment once merged), #3771 (orthogonal: restores web tools for genuinely low-signal turns; no diff overlap), #3668/#3683 (sibling English-only pattern in `_INTENT_RE`).

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Details

Each domain `has(...)` call gets one additional pattern argument with the non-English keywords, e.g. email:

```python
if has(r"\b(emails?|mails?|gmail|inbox|...)\b",
       r"\b(e-?post\w*|innboks\w*|inkorg\w*|indbakke\w*|posteingang\w*|mejl\w*|correos?|courriels?|boîte de réception|bandeja de entrada|posta in arrivo)\b"):
    domains.add("email")
```

Tokens were checked one by one against English and cross-language collisions:

- `termin(?!a[lt])\w*` (German "Termin") does not match "terminal"/"terminate".
- `notiz(?!ie)\w*` (German "Notiz") does not match Italian "notizie" (news) — found via live testing, pinned by a dedicated guard test.
- German search verbs use `suche\w*`, never bare `such`.
- `modell(?:e|en|er|ene|erna|o|i)?` does not match British "modelled"/"modelling".
- `meteo` does not match "meteor"; French/Spanish "activate" verbs are left out (`active\w*`/`activa\w*` would match English "active"/"activate").

A false positive costs a few extra tool schemas offered to the model (same as existing loose English keywords like `buy` → notes), never an action.

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (#3606 adds an English-only `images` domain to the same classifier and #3771 changes `ALWAYS_AVAILABLE` in src/tool_index.py; neither overlaps this diff.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

End-to-end verification on a live instance (qwen3:30b-thinking via Ollama), same Norwegian request before/after:

```
# dev (before)
[agent-intent] latest='Vis meg de fem siste e-postene i innboksen min.' ... low_signal=True domains=[]
[tool-rag] Low-signal agent message; skipping retrieval and using always-available tools only
[agent-intent] selected_tools=['ask_user', 'manage_memory', 'update_plan']

# with this PR
[agent-intent] latest='Vis meg de fem siste e-postene i innboksen min.' ... low_signal=False domains=['email']
[agent-intent] selected_tools=['archive_email', 'ask_user', 'bulk_email', 'delete_email', 'list_email_accounts', 'list_emails', ...]
```

and the agent goes from refusing ("check your email client ... directly") to actually calling `list_emails`. The Italian repro from #3766 was also run live:

```
[agent-intent] latest='Cerca su internet le notizie di oggi sul prezzo di bitcoin.' ... low_signal=False domains=['web']
[agent-intent] selected_tools=[..., 'web_fetch', 'web_search']
```

## How to Test

```
python -m pytest tests/test_tool_rag_multilingual_domains.py -q   # 66 passed (49 fail without the src change)
python -m pytest tests/test_agent_loop.py tests/test_tool_rag_keyword_hints.py tests/test_fenced_example_not_executed_for_native_models.py -q   # 68 passed
python -m py_compile src/agent_loop.py                            # ok
```

The new test file exercises `_classify_agent_request` directly (it is deterministic string matching): 52 non-English requests across seven languages and eight domains must classify into the same domain as their English equivalent with `low_signal=False`; English phrasings are pinned to their current classification; greetings in all languages must stay `low_signal=True`; a guard test pins the notizie/Notiz cross-language collision.

Manual check: in Agent Mode, send `Vis meg de fem siste e-postene i innboksen min.` and watch the `[agent-intent]` log line flip from `low_signal=True domains=[]` to `low_signal=False domains=['email']`.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend tool-selection logic and tests only. No CSS, HTML, SVG, or `static/js/` files changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no visual styling changes.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

This is a single-purpose, AI-assisted fix following the issue-first flow: the bug was root-caused and confirmed on #3713 (with credit to the original reporter) before opening this PR.

### Screenshots / clips

N/A — no visual rendering changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
