### PR TITLE
test(models): expect /v1/models for path-less lookalike hosts

### DIFF
--- a/tests/test_provider_detection.py
+++ b/tests/test_provider_detection.py
@@ -107,7 +107,10 @@ class TestBuildersRejectLookalikeHosts:
         assert build_chat_url("https://notanthropic.com") == "https://notanthropic.com/chat/completions"
 
     def test_lookalike_anthropic_models_is_openai(self):
-        assert build_models_url("https://anthropic.com.evil.com") == "https://anthropic.com.evil.com/models"
+        # Must hit the generic OpenAI branch, not Anthropic — assert the
+        # provider directly since both branches now end in /v1/models.
+        assert llm_core._detect_provider("https://anthropic.com.evil.com") == "openai"
+        assert build_models_url("https://anthropic.com.evil.com") == "https://anthropic.com.evil.com/v1/models"
 
     def test_anthropic_domain_in_path_is_openai(self):
         assert build_chat_url("https://myproxy.internal/anthropic.com/v1") == "https://myproxy.internal/anthropic.com/v1/chat/completions"
@@ -119,7 +122,9 @@ class TestBuildersRejectLookalikeHosts:
         assert build_chat_url("https://notollama.com") == "https://notollama.com/chat/completions"
 
     def test_lookalike_ollama_models_is_openai(self):
-        assert build_models_url("https://notollama.com") == "https://notollama.com/models"
+        # Must hit the generic OpenAI branch, not Ollama.
+        assert llm_core._detect_provider("https://notollama.com") == "openai"
+        assert build_models_url("https://notollama.com") == "https://notollama.com/v1/models"
 
 
 class TestBuildersLocalAndDockerEndpoints:


### PR DESCRIPTION
## Summary

`dev` is currently red on the `Python tests (pytest)` gate, which means every open PR shows a red suite. The cause is #4159 (`4b0a977`), which intentionally taught `build_models_url` to insert `/v1` for path-less bases so LM Studio / vLLM / llama.cpp probe `/v1/models`. Two assertions in `TestBuildersRejectLookalikeHosts` still pinned the old `/models` for path-less lookalike hosts, so they began failing:

```
build_models_url("https://anthropic.com.evil.com")  ->  ".../v1/models"   (test expected ".../models")
build_models_url("https://notollama.com")           ->  ".../v1/models"   (test expected ".../models")
```

This updates both assertions to `/v1/models` so they track #4159's deliberate behaviour. The point these tests actually guard — a lookalike host is routed to the generic OpenAI branch, not mistaken for real Anthropic/Ollama — is unchanged (provider detection still returns `openai`); only the path-less URL suffix moved. Test-only change, no production code touched.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4271

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. *(Test-only change — verified by running the affected suites: `test_provider_detection.py`, `test_provider_endpoints.py`, `test_endpoint_resolver.py`, `test_lmstudio_models_url.py`, `test_model_routes.py` → 262 passed, including the two that were failing.)*

## How to Test

1. On `dev` (`2966ad6`): `python -m pytest tests/test_provider_detection.py::TestBuildersRejectLookalikeHosts -q` → 2 failed.
2. Check out this branch and run the same command → all pass.
3. Sanity-check nothing else regressed: `python -m pytest tests/test_provider_detection.py tests/test_provider_endpoints.py tests/test_endpoint_resolver.py -q` → all green.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual or UI changes — this only edits two assertions in `tests/test_provider_detection.py`. Nothing under `static/` is touched.
