### PR TITLE
fix(tools): recognise FR/non-URL web-search intent in tool selection

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -779,9 +779,16 @@ def _classify_agent_request(messages: List[Dict], last_user: str) -> Dict[str, o
         domains.add("documents")
     if "notes_calendar_tasks" not in domains and has(r"\bwrite\b"):
         domains.add("documents")
-    if has(r"\b(search|web|google|look up|latest|news|current|weather|forecast|stock price|price of|website|url|https?://|www\.)\b"):
+    if has(
+        r"\b(search|web|google|look up|latest|news|current|weather|forecast|stock price|price of|website|url|https?://|www\.)\b",
+        # FR / non-URL web-search intent (mirrors tool_index._WEB_SEARCH_RE):
+        # "cherche/recherche ... (sur le) web/internet/en ligne", "sur le web", "recherche internet".
+        r"\b(?:cherche|recherche|chercher|rechercher)\b(?:\s+[\w'-]+){0,5}?\s+(?:sur\s+(?:le\s+)?)?(?:web|internet|en\s+ligne)\b",
+        r"\bsur\s+(?:le\s+)?(?:web|internet)\b",
+        r"\brecherche\s+(?:web|internet|en\s+ligne)\b",
+    ):
         domains.add("web")
-    if has(r"\b(research|deep dive|investigate|look into)\b"):
+    if has(r"\b(research|deep dive|investigate|look into|recherche approfondie)\b"):
         domains.add("web")
     if has(r"\b(open|show|toggle|turn on|turn off|disable|enable|switch model|change model|settings|theme|panel)\b"):
         domains.add("ui")

--- a/src/tool_index.py
+++ b/src/tool_index.py
@@ -336,6 +336,24 @@ class ToolIndex:
         r"https?://|www\.|\b(?:visit|open|fetch|check|read)\s+(?:this\s+)?(?:url|link|site|website|page)\b",
         re.I,
     )
