### PR TITLE
fix(tokens): owner check on update and delete routes

### DIFF
--- a/routes/api_token_routes.py
+++ b/routes/api_token_routes.py
@@ -154,6 +154,7 @@ def setup_api_token_routes() -> APIRouter:
     @router.patch("/tokens/{token_id}")
     async def update_token(request: Request, token_id: str):
         require_admin(request)
+        current_user = get_current_user(request)
         try:
             payload = await request.json()
         except Exception:
@@ -162,6 +163,8 @@ def setup_api_token_routes() -> APIRouter:
             token = db.query(ApiToken).filter(ApiToken.id == token_id).first()
             if not token:
                 raise HTTPException(404, "Token not found")
+            if current_user and token.owner != current_user:
+                raise HTTPException(403, "Not your token")
             if isinstance(payload.get("name"), str) and payload["name"].strip():
                 token.name = payload["name"].strip()[:MAX_NAME_LEN]
             # Only touch scopes when the caller actually sent them. A partial
@@ -189,10 +192,14 @@ def setup_api_token_routes() -> APIRouter:
     @router.delete("/tokens/{token_id}")
     def delete_token(request: Request, token_id: str):
         require_admin(request)
+        current_user = get_current_user(request)
         with get_db_session() as db:
-            deleted = db.query(ApiToken).filter(ApiToken.id == token_id).delete()
-            if not deleted:
+            token = db.query(ApiToken).filter(ApiToken.id == token_id).first()
+            if not token:
                 raise HTTPException(404, "Token not found")
+            if current_user and token.owner != current_user:
+                raise HTTPException(403, "Not your token")
+            db.delete(token)
         _invalidate_cache(request)
         return {"status": "deleted"}
 

