### PR TITLE
fix(calendar): align week-view event times with local display time

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -1141,13 +1141,13 @@ function _wkEventTopHeight(ev, dayStr) {
   // Date math if the string isn't shaped as expected.
   const _toMin = (iso, fallbackDate) => {
     if (!iso) return null;
-    const m = iso.match(/T(\d{2}):(\d{2})/);
-    if (m) {
+    const mins = _timeToMin(iso);
+    if (mins !== null && iso.includes('T')) {
       // If the event spans into a previous/next day, clamp to today's bounds.
-      const evDate = iso.slice(0, 10);
+      const evDate = _localDateOf(iso);
       if (evDate < fallbackDate) return 0;             // event started before today
       if (evDate > fallbackDate) return 24 * 60;       // event ends after today
-      return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
+      return mins;
     }
     // All-day or date-only — treat as start of day.
     return 0;
@@ -1286,12 +1286,17 @@ async function _renderWeek() {
       if (!ev) return;
       const cols = Array.from(body.querySelectorAll('.cal-wk-grid'));
       if (!cols.length) return;
-      // Original timing
-      const m1 = (ev.dtstart || '').match(/T(\d{2}):(\d{2})/);
-      const m2 = (ev.dtend || '').match(/T(\d{2}):(\d{2})/);
-      const startMin0 = m1 ? parseInt(m1[1], 10) * 60 + parseInt(m1[2], 10) : 0;
-      const endMin0   = m2 ? parseInt(m2[1], 10) * 60 + parseInt(m2[2], 10) : startMin0 + 60;
-      const durationMin = Math.max(15, endMin0 - startMin0);
+      // Local/display timing
+      const startMin0 = _timeToMin(ev.dtstart) ?? 0;
+      const endMin0   = _timeToMin(ev.dtend) ?? startMin0 + 60;
+
+      let durationMin = endMin0 - startMin0;
+      const startDs = _localDateOf(ev.dtstart);
+      const endDs = ev.dtend ? _localDateOf(ev.dtend) : startDs;
+      if (endDs > startDs && endMin0 <= startMin0) {
+        durationMin += 24 * 60;
+      }
+      durationMin = Math.max(15, durationMin);
 
       // Where did the cursor grab the block? (offset from block-top in px)
       const blockRect = block.getBoundingClientRect();
@@ -1365,7 +1370,7 @@ async function _renderWeek() {
         // a plain click (no movement) must still open the event.
         if (moved) block.dataset.justResized = '1';
         // Decide whether anything actually moved.
-        const oldDs = (ev.dtstart || '').slice(0, 10);
+        const oldDs = _localDateOf(ev.dtstart);
         if (!nextDs) return;
         if (nextDs === oldDs && nextStartMin === startMin0) return;
         // Snapshot the original times so we can offer an Undo.
@@ -1374,11 +1379,10 @@ async function _renderWeek() {
         const newEndMin = nextStartMin + durationMin;
         const hh = String(Math.floor(nextStartMin / 60)).padStart(2, '0');
         const mm = String(nextStartMin % 60).padStart(2, '0');
-        const hh2 = String(Math.floor(newEndMin / 60)).padStart(2, '0');
-        const mm2 = String((newEndMin) % 60).padStart(2, '0');
-        const _tz = _tzOffset();
+        const newDtstartDate = new Date(`${nextDs}T${hh}:${mm}:00`);
+        const _tz = _tzOffsetForDate(newDtstartDate);
         const newDtstart = `${nextDs}T${hh}:${mm}:00${_tz}`;
-        const newDtend   = `${nextDs}T${hh2}:${mm2}:00${_tz}`;
+        const newDtend = _addMinutesToLocalIso(newDtstart, durationMin);
         try {
           await _updateEvent(uid, { dtstart: newDtstart, dtend: newDtend });
           _render();
@@ -1410,10 +1414,7 @@ async function _renderWeek() {
       const uid = block.dataset.uid;
       const ev = _events.find(x => x.uid === uid);
       if (!ev || !grid || !ds) return;
-      const startMin = (() => {
-        const m = (ev.dtstart || '').match(/T(\d{2}):(\d{2})/);
-        return m ? parseInt(m[1], 10) * 60 + parseInt(m[2], 10) : 0;
-      })();
+      const startMin = _timeToMin(ev.dtstart) ?? 0;
       const initialTop = parseFloat(block.style.top || '0');
       const gridRect = grid.getBoundingClientRect();
       let newEndMin = startMin;
@@ -1438,9 +1439,8 @@ async function _renderWeek() {
         if (resized) block.dataset.justResized = '1';
         if (newEndMin === startMin) return;
         const prevDtend = ev.dtend;
-        const hh = String(Math.floor(newEndMin / 60)).padStart(2, '0');
-        const mm = String(newEndMin % 60).padStart(2, '0');
-        const newDtend = `${ds}T${hh}:${mm}:00${_tzOffset()}`;
+        const durationMin = newEndMin - startMin;
+        const newDtend = _addMinutesToLocalIso(ev.dtstart, durationMin);
         try {
           await _updateEvent(uid, { dtend: newDtend });
           _render();
@@ -1966,10 +1966,10 @@ function _wireAll(body) {
             const ad = document.getElementById('cal-f-allday');
             if (ad && !ad.checked) { ad.checked = true; ad.dispatchEvent(new Event('change')); }
           } else {
-            const t1 = (ev.dtstart || '').match(/T(\d{2}:\d{2})/);
-            const t2 = (ev.dtend || '').match(/T(\d{2}:\d{2})/);
-            if (t1) set('cal-f-start', t1[1]);
-            if (t2) set('cal-f-end', t2[1]);
+            const t1 = _fmtTime(ev.dtstart);
+            const t2 = _fmtTime(ev.dtend);
+            if (t1) set('cal-f-start', t1);
+            if (t2) set('cal-f-end', t2);
             document.getElementById('cal-f-start')?.dispatchEvent(new Event('input'));
           }
           // Make sure the details panel is open so the user can verify time.
@@ -3215,6 +3215,37 @@ function _fmtTime(s) {
   }
   return s.slice(11, 16);
 }
+
+function _timeToMin(iso) {
+  const hm = _fmtTime(iso);
+  if (!hm) return null;
+  const m = hm.match(/^(\d{1,2}):(\d{2})$/);
+  if (!m) return null;
+  const h = parseInt(m[1], 10);
+  const min = parseInt(m[2], 10);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+
+function _tzOffsetForDate(d) {
+  const off = -d.getTimezoneOffset();
+  const sign = off >= 0 ? '+' : '-';
+  const abs = Math.abs(off);
+  const hh = String(Math.floor(abs / 60)).padStart(2, '0');
+  const mm = String(abs % 60).padStart(2, '0');
+  return `${sign}${hh}:${mm}`;
+}
+
+function _addMinutesToLocalIso(baseIso, addMinutes) {
+  const d = new Date(new Date(baseIso).getTime() + addMinutes * 60000);
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, '0');
+  const da = String(d.getDate()).padStart(2, '0');
+  const h = String(d.getHours()).padStart(2, '0');
+  const m = String(d.getMinutes()).padStart(2, '0');
+  return `${y}-${mo}-${da}T${h}:${m}:00${_tzOffsetForDate(d)}`;
+}
+
 function _e(s) { return uiModule.esc ? uiModule.esc(s || '') : (s || '').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
 
 // Linkify a location string: URLs become clickable, plain addresses get a Maps link.


### PR DESCRIPTION
## Summary

This PR fixes a week-view clock mismatch for timezone-aware calendar events, especially events stored with a `Z` suffix. Previously, parts of the week calendar parsed hour/minute values directly from the raw ISO string, so UTC-backed events could be positioned and edited as if the stored UTC time were already the user's local display time.

The patch routes week-view positioning, drag-to-reschedule, drag-to-resize, and edit-form time population through local/display-time helpers instead of raw ISO substring parsing. It adds `_timeToMin()` on top of `_fmtTime()`, uses `_localDateOf()` for local-day comparisons, and reconstructs updated local ISO timestamps with `_addMinutesToLocalIso()` plus `_tzOffsetForDate()` so cross-midnight and DST-sensitive updates remain consistent with the visible calendar time.

## Target branch

* [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #2948

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Create a timezone-aware UTC event, for example `09:00–10:00Z`, and verify that it renders on the week grid at the browser-local equivalent time.
2. Open the event edit form and confirm that the start/end time inputs match the same local display time shown on the calendar grid.
3. Drag an event to reschedule it across midnight, for example `23:30–00:30`, and confirm that the visual block keeps the correct duration instead of collapsing.
4. Drag the bottom resize handle across midnight, then reopen the edit form and verify that `dtstart` and `dtend` reflect the updated local display times.
5. Verify that date-only/all-day events and events with missing `dtend` still render without crashing the week view.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: this is a calendar logic fix only and does not introduce new CSS, colors, spacing, typography, icons, or component patterns.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips
Timezone-aware event rendered on the week grid at the browser-local display time:
<img width="1050" height="927" alt="image" src="https://github.com/user-attachments/assets/65df667a-fde2-417f-b83e-66b14d269eed" />
The same event opened in the edit form, showing matching local start/end times:
<img width="1057" height="925" alt="image" src="https://github.com/user-attachments/assets/3c65e6e5-7620-432c-bfac-4354b342a88e" />

