### PR TITLE
fix(cookbook): use diag element instead of undefined body in _showDiagnosis

### DIFF
--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -757,7 +757,7 @@ export function _showDiagnosis(panel, diagnosis, sourceText) {
       });
       row.appendChild(btn);
     }
-    body.appendChild(row);
+    diag.appendChild(row);
   }
 }
 


### PR DESCRIPTION
## Summary

The `_showDiagnosis` function in `cookbook-diagnosis.js` references an undefined variable `body` at line 760, which throws a `ReferenceError` and prevents the Cookbook panel from opening whenever a persisted task has a diagnosis with fix buttons.

## Linked Issue

Fixes #4406

## Root Cause

The diagnosis text was refactored from a separate body row into the toolbar (inline with Copy / × Dismiss buttons — see comment at lines 663–666: *"Was a separate body row below the toolbar"*). The `body` element was removed during that refactor, but one reference at line 760 was left behind.

Because `open()` in `cookbook.js` wraps its render in `try/finally` with no `catch`, the thrown `ReferenceError` escapes before `modal.classList.remove('hidden')` runs, so the entire Cookbook panel stays hidden.

## Fix

`static/js/cookbook-diagnosis.js:760`: `body.appendChild(row)` → `diag.appendChild(row)`

The `diag` variable (line 636) is the correct container element — it is the `.cookbook-diagnosis` div that holds all diagnosis content.

## How to Test

1. Start a Cookbook install/serve that fails with a diagnosis containing fix buttons (e.g. a failed `sglang[all]` install).
2. Close the Cookbook panel (or reload the page).
3. Click the Cookbook button to reopen it.
4. **Before fix:** Panel stays hidden, console shows `ReferenceError: body is not defined`.
5. **After fix:** Panel opens normally, diagnosis renders with fix buttons inline.

## Checklist

- [x] I searched open issues/PRs and did not find a duplicate
- [x] `node --check static/js/cookbook-diagnosis.js` passes
- [x] The fix is a single token change (`body` → `diag`) in a well-understood code path

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
