### PR TITLE
docs(architecture): add Phase 0 runtime inventory document

### DIFF
--- a/docs/architecture-runtime-inventory.md
+++ b/docs/architecture-runtime-inventory.md
@@ -1,0 +1,385 @@
+# Architecture Runtime Inventory
+
+> **Purpose**: Phase 0 planning baseline for codebase readability improvements (#4071).
+> **Parent issue**: [#4082](https://github.com/pewdiepie-archdaemon/odysseus/issues/4082)
+> **Last updated**: dev@9d7a3d6 | 2026-06-13
+> **Status**: Draft — to be reviewed before follow-up slices open.
+
+This document maps the current runtime module structure, identifies high-risk boundaries, and recommends safe first refactor slices. It does **not** move files, change imports, or alter runtime behavior.
+
+---
+
+## 1. Current Structure Overview
+
+### 1.1 Top-Level Layout
+
+```
+odysseus/
+├── app.py                    # FastAPI app entrypoint (1,145 lines)
+├── main.py                   # (future) renamed from app.py post-refactor
+├── conf/                     # Configuration (config.py, settings.py, settings_scrub.py)
+├── src/                      # ~60 flat .py files + 3 subdirectories
+│   ├── agent_tools/          # Tool helpers: document, filesystem, subprocess, web
+│   ├── agent/                # Empty (placeholder)
+│   └── search/               # (exists)
+├── routes/                   # 52 flat .py files — HTTP route handlers
+├── core/                     # 10 files — database models, auth, middleware, session
+├── mcp_servers/              # 4 files — MCP server implementations
+├── scripts/                  # CLI tools and one-shot scripts
+├── static/                   # Frontend HTML/CSS/JS
+├── tests/                    # 552 test files (~54,800 lines)
+└── services/                 # (exists as needed)
+```
+
+### 1.2 Directory Flatness Metric
+
+| Directory | Flat `.py` Files | Subdirectories | Concern |
+|-----------|-----------------|----------------|---------|
+| `src/` | **~60** | 3 (`agent_tools/`, `agent/`, `search/`) | No domain grouping; 60 files in one directory |
+| `routes/` | **52** | 0 | All route handlers in one flat directory |
+| `core/` | 10 | 0 | Manageable, but `database.py` is oversized |
+
+---
+
+## 2. Largest Runtime Modules
+
+### 2.1 Python Backend
+
+| Rank | File | Lines | Classes | Functions | Risk |
+|------|------|-------|---------|-----------|------|
+| 1 | `src/tool_implementations.py` | **4,032** | 0 | ~48 | **HIGH** |
+| 2 | `routes/email_routes.py` | **3,245** | — | — | **MEDIUM** |
+| 3 | `routes/cookbook_routes.py` | **2,969** | — | — | **MEDIUM** |
+| 4 | `src/agent_loop.py` | **2,961** | 0 | ~24 | **HIGH** |
+| 5 | `src/task_scheduler.py` | **2,330** | — | ~6 | MEDIUM |
+| 6 | `routes/model_routes.py` | **2,266** | — | — | MEDIUM |
+| 7 | `core/database.py` | **2,265** | 27 | ~59 helpers | **HIGH** |
+| 8 | `src/builtin_actions.py` | **2,262** | 0 | ~26 | MEDIUM |
+| 9 | `src/llm_core.py` | **2,164** | — | — | MEDIUM |
+| 10 | `mcp_servers/email_server.py` | 2,197 | — | — | LOW (separate process) |
+| 11 | `src/visual_report.py` | 1,918 | — | — | LOW |
+| 12 | `routes/gallery_routes.py` | 1,896 | — | — | LOW |
+| 13 | `src/ai_interaction.py` | 1,846 | — | — | MEDIUM |
+| 14 | `routes/document_routes.py` | 1,717 | — | — | LOW |
+| 15 | `routes/skills_routes.py` | 1,648 | — | — | LOW |
+
+**Heuristic**: Files > 2,000 lines with 20+ public symbols and many importers are the highest-risk splits. Files 1,000–2,000 lines are medium-risk if tightly coupled.
+
+### 2.2 Frontend
+
+| File | Lines | Concern |
+|------|-------|---------|
+| `static/style.css` | **36,653** | Entire app CSS in one file (tracked separately in #2617) |
+| `static/js/document.js` | **9,776** | Single JS file for document functionality |
+| `static/js/slashCommands.js` | 6,498 | |
+| `static/js/settings.js` | 5,266 | |
+| `static/js/emailLibrary.js` | 5,217 | |
+| `static/js/notes.js` | 5,124 | |
+| `static/js/chat.js` | 4,985 | |
+| `static/app.js` | 4,090 | |
+
+**Note**: Frontend modularization is tracked separately in #2617 (CSS) and is not the focus of this Phase 0 inventory. Frontend is listed here for completeness but follow-up slices should target Python backend boundaries first.
+
+---
+
+## 3. Import Dependency Graph
+
+### 3.1 Who Depends on `core/database.py`
+
+**49 files** import from `core.database` — this is the most depended-upon module:
+
+- All route handlers (`routes/*.py`)
+- Most `src/*.py` files
+- `core/session_manager.py`, `core/auth.py`
+- Multiple test files
+
+**Implication**: Any split of `core/database.py` is the highest-risk refactor. It should be tackled **last**, never first.
+
+### 3.2 Who Depends on `src/tool_implementations.py`
+
+**18 files** import from `src.tool_implementations`:
+- `src/agent_loop.py`, `src/builtin_actions.py`, `src/tool_index.py`
+- `src/task_scheduler.py`, `src/tool_policy.py`
+- Various tests
+
+### 3.3 Who Depends on `src/agent_loop.py`
+
+- `src/tool_policy.py`, `src/teacher_escalation.py`, `src/bg_monitor.py`
+- `src/task_scheduler.py`
+- 6 test files
+
+### 3.4 Cross-Layer Import Violations
+
+**`src/` importing from `routes/`** (backwards dependency — domain logic depending on HTTP layer):
+
+```
+src/tool_implementations.py ──→ routes/calendar_routes.py
+src/tool_implementations.py ──→ routes/cookbook_helpers.py
+src/tool_implementations.py ──→ routes/email_helpers.py
+src/tool_implementations.py ──→ routes/email_pollers.py
+src/tool_implementations.py ──→ routes/email_routes.py
+src/tool_implementations.py ──→ routes/model_routes.py
+src/tool_implementations.py ──→ routes/note_routes.py
+src/tool_implementations.py ──→ routes/prefs_routes.py
+```
+
+> These are **runtime imports** (inside function bodies, not at module top), which mitigates circular import risk but indicates fuzzy layer boundaries. Function-level inline imports from the HTTP layer into business logic are a code smell.
+
+**Import counts (top-level)**:
+| Direction | Count | Notes |
+|-----------|-------|-------|
+| `routes/` → `src/` | **349** | Expected: HTTP handlers call domain logic |
+| `routes/` → `core/` | **124** | Expected: handlers access DB models |
+| `src/` → `routes/` | **~20** | **Unexpected**: domain logic reaching into HTTP layer |
+| `src/` → `core/` | **49** | Acceptable but could be reduced with a data-access layer |
+
+---
+
+## 4. Route Ownership Map
+
+Routes can be grouped into logical feature domains. Current flat structure obscures these boundaries:
+
+| Domain | Route Files | Total Lines | Review Complexity |
+|--------|-------------|-------------|-------------------|
+| **Email** | `email_routes.py`, `email_helpers.py`, `email_pollers.py` | 5,936 | HIGH — most complex domain |
+| **Chat / Agent** | `chat_routes.py`, `chat_helpers.py`, `shell_routes.py`, `codex_routes.py`, `skills_routes.py` | 6,365 | HIGH — core interaction surface |
+| **Cookbook** | `cookbook_routes.py`, `cookbook_helpers.py`, `cookbook_output.py` | 4,110 | MEDIUM |
+| **Model / LLM** | `model_routes.py`, `assistant_routes.py`, `copilot_routes.py` | 2,764 | MEDIUM |
+| **Calendar / Contacts** | `calendar_routes.py`, `contacts_routes.py` | 2,336 | MEDIUM |
+| **Documents** | `document_routes.py`, `document_helpers.py` | 1,954 | LOW |
+| **Auth** | `auth_routes.py`, `api_token_routes.py`, `device_flow.py` | 1,171 | LOW |
+| **Tasks** | `task_routes.py` (standalone) | 1,157 | LOW |
+| **Session** | `session_routes.py` (standalone) | 1,287 | LOW |
+| **Gallery** | `gallery_routes.py`, `gallery_helpers.py` | 1,896 | LOW |
+| **Memory** | `memory_routes.py` | — | LOW |
+| **Research** | `research_routes.py` | — | LOW |
+| **MCP** | `mcp_routes.py` | — | LOW |
+| **Notes** | `note_routes.py` | — | LOW |
+| **Other** | `prefs_routes.py`, `upload_routes.py`, `vault_routes.py`, `webhook_routes.py`, `workspace_routes.py`, `search_routes.py`, `history_routes.py`, `hwfit_routes.py`, `preset_routes.py`, `signature_routes.py`, `backup_routes.py`, `cleanup_routes.py`, `diagnostics_routes.py`, `embedding_routes.py`, `emoji_routes.py`, `font_routes.py`, `stt_routes.py`, `tts_routes.py`, `compare_routes.py`, `personal_routes.py`, `editor_draft_routes.py`, `admin_wipe_routes.py`, `chatgpt_subscription_routes.py` | 2,000+ | LOW individual, HIGH cumulative |
+
+---
+
+## 5. Tool Registry & Implementation Boundaries
+
+### 5.1 Current Tool Architecture
+
+| Component | File | Lines | Role |
+|-----------|------|-------|------|
+| Tool schemas | `src/tool_schemas.py` | 1,392 | JSON Schema tool definitions (Duck-TypedDict) |
+| Tool index | `src/tool_index.py` | ~580 | RAG-based tool retrieval from ChromaDB |
+| Tool implementations | `src/tool_implementations.py` | 4,032 | 33+ `do_*` functions — all tool execution logic |
+| Tool security | `src/tool_security.py` | — | Owner-scoped tool blocking |
+| Tool policy | `src/tool_policy.py` | — | Guide-only directive, plan-mode disabled tools |
+| Tool utils | `src/tool_utils.py` | — | Shared tool helpers |
+
+### 5.2 Tool Implementation Categories
+
+Tools in `tool_implementations.py` fall into natural groups:
+
+| Category | Tools | Lines (est.) |
+|----------|-------|--------------|
+| **Filesystem** | `read_file`, `write_file`, `list_files`, `edit_file`, `move_file`, `delete_file`, `create_directory`, … | ~600 |
+| **Shell** | `execute_shell`, `manage_sessions` | ~300 |
+| **Email** | `send_email`, `reply_to_email`, `read_email`, `list_emails`, `search_emails`, `manage_email_accounts`, … | ~800 |
+| **Calendar** | `create_event`, `update_event`, `list_events`, `delete_event`, `classify_events`, … | ~500 |
+| **Memory/Notes** | `manage_memory`, `manage_notes`, `search_notes` | ~300 |
+| **Search/Research** | `search_chats`, `deep_research`, `web_search` | ~400 |
+| **Cookbook/Models** | `manage_endpoints`, `manage_cookbook`, `download_model` | ~300 |
+| **System** | `manage_skills`, `manage_tasks`, `manage_mcp`, `ask_user`, `update_plan` | ~400 |
+| **Other** | `manage_contacts`, `manage_vault`, `learn_sender_signatures`, … | ~300 |
+
+---
+
+## 6. Risk Assessment & Candidate Slice Ranking
+
+### 6.1 Risk Scale
+
+| Level | Criteria |
+|-------|----------|
+| **LOW** | File has ≤3 importers AND ≤500 lines, OR is a pure refactor with clear boundaries |
+| **MEDIUM** | File has 4–15 importers OR 500–1,500 lines |
+| **HIGH** | File has 16+ importers OR >2,000 lines, OR has cross-layer import violations |
+
+### 6.2 Ranked Split Candidates
+
+| Priority | Target | Risk | Rationale |
+|----------|--------|------|-----------|
+| **1** | `src/tool_implementations.py` → `src/tools/*.py` | **MEDIUM** | 4,032 lines → ~10 files by tool category. Already has natural boundaries. 18 importers, tracked in #3629. Use `__init__.py` shim to keep existing imports working. |
+| **2** | `routes/` → domain subdirectories | **MEDIUM** | 52 flat files → `routes/email/`, `routes/chat/`, `routes/cookbook/`, etc. Pure file moves + import path updates. Each domain group has clear ownership. |
+| **3** | `src/agent_loop.py` → `src/agent/loop.py` + submodules | **MEDIUM-HIGH** | 2,961 lines, 24 functions. Can extract prompt building, classification, verification, and runaway detection. Tracked in #3266. |
+| **4** | `src/` → `src/pkg/`, `src/domain/`, `src/infra/`, `src/api/` | **MEDIUM** | Structural reorganization. Split flat `src/` into layered packages. Must come after routes and tools are stable. |
+| **5** | `routes/email_*.py` consolidation | **LOW** | Already grouped by filename prefix. Low-risk cleanup within the email domain. |
+| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 27 classes, 49 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
+| **7** | Frontend CSS modularization | **MEDIUM** | 36,653 lines. Tracked in #2617. Separate timeline from backend work. |
+| **8** | Frontend JS modularization | **MEDIUM** | 9,776 lines in `document.js`. Introduce ES modules at minimum. |
+
+### 6.3 Recommended First 3 Behavior-Preserving Slices
+
+**Slice 1: Split `tool_implementations.py`** (Lowest-risk high-impact)
+
+- Create `src/tools/` package with one file per tool category
+- Add `src/tools/__init__.py` re-exporting all symbols with current names
+- Update 18 importers to use new paths (can be deferred via shim)
+- Validation: `python -m pytest tests/ -x -q` + manual smoke test of tool execution
+- Reference: #3629
+
+**Slice 2: Group `routes/` by domain** (Pure reorganization)
+
+- Create `routes/email/`, `routes/chat/`, `routes/cookbook/`, `routes/model/`, `routes/calendar/`, `routes/document/`, `routes/auth/`, `routes/system/` subdirectories
+- Move each route file to its domain directory
+- Add `__init__.py` in each domain package with re-exports
+- Update `app.py` router imports
+- Validation: `python app.py` starts clean, all endpoints respond
+- **No behavior change** — pure file reorganization
+
+**Slice 3: Extract `agent_loop.py` submodules** (Improve reviewability)
+
+- Move prompt assembly → `src/agent/prompt.py`
+- Move request classification → `src/agent/classifier.py`
+- Move sub-agent verification → `src/agent/verifier.py`
+- Move runaway detection → `src/agent/runaway.py`
+- Move context management → `src/agent/context.py`
+- Keep `src/agent/loop.py` as the main orchestration module
+- Validation: `python -m pytest tests/test_agent_loop.py tests/test_loop_breaker_runaway.py -v`
+
+---
+
+## 7. Safety Guardrails for Follow-Up Work
+
+Per maintainer guidance in #4082 and #4071:
+
+- [ ] **One domain/slice per PR** — never mix multiple reorganizations
+- [ ] **No behavior changes** mixed with file moves — pure reorganization only
+- [ ] **Keep compatibility shims** — `__init__.py` re-exports for all existing import paths
+- [ ] **Add or identify focused tests** before risky splits
+- [ ] **Do not start with `core/database.py`** or broad route movement unless this inventory shows a safe boundary
+- [ ] **Prefer small, reviewable slices** over large restructures
+- [ ] **No packaging/runtime/tooling migration** mixed into file moves
+- [ ] **No frontend framework migration** inside this stabilization lane
+- [ ] **Validate with `python -m compileall`** — every PR must pass CI checks
+- [ ] **Validate with `pytest`** — run the full test suite before opening each PR
+
+---
+
+## 8. Validation Commands
+
+Each follow-up PR should be verifiable with these commands before submission:
+
+```bash
+# Syntax check — must pass with zero errors
+python -m compileall src/ routes/ core/ conf/
+
+# Full test suite — must match baseline pass rate
+python -m pytest tests/ -x -q
+
+# Import shim verification — existing import paths must still work
+python -c "from src.tool_implementations import do_search_chats; print('OK')"
+
+# App startup smoke test (if backend touched)
+timeout 5 python app.py 2>&1 | head -5 || true
+```
+
+---
+
+## 9. Open Questions
+
+1. Is `#2538` (specs ground truth) the canonical behavior map baseline, and should this inventory be kept in sync with those specs once merged?
+2. Should route grouping follow the domain map proposed here, or is there a different taxonomy preferred by maintainers?
+3. For the `tool_implementations.py` split (#3629), is the tool categorization in §5.2 acceptable, or should it follow a different grouping?
+4. Should compatibility shims (`__init__.py`) be temporary (removed in a follow-up wave) or permanent?
+5. Should an ADR (Architecture Decision Record) document be started to track decisions made during this process?
+
+---
+
+## Appendix A: Complete File Listing
+
+### `src/` (60 files)
+
+```
+agent_loop.py          tool_implementations.py   tool_schemas.py
+tool_index.py          tool_security.py          tool_policy.py
+tool_utils.py          builtin_actions.py        task_scheduler.py
+llm_core.py            model_context.py          model_discovery.py
+session_search.py      context_budget.py         context_compactor.py
+ai_interaction.py      action_intents.py         agent_runs.py
+app_helpers.py         app_initializer.py        config.py
+database.py            memory.py                 memory_provider.py
+secret_storage.py      prompt_security.py        url_security.py
+url_safety.py          rate_limiter.py           cleanup_service.py
+readiness.py           service_health.py         exceptions.py
+request_models.py      assistant_log.py          bg_monitor.py
+builtin_mcp.py         chat_helpers.py           chroma_client.py
+document_processor.py  embedding_lanes.py        deep_research.py
+research_handler.py    research_utils.py         personal_docs.py
+rag_manager.py         rag_singleton.py          topic_analyzer.py
+visual_report.py       youtube_handler.py        pdf_forms.py
+pdf_form_doc.py        pdf_runtime.py            caldav_writeback.py
+email_thread_parser.py text_helpers.py           user_time.py
+teacher_escalation.py  cookbook_serve_lifecycle.py
+chatgpt_subscription.py  mcp_manager.py
+```
+
+### `routes/` (52 files)
+
+```
+__init__.py    _validators.py
+auth_routes.py              api_token_routes.py       device_flow.py
+chat_routes.py              chat_helpers.py           shell_routes.py
+codex_routes.py             skills_routes.py
+email_routes.py             email_helpers.py          email_pollers.py
+cookbook_routes.py          cookbook_helpers.py       cookbook_output.py
+model_routes.py             assistant_routes.py       copilot_routes.py
+calendar_routes.py          contacts_routes.py
+document_routes.py          document_helpers.py
+gallery_routes.py           gallery_helpers.py
+task_routes.py              session_routes.py
+note_routes.py              memory_routes.py          research_routes.py
+mcp_routes.py               search_routes.py          history_routes.py
+webhook_routes.py           workspace_routes.py       upload_routes.py
+vault_routes.py             prefs_routes.py           preset_routes.py
+signature_routes.py         personal_routes.py        hwfit_routes.py
+backup_routes.py            cleanup_routes.py         diagnostics_routes.py
+embedding_routes.py         emoji_routes.py           font_routes.py
+stt_routes.py               tts_routes.py             compare_routes.py
+editor_draft_routes.py      chatgpt_subscription_routes.py    admin_wipe_routes.py
+```
+
+### `core/` (10 files)
+
+```
+__init__.py    constants.py    database.py    models.py
+auth.py        middleware.py   session_manager.py   exceptions.py
+atomic_io.py   platform_compat.py
+```
+
+---
+
+## Appendix B: Key Import Relationships
+
+```
+core/database.py  ←── 49 importers (routes/*, src/*, core/*, tests/*)
+    ↑
+    ├── routes/auth_routes.py
+    ├── routes/email_routes.py
+    ├── src/builtin_actions.py
+    ├── src/task_scheduler.py
+    ├── src/tool_implementations.py (inline)
+    └── ...44 more
+
+src/tool_implementations.py  ←── 18 importers
+    ↑
+    ├── src/agent_loop.py
+    ├── src/builtin_actions.py
+    ├── src/tool_index.py
+    ├── src/task_scheduler.py
+    ├── src/tool_policy.py
+    └── ...13 more (mostly tests)
+
+src/agent_loop.py  ←── 10 importers
+    ↑
+    ├── src/tool_policy.py
+    ├── src/teacher_escalation.py
+    ├── src/bg_monitor.py
+    ├── src/task_scheduler.py
+    └── 6 test files
+```

--- a/docs/architecture-runtime-inventory.md
+++ b/docs/architecture-runtime-inventory.md
@@ -16,13 +16,11 @@ This document maps the current runtime module structure, identifies high-risk bo
 ```
 odysseus/
 ├── app.py                    # FastAPI app entrypoint (1,145 lines)
-├── main.py                   # (future) renamed from app.py post-refactor
 ├── conf/                     # Configuration (config.py, settings.py, settings_scrub.py)
-├── src/                      # ~60 flat .py files + 3 subdirectories
+├── src/                      # 91 flat .py files + 2 subdirectories
 │   ├── agent_tools/          # Tool helpers: document, filesystem, subprocess, web
-│   ├── agent/                # Empty (placeholder)
-│   └── search/               # (exists)
-├── routes/                   # 52 flat .py files — HTTP route handlers
+│   └── search/               # Search subsystem
+├── routes/                   # 54 flat .py files — HTTP route handlers
 ├── core/                     # 10 files — database models, auth, middleware, session
 ├── mcp_servers/              # 4 files — MCP server implementations
 ├── scripts/                  # CLI tools and one-shot scripts
@@ -35,8 +33,8 @@ odysseus/
 
 | Directory | Flat `.py` Files | Subdirectories | Concern |
 |-----------|-----------------|----------------|---------|
-| `src/` | **~60** | 3 (`agent_tools/`, `agent/`, `search/`) | No domain grouping; 60 files in one directory |
-| `routes/` | **52** | 0 | All route handlers in one flat directory |
+| `src/` | **91** | 2 (`agent_tools/`, `search/`) | No domain grouping; 91 files in one directory |
+| `routes/` | **54** | 0 | All route handlers in one flat directory |
 | `core/` | 10 | 0 | Manageable, but `database.py` is oversized |
 
 ---
@@ -86,7 +84,7 @@ odysseus/
 
 ### 3.1 Who Depends on `core/database.py`
 
-**49 files** import from `core.database` — this is the most depended-upon module:
+**94 files** import from `core.database` — this is the most depended-upon module:
 
 - All route handlers (`routes/*.py`)
 - Most `src/*.py` files
@@ -104,9 +102,11 @@ odysseus/
 
 ### 3.3 Who Depends on `src/agent_loop.py`
 
+**21 files** import from `src.agent_loop`:
+
 - `src/tool_policy.py`, `src/teacher_escalation.py`, `src/bg_monitor.py`
 - `src/task_scheduler.py`
-- 6 test files
+- Multiple test files
 
 ### 3.4 Cross-Layer Import Violations
 
@@ -130,8 +130,8 @@ src/tool_implementations.py ──→ routes/prefs_routes.py
 |-----------|-------|-------|
 | `routes/` → `src/` | **349** | Expected: HTTP handlers call domain logic |
 | `routes/` → `core/` | **124** | Expected: handlers access DB models |
-| `src/` → `routes/` | **~20** | **Unexpected**: domain logic reaching into HTTP layer |
-| `src/` → `core/` | **49** | Acceptable but could be reduced with a data-access layer |
+| `src/` → `routes/` | **38** | **Unexpected**: domain logic reaching into HTTP layer |
+| `src/` → `core/` | **~49** | Acceptable but could be reduced with a data-access layer |
 
 ---
 
@@ -205,11 +205,11 @@ Tools in `tool_implementations.py` fall into natural groups:
 | Priority | Target | Risk | Rationale |
 |----------|--------|------|-----------|
 | **1** | `src/tool_implementations.py` → `src/tools/*.py` | **MEDIUM** | 4,032 lines → ~10 files by tool category. Already has natural boundaries. 18 importers, tracked in #3629. Use `__init__.py` shim to keep existing imports working. |
-| **2** | `routes/` → domain subdirectories | **MEDIUM** | 52 flat files → `routes/email/`, `routes/chat/`, `routes/cookbook/`, etc. Pure file moves + import path updates. Each domain group has clear ownership. |
+| **2** | `routes/` → domain subdirectories (one domain per PR) | **MEDIUM** | 54 flat files. Done **one domain at a time** (e.g. a standalone PR for the email domain, then chat, …), not a broad reorganization — route modules carry helper imports, registration assumptions, and test import paths. |
 | **3** | `src/agent_loop.py` → `src/agent/loop.py` + submodules | **MEDIUM-HIGH** | 2,961 lines, 24 functions. Can extract prompt building, classification, verification, and runaway detection. Tracked in #3266. |
 | **4** | `src/` → `src/pkg/`, `src/domain/`, `src/infra/`, `src/api/` | **MEDIUM** | Structural reorganization. Split flat `src/` into layered packages. Must come after routes and tools are stable. |
 | **5** | `routes/email_*.py` consolidation | **LOW** | Already grouped by filename prefix. Low-risk cleanup within the email domain. |
-| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 27 classes, 49 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
+| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 27 classes, 94 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
 | **7** | Frontend CSS modularization | **MEDIUM** | 36,653 lines. Tracked in #2617. Separate timeline from backend work. |
 | **8** | Frontend JS modularization | **MEDIUM** | 9,776 lines in `document.js`. Introduce ES modules at minimum. |
 
@@ -223,14 +223,16 @@ Tools in `tool_implementations.py` fall into natural groups:
 - Validation: `python -m pytest tests/ -x -q` + manual smoke test of tool execution
 - Reference: #3629
 
-**Slice 2: Group `routes/` by domain** (Pure reorganization)
+**Slice 2: Group `routes/` by domain** (one domain per PR, not a broad sweep)
 
-- Create `routes/email/`, `routes/chat/`, `routes/cookbook/`, `routes/model/`, `routes/calendar/`, `routes/document/`, `routes/auth/`, `routes/system/` subdirectories
-- Move each route file to its domain directory
-- Add `__init__.py` in each domain package with re-exports
-- Update `app.py` router imports
-- Validation: `python app.py` starts clean, all endpoints respond
-- **No behavior change** — pure file reorganization
+Route modules carry helper imports, router registration assumptions, and test import paths, so this must be done **one domain at a time** rather than as a single reorganization PR. Example sequence (each its own PR):
+
+- PR 2a: move the **email** domain (`email_routes.py`, `email_helpers.py`, `email_pollers.py`) → `routes/email/` + shim
+- PR 2b: move the **chat/agent** domain → `routes/chat/` + shim
+- PR 2c: move the **cookbook** domain → `routes/cookbook/` + shim
+- …and so on per domain from §4
+
+Each PR: add `__init__.py` re-exporting old names, update `app.py` router imports, validation `python app.py` starts clean. **No behavior change** — pure file reorganization.
 
 **Slice 3: Extract `agent_loop.py` submodules** (Improve reviewability)
 
@@ -291,9 +293,21 @@ timeout 5 python app.py 2>&1 | head -5 || true
 
 ---
 
+## 10. Future Direction (NOT current state)
+
+The following are **future refactor targets**, recorded here so this inventory does not imply they exist today. None of them are present in the current `dev` tree:
+
+- `main.py` — proposed rename of the `app.py` entrypoint. Today the app boots via `app.py`.
+- `src/agent/` — proposed package to hold `agent_loop.py` submodules (prompt/classifier/verifier/runaway/context). Today `agent_loop.py` is a single flat file in `src/`.
+- `src/infra/`, `src/domain/`, `src/pkg/`, `src/api/` — proposed layered reorganization of the flat `src/` directory (slice 4 in §6).
+
+These become real only when the corresponding slices land.
+
+---
+
 ## Appendix A: Complete File Listing
 
-### `src/` (60 files)
+### `src/` (91 files — representative subset listed)
 
 ```
 agent_loop.py          tool_implementations.py   tool_schemas.py
@@ -319,7 +333,7 @@ teacher_escalation.py  cookbook_serve_lifecycle.py
 chatgpt_subscription.py  mcp_manager.py
 ```
 
-### `routes/` (52 files)
+### `routes/` (54 files)
 
 ```
 __init__.py    _validators.py
@@ -357,14 +371,14 @@ atomic_io.py   platform_compat.py
 ## Appendix B: Key Import Relationships
 
 ```
-core/database.py  ←── 49 importers (routes/*, src/*, core/*, tests/*)
+core/database.py  ←── 94 importers (routes/*, src/*, core/*, tests/*)
     ↑
     ├── routes/auth_routes.py
     ├── routes/email_routes.py
     ├── src/builtin_actions.py
     ├── src/task_scheduler.py
     ├── src/tool_implementations.py (inline)
-    └── ...44 more
+    └── ...89 more
 
 src/tool_implementations.py  ←── 18 importers
     ↑
@@ -375,11 +389,11 @@ src/tool_implementations.py  ←── 18 importers
     ├── src/tool_policy.py
     └── ...13 more (mostly tests)
 
-src/agent_loop.py  ←── 10 importers
+src/agent_loop.py  ←── 21 importers
     ↑
     ├── src/tool_policy.py
     ├── src/teacher_escalation.py
     ├── src/bg_monitor.py
     ├── src/task_scheduler.py
-    └── 6 test files
+    └── 17 more (incl. tests)
 ```

--- a/specs/architecture-runtime-inventory.md
+++ b/specs/architecture-runtime-inventory.md
@@ -25,7 +25,7 @@ odysseus/
 ├── mcp_servers/              # 4 files — MCP server implementations
 ├── scripts/                  # CLI tools and one-shot scripts
 ├── static/                   # Frontend HTML/CSS/JS
-├── tests/                    # 552 test files (~54,800 lines)
+├── tests/                    # 544 test files (~54,800 lines)
 └── services/                 # (exists as needed)
 ```
 
@@ -128,10 +128,10 @@ src/tool_implementations.py ──→ routes/prefs_routes.py
 **Import counts (top-level)**:
 | Direction | Count | Notes |
 |-----------|-------|-------|
-| `routes/` → `src/` | **349** | Expected: HTTP handlers call domain logic |
+| `routes/` → `src/` | **351** | Expected: HTTP handlers call domain logic |
 | `routes/` → `core/` | **124** | Expected: handlers access DB models |
-| `src/` → `routes/` | **38** | **Unexpected**: domain logic reaching into HTTP layer |
-| `src/` → `core/` | **~49** | Acceptable but could be reduced with a data-access layer |
+| `src/` → `routes/` | **30** | **Unexpected**: domain logic reaching into HTTP layer (direct grep of import lines referencing `routes/`) |
+| `src/` → `core/` | **99** | Acceptable but could be reduced with a data-access layer |
 
 ---
 
@@ -191,6 +191,8 @@ Tools in `tool_implementations.py` fall into natural groups:
 ---
 
 ## 6. Risk Assessment & Candidate Slice Ranking
+
+> **Candidate proposals, not a committed plan.** The rankings, package shapes (e.g. `src/pkg/`, `src/domain/`, `src/infra/`, `src/api/`), split ordering, and route-grouping strategy below are **options for maintainer discussion**. Per #4082/#4071, slice ownership and order are settled by maintainers before any follow-up PR. §1–§3 above are the factual current-state inventory.
 
 ### 6.1 Risk Scale
 
@@ -295,7 +297,7 @@ timeout 5 python app.py 2>&1 | head -5 || true
 
 ## 10. Future Direction (NOT current state)
 
-The following are **future refactor targets**, recorded here so this inventory does not imply they exist today. None of them are present in the current `dev` tree:
+The following are **future refactor targets** (candidate directions **pending maintainer agreement**, not committed), recorded here so this inventory does not imply they exist today. None of them are present in the current `dev` tree:
 
 - `main.py` — proposed rename of the `app.py` entrypoint. Today the app boots via `app.py`.
 - `src/agent/` — proposed package to hold `agent_loop.py` submodules (prompt/classifier/verifier/runaway/context). Today `agent_loop.py` is a single flat file in `src/`.

--- a/specs/architecture-runtime-inventory.md
+++ b/specs/architecture-runtime-inventory.md
@@ -232,7 +232,7 @@ The 33 `do_*` functions in `tool_implementations.py` fall into natural domain gr
 
 - Create `src/tools/` package with one file per tool category
 - Add `src/tools/__init__.py` re-exporting all symbols with current names
-- Update 18 importers to use new paths (can be deferred via shim)
+- Update 17 importers to use new paths (can be deferred via shim)
 - Validation: `python -m pytest tests/ -x -q` + manual smoke test of tool execution
 - Reference: #3629
 

--- a/specs/architecture-runtime-inventory.md
+++ b/specs/architecture-runtime-inventory.md
@@ -4,6 +4,7 @@
 > **Parent issue**: [#4082](https://github.com/pewdiepie-archdaemon/odysseus/issues/4082)
 > **Last updated**: dev@b58af42 | 2026-06-16
 > **Status**: Draft — to be reviewed before follow-up slices open.
+> **Snapshot basis**: Importer / file / import-line counts are refreshed to `dev@b58af42` (2026-06-16) and are recomputable via the commands in §3.4. **Line counts** in §2.1 / §2.2 are a snapshot from an earlier baseline and drift as `dev` moves — recompute any of them with `wc -l <file>`. This inventory tracks structure and risk, not live metrics.
 
 This document maps the current runtime module structure, identifies high-risk boundaries, and recommends safe first refactor slices. It does **not** move files, change imports, or alter runtime behavior.
 
@@ -22,7 +23,7 @@ odysseus/
 │   └── search/               # Search subsystem
 ├── routes/                   # 54 flat .py files — HTTP route handlers
 ├── core/                     # 10 files — database models, auth, middleware, session
-├── mcp_servers/              # 4 files — MCP server implementations
+├── mcp_servers/              # 5 files — MCP server implementations
 ├── scripts/                  # CLI tools and one-shot scripts
 ├── static/                   # Frontend HTML/CSS/JS
 ├── tests/                    # 583 test files (~54,800 lines)
@@ -51,7 +52,7 @@ odysseus/
 | 4 | `src/agent_loop.py` | **2,961** | 0 | ~24 | **HIGH** |
 | 5 | `src/task_scheduler.py` | **2,330** | — | 5 | MEDIUM |
 | 6 | `routes/model_routes.py` | **2,266** | — | — | MEDIUM |
-| 7 | `core/database.py` | **2,265** | 27 | ~59 helpers | **HIGH** |
+| 7 | `core/database.py` | **2,265** | 28 | ~59 helpers | **HIGH** |
 | 8 | `src/builtin_actions.py` | **2,262** | 2 | ~24 | MEDIUM |
 | 9 | `src/llm_core.py` | **2,164** | — | — | MEDIUM |
 | 10 | `mcp_servers/email_server.py` | 2,197 | — | — | LOW (separate process) |
@@ -95,7 +96,7 @@ odysseus/
 
 ### 3.2 Who Depends on `src/tool_implementations.py`
 
-**18 files** import from `src.tool_implementations`:
+**17 files** import from `src.tool_implementations`:
 - `src/agent_loop.py`, `src/builtin_actions.py`, `src/tool_index.py`
 - `src/task_scheduler.py`, `src/tool_policy.py`
 - Various tests
@@ -129,7 +130,7 @@ src/tool_implementations.py ──→ routes/prefs_routes.py
 | Direction | Count | Notes |
 |-----------|-------|-------|
 | `routes/` → `src/` | **374** | Expected: HTTP handlers call domain logic |
-| `routes/` → `core/` | **124** | Expected: handlers access DB models |
+| `routes/` → `core/` | **126** | Expected: handlers access DB models |
 | `src/` → `routes/` | **31** | **Unexpected**: domain logic reaching into HTTP layer (direct grep of import lines referencing `routes/`) |
 | `src/` → `core/` | **106** | Acceptable but could be reduced with a data-access layer |
 
@@ -216,12 +217,12 @@ The 33 `do_*` functions in `tool_implementations.py` fall into natural domain gr
 
 | Priority | Target | Risk | Rationale |
 |----------|--------|------|-----------|
-| **1** | `src/tool_implementations.py` → `src/tools/*.py` | **MEDIUM** | 4,032 lines → ~10 files by tool category. Already has natural boundaries. 18 importers, tracked in #3629. Use `__init__.py` shim to keep existing imports working. |
+| **1** | `src/tool_implementations.py` → `src/tools/*.py` | **MEDIUM** | 4,032 lines → ~10 files by tool category. Already has natural boundaries. 17 importers, tracked in #3629. Use `__init__.py` shim to keep existing imports working. |
 | **2** | `routes/` → domain subdirectories (one domain per PR) | **MEDIUM** | 54 flat files. Done **one domain at a time** (e.g. a standalone PR for the email domain, then chat, …), not a broad reorganization — route modules carry helper imports, registration assumptions, and test import paths. |
 | **3** | `src/agent_loop.py` → `src/agent/loop.py` + submodules | **MEDIUM-HIGH** | 2,961 lines, 24 functions. Can extract prompt building, classification, verification, and runaway detection. Tracked in #3266. |
 | **4** | `src/` → `src/pkg/`, `src/domain/`, `src/infra/`, `src/api/` | **MEDIUM** | Structural reorganization. Split flat `src/` into layered packages. Must come after routes and tools are stable. |
 | **5** | `routes/email_*.py` consolidation | **LOW** | Already grouped by filename prefix. Low-risk cleanup within the email domain. |
-| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 27 classes, 102 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
+| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 28 classes, 102 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
 | **7** | Frontend CSS modularization | **MEDIUM** | 36,653 lines. Tracked in #2617. Separate timeline from backend work. |
 | **8** | Frontend JS modularization | **MEDIUM** | 9,776 lines in `document.js`. Introduce ES modules at minimum. |
 
@@ -392,14 +393,14 @@ core/database.py  ←── 102 importers (routes/*, src/*, core/*, tests/*)
     ├── src/tool_implementations.py (inline)
     └── ...97 more
 
-src/tool_implementations.py  ←── 18 importers
+src/tool_implementations.py  ←── 17 importers
     ↑
     ├── src/agent_loop.py
     ├── src/builtin_actions.py
     ├── src/tool_index.py
     ├── src/task_scheduler.py
     ├── src/tool_policy.py
-    └── ...13 more (mostly tests)
+    └── ...12 more (mostly tests)
 
 src/agent_loop.py  ←── 22 importers
     ↑

--- a/specs/architecture-runtime-inventory.md
+++ b/specs/architecture-runtime-inventory.md
@@ -2,7 +2,7 @@
 
 > **Purpose**: Phase 0 planning baseline for codebase readability improvements (#4071).
 > **Parent issue**: [#4082](https://github.com/pewdiepie-archdaemon/odysseus/issues/4082)
-> **Last updated**: dev@9d7a3d6 | 2026-06-13
+> **Last updated**: dev@9d7a3d6 | 2026-06-14
 > **Status**: Draft — to be reviewed before follow-up slices open.
 
 This document maps the current runtime module structure, identifies high-risk boundaries, and recommends safe first refactor slices. It does **not** move files, change imports, or alter runtime behavior.
@@ -52,7 +52,7 @@ odysseus/
 | 5 | `src/task_scheduler.py` | **2,330** | — | ~6 | MEDIUM |
 | 6 | `routes/model_routes.py` | **2,266** | — | — | MEDIUM |
 | 7 | `core/database.py` | **2,265** | 27 | ~59 helpers | **HIGH** |
-| 8 | `src/builtin_actions.py` | **2,262** | 0 | ~26 | MEDIUM |
+| 8 | `src/builtin_actions.py` | **2,262** | 2 | ~24 | MEDIUM |
 | 9 | `src/llm_core.py` | **2,164** | — | — | MEDIUM |
 | 10 | `mcp_servers/email_server.py` | 2,197 | — | — | LOW (separate process) |
 | 11 | `src/visual_report.py` | 1,918 | — | — | LOW |
@@ -167,26 +167,29 @@ Routes can be grouped into logical feature domains. Current flat structure obscu
 |-----------|------|-------|------|
 | Tool schemas | `src/tool_schemas.py` | 1,392 | JSON Schema tool definitions (Duck-TypedDict) |
 | Tool index | `src/tool_index.py` | ~580 | RAG-based tool retrieval from ChromaDB |
-| Tool implementations | `src/tool_implementations.py` | 4,032 | 33+ `do_*` functions — all tool execution logic |
+| Tool implementations | `src/tool_implementations.py` | 4,032 | 33 `do_*` functions — all tool execution logic |
 | Tool security | `src/tool_security.py` | — | Owner-scoped tool blocking |
 | Tool policy | `src/tool_policy.py` | — | Guide-only directive, plan-mode disabled tools |
 | Tool utils | `src/tool_utils.py` | — | Shared tool helpers |
 
 ### 5.2 Tool Implementation Categories
 
-Tools in `tool_implementations.py` fall into natural groups:
+The 33 `do_*` functions in `tool_implementations.py` fall into natural domain groups — the basis for slice 1's split in §6.2:
 
-| Category | Tools | Lines (est.) |
-|----------|-------|--------------|
-| **Filesystem** | `read_file`, `write_file`, `list_files`, `edit_file`, `move_file`, `delete_file`, `create_directory`, … | ~600 |
-| **Shell** | `execute_shell`, `manage_sessions` | ~300 |
-| **Email** | `send_email`, `reply_to_email`, `read_email`, `list_emails`, `search_emails`, `manage_email_accounts`, … | ~800 |
-| **Calendar** | `create_event`, `update_event`, `list_events`, `delete_event`, `classify_events`, … | ~500 |
-| **Memory/Notes** | `manage_memory`, `manage_notes`, `search_notes` | ~300 |
-| **Search/Research** | `search_chats`, `deep_research`, `web_search` | ~400 |
-| **Cookbook/Models** | `manage_endpoints`, `manage_cookbook`, `download_model` | ~300 |
-| **System** | `manage_skills`, `manage_tasks`, `manage_mcp`, `ask_user`, `update_plan` | ~400 |
-| **Other** | `manage_contacts`, `manage_vault`, `learn_sender_signatures`, … | ~300 |
+| Category | `do_*` functions | Count |
+|----------|------------------|-------|
+| **System / config** | `do_manage_skills`, `do_manage_tasks`, `do_manage_endpoints`, `do_manage_mcp`, `do_manage_webhooks`, `do_manage_tokens`, `do_manage_settings`, `do_api_call`, `do_app_api` | 9 |
+| **Cookbook / model serving** | `do_download_model`, `do_serve_model`, `do_list_served_models`, `do_stop_served_model`, `do_tail_serve_output`, `do_list_downloads`, `do_cancel_download`, `do_search_hf_models`, `do_adopt_served_model`, `do_list_cookbook_servers`, `do_list_serve_presets`, `do_serve_preset`, `do_list_cached_models` | 13 |
+| **Notes** | `do_manage_notes` | 1 |
+| **Calendar** | `do_manage_calendar` | 1 |
+| **Search** | `do_search_chats` | 1 |
+| **Research** | `do_manage_research`, `do_trigger_research` | 2 |
+| **Contacts** | `do_resolve_contact`, `do_manage_contact` | 2 |
+| **Vault** | `do_vault_search`, `do_vault_get`, `do_vault_unlock` | 3 |
+| **Image** | `do_edit_image` | 1 |
+| | **Total** | **33** |
+
+> Low-level tools (filesystem, subprocess, web fetch, document parsing) live in `src/agent_tools/`, **not** in `tool_implementations.py` — out of scope for this split.
 
 ---
 
@@ -307,9 +310,9 @@ These become real only when the corresponding slices land.
 
 ---
 
-## Appendix A: Complete File Listing
+## Appendix A: File Listing
 
-### `src/` (91 files — representative subset listed)
+### `src/` (91 files — 61 shown; run `ls src/*.py` for the full list)
 
 ```
 agent_loop.py          tool_implementations.py   tool_schemas.py

--- a/specs/architecture-runtime-inventory.md
+++ b/specs/architecture-runtime-inventory.md
@@ -2,7 +2,7 @@
 
 > **Purpose**: Phase 0 planning baseline for codebase readability improvements (#4071).
 > **Parent issue**: [#4082](https://github.com/pewdiepie-archdaemon/odysseus/issues/4082)
-> **Last updated**: dev@9d7a3d6 | 2026-06-14
+> **Last updated**: dev@b58af42 | 2026-06-16
 > **Status**: Draft — to be reviewed before follow-up slices open.
 
 This document maps the current runtime module structure, identifies high-risk boundaries, and recommends safe first refactor slices. It does **not** move files, change imports, or alter runtime behavior.
@@ -17,7 +17,7 @@ This document maps the current runtime module structure, identifies high-risk bo
 odysseus/
 ├── app.py                    # FastAPI app entrypoint (1,145 lines)
 ├── conf/                     # Configuration (config.py, settings.py, settings_scrub.py)
-├── src/                      # 91 flat .py files + 2 subdirectories
+├── src/                      # 95 flat .py files + 2 subdirectories
 │   ├── agent_tools/          # Tool helpers: document, filesystem, subprocess, web
 │   └── search/               # Search subsystem
 ├── routes/                   # 54 flat .py files — HTTP route handlers
@@ -25,7 +25,7 @@ odysseus/
 ├── mcp_servers/              # 4 files — MCP server implementations
 ├── scripts/                  # CLI tools and one-shot scripts
 ├── static/                   # Frontend HTML/CSS/JS
-├── tests/                    # 544 test files (~54,800 lines)
+├── tests/                    # 583 test files (~54,800 lines)
 └── services/                 # (exists as needed)
 ```
 
@@ -33,7 +33,7 @@ odysseus/
 
 | Directory | Flat `.py` Files | Subdirectories | Concern |
 |-----------|-----------------|----------------|---------|
-| `src/` | **91** | 2 (`agent_tools/`, `search/`) | No domain grouping; 91 files in one directory |
+| `src/` | **95** | 2 (`agent_tools/`, `search/`) | No domain grouping; 95 files in one directory |
 | `routes/` | **54** | 0 | All route handlers in one flat directory |
 | `core/` | 10 | 0 | Manageable, but `database.py` is oversized |
 
@@ -84,7 +84,7 @@ odysseus/
 
 ### 3.1 Who Depends on `core/database.py`
 
-**94 files** import from `core.database` — this is the most depended-upon module:
+**102 files** import from `core.database` — this is the most depended-upon module:
 
 - All route handlers (`routes/*.py`)
 - Most `src/*.py` files
@@ -102,7 +102,7 @@ odysseus/
 
 ### 3.3 Who Depends on `src/agent_loop.py`
 
-**21 files** import from `src.agent_loop`:
+**22 files** import from `src.agent_loop`:
 
 - `src/tool_policy.py`, `src/teacher_escalation.py`, `src/bg_monitor.py`
 - `src/task_scheduler.py`
@@ -128,10 +128,17 @@ src/tool_implementations.py ──→ routes/prefs_routes.py
 **Import counts (top-level)**:
 | Direction | Count | Notes |
 |-----------|-------|-------|
-| `routes/` → `src/` | **351** | Expected: HTTP handlers call domain logic |
+| `routes/` → `src/` | **374** | Expected: HTTP handlers call domain logic |
 | `routes/` → `core/` | **124** | Expected: handlers access DB models |
-| `src/` → `routes/` | **30** | **Unexpected**: domain logic reaching into HTTP layer (direct grep of import lines referencing `routes/`) |
-| `src/` → `core/` | **99** | Acceptable but could be reduced with a data-access layer |
+| `src/` → `routes/` | **31** | **Unexpected**: domain logic reaching into HTTP layer (direct grep of import lines referencing `routes/`) |
+| `src/` → `core/` | **106** | Acceptable but could be reduced with a data-access layer |
+
+> **How the metrics in this document are computed** — recompute against current `dev` before treating any count as authoritative (the tree drifts; these numbers are a snapshot, not a live value):
+> - `src/` flat `.py` files: `find src -maxdepth 1 -name '*.py' | wc -l`
+> - `tests/` test files: `find tests -name 'test_*.py' | wc -l`
+> - `core.database` importers: `grep -rlE '(from|import) +core\.database' --include='*.py' . | grep -v core/database.py | wc -l`
+> - `src.agent_loop` importers: `grep -rlE '(from|import) +src\.agent_loop' --include='*.py' . | grep -v src/agent_loop.py | wc -l`
+> - Cross-layer import lines: `grep -rhE '(from|import) +<pkg>' --include='*.py' <dir>/ | wc -l` (e.g. `(from|import) +routes` over `src/`)
 
 ---
 
@@ -214,7 +221,7 @@ The 33 `do_*` functions in `tool_implementations.py` fall into natural domain gr
 | **3** | `src/agent_loop.py` → `src/agent/loop.py` + submodules | **MEDIUM-HIGH** | 2,961 lines, 24 functions. Can extract prompt building, classification, verification, and runaway detection. Tracked in #3266. |
 | **4** | `src/` → `src/pkg/`, `src/domain/`, `src/infra/`, `src/api/` | **MEDIUM** | Structural reorganization. Split flat `src/` into layered packages. Must come after routes and tools are stable. |
 | **5** | `routes/email_*.py` consolidation | **LOW** | Already grouped by filename prefix. Low-risk cleanup within the email domain. |
-| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 27 classes, 94 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
+| **6** | `core/database.py` → `src/infra/database/models/*.py` | **HIGH** | 27 classes, 102 importers. Highest-risk split. Must be **last** in any sequence. Requires careful import shim strategy. |
 | **7** | Frontend CSS modularization | **MEDIUM** | 36,653 lines. Tracked in #2617. Separate timeline from backend work. |
 | **8** | Frontend JS modularization | **MEDIUM** | 9,776 lines in `document.js`. Introduce ES modules at minimum. |
 
@@ -312,7 +319,7 @@ These become real only when the corresponding slices land.
 
 ## Appendix A: File Listing
 
-### `src/` (91 files — 61 shown; run `ls src/*.py` for the full list)
+### `src/` (95 files — 61 shown; run `ls src/*.py` for the full list)
 
 ```
 agent_loop.py          tool_implementations.py   tool_schemas.py
@@ -376,14 +383,14 @@ atomic_io.py   platform_compat.py
 ## Appendix B: Key Import Relationships
 
 ```
-core/database.py  ←── 94 importers (routes/*, src/*, core/*, tests/*)
+core/database.py  ←── 102 importers (routes/*, src/*, core/*, tests/*)
     ↑
     ├── routes/auth_routes.py
     ├── routes/email_routes.py
     ├── src/builtin_actions.py
     ├── src/task_scheduler.py
     ├── src/tool_implementations.py (inline)
-    └── ...89 more
+    └── ...97 more
 
 src/tool_implementations.py  ←── 18 importers
     ↑
@@ -394,11 +401,11 @@ src/tool_implementations.py  ←── 18 importers
     ├── src/tool_policy.py
     └── ...13 more (mostly tests)
 
-src/agent_loop.py  ←── 21 importers
+src/agent_loop.py  ←── 22 importers
     ↑
     ├── src/tool_policy.py
     ├── src/teacher_escalation.py
     ├── src/bg_monitor.py
     ├── src/task_scheduler.py
-    └── 17 more (incl. tests)
+    └── 18 more (incl. tests)
 ```

--- a/specs/architecture-runtime-inventory.md
+++ b/specs/architecture-runtime-inventory.md
@@ -49,7 +49,7 @@ odysseus/
 | 2 | `routes/email_routes.py` | **3,245** | — | — | **MEDIUM** |
 | 3 | `routes/cookbook_routes.py` | **2,969** | — | — | **MEDIUM** |
 | 4 | `src/agent_loop.py` | **2,961** | 0 | ~24 | **HIGH** |
-| 5 | `src/task_scheduler.py` | **2,330** | — | ~6 | MEDIUM |
+| 5 | `src/task_scheduler.py` | **2,330** | — | 5 | MEDIUM |
 | 6 | `routes/model_routes.py` | **2,266** | — | — | MEDIUM |
 | 7 | `core/database.py` | **2,265** | 27 | ~59 helpers | **HIGH** |
 | 8 | `src/builtin_actions.py` | **2,262** | 2 | ~24 | MEDIUM |
@@ -166,7 +166,7 @@ Routes can be grouped into logical feature domains. Current flat structure obscu
 | Component | File | Lines | Role |
 |-----------|------|-------|------|
 | Tool schemas | `src/tool_schemas.py` | 1,392 | JSON Schema tool definitions (Duck-TypedDict) |
-| Tool index | `src/tool_index.py` | ~580 | RAG-based tool retrieval from ChromaDB |
+| Tool index | `src/tool_index.py` | 542 | RAG-based tool retrieval from ChromaDB |
 | Tool implementations | `src/tool_implementations.py` | 4,032 | 33 `do_*` functions — all tool execution logic |
 | Tool security | `src/tool_security.py` | — | Owner-scoped tool blocking |
 | Tool policy | `src/tool_policy.py` | — | Guide-only directive, plan-mode disabled tools |
@@ -218,7 +218,7 @@ The 33 `do_*` functions in `tool_implementations.py` fall into natural domain gr
 | **7** | Frontend CSS modularization | **MEDIUM** | 36,653 lines. Tracked in #2617. Separate timeline from backend work. |
 | **8** | Frontend JS modularization | **MEDIUM** | 9,776 lines in `document.js`. Introduce ES modules at minimum. |
 
-### 6.3 Recommended First 3 Behavior-Preserving Slices
+### 6.3 Candidate First 3 Behavior-Preserving Slices
 
 **Slice 1: Split `tool_implementations.py`** (Lowest-risk high-impact)
 


### PR DESCRIPTION
## Summary

Phase 0 runtime inventory document for #4082. **No-code** — no runtime behavior change, no file moves, no import rewrites.

Lives at `specs/architecture-runtime-inventory.md` (moved out of `docs/`, which is GitHub Pages public content, per review).

**Current-state inventory (§1–§3):**
- Largest runtime modules (>2,000 lines, ranked by risk)
- Import graph: 94 dependents on `core/database.py`; 30 `src/`→`routes/` cross-layer import lines
- Route ownership: 10 feature domains across 54 flat files
- Tool registry: the actual 33 `do_*` functions grouped by domain

**§6 (rankings / package shapes / split order / route grouping) and §10 (future direction) are framed as candidate proposals pending maintainer agreement, not a committed plan.**

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #4082

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors
- [x] No runtime behavior changes
- [x] No file moves or import rewrites

## How to Test

1. Review `specs/architecture-runtime-inventory.md`
2. Spot-check counts against `dev`:
   - `find src -maxdepth 1 -name '*.py' | wc -l` → 91
   - `find routes -maxdepth 1 -name '*.py' | wc -l` → 54
   - `grep -rhE '(from|import) +routes' --include='*.py' src/ | wc -l` → 30
3. `python -m compileall src/ routes/ core/ conf/` (verify no code changes)

## Visual / UI changes

N/A — documentation-only (`specs/architecture-runtime-inventory.md`); no rendered UI files touched.
