### PR TITLE
fix(llm): configurable connect timeout to stop intermittent 503 on first message

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -7,6 +7,7 @@ import logging
 import hashlib
 import threading
 import re
+import os
 from fastapi import HTTPException
 from typing import Optional, Dict, List, Tuple
 from src.model_context import get_context_length, DEFAULT_CONTEXT
@@ -22,6 +23,24 @@ class LLMConfig:
     MAX_RETRIES = 3
     RETRY_DELAY = 0.5
     STREAM_TIMEOUT = 300
+    # TCP+TLS connect budget for a SINGLE attempt. The old hard-coded 3.0s
+    # assumed LAN/Tailscale peers ('SYN in <100ms'); it is too tight for public
+    # cloud endpoints (offshore APIs take ~0.5-1.5s cold, with jitter), so a
+    # brief blip on the first connect of an idle chat surfaced as a 503 on the
+    # streaming path (which, unlike llm_call, does not retry the connect). A
+    # genuinely dead upstream stays bounded by the dead-host cooldown. Override
+    # with env LLM_CONNECT_TIMEOUT (seconds).
+    CONNECT_TIMEOUT = float(os.getenv('LLM_CONNECT_TIMEOUT', '10') or '10')
+
+
+def _call_timeout(read_timeout) -> httpx.Timeout:
+    """Per-request timeout for non-streaming LLM calls (connect from config)."""
+    return httpx.Timeout(connect=LLMConfig.CONNECT_TIMEOUT, read=float(read_timeout), write=10.0, pool=5.0)
+
+
+def _stream_timeout(read_timeout) -> httpx.Timeout:
+    """Per-request timeout for streaming LLM calls (connect from config)."""
+    return httpx.Timeout(connect=LLMConfig.CONNECT_TIMEOUT, read=float(read_timeout), write=30.0, pool=5.0)
 
 
 # Cache for LLM responses
