### PR TITLE
fix: stabilize cross-platform regression tests

### DIFF
--- a/static/js/cookbookRunning.js
+++ b/static/js/cookbookRunning.js
@@ -2653,16 +2653,14 @@ async function _reconnectTask(el, task) {
           const pipLooksSuccessful = _isPipTask
             && /Successfully installed|Requirement already (?:satisfied|up-to-date)/i.test(lastOutput)
             && !/error:|ERROR:/.test(lastOutput.slice(-1024));
-          const serveLooksReady = task.type === 'serve' && _serveOutputLooksReady({ ...task, output: lastOutput });
+          const serveLooksReady = task.type === 'serve'
+            && (_serveOutputLooksReady({ ...task, output: lastOutput }) || pipLooksSuccessful);
           // Dependency installs are tracked as download tasks but finish with a
           // pip exit-0 sentinel, not HF download markers — check that too.
           // Standalone pip-* serves finish with pip's own success line, not
           // HF or "Uvicorn running on".
           const depInstallSucceeded = !!task.payload?._dep && _depInstallSucceeded(lastOutput);
-          const looksSuccessful = depInstallSucceeded
-            || (task.type === 'download'
-              ? downloadLooksSuccessful
-              : (_isPipTask ? pipLooksSuccessful : serveLooksReady));
+          const looksSuccessful = depInstallSucceeded || (task.type === 'download' ? downloadLooksSuccessful : serveLooksReady);
           if (!lastOutput.trim() || !looksSuccessful) {
             _updateTask(task.sessionId, { status: 'crashed' });
             el.dataset.status = 'crashed';

--- a/tests/test_tool_index_keyword_boundaries.py
+++ b/tests/test_tool_index_keyword_boundaries.py
@@ -11,7 +11,7 @@ pitfall already fixed in topic_analyzer.py.
 `retrieve` (which needs a chroma collection) is stubbed out so these tests
 exercise only the keyword-hint loop.
 """
-from src.tool_index import ToolIndex
+from src.tool_index import ALWAYS_AVAILABLE, ToolIndex
 
 
 def _index():
@@ -40,11 +40,12 @@ def test_substring_inside_word_does_not_force_document_tools():
 
 def test_substring_inside_word_does_not_force_serve_tools():
     ti = _index()
+    baseline = set(ALWAYS_AVAILABLE) - {"serve_model", "serve_preset"}
     # "observe"/"reserve" contain "serve". serve_model/serve_preset are also in
-    # ALWAYS_AVAILABLE, so pass a non-serve base to isolate the keyword loop (an
-    # empty set falls back to ALWAYS_AVAILABLE). The "serve" hint must NOT fire.
+    # ALWAYS_AVAILABLE, so pass a non-serve base to isolate the keyword loop.
     tools = ti.get_tools_for_query(
-        "please observe the reserve levels", always_include={"__base__"}
+        "please observe the reserve levels",
+        always_include=baseline,
     )
     assert "serve_model" not in tools
     assert "serve_preset" not in tools
@@ -52,6 +53,7 @@ def test_substring_inside_word_does_not_force_serve_tools():
 
 def test_genuine_keywords_still_force_include():
     ti = _index()
+    baseline = set(ALWAYS_AVAILABLE) - {"serve_model", "serve_preset"}
     assert "reply_to_email" in ti.get_tools_for_query("reply to this email")
     assert "edit_document" in ti.get_tools_for_query("edit the document")
-    assert "serve_model" in ti.get_tools_for_query("serve the model")
+    assert "serve_model" in ti.get_tools_for_query("serve the model", always_include=baseline)


### PR DESCRIPTION
## Summary

This PR supersedes #4093 with a clean branch based on current `dev`. It keeps the original regression-test stabilization intent while limiting the diff to the two intended files.

The runtime change treats pip-success output as a valid ready signal when reconnecting serve tasks, so a successful pip/dependency install is not incorrectly marked as crashed. The test change keeps the serve keyword-boundary checks honest by excluding serve tools from the always-available baseline when testing serve keyword inclusion/exclusion.

## Linked Issue

Supersedes #4093.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test-only change

## How to Test

Run the focused regression tests for the keyword-boundary logic and cookbook dependency completion path:

```bash
python -m pytest tests/test_tool_index_keyword_boundaries.py -q
python -m pytest tests/test_cookbook_dependency_completion_regression.py -q
git diff --check origin/dev...HEAD
```

Expected result: the pytest commands pass (`4 passed` and `9 passed`) and `git diff --check` reports no whitespace issues.

## Checklist

- [x] I searched existing issues and PRs and found the previous dirty PR #4093, which this clean replacement supersedes.
- [x] I kept the diff scoped to the intended files.
- [x] I ran the focused tests listed above.