### PR TITLE
feat: add confirmation dialog before deleting a message

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -4473,6 +4473,15 @@ import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composer
    * Delete an AI message and its preceding user message from the conversation.
    */
   export async function deleteMessage(msgElement) {
+    if (uiModule && uiModule.styledConfirm) {
+      const ok = await uiModule.styledConfirm('Delete this message?', {
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+      if (!ok) return;
+    }
+
     const box = document.getElementById('chat-history');
     const allMsgs = Array.from(box.querySelectorAll('.msg'));
     const clickedIndex = allMsgs.indexOf(msgElement);


### PR DESCRIPTION
## Summary

This PR introduces a styled confirmation dialog when a user attempts to delete a message in the chat history. Previously, clicking the delete icon ('x') immediately removed the message pair (user and AI message) from the UI and database without warning, causing frustration for users who accidentally click it. Now, clicking delete triggers the app's native `uiModule.styledConfirm` modal, giving users a chance to cancel the deletion and preserve their conversation.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4086

## Type of Change

- [x] New feature (non-breaking — adds new behaviour)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open the app and load or start a chat session.
2. Hover over a message bubble (user or AI) to reveal the message action buttons.
3. Click the delete ('x') button.
4. Verify that the styled confirmation modal ("Delete this message?") appears with options to "Delete" or "Cancel".
5. Click **Cancel** and verify that the message bubble is NOT deleted.
6. Click the delete ('x') button again.
7. Click **Delete** and verify that the message bubble (along with its pair/continuation elements) is successfully deleted.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reused the existing `uiModule.styledConfirm` component so it inherits the project's standard CSS variables, font sizes, and layout classes.
  - Reused the standard button/modal layout classes.
  - Reused the standard Fira Code font stack.
  - The modal automatically shifts with the active theme (e.g. dark mode is correctly supported).
- [x] **No new component patterns**: Reused `styledConfirm` instead of building a new custom modal.
- [x] **I am not an LLM agent submitting a bulk PR**: I am a human contributor filing this fix!

### Screenshots / clips

<img width="1457" height="772" alt="image" src="https://github.com/user-attachments/assets/088895fd-9c0e-43b4-8ca3-c8b4c8de6904" />


