### PR TITLE
fix(llm): resolve Utility model before the session-model fallback (#3961)

### DIFF
--- a/src/endpoint_resolver.py
+++ b/src/endpoint_resolver.py
@@ -250,10 +250,19 @@ def resolve_endpoint(
     ep_id = _stg(f"{setting_prefix}_endpoint_id")
     model = _stg(f"{setting_prefix}_model")
 
-    # If the specific endpoint is not configured, but the caller provided a
-    # valid fallback (e.g. the active session model), use that immediately.
-    # This prevents background tasks from jumping to the global default_model
-    # when the user is mid-conversation with a different model.
+    # An explicitly-configured Utility model is a deliberate choice for
+    # background tasks (memory extraction, auto-naming, research...) and must
+    # win over the session-model fallback. Resolve it *before* the fallback
+    # shortcut below; otherwise the fallback shadows it (#3961 — the inverse of
+    # the regression #534 guarded against).
+    if not ep_id and setting_prefix != "utility":
+        ep_id = _stg("utility_endpoint_id")
+        model = _stg("utility_model")
+
+    # If neither the specific endpoint nor a Utility model is configured, but
+    # the caller provided a valid fallback (e.g. the active session model), use
+    # that immediately. This prevents background tasks from jumping to the
+    # global default_model when the user is mid-conversation (#534).
     if not ep_id and fallback_url and fallback_model:
         return fallback_url, fallback_model, fallback_headers
 
@@ -262,14 +271,10 @@ def resolve_endpoint(
         ep_id = _stg("default_endpoint_id")
         model = _stg("default_model")
 
-    # Fall back to utility model for task/research/auto-naming if not specifically configured.
-    # If Utility itself is unset, the block above makes that resolve to Default Chat.
+    # Utility also unconfigured (and no session fallback) → global default.
     if not ep_id and setting_prefix != "utility":
-        ep_id = _stg("utility_endpoint_id")
-        model = _stg("utility_model")
-        if not ep_id:
-            ep_id = _stg("default_endpoint_id")
-            model = _stg("default_model")
+        ep_id = _stg("default_endpoint_id")
+        model = _stg("default_model")
 
     if not ep_id:
         return fallback_url, fallback_model, fallback_headers

--- a/tests/test_resolve_endpoint_fallbacks.py
+++ b/tests/test_resolve_endpoint_fallbacks.py
@@ -109,6 +109,37 @@ def test_task_uses_utility_when_task_endpoint_unset(monkeypatch):
     assert headers == {"Authorization": "Bearer key-utility"}
 
 
+def test_task_uses_utility_over_session_fallback_when_task_unset(monkeypatch):
+    # Regression for #3961: an explicitly-configured Utility model must win
+    # over the session-model fallback for background tasks (memory extraction,
+    # auto-naming, ...). Callers always pass the active chat model as fallback,
+    # so the #534 early-return must not shadow the Utility setting.
+    settings = {
+        "task_endpoint_id": "",
+        "task_model": "",
+        "utility_endpoint_id": "utility",
+        "utility_model": "utility-chat",
+        "default_endpoint_id": "default",
+        "default_model": "default-chat",
+    }
+    _install_resolver_fakes(
+        monkeypatch,
+        settings,
+        [_endpoint("utility", "utility-chat"), _endpoint("default", "default-chat")],
+    )
+
+    url, model, headers = resolve_endpoint(
+        "task",
+        fallback_url="https://session.example/chat",
+        fallback_model="session-chat",
+        fallback_headers={"X-Test": "session"},
+    )
+
+    assert url == "https://utility.example/v1/chat/completions"
+    assert model == "utility-chat"
+    assert headers == {"Authorization": "Bearer key-utility"}
+
+
 def test_research_uses_default_when_research_and_utility_unset(monkeypatch):
     settings = {
         "research_endpoint_id": "",


### PR DESCRIPTION
## Summary

An explicitly-configured **Utility Model** (the smaller/cheaper model meant for background tasks — memory extraction, auto-naming, research) was being ignored: those tasks ran on the chat/session model instead. Root cause is a branch-ordering bug in `resolve_endpoint()` (`src/endpoint_resolver.py`). Background-task callers pass the active session model as the fallback, and the session-model short-circuit added in #534 ran *before* the Utility lookup, so the Utility settings were never read when a fallback was supplied. This PR moves the Utility lookup ahead of that early-return — an explicitly-configured Utility/task endpoint now wins — while preserving #534's intent (still fall back to the session model when *neither* the task nor the Utility endpoint is configured, so background tasks don't snap to the global `default_model` mid-conversation). One focused function reorder; the `utility`-prefix path and default cascade are unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3961
(inverse of the regression #534 guarded against)

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. _(Backend resolver logic only, no UI surface; verified instead with a regression test that reproduces the exact production call path — see How to Test. Full-app run not performed.)_

## How to Test

This is pure resolver-precedence logic, covered deterministically by unit tests:

1. Add the failing case first to confirm the bug, then the fix:
   ```bash
   python -m pytest tests/test_resolve_endpoint_fallbacks.py::test_task_uses_utility_over_session_fallback_when_task_unset -q
   ```
   The new test sets `task_*` empty, `utility_endpoint_id/utility_model` configured, and passes a session-model fallback — asserting the Utility endpoint wins. It is **RED on the old order, GREEN after the reorder**.
2. Regression sweep (resolver + the background-task consumers that pass a session fallback):
   ```bash
   python -m pytest tests/test_endpoint_resolver.py tests/test_resolve_endpoint_fallbacks.py \
     tests/test_aux_llm_owner_scope.py tests/test_endpoint_owner_scope_followup.py \
     tests/test_research_endpoint_owner_scope.py tests/test_builtin_memory_consolidation.py \
     tests/test_consolidate_memory_explicit_drops.py tests/test_model_routes.py -q
   ```
   → **197 passed** locally. `python -m py_compile src/endpoint_resolver.py` clean.
3. To verify in a running instance: set a Utility Model distinct from your chat model, start a chat, and trigger memory extraction / auto-naming — the background request now uses the Utility model instead of the chat model.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — backend resolver logic only, nothing renders to the DOM.

- [x] **I am not submitting a bulk auto-generated PR.** This is a single focused fix opened after claiming the linked issue, with a regression test.