### PR TITLE
fix(cookbook): point HF token hint at Cookbook -> Settings, not Settings -> Cookbook

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -49,7 +49,7 @@ _HF_TOKEN_STATUS_SNIPPET = (
     'echo "[odysseus] HF token: applied"; '
     'else '
     'echo "[odysseus] HF token: NOT SET — gated/private models will be denied. '
-    'Add one in Odysseus Settings -> Cookbook -> HuggingFace Token."; '
+    'Add one in Odysseus Cookbook -> Settings -> HuggingFace Token."; '
     'fi'
 )
 


### PR DESCRIPTION
## Summary

When you download a gated/private HuggingFace model without an HF token set, Odysseus prints a shell hint:

> [odysseus] HF token: NOT SET — gated/private models will be denied. Add one in Odysseus Settings -> Cookbook -> HuggingFace Token.

That path is reversed. There is no Cookbook section under a global Settings page, so users who follow the hint never find the field (as reported in #3829). The HuggingFace Token input actually lives under the **Cookbook** page's **Settings** tab (`static/js/cookbook.js`: the `cookbook-tab` button with `data-backend="Settings"` and the `data-backend-group="Settings"` group that contains the `HuggingFace Token` heading).

This swaps the two segments so the hint reads `Cookbook -> Settings -> HuggingFace Token`, matching the real UI. One-line change to the `_HF_TOKEN_STATUS_SNIPPET` string in `routes/cookbook_routes.py`; the shell `echo`/`if`-`fi` structure is untouched.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3829

## Type of Change

- [x] Bug fix (non-breaking — corrects a user-facing hint string)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end. *(text-only hint string; verified against the UI source in `static/js/cookbook.js` rather than a live run)*

## How to Test

1. Open `routes/cookbook_routes.py` and find `_HF_TOKEN_STATUS_SNIPPET` — the NOT-SET branch now prints `Add one in Odysseus Cookbook -> Settings -> HuggingFace Token.`
2. Confirm the real location in `static/js/cookbook.js`: the Cookbook tab bar (`cookbook-tabs`) has a `Settings` tab (`data-backend="Settings"`), and the `data-backend-group="Settings"` group renders the `HuggingFace Token` `<h2>` + token input. So the corrected path resolves: Cookbook page → Settings tab → HuggingFace Token.
3. (Optional live run) Start Odysseus, open Cookbook, attempt to download a gated model with no HF token — the printed hint now points to a path that exists.

## Visual / UI changes

None — this is a terminal/log hint string, not rendered app UI.