### PR TITLE
fix(security): restrict API-key encryption key file to 0o600

### DIFF
--- a/src/api_key_manager.py
+++ b/src/api_key_manager.py
@@ -4,6 +4,8 @@ import logging
 from typing import Dict
 from cryptography.fernet import Fernet, InvalidToken
 
+from core.platform_compat import safe_chmod
+
 logger = logging.getLogger(__name__)
 
 class APIKeyManager:
@@ -15,12 +17,20 @@ class APIKeyManager:
     def get_or_create_key(self) -> bytes:
         """Get or create encryption key for API keys"""
         if os.path.exists(self.key_file):
+            # Older versions wrote .key with the process umask (often 0o644,
+            # i.e. group/world-readable). Re-restrict on read so existing
+            # installs heal without needing the key to be regenerated.
+            safe_chmod(self.key_file, 0o600)
             with open(self.key_file, 'rb') as f:
                 return f.read()
         else:
             key = Fernet.generate_key()
             with open(self.key_file, 'wb') as f:
                 f.write(key)
+            # This key decrypts every stored provider credential, so restrict it
+            # to the owner (0o600) — it must not be group/world-readable. No-op
+            # on Windows (files there are ACL-restricted to the user already).
+            safe_chmod(self.key_file, 0o600)
             return key
     
     def encrypt_api_key(self, api_key: str) -> str:

--- a/tests/test_api_key_file_permissions.py
+++ b/tests/test_api_key_file_permissions.py
@@ -1,0 +1,51 @@
+"""Regression: the API-key encryption key file (data/.key) must be owner-only
+(0o600).
+
+``APIKeyManager.get_or_create_key`` writes the Fernet key that decrypts *every*
+stored provider credential. Older versions created it with the process umask
+(commonly 0o644 — group/world-readable). It must be locked to the owner, both
+when freshly created and when an older, too-permissive key is read back.
+
+POSIX-only: ``core.platform_compat.safe_chmod`` is a documented no-op on Windows
+(files under the user profile are ACL-restricted), so the mode assertions are
+skipped there.
+"""
+import os
+import stat
+import sys
+
+import pytest
+
+from src.api_key_manager import APIKeyManager
+
+_WINDOWS = sys.platform.startswith("win")
+
+
+def _mode(path: str) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX permission bits only")
+def test_new_key_file_is_owner_only(tmp_path):
+    mgr = APIKeyManager(str(tmp_path))
+    mgr.get_or_create_key()
+    assert _mode(mgr.key_file) == 0o600, f"expected 0o600, got {oct(_mode(mgr.key_file))}"
+
+
+@pytest.mark.skipif(_WINDOWS, reason="POSIX permission bits only")
+def test_existing_world_readable_key_is_relocked(tmp_path):
+    mgr = APIKeyManager(str(tmp_path))
+    # Simulate a key written by an older version with a permissive umask.
+    with open(mgr.key_file, "wb") as f:
+        f.write(b"x" * 44)
+    os.chmod(mgr.key_file, 0o644)
+    mgr.get_or_create_key()  # existing-file branch should re-lock it
+    assert _mode(mgr.key_file) == 0o600, f"expected re-lock to 0o600, got {oct(_mode(mgr.key_file))}"
+
+
+def test_encrypt_decrypt_roundtrip_still_works(tmp_path):
+    # The permission hardening must not change functional behaviour.
+    mgr = APIKeyManager(str(tmp_path))
+    enc = mgr.encrypt_api_key("sk-secret")
+    assert enc and enc != "sk-secret"
+    assert mgr.decrypt_api_key(enc) == "sk-secret"


### PR DESCRIPTION
## Summary

`data/.key` holds the Fernet key that decrypts every stored provider credential (and webhook secrets), but `APIKeyManager.get_or_create_key()` was writing it with the process umask, so on a normal install it lands at `0o644`, readable by any other account on the box. I lock the file down to `0o600` as soon as it's created, and I re-apply that on read too, so older installs heal themselves without anyone having to regenerate the key (regenerating would orphan everything already encrypted with it). It all goes through the existing `safe_chmod` helper in `core/platform_compat.py`, so it stays a no-op on Windows.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

- [x] Fixes #4192

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched the open issues and open PRs, and this isn't a duplicate. Nothing else touches the key-file permissions, and it isn't already on `dev`.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope above. No unrelated refactors or whitespace.
- [x] I actually ran the app (`uvicorn app:app`) and checked it end to end (output below).

## How to Test

1. Start the app: `python -m uvicorn app:app --host 127.0.0.1 --port 7000`
2. Get it to write an encrypted secret. Quickest way is a webhook with a secret:
   `curl -s -X POST http://127.0.0.1:7000/api/webhooks -F name=t -F url=http://example.com/h -F secret=topsecret -F events=chat.message`
3. Check the key file's mode: `stat -c '%A' data/.key` on Linux, `stat -f '%Sp' data/.key` on macOS.

That's exactly what I ran on `dev` and on this branch:

```text
dev          data/.key -> -rw-r--r-- (644)
this branch  data/.key -> -rw------- (600)
```

The webhook secret still round-trips fine (encrypt/decrypt unchanged). `tests/test_api_key_file_permissions.py` covers a fresh key, re-locking an existing `0o644` key on read, and the round-trip.

## Visual / UI changes (required if you touched anything that renders)

Not applicable. This doesn't touch anything that renders (no CSS/HTML/SVG, nothing under `static/`), it only changes `src/api_key_manager.py` and adds a test. The UI and style items don't apply, but I've left the last one in because it applies either way.

- [X] I am not an LLM agent submitting a bulk PR.

### Screenshots / clips

Not applicable, no UI changes.
