### PR TITLE
docs: clarify ALLOWED_ORIGINS for proxied deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Odysseus serves plain HTTP on its app port. Docker Compose binds Odysseus and th
 4. Keep raw service and model ports internal-only.
 
 Cloudflare Access, Tailscale, Caddy, nginx, and Traefik can all fit this pattern; none are required by Odysseus. If your access layer reaches Odysseus on the same host, proxy to `http://127.0.0.1:7000` and keep `AUTH_ENABLED=true`, `LOCALHOST_BYPASS=false`, and `SECURE_COOKIES=true`.
+`ALLOWED_ORIGINS` lists exact permitted origins for cross-origin browser/API clients; ordinary same-origin reverse-proxy access usually does not need a special CORS entry.
 
 Common internal-only ports from the default docs/compose setup:
 
@@ -389,6 +390,7 @@ Key settings:
 | `APP_PORT` | `7000` | Docker Compose host port for the web UI. |
 | `AUTH_ENABLED` | `true` | Enable/disable login |
 | `LOCALHOST_BYPASS` | `false` | Development-only auth bypass for loopback requests. Keep false for shared/network deployments. |
+| `ALLOWED_ORIGINS` | `http://localhost,http://127.0.0.1` | Comma-separated exact permitted origins for cross-origin browser/API clients. |
 | `SECURE_COOKIES` | `false` | Set true when serving Odysseus through HTTPS at a trusted proxy or private access gateway. |
 | `DATABASE_URL` | `sqlite:///./data/app.db` | Database connection string |
 | `CHROMADB_HOST` | `localhost` | ChromaDB host for vector memory. Docker overrides this to `chromadb`. |


### PR DESCRIPTION
## Summary

Documents `ALLOWED_ORIGINS` in the README configuration table and clarifies when proxied deployments need a CORS entry.

This is documentation-only. It does not change CORS behavior or add proxy-specific configuration examples.

## Target branch

- [x] This PR targets **dev**.

## Linked Issue

Fixes #4129

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling

## Checklist

- [x] I searched open issues, discussions, and PRs for duplicates.
- [x] This PR targets **dev**.
- [x] The change is limited to `README.md`.
- [x] No application or deployment behavior was changed.
- [x] I ran `git diff --check`.

## How to Test

Review the README-only diff and verify that `ALLOWED_ORIGINS` is documented consistently with the existing implementation.

```bash
git diff --check