### PR TITLE
chore: align .gitignore and .dockerignore for secrets.env artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,12 @@ dist/
 build/
 .env
 .env.bak.*
+# Secrets: keep plaintext and every transient secrets.env variant out of
+# the build context. If an encrypted secrets.env is used, it is mounted
+# at runtime — never baked into the image. Mirrored in .gitignore.
+secrets.env
+secrets.env.*
+!secrets.env.example
 /data/
 /logs/
 .git/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ venv/
 .env.bak.*
 !.env.example
 
+# SOPS workflow — encrypted `secrets.env` is intentionally committable,
+# but every variant (plaintext, manual decrypt copy, editor backup)
+# must stay out of git. Mirrored in .dockerignore so the same artifacts
+# also cannot enter image build layers.
+secrets.env.*
+!secrets.env.example
+
 # Data — all user data stays local
 data/
 !services/hwfit/data/


### PR DESCRIPTION
## Summary

Aligns `.gitignore` and `.dockerignore` so plaintext and transient SOPS-decrypt artifacts (`secrets.env.dec`, `secrets.env.bak`, `secrets.env.bak.*`, `secrets.env.plain`, editor backups) cannot leak into either git or Docker image build layers, while keeping `secrets.env.example` as a tracked developer reference.

Split out of #236 per @RaresKeY's review suggestion ([scope comment](https://github.com/pewdiepie-archdaemon/odysseus/pull/236#issuecomment-4691184820)) so it can land independently of the broader SOPS feature design.

## Linked Issue

Refs #233 (the encrypted-at-rest proposal).

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [x] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Verified locally on this branch by listing the artifacts a SOPS user actually produces and asking git which rule (if any) matches each one. Run this in a fresh checkout of the branch with no secrets files present:

```bash
# In a fresh checkout of this branch, with no secrets file present:
for f in secrets.env secrets.env.dec secrets.env.bak secrets.env.bak.1234 secrets.env.plain secrets.env.example; do
    touch "$f"
    git check-ignore -v "$f" 2>/dev/null || echo "$f: NOT IGNORED"
    rm -f "$f"
done
```

Expected:
```
secrets.env: NOT IGNORED                           # encrypted file stays committable in git
.gitignore:22:secrets.env.*     secrets.env.dec
.gitignore:22:secrets.env.*     secrets.env.bak
.gitignore:22:secrets.env.*     secrets.env.bak.1234
.gitignore:22:secrets.env.*     secrets.env.plain
.gitignore:23:!secrets.env.example      secrets.env.example
```

`.dockerignore` mirrors the same set plus the bare `secrets.env` (since the encrypted file is intended to be mounted at runtime, never baked into image layers).

## Asymmetry note

The two files intentionally differ on the bare `secrets.env`:

| File | Bare `secrets.env` | Reason |
|---|---|---|
| `.gitignore` | allowed (committable) | encrypted file is content-addressable, safe to commit per the SOPS workflow |
| `.dockerignore` | blocked | image build context should never carry the file; runtime volume mount is the supported path |

This is defense in depth against accidentally publishing an encrypted file inside a public image alongside the matching `.sops.yaml` recipient list.

## Diff

```
 .dockerignore | 6 ++++++
 .gitignore    | 7 +++++++
 2 files changed, 13 insertions(+)
```

No application code touched. No runtime behavior changes.
