### PR TITLE
fix(calendar): prevent invalid same-day timed events

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -2918,35 +2918,68 @@ function _showEventForm(existing, defaultDate, defaultEndDate) {
     const startEl = document.getElementById('cal-f-start');
     const endEl = document.getElementById('cal-f-end');
     if (!startEl || !endEl) return;
+
     const _toMin = (v) => {
       if (!v || !/^\d{2}:\d{2}$/.test(v)) return null;
       const [h, m] = v.split(':').map(n => parseInt(n, 10));
       return h * 60 + m;
     };
+
     const _toHHMM = (mins) => {
       let m = ((mins % 1440) + 1440) % 1440;
       const hh = String(Math.floor(m / 60)).padStart(2, '0');
       const mm = String(m % 60).padStart(2, '0');
       return `${hh}:${mm}`;
     };
+
+    const _autoAdvanceEndDate = () => {
+      const isAD = document.getElementById('cal-f-allday')?.checked;
+      if (isAD) return;
+
+      const dv = document.getElementById('cal-f-date')?.value;
+      const dvEndEl = document.getElementById('cal-f-date-end');
+      if (!dv || !dvEndEl || dvEndEl.value !== dv) return;
+
+      const sVal = startEl.value;
+      const eVal = endEl.value;
+
+      if (sVal && eVal && eVal <= sVal) {
+        const d = new Date(`${dv}T00:00:00`);
+        d.setDate(d.getDate() + 1);
+
+        dvEndEl.value = _ds(d);
+      }
+    };
+
     let prevStartMin = _toMin(startEl.value);
-    endEl.addEventListener('input', () => { endEl.dataset.userEdited = '1'; });
+
+    endEl.addEventListener('input', () => {
+      endEl.dataset.userEdited = '1';
+    });
+
+    endEl.addEventListener('change', _autoAdvanceEndDate);
+
     startEl.addEventListener('change', () => {
       const newStartMin = _toMin(startEl.value);
       const endMin = _toMin(endEl.value);
-      if (newStartMin == null) { prevStartMin = newStartMin; return; }
-      // Compute the duration before the change. Use the user's existing
-      // start→end gap, fallback to 1 hour.
-      let durationMin = 60;
-      if (prevStartMin != null && endMin != null && endMin > prevStartMin) {
-        durationMin = endMin - prevStartMin;
-      } else if (endMin != null && newStartMin != null && endMin > newStartMin && endEl.dataset.userEdited === '1') {
-        // User already set a custom end before changing start — leave it.
+
+      if (newStartMin == null) {
         prevStartMin = newStartMin;
         return;
       }
+
+      let durationMin = 60;
+
+      if (prevStartMin != null && endMin != null && endMin > prevStartMin) {
+        durationMin = endMin - prevStartMin;
+      } else if (endMin != null && newStartMin != null && endMin > newStartMin && endEl.dataset.userEdited === '1') {
+        prevStartMin = newStartMin;
+        return;
+      }
+
       endEl.value = _toHHMM(newStartMin + durationMin);
       prevStartMin = newStartMin;
+      _autoAdvanceEndDate();
     });
   })();
   // Custom reminder picker
@@ -3007,6 +3040,20 @@ function _showEventForm(existing, defaultDate, defaultEndDate) {
     // proper UTC instants (is_utc=True). Without this, naive "10:00" gets
     // re-interpreted as local elsewhere — the timezone-misfire bug.
     const _tz = _tzOffset();
+    
+    if (!isAD) {
+      const startVal = document.getElementById('cal-f-start').value;
+      const endVal = document.getElementById('cal-f-end').value;
+
+      const startDt = new Date(`${dv}T${startVal}:00`);
+      const endDt = new Date(`${dvEnd}T${endVal}:00`);
+
+      if (endDt <= startDt) {
+        uiModule.showToast('End time must be after start time');
+        return;
+      }
+    }
+
     const payload = {
       summary,
       dtstart: isAD ? dv : `${dv}T${document.getElementById('cal-f-start').value}:00${_tz}`,


### PR DESCRIPTION
## Summary

This PR fixes a bug in the calendar event form where users could save timed events whose end datetime was not after the start datetime, for example `06/14/2026 11:00 PM → 06/14/2026 12:00 AM`. Previously, changing the start time late in the day could wrap the end time modulo 24 hours without advancing the end date, and the save handler did not reject chronologically reversed ranges. This patch auto-advances the end date when the user creates an apparent overnight range and adds a save-time validation guard so invalid timed events cannot be persisted.


## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4227

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Open the event creation form on the calendar.
2. Select any start date (e.g., `06/14/2026`).
3. Change the Start Time to `11:00 PM` and then the End Time to `12:00 AM`.
4. Verify that the End Date field automatically and instantly advances to the next day (`06/15/2026`).
5. Change the End Date back to the same date as the Start Date (`06/14/2026`).
6. Click Save and verify that the form rejects the submission and displays a toast message: "End time must be after start time".

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<img width="1117" height="741" alt="image" src="https://github.com/user-attachments/assets/8f431dc9-1de2-4f03-8050-636f0c416ce9" />
