### PR TITLE
refactor(auth): centralize the internal-tool pseudo-username into a constant

### DIFF
--- a/app.py
+++ b/app.py
@@ -316,7 +316,7 @@ if AUTH_ENABLED:
             # (no admin cookie available in that context). Restricted to
             # loopback clients + matching token to keep it locked down.
             try:
-                from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN as _ITT
+                from core.middleware import INTERNAL_TOOL_HEADER, INTERNAL_TOOL_TOKEN as _ITT, INTERNAL_TOOL_USER
                 _hdr = request.headers.get(INTERNAL_TOOL_HEADER)
                 if _hdr and secrets.compare_digest(_hdr, _ITT) and _is_trusted_loopback(request):
                     # Impersonation: when the agent's loopback call sets
@@ -328,7 +328,7 @@ if AUTH_ENABLED:
                     if _impersonate and _impersonate in getattr(_auth_mgr, "users", {}):
                         request.state.current_user = _impersonate
                     else:
-                        request.state.current_user = "internal-tool"
+                        request.state.current_user = INTERNAL_TOOL_USER
                     request.state.api_token = False
                     return await call_next(request)
             except Exception as _e:

--- a/core/auth.py
+++ b/core/auth.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 from core.atomic_io import atomic_write_json as _atomic_write_json  # noqa: E402
+from core.middleware import INTERNAL_TOOL_USER  # noqa: E402
 
 DEFAULT_PRIVILEGES = {
     "can_use_agent": True,
@@ -65,7 +66,7 @@ TOKEN_TTL = 60 * 60 * 24 * 7  # 7 days
 # of those names would be denied an assistant and inconsistently owner-scoped.
 # Refuse to create or rename into any of them so the sentinels can't be
 # impersonated. (Keep this in sync with that synthetic-owner set.)
-RESERVED_USERNAMES = frozenset({"internal-tool", "api", "demo", "system"})
+RESERVED_USERNAMES = frozenset({INTERNAL_TOOL_USER, "api", "demo", "system"})
 
 
 def normalize_known_username(users: Dict[str, Any], username: str | None) -> Optional[str]:

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -15,6 +15,8 @@ from starlette.responses import Response
 # same value from this module. Never persisted or exposed externally.
 INTERNAL_TOOL_TOKEN = os.environ.get("ODYSSEUS_INTERNAL_TOKEN") or secrets.token_hex(32)
 INTERNAL_TOOL_HEADER = "X-Odysseus-Internal-Token"
+# Pseudo-username on in-process tool-loopback requests; require_admin trusts it and it is reserved.
+INTERNAL_TOOL_USER = "internal-tool"
 
 
 def is_cors_preflight(method: str, headers) -> bool:
@@ -39,7 +41,7 @@ def require_admin(request: Request):
         hdr = request.headers.get(INTERNAL_TOOL_HEADER)
         if hdr and secrets.compare_digest(hdr, INTERNAL_TOOL_TOKEN):
             return
-        if getattr(request.state, "current_user", None) == "internal-tool":
+        if getattr(request.state, "current_user", None) == INTERNAL_TOOL_USER:
             return
     except Exception:
         pass

--- a/routes/note_routes.py
+++ b/routes/note_routes.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from core.database import SessionLocal, Note
+from core.middleware import INTERNAL_TOOL_USER
 from src.auth_helpers import require_user
 from src.constants import DATA_DIR
 from sqlalchemy.orm.attributes import flag_modified
@@ -582,7 +583,7 @@ def setup_note_routes(task_scheduler=None):
         return require_user(request) or None
 
     def _is_admin_or_single_user(request: Request, user: str | None) -> bool:
-        if user == "internal-tool":
+        if user == INTERNAL_TOOL_USER:
             return True
         if not user:
             # require_user() already admitted this request, which only happens

--- a/routes/research_routes.py
+++ b/routes/research_routes.py
@@ -12,6 +12,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel, Field
+from core.middleware import INTERNAL_TOOL_USER
 from src.endpoint_resolver import resolve_endpoint
 from src.auth_helpers import _auth_disabled, get_current_user
 from src.constants import DEEP_RESEARCH_DIR
@@ -385,7 +386,7 @@ def setup_research_routes(research_handler, session_manager=None) -> APIRouter:
         """Launch a research job from the dedicated panel."""
         from src.auth_helpers import require_privilege
         user = require_privilege(request, "can_use_research")
-        if user == "internal-tool":
+        if user == INTERNAL_TOOL_USER:
             tool_owner = (request.headers.get("X-Odysseus-Owner") or "").strip()
             if tool_owner and tool_owner not in {"internal-tool", "api", "demo", "system"}:
                 auth_mgr = getattr(request.app.state, "auth_manager", None)

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -15,6 +15,7 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Dict, Any
 from core.platform_compat import IS_APPLE_SILICON, which_tool
+from core.middleware import INTERNAL_TOOL_USER
 from src.optional_deps import prepare_optional_dependency_import
 
 # POSIX-only: `pty`/`fcntl` transitively import `termios`, which does NOT exist
@@ -55,7 +56,7 @@ def _require_admin(request: Request):
     # In-process tool loopback. The AuthMiddleware already validated the
     # internal token + loopback client before setting this marker, so
     # honour it here as admin-equivalent.
-    if user == "internal-tool":
+    if user == INTERNAL_TOOL_USER:
         return
     if not user or user == "api":
         raise HTTPException(403, "Admin only")

--- a/routes/task_routes.py
+++ b/routes/task_routes.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from core.database import SessionLocal, ScheduledTask, TaskRun
+from core.middleware import INTERNAL_TOOL_USER
 from core.constants import internal_api_base
 from src.auth_helpers import get_current_user
 from src.constants import DATA_DIR, EMAIL_URGENCY_CACHE_DIR
@@ -427,7 +428,7 @@ def setup_task_routes(task_scheduler) -> APIRouter:
         # In-process tool-loopback marker — AuthMiddleware validated
         # the internal token + loopback client before stamping this,
         # so treat as admin-equivalent.
-        if user == "internal-tool":
+        if user == INTERNAL_TOOL_USER:
             return True
         try:
             from core.auth import AuthManager


### PR DESCRIPTION
## Summary

Centralizes the security-sensitive `"internal-tool"` pseudo-username into a single `INTERNAL_TOOL_USER` constant. The in-process tool loopback stamps `current_user = "internal-tool"`, `require_admin` grants admin to that sentinel, and it is a reserved username; the literal was hand-typed in ~7 places (stamp, admin gate, `RESERVED_USERNAMES`, and standalone admin-equivalent checks in note/research/shell/task routes). A typo there silently breaks an auth gate. The constant lives in `core/middleware.py` next to the existing `INTERNAL_TOOL_TOKEN`/`INTERNAL_TOOL_HEADER`, so a typo is now an ImportError. Behaviour is unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #4332

## Type of Change

- [x] Refactor / cleanup (behaviour unchanged)

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors or whitespace changes mixed in.
- [x] Behaviour-preserving; covered by the existing reserved-username / admin-escalation and security-regression tests (ran them, see How to Test).

## How to Test

```
python -m pytest -q tests/test_reserved_username_admin_escalation.py tests/test_security_regressions.py tests/test_notes_fail_closed_auth.py
```

113 passed locally. Also verified the import is acyclic and the value is unchanged:

```
python -c "import core.auth, core.middleware as m; print(m.INTERNAL_TOOL_USER in core.auth.RESERVED_USERNAMES)"  # True
```

What changed:

- `core/middleware.py`: new `INTERNAL_TOOL_USER = "internal-tool"`; the `require_admin` check uses it.
- `core/auth.py`: `RESERVED_USERNAMES` uses the constant (imports it from `core.middleware`, which imports no app modules, so no cycle).
- `app.py`: the loopback stamp uses it.
- `routes/note_routes.py`, `routes/research_routes.py`, `routes/shell_routes.py`, `routes/task_routes.py`: the standalone admin-equivalent checks use it.

Out of scope (left as a follow-up): the multi-sentinel sets that bundle `internal-tool` with `api`/`demo`/`system` (`assistant_routes`, `task_scheduler`, `research_routes`) are a separate reserved-set dedup.

## Visual / UI changes

No rendered UI changed.

- [x] No UI styling changed.
- [x] No new component patterns.
- [x] Not a bulk auto-generated PR.
