### PR TITLE
fix(cookbook): resolve UI clipping of Serve button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15244,6 +15244,10 @@ body.right-dock-active:not(.email-doc-split-active) .doc-editor-pane {
   overflow-y: auto !important;
   overscroll-behavior: contain;
 }
+.cookbook-group[data-backend-group="Serve"] > .admin-card > .hwfit-cached-list .doclib-card.doclib-card-expanded {
+  flex: 0 0 auto !important;
+  overflow: visible !important;
+}
 /* Drag-and-drop visual hint for the email compose pane. Subtle accent
    outline + tinted overlay so it's obvious files will attach if dropped. */
 .doc-editor-pane.email-dragover {


### PR DESCRIPTION
## Summary

This fixes a layout bug where the "Serve" configuration form would permanently clip off the bottom action buttons ("Launch" and "Cancel") on smaller screens or when the "Advanced" drawer was expanded. The `.doclib-card-expanded` container inherited restrictive `flex: 1` and `overflow: hidden` rules. This change updates `static/style.css` to allow the expanded card to grow to its natural height (`flex: 0 0 auto`) and `overflow: visible`, forcing the parent `.hwfit-cached-list` container to provide a scrollbar so users can successfully reach the bottom.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2647

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Navigate to **Cookbook -> Serve** and expand any downloaded model.
2. Ensure the Backend is set to `llama.cpp`.
3. Expand the **▶ Advanced** drawer to reveal all additional fields (which makes the form very tall).
4. Verify that a vertical scrollbar appears and you can scroll to the very bottom to see the "Cancel" and "Launch" buttons without them being clipped off.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

Before : 

<img width="1100" height="811" alt="image" src="https://github.com/user-attachments/assets/fdbab123-b1ec-45a9-bd46-7c265c81c412" />


After :

<img width="1097" height="808" alt="image" src="https://github.com/user-attachments/assets/6125889c-d483-46fd-b08b-4abb639c6702" />

