### PR TITLE
perf(email): run blocking IMAP search/archive in a threadpool

### DIFF
--- a/routes/email_routes.py
+++ b/routes/email_routes.py
@@ -1087,7 +1087,10 @@ def setup_email_routes():
             return {"contacts": [], "error": "Mail operation failed"}
 
     @router.get("/search")
-    async def search_emails(
+    # Sync def: the body is blocking IMAP I/O with no awaits. As `async def` it ran
+    # directly on the event loop and stalled the whole app during a search; as a sync
+    # def FastAPI runs it in a threadpool, keeping the loop responsive.
+    def search_emails(
         q: str = Query(""),
         folder: str = Query("INBOX"),
         limit: int = Query(50),
@@ -1736,7 +1739,9 @@ def setup_email_routes():
             return {"success": False, "error": "Mail operation failed"}
 
     @router.post("/archive/{uid}")
-    async def archive_email(uid: str, folder: str = Query("INBOX"), account_id: str | None = Query(None), owner: str = Depends(require_owner)):
+    # Sync def: blocking IMAP I/O with no awaits — see search_emails above. Runs in a
+    # threadpool instead of blocking the event loop.
+    def archive_email(uid: str, folder: str = Query("INBOX"), account_id: str | None = Query(None), owner: str = Depends(require_owner)):
         """Move email to Archive folder."""
         try:
             with _imap(account_id, owner=owner) as conn:


### PR DESCRIPTION
## Summary
`search_emails` (`GET /search`) and `archive_email` (`POST /archive/{uid}`) in
`routes/email_routes.py` are declared `async def`, but their bodies are synchronous,
blocking IMAP I/O with **zero `await`s**. FastAPI runs `async def` handlers directly on the
event loop, so every email search or archive blocked the **entire app** until the IMAP
round-trip finished (the "everything feels frozen" symptom). This converts both handlers to
plain `def`, so FastAPI runs them in its threadpool and the event loop stays responsive.
No behavior change — identical inputs/outputs; only the execution context changes.

## Linked Issue
Fixes #4232

## Type of Change
- [x] Bug fix / performance (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation

## How to Test
1. On `dev`, hit `GET /search?q=…` (or use the mail UI search) while issuing other requests
   concurrently — unrelated requests stall until the IMAP search returns.
2. Apply this change (both handlers become `def`), restart the server.
3. Repeat step 1: the search/archive now runs in a threadpool and concurrent requests stay
   responsive. Behavior/results of the endpoints are unchanged.

Verified the two functions contain zero `await`s, so dropping `async` is safe.

## Checklist
- [x] I searched existing issues and PRs for duplicates
- [x] No behavior change (same inputs/outputs)
- [x] Change is minimal and scoped to the two endpoints