--- a/tests/test_api_token_routes.py
+++ b/tests/test_api_token_routes.py
@@ -287,8 +287,9 @@ def test_delete_token_deletes_and_invalidates_cache(monkeypatch, token_routes_mo
     monkeypatch.setattr(mod, "get_current_user", lambda req: req.state.current_user)
     monkeypatch.setattr(mod, "ApiToken", MagicMock())
 
+    fake_token = SimpleNamespace(id="abcd1234", owner="alice", name="test")
     fake_session = MagicMock()
-    fake_session.query.return_value.filter.return_value.delete.return_value = 1
+    fake_session.query.return_value.filter.return_value.first.return_value = fake_token
     monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
 
     invalidator = MagicMock()
@@ -297,6 +298,7 @@ def test_delete_token_deletes_and_invalidates_cache(monkeypatch, token_routes_mo
     resp = delete_token(request=req, token_id="abcd1234")
 
     assert resp == {"status": "deleted"}
+    fake_session.delete.assert_called_once_with(fake_token)
     invalidator.assert_called_once()
 
 
@@ -312,7 +314,7 @@ def test_delete_missing_token_returns_404_without_invalidating_cache(monkeypatch
     monkeypatch.setattr(mod, "ApiToken", MagicMock())
 
     fake_session = MagicMock()
-    fake_session.query.return_value.filter.return_value.delete.return_value = 0
+    fake_session.query.return_value.filter.return_value.first.return_value = None
     monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
 
     invalidator = MagicMock()
@@ -404,3 +406,99 @@ def test_update_missing_token_returns_404(monkeypatch, token_routes_mod):
     with pytest.raises(HTTPException) as exc:
         asyncio.run(update_token(request=req, token_id="missing99"))
     assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 7. Owner check — update/delete reject a different admin's token with 403
+# ---------------------------------------------------------------------------
+
+
+def _bob_patch_request(invalidator, body):
+    """An admin request from bob whose async .json() yields `body`."""
+    req = _req("bob", is_admin=True, invalidator=invalidator)
+
+    async def _json():
+        return body
+
+    req.json = _json
+    return req
+
+
+def test_update_token_rejects_non_owner(monkeypatch, token_routes_mod):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    mod = token_routes_mod
+    monkeypatch.setattr(mod, "get_current_user", lambda req: req.state.current_user)
+
+    token = SimpleNamespace(
+        id="tok123", name="alice-token", owner="alice",
+        token_prefix="ody_alic", scopes="chat", is_active=True,
+    )
+    fake_session = MagicMock()
+    fake_session.query.return_value.filter.return_value.first.return_value = token
+    monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
+
+    req = _bob_patch_request(MagicMock(), {"name": "hijacked"})
+    update_token = _get_handler(mod, "PATCH", "/tokens/{token_id}")
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(update_token(request=req, token_id="tok123"))
+    assert exc.value.status_code == 403
+    assert token.name == "alice-token"
+
+
+def test_delete_token_rejects_non_owner(monkeypatch, token_routes_mod):
+    monkeypatch.setenv("AUTH_ENABLED", "true")
+    mod = token_routes_mod
+    monkeypatch.setattr(mod, "get_current_user", lambda req: req.state.current_user)
+    monkeypatch.setattr(mod, "ApiToken", MagicMock())
+
+    fake_token = SimpleNamespace(id="tok123", owner="alice", name="alice-token")
+    fake_session = MagicMock()
+    fake_session.query.return_value.filter.return_value.first.return_value = fake_token
+    monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
+
+    invalidator = MagicMock()
+    req = _req("bob", is_admin=True, invalidator=invalidator)
+    delete_token = _get_handler(mod, "DELETE", "/tokens/{token_id}")
+    with pytest.raises(HTTPException) as exc:
+        delete_token(request=req, token_id="tok123")
+    assert exc.value.status_code == 403
+    fake_session.delete.assert_not_called()
+    invalidator.assert_not_called()
+
+
+def test_update_token_owner_check_skipped_when_auth_disabled(monkeypatch, token_routes_mod):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    mod = token_routes_mod
+    monkeypatch.setattr(mod, "get_current_user", lambda req: None)
+
+    token = SimpleNamespace(
+        id="tok123", name="original", owner="alice",
+        token_prefix="ody_alic", scopes="chat", is_active=True,
+    )
+    fake_session = MagicMock()
+    fake_session.query.return_value.filter.return_value.first.return_value = token
+    monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
+
+    req = _bob_patch_request(MagicMock(), {"name": "renamed-in-single-user"})
+    update_token = _get_handler(mod, "PATCH", "/tokens/{token_id}")
+    resp = asyncio.run(update_token(request=req, token_id="tok123"))
+    assert resp["name"] == "renamed-in-single-user"
+
+
+def test_delete_token_owner_check_skipped_when_auth_disabled(monkeypatch, token_routes_mod):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    mod = token_routes_mod
+    monkeypatch.setattr(mod, "get_current_user", lambda req: None)
+    monkeypatch.setattr(mod, "ApiToken", MagicMock())
+
+    fake_token = SimpleNamespace(id="tok123", owner="alice", name="alice-token")
+    fake_session = MagicMock()
+    fake_session.query.return_value.filter.return_value.first.return_value = fake_token
+    monkeypatch.setattr(mod, "get_db_session", lambda: _db_ctx(fake_session))
+
+    invalidator = MagicMock()
+    req = _req("", is_admin=True, invalidator=invalidator)
+    delete_token = _get_handler(mod, "DELETE", "/tokens/{token_id}")
+    resp = delete_token(request=req, token_id="tok123")
+    assert resp == {"status": "deleted"}
+    fake_session.delete.assert_called_once_with(fake_token)


### PR DESCRIPTION
## Summary

`PATCH /api/tokens/{id}` and `DELETE /api/tokens/{id}` check `require_admin` but don't verify the token belongs to the caller. Any admin can rename, re-scope, or delete another admin's token if they know the ID.

`create_token` already stamps `owner = get_current_user(request)` on every token when it's created — the update and delete paths just never read it. After the 404 check, I added a comparison against `get_current_user(request)` that raises 403 if it doesn't match. The check is a no-op when `current_user` is falsy (auth disabled, single-user), same as the rest of the codebase handles it.

Changed `delete_token` from a bulk `.delete()` to a fetch-then-delete so we can read the owner before removing it.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click Edit on this PR and change the base.

## Linked Issue

Fixes #3898

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Enable auth (`AUTH_ENABLED=true`), create two admin accounts — call them alice and bob.
2. Login as alice, `POST /api/tokens` with any name. Note the returned `id`.
3. Login as bob, `PATCH /api/tokens/<alice-token-id>` with `{"name": "hijacked"}`.
   - Before: 200, token renamed. After: 403.
4. Login as bob, `DELETE /api/tokens/<alice-token-id>`.
   - Before: 200, token gone. After: 403.
5. Login as alice, same PATCH and DELETE on her own token — still 200.
6. Set `AUTH_ENABLED=false`, repeat step 3 and 4 — should still go through (no user context in single-user mode).

Or run the tests directly:

```
pytest tests/test_api_token_routes.py -v
```