### PR TITLE
fix(skills): keep edit mode open on outside-the-textarea click

### DIFF
--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -514,6 +514,8 @@ function _buildBuiltinCards() {
 
     card.addEventListener('click', (e) => {
       if (e.target.closest('button, input, textarea')) return;
+      // Editing in progress → don't collapse on an outside-the-textarea click.
+      if (card.querySelector('.skill-md-editor')) return;
       _expandBuiltinCard(card, b.name);
     });
     return card;
@@ -786,6 +788,10 @@ function renderSkillsList() {
     card.addEventListener('click', (e) => {
       if (card._suppressNextClick) { card._suppressNextClick = false; return; }
       if (e.target.closest('button, input, textarea')) return;
+      // While editing, a click on the card body (outside the textarea) must
+      // NOT collapse the card — that silently discards unsaved edits. Only
+      // Save/Cancel exit edit mode.
+      if (card.querySelector('.skill-md-editor')) return;
       if (_selectMode) {
         const cb = card.querySelector('.skill-select-cb');
         if (cb) { cb.checked = !cb.checked; cb.dispatchEvent(new Event('change')); }

--- a/tests/test_skill_edit_no_collapse_on_outside_click_js.py
+++ b/tests/test_skill_edit_no_collapse_on_outside_click_js.py
@@ -1,0 +1,56 @@
+"""Regression guard for issue #4002 — clicking the card body outside the
+edit textarea collapsed the skill card and silently discarded unsaved edits.
+
+In Brain > Skills, the card's click handler toggles expand/collapse. The
+edit <textarea> stops propagation only for clicks landing ON the textarea,
+so a click on the surrounding card padding bubbled up to the card handler
+and collapsed the card mid-edit — losing the user's changes. The fix bails
+out of the card click handler while a `.skill-md-editor` is present, so the
+card only leaves edit mode via Save (or the Cancel button added in #3580).
+
+skills.js pulls in browser globals (DOM), so it can't be imported under
+node; this guards the fix at the source level so it can't be silently
+dropped. Both the user-skill card (`_expandSkillCard`) and the built-in
+capability card (`_expandBuiltinCard`) share the same bug and the same
+guard, so both are covered here.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "static/js/skills.js"
+
+# The guard the fix introduces inside the card click handler.
+GUARD = re.compile(r"querySelector\(\s*['\"]\.skill-md-editor['\"]\s*\)\s*\)\s*return")
+
+
+def _handler_body(text: str, anchor: str, call: str) -> str:
+    """Return the card click-handler body: the slice from `anchor` (a string
+    unique to the handler we care about) up to its collapse trigger `call`.
+    `_expandSkillCard` is called from several places, so we must anchor on the
+    handler itself rather than the first textual match of the call."""
+    start = text.index(anchor)
+    end = text.index(call, start)
+    return text[start:end]
+
+
+def test_user_skill_card_does_not_collapse_while_editing():
+    text = SRC.read_text(encoding="utf-8")
+    body = _handler_body(
+        text, "// Click to expand/collapse", "_expandSkillCard(card, name)"
+    )
+    assert GUARD.search(body), (
+        "user-skill card click handler must skip collapse while a "
+        ".skill-md-editor is present (issue #4002)"
+    )
+
+
+def test_builtin_card_does_not_collapse_while_editing():
+    text = SRC.read_text(encoding="utf-8")
+    # The built-in capability card has a single handler ending in
+    # _expandBuiltinCard; take the click handler that immediately precedes it.
+    before = text[: text.index("_expandBuiltinCard(card, b.name)")]
+    body = before[before.rindex("card.addEventListener('click'"):]
+    assert GUARD.search(body), (
+        "built-in capability card click handler must skip collapse while a "
+        ".skill-md-editor is present (issue #4002)"
+    )


### PR DESCRIPTION
## Summary

In **Brain → Skills**, opening a skill's editor and then clicking anywhere on the card *outside* the writing area collapsed the whole card and silently discarded the unsaved edits (issue #4002). The edit `<textarea>` only `stopPropagation`s clicks that land **on** it, so a click on the surrounding card padding/header bubbled up to the card's click handler and triggered collapse.

This bails out of the card click handler while a `.skill-md-editor` is present, so the editor only closes when the user presses **Save**. The same guard is mirrored into the built-in capability card, which shared the identical bug.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

Fixes #4002

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end (see recording below).

**Scope notes (deliberate):**
- The reporter also asked for a **Cancel/back button**. That is already in flight as **#3580** (Fixes #3577), which adds the Cancel action + snapshot-restore. This PR intentionally does **not** duplicate it and limits itself to the accidental-collapse data-loss bug. The two are orthogonal and complementary.
- While editing, a click on the card body no longer toggles select-mode either (select-mode + edit-mode aren't used together; clicking the checkbox/buttons still works since those return earlier in the handler).

## How to Test

1. `uvicorn app:app` (or `docker compose up`), log in.
2. Open **Brain** → **Skills** tab.
3. Click **Edit** on any skill; the editor textarea appears.
4. Type something, then click the card **header / padding** (anywhere outside the textarea).
5. **Before this fix:** the card collapses and your edits are gone.
   **After this fix:** the card stays open with your edits intact; only **Save** closes it.

Automated regression guard (skills.js pulls browser globals so it can't be imported under node — guarded at the source level, matching the repo's existing `tests/test_*_js.py` source-guard pattern):

```
python -m pytest tests/test_skill_edit_no_collapse_on_outside_click_js.py
# 2 passed   (covers both the user-skill and built-in capability cards)
python -m pytest tests/ -k skill   # 51 passed
node --check static/js/skills.js   # OK
```

## Visual / UI changes — REQUIRED if you touched anything that renders

Behaviour change only — no visual/style change. Recorded against a real local `uvicorn app:app` (left = current `dev`, right = this branch):

<img width="1000" height="370" alt="ody4002_compare" src="https://github.com/user-attachments/assets/e93dc6b9-4883-462e-ab7e-78c24609ea58" />

- **BEFORE (left):** click outside the textarea → card collapses, edits discarded.
- **AFTER (right):** click outside the textarea → editor stays open with the typed text preserved.

- [x] Screenshot / clip of the change in the running app, attached above.
- [x] **Style match:** no new colors/fonts/spacing; no new classes; no markup or CSS changed — only an early-return guard in two existing click handlers.
- [x] **No new component patterns.**
- [x] I am not submitting a bulk auto-generated PR; this is a single focused one-line-per-handler fix.
