### PR TITLE
fix: respect user scroll-up in thinking section during streaming

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -1552,9 +1552,12 @@ import createResearchSynapse from './researchSynapse.js';
                     var thinkText = roundText.replace(/<\/?think(?:ing)?>/gi, '');
                     thinkText = thinkText.replace(/^\s*Thinking(?:\s+Process)?:\s*/i, '');
                     _liveThinkInner.innerHTML = markdownModule.mdToHtml(thinkText);
-                    // Keep thinking box scrolled to bottom
+                    // Keep thinking box scrolled to bottom, but let user scroll up
                     var thinkBox = _liveThinkInner.closest('.thinking-content');
-                    if (thinkBox) thinkBox.scrollTop = thinkBox.scrollHeight;
+                    if (thinkBox) {
+                      var nearBottom = thinkBox.scrollHeight - thinkBox.clientHeight - thinkBox.scrollTop < 80;
+                      if (nearBottom) thinkBox.scrollTop = thinkBox.scrollHeight;
+                    }
                   }
                   uiModule.scrollHistory();
                   continue;


### PR DESCRIPTION
## Summary

During streaming, the thinking content box forced `scrollTop = scrollHeight` on every update, fighting any user attempt to scroll up and read earlier content. Now it only auto-scrolls if the user is within 80px of the bottom — when you scroll up, auto-scrolling pauses until you scroll back near the bottom.

## Linked Issue

None — reported via user feedback, no GitHub issue filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have searched for existing issues and PRs before opening this one
- [x] The change is limited to a single file with a minimal, focused diff

## How to Test

1. Open the chat UI and start a conversation with a model that emits `<think>` blocks (streaming thinking process).
2. While thinking content is streaming, scroll up inside the thinking content area to view earlier content.
3. Verify that auto-scrolling stops and you can read freely.
4. Scroll back to the bottom — verify auto-scrolling resumes.
5. Repeat with a model that does NOT emit `<think>` blocks to confirm no regression in normal streaming.