### PR TITLE
fix(governance): drop the catch-all single-owner CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
 # Code owners.
 #
-# Every file is owned by the maintainer, so that when branch protection has
-# "Require review from Code Owners" turned on, no pull request can be merged
-# without the maintainer's review. This is the human gate that backs up the
-# automated security checks. See docs/security-ci.md for how to turn it on.
-
-*       @pewdiepie-archdaemon
+# Intentionally empty for now. The catch-all rule that mapped every path to a
+# single owner froze all merges the moment "Require review from Code Owners"
+# was enabled, because no other maintainer's approval could satisfy the gate.
+# A per-area ownership map (security/auth, CI, frontend, agent internals, with
+# multiple named owners per line) is being worked out in issue #593; once
+# agreed it replaces this file. Until then, required reviews and the security
+# CI gate (docs/security-ci.md) remain in force via branch protection.


### PR DESCRIPTION
## Summary

Removes the catch-all `* @pewdiepie-archdaemon` line from `.github/CODEOWNERS`. It shipped inside the #1314 security-CI bundle (authored by nopoz, merged by alteixeira20) and, combined with the "Require review from Code Owners" branch protection, made every merge to `dev` require one person's review. No co-maintainer approval can satisfy the gate, so the whole PR queue is frozen: #428, #3840 and #2769 were the first reviewed, CI-green PRs to hit the wall this morning.

The single-owner mapping was never an explicitly agreed policy. The ownership-routing discussion in #593 was still open when the gate went live, and #3694 holds the broader review/merge policy thread. This PR removes only the catch-all line; branch protection, required reviews, and the entire security CI gate from #1314 (docs/security-ci.md) stay in force. The replacement is the per-area, multi-owner CODEOWNERS map being drafted in #593, which restores a human review gate without a single point of failure.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #593

## Type of Change

- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above.
- [x] Verified: the file change is comment + one line removal; no workflow or code is touched.

## How to Test

CODEOWNERS with no rules satisfies the Code Owner requirement trivially, so reviewed and approved PRs become mergeable by maintainers again while all other protections stay active.
