### PR TITLE
docs: change host from 0.0.0.0 to 127.0.0.1 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Manual development uses Python 3.11+:
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python -m uvicorn app:app --host 0.0.0.0 --port 7000
+python -m uvicorn app:app --host 127.0.0.1 --port 7000
 ```
 
 Windows is not actively tested. Docker on Linux or a Linux/macOS manual install is the safer path for now.


### PR DESCRIPTION
Updated the host address in the run command for clarity.

## Summary

In `CONTRIBUTING.md`, changed the binding host from `0.0.0.0` to `127.0.0.1` to align with standard local development security practices.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #000

## Type of Change

- [x] Documentation only

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.

## How to Test

1. Open `CONTRIBUTING.md`
2. Verify that the host in the final command block is set to `127.0.0.1` instead of `0.0.0.0`.

## Visual / UI changes — REQUIRED if you touched anything that renders

(This is a documentation-only change; no UI changes are included.)