### PR TITLE
fix(cookbook): validate adopt host

### DIFF
--- a/routes/codex_routes.py
+++ b/routes/codex_routes.py
@@ -790,7 +790,7 @@ def setup_codex_routes(
         norm = dict(body or {})
         sess = (norm.get("tmux_session") or norm.get("session_id") or "").strip()
         model = (norm.get("model") or norm.get("repo_id") or "").strip()
-        host = (norm.get("host") or norm.get("remote_host") or "").strip()
+        host = validate_remote_host((norm.get("host") or norm.get("remote_host") or "").strip() or None) or ""
         port = norm.get("port") or 8000
         import re as _re
         if not sess or not _re.fullmatch(r"[a-zA-Z0-9_-]+", sess):

--- a/tests/test_codex_ssh_host_validation.py
+++ b/tests/test_codex_ssh_host_validation.py
@@ -7,10 +7,37 @@ in ``remoteHost`` would be injected into that command.
 These pin validation on the host/port before they reach the ssh string, matching
 the validators the rest of the cookbook routes already apply.
 """
+import asyncio
+
 import pytest
 from fastapi import HTTPException
+from starlette.requests import Request
 
 import routes.codex_routes as codex_routes
+
+
+def _route_endpoint(path: str, method: str):
+    router = codex_routes.setup_codex_routes()
+    for route in router.routes:
+        if route.path == path and method in route.methods:
+            return route.endpoint
+    raise AssertionError(f"{method} {path} route not found")
+
+
+def _launch_request() -> Request:
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/codex/cookbook/adopt",
+            "headers": [],
+            "state": {},
+        }
+    )
+    request.state.api_token = True
+    request.state.api_token_owner = "alice"
+    request.state.api_token_scopes = ["cookbook:launch"]
+    return request
 
 
 def test_rejects_remote_host_with_shell_metacharacters():
@@ -47,3 +74,26 @@ def test_default_ssh_port_omits_flag():
     )
     assert host == "box"
     assert port_flag == ""
+
+
+def test_adopt_rejects_ssh_option_host_before_shell(monkeypatch):
+    calls = []
+
+    async def fail_if_shell_runs(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise RuntimeError("shell should not run for invalid host")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", fail_if_shell_runs)
+
+    endpoint = _route_endpoint("/api/codex/cookbook/adopt", "POST")
+    body = {
+        "tmux_session": "serve_abc123",
+        "model": "org/model",
+        "host": "-oProxyCommand=sh",
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(endpoint(_launch_request(), body))
+
+    assert exc.value.status_code == 400
+    assert calls == []


### PR DESCRIPTION

## Summary

Validates the optional remote host in `/api/codex/cookbook/adopt` before the route builds its SSH session check. This keeps adopt aligned with the other Cookbook SSH paths and rejects invalid remote host values before any shell command is attempted.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4281

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
  - Related but not superseding: #4188 covered adjacent stored-task SSH host validation, while this PR covers the request-payload host used by the adopt route.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  - Not run: this is a route validation guard with focused regression coverage; no rendered UI files changed.

## How to Test

1. Run the focused route validation tests:

```bash
venv/bin/python -m pytest tests/test_codex_ssh_host_validation.py -q
```

2. Run a diff whitespace check:

```bash
git diff --check origin/dev..HEAD
```

3. Optional manual check in an auth-enabled setup:
   - Call `/api/codex/cookbook/adopt` with a valid local session and no remote host; expected: existing local behaviour is unchanged.
   - Call it with an invalid remote host; expected: HTTP 400 before any SSH command is attempted.

## Visual / UI changes - REQUIRED if you touched anything that renders

No rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused single-fix PR.

### Screenshots / clips

N/A - no rendered UI files changed.
