### PR TITLE
fix(agent): let RAG retrieval run for non-English low-signal queries

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -1801,18 +1801,21 @@ async def stream_agent_loop(
         logger.info(f"[tool-rag] Using caller-provided relevant_tools ({len(_relevant_tools)} tools)")
     if not guide_only and not _relevant_tools and bool(_intent.get("low_signal")):
         from src.tool_index import ALWAYS_AVAILABLE
-        _relevant_tools = set(ALWAYS_AVAILABLE)
         if workspace:
             # An active workspace IS the file-work signal: a vague "look at the
             # project" means explore this folder. Surface only the READ-ONLY file
             # tools (intersection with the plan-mode read-only allowlist) so the
             # agent can investigate; write/shell tools stay out until the request
             # actually calls for them (RAG retrieval adds those on a real ask).
+            _relevant_tools = set(ALWAYS_AVAILABLE)
             from src.tool_security import PLAN_MODE_READONLY_TOOLS
             _relevant_tools |= (_DOMAIN_TOOL_MAP["files"] & PLAN_MODE_READONLY_TOOLS)
             logger.info("[tool-rag] Low-signal but workspace active; including read-only file tools")
         else:
-            logger.info("[tool-rag] Low-signal agent message; skipping retrieval and using always-available tools only")
+            # Don't short-circuit: fall through to RAG retrieval below.
+            # Non-English queries are flagged low_signal by the English-only
+            # intent classifier, but fastembed retrieval works across languages.
+            logger.info("[tool-rag] Low-signal query; will run RAG retrieval")
     if not guide_only and not _relevant_tools:
         try:
             from src.tool_index import get_tool_index, ALWAYS_AVAILABLE


### PR DESCRIPTION
## Summary

When a non-English query is flagged as `low_signal` by the English-only intent classifier, the agent short-circuits RAG retrieval and only sends always-available tools. This means non-English users never get `web_search`, `web_fetch`, or other domain tools — even when the query clearly warrants them.

**Root cause:** `low_signal` is used as a hard gate before `ToolIndex.retrieve()`. The intent classifier is English-only, so non-English queries always get `low_signal=True`, and retrieval is skipped entirely.

**Fix:** When `low_signal` is true and no workspace is set, fall through to RAG retrieval instead of short-circuiting. `ToolIndex.retrieve()` uses fastembed which works across languages — the English-only signal from the intent classifier should not suppress it.

The `workspace` branch is unchanged: when a workspace is active, the existing read-only file tool selection still applies.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4160

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I searched existing issues and PRs and found no duplicates.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.

## How to Test

1. Set the agent language to a non-English language (e.g. Swedish)
2. Enable web search
3. Ask a clear web query in that language (e.g. "hur gick det i fotbolls-VM inatt")
4. The agent should now receive `web_search` and `web_fetch` tools
5. Verify English queries still work as before (existing tests pass)

## Test Results

82 passed, 0 failed