+    # Explicit web-SEARCH intent (not just URLs). Requires a search verb AND a
+    # web noun co-occurring, in EN or FR, so trivial prompts ("test", "yo") and
+    # talking *about* the web ("Google released a model") never fire. Without
+    # this, "search the web for X" / "cherche sur le web X" have no deterministic
+    # gate and depend entirely on the top-k embedding retrieval, which silently
+    # drops web_search whenever that budget is crowded (e.g. an open document is
+    # injected into the agent context).
+    _WEB_SEARCH_RE = re.compile(
+        # EN: search-verb ... web-noun
+        r"\b(?:search|look\s+up|browse|find)\b(?:\s+[\w'-]+){0,4}?\s+(?:on\s+)?(?:the\s+)?(?:web|internet|online)\b"
+        r"|\b(?:web|internet|online)\s+search\b"
+        r"|\bgoogle\s+(?:it|this|that|for|the)\b"
+        # FR: cherche/recherche ... web-noun
+        r"|\b(?:cherche|recherche|chercher|rechercher|google\w*)\b(?:\s+[\w'-]+){0,5}?\s+(?:sur\s+(?:le\s+)?)?(?:web|internet|en\s+ligne)\b"
+        r"|\bsur\s+(?:le\s+)?(?:web|internet)\b"
+        r"|\brecherche\s+(?:web|internet|en\s+ligne)\b",
+        re.I,
+    )
 
     # Keyword hints: if the query mentions these words, force-include the tools.
     _KEYWORD_HINTS = {
@@ -497,10 +515,11 @@ class ToolIndex:
         # the agent can actually create the cron job instead of fumbling.
         if self._SCHEDULE_RE.search(ql):
             base.add("manage_tasks")
-        # URL/site requests need web tools even when embedding retrieval is
-        # stubbed/unavailable. Keep this structural, not always-on, so trivial
-        # prompts do not drag web schemas into the agent context.
-        if self._WEB_RE.search(query):
+        # URL/site requests AND explicit web-search intent (EN/FR) need web tools
+        # even when embedding retrieval is stubbed or its top-k budget is crowded
+        # (e.g. an open document is injected). Keep this structural, not
+        # always-on, so trivial prompts do not drag web schemas into the context.
+        if self._WEB_RE.search(query) or self._WEB_SEARCH_RE.search(query):
             base.update({"web_search", "web_fetch"})
         return base
 

--- a/tests/test_web_search_intent_multilang.py
+++ b/tests/test_web_search_intent_multilang.py
@@ -1,0 +1,132 @@
+"""Web-search intent gating (multilingual).
+
+Explicit "search the web" requests — in English AND French, with or without a
+URL — must force-include ``web_search``/``web_fetch`` even when the embedding
+retrieval is stubbed or its top-k budget is crowded (e.g. an open document is
+injected into the agent context). Trivial prompts must NOT pull web tools, so we
+do not reintroduce the #2684 regression (``test``/``yo`` triggering web search).
+
+Reproduces the original report: a FRENCH request ("cherche sur le web les VLM")
+made with a large document open lost ``web_search`` entirely, because the only
+deterministic web gate (``_WEB_RE``) matched URLs only and the RAG top-k was
+crowded out by the injected document.
+"""
+import pytest
+
+from src.agent_loop import _classify_agent_request
+from src.tool_index import ToolIndex
+
+
+def _web_domain(message: str) -> bool:
+    """True when the agent-loop request classifier tags a single-turn message as
+    the 'web' domain, which seeds web_search/web_fetch on every selection path."""
+    intent = _classify_agent_request([{"role": "user", "content": message}], message)
+    return "web" in intent["domains"]
+
+
+def _tools_for(query: str):
+    """Run get_tools_for_query with the heavy __init__ skipped and retrieval
+    stubbed to empty, so only the deterministic gates decide the result."""
+    idx = ToolIndex.__new__(ToolIndex)
+    idx.retrieve = lambda q, k=8: set()
+    return idx.get_tools_for_query(query)
+
+
+WEB_SEARCH_QUERIES = [
+    # FR
+    "cherche sur le web les VLM",
+    "Cherche maintenant sur le web les VLM recents avec ton outil web_search",
+    "fais une recherche internet sur les VLM",
+    "recherche sur internet les derniers modeles",
+    "recherche sur le web des infos sur les transformers",
+    # EN
+    "search the web for recent VLMs",
+    "look up the latest VLMs online",
+    "can you search online for the news",
+    "google the latest AI news",
+    "do a web search for python tutorials",
+]
+
+URL_QUERIES = [
+    "open this link please",
+    "visit https://example.com",
+    "fetch this url for me",
+]
+
+NON_WEB_QUERIES = [
+    "test",
+    "yo",
+    "what is 2+2",
+    "edit the document",
+    "resume ce document en 5 points",
+    "remember that I like coffee",
+    "write a python function",
+    "open the file config.py",
+    "explique moi comment fonctionne un transformer",
+    "Google a publie un nouveau modele",  # talking ABOUT Google, not searching
+]
+
+
+@pytest.mark.parametrize("q", WEB_SEARCH_QUERIES)
+def test_explicit_web_search_intent_includes_web_tools(q):
+    tools = _tools_for(q)
+    assert "web_search" in tools, f"web_search missing for: {q!r}"
+    assert "web_fetch" in tools, f"web_fetch missing for: {q!r}"
+
+
+@pytest.mark.parametrize("q", URL_QUERIES)
+def test_url_intent_still_includes_web_tools(q):
+    tools = _tools_for(q)
+    assert {"web_search", "web_fetch"} <= tools, f"URL gate broken for: {q!r}"
+
+
+@pytest.mark.parametrize("q", NON_WEB_QUERIES)
+def test_trivial_prompts_do_not_pull_web_tools(q):
+    tools = _tools_for(q)
+    assert "web_search" not in tools, f"web_search wrongly added for: {q!r}"
+    assert "web_fetch" not in tools, f"web_fetch wrongly added for: {q!r}"
+
+
+def test_french_doc_open_repro():
+    # The exact reproduction from the bug report.
+    assert "web_search" in _tools_for("cherche sur le web les VLM")
+
+
+# --- Agent-loop domain classifier (the all-paths gate) -----------------------
+# get_tools_for_query only runs on the RAG path; the domain classifier feeds the
+# deterministic "domain seeding" that runs on EVERY path (RAG, keyword fallback,
+# caller-provided). It must recognise FR / non-URL web-search intent too, or a
+# follow-up like "fais une recherche internet" silently loses web_search when the
+# RAG retrieval falls back (e.g. a ChromaDB hiccup) or is crowded by an open doc.
+
+WEB_DOMAIN_QUERIES = [
+    "fais une recherche internet sur les VLM",
+    "cherche sur le web les VLM",
+    "recherche sur internet les derniers modeles",
+    "recherche sur le web des infos sur les transformers",
+    "cherche en ligne des exemples",
+    "search the web for recent VLMs",
+    "google the latest AI news",
+    "look up the latest models online",
+]
+
+NON_WEB_DOMAIN_QUERIES = [
+    "test",
+    "yo",
+    "edit the document",
+    "resume ce document en 5 points",
+    "lis la roadmap et resume-la",          # step 1 of the repro must NOT pull web
+    "explique le protocole internet",        # 'internet' but not a search request
+    "ecris une fonction python",
+    "remember that I like coffee",
+]
+
+
+@pytest.mark.parametrize("q", WEB_DOMAIN_QUERIES)
+def test_web_intent_classified_as_web_domain(q):
+    assert _web_domain(q), f"'web' domain missing for: {q!r}"
+
+
+@pytest.mark.parametrize("q", NON_WEB_DOMAIN_QUERIES)
+def test_non_web_not_classified_as_web_domain(q):
+    assert not _web_domain(q), f"'web' domain wrongly set for: {q!r}"


### PR DESCRIPTION
## What

Make web-search **intent detection** FR / non-URL aware, so the agent reliably gets `web_search`/`web_fetch` for explicit search requests — including French (*"fais une recherche internet…"*, *"cherche sur le web…"*) and English **non-URL** phrasings (*"search the web for…"*), which previously slipped through both gates.

Fixes #3801

## Why

`web_search`/`web_fetch` are intent-gated (not in `ALWAYS_AVAILABLE`). Both deterministic gates were English/URL-only:

- `tool_index._WEB_RE` — URLs only.
- `agent_loop._classify_agent_request` web-domain keywords — `search|web|google|look up|latest|news|…`, `research|investigate` (no `internet`, no `recherche`).

So a French / non-URL request matched neither, leaving `web_search` to the top-k retrieval — which an open document (or any crowding) pushes out, and the keyword-fallback path can't recover. The model then reports it has no web tool. Same class as #1707; aligned with the #2684 / #3464 decision to gate intent rather than make web tools always-available (this does **not** touch `ALWAYS_AVAILABLE`).

## Changes (`src/` only)

- **`tool_index.py`** — add `_WEB_SEARCH_RE` (a sibling of `_WEB_RE`) matching *search-verb + web-noun* (EN+FR: `search the web` / `cherche|recherche … (sur le) web|internet|en ligne`); OR it into the `get_tools_for_query` web gate.
- **`agent_loop.py`** — the `_classify_agent_request` `"web"` domain (which seeds web tools on **every** selection path, including the keyword fallback used when retrieval is unavailable) now matches the same FR/non-URL intent.

Both require a search **verb** AND a web **noun**, so trivial prompts (`test`, `yo`, *"Google released a model"*) still don't pull web tools — **no #2684 regression**.

## Tests / checks

- New `tests/test_web_search_intent_multilang.py` — **40 cases** (FR+EN; both the tool gate and the domain classifier; positives, URL-intent, and negatives incl. the trivial-prompt guard).
- `python -m pytest tests/test_web_search_intent_multilang.py` → **40 passed**. Existing web/tool-selection suite stays green (`-k "web or tool_rag or tool_index or keyword or intent"` → 196 passed).
- `python -m py_compile src/tool_index.py src/agent_loop.py app.py` → OK.
- **Ran the actual app** (agent mode, web toggle on, a document open): *"Lis la ROADMAP…"* → summarised it; then *"fais une recherche internet sur les VLM"* → performed the web search and returned sources. Before this change the same turn answered *"I don't have a web search tool."*

No UI/visual changes.
