### PR TITLE
fix(chat): defer pinned skill prompt submission past the form debounce

### DIFF
--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -338,10 +338,13 @@ function _submitComposedMessage(text) {
   const msgInput = document.getElementById('message');
   const form = document.getElementById('chat-form');
   if (!msgInput || !form) return false;
-  msgInput.value = text;
-  msgInput.dispatchEvent(new Event('input', { bubbles: true }));
-  if (typeof form.requestSubmit === 'function') form.requestSubmit();
-  else form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+  // The slash handler and app-level form debounce must both release before
+  // sending the pinned prompt, otherwise the follow-up submit is dropped.
+  setTimeout(() => {
+    msgInput.value = text;
+    msgInput.dispatchEvent(new Event('input', { bubbles: true }));
+    form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+  }, 350);
   return true;
 }
 


### PR DESCRIPTION
## SummaryWhen a published skill is invoked via a slash command (e.g. `/skills use <skill> ...` or `/<skill-name> <request>`), the composed pinned-skill prompt returned by `/api/skills/<name>/invoke` was built correctly server-side but never sent: the user bubble appeared and no `chat_stream` fired. The cause is a frontend re-entrancy race — `_submitComposedMessage()` fired the follow-up submit synchronously while the slash handler's `_sendInFlight` guard and the app-level form-submit debounce were still active, so the submission was swallowed. This PR defers the input update and form submission until after the slash handler and the form debounce have released, and dispatches a plain `submit` event (the path the app's submit handler already intercepts) instead of `requestSubmit()`, so the pinned prompt is reliably sent as a normal agent turn.## Target branch- [x] This PR targets **`dev`**, not `main`.## Linked IssueFixes #3748## Type of Change- [x] Bug fix (non-breaking — fixes a confirmed issue)- [ ] New feature (non-breaking — adds new behaviour)- [ ] Breaking change (changes or removes existing behaviour)- [ ] Refactor / cleanup (behaviour unchanged)- [ ] Documentation only- [ ] CI / tooling / configuration## Checklist- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (This fixes the existing report #3748.)- [x] This PR targets `dev`- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.## How to Test1. Import + publish any skill so it appears in the slash catalog (e.g. `studio-brain`, or career-ops from the SKILL.md linked in #3748).2. Open a fresh chat and send a normal message (`hello`) — confirm the agent replies (baseline that `chat_stream` works).3. Send `/<skill-name> <request>` (e.g. `/skills use studio-brain ...` or `/career-ops scan`).4. **Before this fix:** the user bubble appears, `invoke` returns 200 with a valid `message`, but no `chat_stream` fires and the agent never responds.5. **With this fix:** the pinned skill prompt is auto-submitted, `chat_stream` fires, the tool call executes, and the agent returns the expected response.6. Static check: `node --check static/js/slashCommands.js` passes.🤖 Generated with [Claude Code](https://claude.com/claude-code)