### PR TITLE
fix(calendar): list_events returns nothing when start == end

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -1643,6 +1643,9 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
             except ValueError as e:
                 return {"error": f"Invalid date format: {e}", "exit_code": 1}
 
+            if end_dt <= start_dt:
+                end_dt = start_dt + timedelta(days=1)
+
             q = _event_query().filter(
                 CalendarEvent.dtstart < end_dt,
                 CalendarEvent.dtend > start_dt,


### PR DESCRIPTION
## Summary

`manage_calendar`'s `list_events` action returns an empty result whenever the model passes the same value for `start` and `end` (e.g. both `"tomorrow"` for a single-day query). Both parse to midnight, the window has zero width, and the `dtstart < end_dt` filter excludes every event that day — so the assistant reports an empty agenda even when events exist. Local models produce this argument shape routinely (verified with qwen2.5:7b via Ollama), so day queries are broken in practice. This PR adds a guard in the `list_events` branch of `src/tool_implementations.py`: if the parsed window is zero-width or inverted, `end_dt` is expanded to `start_dt + 1 day`, making a single-day query mean "that whole day". Explicit multi-day ranges are unaffected.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4058

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate (closest are #2971 — 14-day default cap — and #2890 — RRULE expansion; both different).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in (3 lines added, nothing else).
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end.

## How to Test

1. `docker compose up -d --build` with any chat model connected (tested with qwen2.5:7b via Ollama)
2. In the calendar UI, create an event tomorrow at a non-midnight time, e.g. 07:00–08:00
3. In chat, ask: "What's on my calendar tomorrow?" — the model emits `{"action": "list_events", "start": "tomorrow", "end": "tomorrow"}`
4. **Before this patch:** "No events between ..." despite the event existing in the `calendar_events` table
5. **After this patch:** the event is listed
6. Regression check: "What's on my calendar this week?" (explicit range) still returns the same results as before

## Visual / UI changes

N/A — backend tool logic only, nothing rendered changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)