### PR TITLE
docs(readme): document optional uv install workflow (no tooling changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ venv/
 .env
 .env.bak.*
 !.env.example
+# Local uv lockfile (optional, per-platform — see "Faster installs with uv" in README)
+requirements.lock
 
 # Data — all user data stays local
 data/

--- a/README.md
+++ b/README.md
@@ -333,6 +333,25 @@ To expose Odysseus on a local network or Tailscale with HTTPS:
 | `PyMuPDF` | PDF page rendering in the side viewer panel and form-filling. (Note: AGPL-3.0) |
 | `markitdown` | Office/EPUB document text extraction (converts .docx/.xlsx/.pptx/.xls/.epub to Markdown). |
 
+### Faster, reproducible installs with uv (optional)
+[uv](https://docs.astral.sh/uv/) works as a drop-in replacement for the
+venv + pip steps in the native install guides, no project changes are needed but this change results in faster installs along with a lockfile for reproducible environments. After [installing `uv`](https://docs.astral.sh/uv/getting-started/installation/), use:
+
+```bash
+uv venv venv --python 3.13
+uv pip install -r requirements.txt
+# then continue as usual: python setup.py, uvicorn, ...
+```
+
+`requirements.txt` is intentionally unpinned, so two installs at different times can produce different package versions. If you want a reproducible environment (e.g. across your own machines, or to roll back after a bad upgrade), snapshot and restore exact versions with:
+
+```bash
+uv pip compile requirements.txt -o requirements.lock   # snapshot current resolution
+uv pip sync requirements.lock                          # reproduce it exactly later
+```
+
+`requirements.lock` is gitignored and platform-specific (compile it on the OS you deploy to). Regenerate it deliberately when you want to take upgrades. The plain `uv pip install -r requirements.txt` keeps following the unpinned requirements like pip does.
+
 ### Outlook / Office 365 email
 Odysseus email accounts currently use IMAP/SMTP username-password auth. Outlook
 and Microsoft 365 generally require OAuth instead, so normal Microsoft mailbox


### PR DESCRIPTION
## Summary

Adds an optional **"Faster, reproducible installs with uv"** section to the README under *Troubleshooting & Advanced Setup*, plus a `.gitignore` entry for the local lockfile it describes. uv already works as a drop-in for the documented `venv` + `pip` install steps (dependency install drops from minutes to ~11s on my machine), and since `requirements.txt` is intentionally unpinned, the section also documents an optional **local** snapshot/restore workflow (`uv pip compile` / `uv pip sync`) for reproducing an environment or rolling back after a bad upgrade. This is **not** a uv migration: pip remains the documented default, no scripts/Docker/CI/install paths change, and the lockfile is gitignored and never committed.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Prior migration PRs ([#35](https://github.com/pewdiepie-archdaemon/odysseus/pull/35), [#54](https://github.com/pewdiepie-archdaemon/odysseus/pull/54), [#459](https://github.com/pewdiepie-archdaemon/odysseus/pull/459), [#579](https://github.com/pewdiepie-archdaemon/odysseus/pull/579), [#685](https://github.com/pewdiepie-archdaemon/odysseus/pull/685), [#913](https://github.com/pewdiepie-archdaemon/odysseus/pull/913), [#1023](https://github.com/pewdiepie-archdaemon/odysseus/pull/1023)) were closed as too large for the v1 window; #685 was closed with the suggestion to *"split it into a docs-only proposal first"*.

**This PR is that proposal.**

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs] https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Read the new README section (*Troubleshooting & Advanced Setup → Faster, reproducible installs with uv*) and confirm it changes no defaults. The Quick Start / native install guides are untouched and still document pip.
2. Follow it on a clean checkout: install uv, then `uv venv venv --python 3.13` and `uv pip install -r requirements.txt` — same packages as the pip path, just faster. Continue as documented: `python setup.py`, `python -m uvicorn app:app --host 127.0.0.1 --port 7000`, log in at `http://localhost:7000`.
3. Snapshot/restore: `uv pip compile requirements.txt -o requirements.lock`, delete `venv/`, recreate it with `uv venv venv --python 3.13` + `uv pip sync requirements.lock` — the app boots identically from the pinned environment.
4. `git status` shows `requirements.lock` is ignored (new `.gitignore` entry); nothing else in the working tree changes.
