### PR TITLE
refactor(search): import REQUEST_TIMEOUT from constants in providers.py

### DIFF
--- a/services/search/providers.py
+++ b/services/search/providers.py
@@ -9,13 +9,11 @@ from urllib.parse import urljoin, urlparse, parse_qs
 import httpx
 from bs4 import BeautifulSoup
 
-from src.constants import SEARXNG_INSTANCE
+from src.constants import SEARXNG_INSTANCE, REQUEST_TIMEOUT
 from .analytics import RateLimitError, error_logger
 from .query import build_enhanced_query
 
 logger = logging.getLogger(__name__)
-
-REQUEST_TIMEOUT = 20
 
 # Provider registry — maps setting value to (label, needs_key, needs_url)
 PROVIDER_INFO = {


### PR DESCRIPTION
## Summary

`services/search/providers.py` redefined `REQUEST_TIMEOUT = 20` locally and used it for five outbound search-provider requests, shadowing the same value already in `src/constants.py`. Bumping the constant would silently leave the search providers on the old value. This imports `REQUEST_TIMEOUT` from `src.constants` and drops the local copy. Same value, one source of truth, no behaviour change.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #4329

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Behaviour-preserving import dedup; the search providers are exercised by the existing provider/search tests (no value change to assert).

## How to Test

```
python -m pytest -q tests/ -k 'provider or search_content'
```

`providers.REQUEST_TIMEOUT` still resolves to `20` (now from `src.constants`) and is used unchanged at the five `timeout=REQUEST_TIMEOUT` call sites. 261 passed locally.

## Visual / UI changes

No rendered UI changed.

- [x] No UI styling changed.
- [x] No new component patterns.
- [x] Not a bulk auto-generated PR.
