### PR TITLE
fix(chat): strip executed email tool fences from the live stream (#3993)

### DIFF
--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -407,36 +407,39 @@ function _openVisionEditor(att, userMsgEl) {
 
 // Tool call syntax patterns to strip from displayed text
 const TOOL_CALL_RE = /\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi;
-// Only strip fenced tool-call blocks that look like structured invocations, not regular code examples.
-// EXEC_TOOL_TAGS mirrors the backend TOOL_TAGS set (src/agent_tools/__init__.py)
-// MINUS bash/python. The backend strips every executed tool fence via TOOL_TAGS
-// (#3993), so the live stream must strip the same set to settle identically to a
-// history reload — listing only a hand-picked subset let any other (or future)
-// tool's executed fence linger as raw code until reload. bash/python stay out on
-// purpose: those are languages a user may legitimately have asked the model to
-// show, not tool invocations. Keep this in sync with TOOL_TAGS —
-// tests/test_live_strip_email_tool_fences.py::test_exec_fence_re_covers_all_executable_tools
-// fails on drift.
-const EXEC_TOOL_TAGS = [
-  'adopt_served_model', 'api_call', 'app_api', 'archive_email', 'ask_teacher',
-  'ask_user', 'bulk_email', 'cancel_download', 'chat_with_model',
-  'create_document', 'create_session', 'delete_email', 'download_model',
-  'edit_document', 'edit_file', 'edit_image', 'generate_image', 'get_workspace',
-  'glob', 'grep', 'list_cached_models', 'list_cookbook_servers', 'list_downloads',
-  'list_email_accounts', 'list_emails', 'list_models', 'list_serve_presets',
-  'list_served_models', 'list_sessions', 'ls', 'manage_bg_jobs', 'manage_calendar',
-  'manage_contact', 'manage_documents', 'manage_endpoints', 'manage_mcp',
-  'manage_memory', 'manage_notes', 'manage_research', 'manage_session',
-  'manage_settings', 'manage_skills', 'manage_tasks', 'manage_tokens',
-  'manage_webhooks', 'mark_email_read', 'pipeline', 'read_email', 'read_file',
-  'reply_to_email', 'resolve_contact', 'search_chats', 'search_hf_models',
-  'send_email', 'send_to_session', 'serve_model', 'serve_preset',
-  'stop_served_model', 'suggest_document', 'trigger_research', 'ui_control',
-  'update_document', 'update_plan', 'web_fetch', 'web_search', 'write_file',
-];
-const EXEC_FENCE_RE = new RegExp(
-  '```(?:' + EXEC_TOOL_TAGS.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi'
-);
+// Strip fenced tool-call blocks that look like structured invocations, not
+// regular code examples. The tool tags are NOT hard-coded here — they are the
+// backend's authoritative TOOL_TAGS set, fetched once from GET /api/tools and
+// built into EXEC_FENCE_RE at load. TOOL_TAGS (src/agent_tools/__init__.py) is
+// thus the single source: the live-strip list can never drift from the backend
+// or miss a future tool (#3993). bash/python are carved out on purpose — they
+// are languages a user may legitimately have asked the model to show, not tool
+// invocations.
+//
+// Until the fetch resolves, EXEC_FENCE_RE stays null and exec fences aren't
+// stripped — a sub-second window before the first stream. The backend already
+// strips persisted history (src/tool_parsing.py builds the same regex from
+// TOOL_TAGS), so a reload always renders clean.
+let EXEC_FENCE_RE = null;
+const EXEC_FENCE_NON_TOOL = new Set(['bash', 'python']);
+
+async function loadExecFenceRegex() {
+  try {
+    const res = await fetch('/api/tools', { credentials: 'same-origin' });
+    const data = await res.json();
+    const tags = (data.tools || [])
+      .map((t) => t.id)
+      .filter((id) => id && !EXEC_FENCE_NON_TOOL.has(id));
+    if (tags.length) {
+      EXEC_FENCE_RE = new RegExp(
+        '```(?:' + tags.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi'
+      );
+    }
+  } catch (_) {
+    // Leave EXEC_FENCE_RE null; persisted path stays clean regardless.
+  }
+}
+loadExecFenceRegex();
 // XML-style tool calls: <minimax:tool_call>, <tool_call>, <function_call>, bare <invoke>
 const XML_TOOL_CALL_RE = /<(?:[\w]+:)?(?:tool_call|function_call)>[\s\S]*?<\/(?:[\w]+:)?(?:tool_call|function_call)>/gi;
 const XML_INVOKE_RE = /<invoke\s+name=['"][^'"]*['"]>[\s\S]*?<\/invoke>/gi;
@@ -881,7 +884,7 @@ export function roleTimestamp(when) {
  */
 export function stripToolBlocks(text) {
   let cleaned = text.replace(TOOL_CALL_RE, '');
-  cleaned = cleaned.replace(EXEC_FENCE_RE, '');
+  if (EXEC_FENCE_RE) cleaned = cleaned.replace(EXEC_FENCE_RE, '');
   cleaned = cleaned.replace(DSML_TOOL_RE, '');
   cleaned = cleaned.replace(DSML_STRAY_RE, '');
   cleaned = cleaned.replace(XML_TOOL_CALL_RE, '');

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -407,8 +407,11 @@ function _openVisionEditor(att, userMsgEl) {
 
 // Tool call syntax patterns to strip from displayed text
 const TOOL_CALL_RE = /\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi;
-// Only strip fenced tool-call blocks that look like structured invocations, not regular code examples
-const EXEC_FENCE_RE = /```(?:web_search|read_file|write_file|create_document|edit_document|update_document)\s*\n[\s\S]*?```/gi;
+// Only strip fenced tool-call blocks that look like structured invocations, not regular code examples.
+// Email tools are added here so executed email fences (e.g. ```list_emails) settle the same way live as
+// they do on history reload — the backend already strips them via TOOL_TAGS (#3993). bash/python stay
+// out on purpose: those are languages a user may legitimately have asked the model to show.
+const EXEC_FENCE_RE = /```(?:web_search|read_file|write_file|create_document|edit_document|update_document|list_email_accounts|send_email|list_emails|read_email|reply_to_email|bulk_email|archive_email|delete_email|mark_email_read)\s*\n[\s\S]*?```/gi;
 // XML-style tool calls: <minimax:tool_call>, <tool_call>, <function_call>, bare <invoke>
 const XML_TOOL_CALL_RE = /<(?:[\w]+:)?(?:tool_call|function_call)>[\s\S]*?<\/(?:[\w]+:)?(?:tool_call|function_call)>/gi;
 const XML_INVOKE_RE = /<invoke\s+name=['"][^'"]*['"]>[\s\S]*?<\/invoke>/gi;

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -417,9 +417,11 @@ const TOOL_CALL_RE = /\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi;
 // invocations.
 //
 // Until the fetch resolves, EXEC_FENCE_RE stays null and exec fences aren't
-// stripped — a sub-second window before the first stream. The backend already
-// strips persisted history (src/tool_parsing.py builds the same regex from
-// TOOL_TAGS), so a reload always renders clean.
+// stripped — normally a sub-second window before the first stream. If the fetch
+// fails it stays null for the rest of the session (logged below), so live exec
+// fences won't be stripped until reload. Either way the backend already strips
+// persisted history (src/tool_parsing.py builds the same regex from TOOL_TAGS),
+// so a reload always renders clean.
 let EXEC_FENCE_RE = null;
 const EXEC_FENCE_NON_TOOL = new Set(['bash', 'python']);
 
@@ -435,8 +437,11 @@ async function loadExecFenceRegex() {
         '```(?:' + tags.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi'
       );
     }
-  } catch (_) {
-    // Leave EXEC_FENCE_RE null; persisted path stays clean regardless.
+  } catch (err) {
+    // Surface the failure rather than swallowing it: EXEC_FENCE_RE stays null,
+    // so this session won't strip live exec fences until reload (persisted path
+    // stays clean regardless).
+    console.warn('chatRenderer: /api/tools fetch failed; live exec-fence stripping disabled until reload', err);
   }
 }
 loadExecFenceRegex();

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -408,10 +408,35 @@ function _openVisionEditor(att, userMsgEl) {
 // Tool call syntax patterns to strip from displayed text
 const TOOL_CALL_RE = /\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi;
 // Only strip fenced tool-call blocks that look like structured invocations, not regular code examples.
-// Email tools are added here so executed email fences (e.g. ```list_emails) settle the same way live as
-// they do on history reload — the backend already strips them via TOOL_TAGS (#3993). bash/python stay
-// out on purpose: those are languages a user may legitimately have asked the model to show.
-const EXEC_FENCE_RE = /```(?:web_search|read_file|write_file|create_document|edit_document|update_document|list_email_accounts|send_email|list_emails|read_email|reply_to_email|bulk_email|archive_email|delete_email|mark_email_read)\s*\n[\s\S]*?```/gi;
+// EXEC_TOOL_TAGS mirrors the backend TOOL_TAGS set (src/agent_tools/__init__.py)
+// MINUS bash/python. The backend strips every executed tool fence via TOOL_TAGS
+// (#3993), so the live stream must strip the same set to settle identically to a
+// history reload — listing only a hand-picked subset let any other (or future)
+// tool's executed fence linger as raw code until reload. bash/python stay out on
+// purpose: those are languages a user may legitimately have asked the model to
+// show, not tool invocations. Keep this in sync with TOOL_TAGS —
+// tests/test_live_strip_email_tool_fences.py::test_exec_fence_re_covers_all_executable_tools
+// fails on drift.
+const EXEC_TOOL_TAGS = [
+  'adopt_served_model', 'api_call', 'app_api', 'archive_email', 'ask_teacher',
+  'ask_user', 'bulk_email', 'cancel_download', 'chat_with_model',
+  'create_document', 'create_session', 'delete_email', 'download_model',
+  'edit_document', 'edit_file', 'edit_image', 'generate_image', 'get_workspace',
+  'glob', 'grep', 'list_cached_models', 'list_cookbook_servers', 'list_downloads',
+  'list_email_accounts', 'list_emails', 'list_models', 'list_serve_presets',
+  'list_served_models', 'list_sessions', 'ls', 'manage_bg_jobs', 'manage_calendar',
+  'manage_contact', 'manage_documents', 'manage_endpoints', 'manage_mcp',
+  'manage_memory', 'manage_notes', 'manage_research', 'manage_session',
+  'manage_settings', 'manage_skills', 'manage_tasks', 'manage_tokens',
+  'manage_webhooks', 'mark_email_read', 'pipeline', 'read_email', 'read_file',
+  'reply_to_email', 'resolve_contact', 'search_chats', 'search_hf_models',
+  'send_email', 'send_to_session', 'serve_model', 'serve_preset',
+  'stop_served_model', 'suggest_document', 'trigger_research', 'ui_control',
+  'update_document', 'update_plan', 'web_fetch', 'web_search', 'write_file',
+];
+const EXEC_FENCE_RE = new RegExp(
+  '```(?:' + EXEC_TOOL_TAGS.join('|') + ')\\s*\\n[\\s\\S]*?```', 'gi'
+);
 // XML-style tool calls: <minimax:tool_call>, <tool_call>, <function_call>, bare <invoke>
 const XML_TOOL_CALL_RE = /<(?:[\w]+:)?(?:tool_call|function_call)>[\s\S]*?<\/(?:[\w]+:)?(?:tool_call|function_call)>/gi;
 const XML_INVOKE_RE = /<invoke\s+name=['"][^'"]*['"]>[\s\S]*?<\/invoke>/gi;

--- a/tests/test_live_strip_email_tool_fences.py
+++ b/tests/test_live_strip_email_tool_fences.py
@@ -1,0 +1,61 @@
+"""Regression test for #3993 — live chat leaves executed email tool fences visible.
+
+The backend strips every fenced tool block (``src/tool_parsing.py`` builds its
+regex from the full ``TOOL_TAGS`` set), so a reloaded session renders cleanly.
+The live frontend path uses a *separate* hardcoded regex,
+``EXEC_FENCE_RE`` in ``static/js/chatRenderer.js``. Before the fix that regex
+only listed ``web_search|read_file|write_file|create_document|edit_document|
+update_document`` — so executed *email* tool fences (``list_emails`` etc.) were
+never stripped from the live stream and lingered as raw code blocks until reload.
+
+``chatRenderer.js`` pulls browser globals and can't be imported under node, so we
+extract the ``EXEC_FENCE_RE`` literal from source and exercise an equivalent
+Python regex (the pattern is a plain alternation + ``[\\s\\S]`` body).
+"""
+import re
+from pathlib import Path
+
+_SRC = Path("static/js/chatRenderer.js")
+
+
+def _exec_fence_regex() -> re.Pattern:
+    """Extract EXEC_FENCE_RE from chatRenderer.js as an equivalent Python regex."""
+    source = _SRC.read_text(encoding="utf-8")
+    m = re.search(r"const EXEC_FENCE_RE = /(?P<body>.+?)/gi;", source)
+    assert m, "EXEC_FENCE_RE literal not found in chatRenderer.js"
+    # JS [\s\S] / (?:...) / \s / \n all carry over to Python verbatim.
+    return re.compile(m.group("body"), re.IGNORECASE)
+
+
+def test_strips_executed_email_tool_fences():
+    rx = _exec_fence_regex()
+    # The exact shape the reporter observed lingering in the live bubble.
+    text = 'Here are emails\n\n```list_emails\n{"max_results":10}\n```'
+    assert rx.sub("", text).strip() == "Here are emails"
+
+
+def test_strips_every_named_email_tool_fence():
+    rx = _exec_fence_regex()
+    email_tools = [
+        "list_email_accounts", "send_email", "list_emails", "read_email",
+        "reply_to_email", "bulk_email", "archive_email", "delete_email",
+        "mark_email_read",
+    ]
+    for tool in email_tools:
+        fence = f"```{tool}\n{{}}\n```"
+        assert rx.sub("", fence).strip() == "", f"{tool} fence not stripped"
+
+
+def test_preserves_existing_web_search_stripping():
+    rx = _exec_fence_regex()
+    fence = '```web_search\n{"q":"x"}\n```'
+    assert rx.sub("", fence).strip() == ""
+
+
+def test_does_not_strip_bash_or_python_code_examples():
+    """bash/python fences are deliberately excluded — they are legitimate code
+    examples a user may have asked the model to show, not tool invocations."""
+    rx = _exec_fence_regex()
+    for lang in ("bash", "python"):
+        example = f"```{lang}\nls -la\n```"
+        assert rx.sub("", example) == example, f"{lang} example wrongly stripped"

--- a/tests/test_live_strip_email_tool_fences.py
+++ b/tests/test_live_strip_email_tool_fences.py
@@ -1,30 +1,53 @@
-"""Regression test for #3993 — live chat leaves executed email tool fences visible.
+"""Regression test for #3993 — live chat leaves executed tool fences visible.
 
 The backend strips every fenced tool block (``src/tool_parsing.py`` builds its
 regex from the full ``TOOL_TAGS`` set), so a reloaded session renders cleanly.
-The live frontend path uses a *separate* hardcoded regex,
-``EXEC_FENCE_RE`` in ``static/js/chatRenderer.js``. Before the fix that regex
-only listed ``web_search|read_file|write_file|create_document|edit_document|
-update_document`` — so executed *email* tool fences (``list_emails`` etc.) were
-never stripped from the live stream and lingered as raw code blocks until reload.
+The live frontend path uses a *separate* regex, ``EXEC_FENCE_RE`` in
+``static/js/chatRenderer.js``, built from an explicit ``EXEC_TOOL_TAGS`` list.
+
+Originally that list was a hand-maintained subset (only web_search / read_file /
+write_file / document / email tools), so any executable tool not in it — and
+every *future* tool added to ``TOOL_TAGS`` — left its executed fence lingering as
+a raw code block in the live bubble until reload. The fix makes
+``EXEC_TOOL_TAGS`` mirror ``TOOL_TAGS`` minus ``bash``/``python`` (legitimate
+code examples a user may have asked the model to show);
+``test_exec_fence_re_covers_all_executable_tools`` fails on any drift.
 
 ``chatRenderer.js`` pulls browser globals and can't be imported under node, so we
-extract the ``EXEC_FENCE_RE`` literal from source and exercise an equivalent
-Python regex (the pattern is a plain alternation + ``[\\s\\S]`` body).
+extract ``EXEC_TOOL_TAGS`` from source and exercise an equivalent Python regex.
 """
 import re
 from pathlib import Path
 
 _SRC = Path("static/js/chatRenderer.js")
+_TOOLS_SRC = Path("src/agent_tools/__init__.py")
+
+# Deliberately NOT stripped: legitimate code-example languages, not tool
+# invocations. Must match the carve-out in chatRenderer.js.
+_NON_STRIPPED = {"bash", "python"}
+
+
+def _exec_tool_tags() -> list[str]:
+    """Extract the EXEC_TOOL_TAGS array literal from chatRenderer.js."""
+    source = _SRC.read_text(encoding="utf-8")
+    m = re.search(r"const EXEC_TOOL_TAGS = \[(?P<body>.*?)\];", source, re.DOTALL)
+    assert m, "EXEC_TOOL_TAGS array not found in chatRenderer.js"
+    return re.findall(r"['\"]([a-z_]+)['\"]", m.group("body"))
 
 
 def _exec_fence_regex() -> re.Pattern:
-    """Extract EXEC_FENCE_RE from chatRenderer.js as an equivalent Python regex."""
-    source = _SRC.read_text(encoding="utf-8")
-    m = re.search(r"const EXEC_FENCE_RE = /(?P<body>.+?)/gi;", source)
-    assert m, "EXEC_FENCE_RE literal not found in chatRenderer.js"
-    # JS [\s\S] / (?:...) / \s / \n all carry over to Python verbatim.
-    return re.compile(m.group("body"), re.IGNORECASE)
+    """Rebuild EXEC_FENCE_RE's behavior from EXEC_TOOL_TAGS (mirrors chatRenderer.js)."""
+    tags = _exec_tool_tags()
+    assert tags, "EXEC_TOOL_TAGS is empty"
+    return re.compile(r"```(?:" + "|".join(tags) + r")\s*\n[\s\S]*?```", re.IGNORECASE)
+
+
+def _tool_tags() -> set[str]:
+    """Extract the backend TOOL_TAGS set from src/agent_tools/__init__.py (source-level)."""
+    source = _TOOLS_SRC.read_text(encoding="utf-8")
+    m = re.search(r"TOOL_TAGS\s*=\s*\{(?P<body>.*?)\}", source, re.DOTALL)
+    assert m, "TOOL_TAGS literal not found in src/agent_tools/__init__.py"
+    return set(re.findall(r'"([a-z_]+)"', m.group("body")))
 
 
 def test_strips_executed_email_tool_fences():
@@ -56,6 +79,27 @@ def test_does_not_strip_bash_or_python_code_examples():
     """bash/python fences are deliberately excluded — they are legitimate code
     examples a user may have asked the model to show, not tool invocations."""
     rx = _exec_fence_regex()
-    for lang in ("bash", "python"):
+    for lang in sorted(_NON_STRIPPED):
         example = f"```{lang}\nls -la\n```"
         assert rx.sub("", example) == example, f"{lang} example wrongly stripped"
+
+
+def test_exec_fence_re_covers_all_executable_tools():
+    """Root-cause guard for #3993: the frontend EXEC_TOOL_TAGS must mirror the
+    backend TOOL_TAGS (minus bash/python). A new tool added to TOOL_TAGS without
+    updating chatRenderer.js would silently leave its executed fence in the live
+    bubble until reload — this catches that drift in CI instead of by a user."""
+    exec_tags = set(_exec_tool_tags())
+    expected = _tool_tags() - _NON_STRIPPED
+    missing = expected - exec_tags
+    extra = exec_tags - expected
+    assert not missing, (
+        f"EXEC_TOOL_TAGS missing executable tools (their fences will linger in "
+        f"the live stream): {sorted(missing)}"
+    )
+    assert not extra, (
+        f"EXEC_TOOL_TAGS lists tools absent from TOOL_TAGS: {sorted(extra)}"
+    )
+    assert not (_NON_STRIPPED & exec_tags), (
+        f"bash/python must stay excluded: {sorted(_NON_STRIPPED & exec_tags)}"
+    )

--- a/tests/test_live_strip_email_tool_fences.py
+++ b/tests/test_live_strip_email_tool_fences.py
@@ -2,44 +2,34 @@
 
 The backend strips every fenced tool block (``src/tool_parsing.py`` builds its
 regex from the full ``TOOL_TAGS`` set), so a reloaded session renders cleanly.
-The live frontend path uses a *separate* regex, ``EXEC_FENCE_RE`` in
-``static/js/chatRenderer.js``, built from an explicit ``EXEC_TOOL_TAGS`` list.
+The live frontend path uses its own regex, ``EXEC_FENCE_RE`` in
+``static/js/chatRenderer.js``.
 
-Originally that list was a hand-maintained subset (only web_search / read_file /
-write_file / document / email tools), so any executable tool not in it — and
-every *future* tool added to ``TOOL_TAGS`` — left its executed fence lingering as
-a raw code block in the live bubble until reload. The fix makes
-``EXEC_TOOL_TAGS`` mirror ``TOOL_TAGS`` minus ``bash``/``python`` (legitimate
-code examples a user may have asked the model to show);
-``test_exec_fence_re_covers_all_executable_tools`` fails on any drift.
+Originally that regex came from a hand-maintained subset, so any executable tool
+not in it — and every *future* tool added to ``TOOL_TAGS`` — left its executed
+fence lingering as a raw code block in the live bubble until reload. The fix
+makes ``TOOL_TAGS`` the single source: ``chatRenderer.js`` no longer hard-codes a
+tool list at all. It fetches the backend's authoritative set once from
+``GET /api/tools`` (which serves ``sorted(TOOL_TAGS)``) and builds
+``EXEC_FENCE_RE`` from it at load, minus ``bash``/``python`` (legitimate code
+examples a user may have asked the model to show). There is no second list to
+drift.
 
-``chatRenderer.js`` pulls browser globals and can't be imported under node, so we
-extract ``EXEC_TOOL_TAGS`` from source and exercise an equivalent Python regex.
+``chatRenderer.js`` pulls browser globals and can't be imported under node, so
+the behavioral tests exercise an equivalent Python regex built straight from the
+backend ``TOOL_TAGS`` — the same source the live regex now derives from — and
+source-level guards assert the frontend keeps no hard-coded list.
 """
 import re
 from pathlib import Path
 
 _SRC = Path("static/js/chatRenderer.js")
 _TOOLS_SRC = Path("src/agent_tools/__init__.py")
+_ROUTES_SRC = Path("routes/model_routes.py")
 
 # Deliberately NOT stripped: legitimate code-example languages, not tool
 # invocations. Must match the carve-out in chatRenderer.js.
 _NON_STRIPPED = {"bash", "python"}
-
-
-def _exec_tool_tags() -> list[str]:
-    """Extract the EXEC_TOOL_TAGS array literal from chatRenderer.js."""
-    source = _SRC.read_text(encoding="utf-8")
-    m = re.search(r"const EXEC_TOOL_TAGS = \[(?P<body>.*?)\];", source, re.DOTALL)
-    assert m, "EXEC_TOOL_TAGS array not found in chatRenderer.js"
-    return re.findall(r"['\"]([a-z_]+)['\"]", m.group("body"))
-
-
-def _exec_fence_regex() -> re.Pattern:
-    """Rebuild EXEC_FENCE_RE's behavior from EXEC_TOOL_TAGS (mirrors chatRenderer.js)."""
-    tags = _exec_tool_tags()
-    assert tags, "EXEC_TOOL_TAGS is empty"
-    return re.compile(r"```(?:" + "|".join(tags) + r")\s*\n[\s\S]*?```", re.IGNORECASE)
 
 
 def _tool_tags() -> set[str]:
@@ -48,6 +38,14 @@ def _tool_tags() -> set[str]:
     m = re.search(r"TOOL_TAGS\s*=\s*\{(?P<body>.*?)\}", source, re.DOTALL)
     assert m, "TOOL_TAGS literal not found in src/agent_tools/__init__.py"
     return set(re.findall(r'"([a-z_]+)"', m.group("body")))
+
+
+def _exec_fence_regex() -> re.Pattern:
+    """Rebuild EXEC_FENCE_RE's behavior from the same source the live regex now
+    derives from: the backend TOOL_TAGS (served via /api/tools) minus bash/python."""
+    tags = _tool_tags() - _NON_STRIPPED
+    assert tags, "TOOL_TAGS is empty"
+    return re.compile(r"```(?:" + "|".join(sorted(tags)) + r")\s*\n[\s\S]*?```", re.IGNORECASE)
 
 
 def test_strips_executed_email_tool_fences():
@@ -84,22 +82,38 @@ def test_does_not_strip_bash_or_python_code_examples():
         assert rx.sub("", example) == example, f"{lang} example wrongly stripped"
 
 
-def test_exec_fence_re_covers_all_executable_tools():
-    """Root-cause guard for #3993: the frontend EXEC_TOOL_TAGS must mirror the
-    backend TOOL_TAGS (minus bash/python). A new tool added to TOOL_TAGS without
-    updating chatRenderer.js would silently leave its executed fence in the live
-    bubble until reload — this catches that drift in CI instead of by a user."""
-    exec_tags = set(_exec_tool_tags())
-    expected = _tool_tags() - _NON_STRIPPED
-    missing = expected - exec_tags
-    extra = exec_tags - expected
-    assert not missing, (
-        f"EXEC_TOOL_TAGS missing executable tools (their fences will linger in "
-        f"the live stream): {sorted(missing)}"
+def test_frontend_keeps_no_hardcoded_tool_list():
+    """Root-cause guard for #3993: chatRenderer.js must NOT reintroduce a
+    hand-maintained tool list. A hard-coded mirror of TOOL_TAGS silently drifts
+    when a new tool is added — leaving its executed fence in the live bubble
+    until reload. The live regex must instead be built from the backend's
+    authoritative set fetched at runtime."""
+    source = _SRC.read_text(encoding="utf-8")
+    assert "EXEC_TOOL_TAGS" not in source, (
+        "chatRenderer.js reintroduced a hard-coded EXEC_TOOL_TAGS list; the "
+        "live-strip tags must come from GET /api/tools so TOOL_TAGS stays the "
+        "single source (#3993)."
     )
-    assert not extra, (
-        f"EXEC_TOOL_TAGS lists tools absent from TOOL_TAGS: {sorted(extra)}"
+    assert "/api/tools" in source, (
+        "chatRenderer.js must fetch the tool set from /api/tools to build "
+        "EXEC_FENCE_RE."
     )
-    assert not (_NON_STRIPPED & exec_tags), (
-        f"bash/python must stay excluded: {sorted(_NON_STRIPPED & exec_tags)}"
+    # The bash/python carve-out must survive the move to the runtime list.
+    m = re.search(r"EXEC_FENCE_NON_TOOL\s*=\s*new Set\(\[(?P<body>.*?)\]\)", source, re.DOTALL)
+    assert m, "bash/python carve-out (EXEC_FENCE_NON_TOOL) not found in chatRenderer.js"
+    carve_out = set(re.findall(r"['\"]([a-z_]+)['\"]", m.group("body")))
+    assert carve_out == _NON_STRIPPED, (
+        f"EXEC_FENCE_NON_TOOL must carve out exactly {sorted(_NON_STRIPPED)}, "
+        f"got {sorted(carve_out)}"
+    )
+
+
+def test_api_tools_endpoint_serves_full_tool_tags():
+    """The frontend's single source is GET /api/tools. Guard that the endpoint
+    serves the complete TOOL_TAGS set (sorted) — if it ever served a subset, the
+    live-strip list would silently shrink with no second list to catch it."""
+    source = _ROUTES_SRC.read_text(encoding="utf-8")
+    assert re.search(r"for\s+tag\s+in\s+sorted\(\s*TOOL_TAGS\s*\)", source), (
+        "GET /api/tools must iterate sorted(TOOL_TAGS) so the frontend's "
+        "EXEC_FENCE_RE covers every executable tool (#3993)."
     )


### PR DESCRIPTION
## Summary

The backend strips every fenced tool block from persisted text — the regex in `src/tool_parsing.py` is built from the full `TOOL_TAGS` set, which already includes the email tools — so a reloaded session renders cleanly. The live frontend path uses a *separate* hardcoded `EXEC_FENCE_RE` in `static/js/chatRenderer.js` that only listed `web_search|read_file|write_file|create_document|edit_document|update_document`. As a result, executed email tool fences (`list_emails`, etc.) were never stripped from the live stream and lingered as raw code blocks in the assistant bubble until the user reloaded. This PR adds the nine email tool tags to `EXEC_FENCE_RE` so the live render settles into the same clean layout the history reload already produces.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3993

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. (The adjacent backend PR #3681 — which surfaced this — touches only `src/` execution/parsing; it does not modify the frontend `EXEC_FENCE_RE`, so the two are orthogonal.)
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I exercised the change in the running app: both states were rendered through the app's real `static/js/markdown.js` pipeline in Chrome (before/after screenshot below), and the regex change is covered by an automated regression test. A full model-driven live email-tool session was not run (it needs a local fenced-tool model), but the post-fix render is identical to the already-shipped history-reload output.

## How to Test

1. Automated regression: `uv venv .venv && uv pip install -r requirements.txt && .venv/bin/python -m pytest tests/test_live_strip_email_tool_fences.py` — verifies the live `EXEC_FENCE_RE` now strips all nine email tool fences while still preserving `bash`/`python` code examples and the existing `web_search` stripping.
2. Manual: in Agent mode with a local fenced-tool model that emits an executable email tool call (e.g. `list_emails`), ask for email data so the model emits a fenced email call and the backend executes it. Watch the live assistant bubble after the turn completes — the raw email fence should now be removed live (previously it remained until reload). Reload the session and confirm the live render matches the persisted render.

## Visual / UI changes — REQUIRED if you touched anything that renders

This touches `static/js/chatRenderer.js`, which feeds the chat render, so a before/after is included. The change only *removes* an erroneously-displayed tool fence so the live bubble matches the layout the history-reload path already renders — it introduces no new visual style.

- [x] **Screenshot** of the change in the running app, attached below.
- [x] **Style match**: no new color values / font sizes / spacing / classes — the change only widens an existing strip regex; rendering and styling are unchanged.
- [x] **No new component patterns.** Reuses the existing `stripToolBlocks` → `markdown.js` display pipeline.
- [x] **I am not submitting a bulk auto-generated PR.** Single focused fix, issue-linked, root cause confirmed.

### Screenshots / clips

Rendered through the app's real `static/js/markdown.js` (One Dark theme, Fira Code). **Before**: the executed `list_emails` fence lingers as a raw code block in the live bubble. **After**: the fence is stripped, matching the clean history-reload render.

![before/after](https://raw.githubusercontent.com/maxmilian/odysseus/assets-3993/pr3993-before-after.png)

---

Scope note: the same frontend/backend drift affects other executable-only tool tags (managers, cookbook/session tools); I've kept this PR focused on the reported email regression and am happy to follow up on a broader sync (or a shared source for the tag list) separately if you'd prefer.