### PR TITLE
fix(hwfit): serve profiles for models with a sub-8192 context

### DIFF
--- a/services/hwfit/profiles.py
+++ b/services/hwfit/profiles.py
@@ -188,12 +188,18 @@ def compute_serve_profiles(system, model, serve_weights_gb=None, serve_quant=Non
         # Shrink context if even the chosen KV won't fit alongside weights.
         # Start from the smaller of the profile's target and the model's limit.
         cur_ctx = min(ctx, model_ctx_max)
-        while cur_ctx >= 8192:
+        # Floor the context-shrink loop at 8192, but never above the model's own
+        # trained limit. A model with a sub-8192 context (e.g. a 2048-token
+        # SmolLM) starts below 8192, so a hard-coded 8192 guard skipped the loop
+        # entirely and produced NO profile — the serve UI then fell back to
+        # manual flags even though the model fits the GPU trivially.
+        ctx_floor = min(8192, model_ctx_max)
+        while cur_ctx >= ctx_floor:
             kv = _kv_gb(model, cur_ctx, kv_type)
             n_cpu_moe, fits = _cpu_moe_for_budget(model, quant, kv, budget, fixed_gb=serve_weights_gb)
             est = _weights_gb(model, quant, serve_weights_gb) + kv + 0.6
             # If a non-MoE model can't fit even fully offloaded, try less context.
-            if model.get("is_moe") or fits or cur_ctx <= 8192:
+            if model.get("is_moe") or fits or cur_ctx <= ctx_floor:
                 profiles.append({
                     "key": key,
                     "label": label,

--- a/tests/test_serve_profiles.py
+++ b/tests/test_serve_profiles.py
@@ -81,6 +81,18 @@ def test_context_capped_at_model_limit():
         assert p["ctx"] <= 32768, p
 
 
+def test_small_context_model_still_gets_profiles():
+    """A model whose trained context is below the 8192 shrink floor must still
+    produce serve profiles, capped at its own limit — the loop floor must not
+    exclude it entirely (125 of the catalog models have context_length < 8192)."""
+    small_ctx_model = dict(_DENSE_8B, name="SmolLM-135M", context_length=2048)
+    profs = compute_serve_profiles(_sys(24.0), small_ctx_model)
+    assert profs, "sub-8192-context model produced no profiles"
+    for p in profs:
+        assert p["ctx"] <= 2048, p          # never exceeds the model's trained limit
+        assert p["ctx"] > 0
+
+
 def test_no_gpu_returns_empty():
     """No VRAM detected → no GPU profiles (caller falls back to manual flags)."""
     assert compute_serve_profiles({"backend": "cpu_x86", "gpu_vram_gb": 0}, _QWEN_35B_MOE) == []


### PR DESCRIPTION
**Impact:** 125 of the 912 catalog models — every model trained for under 8K context (SmolLM, gpt-neo, DialoGPT, Phi-style small models) — currently show **zero** Cookbook serve profiles and silently fall back to manual flags, even on a GPU with room to spare. This restores them.

## Summary

While poking at the Cookbook serve UI I noticed a model with a small context window showed no Quality/Balanced/Speed profiles at all — it just dropped to the manual-flags fallback. Turns out `compute_serve_profiles()` floors its context-shrink loop at a hard-coded `8192`, but `cur_ctx` starts at `min(target, model_ctx_max)`. So for any model whose trained context is below 8192 (a 2048-token SmolLM, gpt-neo-125m, DialoGPT, etc.), `cur_ctx` starts under the floor, `while cur_ctx >= 8192` is false on the very first check, the loop body never runs, and nothing gets appended. All three profile specs hit the same guard, so the function returns `[]` even though the model fits the GPU with room to spare. 125 of the 912 catalog models have `context_length < 8192`.

The `8192` is meant as a *floor for shrinking* (don't trim context below 8K), but it was doubling as the loop's *entry guard*. The fix floors at `min(8192, model_ctx_max)` instead, so the shrink still stops at 8K for normal models but never excludes one whose real ceiling is already lower. Big-context models are completely unaffected.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4167

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate. (PR #1827 touches the same function but only adds an input type-guard; it doesn't go near this loop.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end against my real GPU (RTX 3070 Ti, 8 GB).

## How to Test

Reproducible without a GPU via the pure function, but I also confirmed it live:

**1. Unit / function level**

```python
from services.hwfit.models import get_models
from services.hwfit.profiles import compute_serve_profiles

ms = {m["name"]: m for m in get_models()}
system = {"gpu_vram_gb": 24.0, "gpu_count": 1, "backend": "cuda", "has_gpu": True}

# before this PR -> 0 ;  after -> 2 (each capped at ctx 2048)
print(len(compute_serve_profiles(system, ms["HuggingFaceTB/SmolLM-135M-Instruct"])))
# big-context model is unchanged -> 3
print(len(compute_serve_profiles(system, ms["allenai/Olmo-3-7B-Instruct"])))
```

**2. Live endpoint** (`uvicorn app:app`, then):

```
GET /api/hwfit/profiles?model=HuggingFaceTB/SmolLM-135M-Instruct
```

Before/after on my box (RTX 3070 Ti, 8 GB), profile counts returned:

| model | context_length | before | after |
|-------|---------------:|-------:|------:|
| HuggingFaceTB/SmolLM-135M-Instruct | 2048 | 0 | 2 (ctx 2048) |
| EleutherAI/gpt-neo-125m | 2048 | 0 | 2 (ctx 2048) |
| allenai/Olmo-3-7B-Instruct | 65536 | 3 | 3 (unchanged) |

**3. Tests**

```
python -m pytest tests/test_serve_profiles.py
```

Added `test_small_context_model_still_gets_profiles` (a 2048-ctx model must yield profiles capped at its own limit). All serve-profile tests pass; the existing `test_flags_are_launchable` (which asserts `ctx >= 8192`) only exercises the 131072-ctx MoE model, so it's unaffected.

