### PR TITLE
fix(agent): skill-prescribed tools never reach the model's schema list

### DIFF
--- a/services/memory/skills.py
+++ b/services/memory/skills.py
@@ -603,7 +603,6 @@ class SkillsManager:
         escalation) — those are work-in-progress and pollute the
         prompt with half-finished procedures.
         """
-        active_toolsets = active_toolsets or []
         out = []
         for s in self.load(owner=owner):
             status = s.get("status")
@@ -617,13 +616,16 @@ class SkillsManager:
             # Platform gating
             if platform and s.get("platforms") and platform not in s["platforms"]:
                 continue
-            # requires_toolsets: hide unless every required toolset is active
+            # requires_toolsets: hide unless every required toolset is active.
+            # active_toolsets=None means the caller doesn't know the active
+            # set (API listings, chat preface) — don't gate in that case;
+            # only an explicit list filters.
             req = s.get("requires_toolsets") or []
-            if req and not all(t in active_toolsets for t in req):
+            if req and active_toolsets is not None and not all(t in active_toolsets for t in req):
                 continue
             # fallback_for_toolsets: hide when any of those toolsets is active
             fb = s.get("fallback_for_toolsets") or []
-            if fb and any(t in active_toolsets for t in fb):
+            if fb and active_toolsets and any(t in active_toolsets for t in fb):
                 continue
             out.append({
                 "name": s["name"],

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1887,6 +1887,39 @@ async def stream_agent_loop(
     if _relevant_tools is not None and active_document is not None:
         _relevant_tools.update({"edit_document", "update_document", "suggest_document"})
 
+    # The skill index injected by _build_system_prompt tells the model to
+    # call `manage_skills action=view`, and Jaccard-matched skills are pasted
+    # into the prompt as procedures to follow — but neither path goes through
+    # tool selection, so the model can be handed a procedure naming tools
+    # (grep, read_file, ...) that aren't in its schema list. Keep the schemas
+    # in lockstep: manage_skills is callable whenever any skill is indexed,
+    # and a matched skill's declared requires_toolsets ride along with it.
+    if not guide_only and _relevant_tools is not None:
+        try:
+            from services.memory.skills import SkillsManager
+            from src.constants import DATA_DIR
+            _skills_on = True
+            try:
+                from routes.prefs_routes import _load_for_user as _load_prefs
+                _skills_on = (_load_prefs(owner) or {}).get("skills_enabled", True)
+            except Exception:
+                pass
+            _sm = SkillsManager(DATA_DIR)
+            _owner_skills = _sm.load(owner=owner) if _skills_on else []
+            if _owner_skills:
+                _relevant_tools.add("manage_skills")
+                if _retrieval_query:
+                    for _sk in _sm.get_relevant_skills(
+                        _retrieval_query, skills=_owner_skills,
+                        threshold=0.25, max_items=3,
+                    ):
+                        _relevant_tools.update(
+                            t for t in (_sk.get("requires_toolsets") or [])
+                            if t in TOOL_SECTIONS
+                        )
+        except Exception as _e:
+            logger.debug(f"[tool-rag] skill-aware tool include skipped: {_e}")
+
     if _relevant_tools is not None:
         logger.info("[agent-intent] selected_tools=%s", sorted(_relevant_tools)[:50])
 
@@ -2141,9 +2174,17 @@ async def stream_agent_loop(
         elif _is_api_model:
             # Filter schemas by RAG-selected tools (if available)
             if _relevant_tools:
+                # _build_base_prompt unions _ADMIN_TOOLS into the prompt
+                # sections when admin intent fires — the schema list must
+                # offer the same names, or the model reads prose describing
+                # tools it cannot call and substitutes the nearest schema
+                # it does have (e.g. manage_memory for manage_skills).
+                _schema_names = set(_relevant_tools)
+                if _needs_admin:
+                    _schema_names |= _ADMIN_TOOLS
                 base_schemas = [
                     s for s in FUNCTION_TOOL_SCHEMAS
-                    if s.get("function", {}).get("name") in _relevant_tools
+                    if s.get("function", {}).get("name") in _schema_names
                 ]
                 _mcp_filtered = [
                     s for s in mcp_schemas
@@ -2678,6 +2719,44 @@ async def stream_agent_loop(
                         f'data: {json.dumps({"type": "tool_progress", "tool": block.tool_type, "round": round_num, **evt})}\n\n'
                     )
                 desc, result = await _tool_task
+
+            # A skill the model just loaded can prescribe tools that weren't
+            # RAG-selected this turn (declared via requires_toolsets in its
+            # frontmatter). Union them into the selection so the NEXT round's
+            # schema list includes them — otherwise the model reads "use
+            # grep" from the skill it fetched but has no grep schema to call.
+            if (
+                block.tool_type == "manage_skills"
+                and _relevant_tools is not None
+                and not result.get("error")
+            ):
+                _ms_args = {}
+                _ms_raw = (block.content or "").strip()
+                if _ms_raw.startswith("{"):
+                    try:
+                        _ms_args = json.loads(_ms_raw)
+                    except json.JSONDecodeError:
+                        _ms_args = {}
+                _ms_name = str(_ms_args.get("name", "") or "").strip()
+                if _ms_name and _ms_args.get("action") in ("view", "view_ref"):
+                    try:
+                        from services.memory.skills import SkillsManager as _SkM
+                        from src.constants import DATA_DIR as _DD
+                        for _sk in _SkM(_DD).load(owner=owner):
+                            if _sk.get("name") == _ms_name:
+                                _new = {
+                                    t for t in (_sk.get("requires_toolsets") or [])
+                                    if t in TOOL_SECTIONS and t not in _relevant_tools
+                                }
+                                if _new:
+                                    _relevant_tools.update(_new)
+                                    logger.info(
+                                        "[tool-rag] skill '%s' unlocked tools for next round: %s",
+                                        _ms_name, sorted(_new),
+                                    )
+                                break
+                    except Exception as _e:
+                        logger.debug(f"skill requires_toolsets unlock skipped: {_e}")
 
             # Extract structured web sources from web_search tool output.
             # web_search returns {"output": ..., "exit_code": 0}; check "output"

--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1909,13 +1909,18 @@ async def stream_agent_loop(
             if _owner_skills:
                 _relevant_tools.add("manage_skills")
                 if _retrieval_query:
+                    # Validate against every known executable tool, not just
+                    # TOOL_SECTIONS — code-nav tools (grep/glob/ls) ship as
+                    # schemas without a prompt-prose section.
+                    from src.tool_policy import known_tool_names
+                    _known = known_tool_names()
                     for _sk in _sm.get_relevant_skills(
                         _retrieval_query, skills=_owner_skills,
                         threshold=0.25, max_items=3,
                     ):
                         _relevant_tools.update(
                             t for t in (_sk.get("requires_toolsets") or [])
-                            if t in TOOL_SECTIONS
+                            if t in _known
                         )
         except Exception as _e:
             logger.debug(f"[tool-rag] skill-aware tool include skipped: {_e}")
@@ -2742,11 +2747,13 @@ async def stream_agent_loop(
                     try:
                         from services.memory.skills import SkillsManager as _SkM
                         from src.constants import DATA_DIR as _DD
+                        from src.tool_policy import known_tool_names as _ktn
+                        _known = _ktn()
                         for _sk in _SkM(_DD).load(owner=owner):
                             if _sk.get("name") == _ms_name:
                                 _new = {
                                     t for t in (_sk.get("requires_toolsets") or [])
-                                    if t in TOOL_SECTIONS and t not in _relevant_tools
+                                    if t in _known and t not in _relevant_tools
                                 }
                                 if _new:
                                     _relevant_tools.update(_new)

--- a/tests/test_skill_index_toolset_gating.py
+++ b/tests/test_skill_index_toolset_gating.py
@@ -1,0 +1,98 @@
+"""index_for() toolset gating: requires_toolsets must only filter when the
+caller provides an explicit active-toolset list.
+
+Callers that don't know the active tool set (API skill listings, the chat
+preface) pass active_toolsets=None. The old behavior coerced None to [] and
+hid every skill that declared requires_toolsets — so a skill like a local
+notes lookup that needs grep + read_file silently vanished from the index
+the moment it declared its tool needs. None now means "don't gate".
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# ── module-load stubbing (matches other tests in this repo) ──────────
+for _mod in ("sqlalchemy", "sqlalchemy.orm", "sqlalchemy.ext", "sqlalchemy.ext.declarative"):
+    if _mod not in sys.modules:
+        try:
+            __import__(_mod)
+        except ImportError:
+            sys.modules[_mod] = MagicMock()
+
+from services.memory.skills import SkillsManager  # noqa: E402
+
+
+def _write_skill_md(skills_root: Path, name: str, *, requires: str = "",
+                    fallback: str = "") -> Path:
+    skill_dir = skills_root / "general" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    fm = [
+        "---",
+        f"name: {name}",
+        "description: test skill",
+        "version: 1.0.0",
+        "category: general",
+        "tags: []",
+    ]
+    if requires:
+        fm.append(f"requires_toolsets: [{requires}]")
+    if fallback:
+        fm.append(f"fallback_for_toolsets: [{fallback}]")
+    fm += [
+        "status: published",
+        "confidence: 0.9",
+        "source: learned",
+        "created: 2026-01-01T00:00:00Z",
+        "---",
+        "",
+        "## When to Use",
+        "- test",
+        "",
+        "## Procedure",
+        "1. step 1",
+        "",
+    ]
+    path = skill_dir / "SKILL.md"
+    path.write_text("\n".join(fm), encoding="utf-8")
+    return path
+
+
+def _names(idx):
+    return {s["name"] for s in idx}
+
+
+def test_requires_toolsets_not_gated_when_active_set_unknown(tmp_path):
+    (tmp_path / "skills").mkdir()
+    _write_skill_md(tmp_path / "skills", "notes-lookup", requires="grep, read_file")
+    sm = SkillsManager(str(tmp_path))
+
+    # None = caller doesn't know the active tool set → no gating.
+    assert "notes-lookup" in _names(sm.index_for())
+    assert "notes-lookup" in _names(sm.index_for(active_toolsets=None))
+
+
+def test_requires_toolsets_gates_on_explicit_list(tmp_path):
+    (tmp_path / "skills").mkdir()
+    _write_skill_md(tmp_path / "skills", "notes-lookup", requires="grep, read_file")
+    sm = SkillsManager(str(tmp_path))
+
+    # Explicit list missing a required tool → hidden.
+    assert "notes-lookup" not in _names(sm.index_for(active_toolsets=["grep"]))
+    assert "notes-lookup" not in _names(sm.index_for(active_toolsets=[]))
+    # All required tools active → visible.
+    assert "notes-lookup" in _names(
+        sm.index_for(active_toolsets=["grep", "read_file", "ls"]))
+
+
+def test_fallback_for_toolsets_unaffected_by_none(tmp_path):
+    (tmp_path / "skills").mkdir()
+    _write_skill_md(tmp_path / "skills", "web-fallback", fallback="web_search")
+    sm = SkillsManager(str(tmp_path))
+
+    # Fallback skills hide only when the toolset they substitute for is
+    # known to be active.
+    assert "web-fallback" in _names(sm.index_for(active_toolsets=None))
+    assert "web-fallback" in _names(sm.index_for(active_toolsets=[]))
+    assert "web-fallback" not in _names(
+        sm.index_for(active_toolsets=["web_search"]))


