### PR TITLE
fix(cookbook): open() no longer crashes when a task has a diagnosis

### DIFF
--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -757,7 +757,7 @@ export function _showDiagnosis(panel, diagnosis, sourceText) {
       });
       row.appendChild(btn);
     }
-    body.appendChild(row);
+    diag.appendChild(row);
   }
 }
 

--- a/static/js/cookbook.js
+++ b/static/js/cookbook.js
@@ -2462,10 +2462,13 @@ export async function open(opts) {
   // returned before hydration — and since close/reopen doesn't reset the page,
   // only a full reload recovered it. Re-rendering is cheap and the in-progress
   // Running tab is rendered separately just below.
-  _renderRecipes();
+  // Guard the render passes: a single broken task card must not throw out of
+  // open() and leave the modal stuck hidden (it has no catch, so the panel
+  // would silently never appear). Show the window regardless; log and move on.
+  try { _renderRecipes(); } catch (e) { console.error('[cookbook] renderRecipes failed', e); }
   _rendered = true;
   _clearCookbookNotif();
-  _renderRunningTab();
+  try { _renderRunningTab(); } catch (e) { console.error('[cookbook] renderRunningTab failed', e); }
   // Self-heal: revive any download tasks whose tmux session is still alive
   // but were persisted as done/error (covers the "restarted server while a
   // big multi-shard download was in flight" case — the task survived in


### PR DESCRIPTION
## Summary

This PR contains two related changes — one root-cause fix and one defensive guard that
makes the same failure mode impossible to reach again.

**1. Root-cause fix (`cookbook-diagnosis.js`).** With a failed task sitting in the
Cookbook's Active tab, clicking the Cookbook button did nothing — the panel never opened.
The console showed `ReferenceError: body is not defined` from `_showDiagnosis`. The
diagnosis text was refactored into the toolbar and the old `body` element removed, but one
`body.appendChild(row)` reference was left behind; the in-scope container is `diag`. This
one-line change (`body` → `diag`) restores the diagnosis fix-button rendering.

**2. Defensive guard (`cookbook.js`).** The reason that single `ReferenceError` took down
the *entire* Cookbook is that `open()` wraps its render in `try/finally` with **no
`catch`**, so any throw during render escapes before the modal is un-hidden — the whole
panel silently fails to open. To stop a future broken task card from reintroducing this
class of bug, `open()` now wraps its two render passes — `_renderRecipes()` and
`_renderRunningTab()` — in `try/catch`. A render exception is now logged to the console
and the Cookbook window still opens, instead of staying stuck hidden.

The tradeoff is intentional: a partially-broken render is strictly better than a panel
that won't open at all, and the `console.error` preserves the signal needed to debug the
underlying render fault. This guard does not paper over bug #1 — that is fixed at the root
by change #1; the guard only ensures the *symptom* (a dead, un-openable Cookbook) can't
recur from an unrelated future render error.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #4406

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end.

## How to Test

**Change #1 — the crash is fixed:**

1. Have a failed Cookbook task whose diagnosis renders fix buttons (e.g. a dependency install that fails).
2. Reload the page, then click the Cookbook button.
   - **Before:** nothing happens; the console shows `ReferenceError: body is not defined at _showDiagnosis`.
   - **After:** the Cookbook opens and shows the failed task with its diagnosis and fix buttons.

**Change #2 — the guard keeps the panel openable even if a render throws:**

3. To confirm the guard independently of change #1, temporarily `throw new Error('test')`
   at the top of `_renderRunningTab()` and click the Cookbook button.
   - **Before the guard:** the modal stays hidden and never opens.
   - **After the guard:** the Cookbook window opens, and the console logs
     `[cookbook] renderRunningTab failed`. Remove the temporary `throw` afterwards.

**Syntax check:** `node --check static/js/cookbook-diagnosis.js && node --check static/js/cookbook.js`

## Visual / UI changes

This restores intended rendering — the diagnosis and its existing fix buttons now appear instead of the panel crashing. It introduces **no new visual language**: it only changes where an already-styled row (`.cookbook-diag-fixes`, built from existing `cookbook-btn` / `cookbook-diag-btn` classes) is appended, plus the defensive `try/catch` guards in `open()` described above. No new colors, classes, fonts, spacing, or emoji.

- [ ] Screenshot — to add (Cookbook opening normally with a failed task's diagnosis).
- [x] Style match — reuses existing CSS variables/classes; no new styling introduced.
- [x] No new component patterns — extends existing diagnosis rendering, no parallel widgets.

> Note on the "not an LLM agent" item: being upfront — this fix was **drafted with AI assistance**, but it's a single, human-reproduced-and-verified fix and I opened issue #4406 first (per the contributing policy), so it is not a bulk auto-generated PR.
