### PR TITLE
fix(cookbook): stop local Windows process trees

### DIFF
--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -353,7 +353,11 @@ def setup_cookbook_routes() -> APIRouter:
             # all output to the log the poller reads. Paths handed to bash use
             # POSIX form + shell-quoting so drive paths / spaces survive.
             inner = TMUX_LOG_DIR / f"{session_id}_run.sh"
-            inner.write_text("\n".join(bash_lines) + "\n", encoding="utf-8")
+            pp = shlex.quote(pid_path.as_posix())
+            inner.write_text(
+                f"printf '%s\\n' \"$$\" > {pp}\n" + "\n".join(bash_lines) + "\n",
+                encoding="utf-8",
+            )
             lp = shlex.quote(log_path.as_posix())
             ip = shlex.quote(inner.as_posix())
             script_path = TMUX_LOG_DIR / f"{session_id}.sh"

--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -793,9 +793,10 @@ function _winSessionCmd(task, tmuxArgs) {
     return host ? `ssh ${pf}${host} "powershell -Command \\"${ps}\\""` : `powershell -Command "${ps}"`;
   }
   if (tmuxArgs.includes('kill-session')) {
+    const stopTree = `function Stop-Tree([int]$Id) { Get-CimInstance Win32_Process -Filter "ParentProcessId = $Id" -ErrorAction SilentlyContinue | ForEach-Object { Stop-Tree ([int]$_.ProcessId) }; Stop-Process -Id $Id -Force -ErrorAction SilentlyContinue }`;
     const ps = host
-      ? `$p = Get-Content '${sd}\\${sid}.pid' -ErrorAction SilentlyContinue; if ($p) { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue }; Remove-Item '${sd}\\${sid}.*' -Force -ErrorAction SilentlyContinue`
-      : `$p = Get-Content (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.pid') -ErrorAction SilentlyContinue; if ($p) { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue }; Remove-Item (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.*') -Force -ErrorAction SilentlyContinue`;
+      ? `${stopTree}; $p = Get-Content '${sd}\\${sid}.pid' -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Stop-Tree ([int]$p) }; Remove-Item '${sd}\\${sid}.*' -Force -ErrorAction SilentlyContinue`
+      : `${stopTree}; $p = Get-Content (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.pid') -ErrorAction SilentlyContinue; if ($p -match '^\\d+$') { Stop-Tree ([int]$p) }; Remove-Item (Join-Path $env:TEMP 'odysseus-tmux\\${sid}.*') -Force -ErrorAction SilentlyContinue`;
     return host ? `ssh ${pf}${host} "powershell -Command \\"${ps}\\""` : `powershell -Command "${ps}"`;
   }
   if (tmuxArgs.includes('send-keys') && tmuxArgs.includes('C-c')) {

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
@@ -671,6 +672,16 @@ def test_llama_cpp_rebuild_cmd_clears_cached_build_paths():
     assert 'pip install' not in cmd
     assert 'git clone' not in cmd
     assert 'curl' not in cmd and 'wget' not in cmd
+
+
+def test_local_windows_download_pid_tracks_inner_bash_and_stop_kills_tree():
+    routes_src = (Path(__file__).resolve().parents[1] / "routes" / "cookbook_routes.py").read_text(encoding="utf-8")
+    running_src = (Path(__file__).resolve().parents[1] / "static" / "js" / "cookbookRunning.js").read_text(encoding="utf-8")
+
+    assert 'printf \'%s\\\\n\' \\"$$\\" > {pp}' in routes_src
+    assert "function Stop-Tree([int]$Id)" in running_src
+    assert "ParentProcessId = $Id" in running_src
+    assert "Stop-Tree ([int]$p)" in running_src
 
 
 def test_llama_cpp_rebuild_cmd_runs_clean_on_a_fresh_home(tmp_path):


### PR DESCRIPTION
## Summary

Local Windows Cookbook serve/download tasks are launched through a Git Bash wrapper. The pid file previously tracked the outer launcher, so Stop could leave child `bash`, `python`, or `hf` processes alive. A retry could then fight the old process over the same Hugging Face cache locks.

This PR only changes local Windows cleanup:

- write the inner Bash runner PID into the session pid file;
- use a recursive PowerShell `Stop-Tree` helper when killing local Windows sessions;
- keep the existing log and session cleanup behavior.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Related to #2636

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I ran focused tests for the changed behavior.

## How to Test

Focused test:

```powershell
G:\AI\odysseus\venv\Scripts\python.exe -m pytest tests\test_cookbook_helpers.py::test_local_windows_download_pid_tracks_inner_bash_and_stop_kills_tree -q
```

Result: `1 passed`.

## Visual / UI changes

No visual changes. This is process lifecycle cleanup for local Windows Cookbook tasks.