### PR DESCRIPTION
## Summary

In agent mode, the prompt and the function-schema list disagree about which tools exist. The injected skill index tells the model to call `manage_skills action=view`, and Jaccard-matched skill procedures are pasted into the prompt — but RAG tool selection never adds `manage_skills` (or the tools a skill prescribes, like `grep`/`read_file`) to the schema list, and the `_needs_admin` union in `_build_base_prompt` widens only the prompt text, never the schemas. Models that follow the provided schemas (e.g. gpt-oss-20b on llama.cpp) substitute the nearest available schema (`manage_memory`), flail for a few rounds, and apologize. This PR keeps schemas in lockstep with what the prompt advertises: `manage_skills` rides along whenever skills are indexed, a matched skill's `requires_toolsets` frontmatter joins the selection, viewing a skill mid-turn unlocks its `requires_toolsets` for later rounds, admin-intent turns send the `_ADMIN_TOOLS` schemas the prompt already describes, and `SkillsManager.index_for(active_toolsets=None)` no longer hides `requires_toolsets` skills from callers that don't know the active set.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4013

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (#3041 is agent-tools-adjacent but a different failure; #2959 covers the untrusted-data wrapper.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`, macOS manual install) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `python -m pytest tests/test_skill_index_toolset_gating.py tests/test_agent_loop.py tests/test_skill_index_prompt_injection.py tests/test_skills_manager_owner_isolation.py` — 63 pass (the first file is new and covers the `index_for` gating change).
2. Create a published skill under `data/skills/<category>/<name>/SKILL.md` whose frontmatter declares `requires_toolsets: [grep, read_file, glob, ls]` and whose Procedure says to grep a local directory (add that directory to the `tool_path_extra_roots` setting so the file tools may touch it).
3. In agent mode with a schema-following local model (tested: gpt-oss-20b-Q4_K_M.gguf on llama.cpp), ask a question the skill covers.
4. Before this PR: the `[agent-debug] ... tool_names=[...]` log line lacks `manage_skills`/`grep`/`read_file`; the model calls `manage_memory` instead and answers "I don't have access". After: the log shows them in the schema list, the model greps and reads the files, and the answer cites them. A query that *doesn't* lexically match the skill still works via the second path: `manage_skills action=view` executes, and the next round's log shows the skill's `requires_toolsets` unlocked (`[tool-rag] skill '<name>' unlocked tools for next round`).

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — no UI/rendering changes (src/agent_loop.py, services/memory/skills.py, and a new test file only).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — LLM-assisted, human-directed, and verified end-to-end on a real install (see issue #4013 for the discovery context).