### PR TITLE
fix(llm): don't send llama.cpp slot-affinity extras to cloud OpenAI-compatible APIs

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -455,17 +455,32 @@ def _detect_provider(url: str) -> str:
     return "openai"
 
 
+# Cloud APIs that speak the OpenAI-compatible protocol but fall through
+# _detect_provider to "openai" (no dedicated provider branch). They are not
+# self-hosted servers: none of them honor llama.cpp's slot-affinity extras,
+# and Mistral actively rejects unknown top-level fields with a 422
+# ("extra_forbidden" for session_id/cache_prompt).
+_CLOUD_OPENAI_COMPAT_DOMAINS = (
+    "openai.com", "mistral.ai", "deepseek.com", "x.ai", "googleapis.com",
+    "together.xyz", "together.ai", "fireworks.ai", "ollama.com",
+)
+
+
 def _is_self_hosted_openai_compatible(url: str) -> bool:
     """True for custom/local OpenAI-compatible servers (llama.cpp, LM Studio,
-    vLLM, text-generation-webui, etc.) as opposed to api.openai.com itself.
+    vLLM, text-generation-webui, etc.) as opposed to cloud APIs.
 
     Used to gate llama.cpp-server-specific payload extras (``session_id``,
     ``cache_prompt``) — sending unrecognized top-level fields to OpenAI's
-    actual API returns a 400 ("Unrecognized request argument"), but
-    self-hosted servers generally ignore unknown fields and many (notably
-    llama.cpp's server) use them for KV-cache slot affinity (issue #2927).
+    actual API returns a 400 ("Unrecognized request argument") and to
+    Mistral's a 422 ("extra_forbidden"), but self-hosted servers generally
+    ignore unknown fields and many (notably llama.cpp's server) use them for
+    KV-cache slot affinity (issue #2927).
     """
-    return _detect_provider(url) == "openai" and not _host_match(url, "openai.com")
+    return (
+        _detect_provider(url) == "openai"
+        and not _host_match(url, *_CLOUD_OPENAI_COMPAT_DOMAINS)
+    )
 
 
 def _apply_local_cache_affinity(payload: Dict, url: str, session_id: Optional[str]) -> None:

--- a/tests/test_kv_cache_invalidation_2927.py
+++ b/tests/test_kv_cache_invalidation_2927.py
@@ -442,6 +442,39 @@ def test_payload_omits_session_id_for_official_openai_api(monkeypatch):
     assert "cache_prompt" not in captured[0]
 
 
+@pytest.mark.parametrize("url", [
+    # Mistral rejects the extras outright — 422 {"type":"extra_forbidden",
+    # "loc":["body","session_id"]} / ["body","cache_prompt"] — which broke
+    # every chat turn against api.mistral.ai (primary AND fallback model).
+    "https://api.mistral.ai/v1/chat/completions",
+    "https://api.deepseek.com/v1/chat/completions",
+    "https://api.x.ai/v1/chat/completions",
+    "https://api.together.xyz/v1/chat/completions",
+    "https://api.fireworks.ai/inference/v1/chat/completions",
+    "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+])
+def test_payload_omits_session_id_for_cloud_openai_compatible_apis(monkeypatch, url):
+    """Cloud APIs that fall through provider detection to the OpenAI-compatible
+    default are still NOT self-hosted: they must never receive the llama.cpp
+    slot-affinity extras. Before this gate covered them, api.mistral.ai
+    rejected every request carrying session_id/cache_prompt with HTTP 422."""
+    from src import llm_core
+
+    captured = []
+    monkeypatch.setattr(llm_core, "_get_http_client", lambda: _FakeStreamClient(captured))
+    monkeypatch.setattr(llm_core, "_is_host_dead", lambda u: False)
+    monkeypatch.setattr(llm_core, "note_model_activity", lambda *a, **k: None)
+    monkeypatch.setattr(llm_core, "_clear_host_dead", lambda *a, **k: None)
+
+    messages = [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+
+    _drain(llm_core.stream_llm(url, "some-model", messages, session_id="session-A"))
+
+    assert len(captured) == 1
+    assert "session_id" not in captured[0]
+    assert "cache_prompt" not in captured[0]
+
+
 def test_payload_omits_session_id_when_not_provided(monkeypatch):
     """No session_id kwarg → no extras added (e.g. title generation, internal
     one-off calls that don't carry a session)."""


### PR DESCRIPTION
## Summary

`_apply_local_cache_affinity` injects `session_id` / `cache_prompt` (llama.cpp KV-cache slot-affinity hints from #2927) into outgoing payloads, gated by `_is_self_hosted_openai_compatible()` — which treated every OpenAI-compatible URL except `api.openai.com` as self-hosted. Cloud APIs with no dedicated branch in `_detect_provider` (Mistral, DeepSeek, xAI, Google's OpenAI-compat endpoint, Together, Fireworks, Ollama Cloud) fell through to `"openai"` and received the extras. Mistral validates request bodies strictly and rejects every such request with `422 {"type":"extra_forbidden","loc":["body","session_id"]}` — breaking **every chat turn** against `api.mistral.ai`, on the primary and the fallback model alike. The fix excludes a `_CLOUD_OPENAI_COMPAT_DOMAINS` tuple from the self-hosted gate; the domain list mirrors the providers the codebase already knows about in `_provider_label`. Local backends (llama.cpp / LM Studio) keep receiving the extras — the existing #2927 tests still pin that.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #3793 (same bug also reported as #3819)

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

> **Overlap disclosure:** #3820 and #3823 also address this bug; found them during the duplicate search. Differences: #3820 changes the same gate but ships no tests and its domain list (deepinfra/anyscale/perplexity) doesn't track the codebase's own provider inventory; #3823 bundles an unrelated Gemini payload builder into the fix. This PR keeps the fix surgical (one gate + one tuple), pins it with parametrized regression tests, and the domain list mirrors `_provider_label`. Maintainer's call which to take — happy to close in favour of either.

## How to Test

1. On `dev`, configure a Mistral endpoint (`https://api.mistral.ai/v1`, e.g. `mistral-large-latest`) and send any chat message: every turn fails with `Mistral returned HTTP 422 … "extra_forbidden", "loc": ["body","session_id"] / ["body","cache_prompt"]` (primary and fallback both die, so the reply is empty).
2. `git checkout` this branch, restart, send the same message: requests to `api.mistral.ai` return `200 OK` and chat/agent turns work — verified live against a real Mistral key, including multi-round agent tool-calling.
3. Confirm local backends are unaffected: a llama.cpp / LM Studio endpoint still receives `session_id` + `cache_prompt` (slot affinity, #2927) — pinned by the pre-existing tests.
4. Automated: `python -m pytest tests/test_kv_cache_invalidation_2927.py` — 14 passed, including the new parametrized cases asserting the real streaming payload to `api.mistral.ai` (and deepseek/x.ai/together/fireworks/Google's OpenAI-compat endpoint) carries neither field; the test fails on `dev` before the fix. Full suite on this branch: **3125 passed, 1 skipped**. Also ran `python -m py_compile app.py routes/*.py src/*.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — no rendering changes (backend payload gating + tests only).

---

*Disclosure: this PR was written with Claude Code; it is a single scoped fix linked to an existing issue, driven, reviewed, and manually verified against the live app by the author (not a bulk submission).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)