### PR TITLE
fix(gallery): confine replacement image paths

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -232,8 +232,6 @@ def setup_gallery_routes() -> APIRouter:
     @router.post("/api/gallery/{image_id}/replace")
     async def gallery_replace(request: Request, image_id: str):
         """Replace an existing gallery image file with a new one."""
-        from pathlib import Path
-
         user = get_current_user(request)
         db = SessionLocal()
         try:
@@ -249,9 +247,8 @@ def setup_gallery_routes() -> APIRouter:
                 raise HTTPException(400, "No image provided")
 
             content = await read_upload_limited(file, GALLERY_UPLOAD_MAX_BYTES, "Gallery replacement")
-            img_dir = Path(GENERATED_IMAGES_DIR)
-            img_dir.mkdir(parents=True, exist_ok=True)
-            img_path = img_dir / _sanitize_gallery_filename(img.filename)
+            GALLERY_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+            img_path = _gallery_image_path(img.filename)
             img_path.write_bytes(content)
 
             # Refresh dimensions in case the editor resized the canvas.

--- a/tests/test_gallery_filename_confinement.py
+++ b/tests/test_gallery_filename_confinement.py
@@ -2,7 +2,14 @@ import os
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+
+from core.database import Base, GalleryImage
 
 
 def _gallery_module():
@@ -51,6 +58,57 @@ def test_gallery_image_path_rejects_symlink_escape(tmp_path, monkeypatch):
         gallery_routes._gallery_image_path("escape.png")
 
     assert exc.value.status_code == 400
+
+
+def test_gallery_replace_rejects_symlink_escape(tmp_path, monkeypatch):
+    gallery_routes = _gallery_module()
+    image_dir = tmp_path / "generated_images"
+    image_dir.mkdir()
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"outside image root")
+    link = image_dir / "escape.png"
+    try:
+        os.symlink(outside, link)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'gallery.db'}",
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    try:
+        db.add(
+            GalleryImage(
+                id="img-1",
+                filename="escape.png",
+                prompt="escape",
+                owner="alice",
+                is_active=True,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    monkeypatch.setattr(gallery_routes, "GALLERY_IMAGE_DIR", image_dir)
+    monkeypatch.setattr(gallery_routes, "SessionLocal", SessionLocal)
+    monkeypatch.setattr(gallery_routes, "get_current_user", lambda request: "alice")
+
+    app = FastAPI()
+    app.include_router(gallery_routes.setup_gallery_routes())
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/gallery/img-1/replace",
+        files={"image": ("replacement.png", b"replacement bytes", "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert outside.read_bytes() == b"outside image root"
 
 
 def test_gallery_file_operations_use_confining_resolver():


### PR DESCRIPTION

## Summary

Routes gallery image replacement through the existing generated-image path resolver so replace now fails closed on stored filenames that resolve outside the image root. This keeps replace aligned with rotate, delete, ZIP export, and AI tag gallery file operations, and adds a focused endpoint regression for the symlink escape path.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Closes #4284

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
  - Related but not superseding: #2827 / #2828.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  - Not run: this is a backend path-confinement guard with focused endpoint regression coverage; no rendered UI files changed.

## How to Test

1. Run the focused gallery path-confinement tests:

```bash
venv/bin/python -m pytest tests/test_gallery_filename_confinement.py -q
```

2. Run a diff whitespace check:

```bash
git diff --check origin/dev..HEAD
```

3. Optional manual check from an authenticated session:
   - Replace a normal owned gallery image; expected: replacement still works.
   - Replace an owned image whose stored filename resolves outside the generated-image root; expected: HTTP 400 before writing replacement bytes.

## Visual / UI changes - REQUIRED if you touched anything that renders

No rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused single-fix PR.

### Screenshots / clips

N/A - no rendered UI files changed.
