### PR TITLE
fix(ui): share one z-order stack across Notes and modals

### DIFF
--- a/static/js/modalManager.js
+++ b/static/js/modalManager.js
@@ -28,6 +28,7 @@
 import { previewZoneAt, clearPreview, snapModalToZone } from './tileManager.js';
 import { suspendDock, resumeDock, clearRightDock, applyEdgeDock } from './modalSnap.js';
 import { dismissOrRemove } from './escMenuStack.js';
+import { nextToolWindowZ } from './toolWindowZOrder.js';
 
 const _state = new Map(); // id -> { restoreFn, closeFn, railBtnId, isMinimized, restoreMinHeight }
 
@@ -63,7 +64,14 @@ function _applyRememberedDock(id) {
 // those statics and bump on every bring-to-front.
 let _modalTopZ = 300;
 function _bringToFront(modal) {
-  if (modal) modal.style.setProperty('z-index', String(++_modalTopZ), 'important');
+  if (!modal) return;
+  const z = nextToolWindowZ({
+    exclude: modal,
+    current: getComputedStyle(modal).zIndex,
+    floor: _modalTopZ,
+  });
+  _modalTopZ = Math.max(_modalTopZ, z);
+  modal.style.setProperty('z-index', String(z), 'important');
 }
 
 function _emitModalOpened(id, modal) {

--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -200,6 +200,33 @@ function _restoreNotesSidebarDock(pane) {
   applyEdgeDock(pane, 'right');
 }
 
+// Notes is not a `.modal`; its backdrop is the top-level stacking surface.
+function _topToolWindowZ(exclude = null) {
+  let top = 250;
+  document.querySelectorAll('body > .modal, body > .research-overlay, body > .notes-pane-backdrop')
+    .forEach(el => {
+      if (!el || el === exclude) return;
+      if (el.classList.contains('hidden') || el.classList.contains('modal-minimized')) return;
+      const cs = getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return;
+      const z = parseInt(cs.zIndex, 10);
+      if (Number.isFinite(z)) top = Math.max(top, z);
+    });
+  return top;
+}
+
+function _bringNotesToFront(pane = document.getElementById('notes-pane')) {
+  if (!pane) return;
+  const backdrop = document.getElementById('notes-pane-backdrop') || pane.parentElement;
+  const z = _topToolWindowZ(backdrop) + 1;
+  if (backdrop) backdrop.style.setProperty('z-index', String(z), 'important');
+  try {
+    window.dispatchEvent(new CustomEvent('odysseus:modal-opened', {
+      detail: { id: 'notes-panel', modal: pane },
+    }));
+  } catch (_) {}
+}
+
 function _loadPendingHighlights() {
   try { return new Set(JSON.parse(localStorage.getItem(REMINDER_PENDING_HIGHLIGHT_KEY) || '[]')); }
   catch { return new Set(); }
@@ -1096,7 +1123,10 @@ export async function refreshDueBadge(opts = {}) {
 // ---- Panel ----
 
 export function openPanel() {
-  if (_open) return;
+  if (_open) {
+    _bringNotesToFront();
+    return;
+  }
   _open = true;
   _editingId = null;
   // Reset the search filter — the rebuilt pane's search input renders empty, so a
@@ -1190,8 +1220,10 @@ export function openPanel() {
   });
   backdrop.appendChild(pane);
   document.body.appendChild(backdrop);
+  _bringNotesToFront(pane);
   _wireNotesWindow(pane);
   _restoreNotesSidebarDock(pane);
+  _bringNotesToFront(pane);
 
   // Events
   // (Close chevron removed — swipe down on mobile, tool-rail toggle on desktop.)
@@ -1201,6 +1233,9 @@ export function openPanel() {
   // dismiss, rubber-band on up-drag, spring snap-back.
   _wireNotesSwipeDismiss(pane.querySelector('.notes-mobile-grabber'), pane);
   _wireNotesSwipeDismiss(pane.querySelector('.notes-pane-header'), pane);
+
+  pane.addEventListener('pointerdown', () => _bringNotesToFront(pane), true);
+  pane.addEventListener('focusin', () => _bringNotesToFront(pane), true);
 
   const minBtn = document.getElementById('notes-minimize-btn');
   if (minBtn) minBtn.addEventListener('click', (e) => {

--- a/static/js/notes.js
+++ b/static/js/notes.js
@@ -10,6 +10,7 @@ import { attachColorPicker } from './colorPicker.js';
 import { makeWindowDraggable } from './windowDrag.js';
 import { snapModalToZone } from './tileManager.js';
 import { applyEdgeDock, clearDockSide } from './modalSnap.js';
+import { topToolWindowZ } from './toolWindowZOrder.js';
 
 const API_BASE = window.location.origin;
 let _open = false;
@@ -202,17 +203,7 @@ function _restoreNotesSidebarDock(pane) {
 
 // Notes is not a `.modal`; its backdrop is the top-level stacking surface.
 function _topToolWindowZ(exclude = null) {
-  let top = 250;
-  document.querySelectorAll('body > .modal, body > .research-overlay, body > .notes-pane-backdrop')
-    .forEach(el => {
-      if (!el || el === exclude) return;
-      if (el.classList.contains('hidden') || el.classList.contains('modal-minimized')) return;
-      const cs = getComputedStyle(el);
-      if (cs.display === 'none' || cs.visibility === 'hidden') return;
-      const z = parseInt(cs.zIndex, 10);
-      if (Number.isFinite(z)) top = Math.max(top, z);
-    });
-  return top;
+  return topToolWindowZ({ exclude });
 }
 
 function _bringNotesToFront(pane = document.getElementById('notes-pane')) {
@@ -1220,7 +1211,6 @@ export function openPanel() {
   });
   backdrop.appendChild(pane);
   document.body.appendChild(backdrop);
-  _bringNotesToFront(pane);
   _wireNotesWindow(pane);
   _restoreNotesSidebarDock(pane);
   _bringNotesToFront(pane);

--- a/static/js/toolWindowZOrder.js
+++ b/static/js/toolWindowZOrder.js
@@ -1,0 +1,29 @@
+export const TOOL_WINDOW_SELECTOR = 'body > .modal, body > .research-overlay, body > .notes-pane-backdrop';
+
+export function topToolWindowZ(options = {}) {
+  const {
+    exclude = null,
+    root = globalThis.document,
+    getStyle = globalThis.getComputedStyle,
+    floor = 250,
+  } = options;
+  let top = floor;
+  if (!root || typeof root.querySelectorAll !== 'function' || typeof getStyle !== 'function') return top;
+  root.querySelectorAll(TOOL_WINDOW_SELECTOR).forEach(el => {
+    if (!el || el === exclude) return;
+    if (el.classList?.contains('hidden') || el.classList?.contains('modal-minimized')) return;
+    const cs = getStyle(el);
+    if (cs.display === 'none' || cs.visibility === 'hidden') return;
+    const z = parseInt(cs.zIndex, 10);
+    if (Number.isFinite(z)) top = Math.max(top, z);
+  });
+  return top;
+}
+
+export function nextToolWindowZ(options = {}) {
+  const { current = null } = options;
+  const top = topToolWindowZ(options);
+  const currentZ = parseInt(current, 10);
+  if (Number.isFinite(currentZ) && currentZ > top) return currentZ;
+  return top + 1;
+}

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -8,6 +8,7 @@ import themeModule from './theme.js';
 import * as Modals from './modalManager.js';
 import spinnerModule from './spinner.js';
 import { registerMenuDismiss, dismissTopMenu, dismissOrRemove } from './escMenuStack.js';
+import { nextToolWindowZ, topToolWindowZ } from './toolWindowZOrder.js';
 
 let toastEl = null;
 let autoScrollEnabled = true;
@@ -1088,14 +1089,22 @@ if ('ontouchstart' in window) {
 
 // ---- Bring modal to front on click ----
 {
-  let topModalZ = 250;
+  const raiseModalToFront = (modal, floor = 250) => {
+    const z = nextToolWindowZ({
+      exclude: modal,
+      current: getComputedStyle(modal).zIndex,
+      floor,
+    });
+    modal.style.setProperty('z-index', String(z), 'important');
+    return z;
+  };
+
   document.addEventListener('mousedown', (e) => {
     const modalContent = e.target.closest('.modal-content');
     if (!modalContent) return;
     const modal = modalContent.closest('.modal');
     if (!modal) return;
-    topModalZ += 1;
-    modal.style.zIndex = topModalZ;
+    raiseModalToFront(modal);
   });
 
   // Backdrop tap to close — delegated for all modals
@@ -1190,9 +1199,15 @@ if (!window._odyEscExpandGuard) {
     // Re-entry guard: setting style.zIndex itself fires the observer that
     // calls us back. Skip if this element is already pinned to the top
     // (matches the current counter) so we don't spin into an infinite loop.
-    const cur = parseInt(m.style.zIndex, 10) || 0;
-    if (cur === _zCounter) return;
-    m.style.zIndex = String(++_zCounter);
+    const cur = parseInt(getComputedStyle(m).zIndex, 10) || 0;
+    if (cur === _zCounter && cur > topToolWindowZ({ exclude: m })) return;
+    const z = nextToolWindowZ({
+      exclude: m,
+      current: cur,
+      floor: _zCounter,
+    });
+    _zCounter = Math.max(_zCounter, z);
+    if (z !== cur) m.style.setProperty('z-index', String(z), 'important');
   };
   new MutationObserver((muts) => {
     for (const m of muts) {

--- a/tests/test_notes_z_order_js.py
+++ b/tests/test_notes_z_order_js.py
@@ -1,0 +1,139 @@
+"""Node-driven regression coverage for Notes pane z-order selection.
+
+Notes uses a body-level backdrop instead of the shared `.modal` element, so the
+shared tool-window stack helper must account for both Notes and normal modals
+without importing the full browser-heavy modules.
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "static" / "js" / "toolWindowZOrder.js"
+pytestmark = pytest.mark.skipif(not shutil.which("node"), reason="node binary not on PATH")
+
+
+def _node_eval(source: str):
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=source,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+def test_notes_z_order_uses_floor_when_no_tool_windows_are_open():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ topToolWindowZ }} from '{HELPER.as_uri()}';
+            const root = {{ querySelectorAll() {{ return []; }} }};
+            console.log(JSON.stringify({{ z: topToolWindowZ({{ root, getStyle: () => ({{}}) }}) }}));
+            """
+        )
+    )
+
+    assert values == {"z": 250}
+
+
+def test_notes_z_order_lands_above_highest_visible_tool_window():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ topToolWindowZ }} from '{HELPER.as_uri()}';
+            const cls = (...names) => ({{ contains: (name) => names.includes(name) }});
+            const elements = [
+              {{ id: 'memory', classList: cls(), style: {{ zIndex: '320' }} }},
+              {{ id: 'research', classList: cls(), style: {{ zIndex: '415' }} }},
+              {{ id: 'invalid', classList: cls(), style: {{ zIndex: 'auto' }} }},
+            ];
+            const root = {{ querySelectorAll() {{ return elements; }} }};
+            const top = topToolWindowZ({{ root, getStyle: (el) => el.style }});
+            console.log(JSON.stringify({{ top, notes: top + 1 }}));
+            """
+        )
+    )
+
+    assert values == {"top": 415, "notes": 416}
+
+
+def test_modal_z_order_handoff_lands_above_notes_tie_on_first_click():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ nextToolWindowZ }} from '{HELPER.as_uri()}';
+            const cls = (...names) => ({{ contains: (name) => names.includes(name) }});
+            const modal = {{ id: 'modal', classList: cls(), style: {{ zIndex: '416' }} }};
+            const notes = {{ id: 'notes', classList: cls(), style: {{ zIndex: '416' }} }};
+            const elements = [modal, notes];
+            const root = {{ querySelectorAll() {{ return elements; }} }};
+            const z = nextToolWindowZ({{
+              exclude: modal,
+              current: modal.style.zIndex,
+              root,
+              getStyle: (el) => el.style,
+            }});
+            console.log(JSON.stringify({{ z }}));
+            """
+        )
+    )
+
+    assert values == {"z": 417}
+
+
+def test_modal_z_order_keeps_current_z_when_already_above_stack():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ nextToolWindowZ }} from '{HELPER.as_uri()}';
+            const cls = (...names) => ({{ contains: (name) => names.includes(name) }});
+            const modal = {{ id: 'modal', classList: cls(), style: {{ zIndex: '420' }} }};
+            const notes = {{ id: 'notes', classList: cls(), style: {{ zIndex: '416' }} }};
+            const root = {{ querySelectorAll() {{ return [modal, notes]; }} }};
+            const z = nextToolWindowZ({{
+              exclude: modal,
+              current: modal.style.zIndex,
+              root,
+              getStyle: (el) => el.style,
+            }});
+            console.log(JSON.stringify({{ z }}));
+            """
+        )
+    )
+
+    assert values == {"z": 420}
+
+
+def test_notes_z_order_ignores_hidden_minimized_and_excluded_windows():
+    values = _node_eval(
+        textwrap.dedent(
+            f"""
+            import {{ topToolWindowZ }} from '{HELPER.as_uri()}';
+            const cls = (...names) => ({{ contains: (name) => names.includes(name) }});
+            const excluded = {{ id: 'notes', classList: cls(), style: {{ zIndex: '900' }} }};
+            const elements = [
+              excluded,
+              {{ id: 'hidden-class', classList: cls('hidden'), style: {{ zIndex: '800' }} }},
+              {{ id: 'minimized', classList: cls('modal-minimized'), style: {{ zIndex: '700' }} }},
+              {{ id: 'display-none', classList: cls(), style: {{ zIndex: '600', display: 'none' }} }},
+              {{ id: 'visibility-hidden', classList: cls(), style: {{ zIndex: '500', visibility: 'hidden' }} }},
+              {{ id: 'visible', classList: cls(), style: {{ zIndex: '310' }} }},
+            ];
+            const root = {{ querySelectorAll() {{ return elements; }} }};
+            const top = topToolWindowZ({{ exclude: excluded, root, getStyle: (el) => el.style }});
+            console.log(JSON.stringify({{ top }}));
+            """
+        )
+    )
+
+    assert values == {"top": 310}


### PR DESCRIPTION
## Summary

Notes is mounted as a standalone pane inside `#notes-pane-backdrop`, while the other tool windows are top-level `.modal` surfaces. This raises the Notes backdrop above the highest visible tool window when Notes opens or receives focus/pointer interaction, so the focused Notes pane is no longer stuck behind Cookbook, Tasks, Gallery, or other windows.

This also centralizes tool-window stacking through `toolWindowZOrder.js`, so Notes and regular modals share one z-index calculation and avoid the previous `modalManager.js` / `ui.js` counter handoff where a clicked window could fail to surface on the first click.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click Edit on this PR and change the base.

## Linked Issue

Fixes #3788

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run Odysseus with Docker Compose and open the app.
2. Open overlapping tool windows such as Cookbook, Tasks, and Gallery.
3. Open Notes, then click or focus the Notes pane.
4. Confirm Notes appears above the other open tool windows and the underlying chat model selector.
5. Click another tool window and then click Notes again to confirm Notes can be brought back to the front.

Checks run locally:

```bash
docker compose up -d --build
docker compose exec -T odysseus node --check static/js/notes.js
docker compose exec -T odysseus node --check static/js/modalManager.js
git diff --check
```

Manual verification: reproduced with overlapping tool windows; confirmed the focused Notes pane now appears above them.

## Visual / UI changes - REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like - buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM - needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) - do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first - bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

https://github.com/user-attachments/assets/5c3a18a3-44b8-4db1-8f02-22b40d04e92b