### PR TITLE
fix(personal): resolve upload delete paths before unlinking

### DIFF
--- a/routes/personal_routes.py
+++ b/routes/personal_routes.py
@@ -278,8 +278,8 @@ def setup_personal_routes(personal_docs_manager, rag_manager, rag_available):
             # Delete file from disk if it's in uploads dir
             deleted_from_disk = False
             try:
-                abs_target = os.path.abspath(filepath)
-                base_abs = os.path.abspath(UPLOADS_DIR)
+                abs_target = os.path.realpath(filepath)
+                base_abs = os.path.realpath(UPLOADS_DIR)
                 in_uploads = (
                     abs_target == base_abs
                     or os.path.commonpath([abs_target, base_abs]) == base_abs

--- a/tests/test_personal_delete_file_confinement.py
+++ b/tests/test_personal_delete_file_confinement.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+from pathlib import Path
+
+from routes import personal_routes
+
+
+class _FakePersonalDocs:
+    def __init__(self):
+        self.excluded = []
+
+    def exclude_file(self, filepath):
+        self.excluded.append(filepath)
+
+
+class _FakeRAG:
+    def __init__(self):
+        self.deleted_sources = []
+
+    def delete_by_source(self, filepath):
+        self.deleted_sources.append(filepath)
+        return 1
+
+
+def _delete_endpoint(personal_docs):
+    router = personal_routes.setup_personal_routes(personal_docs, None, True)
+    for route in router.routes:
+        if getattr(route, "path", "") == "/api/personal/file" and "DELETE" in getattr(route, "methods", set()):
+            return route.endpoint
+    raise AssertionError("DELETE /api/personal/file endpoint not found")
+
+
+def test_delete_file_refuses_symlink_directory_escape(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.txt"
+    victim.write_text("keep me", encoding="utf-8")
+    os.symlink(outside, uploads / "linked")
+
+    docs = _FakePersonalDocs()
+    rag = _FakeRAG()
+    monkeypatch.setattr(personal_routes, "UPLOADS_DIR", str(uploads))
+    monkeypatch.setattr(personal_routes, "get_rag_manager", lambda: rag)
+
+    filepath = str(uploads / "linked" / "victim.txt")
+    result = asyncio.run(_delete_endpoint(docs)(filepath=filepath, owner="alice", _admin=None))
+
+    assert result["deleted_from_disk"] is False
+    assert victim.read_text(encoding="utf-8") == "keep me"
+    assert docs.excluded == [filepath]
+    assert rag.deleted_sources == [filepath]
+
+
+def test_delete_file_removes_regular_file_inside_upload_root(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    uploaded_file = uploads / "alice" / "notes.txt"
+    uploaded_file.parent.mkdir()
+    uploaded_file.write_text("delete me", encoding="utf-8")
+
+    docs = _FakePersonalDocs()
+    rag = _FakeRAG()
+    monkeypatch.setattr(personal_routes, "UPLOADS_DIR", str(uploads))
+    monkeypatch.setattr(personal_routes, "get_rag_manager", lambda: rag)
+
+    filepath = str(uploaded_file)
+    result = asyncio.run(_delete_endpoint(docs)(filepath=filepath, owner="alice", _admin=None))
+
+    assert result["deleted_from_disk"] is True
+    assert not uploaded_file.exists()
+    assert docs.excluded == [filepath]
+    assert rag.deleted_sources == [filepath]


### PR DESCRIPTION

## Summary

Resolves the requested file path and upload root before `DELETE /api/personal/file` unlinks anything from disk. This keeps normal upload-root deletes working while refusing paths that only appear to be under the upload root because of a symlinked directory.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4290

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
  - Related but not superseding: #4198 covered adjacent personal-directory confinement; this PR covers file deletion under the upload root.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  - Not run: this is a backend path-confinement guard with focused endpoint-level regression coverage; no rendered UI files changed.

## How to Test

1. Run the focused personal upload delete tests:

```bash
venv/bin/python -m pytest tests/test_personal_delete_file_confinement.py -q
```

2. Run a diff whitespace check:

```bash
git diff --check origin/dev..HEAD
```

3. Optional manual check from an admin/owner session:
   - Delete a normal uploaded file under the upload root; expected: it is removed.
   - Try deleting a path that resolves outside the upload root through a symlinked directory; expected: no outside file is removed.

## Visual / UI changes - REQUIRED if you touched anything that renders

No rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused single-fix PR.

### Screenshots / clips

N/A - no rendered UI files changed.
