### PR TITLE
fix(rag): normalize remove_directory path

### DIFF
--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -133,8 +133,9 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         directory = _dir.strip() if isinstance(_dir, str) else ""
         if not directory:
             return [TextContent(type="text", text="Error: remove_directory needs a directory path")]
-        # Expand ~ to match add_directory, which indexes the expanded path.
-        # Without this, removing "~/docs" never matches the stored absolute path.
+      # Normalize the path the same way as add_directory.
+      # This ensures both "~" and relative paths resolve to the same
+      # absolute path stored in the index.
         directory = os.path.abspath(os.path.expanduser(directory))
         if not _personal_docs_manager:
             return [TextContent(type="text", text="Error: Personal docs manager not available")]

--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -135,7 +135,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             return [TextContent(type="text", text="Error: remove_directory needs a directory path")]
         # Expand ~ to match add_directory, which indexes the expanded path.
         # Without this, removing "~/docs" never matches the stored absolute path.
-        directory = os.path.expanduser(directory)
+        directory = os.path.abspath(os.path.expanduser(directory))
         if not _personal_docs_manager:
             return [TextContent(type="text", text="Error: Personal docs manager not available")]
         try:

--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -105,8 +105,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         directory = _dir.strip() if isinstance(_dir, str) else ""
         if not directory:
             return [TextContent(type="text", text="Error: add_directory needs a directory path")]
-        # Store an absolute path so indexed `source` metadata is absolute and
-        # remove_directory (which abspath-normalizes) can match it later (#1660).
+
         directory = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(directory):
             return [TextContent(type="text", text=f"Error: Directory not found: {directory}")]
@@ -115,10 +114,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         try:
             result = _rag_manager.index_personal_documents(directory)
             indexed = result.get("indexed_count", 0) if isinstance(result, dict) else 0
-            # Record the directory so `list` and `remove_directory` can see it.
-            # Indexing was just done above, so pass index=False to avoid a second
-            # (ownerless) pass. Without this the directory was indexed but never
-            # tracked in indexed_directories, so it was invisible/unremovable.
+          
             if _personal_docs_manager and hasattr(_personal_docs_manager, "add_directory"):
                 try:
                     _personal_docs_manager.add_directory(directory, index=False)

--- a/mcp_servers/rag_server.py
+++ b/mcp_servers/rag_server.py
@@ -133,9 +133,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         directory = _dir.strip() if isinstance(_dir, str) else ""
         if not directory:
             return [TextContent(type="text", text="Error: remove_directory needs a directory path")]
-      # Normalize the path the same way as add_directory.
-      # This ensures both "~" and relative paths resolve to the same
-      # absolute path stored in the index.
+    
         directory = os.path.abspath(os.path.expanduser(directory))
         if not _personal_docs_manager:
             return [TextContent(type="text", text="Error: Personal docs manager not available")]


### PR DESCRIPTION
## Summary

Fixes a path normalization mismatch in `mcp_servers/rag_server.py`. The `remove_directory` function now normalizes the directory path using `os.path.abspath(os.path.expanduser(directory))` to match the canonical form stored during `add_directory`, ensuring directories added with tilde paths (e.g., `~/docs`) can be correctly removed.

## Linked Issue

Fixes #18

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Test improvement

## Checklist

- [x] I searched existing issues and PRs
- [x] I ran tests locally
- [x] I verified the fix
- [x] No unrelated files changed

## How to Test

1. Create a test directory: `mkdir ~/test_rag_dir && echo "test content" > ~/test_rag_dir/file.txt`
2. Index it via the MCP tool: Use `manage_rag` with action `add_directory` and directory `~/test_rag_dir`
3. Remove it via the MCP tool: Use `manage_rag` with action `remove_directory` and directory `~/test_rag_dir`
4. Verify the directory was removed: Confirm no error is raised and the path no longer appears in `list` output.