### PR TITLE
fix(llm): convert multimodal content arrays for Ollama vision models

### DIFF
--- a/src/llm_core.py
+++ b/src/llm_core.py
@@ -8,6 +8,7 @@ import hashlib
 import threading
 import re
 import os
+import base64
 from fastapi import HTTPException
 from typing import Optional, Dict, List, Tuple
 from src.model_context import get_context_length, DEFAULT_CONTEXT
@@ -351,10 +352,43 @@ def _ollama_normalize_tool_messages(messages: List[Dict]) -> List[Dict]:
     here, on a shallow copy, leaving non-tool messages untouched. The opaque
     Gemini `extra_content` (thought_signature) is dropped — it is meaningless to
     Ollama and only matters when the conversation is replayed to Gemini.
+
+    OpenAI-style multimodal content arrays (list of {type, text/image_url} blocks)
+    are also converted: text parts are joined into a plain ``content`` string and
+    base64 image data is moved to Ollama's ``images`` list field.  Without this,
+    Ollama's Go backend rejects the request with HTTP 400 — "cannot unmarshal
+    array into Go struct field ChatRequest.messages.content of type string".
     """
     out: List[Dict] = []
     for m in messages or []:
-        tcs = m.get("tool_calls") if isinstance(m, dict) else None
+        if not isinstance(m, dict):
+            out.append(m)
+            continue
+
+        # --- Convert OpenAI multimodal content arrays to Ollama format ---
+        content = m.get("content")
+        if isinstance(content, list):
+            text_parts: List[str] = []
+            images: List[str] = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                ptype = part.get("type", "")
+                if ptype == "text":
+                    text_parts.append(part.get("text", ""))
+                elif ptype == "image_url":
+                    url_obj = part.get("image_url") or {}
+                    url = url_obj.get("url", "")
+                    if url.startswith("data:") and ";base64," in url:
+                        images.append(url.split(";base64,", 1)[1])
+            if text_parts or images:
+                nm = dict(m)
+                nm["content"] = "\n".join(text_parts) if text_parts else ""
+                if images:
+                    nm["images"] = images
+                m = nm
+
+        tcs = m.get("tool_calls")
         if not tcs:
             out.append(m)
             continue

--- a/tests/test_ollama_multimodal_content.py
+++ b/tests/test_ollama_multimodal_content.py
@@ -1,0 +1,94 @@
+"""Regression tests for Ollama multimodal content conversion (#4249)."""
+
+from src.llm_core import _ollama_normalize_tool_messages
+
+
+class TestOllamaMultimodalContent:
+    """Verify that OpenAI-style multimodal content arrays are converted
+    to Ollama's expected format (string content + images list)."""
+
+    def test_single_image_with_text(self):
+        msg = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="}},
+            ],
+        }]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["content"] == "What is in this image?"
+        assert result[0]["images"] == ["iVBORw0KGgo="]
+
+    def test_multiple_images(self):
+        msg = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Compare these"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,def456"}},
+            ],
+        }]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["content"] == "Compare these"
+        assert result[0]["images"] == ["abc123", "def456"]
+
+    def test_image_only_no_text(self):
+        msg = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        }]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["content"] == ""
+        assert result[0]["images"] == ["abc"]
+
+    def test_plain_text_unchanged(self):
+        msg = [{"role": "user", "content": "Hello"}]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["content"] == "Hello"
+        assert "images" not in result[0]
+
+    def test_non_data_uri_images_skipped(self):
+        """External HTTP image URLs are not base64 data -- skip them."""
+        msg = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Look"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            ],
+        }]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["content"] == "Look"
+        assert "images" not in result[0]
+
+    def test_tool_calls_still_normalized(self):
+        msg = [{
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "test", "arguments": '{"key": "value"}'}},
+            ],
+        }]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == {"key": "value"}
+
+    def test_mixed_content_and_tool_calls(self):
+        """A message with both multimodal content and tool_calls."""
+        msg = [{
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Analyzing..."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,xyz"}},
+            ],
+            "tool_calls": [
+                {"function": {"name": "analyze", "arguments": "{}"}},
+            ],
+        }]
+        result = _ollama_normalize_tool_messages(msg)
+        assert result[0]["content"] == "Analyzing..."
+        assert result[0]["images"] == ["xyz"]
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == {}
+
+    def test_non_dict_messages_pass_through(self):
+        result = _ollama_normalize_tool_messages(["text", 42, None])
+        assert result == ["text", 42, None]


### PR DESCRIPTION
## Summary

Ollama vision models (e.g. Gemma4) fail with HTTP 400 when receiving OpenAI-style multimodal content arrays. The Ollama native `/api/chat` endpoint expects `content` as a plain string and images in a separate `images` field, but Odysseus sends the raw OpenAI content array format. This fix extends the existing Ollama message normalization to convert multimodal content arrays into Ollama's expected format.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #4249

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. Run the existing Ollama tests: `python -m pytest tests/test_llm_core_ollama_thinking.py -v` (19 pass)
2. Run the new regression tests: `python -m pytest tests/test_ollama_multimodal_content.py -v` (8 pass)
3. Run the broader LLM suite: `python -m pytest tests/test_endpoint_resolver.py tests/test_provider_endpoints.py -v` (88 pass)
4. All 88 existing + 8 new regression tests pass with 0 regressions.

## Problem

When attaching an image to a vision model through Ollama (e.g. Gemma4), the chat fails with HTTP 400:

```
json: cannot unmarshal array into Go struct field ChatRequest.messages.content of type string
```

This breaks the entire chat -- subsequent messages to any model in the same session also fail.

## Root Cause

Odysseus builds an OpenAI-style content array for multimodal messages:
```json
[
  {"type": "text", "text": "What is in this image?"},
  {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
]
```

Ollama native `/api/chat` expects `content` to be a plain string and images in a separate `images` field as base64 strings. Sending the array directly causes Go JSON unmarshaler to reject it.

## Fix

Extend `_ollama_normalize_tool_messages` (already responsible for adapting OpenAI-style messages to Ollama) to also convert multimodal content arrays:

- Join `text` parts into a plain `content` string
- Extract base64 data from `data:` URIs into an `images` list
- Skip external HTTP/HTTPS image URLs (not base64 data)

Single-file change (`src/llm_core.py`, +35/-1). Focused test file covers single image, multiple images, text-only passthrough, mixed content + tool calls, and non-data URI edge cases.

## Notes

- Fix lives in the same normalization function that already handles tool-call argument parsing -- no new code path for non-vision requests.
- External image URLs (http/https) intentionally not extracted -- Ollama `images` field expects raw base64 data, not URLs.