### PR TITLE
fix(memory): exempt audits from request timeout

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,6 +140,7 @@ _TIMEOUT_EXEMPT_PREFIXES = (
     "/api/cookbook/setup",  # remote pacman/apt installs
     "/api/upload",          # large files
     "/api/image",           # diffusion proxies (inpaint/harmonize/upscale/etc.) — own 120s httpx timeout
+    "/api/memory/audit",    # retains own 120s LLM inactivity timeout
 )
 
 

--- a/tests/test_memory_audit_timeout.py
+++ b/tests/test_memory_audit_timeout.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_memory_audit_uses_its_own_llm_timeout():
+    source = Path("app.py").read_text()
+    start = source.index("_TIMEOUT_EXEMPT_PREFIXES =")
+    end = source.index("\n)\n", start)
+    timeout_exemptions = source[start:end]
+
+    assert '"/api/memory/audit"' in timeout_exemptions


### PR DESCRIPTION
## Summary

Memory tidy can legitimately take longer than the application's 45-second
global request timeout, especially with a large memory collection or a
reasoning model. The audit call already has its own 120-second LLM timeout, but
the outer middleware returned `504 Gateway Timeout` before that limit could
take effect.

This exempts `/api/memory/audit` from the global request timeout so the audit's
operation-specific timeout remains authoritative.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3890

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behavior)
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Root cause

`audit_memories()` allows the LLM request up to 120 seconds, but
`_RequestTimeoutMiddleware` applied the generic 45-second request deadline to
`POST /api/memory/audit`. Large audits were therefore cancelled by the outer
request before the audit's own timeout and error handling could finish.

## Fix

Add `/api/memory/audit` to `_TIMEOUT_EXEMPT_PREFIXES`, alongside the other
long-running routes that manage their own lifecycle or timeout.

The audit remains bounded by the existing 120-second timeout passed to
`llm_call_async`; this does not make the underlying LLM call unbounded.

## Tests

Added a focused regression test that verifies the memory-audit route remains in
the timeout exemption list.

```bash
python -m pytest -q tests/test_memory_audit_timeout.py
```

Result: `1 passed`.

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Set `REQUEST_HARD_TIMEOUT=5`.
2. Configure an LLM endpoint that takes longer than five seconds to complete a
   memory audit.
3. Run memory tidy.
4. Confirm the request is not terminated by the global middleware after five
   seconds.
5. Confirm the audit still respects the 120-second timeout in
   `audit_memories()`.

## Visual / UI changes

None — backend timeout handling only.