@@ -1446,7 +1465,7 @@ async def llm_call_async(
     if _is_host_dead(target_url):
         raise HTTPException(503, f"Upstream {_host_key(target_url)} marked unreachable (cooldown active)")
 
-    call_timeout = httpx.Timeout(connect=3.0, read=float(timeout), write=10.0, pool=5.0)
+    call_timeout = _call_timeout(timeout)
     attempt = 0
     while attempt < max_retries:
         attempt += 1
@@ -1570,9 +1589,12 @@ async def stream_llm(url: str, model: str, messages: List[Dict], temperature: fl
             from src.copilot import apply_request_headers
             apply_request_headers(h, messages_copy)
 
-    # Short connect timeout: a reachable peer answers SYN in <100ms even on
-    # Tailscale. 3s is plenty; 30s let one dead upstream wedge the UI.
-    stream_timeout = httpx.Timeout(connect=3.0, read=float(timeout), write=30.0, pool=5.0)
+    # Connect budget from LLMConfig.CONNECT_TIMEOUT (env LLM_CONNECT_TIMEOUT).
+    # The dead-host cooldown still bounds a genuinely unreachable upstream, so a
+    # wider connect budget only affects first contact and stops a brief cold
+    # connect blip (offshore/public endpoints) surfacing as a 503 on this stream
+    # path, which -- unlike llm_call -- does not retry the connect.
+    stream_timeout = _stream_timeout(timeout)
 
     if _is_host_dead(target_url):
         yield f'event: error\ndata: {json.dumps({"error": f"Upstream {_host_key(target_url)} unreachable (cooldown active)", "status": 503})}\n\n'

--- a/tests/test_llm_core_connect_timeout.py
+++ b/tests/test_llm_core_connect_timeout.py
@@ -1,0 +1,57 @@
+"""Regression tests for the configurable LLM connect timeout.
+
+Background: chat uses the streaming path, which (unlike llm_call) does not retry
+a connect error -- it marks the host and emits a 503 immediately. With the old
+hard-coded connect=3.0s, a brief blip on the first (cold) connect of an idle
+chat to an offshore/public endpoint surfaced as an intermittent 503 that cleared
+on resend. The connect budget is now LLMConfig.CONNECT_TIMEOUT (env
+LLM_CONNECT_TIMEOUT), applied via _call_timeout/_stream_timeout helpers.
+"""
+import importlib
+import httpx
+import pytest
+
+from src import llm_core
+from src.llm_core import LLMConfig, _call_timeout, _stream_timeout
+
+
+def test_default_connect_timeout_is_widened_not_three():
+    # Regression guard: must not regress to the old too-tight 3.0s default.
+    assert LLMConfig.CONNECT_TIMEOUT >= 8.0
+    assert LLMConfig.CONNECT_TIMEOUT != 3.0
+    assert LLMConfig.CONNECT_TIMEOUT == 10.0
+
+
+def test_call_timeout_uses_config_connect_and_passes_read():
+    t = _call_timeout(45)
+    assert isinstance(t, httpx.Timeout)
+    assert t.connect == LLMConfig.CONNECT_TIMEOUT
+    assert t.read == 45.0
+    assert t.write == 10.0
+    assert t.pool == 5.0
+
+
+def test_stream_timeout_uses_config_connect_and_passes_read():
+    t = _stream_timeout(300)
+    assert isinstance(t, httpx.Timeout)
+    assert t.connect == LLMConfig.CONNECT_TIMEOUT
+    assert t.read == 300.0
+    assert t.write == 30.0
+    assert t.pool == 5.0
+
+
+def test_helpers_are_config_driven(monkeypatch):
+    # Helpers read LLMConfig at call time, so ops can tune without code edits.
+    monkeypatch.setattr(LLMConfig, "CONNECT_TIMEOUT", 4.5)
+    assert _call_timeout(30).connect == 4.5
+    assert _stream_timeout(30).connect == 4.5
+
+
+def test_env_override_is_honoured(monkeypatch):
+    monkeypatch.setenv("LLM_CONNECT_TIMEOUT", "6.5")
+    reloaded = importlib.reload(llm_core)
+    try:
+        assert reloaded.LLMConfig.CONNECT_TIMEOUT == 6.5
+    finally:
+        monkeypatch.delenv("LLM_CONNECT_TIMEOUT", raising=False)
+        importlib.reload(llm_core)  # restore module-level default for other tests


### PR DESCRIPTION
## Summary

Chat uses the streaming path (`stream_llm` in `src/llm_core.py`), which — unlike the non-streaming `llm_call_async` — does not retry a connect error: on `httpx.ConnectError`/`ConnectTimeout` it marks the host dead and immediately emits a 503. Combined with a hard-coded `connect=3.0s` budget and the HTTP client's `keepalive_expiry=30.0`, the first (cold) connect of an idle chat to a public/offshore endpoint could exceed 3s on a transient blip and surface as an intermittent 503 that cleared on re-send.

This makes the connect budget configurable via `LLMConfig.CONNECT_TIMEOUT` (env `LLM_CONNECT_TIMEOUT`, default `10`), applied through new `_call_timeout` / `_stream_timeout` helpers used by both the streaming and non-streaming paths. A genuinely unreachable upstream is still bounded by the existing dead-host cooldown, so this only widens the first-contact budget; it does not change retry or streaming control flow.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4133

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. (#166 was a persistent OpenRouter 503/endpoint issue; #2159 is about read-timeouts aborting slow generations; neither is the connect-budget / connect-retry asymmetry.)
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes.
- [x] I actually ran the app and verified the change works end-to-end. (Deployed to our Docker instance: `CONNECT_TIMEOUT` is live in the running container, the app serves normally with no regression, and zero connect-503 lines since deploy. Note: the failure is intermittent/timing-dependent and cannot be force-triggered, so this is "deployed + live + healthy + monitoring" rather than an observed fail-then-pass.)

## How to Test

1. `git fetch && git checkout <this-branch>`
2. Run the new + adjacent suites:
   `python -m pytest tests/test_llm_core_connect_timeout.py tests/test_llm_core_streaming.py tests/test_llm_core_fallback.py tests/test_llm_core_concurrency.py tests/test_llm_core_sse_no_space.py -q`
   — expect all passing (20 in our run).
3. `_call_timeout(t).connect` and `_stream_timeout(t).connect` both reflect `LLMConfig.CONNECT_TIMEOUT`; setting `LLM_CONNECT_TIMEOUT` overrides it.
4. Optional manual check: point chat at a cloud OpenAI-compatible endpoint, leave the app idle >30s, then send a first message — it should connect rather than intermittently returning a 503 on the cold connect.

## Verification

- New regression test `tests/test_llm_core_connect_timeout.py` (5): default is widened (not 3.0s), helpers apply the configured connect to both `httpx.Timeout`s, helpers are config-driven (tunable at runtime), and the `LLM_CONNECT_TIMEOUT` env override is honoured.
- Existing llm_core streaming/fallback/concurrency/SSE suites pass alongside it: **20 passed**.
- Deployed and verified live on a Docker instance (connect timeout active, app healthy, zero connect-503 since deploy).