### PR TITLE
fix(cookbook): diagnose SGLang native dependency errors

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -1047,6 +1047,16 @@ def _diagnose_serve_output(text: str) -> dict | None:
             [{"label": "install vLLM in Cookbook Dependencies", "op": "dependency", "package": "vllm"}],
         ),
         (
+            r"sgl_kernel[\s\S]*(Python\.h|libnuma\.so\.1|common_ops)|"
+            r"(Python\.h|libnuma\.so\.1|common_ops)[\s\S]*sgl_kernel|"
+            r"Please ensure sgl_kernel is properly installed",
+            "SGLang native dependencies are missing on this server.",
+            [
+                {"label": "install OS packages: libnuma-dev python3.12-dev build-essential", "op": "manual"},
+                {"label": "upgrade sglang-kernel after OS packages are installed", "op": "manual"},
+            ],
+        ),
+        (
             r"sglang.*command not found|No module named sglang|SGLang is not installed",
             "SGLang is not installed or not in PATH on this server.",
             [{"label": "install SGLang in Cookbook Dependencies", "op": "dependency", "package": "sglang[all]"}],

--- a/routes/cookbook_routes.py
+++ b/routes/cookbook_routes.py
@@ -171,6 +171,16 @@ def setup_cookbook_routes() -> APIRouter:
                 [{"label": "install vLLM in Cookbook Dependencies", "op": "dependency", "package": "vllm"}],
             ),
             (
+                r"sgl_kernel[\s\S]*(Python\.h|libnuma\.so\.1|common_ops)|"
+                r"(Python\.h|libnuma\.so\.1|common_ops)[\s\S]*sgl_kernel|"
+                r"Please ensure sgl_kernel is properly installed",
+                "SGLang native dependencies are missing on this server.",
+                [
+                    {"label": "install OS packages: libnuma-dev python3.12-dev build-essential", "op": "manual"},
+                    {"label": "upgrade sglang-kernel after OS packages are installed", "op": "manual"},
+                ],
+            ),
+            (
                 r"sglang.*command not found|No module named sglang|SGLang is not installed",
                 "SGLang is not installed or not in PATH on this server.",
                 [{"label": "install SGLang in Cookbook Dependencies", "op": "dependency", "package": "sglang[all]"}],

--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -321,6 +321,15 @@ export const ERROR_PATTERNS = [
     ],
   },
   {
+    pattern: /sgl_kernel[\s\S]*(Python\.h|libnuma\.so\.1|common_ops)|(Python\.h|libnuma\.so\.1|common_ops)[\s\S]*sgl_kernel|Please ensure sgl_kernel is properly installed/i,
+    message: 'SGLang native dependencies are missing on this server.',
+    fixes: [
+      { label: 'Copy OS package command', action: () => _copyText('sudo apt-get install -y libnuma-dev python3.12-dev build-essential') },
+      { label: 'Copy kernel upgrade', action: () => _copyText('python3 -m pip install --upgrade sglang-kernel') },
+      { label: 'Open Dependencies', action: () => _openCookbookDependencies('sglang') },
+    ],
+  },
+  {
     pattern: /sglang.*command not found|No module named sglang|SGLang is not installed/i,
     message: 'SGLang is not installed or not in PATH.',
     fixes: [

--- a/tests/test_cookbook_diagnosis.py
+++ b/tests/test_cookbook_diagnosis.py
@@ -13,3 +13,24 @@ def test_diagnose_vllm_modelopt_lm_head_error():
     assert "ModelOpt LM-head" in diagnosis["message"]
     assert diagnosis["suggestions"][0]["op"] == "manual"
     assert "provides this CLI" in diagnosis["suggestions"][0]["label"]
+
+
+def test_diagnose_sglang_native_dependency_errors():
+    output = """
+    /tmp/cuda_utils.c:7:10: fatal error: Python.h: No such file or directory
+    ImportError:
+    [sgl_kernel] CRITICAL: Could not load any common_ops library!
+    Please ensure sgl_kernel is properly installed with:
+    pip install --upgrade sglang-kernel
+    Error details from previous import attempts:
+    - ImportError: libnuma.so.1: cannot open shared object file
+    """
+
+    diagnosis = _diagnose_serve_output(output)
+
+    assert diagnosis is not None
+    assert "SGLang native dependencies" in diagnosis["message"]
+    labels = [suggestion["label"] for suggestion in diagnosis["suggestions"]]
+    assert any("libnuma-dev" in label for label in labels)
+    assert any("python3.12-dev" in label for label in labels)
+    assert any("sglang-kernel" in label for label in labels)

--- a/tests/test_cookbook_diagnosis_js.py
+++ b/tests/test_cookbook_diagnosis_js.py
@@ -10,3 +10,13 @@ def test_repair_kernels_pip_spec_is_shell_quoted():
 
     assert '"kernels<0.15"' in source
     assert " --break-system-packages kernels<0.15" not in source
+
+
+def test_sglang_native_dependency_diagnosis_is_exposed_to_browser():
+    source = DIAGNOSIS_JS.read_text(encoding="utf-8")
+
+    assert r"Python\.h" in source
+    assert r"libnuma\.so\.1" in source
+    assert "SGLang native dependencies" in source
+    assert "libnuma-dev python3.12-dev build-essential" in source
+    assert "sglang-kernel" in source


### PR DESCRIPTION
## Summary

Detect SGLang `sgl_kernel` failures involving missing `Python.h`, `libnuma.so.1`, or `common_ops` in Cookbook serve diagnosis, and show manual install guidance for `libnuma-dev python3.12-dev build-essential` plus `sglang-kernel`. This leaves Docker images, dependency installers, and lockfiles unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #4010

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Run `python3 -m pytest tests/test_cookbook_diagnosis.py tests/test_cookbook_diagnosis_js.py tests/test_cookbook_error_feedback.py tests/test_cookbook_error_tail_lines.py tests/test_cookbook_package_detection.py tests/test_cookbook_dependency_completion_regression.py -q`.
2. Run `node --check static/js/cookbook-diagnosis.js`.
3. Run `python3 -m py_compile routes/cookbook_helpers.py routes/cookbook_routes.py tests/test_cookbook_diagnosis.py tests/test_cookbook_diagnosis_js.py`.
4. Confirm SGLang errors mentioning missing `Python.h`, `libnuma.so.1`, or `common_ops` produce the SGLang native dependency diagnosis.

## Visual / UI changes — REQUIRED if you touched anything that renders

No new UI surface. Existing Cookbook diagnosis output may show the new SGLang dependency guidance when the matching error appears.

### Screenshots / clips

N/A — no live app run or new visual surface.
