### PR TITLE
fix(cookbook): log malformed state + re-read before write in lifecycle tick

### DIFF
--- a/src/cookbook_serve_lifecycle.py
+++ b/src/cookbook_serve_lifecycle.py
@@ -136,7 +136,8 @@ async def _tick() -> None:
         return
     try:
         state = json.loads(state_path.read_text(encoding="utf-8"))
-    except Exception:
+    except Exception as e:
+        logger.warning("cookbook_serve_lifecycle: state file unreadable (%s), skipping tick", e)
         return
     tasks = state.get("tasks") or []
     now_ms = int(time.time() * 1000)
@@ -178,8 +179,26 @@ async def _tick() -> None:
     if stopped_any:
         try:
             from core.atomic_io import atomic_write_json
-            state["tasks"] = tasks
-            atomic_write_json(state_path, state)
+            # Re-read the state file so concurrent UI writes (task adds,
+            # status flips, config edits) are not silently overwritten.
+            # Apply only our stop mutations to the fresh snapshot.
+            try:
+                fresh = json.loads(state_path.read_text(encoding="utf-8"))
+                fresh_tasks = fresh.get("tasks") or []
+            except Exception:
+                fresh = state
+                fresh_tasks = tasks
+            stopped_sids = {sid for sid, _, _ in to_stop}
+            for ft in fresh_tasks:
+                if not isinstance(ft, dict):
+                    continue
+                ft_sid = ft.get("sessionId") or ft.get("id")
+                if ft_sid in stopped_sids:
+                    ft["status"] = "stopped"
+                    ft["_scheduledStopAtMs"] = None
+                    ft["_lastStatusFlipAt"] = now_ms
+            fresh["tasks"] = fresh_tasks
+            atomic_write_json(state_path, fresh)
         except Exception as e:
             logger.warning(f"cookbook_serve_lifecycle: state write failed: {e}")
 


### PR DESCRIPTION
## Summary

Two fixes in \`cookbook_serve_lifecycle._tick()\`:

1. **Silent JSON failure**: the \`except Exception: return\` for state file parsing returned with no log, so a corrupted/truncated state file silently disabled all scheduled stops. Now logs a warning.

2. **Stale state overwrite**: the comment at line 160 said "Re-read state once before writing" but the re-read was never performed. The stale snapshot from the top of \`_tick()\` was written back, overwriting concurrent UI changes (task adds, status flips, config edits). Now re-reads the file before writing and applies only the stop mutations to the fresh snapshot.

## Linked Issue

Fixes #4131

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets \`dev\`
- [x] My changes are limited to the scope described above.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. \`python -m py_compile src/cookbook_serve_lifecycle.py\` — OK
2. Corrupt \`data/cookbook_state.json\` with invalid JSON → verify warning is logged instead of silent return
3. Schedule a serve stop, then add a task via UI during the 60s tick interval → verify the UI-added task is preserved after the lifecycle write

🤖 Generated with [Claude Code](https://claude.com/claude-code)