### PR TITLE
docs(readme): flag no-Metal-on-Docker for Apple Silicon in the Docker…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ binds the web UI to `127.0.0.1` by default. If the port is taken, set
 `APP_PORT=7001` in `.env` and recreate the container. Set `APP_BIND=0.0.0.0`
 only when you intentionally want LAN/reverse-proxy access.
 
+> **On Apple Silicon (M-series) Macs:** Docker can't reach the Metal GPU, so
+> Cookbook serves local models on CPU only. For GPU-accelerated model serving,
+> run natively instead — see [Apple Silicon](#apple-silicon) below.
+
 ### Native Linux / macOS
 ```bash
 git clone https://github.com/pewdiepie-archdaemon/odysseus.git


### PR DESCRIPTION
## Summary

The Docker block is the first install path in the README, but Docker on macOS can't reach the Metal GPU, so on Apple Silicon the Cookbook ends up serving models on CPU. That's already explained further down in the Apple Silicon section, but it's easy to miss if you follow the "recommended" Docker steps at the top and stop there. I added a one-line note in the Docker section pointing M-series Mac users down to the Apple Silicon section. It's deliberately not "don't use Docker", because Docker is fine for the core app and CPU-only serving. It just surfaces the GPU caveat where people will actually run into it. I came across this personally, and felt it's worth a PR due to the self hosting of AI models, the difference is light and day on Apple Silicon when using Metal GPU. 

I am not an expert myself in any way, however a 'noob' will always go with the recommended option and refuse to look any further down the README.md haha. In some ways, I am that noob as I followed the recommended. IWasOfficiallyHumbled.com.

This tweak will help guide Apple M chip users towards the right install direction, especially with Apple Silicon only going to become more prominent over the next few years. It's more accessible and affordable than ever, and the project may even inspire people to invest in one, just for running Odysseus. Hope helps. After all, your fans will be happy with performance (both kinds of fans!).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

- [X] Fixes #3396

## Type of Change

- [ ] Bug fix (non-breaking, fixes a confirmed issue)
- [ ] New feature (non-breaking, adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched the open issues and open PRs, and this isn't a duplicate. Nothing open on this README wording.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope above. One note added to `README.md`, nothing else.
- [ ] Not applicable, docs-only change with no app behaviour to run. I did check the rendered Markdown and that the `#apple-silicon` anchor jumps to the existing section.

## How to Test

1. Open `README.md` and look at the **Docker (recommended)** section.
2. The new note sits right under the Docker steps and links to the **Apple Silicon** section below.
3. Confirm the anchor (`#apple-silicon`) jumps to the existing Apple Silicon heading.
4. Noob mode: Use the Docker install method on Apple Silicon, run a few Ollama local models, and compare the fan noise from that method, to using the Metal GPU method. Light and day on my M1 Max 32gb. 

## Visual / UI changes (required if you touched anything that renders)

Not applicable. README Markdown only, nothing under `static/`, no app UI. The UI and style items don't apply, but I've left the last one in because it applies either way.

- [X] I am not an LLM agent submitting a bulk PR.

### Screenshots / clips

Not applicable, no UI changes.

