### PR TITLE
fix(agent): detect Polish web lookup intent

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -787,6 +787,12 @@ def _classify_agent_request(messages: List[Dict], last_user: str) -> Dict[str, o
         domains.add("documents")
     if has(r"\b(search|web|google|look up|latest|news|current|weather|forecast|stock price|price of|website|url|https?://|www\.)\b"):
         domains.add("web")
+    if has(
+        r"\b(wyszukaj|wyszukać|wyszukac)\b.*\b(internet|internecie|online|web)\b",
+        r"\b(sprawd[zź]|znajd[zź])\b.*\b(internet|internecie|online|web)\b",
+        r"\b(aktualn\w*|bieżąc\w*|biezac\w*|dzisiaj|teraz)\b.*\b(pogod\w*|temperatur\w*)\b",
+    ):
+        domains.add("web")
     if has(r"\b(research|deep dive|investigate|look into)\b"):
         domains.add("web")
     if has(r"\b(open|show|toggle|turn on|turn off|disable|enable|switch model|change model|settings|theme|panel)\b"):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -36,6 +36,7 @@ _IMPORTED_AGENT_LOOP = None
 try:
     from src.agent_loop import (
         _detect_admin_intent,
+        _classify_agent_request,
         _compute_final_metrics,
         _append_tool_results,
         _MCP_KEYWORDS,
@@ -60,6 +61,16 @@ def test_import_stubs_do_not_leak_into_later_tests():
 
 def test_mcp_keyword_gate_matches_literal_mcp_requests():
     assert "mcp" in _MCP_KEYWORDS
+
+
+def test_polish_internet_search_request_classifies_as_web():
+    intent = _classify_agent_request(
+        [],
+        "Wyszukaj w internecie i podaj temperaturę w Lubartowie dzisiaj",
+    )
+
+    assert intent["low_signal"] is False
+    assert "web" in intent["domains"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Classify common Polish web-search and current-weather phrasing as web intent, so a request like `Wyszukaj w internecie i podaj temperaturę w Lubartowie dzisiaj` no longer falls into the low-signal path without `web_search`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4055

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `python3 -m pytest tests/test_agent_loop.py tests/test_workspace_confine.py tests/test_chat_route_tool_policy.py tests/test_tool_rag_keyword_hints.py -q`.
2. Confirm `test_polish_internet_search_request_classifies_as_web` passes.
3. Confirm the classifier returns `low_signal=False` and includes `web` for the Polish repro text from #4055.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual/UI change. This only adjusts server-side agent intent classification and adds a regression test.

### Screenshots / clips

N/A — no visual/UI change.
