### PR TITLE
fix(agent): keep gpt-oss on text tool mode

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1937,6 +1937,10 @@ async def stream_agent_loop(
     # and can override this list for users who know their setup.
     _model_no_tools = any(kw in _model_lc for kw in (
         "deepseek-r1",
+        # Open-weight GPT-OSS models are commonly served through llama.cpp /
+        # llama-cpp-python. Their names contain "gpt-o", but they do not use
+        # OpenAI's native tool-call channel unless the endpoint opts in.
+        "gpt-oss",
     ))
     # Native Ollama endpoints (/api/chat) handle tool schemas differently from
     # the OpenAI-compat path. Models like gemma4, qwen3.5, ministral respond to

--- a/tests/test_tool_support_heuristic.py
+++ b/tests/test_tool_support_heuristic.py
@@ -25,6 +25,7 @@ def _compute_is_api_model(model: str, endpoint_url: str, endpoint_supports=None)
     ))
     model_no_tools = any(kw in model_lc for kw in (
         "deepseek-r1",
+        "gpt-oss",
     ))
 
     if endpoint_supports is True:
@@ -72,6 +73,11 @@ class TestDeepSeekToolSupport:
             "gemma4:e4b", "http://host.docker.internal:11434/v1"
         ) is False
 
+    def test_gpt_oss_local_openai_compat_defaults_to_fenced_tools(self):
+        assert _compute_is_api_model(
+            "gpt-oss-20b", "http://localhost:8000/v1"
+        ) is False
+
     def test_qwen_native_ollama_defaults_to_fenced_tools(self):
         assert _compute_is_api_model(
             "qwen3.5:4b", "http://localhost:11434/api/chat"
@@ -114,6 +120,12 @@ class TestDeepSeekToolSupport:
     def test_endpoint_supports_true_overrides_native_ollama_default(self):
         result = _compute_is_api_model(
             "qwen3.5:4b", "http://localhost:11434/api/chat", endpoint_supports=True
+        )
+        assert result is True
+
+    def test_endpoint_supports_true_overrides_gpt_oss_default(self):
+        result = _compute_is_api_model(
+            "gpt-oss-20b", "http://localhost:8000/v1", endpoint_supports=True
         )
         assert result is True
 


### PR DESCRIPTION
## Summary

`gpt-oss` local models were matching the `"gpt-o"` native-tool heuristic, so Odysseus treated names like `gpt-oss-20b` as OpenAI-style native tool-calling models. That pushes the agent toward native tool schemas / compact prompts and away from the text/fenced tool path used by llama.cpp-style local endpoints.

This PR adds `gpt-oss` to the no-native-tools default list while preserving the explicit endpoint override: if a user marks the endpoint as `supports_tools=True`, native tool calling still wins.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4103

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [x] I ran focused tests for the changed behavior.

## How to Test

Focused test:

```powershell
$env:PYTHONPATH='G:\AI\odysseus-dev'
G:\AI\odysseus\venv\Scripts\python.exe -m pytest tests\test_tool_support_heuristic.py -q
```

Result: `22 passed`.

The added regression verifies `gpt-oss-20b` on `http://localhost:8000/v1` defaults to fenced/text tools, and that `endpoint_supports=True` still overrides the default.

## Visual / UI changes

No visual changes. This only adjusts agent tool-mode classification.
