### PR TITLE
fix(cookbook): recover completed downloads from DOWNLOAD_OK in background reconciler

### DIFF
--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -3532,12 +3532,22 @@ async function _pollBackgroundStatus() {
         // dead-session check inspects). Recover "done" from the retained output's
         // exit-0 sentinel so a clean install isn't downgraded to crashed.
         const depDone = !!task.payload?._dep && _depInstallSucceeded(task.output);
+        // A finished model download whose tmux pane is gone is also reported
+        // "stopped" (the dead-session check can miss the landed snapshot).
+        // Recover "done" from the terminal `DOWNLOAD_OK` sentinel — emitted
+        // only after the runner exits 0 — so a completed download isn't
+        // downgraded to crashed. This background poll runs blind (no live
+        // stream to debounce against), so unlike the reconnect loop it keys
+        // off the conclusive exit sentinel only, never the `/snapshots/` path,
+        // which can be printed mid-stream for multi-file downloads.
+        const downloadDone = task.type === 'download'
+          && String(task.output || '').includes('DOWNLOAD_OK');
         const nextStatus = live.status === 'completed'
           ? 'done'
           : (live.status === 'error'
             ? 'error'
             : (live.status === 'stopped'
-                ? (depDone ? 'done' : (task.type === 'download' ? 'crashed' : 'stopped'))
+                ? ((depDone || downloadDone) ? 'done' : (task.type === 'download' ? 'crashed' : 'stopped'))
                 : null));
         if (nextStatus && task.status !== nextStatus) {
           updates.status = nextStatus;

--- a/tests/test_cookbook_dependency_completion_regression.py
+++ b/tests/test_cookbook_dependency_completion_regression.py
@@ -74,7 +74,23 @@ def test_background_poll_recovers_done_for_stopped_dependency_install():
     source = _read("static/js/cookbookRunning.js")
 
     assert "const depDone = !!task.payload?._dep && _depInstallSucceeded(task.output);" in source
-    assert "depDone ? 'done' : (task.type === 'download' ? 'crashed' : 'stopped')" in source
+    assert "(depDone || downloadDone) ? 'done' : (task.type === 'download' ? 'crashed' : 'stopped')" in source
+
+
+def test_background_poll_recovers_done_for_completed_download():
+    """When the backend reports a finished model download as "stopped" (its
+    tmux pane is gone after DOWNLOAD_OK, so the dead-session check can miss the
+    landed snapshot), the reconciler must recover "done" from the terminal
+    DOWNLOAD_OK sentinel instead of downgrading the card to crashed. The
+    background poll keys off DOWNLOAD_OK only (not the "/snapshots/" path, which
+    can appear mid-stream for multi-file downloads)."""
+    source = _read("static/js/cookbookRunning.js")
+
+    normalized = " ".join(source.split())
+    assert (
+        "const downloadDone = task.type === 'download' "
+        "&& String(task.output || '').includes('DOWNLOAD_OK');"
+    ) in normalized
 
 
 def test_dependency_install_payload_keeps_env_path_for_refresh():


### PR DESCRIPTION
## Summary

A completed model download was being shown as **crashed** on the dashboard. The background status reconciler (`static/js/cookbookRunning.js`, `_pollBackgroundStatus`) only recovered `done` for **dependency installs** when the backend reported a finished task as `stopped`. A real model download whose tmux pane is gone after `DOWNLOAD_OK` (so the dead-session check misses the landed snapshot) fell through to `task.type === 'download' ? 'crashed'`, so a download you watched reach `DOWNLOAD OK` showed up as crashed after navigating away (and `stalled` on the Serve tab). This mirrors the existing dep-install recovery into the download branch.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3897

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change end-to-end — see the before/after below.

## How to Test

1. Open Cookbook, download a model and wait for `DOWNLOAD OK`.
2. Navigate away (e.g. to the Serve tab) so the download's tmux pane is reaped and the next `/api/cookbook/tasks/status` poll reports the task as `stopped`.
3. Return to the Download/Running tab.
   - **Before:** the finished model is shown as **crashed** (and **stalled** on Serve).
   - **After:** because the retained output still carries `DOWNLOAD_OK`, the reconciler recovers it to **finished/done** instead of crashed.

Regression test (source-invariant pin, same style as the existing dep-install test — this repo has no JS test runner):

```
python -m pytest tests/test_cookbook_dependency_completion_regression.py
```

`node --check static/js/cookbookRunning.js` passes.

## Root cause

`_pollBackgroundStatus()`: on `live.status === 'stopped'`, only `depDone` (`payload._dep` + `_depInstallSucceeded`) recovered `done`; a model download had no equivalent recovery, so `task.type === 'download'` mapped straight to `crashed`.

## Fix

Add `downloadDone = task.type === 'download' && String(task.output || '').includes('DOWNLOAD_OK')` and treat `depDone || downloadDone` as recovered. `DOWNLOAD_OK` is emitted by the runner **only after it exits 0** (`if [ $_ec -eq 0 ]; then echo "DOWNLOAD_OK"`), so it's a conclusive terminal marker.

This background poll keys off `DOWNLOAD_OK` **only** — deliberately *not* the `/snapshots/` path that the reconnect loop also accepts. The reconnect loop runs with the live stream in view and can debounce ambiguous markers; this poll runs blind after a refresh, and `/snapshots/` can be printed mid-stream for multi-file downloads, so accepting it here could mark an incomplete download `done`. Keying off the exit-0 sentinel keeps the blind path conservative.

## Visual / UI changes

This is a **status-computation** change inside a `static/js/` module, not a styling change: a finished download resolves to the *existing* `done`/`finished` badge instead of the `crashed` one — no new colors, classes, fonts, spacing, SVG, or component patterns, and the same rendering path is reused.

Verified end-to-end against a locally-run app (`uvicorn app:app`): a `download` task whose output carries `DOWNLOAD_OK` is driven into the dead-session (`stopped`) state that the `/api/cookbook/tasks/status` poll reports, then the Running tab is rendered.

**Before** (current `dev`) — the completed download is mislabeled **crashed**:

<img width="732" height="177" alt="odysseus-3897-before-crashed" src="https://github.com/user-attachments/assets/317e3a11-efc8-4f2a-9201-3e3e9049ec67" />

**After** (this PR) — the same task recovers to **finished**:

<img width="732" height="177" alt="odysseus-3897-after-finished" src="https://github.com/user-attachments/assets/9d74fdbc-4976-4451-bf04-e16f98a14c8e" />

- [x] Screenshot of the change in the running app (before/after above).
- [x] Style match: reuses the existing `finished`/`done` badge + green check; no new colors/classes/fonts/spacing/SVG.
- [x] No new component patterns — the existing card rendering path is reused.
- [x] Not a bulk auto-generated PR — single focused fix; root cause filed and claimed on #3897 first.

## Scope

Deliberately does **not** touch the backend status detection. If the backend separately reports `stopped` for GGUF cache layouts where it should report `completed`, that's a distinct follow-up; this PR fixes the frontend mislabel of a download that already emitted `DOWNLOAD_OK`.
