### PR TITLE
fix(personal): confine remove_directory_from_rag to PERSONAL_DIR

### DIFF
--- a/routes/personal_routes.py
+++ b/routes/personal_routes.py
@@ -160,8 +160,11 @@ def setup_personal_routes(personal_docs_manager, rag_manager, rag_available):
             JSON response confirming removal
         """
         try:
-            if not directory:
-                raise HTTPException(400, "Directory path is required")
+            # Confine to PERSONAL_DIR — parity with add_directory_to_rag (which
+            # resolves the path the same way). Without this, an arbitrary or
+            # `..`-escaping path is passed straight to
+            # personal_docs_manager.remove_directory / rag.remove_directory.
+            directory = _resolve_allowed_personal_dir(directory)
 
             logger.info(f"Removing directory from RAG: {directory}")
 

--- a/tests/test_personal_remove_dir_confinement.py
+++ b/tests/test_personal_remove_dir_confinement.py
@@ -1,0 +1,43 @@
+"""Regression: remove_directory_from_rag must confine its path to PERSONAL_DIR.
+
+DELETE /api/personal/remove_directory took a raw ``directory`` query parameter
+and passed it straight to ``personal_docs_manager.remove_directory`` /
+``rag.remove_directory`` with no containment check — unlike add_directory_to_rag,
+which resolves the path via ``_resolve_allowed_personal_dir`` first. This pins
+the parity fix.
+
+``_resolve_allowed_personal_dir`` is a closure inside ``setup_personal_routes``,
+so this is a source-level test, matching test_personal_dir_symlink_escape.py.
+"""
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "routes" / "personal_routes.py"
+
+
+def _function_source(src_text: str, name: str) -> str:
+    tree = ast.parse(src_text)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return ast.get_source_segment(src_text, node)
+    raise AssertionError(f"{name} not found in {SRC}")
+
+
+def test_remove_directory_confines_path():
+    body = _function_source(SRC.read_text(), "remove_directory_from_rag")
+    assert "_resolve_allowed_personal_dir(" in body, (
+        "remove_directory_from_rag must call _resolve_allowed_personal_dir to "
+        "confine the user-supplied directory to PERSONAL_DIR (parity with "
+        "add_directory_to_rag)"
+    )
+
+
+def test_confinement_runs_before_removal_sinks():
+    """The confinement must happen before the path reaches either removal sink."""
+    body = _function_source(SRC.read_text(), "remove_directory_from_rag")
+    resolve_idx = body.index("_resolve_allowed_personal_dir(")
+    for sink in ("personal_docs_manager.remove_directory(", "rag.remove_directory("):
+        assert sink in body, f"expected sink {sink} in remove_directory_from_rag"
+        assert body.index(sink) > resolve_idx, (
+            f"{sink} runs before _resolve_allowed_personal_dir — path not confined"
+        )


### PR DESCRIPTION
## Summary

`add_directory_to_rag` runs its user-supplied path through `_resolve_allowed_personal_dir()` (realpath plus commonpath, so it can't point outside `PERSONAL_DIR`), but the matching DELETE route `remove_directory_from_rag` didn't. It took the raw `directory` query parameter and handed it straight to `personal_docs_manager.remove_directory()` and `rag.remove_directory()`, so the add side was confined and the remove side wasn't. I made remove call the same resolver, which also lines up with how add stores directories (by their resolved path). The route is admin only, so this is really about parity and defence in depth rather than an auth bypass, but the two endpoints ought to behave the same way.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

- [x] Fixes #4193

## Type of Change

- [x] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched the open issues and open PRs, and this isn't a duplicate. Nothing covers the remove-directory path check, and it isn't already on `dev`.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope above. One resolver call plus a test, nothing else.
- [x] I actually ran the app (`uvicorn app:app`) and checked it end to end over HTTP (output below).

## How to Test

1. Start the app: `python -m uvicorn app:app --host 127.0.0.1 --port 7000`
2. Try to remove a directory outside the personal docs root:
   `curl -s -o /dev/null -w '%{http_code}\n' -X DELETE 'http://127.0.0.1:7000/api/personal/remove_directory?directory=/etc'`
3. A normal removal of a directory under your personal docs still works.

On `dev` versus this branch:

```text
dev          DELETE ?directory=/etc -> 200   (a path outside PERSONAL_DIR was accepted)
this branch  DELETE ?directory=/etc -> 403   ("Directory must be inside personal documents")
```

`tests/test_personal_remove_dir_confinement.py` pins it at source level (the resolver is a closure inside `setup_personal_routes`, so I followed the same approach as the existing `test_personal_dir_symlink_escape.py`).

## Visual / UI changes (required if you touched anything that renders)

Not applicable. This doesn't touch anything that renders, only `routes/personal_routes.py` and a test. The UI and style items don't apply, but I've left the last one in because it applies either way.

- [X] I am not an LLM agent submitting a bulk PR.

### Screenshots / clips

Not applicable, no UI changes.
