### PR TITLE
fix(memory): return complete memory lists

### DIFF
--- a/mcp_servers/memory_server.py
+++ b/mcp_servers/memory_server.py
@@ -93,16 +93,15 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             if category_filter:
                 msg += f" in category '{category_filter}'"
             return [TextContent(type="text", text=msg + ".")]
+
         lines = [f"Found {len(memories)} memory entries:\n"]
-        for m in memories[:100]:
+        for m in memories:
             cat = m.get("category", "fact")
             mid = m.get("id", "?")[:8]
             text = m.get("text", "")
             if len(text) > 150:
                 text = text[:150] + "..."
             lines.append(f"- [{cat}] `{mid}` — {text}")
-        if len(memories) > 100:
-            lines.append(f"... and {len(memories) - 100} more")
         return [TextContent(type="text", text="\n".join(lines))]
 
     elif action == "add":

--- a/src/ai_interaction.py
+++ b/src/ai_interaction.py
@@ -972,16 +972,15 @@ async def do_manage_memory(content: str, session_id: Optional[str] = None, owner
             memories = [m for m in memories if m.get("category", "").lower() == category_filter]
         if not memories:
             return {"results": "No memories found" + (f" in category '{category_filter}'" if category_filter else "") + "."}
+
         result_lines = [f"Found {len(memories)} memory entries:\n"]
-        for m in memories[:100]:
+        for m in memories:
             cat = m.get("category", "fact")
             mid = m.get("id", "?")[:8]
             text = m.get("text", "")
             if len(text) > 150:
                 text = text[:150] + "..."
             result_lines.append(f"- [{cat}] `{mid}` — {text}")
-        if len(memories) > 100:
-            result_lines.append(f"... and {len(memories) - 100} more")
         return {"results": "\n".join(result_lines)}
 
     elif action == "add":

--- a/tests/test_manage_memory_list.py
+++ b/tests/test_manage_memory_list.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_memory_list_implementations_do_not_truncate_results():
+    for path in ("mcp_servers/memory_server.py", "src/ai_interaction.py"):
+        source = Path(path).read_text()
+        assert "memories[:100]" not in source


### PR DESCRIPTION
## Summary

The `manage_memory` list action reported the total number of stored memories
but returned only the first 100. There was no cursor, offset, or follow-up
action that allowed the model to retrieve the omitted entries, so memories
after the first 100 were inaccessible to the agent.

This removes the silent truncation from both memory-tool implementations so
`action=list` fulfills its existing contract and returns every matching memory.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3888

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behavior)
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Root cause

Both the built-in memory action and the standalone memory MCP server iterated
over `memories[:100]`, then appended a count of the omitted entries. Because the
tool schema exposed no pagination mechanism, the model could see that more
memories existed but could never inspect, edit, or delete them by ID.

## Fix

Replace the two truncated iterations with normal iteration over the filtered
memory collection. No schema or protocol changes are introduced.

## Tests

Added a focused regression test covering both implementations and guarding
against reintroducing the inaccessible `memories[:100]` slice.

```bash
python -m pytest -q tests/test_manage_memory_list.py
```

Result: `1 passed`.

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Store more than 100 memories.
2. Ask the agent to call `manage_memory` with `action=list`.
3. Confirm the response includes every stored memory entry, including entries
   after number 100.
4. Repeat through the standalone memory MCP server and confirm the same result.
5. Apply a category filter and confirm every matching entry is returned.

## Scope / Follow-up

If memory collections become large enough for full output to cause context
pressure, explicit pagination can be added separately. It should include a
documented cursor or offset that lets the model request every page rather than
silently making later entries unreachable.

## Visual / UI changes

None — tool response behavior only.
