### PR TITLE
fix(gallery): confine gallery image path resolution

### DIFF
--- a/routes/gallery_routes.py
+++ b/routes/gallery_routes.py
@@ -67,14 +67,6 @@ def _gallery_image_path(filename: str) -> Path:
         raise HTTPException(400, "Unsafe gallery filename")
     if safe_name != original:
         raise HTTPException(400, "Unsafe gallery filename")
-    if not path.exists():
-        cwd_root = (Path.cwd() / "data" / "generated_images").resolve()
-        cwd_path = (cwd_root / safe_name).resolve()
-        try:
-            if os.path.commonpath([str(cwd_root), str(cwd_path)]) == str(cwd_root) and cwd_path.exists():
-                return cwd_path
-        except Exception:
-            pass
     return path
 
 

--- a/tests/test_gallery_filename_confinement.py
+++ b/tests/test_gallery_filename_confinement.py
@@ -28,6 +28,22 @@ def test_gallery_image_path_allows_safe_filename(tmp_path, monkeypatch):
     assert path == image_dir / "abc123.png"
 
 
+def test_gallery_image_path_does_not_fallback_to_cwd_data_dir(tmp_path, monkeypatch):
+    gallery_routes = _gallery_module()
+    configured_dir = tmp_path / "configured" / "generated_images"
+    cwd_root = tmp_path / "cwd"
+    cwd_image_dir = cwd_root / "data" / "generated_images"
+    cwd_image_dir.mkdir(parents=True)
+    (cwd_image_dir / "abc123.png").write_bytes(b"wrong root")
+    monkeypatch.setattr(gallery_routes, "GALLERY_IMAGE_DIR", configured_dir)
+    monkeypatch.chdir(cwd_root)
+
+    path = gallery_routes._gallery_image_path("abc123.png")
+
+    assert path == configured_dir / "abc123.png"
+    assert path != cwd_image_dir / "abc123.png"
+
+
 @pytest.mark.parametrize("filename", ["../../secret.png", "..\\secret.png", None, 12345])
 def test_gallery_image_path_rejects_unsafe_stored_filenames(tmp_path, monkeypatch, filename):
     gallery_routes = _gallery_module()


### PR DESCRIPTION
## Summary

Gallery file operations now resolve stored image filenames only against the configured generated-image directory. The shared gallery filename resolver no longer falls back to `cwd/data/generated_images` when the configured-root file is missing, so custom data-dir deployments and changed working directories cannot operate on a same-named file from an unintended root.

This keeps the existing filename sanitization, traversal check, and symlink escape rejection in place. It also adds a focused regression test that plants a matching cwd-relative generated image and verifies the resolver still returns the configured-root path.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4351
## Type of Change

- [x] Bug fix (non-breaking - fixes a confirmed issue)
- [ ] New feature (non-breaking - adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues, open PRs, and discussions - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above - no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

App-live validation was not run because this is a backend path-resolution helper change with focused regression coverage and no rendering change.

## How to Test

1. Run `./venv/bin/python -m pytest tests/test_gallery_filename_confinement.py tests/test_gallery_delete_file_ordering.py tests/test_ai_image_url_safety.py tests/test_gallery_result_image_ssrf.py tests/test_gallery_image_privileges.py`.
2. Run `./venv/bin/python -m py_compile routes/gallery_routes.py src/ai_interaction.py`.
3. Optional focused probe: run `./venv/bin/python -m pytest tests/test_gallery_filename_confinement.py::test_gallery_image_path_does_not_fallback_to_cwd_data_dir tests/test_gallery_filename_confinement.py::test_gallery_image_path_rejects_symlink_escape tests/test_ai_image_url_safety.py::test_generate_image_rejects_unsafe_provider_url_without_download`.

## Visual / UI changes - REQUIRED if you touched anything that renders

N/A - backend only; no UI rendering changed.

### Screenshots / clips

N/A - backend only.