### PR TITLE
fix(llm): omit temperature for Kimi K2.5 and K2.6

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -446,6 +446,8 @@ def _detect_provider(url: str) -> str:
         return "groq"
     if _host_match(url, "nvidia.com"):
         return "nvidia"
+    if _host_match(url, "moonshot.ai") or _host_match(url, "moonshot.cn"):
+        return "moonshot"
     from src.chatgpt_subscription import is_chatgpt_subscription_base
     if is_chatgpt_subscription_base(url):
         return "chatgpt-subscription"
@@ -690,6 +692,28 @@ def _restricts_temperature(model: str) -> bool:
         return False
     m = model.lower()
     return any(m.startswith(p) or f"/{p}" in m for p in _FIXED_TEMPERATURE_MODELS)
+
+
+# The official Moonshot API fixes temperature at 1.0 in thinking mode and 0.6
+# when thinking is explicitly disabled for Kimi K2.5/K2.6. Any other explicit
+# value returns HTTP 400. Odysseus does not currently send the `thinking` mode
+# control, so omit temperature and let Moonshot use its default thinking mode.
+# Keep the gate provider-specific: self-hosted Kimi deployments may accept
+# custom sampling values, and older Moonshot models have different defaults.
+def _moonshot_rejects_custom_temperature(provider: str, model: str) -> bool:
+    """Check if the official Moonshot API fixes temperature for this model."""
+    if provider != "moonshot" or not isinstance(model, str):
+        return False
+    model_id = model.lower().rsplit("/", 1)[-1]
+    return bool(re.match(r"^kimi-k2\.(?:5|6)(?:$|[-_:])", model_id))
+
+
+def _omit_temperature(provider: str, model: str) -> bool:
+    """Check if a request should use the provider's default temperature."""
+    return _restricts_temperature(model) or _moonshot_rejects_custom_temperature(
+        provider, model
+    )
+
 
 # Anthropic removed the sampling parameters (temperature, top_p, top_k) starting
 # with Claude Opus 4.7. On Opus 4.7 and later, sending `temperature` at all —
@@ -1239,7 +1263,7 @@ def llm_call(url: str, model: str, messages: List[Dict], temperature: float = LL
             "messages": messages_copy,
             "temperature": temperature,
         }
-        if _restricts_temperature(model):
+        if _omit_temperature(provider, model):
             payload.pop("temperature", None)
         if max_tokens and max_tokens > 0:
             tok_key = "max_completion_tokens" if _uses_max_completion_tokens(model) else "max_tokens"
@@ -1433,7 +1457,7 @@ async def llm_call_async(
             "messages": messages_copy,
             "temperature": temperature,
         }
-        if _restricts_temperature(model):
+        if _omit_temperature(provider, model):
             payload.pop("temperature", None)
         if max_tokens and max_tokens > 0:
             tok_key = "max_completion_tokens" if _uses_max_completion_tokens(model) else "max_tokens"
@@ -1550,7 +1574,7 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             "temperature": temperature,
             "stream": True,
         }
-        if _restricts_temperature(model):
+        if _omit_temperature(provider, model):
             payload.pop("temperature", None)
         if provider not in {"openrouter", "groq"}:
             payload["stream_options"] = {"include_usage": True}

--- a/tests/test_llm_core_temperature.py
+++ b/tests/test_llm_core_temperature.py
@@ -29,7 +29,12 @@ def test_normal_models_allow_temperature(model):
     assert llm_core._restricts_temperature(model) is False
 
 
-def _capture_openai_payload(monkeypatch, model, temperature):
+def _capture_openai_payload(
+    monkeypatch,
+    model,
+    temperature,
+    url="https://api.openai.com/v1/chat/completions",
+):
     """Run a synchronous OpenAI-compatible call and return the posted JSON body."""
     llm_core._response_cache.clear()
     seen = {}
