### PR TITLE
fix(chat): sync live-stream fence strip regex with backend TOOL_TAGS

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -406,8 +406,34 @@ function _openVisionEditor(att, userMsgEl) {
 
 // Tool call syntax patterns to strip from displayed text
 const TOOL_CALL_RE = /\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi;
-// Only strip fenced tool-call blocks that look like structured invocations, not regular code examples
-const EXEC_FENCE_RE = /```(?:web_search|read_file|write_file|create_document|edit_document|update_document)\s*\n[\s\S]*?```/gi;
+// Executable fenced tool-call blocks: must stay in sync with src/agent_tools/__init__.py TOOL_TAGS.
+// Excludes bash/python/ls which commonly appear as fenced-code language identifiers.
+const EXEC_TOOL_TAGS = [
+  'web_search', 'web_fetch', 'read_file', 'write_file', 'edit_file',
+  'grep', 'glob', 'get_workspace',
+  'create_document', 'update_document', 'edit_document',
+  'search_chats',
+  'chat_with_model', 'create_session', 'list_sessions', 'send_to_session',
+  'pipeline',
+  'manage_session', 'manage_memory', 'list_models',
+  'ui_control', 'generate_image', 'ask_user', 'update_plan',
+  'manage_tasks', 'api_call', 'ask_teacher', 'manage_skills',
+  'suggest_document',
+  'manage_endpoints', 'manage_mcp', 'manage_webhooks',
+  'manage_tokens', 'manage_documents', 'manage_settings',
+  'manage_notes', 'manage_calendar',
+  'resolve_contact', 'manage_contact', 'list_email_accounts', 'send_email',
+  'list_emails', 'read_email', 'reply_to_email', 'bulk_email',
+  'archive_email', 'delete_email', 'mark_email_read',
+  'download_model', 'serve_model', 'list_served_models', 'stop_served_model',
+  'list_downloads', 'cancel_download',
+  'search_hf_models', 'list_cached_models',
+  'list_serve_presets', 'serve_preset', 'adopt_served_model',
+  'list_cookbook_servers',
+  'edit_image', 'trigger_research', 'manage_research',
+  'app_api',
+];
+const EXEC_FENCE_RE = new RegExp('```(?:' + EXEC_TOOL_TAGS.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi');
 // XML-style tool calls: <minimax:tool_call>, <tool_call>, <function_call>, bare <invoke>
 const XML_TOOL_CALL_RE = /<(?:[\w]+:)?(?:tool_call|function_call)>[\s\S]*?<\/(?:[\w]+:)?(?:tool_call|function_call)>/gi;
 const XML_INVOKE_RE = /<invoke\s+name=['"][^'"]*['"]>[\s\S]*?<\/invoke>/gi;


### PR DESCRIPTION
## Summary

The browser-side `EXEC_FENCE_RE` regex in `chatRenderer.js` only covered 6 tool names (`web_search`, `read_file`, `write_file`, `create_document`, `edit_document`, `update_document`). The backend strips all `TOOL_TAGS` from persisted `round_texts` via `tool_parsing.py`, but the live streaming path uses the narrower frontend regex. This mismatch causes executed fenced tool calls for email, cookbook, MCP, and other tools to remain visible in the live chat view until the session is reloaded.

This PR replaces the hardcoded `EXEC_FENCE_RE` with an `EXEC_TOOL_TAGS` array that mirrors `src/agent_tools/__init__.py TOOL_TAGS` (excluding `bash`, `python`, `ls` which are valid fenced-code language identifiers), and builds the regex from it.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3993

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Start Odysseus with a local fenced-tool model (e.g. Ollama).
2. Enable an email tool (e.g. list_emails) via agent tool config.
3. Ask the agent to list emails so the model emits a fenced `list_emails` call.
4. Watch the live streaming bubble during and after tool execution.
5. Before fix: the raw fenced block remains visible until session reload.
6. After fix: the fence is stripped from the live view immediately.

Regex verification:
- `EXEC_FENCE_RE.test("```list_emails\n{\"max_results\":10}\n```")` -> true
- `EXEC_FENCE_RE.test("```python\nprint(\"hello\")\n```")` -> false

## Visual / UI changes

- [x] No visible UI change — this only affects text stripping logic in `stripToolBlocks()`. No new CSS, colors, fonts, or component patterns.