### PR TITLE
fix(agent): resolve_contact drops phone-only CardDAV contacts — reports 'No contacts found'

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -3797,7 +3797,7 @@ async def do_resolve_contact(content: str, owner: Optional[str] = None) -> Dict:
     if not name:
         return {"error": "name is required", "exit_code": 1}
 
-    contacts = {}  # email -> {name, source}
+    contacts = {}  # email_or_phone -> {name, source, phone?}
 
     # 1. CardDAV (Radicale) — structured contacts. Call in-process: a
     # server-side httpx GET to /api/contacts/search carries no session
@@ -3812,10 +3812,18 @@ async def do_resolve_contact(content: str, owner: Optional[str] = None) -> Dict:
             match = q in hay_name or any(q in (e or "").lower() for e in c.get("emails", []))
             if not match:
                 continue
+            has_email = False
             for email in (c.get("emails") or []):
                 email = (email or "").strip().lower()
                 if email and "@" in email:
                     contacts[email] = {"name": c.get("name") or email, "source": "contacts"}
+                    has_email = True
+            # Fall back to phone numbers when the contact has no email address
+            if not has_email:
+                for phone in (c.get("phones") or []):
+                    phone = (phone or "").strip()
+                    if phone:
+                        contacts[phone] = {"name": c.get("name") or phone, "source": "contacts", "phone": phone}
     except Exception:
         pass
 
@@ -3835,8 +3843,11 @@ async def do_resolve_contact(content: str, owner: Optional[str] = None) -> Dict:
         return {"output": f"No contacts found matching '{name}'.", "exit_code": 0}
 
     lines = [f"Contacts matching '{name}':"]
-    for email, info in contacts.items():
-        lines.append(f"- {info['name']} <{email}> ({info['source']})")
+    for key, info in contacts.items():
+        if info.get("phone"):
+            lines.append(f"- {info['name']} — phone: {info['phone']} ({info['source']})")
+        else:
+            lines.append(f"- {info['name']} <{key}> ({info['source']})")
     return {"output": "\n".join(lines), "exit_code": 0}
 
 

--- a/src/tool_schemas.py
+++ b/src/tool_schemas.py
@@ -1008,7 +1008,7 @@ FUNCTION_TOOL_SCHEMAS = [
         "type": "function",
         "function": {
             "name": "resolve_contact",
-            "description": "Look up a contact's email address by name. Searches CardDAV address book and sent email history. Use when the user says 'message [name]' or 'email [name]' without an email address.",
+            "description": "Look up a contact by name. Searches CardDAV address book and sent email history. Returns email addresses (when available) or phone numbers. Use when the user says 'message [name]', 'email [name]', or asks for someone's contact details.",
             "parameters": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Summary

`resolve_contact` searches CardDAV and collects results keyed by email address. When a matching contact has **no email** (only phone numbers), the inner loop body never executes, the result dict stays empty, and the tool reports `No contacts found matching …` — even though a matching contact exists in CardDAV.

This was masked until #4178 taught the tool-RAG classifier about the `contacts` domain. Before that fix the model rarely called `resolve_contact` for contacts queries, so the gap went unnoticed. With #4178 merged, the model correctly reaches for `resolve_contact` and the bug is now visible.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #4328

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Ensure CardDAV is configured with at least one contact that has a phone number but no email address
2. Ask the agent "What is [that contact's name] contact?" in agent mode
3. Before the fix: tool returns `No contacts found matching …`
4. After the fix: tool returns the contact name and phone number, formatted as `Name — phone: +39…`
5. Regression check: contacts that DO have an email address still return the email as before

## Changes

Two files, +15 / −4:

1. **`src/tool_implementations.py`** — in the CardDAV loop, track `has_email`; when false, fall back to the contact's `phones` list. In the output formatter, detect the `"phone"` marker and render `Name — phone: …` instead of the email `<…>` format.
2. **`src/tool_schemas.py`** — broaden the `resolve_contact` description so the model knows the tool can return phone numbers when no email is available.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** — N/A (no UI changes)
- [ ] **Style match** — N/A
- [ ] **No new component patterns** — N/A
- [x] **I am not an LLM agent submitting a bulk PR.**