### PR TITLE
fix(gallery): validate upstream result image URLs before fetching

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -108,6 +108,32 @@ def _visible_image_endpoint_for_base(db, base: str, owner: str | None):
     return fallback
 
 
+async def _fetch_result_image_b64(url: str) -> Optional[str]:
+    """Fetch an image URL returned in an upstream response body, base64-encoded
+    (or None on a non-200).
+
+    The URL comes from the diffusion/OpenAI server's response, not from our own
+    config, so a malicious or compromised endpoint could otherwise steer this
+    fetch at an internal or cloud-metadata address. Validate it the same way the
+    client-supplied endpoint is validated before the first request.
+    """
+    import base64
+    import httpx
+    from src.url_safety import check_outbound_url
+
+    ok, reason = check_outbound_url(
+        url,
+        block_private=os.getenv("IMAGE_BLOCK_PRIVATE_IPS", "false").lower() == "true",
+    )
+    if not ok:
+        raise HTTPException(502, f"Upstream returned an unsafe image URL: {reason}")
+    async with httpx.AsyncClient(timeout=60) as c2:
+        ir = await c2.get(url)
+        if ir.status_code == 200:
+            return base64.b64encode(ir.content).decode()
+    return None
+
+
 def setup_gallery_routes() -> APIRouter:
     router = APIRouter(tags=["gallery"])
 
@@ -1142,10 +1168,7 @@ def setup_gallery_routes() -> APIRouter:
                         if item.get("b64_json"):
                             raw_b64 = item["b64_json"]
                         elif item.get("url"):
-                            async with httpx.AsyncClient(timeout=60) as c2:
-                                img_r = await c2.get(item["url"])
-                                if img_r.status_code == 200:
-                                    raw_b64 = base64.b64encode(img_r.content).decode()
+                            raw_b64 = await _fetch_result_image_b64(item["url"])
                     if not raw_b64:
                         raise HTTPException(502, "OpenAI returned no image")
 
@@ -1206,7 +1229,7 @@ def setup_gallery_routes() -> APIRouter:
         original and regenerates `strength` fraction. With strength ~0.4
         you get edge blending + lighting unification while keeping the
         composition recognisable."""
-        import httpx, base64 as _b64
+        import httpx
         user = require_privilege(request, "can_generate_images")
         body = await request.json()
 
@@ -1382,10 +1405,9 @@ def setup_gallery_routes() -> APIRouter:
                             if item.get("b64_json"):
                                 return {"image": item["b64_json"]}
                             if item.get("url"):
-                                async with httpx.AsyncClient(timeout=60) as c2:
-                                    ir = await c2.get(item["url"])
-                                    if ir.status_code == 200:
-                                        return {"image": _b64.b64encode(ir.content).decode()}
+                                img_b64 = await _fetch_result_image_b64(item["url"])
+                                if img_b64:
+                                    return {"image": img_b64}
                     last_err = f"{path}: server returned no image"
                 except httpx.ConnectError as e:
                     raise HTTPException(502, f"Can't reach diffusion server at {base}: {e}")

--- a/tests/test_gallery_result_image_ssrf.py
+++ b/tests/test_gallery_result_image_ssrf.py
@@ -1,0 +1,69 @@
+"""The gallery image-edit proxies (inpaint, harmonize) accept an upstream
+diffusion / OpenAI response that may carry an image *URL* instead of inline
+base64, and then fetch that URL server-side. That URL is controlled by whatever
+server the request was sent to, so a malicious or compromised endpoint can
+return e.g. ``http://169.254.169.254/...`` and turn the result fetch into an
+SSRF primitive (cloud-metadata credential exfil).
+
+The client-supplied ``_endpoint`` is already validated through
+``check_outbound_url`` before the first request; this pins the same guard on the
+*result* URL pulled from the response body, which previously went unchecked.
+"""
+import base64
+
+import pytest
+from fastapi import HTTPException
+
+import routes.gallery_routes as gallery_routes
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, content: bytes = b""):
+        self.status_code = status_code
+        self.content = content
+
+
+class _FakeAsyncClient:
+    instances: list["_FakeAsyncClient"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.gets: list[str] = []
+        _FakeAsyncClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, **kwargs):
+        self.gets.append(url)
+        return _FakeResp(200, b"PNGDATA")
+
+
+@pytest.fixture(autouse=True)
+def _fake_httpx(monkeypatch):
+    import httpx
+
+    _FakeAsyncClient.instances = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+
+async def test_rejects_link_local_result_url():
+    # A compromised upstream returns the cloud-metadata address as the image
+    # URL. The helper must refuse it and never issue the fetch.
+    with pytest.raises(HTTPException) as exc:
+        await gallery_routes._fetch_result_image_b64(
+            "http://169.254.169.254/latest/meta-data"
+        )
+    assert exc.value.status_code == 502
+    assert all(c.gets == [] for c in _FakeAsyncClient.instances), (
+        "the unsafe result URL must not be fetched"
+    )
+
+
+async def test_fetches_safe_result_url():
+    # A normal loopback/LAN diffusion server result URL is allowed (local-first)
+    # and returned base64-encoded, matching the prior inline behavior.
+    out = await gallery_routes._fetch_result_image_b64("http://127.0.0.1/img.png")
+    assert out == base64.b64encode(b"PNGDATA").decode()


### PR DESCRIPTION
## Summary

The inpaint and harmonize image proxies accept an upstream diffusion/OpenAI response that may return an image URL instead of inline base64, then fetch that URL server-side. The client-supplied `_endpoint` already goes through `check_outbound_url` before the first request, but the result URL pulled from the response body was unchecked, so its destination was effectively controlled by whichever endpoint the request was sent to (a compromised or attacker-chosen endpoint could steer the fetch at an internal or cloud-metadata address). Both proxies now run that result URL through the same guard, via one shared helper. Reachable by users with the `can_generate_images` privilege.

## Linked Issue

Fixes #4189

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. (Validated via the test suite below; I do not have a diffusion endpoint set up to exercise the full image path locally.)

## How to Test

```
python -m pytest tests/test_gallery_result_image_ssrf.py
python -m pytest tests/ -k "gallery or url_safety"
```

The new test pins the guard: a link-local result URL (`http://169.254.169.254/...`) is rejected with 502 and never fetched, while a normal loopback URL is allowed and returned base64-encoded (local-first behaviour preserved). The wider gallery + url_safety suite stays green (60 passed).
