### PR TITLE
docs: add community MCP servers list

### DIFF
--- a/docs/community-mcp-servers.md
+++ b/docs/community-mcp-servers.md
@@ -1,0 +1,17 @@
+# Community MCP Servers
+
+Third-party MCP servers compatible with Odysseus. Add your server via pull request.
+
+## Data & Research
+
+| Server | Description | Tools | Docs |
+|--------|-------------|-------|------|
+| [LoneStarOracle](https://github.com/Homie4570/lso-mcp) | 38 real-world data tools — live weather forecasts, crypto token risk analysis, smart contract audits, energy grid status, real estate pulse, on-chain whale tracking, and more. Pay-per-query via x402 USDC micropayments ($0.02–$2). | 38 | [Registry](https://registry.modelcontextprotocol.io/servers/xyz.lonestaroracle/mcp-server) |
+
+## Adding Your Server
+
+Submit a PR adding a row to the appropriate category. Include:
+- Server name linking to the GitHub repo
+- One-sentence description
+- Number of tools
+- Link to docs or registry listing


### PR DESCRIPTION
## Summary

Odysseus has full MCP server support but no community listing of third-party servers. This PR adds `docs/community-mcp-servers.md` as a simple reference page where the community can discover and contribute compatible MCP servers.

First entry: LoneStarOracle -- 38 real-world data tools (live weather forecasts, crypto token risk, smart contract audits, energy grid, real estate, on-chain whale tracking) published to the official MCP registry. Addresses the gap for agents that need live external data that cannot run locally.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3848

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs -- this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] Documentation-only change -- no app behaviour affected.

## How to Test

1. Open `docs/community-mcp-servers.md` and verify the table renders correctly.
2. Click the GitHub repo link and MCP registry link to confirm they resolve.
3. Optionally: add `https://mcp.lonestaroracle.xyz` in the Odysseus admin MCP panel and confirm the 38 tools load.

## Visual / UI changes

N/A -- documentation only, no UI changes.
