### PR TITLE
fix(models): scope API-token catalog access

### DIFF
--- a/routes/model_routes.py
+++ b/routes/model_routes.py
@@ -26,7 +26,7 @@ from src.endpoint_resolver import (
     build_models_url,
     build_headers,
 )
-from src.auth_helpers import _auth_disabled, owner_filter
+from src.auth_helpers import _auth_disabled, effective_user, owner_filter
 
 logger = logging.getLogger(__name__)
 
@@ -1255,13 +1255,16 @@ def setup_model_routes(model_discovery):
         # Require auth; "" is the unconfigured single-user mode, treated as
         # "see everything" by _fetch_models.
         try:
-            from src.auth_helpers import get_current_user as _gcu
-            owner = _gcu(request) or ""
-        except Exception:
-            owner = ""
-        # Reject anonymous in configured deployments — no leaking the model
-        # list to unauthenticated callers.
-        try:
+            if getattr(request.state, "api_token", False):
+                scopes = set(getattr(request.state, "api_token_scopes", []) or [])
+                if "chat" not in scopes:
+                    raise HTTPException(403, "API token is not scoped for chat")
+                if not getattr(request.state, "api_token_owner", None):
+                    raise HTTPException(403, "API token has no owner")
+            owner = effective_user(request) or ""
+
+            # Reject anonymous in configured deployments — no leaking the model
+            # list to unauthenticated callers.
             auth_mgr = getattr(request.app.state, "auth_manager", None)
             if not owner and not _auth_disabled() and auth_mgr is not None and getattr(auth_mgr, "is_configured", False):
                 raise HTTPException(401, "Not authenticated")

--- a/tests/test_model_routes.py
+++ b/tests/test_model_routes.py
@@ -1286,6 +1286,14 @@ class _ImmediateThread:
         self.target()
 
 
+class _NoopThread:
+    def __init__(self, target, daemon=None):
+        self.target = target
+
+    def start(self):
+        return None
+
+
 def _wait_for(predicate, timeout=2.0):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -1313,6 +1321,7 @@ def _route_ep(
     pinned_models=None,
     refresh_mode="auto",
     refresh_timeout=None,
+    owner=None,
 ):
     return SimpleNamespace(
         id=id,
@@ -1329,7 +1338,7 @@ def _route_ep(
         model_refresh_interval=None,
         model_refresh_timeout=refresh_timeout,
         supports_tools=None,
-        owner=None,
+        owner=owner,
         created_at=None,
         updated_at=None,
     )
@@ -1340,6 +1349,72 @@ def _route_request():
         state=SimpleNamespace(current_user=None),
         app=SimpleNamespace(state=SimpleNamespace(auth_manager=None)),
     )
+
+
+def test_api_models_rejects_api_token_without_chat_scope(monkeypatch):
+    router = model_routes.setup_model_routes(model_discovery=None)
+
+    def fail_session():
+        raise AssertionError("model DB should not be queried without chat scope")
+
+    monkeypatch.setattr(model_routes, "SessionLocal", fail_session)
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            current_user="api",
+            api_token=True,
+            api_token_owner="alice",
+            api_token_scopes=["documents:read"],
+        ),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=SimpleNamespace(is_configured=True, is_admin=lambda user: False),
+            ),
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _route_endpoint(router, "/api/models")(request)
+
+    assert exc.value.status_code == 403
+    assert "chat" in str(exc.value.detail)
+
+
+def test_api_models_scopes_api_token_to_token_owner(monkeypatch):
+    rows = [
+        _route_ep("alice", "http://alice.example/v1", cached_models=["alice-model"], owner="alice"),
+        _route_ep("shared", "http://shared.example/v1", cached_models=["shared-model"], owner=None),
+        _route_ep("bob", "http://bob.example/v1", cached_models=["bob-model"], owner="bob"),
+    ]
+    db = _RouteDb(rows)
+    router = model_routes.setup_model_routes(model_discovery=None)
+    admin_checks = []
+
+    monkeypatch.setattr(model_routes, "ModelEndpoint", _RouteModelEndpoint)
+    monkeypatch.setattr(model_routes, "SessionLocal", lambda: db)
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            current_user="api",
+            api_token=True,
+            api_token_owner="alice",
+            api_token_scopes=["chat"],
+        ),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                auth_manager=SimpleNamespace(
+                    is_configured=True,
+                    is_admin=lambda user: admin_checks.append(user) or False,
+                ),
+            ),
+        ),
+    )
+
+    result = _route_endpoint(router, "/api/models")(request)
+
+    assert [item["endpoint_name"] for item in result["items"]] == ["alice", "shared"]
+    assert admin_checks == ["alice"]
 
 
 def test_api_models_returns_cached_proxy_models_without_refresh_probe(monkeypatch):


### PR DESCRIPTION

## Summary

Makes `/api/models` scope-aware for bearer API tokens. API-token calls now require the `chat` scope, reject ownerless tokens, and resolve the route caller through the token owner instead of the `api` pseudo-user.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #4052

## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) - this is not a duplicate.
  - Related open PR: #4054 is the broader owner-attribution migration. This PR is the narrower `/api/models` scope/owner gate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.
  - Not run: this is a backend API-token authorization guard with focused route regression coverage; no rendered UI files changed.

## How to Test

1. Run the model route regression tests:

```bash
venv/bin/python -m pytest tests/test_model_routes.py -q
```

2. Run a diff whitespace check:

```bash
git diff --check origin/dev..HEAD
```

3. Optional manual check in an auth-enabled setup:
   - Call `/api/models` with an unrelated-scope bearer token; expected: HTTP 403.
   - Call `/api/models` with a chat-scoped token owned by a normal user; expected: that owner's private endpoints plus shared endpoints.
   - Call `/api/models` with a chat-scoped token owned by a user; expected: that owner is used for model-catalog visibility instead of the `api` pseudo-user.

## Visual / UI changes - REQUIRED if you touched anything that renders

No rendered UI files are changed.

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI styling changed.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.** This is a focused single-fix PR.

### Screenshots / clips

N/A - no rendered UI files changed.
