### PR TITLE
fix(cookbook): avoid launching Ollama during Windows cache scan

### DIFF
--- a/routes/cookbook_helpers.py
+++ b/routes/cookbook_helpers.py
@@ -505,6 +505,8 @@ def _cached_model_scan_script(model_dirs: list[str] | None = None, add_hf_cache:
         "    if u.startswith('KB'): return int(n * 1024)",
         "    return int(n)",
         "def scan_ollama():",
+        "    if any(m.get('is_ollama') for m in models): return",
+        "    if os.name == 'nt' and not os.environ.get('ODYSSEUS_ALLOW_OLLAMA_CLI_SCAN'): return",
         "    if not shutil.which('ollama'): return",
         "    try:",
         "        p = subprocess.run(['ollama', 'list'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=6)",
@@ -535,8 +537,8 @@ def _cached_model_scan_script(model_dirs: list[str] | None = None, add_hf_cache:
         "            models.append({'repo_id':name,'size_bytes':size_bytes,'nb_files':1,'has_incomplete':False,'path':'ollama','backend':'ollama','is_ollama':True})",
         "        return",
         "for _hf_cache in hf_cache_paths(): scan_hf(_hf_cache)",
-        "scan_ollama()",
         "scan_ollama_api()",
+        "scan_ollama()",
     ]
     for model_dir in model_dirs or []:
         lines.append(f"scan_dir(os.path.expanduser({model_dir!r}))")

--- a/tests/test_cookbook_helpers.py
+++ b/tests/test_cookbook_helpers.py
@@ -786,6 +786,50 @@ def test_cached_model_scan_reports_plain_dir_gguf(tmp_path):
     assert ggufs[3]["quant"] == "BF16"
 
 
+def test_cached_model_scan_uses_ollama_api_before_cli_and_windows_opt_in():
+    script = _cached_model_scan_script()
+
+    assert "scan_ollama_api()\nscan_ollama()" in script
+    assert "if any(m.get('is_ollama') for m in models): return" in script
+    assert "os.name == 'nt'" in script
+    assert "ODYSSEUS_ALLOW_OLLAMA_CLI_SCAN" in script
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows Ollama CLI startup guard")
+def test_cached_model_scan_does_not_launch_ollama_cli_on_windows(tmp_path):
+    """Official Ollama for Windows can auto-start the tray/server on `ollama list`.
+    The read-only cache scanner must not invoke that CLI unless explicitly opted in.
+    """
+    marker = tmp_path / "ollama-called.txt"
+    fake_ollama = tmp_path / "ollama.cmd"
+    fake_ollama.write_text(
+        "@echo off\r\n"
+        f'echo called>"{marker}"\r\n'
+        "echo NAME ID SIZE MODIFIED\r\n"
+        "echo local-model:latest abc 1 GB now\r\n",
+        encoding="utf-8",
+    )
+
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    scan_py = tmp_path / "scan_cache.py"
+    scan_py.write_text(_cached_model_scan_script(), encoding="utf-8")
+    env = dict(os.environ)
+    env["PATH"] = str(tmp_path) + os.pathsep + env.get("PATH", "")
+    env["HOME"] = str(empty_home)
+    env.pop("ODYSSEUS_ALLOW_OLLAMA_CLI_SCAN", None)
+    proc = subprocess.run(
+        [sys.executable, str(scan_py)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert marker.exists() is False
+    assert all(m.get("backend") != "ollama" for m in json.loads(proc.stdout))
+
+
 def test_cached_model_scan_uses_huggingface_cache_env(tmp_path):
     """Docker recreates can leave the persisted HF cache outside HOME.
     The Serve scanner should honor the cache env path instead of only ~/.cache.


### PR DESCRIPTION
## Summary

The Cookbook cached-model scanner now avoids launching native Ollama on Windows during a read-only cache scan. It checks the already-running Ollama HTTP API first, skips the CLI fallback if the API already returned models, and only permits `ollama list` on Windows when `ODYSSEUS_ALLOW_OLLAMA_CLI_SCAN` is explicitly set. This preserves existing discovery for running Ollama servers while removing the surprising Windows side effect where `ollama list` can start `ollama app.exe` / `ollama.exe serve`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click Edit on this PR and change the base.

## Linked Issue

Fixes #4367

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate; issue #4367 was opened for this exact side effect.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. On Windows with native Ollama installed but stopped, run the generated cached-model scanner through `tests/test_cookbook_helpers.py`. The new regression test places a fake `ollama.cmd` first on `PATH` and asserts the scanner does not invoke it unless `ODYSSEUS_ALLOW_OLLAMA_CLI_SCAN` is set.
2. Run:

```powershell
C:\IAlice\Odysseus\.venv\Scripts\python.exe -m pytest tests\test_cookbook_helpers.py -q
```

Result from the clean upstream worktree: `65 passed, 1 warning`.

3. I also ran the app through the existing local Docker live-deploy helper with this fix present and opened Cookbook in the browser. The Cookbook modal loaded with Launch / Download / Dependencies / Settings surfaces visible, console errors were `0`, and no `scan_cache.py` or Ollama processes remained after the fixed validation run.

## Visual / UI changes — REQUIRED if you touched anything that renders

No visual/UI changes. This PR only changes the backend-generated cache scan script and tests; it does not touch `static/js`, CSS, HTML, icons, layout, colors, or rendered copy.

### Screenshots / clips

Not applicable — no rendering changes.