### PR TITLE
feat(cookbook): Allow to override llm serve command

### DIFF
--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -773,6 +773,7 @@ function _rerenderCachedModels() {
       // button can sit at its top-right corner — same pattern as the chat
       // run-output panel.
       panelHtml += `<div class="hwfit-serve-cmd-wrap">`;
+      panelHtml += `<div class="hwfit-serve-cmd-override-bar"><button type="button" class="cookbook-btn hwfit-serve-override-toggle" title="Toggle custom command - type your own launch command instead of the auto-generated one">Custom</button><span class="hwfit-serve-override-hint" style="display:none;">Editing command manually - UI options are disabled</span></div>`;
       panelHtml += `<textarea class="hwfit-serve-cmd" spellcheck="false" rows="2"></textarea>`;
       panelHtml += `<button type="button" class="cookbook-btn hwfit-serve-copy hwfit-serve-copy-inline" title="Copy launch command" aria-label="Copy"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>`;
       panelHtml += `</div>`;
@@ -810,6 +811,13 @@ function _rerenderCachedModels() {
       // Scroll the serve panel into view within its nearest scrollable ancestor
       requestAnimationFrame(() => panel.scrollIntoView({ block: 'nearest', behavior: 'smooth' }));
 
+      // Override state: when _cmdOverride is true the textarea holds a
+      // user-written command that takes precedence over the auto-generated one.
+      // Only restore from per-repo state — NOT from _lastUsed, which would
+      // leak the override flag from a different model's launch.
+      const _repoState = (_byRepo[repo] && typeof _byRepo[repo] === 'object') ? _byRepo[repo] : {};
+      panel._cmdOverride = !!(_repoState._cmdOverride);
+      panel._customCmd = _repoState._customCmd || '';
       // Build command preview
       function updateCmd() {
         const f = {};
@@ -822,23 +830,13 @@ function _rerenderCachedModels() {
         if (backend === 'llamacpp') {
           const ggufChoices = _runnableGgufFiles(m);
           const selectedGguf = ggufChoices.find(file => file.rel_path === f.gguf_file);
-          // For multi-part GGUFs, llama.cpp requires the first split
-          // (-00001-of-NNNNN.gguf). Prefer it (sorted, so UD-IQ4_XS/001 comes
-          // before Q4_K_M/001 etc); fall back to any single GGUF sorted.
           const dir = _ggufSearchDirExpr(m, repo);
-          // GGUF needs the actual .gguf FILE, not the folder. For a custom-dir
-          // model the file lives under "<path>/<repo>" — search there just like we
-          // search the HF snapshots dir, so serving a GGUF from a custom dir works
-          // instead of handing llama.cpp a directory (which fails).
           const _ldir = m.path ? _shellQuote(`${m.path}/${repo}`) : '""';
           f._gguf_path = selectedGguf
             ? _selectedGgufExpr(m, repo, selectedGguf.rel_path)
             : m.is_local_dir && m.path
             ? `$({ find ${_ldir} -name '*-00001-of-*.gguf' 2>/dev/null | sort; find ${_ldir} -name '*.gguf' 2>/dev/null | sort; } | head -1)`
             : `$({ find ${dir} -name '*-00001-of-*.gguf' 2>/dev/null | sort; find ${dir} -name '*.gguf' 2>/dev/null | sort; } | head -1)`;
-          // Vision: auto-find the mmproj (CLIP/projector) file in the same dir.
-          // Resolved at runtime so the toggle just works if an mmproj-*.gguf is
-          // present (downloaded alongside the model). Empty if none → cmd omits it.
           const _vsearchdir = (m.is_local_dir && m.path) ? _ldir : dir;
           f._mmproj_path = `$(find ${_vsearchdir} -iname 'mmproj*.gguf' 2>/dev/null | sort | head -1)`;
         }
@@ -848,12 +846,23 @@ function _rerenderCachedModels() {
         }
         let cmd = _buildServeCmd(f, serveModel, backend);
         if (f.extra && f.extra.trim()) cmd += ' ' + f.extra.trim();
-        const _ce2 = panel.querySelector('.hwfit-serve-cmd'); _ce2.value = cmd; _ce2.style.height = 'auto'; _ce2.style.height = _ce2.scrollHeight + 'px';
-        panel._cmd = cmd;
+        panel._cmdAutoGen = cmd;
         panel._host = f.host || '';
+        const _ce2 = panel.querySelector('.hwfit-serve-cmd');
+        if (panel._cmdOverride) {
+          cmd = panel._customCmd || cmd;
+        }
+        _ce2.value = cmd; _ce2.style.height = 'auto'; _ce2.style.height = _ce2.scrollHeight + 'px';
+        panel._cmd = cmd;
         return cmd;
       }
       updateCmd();
+      // If restoring an override, populate textarea with the custom command
+      if (panel._cmdOverride && panel._customCmd) {
+        const _ce3 = panel.querySelector('.hwfit-serve-cmd');
+        if (_ce3) { _ce3.value = panel._customCmd; _ce3.style.height = 'auto'; _ce3.style.height = _ce3.scrollHeight + 'px'; }
+        panel._cmd = panel._customCmd;
+      }
 
       // Context clamp. Two ceilings:
       //  - ABSOLUTE_CTX_MAX: a hard sanity cap (no LLM trains past ~1M tokens),
@@ -1084,7 +1093,27 @@ function _rerenderCachedModels() {
         if (_gf) _gf.value = activeGpus.join(',');
         updateBackendVisibility();
         updateRuntimeReadinessNote();
+        // Restore custom-command override state from the saved preset
+        if (p.fields && p.fields._cmdOverride) {
+          panel._cmdOverride = true;
+          panel._customCmd = p.fields._customCmd || cmd;
+        } else {
+          panel._cmdOverride = false;
+          panel._customCmd = '';
+        }
         updateCmd();
+        // After updateCmd (which respects override), if override is active
+        // force the textarea to show the saved custom command.
+        if (panel._cmdOverride && panel._customCmd) {
+          const _ce4 = panel.querySelector('.hwfit-serve-cmd');
+          if (_ce4) {
+            _ce4.value = panel._customCmd;
+            _ce4.style.height = 'auto';
+            _ce4.style.height = _ce4.scrollHeight + 'px';
+          }
+          panel._cmd = panel._customCmd;
+        }
+        _updateOverrideVisuals();
         panel.querySelectorAll('.cookbook-slot-btn').forEach(b => b.classList.remove('active'));
         panel.querySelector(`.cookbook-slot-btn[data-slot="${slotIdx}"]`)?.classList.add('active');
       }
@@ -1105,8 +1134,8 @@ function _rerenderCachedModels() {
       async function _saveCurrentConfig() {
         const presets = _loadPresets();
         const modelSlots = _presetsForModel(presets, repo);
-        // Compute the current launch command first so we can detect a no-op save.
-        updateCmd();
+        // Use the current command — when override is active, this is the
+        // user's custom command, NOT the auto-generated one.
         const cmd = panel._cmd;
         // Already saved? If an existing preset for this model has the identical
         // launch command, don't make a duplicate — tell the user via a popup.
@@ -1127,6 +1156,10 @@ function _rerenderCachedModels() {
           if (el.type === 'checkbox') fields[el.dataset.field] = el.checked;
           else fields[el.dataset.field] = el.value;
         });
+        if (panel._cmdOverride) {
+          fields._cmdOverride = true;
+          fields._customCmd = panel._customCmd || cmd;
+        }
         presets.push({ name: shortName, model: repo, cmd, remoteHost: host, port: fields.port || '8000', label, fields });
         _savePresets(presets);
         uiModule.showToast(`Saved "${label}"`);
@@ -1685,6 +1718,64 @@ function _rerenderCachedModels() {
       const _cmdTextarea = panel.querySelector('.hwfit-serve-cmd');
       if (_cmdTextarea) _cmdTextarea.addEventListener('input', () => { _cmdManuallyEdited = true; });
 
+      // ── Custom command override ──
+      const _overrideBtn = panel.querySelector('.hwfit-serve-override-toggle');
+      const _overrideHint = panel.querySelector('.hwfit-serve-override-hint');
+      function _setFieldsDisabled(disabled) {
+        panel.querySelectorAll('.hwfit-sf').forEach(el => {
+          if (el.type === 'checkbox') el.disabled = disabled;
+          else if (el.tagName === 'SELECT' || el.tagName === 'INPUT') el.disabled = disabled;
+        });
+        panel.querySelectorAll('.cookbook-gpu-btn').forEach(b => { b.disabled = disabled; });
+        const adv = panel.querySelector('.hwfit-serve-advanced');
+        if (adv) {
+          adv.querySelectorAll('.hwfit-sf').forEach(el => {
+            if (el.type === 'checkbox') el.disabled = disabled;
+            else if (el.tagName === 'SELECT' || el.tagName === 'INPUT') el.disabled = disabled;
+          });
+          adv.querySelectorAll('.cookbook-gpu-btn').forEach(b => { b.disabled = disabled; });
+          adv.querySelectorAll('.hwfit-numstep-btn').forEach(b => { b.disabled = disabled; });
+        }
+      }
+      function _updateOverrideVisuals() {
+        const on = !!panel._cmdOverride;
+        if (_overrideBtn) {
+          _overrideBtn.classList.toggle('active', on);
+          _overrideBtn.textContent = on ? 'Custom ✓' : 'Custom';
+        }
+        if (_overrideHint) _overrideHint.style.display = on ? '' : 'none';
+        if (_cmdTextarea) {
+          _cmdTextarea.classList.toggle('hwfit-serve-cmd-override', on);
+          _cmdTextarea.readOnly = !on;
+        }
+        _setFieldsDisabled(on);
+      }
+      _updateOverrideVisuals();
+      if (_overrideBtn) {
+        _overrideBtn.addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          if (!panel._cmdOverride) {
+            panel._cmdOverride = true;
+            panel._customCmd = _cmdTextarea ? _cmdTextarea.value : panel._cmdAutoGen || '';
+            _cmdManuallyEdited = true;
+          } else {
+            panel._cmdOverride = false;
+            panel._customCmd = '';
+            _cmdManuallyEdited = false;
+            updateCmd();
+          }
+          _updateOverrideVisuals();
+        });
+      }
+      if (_cmdTextarea) {
+        _cmdTextarea.addEventListener('input', () => {
+          if (panel._cmdOverride) {
+            panel._customCmd = _cmdTextarea.value;
+            panel._cmd = _cmdTextarea.value;
+          }
+        });
+      }
+
       // Cancel button — collapses the serve config panel (same effect as
       // tapping the row to toggle it shut). Mobile users wanted an explicit
       // "back out" affordance next to Launch.
@@ -1734,9 +1825,10 @@ function _rerenderCachedModels() {
         // limit (or the absolute sanity ceiling when the limit is unknown). A
         // stale preset or typo (e.g. 16000000) overflows and, with a quantized
         // KV cache, can crash the GPU. Skip only if the user hand-edited the raw
-        // command (then we respect their literal text).
-        if (!_cmdManuallyEdited) _clampCtx(true);
-        if (!_cmdManuallyEdited) updateCmd();
+        // command or is using custom override (then we respect their literal text).
+        const _isOverride = !!panel._cmdOverride;
+        if (!_cmdManuallyEdited && !_isOverride) _clampCtx(true);
+        if (!_cmdManuallyEdited && !_isOverride) updateCmd();
         // Pasted commands often carry hidden newlines / CRs / tabs from copies
         // out of model cards or wrapped help text. The backend cmd allowlist
         // rejects \n / \r outright (`Invalid characters in cmd`), so collapse
@@ -1856,6 +1948,10 @@ function _rerenderCachedModels() {
           try { cur = JSON.parse(localStorage.getItem(SERVE_STATE_KEY)) || {}; } catch {}
           const byRepo = (cur && cur._byRepo && typeof cur._byRepo === 'object') ? cur._byRepo : {};
           const _saved = { ...serveState, _forceBackend: true };
+          if (panel._cmdOverride) {
+            _saved._cmdOverride = true;
+            _saved._customCmd = panel._customCmd || launchCmd;
+          }
           byRepo[repo] = _saved;
           localStorage.setItem(SERVE_STATE_KEY, JSON.stringify({ _byRepo: byRepo, _lastUsed: _saved }));
         } catch {}

--- a/static/js/cookbookServe.js
+++ b/static/js/cookbookServe.js
@@ -1741,7 +1741,9 @@ function _rerenderCachedModels() {
         const on = !!panel._cmdOverride;
         if (_overrideBtn) {
           _overrideBtn.classList.toggle('active', on);
-          _overrideBtn.textContent = on ? 'Custom ✓' : 'Custom';
+          _overrideBtn.innerHTML = on
+            ? 'Custom <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px;margin-left:2px;"><polyline points="20 6 9 17 4 12"/></svg>'
+            : 'Custom';
         }
         if (_overrideHint) _overrideHint.style.display = on ? '' : 'none';
         if (_cmdTextarea) {

--- a/static/style.css
+++ b/static/style.css
@@ -19508,8 +19508,7 @@ body.gallery-selecting .gallery-dl-btn,
   margin-top: 6px;
   margin-bottom: 2px;
 }
-.hwfit-serve-override-toggle,
-.hwfit-serve-override-reset {
+.hwfit-serve-override-toggle {
   padding: 2px 10px !important;
   font-size: 10px !important;
   border-radius: 3px;
@@ -19517,8 +19516,7 @@ body.gallery-selecting .gallery-dl-btn,
   opacity: 0.65;
   transition: opacity 0.12s;
 }
-.hwfit-serve-override-toggle:hover,
-.hwfit-serve-override-reset:hover { opacity: 1; }
+.hwfit-serve-override-toggle:hover { opacity: 1; }
 .hwfit-serve-override-toggle.active {
   opacity: 1;
   background: color-mix(in srgb, var(--accent-primary, var(--red)) 20%, transparent);

--- a/static/style.css
+++ b/static/style.css
@@ -19500,6 +19500,51 @@ body.gallery-selecting .gallery-dl-btn,
 .hwfit-serve-copy-inline.copied { opacity: 1; color: var(--color-save-green, #4caf50); }
 .hwfit-serve-copy-inline svg { display: block; }
 
+/* Custom command override bar */
+.hwfit-serve-cmd-override-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  margin-bottom: 2px;
+}
+.hwfit-serve-override-toggle,
+.hwfit-serve-override-reset {
+  padding: 2px 10px !important;
+  font-size: 10px !important;
+  border-radius: 3px;
+  cursor: pointer;
+  opacity: 0.65;
+  transition: opacity 0.12s;
+}
+.hwfit-serve-override-toggle:hover,
+.hwfit-serve-override-reset:hover { opacity: 1; }
+.hwfit-serve-override-toggle.active {
+  opacity: 1;
+  background: color-mix(in srgb, var(--accent-primary, var(--red)) 20%, transparent);
+  border-color: var(--accent-primary, var(--red));
+  color: var(--accent-primary, var(--red));
+}
+.hwfit-serve-override-hint {
+  font-size: 10px;
+  color: var(--accent-primary, var(--red));
+  opacity: 0.7;
+}
+.hwfit-serve-cmd.hwfit-serve-cmd-override {
+  border-color: color-mix(in srgb, var(--accent-primary, var(--red)) 50%, var(--border));
+  background: color-mix(in srgb, var(--accent-primary, var(--red)) 6%, transparent);
+}
+.hwfit-serve-cmd:not(.hwfit-serve-cmd-override):not(:focus) {
+  opacity: 0.7;
+  cursor: default;
+}
+.hwfit-serve-advanced .hwfit-sf:disabled,
+.hwfit-serve-advanced .cookbook-gpu-btn:disabled,
+.hwfit-serve-advanced .hwfit-numstep-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 /* Split button: Clear Server (main) + ^ arrow (more actions). The two halves
    are visually joined — left button square on its right edge, arrow square
    on its left edge — so they read as one widget. */


### PR DESCRIPTION
## Summary

Added "Custom" toggle button above the command textarea in the Cookbook Serve panel. I needed to modify a few parameters to run llama.cpp (such as removing `-ngl` and adding `top-k`, `top-p`, `temperature`, etc) but it would automatically set them back again causing the launching of `llama.cpp` to fail, and even if I tried to save my custom command, it wouldn't save it.

### New behavior

Default state (Custom OFF):
- The command textarea is read-only, it displays the auto-generated launch command and cannot be edited directly, just through the UI options. Just as it is right now.

Custom mode ON (click "Custom"):
- The textarea becomes editable, the user can type any launch command
- All UI options (inputs, selects, checkboxes, GPU buttons, Advanced inner fields) are disabled to avoid confusion between the UI-generated command and the manual one

Clicking "Custom" again (toggle back OFF):
- The textarea returns to read-only
- All UI options are re-enabled
- The auto-generated command is restored from the current UI field values

Persistence

- The override state and custom command are saved per-model in localStorage (cookbook-serve-state → _byRepo[repo]._cmdOverride, _byRepo[repo]._customCmd)
- Only the per-model state is used,  no leakage between different models
- When saving a preset (Save button), the override state and custom command are stored in the preset's fields
- Loading a saved preset restores the override state if it was active when saved
- Launching with Custom ON sends the user's custom command directly to the backend

At the bottom I have attached old and new behaviour video.

---

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #1291

Which is somewhat related as someone has problem with the launch command because it defaults to certain values, and can't manually modify.
This could solve many problems people have with the default launch command that cookbook provides.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. In the sidebar go to "Cookbook"
2. In the "Cookbook" widget go to the tab "Serve"
3. Select a model to launch
4. Press the "Custom" button, modify the launch command and launch.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

OLD BEHAVIOUR (Trying to modify and save the parameters for launching would reset):

https://github.com/user-attachments/assets/32594fbc-dc36-43df-95fc-f73c32e1a562

NEW BEHAVIOUR (Can completely modify the launch command without getting overriden by defaults and can also store them for next launch.)

https://github.com/user-attachments/assets/c8675681-e4b0-4740-a296-45ae00340b0e