### PR TITLE
test(email): cover sender signature owner cache writes

### DIFF
--- a/tests/test_builtin_actions_owner_scope.py
+++ b/tests/test_builtin_actions_owner_scope.py
@@ -1,5 +1,6 @@
 """Regression tests for owner-scoped model resolution in scheduled actions."""
 
+import sqlite3
 from datetime import datetime
 from types import SimpleNamespace
 
@@ -136,6 +137,108 @@ async def test_learn_sender_signatures_resolves_llm_for_task_owner(monkeypatch):
     assert message == "No LLM endpoint available"
     assert calls == [("utility", "alice"), ("default", "alice")]
     assert imap_owners == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_learn_sender_signatures_writes_owner_scoped_cache(monkeypatch, tmp_path):
+    from routes import email_helpers
+    from src import endpoint_resolver, llm_core
+    from src.builtin_actions import action_learn_sender_signatures
+
+    db_path = tmp_path / "scheduled_emails.db"
+    monkeypatch.setattr(email_helpers, "SCHEDULED_DB", db_path)
+    email_helpers._init_scheduled_db()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO sender_signatures
+            (from_address, owner, signature_text, sample_count, last_built_at, model_used, source)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "writer@example.com",
+                "bob",
+                "bob cached signature",
+                3,
+                "2999-01-01T00:00:00",
+                "old-model",
+                "llm",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    class FakeImap:
+        def select(self, *_args, **_kwargs):
+            return "OK", []
+
+        def search(self, *_args, **_kwargs):
+            return "OK", [b"1 2 3"]
+
+        def fetch(self, uid, query):
+            if "HEADER.FIELDS" in query:
+                return "OK", [(None, b"From: Writer <writer@example.com>\r\n\r\n")]
+            return "OK", [
+                (
+                    None,
+                    (
+                        b"Thanks for the update.\r\n\r\n"
+                        b"Regards,\r\n"
+                        b"Writer Example\r\n"
+                        b"Example Co.\r\n"
+                        + str(uid).encode()
+                    ),
+                )
+            ]
+
+        def logout(self):
+            return None
+
+    imap_owners = []
+
+    def fake_imap_connect(_account_id=None, owner=""):
+        imap_owners.append(owner)
+        return FakeImap()
+
+    monkeypatch.setattr(email_helpers, "_imap_connect", fake_imap_connect)
+    monkeypatch.setattr(
+        endpoint_resolver,
+        "resolve_endpoint",
+        lambda kind, *args, **kwargs: ("http://llm", "alice-model", {}),
+    )
+
+    async def fake_llm_call_async(**_kwargs):
+        return "Writer Example\nExample Co.\nwriter@example.com"
+
+    monkeypatch.setattr(llm_core, "llm_call_async", fake_llm_call_async)
+
+    message, ok = await action_learn_sender_signatures("alice")
+
+    assert ok is True
+    assert message.startswith("Learned sigs: 1 found")
+    assert imap_owners == ["alice", "alice"]
+
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT owner, signature_text, model_used
+            FROM sender_signatures
+            WHERE from_address = ?
+            ORDER BY owner
+            """,
+            ("writer@example.com",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [
+        ("alice", "Writer Example\nExample Co.\nwriter@example.com", "alice-model"),
+        ("bob", "bob cached signature", "old-model"),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Suggested title: test(email): cover sender signature owner cache writes -->

## Summary

Adds focused regression coverage for the learned sender-signature owner-scope fix from #3724. The test seeds a fresh signature row for one owner, runs `learn_sender_signatures` as another owner, and verifies the task still scans through that owner's IMAP connection and writes a separate cache row instead of reusing or replacing another owner's data.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3723

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Not run: this is a backend regression-test-only change with no UI or live IMAP dependency.

## How to Test

```bash
python -m py_compile tests/test_builtin_actions_owner_scope.py
python -m pytest tests/test_builtin_actions_owner_scope.py::test_learn_sender_signatures_resolves_llm_for_task_owner tests/test_builtin_actions_owner_scope.py::test_learn_sender_signatures_writes_owner_scoped_cache tests/test_email_owner_scope.py::test_sender_signature_cache_is_owner_scoped_and_migrates_legacy_rows tests/test_email_owner_scope.py::test_sender_signature_read_lookup_is_owner_scoped tests/test_email_owner_scope.py::test_sender_signature_clear_cache_keeps_other_owner_rows
```

Expected result: the focused owner-scope tests pass, and `py_compile` exits successfully.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - backend regression test only; no UI rendering changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: N/A - no UI rendering changed.
- [x] **No new component patterns.** N/A - no UI rendering changed.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused regression-test follow-up, not a bulk PR.

### Screenshots / clips

N/A - backend regression test only; no UI rendering changed.
