### PR TITLE
fix(tests): add httpx2 so starlette.testclient stops warning on every run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,7 @@ qrcode[pil]
 croniter
 pytest
 pytest-asyncio
+# starlette.testclient prefers httpx2 since Starlette 1.2.0 and warns on every
+# TestClient import when only classic httpx is present. Runtime code keeps
+# using `httpx` above; this is test-client only.
+httpx2


### PR DESCRIPTION
## Summary

Every pytest run that imports a TestClient emits `StarletteDeprecationWarning: Using httpx with starlette.testclient is deprecated; install httpx2 instead.` Starlette 1.2.0 added httpx2 support in the test client (encode/starlette#3291) and its testclient module tries `import httpx2 as httpx` first, falling back to classic httpx with that warning. Adding `httpx2` to requirements silences the suite-wide warning at the source. Runtime code keeps importing `httpx` directly and is unaffected; the TestClient interface is identical.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3942

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs and this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above.
- [x] I actually verified the change end-to-end (warning gone, suite green).

## How to Test

1. `pip install -r requirements.txt` (pulls in httpx2).
2. `python -W error::DeprecationWarning -c "from starlette.testclient import TestClient"` succeeds (it raises on current dev).
3. Run any TestClient-using subset, e.g. `python -m pytest tests/ -k "search or provider or diagnostics" -q`: 575 passed locally, and the warnings summary no longer lists StarletteDeprecationWarning. The only remaining recurring warning is the SQLAlchemy MovedIn20Warning tracked by #2740.

No UI/visual changes; dependency addition only.
