### PR TITLE
chore(ci): narrow CODEOWNERS to critical paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
-# Code owners.
+# Critical-path code owners.
 #
-# Every file is owned by the maintainer, so that when branch protection has
-# "Require review from Code Owners" turned on, no pull request can be merged
-# without the maintainer's review. This is the human gate that backs up the
-# automated security checks. See docs/security-ci.md for how to turn it on.
+# Code Owner review is limited to repo-control and security-CI paths. General
+# application changes should rely on normal branch protection and maintainer
+# review instead of requiring the project owner on every pull request.
 
-*       @pewdiepie-archdaemon
+/.github/CODEOWNERS        @pewdiepie-archdaemon
+/.github/dependabot.yml    @pewdiepie-archdaemon
+/.github/scripts/          @pewdiepie-archdaemon
+/.github/workflows/        @pewdiepie-archdaemon
+/docs/security-ci.md       @pewdiepie-archdaemon

--- a/docs/security-ci.md
+++ b/docs/security-ci.md
@@ -75,8 +75,9 @@ This makes the **Merge** button refuse to work until the gating checks pass.
    security suite. Leave pytest, pip-audit, Trivy, and CodeQL unchecked so they
    stay advisory.
 7. Also enable **Require a pull request before merging** and **Require review
-   from Code Owners** (this uses the `.github/CODEOWNERS` file so every change
-   needs your sign-off).
+   from Code Owners**. This uses `.github/CODEOWNERS` for the critical
+   repo-control and security-CI paths listed there; ordinary application changes
+   still rely on the normal pull-request review rule.
 8. Click **Create** / **Save changes**.
 
 Note: a check name only appears in the list after it has run at least once, so


### PR DESCRIPTION
## Summary

Narrow `.github/CODEOWNERS` from a repository-wide owner rule to explicit repo-control and security-CI paths. This is the smallest proposed fix for the current merge-routing bottleneck discussed in #593: ordinary app/test/docs PRs stop needing project-owner Code Owner approval, while workflow/security gate changes still route through `@pewdiepie-archdaemon`.

This does not assign area ownership, redesign review policy, or decide which collaborators should become Code Owners. If @pewdiepie-archdaemon wants the current all-files Code Owner gate to remain, or wants a different critical-path set, this PR should be closed or adjusted rather than treated as policy by default.

CODEOWNERS does not grant merge access; it only controls who can satisfy the Code Owner review requirement when that branch rule is enabled. Actual merging still depends on repository permissions and the `dev` branch protection/ruleset. This first version also keeps the critical paths owned only by `@pewdiepie-archdaemon`, so it does not add a backup reviewer for urgent CI/workflow/dependabot fixes; that should be a follow-up decision rather than hidden inside this unblocker.

I am treating this as reviewer/triage follow-up from #551 because the merged review-gate behavior is now blocking reviewed/CI-green PRs unless `@pewdiepie-archdaemon` personally approves every path. If maintainers want this handled differently, I am happy to adjust or close it. The PR is meant as the narrowest reversible fix, not a decision on ownership policy.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #593

## Type of Change

- [ ] Bug fix (non-breaking -- fixes a confirmed issue)
- [ ] New feature (non-breaking -- adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) -- this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above -- no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Not applicable for the app-runtime checkbox: this changes GitHub metadata and the security CI guide only. The runtime app cannot exercise Code Owner routing.

## Follow-up Needed

- Confirm the `dev` branch protection/ruleset still requires at least one approving review from someone with write access who is not the PR author, plus required CI/security checks.
- Consider enabling "Require approval of the most recent reviewable push" so new commits after review need a fresh non-pusher approval.
- Decide in #593 whether the project wants a broader area-based CODEOWNERS map after the queue is unblocked.
- Decide in #3694 what the normal review/merge policy should require for ordinary application PRs once CODEOWNERS no longer covers every file.
- Decide how maintainer-authored changes to the critical CODEOWNERS paths should be handled. With only `@pewdiepie-archdaemon` listed on those paths, the repo owner's own approval cannot satisfy the required review if he authors one of those PRs; that needs an explicit bypass choice, an additional trusted Code Owner later, or a different ruleset.
- If maintainers delegate specific critical paths later, update `.github/CODEOWNERS` in a separate focused PR so the ownership change is easy to review.

## How to Test

1. Review `.github/CODEOWNERS` and confirm there is no repository-wide `* @pewdiepie-archdaemon` rule.
2. Confirm the remaining owner rules are explicit repo-control/security-CI paths only: `.github/CODEOWNERS`, `.github/dependabot.yml`, `.github/scripts/`, `.github/workflows/`, and `docs/security-ci.md`.
3. Confirm `docs/security-ci.md` now describes Code Owner review as applying to the critical paths listed in `.github/CODEOWNERS`, while ordinary application changes rely on the normal pull-request review rule.
4. After the branch is pushed, use GitHub's CODEOWNERS validation / PR review requests to confirm the file parses and only the listed paths request Code Owner review.
5. Check the `dev` branch protection/ruleset settings separately; this PR changes repository files only and cannot itself enforce the ordinary non-author approval rule.

## Visual / UI changes -- REQUIRED if you touched anything that renders

Not applicable. This PR does not touch UI, CSS, HTML, SVG, images, or frontend rendering code.

### Screenshots / clips

Not applicable.
