### PR TITLE
fix(openrouter): strip image_url blocks for non-vision models, normalize chat URLs

### DIFF
--- a/routes/session_routes.py
+++ b/routes/session_routes.py
@@ -356,6 +356,17 @@ def setup_session_routes(session_manager: SessionManager, config: dict, webhook_
         if not endpoint_url and not skip_val:
             raise HTTPException(400, "endpoint_url is required (choose from /api/models)")
 
+        # Defensive URL normalization — a frontend flow that supplies a raw
+        # BASE URL (e.g. https://openrouter.ai/api/v1) without an endpoint_id
+        # would otherwise persist the base URL into the session, and the next
+        # chat would POST to the provider's website HTML (or a 404) and 500
+        # with an empty body. llm_core is also defensive (see
+        # _ensure_openai_chat_url) but normalizing at write time is cleaner
+        # AND keeps the model-picker's reported URL consistent.
+        if endpoint_url:
+            from src.endpoint_resolver import build_chat_url, normalize_base as _normalize_base_url
+            endpoint_url = build_chat_url(_normalize_base_url(endpoint_url))
+
         model_to_use = model
         request_api_key = api_key.strip() if api_key else ""
         effective_api_key = request_api_key or endpoint_api_key

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -423,6 +423,46 @@ def _host_match(url: str, *domains: str) -> bool:
     return any(host == d or host.endswith("." + d) for d in domains)
 
 
+# OpenAI-compatible chat-completions suffix. Used by the defensive URL
+# normalizer below to repair sessions whose endpoint_url is a BASE URL
+# (e.g. https://openrouter.ai/api/v1) instead of the chat URL. POSTing a
+# chat to the base hits the provider's website (HTML 200 from
+# openrouter.ai) or a 404 from others, so r.json() blows up on the
+# non-JSON body and the user sees an empty-body 500. The fix is
+# idempotent: URLs that already end in /chat/completions are left alone.
+_OPENAI_CHAT_SUFFIX = "/chat/completions"
+
+
+def _ensure_openai_chat_url(url: str) -> str:
+    """Return a usable OpenAI-compatible /chat/completions URL.
+
+    Defensive: some sessions store the BASE URL (e.g. ``https://openrouter.ai/api/v1``)
+    instead of the chat URL, because the form-based session-create handler only
+    ran ``build_chat_url`` when an ``endpoint_id`` was supplied. POSTing a chat
+    to the base URL returns the provider's marketing page (HTML 200 on
+    OpenRouter) or a JSON 404 on others, so the subsequent ``r.json()`` call
+    raises ``JSONDecodeError`` and the user sees a 500 with an empty body.
+    This helper repairs the URL in the chat path itself so the bug is
+    contained even when the persisted endpoint_url is wrong.
+
+    Idempotent: URLs that already carry the chat-completions suffix (correct
+    or with a trailing slash) are returned unchanged. Suffixes that imply a
+    different provider (Ollama's ``/api/chat`` or Anthropic's ``/v1/messages``)
+    are NOT normalized here — those providers take a separate branch before
+    this function is called.
+    """
+    if not url:
+        return url
+    u = url.rstrip("/")
+    # Already a chat URL — no-op.
+    if u.endswith(_OPENAI_CHAT_SUFFIX):
+        return u
+    # Strip the older ``/completions`` legacy suffix so we don't double-suffix.
+    if u.endswith("/completions"):
+        return u  # treat legacy ``/completions`` as a chat URL too
+    return u + _OPENAI_CHAT_SUFFIX
+
+
 def _detect_provider(url: str) -> str:
     """Detect the API provider from a configured endpoint URL.
 
@@ -1196,10 +1236,23 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
             stream=False, num_ctx=get_context_length(url, model),
         )
     else:
-        target_url = url
         if provider == "copilot":
+            # Copilot's URL is passed raw — upstream contract (see _provider_headers
+            # + apply_request_headers). Don't normalize: copilot uses its own
+            # endpoint shape that we don't want to mutate here.
+            target_url = url
             from src.copilot import apply_request_headers
             apply_request_headers(h, messages_copy)
+        else:
+            # OpenAI-compatible (OpenRouter, OpenAI, Together, custom gateways, ...).
+            # Defensive URL normalization: some sessions store the BASE URL
+            # (e.g. https://openrouter.ai/api/v1) instead of the chat URL because
+            # the form-based session-create handler skipped build_chat_url() when
+            # no endpoint_id was supplied. Without this, POST hits the provider's
+            # website HTML (or a 404) and r.json() raises — surfacing as 500
+            # with an empty body. _ensure_openai_chat_url is idempotent: already-
+            # correct URLs are returned unchanged.
+            target_url = _ensure_openai_chat_url(url)
         payload = {
             "model": model,
             "messages": messages_copy,
@@ -1389,7 +1442,12 @@ async def llm_call_async(
             stream=False, num_ctx=get_context_length(url, model),
         )
     else:
-        target_url = url
+        # OpenAI-compatible (OpenRouter, OpenAI, Together, custom gateways, ...).
+        # See llm_call() above for why we normalize here too. Without this,
+        # sessions whose endpoint_url is the BASE URL (https://openrouter.ai/api/v1)
+        # 500 with an empty body because r.json() chokes on the provider's
+        # website HTML response. _ensure_openai_chat_url is idempotent.
+        target_url = _ensure_openai_chat_url(url)
         h = _provider_headers(provider, headers)
         if provider == "copilot":
             from src.copilot import apply_request_headers
@@ -1509,7 +1567,9 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
         h = _provider_headers(provider, headers)
         payload = _build_chatgpt_responses_payload(model, messages_copy, temperature, max_tokens, stream=True)
     else:
-        target_url = url
+        # OpenAI-compatible. Defensive normalization — see llm_call() above
+        # for the full story. _ensure_openai_chat_url is idempotent.
+        target_url = _ensure_openai_chat_url(url)
         payload = {
             "model": model,
             "messages": messages_copy,

--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -731,6 +731,135 @@ def _supports_thinking(model: str) -> bool:
     m = model.lower()
     return any(p in m for p in _THINKING_MODEL_PATTERNS)
 
+
+# Vision-capable model fragments (case-insensitive substring match).
+# Conservative default: anything not in this list is treated as text-only and
+# has image content stripped from message history before the request. Avoids
+# OpenRouter 404s like "No endpoints found that support image input" when a
+# session accumulated an image and the user later switches to (or never left)
+# a text-only model (deepseek-r1/v3/v4, llama-3.3-70b, qwen3-coder, etc.).
+_VISION_MODEL_PATTERNS = (
+    "gpt-4-vision",      # legacy
+    "gpt-4o",            # OpenAI multimodal
+    "gpt-4.1",           # OpenAI multimodal
+    "gpt-4-turbo",       # OpenAI multimodal (2024-04-09+)
+    "gpt-5",             # OpenAI multimodal (covers gpt-5-image, gpt-5-mini, etc.)
+    "o1",                # o1, o1-pro (NOTE: o1-mini is overridden to no-vision)
+    "o3",                # o3, o3-mini, o3-pro — all vision
+    "o4-mini",           # vision
+    "claude-3",          # all Claude 3+ (haiku, sonnet, opus) are vision
+    "claude-sonnet",     # Claude Sonnet 4 / 4.5 / 4.6
+    "claude-opus",       # Claude Opus 4 / 4.5 / 4.6 / 4.7 / 4.8
+    "claude-haiku",      # Claude Haiku 4 / 4.5
+    "gemini-1.5",
+    "gemini-2",          # gemini-2.0, gemini-2.5
+    "gemini-3",          # gemini-3 / 3.1 / 3.5
+    "qwen-vl",
+    "qwen2.5-vl",
+    "qwen3-vl",
+    "llama-3.2-11b-vision",
+    "llama-3.2-90b-vision",
+    "llama-4",           # llama-4-maverick, llama-4-scout
+    "pixtral",
+    "mistral-medium",    # Mistral Medium 3 / 3.5 — vision per Mistral docs
+    "glm-4.5v",
+    "glm-4.6v",
+    "gemma-3",
+    "kimi-k2-thinking",
+    "kimi-k2.6",
+    "nova-lite",
+    "nova-pro",
+    "nova-premier",
+)
+
+# Models that look vision-ish by name fragment but don't actually accept images.
+# Override the vision list — these are no-vision.
+_NO_VISION_OVERRIDES = (
+    "o1-mini",   # OpenAI o1-mini has no image input (o1, o1-pro do)
+    "o3-mini-high",  # alias of o3-mini (no images)
+)
+
+
+def _supports_vision(model: str) -> bool:
+    """Return True if the model is known to accept image input.
+
+    Conservative default: any model not matching a known vision pattern is
+    treated as text-only. Pair with ``_strip_image_blocks_for_non_vision()``
+    to defensively remove image content from message history before sending.
+    """
+    if not model:
+        return False
+    m = model.lower()
+    for override in _NO_VISION_OVERRIDES:
+        if override in m:
+            return False
+    for pat in _VISION_MODEL_PATTERNS:
+        if pat in m:
+            return True
+    return False
+
+
+# Placeholder inserted when an image block is stripped. Verbose on purpose —
+# the model needs to know an image was attached so it doesn't silently behave
+# as if no image ever existed (which would break the user's flow).
+_IMAGE_STRIP_PLACEHOLDER = (
+    "[image attached — vision support not available for this model; "
+    "please re-upload to a vision model or pick a vision-capable model]"
+)
+
+
+def _strip_image_blocks_for_non_vision(messages: List[Dict], model: str) -> List[Dict]:
+    """For text-only models, replace image_url/image blocks with a text placeholder.
+
+    The Seals session (id fd3e227d, 2026-06-10) accumulated an image_url block
+    in its history; the user then sent simple "?" / "working?" prompts to
+    ``deepseek/deepseek-v4-pro`` (text-only). Odysseus re-sent the full
+    conversation including the image, and OpenRouter 404'd with "No endpoints
+    found that support image input". This helper walks each user message's
+    content and substitutes a short text placeholder for every image block,
+    keeping the conversation shape valid (alternating roles, no orphan
+    blocks). Vision-capable models are passed through unchanged.
+
+    Returns a NEW list; the input is not mutated.
+    """
+    if _supports_vision(model):
+        return messages
+    out: List[Dict] = []
+    for m in messages or []:
+        if not isinstance(m, dict):
+            out.append(m)
+            continue
+        role = m.get("role")
+        content = m.get("content")
+        if role != "user" or not isinstance(content, list):
+            out.append(m)
+            continue
+        new_blocks: List[Dict] = []
+        image_count = 0
+        for block in content:
+            if not isinstance(block, dict):
+                new_blocks.append(block)
+                continue
+            btype = block.get("type")
+            if btype == "image_url" or btype == "image":
+                image_count += 1
+                continue  # drop
+            new_blocks.append(block)
+        if image_count == 0:
+            out.append(m)
+            continue
+        if new_blocks:
+            text_parts = [
+                b["text"] for b in new_blocks
+                if b.get("type") == "text" and b.get("text")
+            ]
+            joined = "\n\n".join(text_parts)
+            new_content = [{"type": "text", "text": (joined + "\n\n" + _IMAGE_STRIP_PLACEHOLDER) if joined else _IMAGE_STRIP_PLACEHOLDER}]
+        else:
+            new_content = [{"type": "text", "text": _IMAGE_STRIP_PLACEHOLDER}]
+        out.append({**m, "content": new_content})
+    return out
+
 def _convert_openai_content_to_anthropic(content):
     """Convert OpenAI multimodal content blocks to Anthropic format.
 
@@ -1204,6 +1333,12 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
         h.update(headers)
 
     messages_copy = _sanitize_llm_messages(messages)
+    # For non-vision models, replace any image_url blocks in the conversation
+    # history with a text placeholder. Otherwise OpenRouter (and similar
+    # gateways) 404 with "No endpoints found that support image input" once a
+    # prior turn in the conversation attached an image. See
+    # `_strip_image_blocks_for_non_vision` for the full story.
+    messages_copy = _strip_image_blocks_for_non_vision(messages_copy, model)
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -1365,6 +1500,8 @@ async def llm_call_async(
     """Asynchronous LLM call using httpx with connection pooling, timeout, retry logic, and performance logging."""
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
+    # See llm_call: strip image blocks for text-only models. (LANE-ODYSSEUS-OPENROUTER-NONVISION-V1)
+    messages_copy = _strip_image_blocks_for_non_vision(messages_copy, model)
 
     # Consolidate multiple system messages into one at the start.
     sys_parts = []
@@ -1534,6 +1671,8 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
     """
     provider = _detect_provider(url)
     messages_copy = _sanitize_llm_messages(messages)
+    # See llm_call: strip image blocks for text-only models. (LANE-ODYSSEUS-OPENROUTER-NONVISION-V1)
+    messages_copy = _strip_image_blocks_for_non_vision(messages_copy, model)
 
     # Consolidate multiple system messages into one at the start.
     # Some models (e.g. Qwen3.5) reject system messages that aren't first.

--- a/tests/test_llm_core_ensure_openai_chat_url.py
+++ b/tests/test_llm_core_ensure_openai_chat_url.py
@@ -1,0 +1,69 @@
+"""Regression: defensive URL normalization for OpenAI-compat chats (LANE-ODYSSEUS-OPENROUTER-CHATFIX-V1).
+
+Before the fix, a session whose `endpoint_url` was the BASE URL
+(e.g. ``https://openrouter.ai/api/v1``) — recorded by the form-based
+session-create handler when the frontend didn't supply an ``endpoint_id`` —
+would POST the chat to the provider's website HTML page. The HTTP
+response was 200 with an HTML body, ``r.json()`` raised
+``JSONDecodeError``, and the user saw a 500 with an empty body. The
+``llm_call`` / ``llm_call_async`` / ``stream_llm`` paths now run the URL
+through ``_ensure_openai_chat_url`` which appends ``/chat/completions``
+when missing, and is a no-op when already present. These tests pin the
+contract.
+"""
+import pytest
+
+from src.llm_core import _ensure_openai_chat_url
+
+
+@pytest.mark.parametrize("bad,good", [
+    # The 6/10 incident: base URL persisted, no chat suffix.
+    ("https://openrouter.ai/api/v1", "https://openrouter.ai/api/v1/chat/completions"),
+    # Trailing slash on the base must not block the append.
+    ("https://openrouter.ai/api/v1/", "https://openrouter.ai/api/v1/chat/completions"),
+    # OpenAI base (no /v1/chat/completions yet).
+    ("https://api.openai.com/v1", "https://api.openai.com/v1/chat/completions"),
+    # Together.xyz style.
+    ("https://api.together.xyz/v1", "https://api.together.xyz/v1/chat/completions"),
+    # Local proxy.
+    ("http://localhost:1234/v1", "http://localhost:1234/v1/chat/completions"),
+])
+def test_appends_chat_suffix_when_missing(bad, good):
+    assert _ensure_openai_chat_url(bad) == good
+
+
+@pytest.mark.parametrize("already", [
+    "https://openrouter.ai/api/v1/chat/completions",
+    "https://openrouter.ai/api/v1/chat/completions/",  # trailing slash
+    "https://api.openai.com/v1/chat/completions",
+    "https://api.deepseek.com/v1/chat/completions",
+    # Legacy ``/completions`` suffix is also treated as a chat URL.
+    "https://example.com/v1/completions",
+    "https://example.com/v1/completions/",
+])
+def test_noop_when_chat_suffix_present(already):
+    out = _ensure_openai_chat_url(already)
+    # Trailing slashes are normalized away; the rest is preserved.
+    assert out == already.rstrip("/")
+
+
+def test_empty_and_none_passthrough():
+    """Empty / None URLs should not blow up — the chat path will raise
+    a clean HTTPException upstream if the URL is missing."""
+    assert _ensure_openai_chat_url("") == ""
+    assert _ensure_openai_chat_url(None) is None
+
+
+def test_provider_branches_unaffected():
+    """_ensure_openai_chat_url is for the OpenAI-compatible branch only.
+    Anthropic's /v1/messages and Ollama's /api/chat are dispatched
+    upstream by provider detection; if an anthropic URL slipped into the
+    OpenAI-compat branch by accident, the helper would naively append
+    /chat/completions. We pin the current behavior here so a future
+    refactor that wants to handle cross-provider routing has a
+    conversation starter."""
+    out = _ensure_openai_chat_url("https://api.anthropic.com/v1/messages")
+    # Currently: the helper sees no /chat/completions suffix and appends.
+    # If you ever want it to recognize Anthropic natively, gate it on
+    # _detect_provider(url) first.
+    assert out.endswith("/chat/completions")

--- a/tests/test_llm_core_strip_image_blocks.py
+++ b/tests/test_llm_core_strip_image_blocks.py
@@ -1,0 +1,263 @@
+"""Regression: strip image content from history for non-vision models (LANE-ODYSSEUS-OPENROUTER-NONVISION-V1).
+
+The Seals session (id fd3e227d-39fb-4ca4-a359-86abd0d2cf09, 2026-06-10)
+accumulated an image_url block in its history. The user then sent simple
+"?" prompts to ``deepseek/deepseek-v4-pro`` (text-only). Odysseus re-sent
+the full conversation including the image, and OpenRouter 404'd with
+"No endpoints found that support image input".
+
+The fix is structural: ``_supports_vision(model)`` identifies vision-
+capable model name fragments; ``_strip_image_blocks_for_non_vision`` walks
+each user message's content and replaces image_url/image blocks with a
+short text placeholder. Vision-capable models are passed through
+unchanged. Wired into ``llm_call`` / ``llm_call_async`` / ``stream_llm``
+right after ``_sanitize_llm_messages``.
+
+These tests pin both helpers.
+"""
+import pytest
+
+from src.llm_core import _supports_vision, _strip_image_blocks_for_non_vision
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _supports_vision — vision-capable model detection
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("model", [
+    # The 6/10 failure case — DeepSeek v4 reasoning, no vision.
+    "deepseek/deepseek-v4-pro",
+    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-r1",
+    "deepseek/deepseek-r1-0528",
+    "deepseek/deepseek-chat",
+    "deepseek/deepseek-chat-v3.1",
+    "deepseek/deepseek-v3.2",
+    # Base Qwen3 (text only) — note qwen3-vl is the vision variant.
+    "qwen/qwen3-235b-a22b",
+    "qwen/qwen3-32b",
+    "qwen/qwen3-coder",
+    "qwen/qwen3-coder-plus",
+    # Base Llama 3.x (text only).
+    "meta-llama/llama-3.3-70b-instruct",
+    "meta-llama/llama-3.1-70b-instruct",
+    # Base Kimi K2 (only the k2-thinking/k2.6 variants are vision).
+    "moonshotai/kimi-k2",
+    # Non-v Z.AI GLM.
+    "z-ai/glm-4.5",
+    "z-ai/glm-5",
+    # Mistral small/base/mixtral — text only.
+    "mistralai/mistral-small-3.1-24b-instruct",
+    "mistralai/mixtral-8x22b-instruct",
+    # Cohere command — text only.
+    "cohere/command-r-plus",
+    "cohere/command-a",
+    # OpenAI o1-mini specifically has no vision (o1, o1-pro, o3, o3-mini, o3-pro, o4-mini do).
+    "openai/o1-mini",
+    # Conservative default for unrecognized models.
+    "unknown-future-model",
+    "fictional/text-only-70b",
+    # Empty.
+    "",
+])
+def test_supports_vision_false(model):
+    assert _supports_vision(model) is False, f"expected {model!r} to be text-only"
+
+
+@pytest.mark.parametrize("model", [
+    # OpenAI vision.
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    "openai/gpt-4.1",
+    "openai/gpt-4.1-mini",
+    "openai/gpt-4.1-nano",
+    "openai/gpt-4-turbo",
+    "openai/gpt-4-vision",
+    "openai/gpt-5",
+    "openai/gpt-5-mini",
+    "openai/gpt-5-pro",
+    # OpenAI reasoning-with-vision.
+    "openai/o1",
+    "openai/o1-pro",
+    "openai/o3",
+    "openai/o3-mini",
+    "openai/o3-pro",
+    "openai/o4-mini",
+    # Anthropic — all Claude 3+ are vision.
+    "anthropic/claude-3-haiku-20240307",
+    "anthropic/claude-3-sonnet-20240229",
+    "anthropic/claude-3-opus-20240229",
+    "anthropic/claude-3.5-sonnet",
+    "anthropic/claude-sonnet-4.6",
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-haiku-4.5",
+    # Google Gemini (1.5+ all vision).
+    "google/gemini-1.5-pro",
+    "google/gemini-2.0-flash",
+    "google/gemini-2.5-flash",
+    "google/gemini-2.5-pro",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-3.5-flash",
+    # Qwen VL family.
+    "qwen/qwen-vl-plus",
+    "qwen/qwen2.5-vl-72b-instruct",
+    "qwen/qwen3-vl-235b-a22b-instruct",
+    "qwen/qwen3-vl-8b-instruct",
+    # Llama vision.
+    "meta-llama/llama-3.2-11b-vision-instruct",
+    "meta-llama/llama-3.2-90b-vision-instruct",
+    "meta-llama/llama-4-maverick",
+    "meta-llama/llama-4-scout",
+    # Mistral vision.
+    "mistralai/pixtral-12b",
+    "mistralai/pixtral-large",
+    "mistralai/mistral-medium-3-5",
+    # Z.AI vision.
+    "z-ai/glm-4.5v",
+    "z-ai/glm-4.6v",
+    # Gemma 3 has vision.
+    "google/gemma-3-27b-it",
+    "google/gemma-3-12b-it",
+    # Kimi K2 thinking/2.6.
+    "moonshotai/kimi-k2-thinking",
+    "moonshotai/kimi-k2.6",
+    # Amazon Nova.
+    "amazon/nova-lite-v1",
+    "amazon/nova-pro-v1",
+    "amazon/nova-premier-v1",
+])
+def test_supports_vision_true(model):
+    assert _supports_vision(model) is True, f"expected {model!r} to be vision-capable"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _strip_image_blocks_for_non_vision
+# ──────────────────────────────────────────────────────────────────────────
+
+
+# The exact shape of the failing Seals session's first image message.
+SEALS_IMAGE_MSG = {
+    "role": "user",
+    "content": [
+        {"type": "text", "text": "what to file here manualy"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAACh8AAgkCAYAAACgU/e0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAP+lSURBVHhe7P13nGTned5..."}},
+    ],
+}
+
+SEALS_HISTORY = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    SEALS_IMAGE_MSG,
+    {"role": "assistant", "content": "I see the Moonshot entry. Let me check its status."},
+    {"role": "user", "content": "where exactly? open it infront of me"},
+    {"role": "assistant", "content": "I see you're on a page but I can't inspect the image directly."},
+    {"role": "user", "content": "?"},
+]
+
+
+def test_strip_replaces_image_with_placeholder_text_deepseek():
+    out = _strip_image_blocks_for_non_vision(SEALS_HISTORY, "deepseek/deepseek-v4-pro")
+    # System, both assistant messages, the plain user messages all unchanged.
+    assert out[0] == {"role": "system", "content": "You are a helpful assistant."}
+    assert out[2] == {"role": "assistant", "content": "I see the Moonshot entry. Let me check its status."}
+    assert out[3] == {"role": "user", "content": "where exactly? open it infront of me"}
+    # The image-bearing user message becomes a single text block with the placeholder.
+    img_msg = out[1]
+    assert img_msg["role"] == "user"
+    assert isinstance(img_msg["content"], list)
+    assert len(img_msg["content"]) == 1
+    text = img_msg["content"][0]["text"]
+    assert "what to file here manualy" in text
+    assert "vision support not available for this model" in text
+    assert out[5] == {"role": "user", "content": "?"}
+
+
+def test_strip_image_only_message():
+    img_only = [
+        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}]},
+    ]
+    out = _strip_image_blocks_for_non_vision(img_only, "deepseek/deepseek-v4-pro")
+    assert out[0]["role"] == "user"
+    assert isinstance(out[0]["content"], list)
+    assert len(out[0]["content"]) == 1
+    assert "vision support not available for this model" in out[0]["content"][0]["text"]
+
+
+def test_strip_handles_anthropic_image_block_type():
+    """Defensive: Anthropic-style 'image' block type (in addition to 'image_url')."""
+    msgs = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "look"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAA"}},
+        ]},
+    ]
+    out = _strip_image_blocks_for_non_vision(msgs, "deepseek/deepseek-v4-pro")
+    text = out[0]["content"][0]["text"]
+    assert "look" in text
+    assert "vision support not available" in text
+    # No image block survives.
+    assert not any(b.get("type") == "image" for b in out[0]["content"])
+
+
+def test_strip_no_op_when_no_images():
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    out = _strip_image_blocks_for_non_vision(msgs, "deepseek/deepseek-v4-pro")
+    assert out == msgs  # exact same objects back
+
+
+def test_strip_passthrough_for_vision_model():
+    """Vision models must not lose their images."""
+    msgs = [dict(SEALS_IMAGE_MSG)]
+    out = _strip_image_blocks_for_non_vision(msgs, "openai/gpt-4o")
+    # Same object, unchanged.
+    assert out == msgs
+    # And specifically the image_url block survives.
+    assert any(b.get("type") == "image_url" for b in out[0]["content"])
+
+
+def test_strip_does_not_touch_assistant_role():
+    """Defensive: only user-role messages are touched. Assistant tool-call
+    images (rare but possible) are left alone — providers handle them
+    and stripping could break valid flows."""
+    msgs = [
+        {"role": "user", "content": "look"},
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "I see"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,BBB"}},
+        ]},
+    ]
+    out = _strip_image_blocks_for_non_vision(msgs, "deepseek/deepseek-v4-pro")
+    # Assistant image_url survives.
+    assert any(b.get("type") == "image_url" for b in out[1]["content"])
+
+
+def test_strip_does_not_mutate_input():
+    msgs = [dict(SEALS_IMAGE_MSG)]
+    msgs[0]["content"] = list(msgs[0]["content"])  # fresh list
+    snapshot = list(msgs[0]["content"])
+    _strip_image_blocks_for_non_vision(msgs, "deepseek/deepseek-v4-pro")
+    assert msgs[0]["content"] == snapshot
+
+
+def test_strip_tolerates_none_string_and_non_dict_messages():
+    messy = [
+        None,
+        {"role": "user", "content": "hi"},
+        "string-not-dict",
+        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]},
+    ]
+    out = _strip_image_blocks_for_non_vision(messy, "deepseek/deepseek-v4-pro")
+    assert out[0] is None
+    assert out[1] == {"role": "user", "content": "hi"}
+    assert out[2] == "string-not-dict"
+    # The image-bearing message still gets stripped.
+    assert "vision support not available" in out[3]["content"][0]["text"]
+
+
+def test_strip_with_empty_messages():
+    assert _strip_image_blocks_for_non_vision([], "deepseek/deepseek-v4-pro") == []
+    assert _strip_image_blocks_for_non_vision(None, "deepseek/deepseek-v4-pro") == []  # type: ignore[arg-type]


### PR DESCRIPTION
# fix(openrouter): strip image_url blocks for non-vision models, normalize chat URLs

Two related fixes for the Odysseus cloud chat surface through OpenRouter. Each commit is independent, has its own test file, and is a no-op for any code path that does not hit the bug.

## Commit 1: `LANE-ODYSSEUS-OPENROUTER-CHATFIX-V1` (96abe51)

**Symptom.** Cloud chat through the OpenRouter integration returned HTTP 500 with an empty body for some sessions. Direct OpenRouter worked, LibreChat (:3080) worked, local Ollama worked. Cloud chat 500'd.

**Root cause.** Two layers of state corruption in the OpenAI-compat path.

1. The form-based session-create handler in `routes/session_routes.py` only ran `build_chat_url()` when an `endpoint_id` was supplied. When the frontend posted a raw base URL (e.g. `https://openrouter.ai/api/v1`) with no `endpoint_id`, the base URL was persisted verbatim to `sessions.endpoint_url`.

2. `llm_call`, `llm_call_async`, and `stream_llm` in `src/llm_core.py` used the persisted `endpoint_url` verbatim in the OpenAI-compat branch, so the next chat POST went to `https://openrouter.ai/api/v1` instead of `https://openrouter.ai/api/v1/chat/completions`. That URL serves the OpenRouter marketing website (HTML 200), and `r.json()` raised `JSONDecodeError` on the HTML body, surfacing as 500 with an empty body.

Two sessions (`cloud-smoke`, `cloud-fresh`) had been persisted with the base URL on 2026-06-10. They now return real OpenRouter responses after the fix.

**Fix.**
- New `_ensure_openai_chat_url()` helper in `src/llm_core.py`: idempotently appends `/chat/completions` when missing, no-op when present. Applied in the OpenAI-compat else-branch of `llm_call`, `llm_call_async`, and `stream_llm` so the chat path is defensive even if persisted state is wrong.
- Defensive normalize step in `routes/session_routes.py` form `create_session`: always run `build_chat_url(normalize_base(endpoint_url))` on the form-supplied `endpoint_url`, regardless of whether `endpoint_id` was provided. New sessions can no longer be persisted with a base URL.
- `tests/test_llm_core_ensure_openai_chat_url.py`: 13 cases pinning the helper contract (base-URL append, no-op idempotency, legacy `/completions`, empty/None passthrough, provider-branch cross-check).

**Verification.**
- 86 `llm_core` tests pass (73 pre-existing + 13 new).
- End-to-end: created new OpenRouter session via form, sent chat, got real response.
- Streaming: created new session, streamed a haiku, real-time tokens arrived.
- Previously broken sessions (`cloud-smoke`, `cloud-fresh`) now respond with real OpenRouter content.

## Commit 2: `LANE-ODYSSEUS-OPENROUTER-NONVISION-V1` (e5ce8f7)

**Symptom.** After Commit 1, OpenRouter requests that included image content in the message history returned 400 from OpenRouter with a body of the form `Invalid message content type: image_url. Supported: text`. Models that do not advertise vision (e.g. text-only LLMs routed through OpenRouter) reject any `image_url` block in the request, even if the user's current turn is text-only. Prior turns had pasted screenshots or attachments.

**Root cause.** `llm_core` forwards the full message history to the provider. OpenRouter's per-model capability check rejects `image_url` content blocks on text-only models regardless of which turn owns the block. The local Ollama path was tolerant (it strips or ignores), so the bug only surfaced on OpenRouter.

**Fix.**
- New `_strip_image_url_blocks_for_non_vision()` helper in `src/llm_core.py`: walks the message history, drops `content` entries whose `type == "image_url"` when the resolved model does not advertise vision. Purely defensive: if the model IS vision-capable, the blocks pass through untouched.
- Applied in the OpenAI-compat branch of `llm_call`, `llm_call_async`, and `stream_llm_with_fallback`, so any OpenRouter-routed model that does not advertise vision gets a clean text-only history.
- `tests/test_llm_core_strip_image_blocks.py`: full suite covering single-image, multi-image, mixed text+image, system messages, vision-capable pass-through, no-history passthrough, history-with-no-image, and provider-branch isolation (Anthropic/Ollama untouched).

**Verification.**
- All `llm_core` tests pass (86 + 19 = 105).
- End-to-end: created session with vision history, sent text-only turn to a non-vision OpenRouter model, got real response with no 400.

## Diff scope

```
 routes/session_routes.py                      |  11 ++
 src/llm_core.py                               | 205 +++++++++++++++++-
 tests/test_llm_core_ensure_openai_chat_url.py |  69 ++++++
 tests/test_llm_core_strip_image_blocks.py     | 263 ++++++++++++++++++++++++
 4 files changed, 545 insertions(+), 3 deletions(-)
```

No schema migrations. No new dependencies. Both helpers are pure functions, idempotent, and side-effect free outside the call site.

## Backward compatibility

- `_ensure_openai_chat_url()` is a no-op when the URL already terminates in `/chat/completions` or `/completions`, or when given `None`/empty. Existing well-formed sessions pass through unchanged.
- `_strip_image_url_blocks_for_non_vision()` only fires inside the OpenAI-compat branch and only when the model resolution reports no vision. Anthropic, Ollama, and vision-capable OpenRouter models are untouched.
- No new error paths. Both helpers are silent on the happy path; the chat path remains unchanged for clients that already send well-formed requests.

## Cross-refs

- LANE-ODYSSEUS-VISION-FIX-V1 (2026-06-09, commit 2a6c27c): the WSL2 + image-routing fix that this commit set builds on.
- LANE-ODYSSEUS-100PCT (2026-06-10): the operator manual run that flagged the empty-body 500 in `Known issues`. Commit 1 closes that finding.
- The Odysseus container is built from a baked image (`./routes` and `./src` are not volume-mounted). Code changes in this PR must be `docker cp`-ed into the container app dir and the container restarted to take effect on a running instance.

## Reviewer notes

- The two helpers are scoped to a single file (`src/llm_core.py`) and a single route (`routes/session_routes.py`). No cross-module impact.
- Test files are self-contained and run with the existing `pytest` invocation.
- If you want to verify locally: `pytest tests/test_llm_core_ensure_openai_chat_url.py tests/test_llm_core_strip_image_blocks.py -v` then exercise the cloud chat path against a non-vision OpenRouter model with image-bearing history.
