### PR TITLE
test: stop test_skill_index_prompt_injection leaking a stub prefs_routes

### DIFF
--- a/tests/test_skill_index_prompt_injection.py
+++ b/tests/test_skill_index_prompt_injection.py
@@ -105,7 +105,7 @@ def _patch_prefs(monkeypatch, data_dir):
         "skills_enabled": True,
         "auto_approve_skills": True,
     }
-    sys.modules["routes.prefs_routes"] = fake_prefs
+    monkeypatch.setitem(sys.modules, "routes.prefs_routes", fake_prefs)
 
     # Bust the base-prompt cache so our test re-reads the skill index.
     from src import agent_loop


### PR DESCRIPTION
## Summary

`tests/test_skill_index_prompt_injection.py` installs a fake `routes.prefs_routes` with a bare `sys.modules[...] =` assignment that is never undone, leaving an empty stub module behind. A later test that imports from `routes.prefs_routes` (for example `test_backup_import_skills`) then fails with an ImportError depending on test order. This installs the stub with `monkeypatch.setitem` so it is reverted at teardown.

## Target branch

- [x] This PR targets `dev`, not `main`.

## Linked Issue

Fixes #4386

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched the open issues and open PRs; this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above; no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app and verified end-to-end. Not applicable here: this is a test-only change with no runtime behaviour change. Verified by running the affected tests (below).

## How to Test

This is a test-ordering bug, so the repro is about collection order rather than the running app.

1. `pip install -r requirements.txt`
2. Run the two files together so the skill-index file is collected first:
   `python -m pytest tests/test_skill_index_prompt_injection.py tests/test_backup_import_skills.py`
   Before this change: 1 failed (`ImportError: cannot import name '_save_for_user' from 'routes.prefs_routes'`). After: 5 passed.
3. `python -m pytest tests/test_skill_index_prompt_injection.py` on its own still passes (3 passed), so the stub still works within the test.

## Visual / UI changes

None. This only touches `tests/test_skill_index_prompt_injection.py`; nothing that renders is affected.
