### PR TITLE
fix(tests): isolate webhook task reference imports

### DIFF
--- a/tests/test_webhook_task_refs.py
+++ b/tests/test_webhook_task_refs.py
@@ -7,16 +7,20 @@ releases it on completion.
 """
 import asyncio
 import sys
+import types
 
-# webhook_manager does `from src.database import SessionLocal, Webhook` at import
-# time. The shared test harness stubs src.database without Webhook, so ensure the
-# attribute exists before importing the manager. These tests never touch the DB
-# (the manager is built via __new__), so a placeholder class is sufficient.
-_db = sys.modules.get("src.database")
-if _db is not None and not hasattr(_db, "Webhook"):
+from tests.helpers.import_state import clear_module, preserve_import_state
+
+# Import the manager against a private database stub, then restore both modules
+# so collection does not mutate shared import state.
+with preserve_import_state("src.database", "src.webhook_manager"):
+    clear_module("src.database")
+    clear_module("src.webhook_manager")
+    _db = types.ModuleType("src.database")
+    _db.SessionLocal = object()
     _db.Webhook = type("Webhook", (), {})
-
-from src.webhook_manager import WebhookManager  # noqa: E402
+    sys.modules["src.database"] = _db
+    from src.webhook_manager import WebhookManager
 
 
 def test_spawn_tracked_holds_then_releases_reference():


### PR DESCRIPTION
## Summary

Fixes the test-isolation portion of #3964 by importing `WebhookManager` against a private `src.database` stub and restoring `src.database` / `src.webhook_manager` import state after collection.

This keeps the change limited to `tests/test_webhook_task_refs.py`. Runtime webhook emitter behavior remains unchanged.

## Target branch

- [x] This PR targets **dev**.

## Linked Issue

Part of #3964

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling

## Checklist

- [x] I searched open issues, discussions, and PRs for duplicates.
- [x] This PR targets **dev**.
- [x] The change is limited to `tests/test_webhook_task_refs.py`.
- [x] No production/runtime behavior was changed.
- [x] I ran the focused webhook task reference test.
- [x] I ran the documented order-dependent reproduction from #3964.
- [x] I ran `python3 -m py_compile tests/test_webhook_task_refs.py`.
- [x] I ran `git diff --check`.

## How to Test

Verify the focused test file and the documented order-dependent reproduction from #3964:

```bash
python -m pytest tests/test_webhook_task_refs.py -q -p no:cacheprovider
python -m pytest tests/test_webhook_task_refs.py tests/test_webhook_ssrf_resilience.py -q -p no:cacheprovider
python3 -m py_compile tests/test_webhook_task_refs.py
git diff --check