### PR TITLE
fix(cookbook): create bin dir before llama-server link

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -742,6 +742,7 @@ def _append_llama_cpp_linux_accel_build_lines(runner_lines: list[str]) -> None:
     runner_lines.append('    done')
     # rm -rf build so a prior poisoned CMakeCache.txt (e.g. from a failed CUDA
     # or HIP attempt) doesn't cause the next configure to reuse stale settings.
+    runner_lines.append('    mkdir -p ~/bin')
     runner_lines.append('    cd ~/llama.cpp && rm -rf build')
     runner_lines.append('    if command -v hipconfig &>/dev/null || [ -d /opt/rocm ] || [ -n "$ROCM_PATH" ] || [ -n "$HIP_PATH" ]; then')
     runner_lines.append('      if command -v hipconfig &>/dev/null; then')

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -588,6 +588,8 @@ def test_llama_cpp_linux_bootstrap_prefers_rocm_before_cuda():
     _append_llama_cpp_linux_accel_build_lines(runner_lines)
     script = "\n".join(runner_lines)
 
+    assert "mkdir -p ~/bin" in script
+    assert script.index("mkdir -p ~/bin") < script.index("cd ~/llama.cpp && rm -rf build")
     assert 'command -v hipconfig &>/dev/null || [ -d /opt/rocm ] || [ -n "$ROCM_PATH" ] || [ -n "$HIP_PATH" ]' in script
     assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_HIP=ON' in script
     assert 'cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON' in script


### PR DESCRIPTION
## Summary

The llama.cpp accelerated Linux build helper can link `~/bin/llama-server` after building, but the helper did not guarantee `~/bin` exists before that link step. A fresh host can fail at the symlink step even after the build succeeds.

This PR only adds `mkdir -p ~/bin` to the accelerated llama.cpp bootstrap helper before it changes into `~/llama.cpp` and builds.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Related to #2636

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I ran focused tests for the changed behavior.

## How to Test

Focused test:

```powershell
G:\AI\odysseus\venv\Scripts\python.exe -m pytest tests\test_cookbook_helpers.py::test_llama_cpp_linux_bootstrap_prefers_rocm_before_cuda -q
```

Result: `1 passed`.

## Visual / UI changes

No visual changes. This only affects the shell bootstrap emitted for llama.cpp native builds.