### PR TITLE
test(hwfit): cover SSH target validation regressions

### DIFF
--- a/tests/test_hwfit_remote_validation.py
+++ b/tests/test_hwfit_remote_validation.py
@@ -31,6 +31,24 @@ def test_hwfit_routes_reject_ssh_option_host(path, kwargs):
     assert exc.value.status_code == 400
 
 
+@pytest.mark.parametrize(
+    "path,kwargs",
+    [
+        ("/api/hwfit/system", {}),
+        ("/api/hwfit/models", {"limit": 1}),
+        ("/api/hwfit/profiles", {"model": "demo"}),
+        ("/api/hwfit/image-models", {}),
+    ],
+)
+def test_hwfit_routes_reject_invalid_ssh_port(path, kwargs):
+    endpoint = _endpoint(path)
+
+    with pytest.raises(HTTPException) as exc:
+        endpoint(host="alice@gpu-box", ssh_port="-oProxyCommand=sh", **kwargs)
+
+    assert exc.value.status_code == 400
+
+
 def test_hwfit_routes_reject_port_without_host():
     endpoint = _endpoint("/api/hwfit/system")
 
@@ -45,3 +63,36 @@ def test_ssh_argv_rejects_option_shaped_remote():
         _ssh_exec_argv("-oProxyCommand=sh", "22", remote_cmd="true")
     with pytest.raises(ValueError):
         _ssh_exec_argv("alice@-oProxyCommand=sh", "22", remote_cmd="true")
+
+
+def test_detect_system_option_host_never_starts_ssh(monkeypatch):
+    from core import platform_compat
+    from services.hwfit import hardware
+
+    calls = []
+
+    def _record_subprocess_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("ssh subprocess should not start")
+
+    monkeypatch.setattr(platform_compat.subprocess, "run", _record_subprocess_run)
+    hardware._cache_by_host.clear()
+
+    try:
+        result = hardware.detect_system(
+            host="-oProxyCommand=sh",
+            ssh_port="22",
+            platform="linux",
+            fresh=True,
+        )
+    finally:
+        hardware._cache_by_host.clear()
+        hardware._remote_host = None
+        hardware._remote_port = None
+        hardware._remote_platform = None
+
+    assert result == {
+        "error": "Cannot connect to -oProxyCommand=sh",
+        "host": "-oProxyCommand=sh",
+    }
+    assert calls == []


### PR DESCRIPTION
<!-- Suggested title: test(hwfit): cover SSH target validation regressions -->

## Summary

Adds focused regression coverage for the HW Fit SSH target validation fix from #3718. The tests keep every HW Fit remote-detection endpoint rejecting invalid `ssh_port` values before hardware detection runs, and they prove a direct `detect_system()` call with an option-shaped host cannot start an `ssh` subprocess through the shared SSH argv builder.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3717

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

Not run: this is backend-only regression coverage for rejected SSH target inputs. No UI, live remote host, or runtime rendering behavior changed.

## How to Test

```bash
python -m pytest tests/test_hwfit_remote_validation.py tests/test_route_validators.py tests/test_platform_compat.py
python -m py_compile routes/hwfit_routes.py routes/_validators.py services/hwfit/hardware.py core/platform_compat.py tests/test_hwfit_remote_validation.py
```

Expected result: the focused pytest selection passes, and `py_compile` exits successfully.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - backend regression test only; no UI rendering changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: N/A - no UI rendering changed.
- [x] **No new component patterns.** N/A - no UI rendering changed.
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused regression-test follow-up, not a bulk PR.

### Screenshots / clips

N/A - backend regression test only; no UI rendering changed.
