### PR TITLE
fix(cookbook): only persist successfully stopped scheduled serves

### DIFF
--- a/src/cookbook_serve_lifecycle.py
+++ b/src/cookbook_serve_lifecycle.py
@@ -161,11 +161,13 @@ async def _tick() -> None:
     # Re-read state once before writing so we capture any updates from
     # concurrent UI syncs.
     stopped_any = False
+    successfully_stopped_sids = set()
     for sid, host, port in to_stop:
         ok = await _stop_serve(sid, host, port)
         logger.info(f"cookbook_serve_lifecycle: stop {sid} (host={host or 'local'}): {'ok' if ok else 'failed'}")
         if ok:
             stopped_any = True
+            successfully_stopped_sids.add(sid)
             # Drop the auto-registered endpoint so the model picker and
             # the chat router don't keep pointing at a dead server.
             for t in tasks:
@@ -188,12 +190,11 @@ async def _tick() -> None:
             except Exception:
                 fresh = state
                 fresh_tasks = tasks
-            stopped_sids = {sid for sid, _, _ in to_stop}
             for ft in fresh_tasks:
                 if not isinstance(ft, dict):
                     continue
                 ft_sid = ft.get("sessionId") or ft.get("id")
-                if ft_sid in stopped_sids:
+                if ft_sid in successfully_stopped_sids:
                     ft["status"] = "stopped"
                     ft["_scheduledStopAtMs"] = None
                     ft["_lastStatusFlipAt"] = now_ms

--- a/tests/test_cookbook_serve_lifecycle.py
+++ b/tests/test_cookbook_serve_lifecycle.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+from src import cookbook_serve_lifecycle as lifecycle
+
+
+@pytest.mark.asyncio
+async def test_tick_persists_only_successfully_stopped_serves(tmp_path, monkeypatch):
+    state_path = tmp_path / "cookbook_state.json"
+    state_path.write_text(
+        json.dumps({
+            "tasks": [
+                {
+                    "id": "stop-succeeds",
+                    "type": "serve",
+                    "status": "running",
+                    "_scheduledStopAtMs": 0,
+                },
+                {
+                    "id": "stop-fails",
+                    "type": "serve",
+                    "status": "running",
+                    "_scheduledStopAtMs": 0,
+                },
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    async def fake_stop_serve(session_id, remote_host="", ssh_port=""):
+        return session_id == "stop-succeeds"
+
+    async def fake_delete_endpoint(task):
+        return None
+
+    monkeypatch.setattr(lifecycle, "COOKBOOK_STATE_FILE", str(state_path))
+    monkeypatch.setattr(lifecycle, "_stop_serve", fake_stop_serve)
+    monkeypatch.setattr(lifecycle, "_delete_endpoint_for_task", fake_delete_endpoint)
+
+    await lifecycle._tick()
+
+    tasks = {
+        task["id"]: task
+        for task in json.loads(state_path.read_text(encoding="utf-8"))["tasks"]
+    }
+    assert tasks["stop-succeeds"]["status"] == "stopped"
+    assert tasks["stop-succeeds"]["_scheduledStopAtMs"] is None
+    assert tasks["stop-fails"]["status"] == "running"
+    assert tasks["stop-fails"]["_scheduledStopAtMs"] == 0


### PR DESCRIPTION
## Linked Issue

Fixes #4268

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests only
- [ ] Other

## Summary

The scheduled-stop lifecycle tick was marking every expired serve as stopped during the persistence pass, even when `_stop_serve()` returned `False`.

That meant failed stop attempts could lose their `_scheduledStopAtMs` timestamp and no longer be retried.

This patch tracks only the session IDs that actually stop successfully, and applies the fresh-state stopped mutation only to that subset.

## How to Test

Run the focused regression test:

    uv run --isolated --with-requirements requirements.txt pytest -q tests/test_cookbook_serve_lifecycle.py

Run syntax and diff checks:

    python3 -m py_compile src/cookbook_serve_lifecycle.py tests/test_cookbook_serve_lifecycle.py
    git diff --check

The regression test covers two expired serves in one lifecycle tick:

- one stop succeeds and is persisted as `stopped`;
- one stop fails and remains `running` with `_scheduledStopAtMs` intact, so it can be retried.

## Checklist

- [x] I searched existing issues and PRs for duplicates.
- [x] I kept the change narrowly scoped.
- [x] I added or updated tests.
- [x] I ran the relevant tests locally.