### PR TITLE
fix(webhooks): route public emitters through fire_and_forget (#3964)

### DIFF
--- a/routes/chat_helpers.py
+++ b/routes/chat_helpers.py
@@ -346,9 +346,9 @@ def add_user_message(sess, chat_handler, preprocessed: PreprocessedMessage, inco
 def fire_message_event(request, webhook_manager, session_id: str, sess, message: str, compare_mode: bool = False):
     """Fire webhook and event_bus events for a new user message."""
     if webhook_manager and not compare_mode:
-        asyncio.create_task(webhook_manager.fire("chat.message", {
+        webhook_manager.fire_and_forget("chat.message", {
             "session_id": session_id, "model": sess.model, "message": message[:2000],
-        }))
+        })
     from src.event_bus import fire_event
     user = get_current_user(request)
     fire_event("message_sent", user)
@@ -1120,10 +1120,10 @@ def run_post_response_tasks(
 
     # Webhook
     if webhook_manager and not compare_mode:
-        asyncio.create_task(webhook_manager.fire("chat.completed", {
+        webhook_manager.fire_and_forget("chat.completed", {
             "session_id": session_id, "model": sess.model,
             "user_message": message, "response": full_response[:2000],
-        }))
+        })
 
     # Auto-name
     if needs_auto_name(sess.name):

--- a/routes/webhook_routes.py
+++ b/routes/webhook_routes.py
@@ -1,6 +1,5 @@
 """Webhook, API Token, and sync chat routes."""
 
-import asyncio
 import uuid
 import logging
 from typing import Optional
@@ -385,10 +384,10 @@ def setup_webhook_routes(
         sess.add_message(ChatMessage("assistant", reply))
         session_manager.save_sessions()
 
-        asyncio.create_task(webhook_manager.fire("chat.completed", {
+        webhook_manager.fire_and_forget("chat.completed", {
             "session_id": session_id, "model": sess.model,
             "user_message": message[:2000], "response": reply[:2000],
-        }))
+        })
 
         return {"response": reply, "session_id": session_id, "model": sess.model}
 

--- a/tests/test_webhook_emitters_use_manager.py
+++ b/tests/test_webhook_emitters_use_manager.py
@@ -1,0 +1,54 @@
+"""Guard: every public webhook emitter goes through the manager.
+
+Public emitters in `routes/` must schedule their fire through
+`webhook_manager.fire_and_forget(...)` (or `_spawn_tracked`). A bare
+`asyncio.create_task(webhook_manager.fire(...))` escapes
+`WebhookManager._bg_tasks`, so asyncio only holds a weak reference to the
+delivery task and the GC can collect it before it sends — silently dropping
+the webhook. Catching this with a scan stops a regression from sneaking
+back in via a copy-paste.
+"""
+import ast
+from pathlib import Path
+
+ROUTES_DIR = Path(__file__).resolve().parent.parent / "routes"
+
+
+def _untracked_fire_calls(tree: ast.AST) -> list[tuple[int, str]]:
+    """Return (lineno, snippet) for any asyncio.create_task(webhook_manager.fire(...))."""
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "create_task"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "asyncio"):
+            continue
+        if not node.args:
+            continue
+        inner = node.args[0]
+        if not isinstance(inner, ast.Call):
+            continue
+        inner_func = inner.func
+        if (
+            isinstance(inner_func, ast.Attribute)
+            and inner_func.attr == "fire"
+            and isinstance(inner_func.value, ast.Name)
+            and inner_func.value.id == "webhook_manager"
+        ):
+            hits.append((node.lineno, ast.unparse(node)))
+    return hits
+
+
+def test_no_untracked_webhook_fire_in_routes():
+    offenders: list[str] = []
+    for path in ROUTES_DIR.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for lineno, snippet in _untracked_fire_calls(tree):
+            offenders.append(f"{path.relative_to(ROUTES_DIR.parent)}:{lineno}: {snippet}")
+    assert not offenders, (
+        "Public webhook emitters must use webhook_manager.fire_and_forget(...) "
+        "so the delivery task is tracked in WebhookManager._bg_tasks. Found "
+        "untracked emitter(s):\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

Three public webhook emitters in `routes/` scheduled deliveries via `asyncio.create_task(webhook_manager.fire(...))`, which bypasses `WebhookManager._bg_tasks`. asyncio only holds a weak reference to the outer task, so the GC can collect it mid-delivery and the webhook is silently dropped. This PR routes all three through the existing `webhook_manager.fire_and_forget()` helper so `_spawn_tracked()` owns the lifecycle — the same invariant `session.created` already follows in `routes/session_routes.py:437`. Adds an AST-level guard test so the pattern can't regress. Fixes the runtime half of #3964 (the test-isolation half landed in #4212).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #3964

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. #3964 is open with the test-isolation half landed via #4212; no open PR covers the runtime half.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. _Not run end-to-end: my dev environment has no live webhook receiver. Verified via the existing webhook test suite plus a new AST guard that asserts no untracked emitter survives in `routes/`._

## How to Test

1. Inspect the diff: the three `asyncio.create_task(webhook_manager.fire(...))` call sites in `routes/chat_helpers.py` (`chat.message`, `chat.completed`) and `routes/webhook_routes.py` (`chat.completed`) now call `webhook_manager.fire_and_forget(...)`. `import asyncio` is dropped from `routes/webhook_routes.py` because nothing else in that file used it.
2. Run the webhook test suite — all should pass:
   ```bash
   pytest tests/test_webhook_task_refs.py \
          tests/test_webhook_ssrf_resilience.py \
          tests/test_webhook_sanitize_error_ipv6.py \
          tests/test_webhook_trigger_auth_exempt.py \
          tests/test_webhook_emitters_use_manager.py
   ```
   Locally: 15 passed.
3. Confirm the new guard catches regressions: temporarily revert one call site to `asyncio.create_task(webhook_manager.fire("chat.message", {...}))` and re-run `pytest tests/test_webhook_emitters_use_manager.py` — `test_no_untracked_webhook_fire_in_routes` should fail with the offending file and line. Restore the fix and it goes green.
4. Optional end-to-end sanity (requires a receiver): start the app, point a webhook subscription at e.g. https://webhook.site, post a chat message, and verify `chat.message` then `chat.completed` arrive — same UX as before, only the task lifecycle changed.

Byte-compile per CONTRIBUTING.md is clean:
```bash
python -m py_compile app.py routes/*.py src/*.py
```