@@ -45,7 +50,7 @@ def _capture_openai_payload(monkeypatch, model, temperature):
 
     monkeypatch.setattr(llm_core.httpx, "post", fake_post)
     result = llm_core.llm_call(
-        "https://api.openai.com/v1/chat/completions",
+        url,
         model,
         [{"role": "user", "content": "Say OK"}],
         temperature=temperature,
@@ -125,3 +130,61 @@ def test_anthropic_payload_clamps_negative():
 def test_anthropic_payload_none_temperature_does_not_crash():
     payload = _anthropic_payload(None)
     assert payload["temperature"] is None
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "kimi-k2.5",
+        "kimi-k2.6",
+        "moonshot/kimi-k2.6",
+        "kimi-k2.6-preview",
+    ],
+)
+def test_moonshot_k2_5_plus_uses_fixed_temperature(model):
+    assert llm_core._moonshot_rejects_custom_temperature("moonshot", model)
+
+
+@pytest.mark.parametrize(
+    "provider,model",
+    [
+        ("openai", "kimi-k2.6"),
+        ("moonshot", "kimi-k2-0905-preview"),
+        ("moonshot", "kimi-k2-thinking"),
+        ("moonshot", "kimi-k2.50"),
+        ("moonshot", None),
+    ],
+)
+def test_other_models_keep_temperature(provider, model):
+    assert not llm_core._moonshot_rejects_custom_temperature(provider, model)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.moonshot.ai/v1/chat/completions",
+        "https://api.moonshot.cn/v1/chat/completions",
+    ],
+)
+def test_moonshot_provider_detection(url):
+    assert llm_core._detect_provider(url) == "moonshot"
+
+
+def test_moonshot_k2_6_payload_omits_temperature(monkeypatch):
+    payload = _capture_openai_payload(
+        monkeypatch,
+        "kimi-k2.6",
+        0.7,
+        url="https://api.moonshot.ai/v1/chat/completions",
+    )
+    assert "temperature" not in payload
+
+
+def test_self_hosted_kimi_k2_6_payload_keeps_temperature(monkeypatch):
+    payload = _capture_openai_payload(
+        monkeypatch,
+        "kimi-k2.6",
+        0.7,
+        url="http://localhost:8000/v1/chat/completions",
+    )
+    assert payload["temperature"] == 0.7


### PR DESCRIPTION
## Summary

The OpenAI-compatible request paths always include the caller's `temperature`.
That breaks Kimi K2.5 and K2.6 on Moonshot's official API whenever an Odysseus
workflow supplies a normal sampling value such as `0.1`, `0.3`, or `0.7`.

Moonshot documents these models as using fixed temperatures: `1.0` in the
default thinking mode and `0.6` when thinking is explicitly disabled. Any other
explicit value returns HTTP 400. Odysseus does not currently send Kimi's
`thinking` mode control, so this omits `temperature` for K2.5/K2.6 on the
official Moonshot endpoints and lets the API use its default thinking-mode
value.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3959

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Root cause

`llm_call()`, `llm_call_async()`, and `stream_llm()` build
OpenAI-compatible payloads with `temperature` unconditionally. Kimi K2.5/K2.6
accept only the fixed value associated with their active thinking mode, so
internal calls such as memory audit (`temperature=0.1`) fail before the model
can respond.

The existing `_restricts_temperature()` guard only recognizes OpenAI reasoning
model families. Moonshot was not identified as its own provider, so there was
no way to apply the Kimi rule only to the official API.

## Fix

- Detect both official Moonshot API hosts: `api.moonshot.ai` and
  `api.moonshot.cn`.
- Add a model gate for `kimi-k2.5` and `kimi-k2.6`, including provider-prefixed
  IDs and snapshot-style suffixes.
- Extend the existing temperature-omission decision used by synchronous,
  asynchronous, and streaming OpenAI-compatible requests.
- Leave older Kimi models and self-hosted OpenAI-compatible endpoints
  unchanged.

This intentionally omits the field instead of forcing `1.0`. That follows
Moonshot's official examples, preserves the API's default thinking mode, and
does not pretend to provide Instant mode without also sending
`"thinking": {"type": "disabled"}`.

## Tests

Extended `tests/test_llm_core_temperature.py` to cover:

- Kimi K2.5/K2.6 model matching;
- both official Moonshot API domains;
- provider-prefixed and suffixed model IDs;
- older Kimi models and false-positive model names;
- payload-level omission on the official API;
- retention of custom temperature on a self-hosted Kimi endpoint.

```bash
python -m pytest -q \
  tests/test_llm_core_temperature.py \
  tests/test_llm_core_anthropic_temp_omit.py
```

Result: `71 passed`.

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified the change works end-to-end.

> The updated application was rebuilt successfully and the focused regression
> suite passes. I did not make a billable live Kimi API call while preparing
> this PR, so the end-to-end box remains unchecked.

## How to Test

1. Configure `https://api.moonshot.ai/v1` with `kimi-k2.6`.
2. Use a preset with `temperature=0.7`, or run memory tidy, which requests
   `temperature=0.1`.
3. Before this change, Moonshot returns HTTP 400 because the model only permits
   its fixed thinking-mode temperature.
4. After this change, inspect the request body and confirm `temperature` is
   omitted; the API should use its default thinking mode and complete.
5. Point the same model ID at a self-hosted OpenAI-compatible endpoint and
   confirm the configured temperature is still included.
6. Switch to an older Moonshot model such as `kimi-k2-0905-preview` and confirm
   its temperature behavior is unchanged.

## Scope / Follow-up

This does not add a Thinking/Instant mode selector. Supporting Instant mode
would require an explicit setting that sends
`"thinking": {"type": "disabled"}` and should be handled separately rather
than inferred from a generic temperature preset.

## Visual / UI changes

None — provider detection and request payload handling only.
