### PR TITLE
test(gallery): point delete-ordering tests at the tmp image dir

### DIFF
--- a/tests/test_gallery_delete_file_ordering.py
+++ b/tests/test_gallery_delete_file_ordering.py
@@ -41,8 +41,10 @@ def _seed(tmp_path):
 
 
 def test_file_kept_when_commit_fails(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
     SessionLocal = _seed(tmp_path)
+    # GALLERY_IMAGE_DIR is an absolute path fixed at import, so a chdir can't
+    # redirect the delete; point the resolver at the seeded tmp dir directly.
+    monkeypatch.setattr(gallery_routes, "GALLERY_IMAGE_DIR", tmp_path / "data" / "generated_images")
     monkeypatch.setattr(gallery_routes, "get_current_user", lambda r: "alice")
 
     # A session whose commit always fails, to simulate a DB error mid-delete.
@@ -67,8 +69,8 @@ def test_file_kept_when_commit_fails(tmp_path, monkeypatch):
 
 
 def test_file_removed_on_successful_delete(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
     SessionLocal = _seed(tmp_path)
+    monkeypatch.setattr(gallery_routes, "GALLERY_IMAGE_DIR", tmp_path / "data" / "generated_images")
     monkeypatch.setattr(gallery_routes, "get_current_user", lambda r: "alice")
     monkeypatch.setattr(gallery_routes, "SessionLocal", SessionLocal)
 


### PR DESCRIPTION
## Summary

`tests/test_gallery_delete_file_ordering.py::test_file_removed_on_successful_delete` fails on current `dev`, so the `Python tests (pytest)` gate is red — and every open PR inherits it. The tests do `monkeypatch.chdir(tmp_path)` and write the image to `tmp_path/data/generated_images/x.png`, expecting the delete to act there. But `DATA_DIR = os.getenv("ODYSSEUS_DATA_DIR", os.path.join(BASE_DIR, "data"))` is always absolute, so `gallery_routes.GALLERY_IMAGE_DIR` (and the `_gallery_image_path` resolver) point at the repo's real `data/generated_images` — the chdir has no effect.

As a result the "removed on success" test deletes from the wrong directory and the tmp file it asserts on is never touched, and the "kept on failed commit" test passed only by accident (the tmp file always survives because deletion never points at it).

This points `GALLERY_IMAGE_DIR` at the seeded tmp dir with `monkeypatch.setattr` instead of relying on `chdir`, so both tests exercise the real resolver path and pass deterministically. The production delete logic from #2196 is correct and untouched — this is a test-only fix.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4299

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. *(Test-only fix — verified by running the affected file under default env, an absolute `ODYSSEUS_DATA_DIR`, and repeated runs: 2 passed every time, where `dev` currently fails 1.)*

## How to Test

1. On `dev` (`cd02ac7`): `python -m pytest tests/test_gallery_delete_file_ordering.py -q` → 1 failed, 1 passed.
2. Check out this branch and run the same command → 2 passed.
3. Confirm it's robust to the data-dir config: `ODYSSEUS_DATA_DIR=/tmp/whatever python -m pytest tests/test_gallery_delete_file_ordering.py -q` → 2 passed.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual or UI changes — this only edits `tests/test_gallery_delete_file_ordering.py`. Nothing under `static/` is touched.
