### PR TITLE
fix(calendar): parse "mins"/"hrs" reminder offsets in manage_calendar

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -1579,10 +1579,10 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
         text = str(raw).strip().lower()
         if text in {"none", "no", "off", "false"}:
             return None
-        m = re.search(r"(\d+)\s*(?:m|min|minute|minutes)\b", text)
+        m = re.search(r"(\d+)\s*(?:minutes?|mins?|m)\b", text)
         if m:
             return max(0, int(m.group(1)))
-        m = re.search(r"(\d+)\s*(?:h|hr|hour|hours)\b", text)
+        m = re.search(r"(\d+)\s*(?:hours?|hrs?|h)\b", text)
         if m:
             return max(0, int(m.group(1)) * 60)
         if text.isdigit():
@@ -1595,7 +1595,7 @@ async def do_manage_calendar(content: str, owner: Optional[str] = None) -> Dict:
             return desc
         reminder_only = re.compile(
             r"^\s*(?:remind(?:er)?|alarm)\s*:?\s*\d+\s*"
-            r"(?:m|min|minute|minutes|h|hr|hour|hours)\b.*$",
+            r"(?:minutes?|mins?|m|hours?|hrs?|h)\b.*$",
             re.I,
         )
         return "" if reminder_only.match(desc) else desc

--- a/tests/test_calendar_reminder_minutes_parsing.py
+++ b/tests/test_calendar_reminder_minutes_parsing.py
@@ -1,0 +1,88 @@
+"""do_manage_calendar must honour abbreviated reminder phrasings like "mins"/"hrs".
+
+`_reminder_minutes` parsed the reminder offset with regexes anchored on
+`(?:m|min|minute|minutes)\b` / `(?:h|hr|hour|hours)\b`. The trailing `\b`
+made the very common plural abbreviations "mins" and "hrs" fail to match
+(after "min" the next char "s" is a word char, so no boundary), so a request
+like ``reminder_minutes: "5 mins"`` silently produced no reminder at all —
+even though the sibling duration parser (no `\b`) already accepted them.
+"""
+
+import json
+import sys
+import uuid
+
+import pytest
+
+from tests.helpers.import_state import clear_fake_database_modules
+from tests.helpers.sqlite_db import make_temp_sqlite
+
+clear_fake_database_modules()
+
+import core.database as cdb
+from core.database import Note
+
+_TS, _ENGINE, _TMPDB = make_temp_sqlite(cdb.Base.metadata)
+
+
+@pytest.fixture(autouse=True)
+def _bind_temp_db(monkeypatch):
+    monkeypatch.setitem(sys.modules, "core.database", cdb)
+    parent = sys.modules.get("core")
+    if parent is not None:
+        monkeypatch.setattr(parent, "database", cdb, raising=False)
+    monkeypatch.setattr(cdb, "SessionLocal", _TS)
+    yield
+
+
+async def _create_with_reminder(reminder, owner):
+    from src.tool_implementations import do_manage_calendar
+
+    payload = {
+        "action": "create_event",
+        "summary": "Dentist",
+        # Far-future so the reminder is never "already passed".
+        "dtstart": "2030-01-01T10:00:00",
+        "reminder_minutes": reminder,
+    }
+    return await do_manage_calendar(json.dumps(payload), owner=owner)
+
+
+@pytest.mark.parametrize("reminder,expected", [
+    ("5 mins", 5),
+    ("10 mins", 10),
+    ("2 hrs", 120),
+    ("1 hr", 60),
+    ("15 minutes", 15),   # regression: long form still works
+    ("30m", 30),          # regression: bare unit still works
+])
+async def test_reminder_minutes_accepts_abbreviations(reminder, expected):
+    owner = "tester-" + uuid.uuid4().hex[:6]
+    res = await _create_with_reminder(reminder, owner)
+    assert res.get("exit_code") == 0, res
+    assert f"reminder {expected} min before" in res.get("response", ""), res
+
+    db = _TS()
+    try:
+        note = (
+            db.query(Note)
+            .filter(Note.owner == owner, Note.title == "Reminder: Dentist")
+            .first()
+        )
+        assert note is not None, "reminder note should have been created"
+    finally:
+        db.close()
+
+
+async def test_no_reminder_when_offset_absent():
+    owner = "tester-" + uuid.uuid4().hex[:6]
+    from src.tool_implementations import do_manage_calendar
+
+    payload = {
+        "action": "create_event",
+        "summary": "No Reminder Event",
+        "dtstart": "2030-02-01T10:00:00",
+    }
+    res = await do_manage_calendar(json.dumps(payload), owner=owner)
+    assert res.get("exit_code") == 0, res
+    assert "reminder set" not in res.get("response", ""), res


### PR DESCRIPTION
## Summary

Reminder offsets phrased as "mins" or "hrs" were silently dropped when creating a calendar event. `do_manage_calendar._reminder_minutes` matched the offset with `(?:m|min|minute|minutes)\b` and `(?:h|hr|hour|hours)\b` — the trailing `\b` means `"5 mins"` never matches (the `s` after `min` is a word char, so there's no boundary, and `mins`/`hrs` aren't in the alternation). The function returned `None`, so the event got created with no reminder and no error — the user thinks they set one and it just never fires.

The same gap was in the `reminder_only` description regex just below, so I widened both. The replacements are strict supersets of the originals (`(?:minutes?|mins?|m)\b`, `(?:hours?|hrs?|h)\b`), so every input that worked before still works — they just also accept the plural abbreviations now. This also lines the reminder parser up with the sibling `duration:` parser in `create_event`, which already accepts these forms because it has no `\b`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4265

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. On `dev` (before this change), start the app: `uvicorn app:app` (auth off is fine).
2. Have the agent create an event with a reminder using the everyday phrasing, e.g. `manage_calendar` `create_event` with `{"summary": "Dentist", "dtstart": "2030-03-01T09:00:00", "reminder_minutes": "5 mins"}`. The response says the event was created but with **no** reminder, and no `Reminder: Dentist` note is created.
3. Repeat with `"5 min"` (singular) — the reminder *is* created. That's the inconsistency.
4. Check out this branch and repeat step 2: the response now reads `...with reminder 5 min before` and a `Reminder: Dentist` note exists. `"2 hrs"` likewise produces a 120-minute reminder.
5. Run the focused tests: `pytest tests/test_calendar_reminder_minutes_parsing.py` (also covers `"15 minutes"` / `"30m"` so the long and bare-unit forms don't regress).

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual or UI changes — this is a backend regex fix in `src/tool_implementations.py`. Nothing under `static/` is touched.
