### PR TITLE
fix(agent): honor auth-disabled tool access after setup

### DIFF
--- a/src/tool_security.py
+++ b/src/tool_security.py
@@ -177,13 +177,16 @@ def owner_is_admin_or_single_user(owner: Optional[str]) -> bool:
     defense-in-depth for callers that bypass it (e.g. trusted loopback).
     """
     try:
+        from src.auth_helpers import _auth_disabled
+
+        if _auth_disabled():
+            return True
+
         from core.auth import AuthManager
 
         auth = AuthManager()
         if not auth.is_configured:
-            from src.auth_helpers import _auth_disabled
-
-            return _auth_disabled()
+            return False
         return bool(owner and auth.is_admin(owner))
     except Exception as exc:
         logger.warning("Unable to evaluate owner admin status: %s", exc)

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -701,6 +701,34 @@ def test_single_user_mode_keeps_full_tool_access_when_auth_disabled(monkeypatch)
     assert blocked_tools_for_owner(None) == set()
 
 
+def test_auth_disabled_configured_mode_keeps_full_tool_access(monkeypatch):
+    """AUTH_ENABLED=false is still intentional single-user mode after setup.
+
+    Once an admin account exists, AuthManager.is_configured becomes true. The
+    tool gate must still honor explicit auth-disabled mode before requiring an
+    owner/admin match, otherwise agent mode hides email/MCP/local tools from the
+    operator.
+    """
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    auth_mod = _install_core_auth_stub(monkeypatch)
+
+    class FakeAuth:
+        is_configured = True
+
+        def is_admin(self, username):
+            return False
+
+    monkeypatch.setattr(auth_mod, "AuthManager", lambda: FakeAuth())
+
+    from src.tool_security import (
+        blocked_tools_for_owner,
+        owner_is_admin_or_single_user,
+    )
+
+    assert owner_is_admin_or_single_user(None) is True
+    assert blocked_tools_for_owner(None) == set()
+
+
 @pytest.mark.asyncio
 async def test_webhook_tool_reuses_private_url_validation():
     class FakeDb:


### PR DESCRIPTION
## Summary

When auth is explicitly disabled, Odysseus should keep the local single-user tool policy even after first setup has created an auth store. The agent tool gate was checking whether auth was configured before honoring `AUTH_ENABLED=false`, so configured auth-disabled instances treated `owner=None` as a public/non-admin caller and hid email, MCP, shell/file, memory, and other local tools before the model saw them.

This PR checks explicit auth-disabled mode first in `owner_is_admin_or_single_user()` and adds a regression test for the configured-auth-store case.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4194

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Automated validation:

```bash
python -m py_compile src/tool_security.py tests/test_review_regressions.py
python -m pytest -q tests/test_review_regressions.py tests/test_edit_file.py tests/test_workspace_confine.py tests/test_security_regressions.py::test_require_user_accepts_anyone_when_auth_disabled tests/test_security_regressions.py::test_require_admin_rejects_unconfigured_public_api tests/test_security_regressions.py::test_require_admin_allows_when_auth_explicitly_disabled
python -m pytest -q
```

Results:

- Focused regression set: `5 passed, 1 warning`
- Expanded targeted suite: `54 passed, 1 warning`
- Full suite on the fix branch: `3268 passed, 1 skipped, 57 warnings`

Live validation already run:

- Started a Docker Compose stack with this fix under PR #3681, `AUTH_ENABLED=false`, configured auth store, GreenMail, and Gemini 2.5 Pro.
- Server-side predicate reported `owner_none_admin_or_single=true`, `blocked_count=0`, and `blocks_list_emails=false`.
- `/api/chat_stream` in agent mode emitted `mcp__email__list_emails`; the tool output contained the seeded GreenMail subject; the final answer was that subject.

Manual/live validation path:

1. Run Odysseus from current `dev`, complete setup so an auth store exists, then restart with `AUTH_ENABLED=false`.
2. Configure a working email account or disposable IMAP/SMTP fixture and a tool-capable model endpoint.
3. In agent mode, ask for `list_emails` with `max_results: 1`.
4. Confirm the model receives/calls the email tool instead of saying it has no email access.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: N/A - backend auth/tool-policy only; no UI rendering changed.
- [x] **No new component patterns.** N/A - backend auth/tool-policy only.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused, narrow bug fix for a reproduced auth-disabled tool exposure regression.

### Screenshots / clips

N/A - backend auth/tool-policy only; no UI rendering changed.
