### PR TITLE
fix(settings): clear the one-time API token reveal after copy & on reopen

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -2373,7 +2373,17 @@ function _renderTokenScopeRows(t) {
   }).join('');
 }
 
+function clearTokenReveal() {
+  // The full token is shown ONCE on create. Never leave it lingering in the DOM
+  // (it survives the settings modal being hidden/reshown), so wipe it on refresh.
+  const value = el('adm-tokenValue');
+  const reveal = el('adm-tokenReveal');
+  if (value) value.textContent = '';
+  if (reveal) reveal.style.display = 'none';
+}
+
 async function loadTokens() {
+  clearTokenReveal();
   const list = el('adm-tokenList');
   if (!list) return;
   try {
@@ -2479,11 +2489,11 @@ function initTokenForm() {
       const res = await fetch('/api/tokens', { method: 'POST', body: fd, credentials: 'same-origin' });
       const data = await res.json();
       if (res.ok) {
-        el('adm-tokenValue').textContent = data.token;
-        reveal.style.display = '';
         el('adm-tokenName').value = '';
         if (el('adm-tokenScopes')) el('adm-tokenScopes').value = '';
-        loadTokens();
+        await loadTokens();              // refresh list (also clears any stale reveal)
+        el('adm-tokenValue').textContent = data.token;
+        reveal.style.display = '';       // then surface the fresh one-time token
       }
       else { msg.textContent = data.detail || 'Failed'; msg.className = 'admin-error'; }
     } catch (e) { msg.textContent = 'Request failed'; msg.className = 'admin-error'; }
@@ -2501,6 +2511,8 @@ function initTokenForm() {
         btn.innerHTML = TOKEN_COPY_ICON;
         btn.style.color = '';
         btn.style.opacity = '0.7';
+        // Once it's safely on the clipboard, retire the one-time reveal.
+        clearTokenReveal();
       }, 1600);
     });
   });


### PR DESCRIPTION
## Summary

The full API token is shown **once** on create, but the reveal box (`#adm-tokenReveal` / `#adm-tokenValue`) was never cleared — it lingered in the DOM after **Copy** and survived the settings modal being hidden/reshown. This adds a small `clearTokenReveal()` and calls it on every Tokens load (each settings open) and shortly after a successful copy, and reorders the create flow to refresh the list first then surface the fresh one-time token. Front-end only, no API change.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4371

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified end-to-end (see note under Screenshots — verified by reading + `node --check`; can confirm in-app on request).

## How to Test

1. Settings → System → Tokens → create a token; confirm the full token appears in the reveal box.
2. Click **Copy**; after ~1.6s confirm `#adm-tokenValue` is emptied and the reveal box is hidden.
3. Close and reopen the settings modal; confirm no stale token value remains in the DOM.
4. Create another token; confirm the new one-time value is shown (after the list refresh), not wiped immediately.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [ ] **Screenshot or short clip** — see note below (no new visual element; the change *removes* a lingering value).
- [x] **Style match**: no new colors/fonts/spacing/classes introduced; no Unicode emoji added; existing markup reused.
- [x] **No new component patterns** — reuses the existing token reveal box; only adds a clear-and-reorder behaviour.
- [x] **I am not submitting a bulk auto-generated PR** — this is a single, focused, issue-first fix (opened #4371 first).

### Screenshots / clips

This change has no new visual element and introduces no styling — it *removes* a one-time secret that was lingering in the DOM. The only observable effect is the reveal box clearing (per the How to Test steps). Happy to attach a before/after capture if you'd like one.
