### PR TITLE
fix(security): allowlist manage_mcp 'add' to close the agent-path RCE

### DIFF
--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -645,6 +645,130 @@ async def do_manage_endpoints(content: str, owner: Optional[str] = None) -> Dict
 # MCP server management tool
 # ---------------------------------------------------------------------------
 
+# Parallel to routes/cookbook_helpers._validate_serve_cmd but deliberately the
+# opposite policy: that gate guards an admin-only serve command and allows
+# interpreters (python3/etc) because model-serving needs them, whereas this is
+# the model/prompt-injection-reachable manage_mcp path, so interpreters and
+# runners are denied here.
+#
+# Commands that can execute arbitrary code regardless of their arguments. These
+# are NEVER accepted on the manage_mcp agent path, even if an operator lists one
+# in ODYSSEUS_MCP_ALLOWED_COMMANDS -- a stdio server that genuinely needs an
+# interpreter or package runner must be registered via the trusted admin route.
+_MCP_DENIED_COMMANDS = frozenset({
+    "sh", "bash", "zsh", "fish", "dash", "ksh", "csh", "tcsh", "ash", "busybox",
+    "cmd", "command.com", "powershell", "pwsh",
+    "python", "python2", "python3", "node", "nodejs", "deno", "bun", "ruby",
+    "perl", "php", "lua", "tclsh", "rscript", "groovy", "scala", "elixir", "erl",
+    "npx", "uvx", "pipx", "npm", "pnpm", "yarn", "pip", "pip2", "pip3", "uv",
+    "gem", "cargo", "go", "bundle", "poetry", "conda", "mamba", "brew",
+    "apt", "apt-get", "yum", "dnf", "pacman", "apk",
+    "env", "xargs", "nohup", "setsid", "nice", "ionice", "time", "timeout",
+    "watch", "stdbuf", "unbuffer", "script", "ssh", "scp", "sshpass", "sudo",
+    "doas", "su", "make", "cmake", "docker", "podman", "kubectl", "find",
+    "awk", "gawk", "sed", "vi", "vim", "nvim", "emacs", "ed", "tee", "eval",
+})
+
+# Argv flags that make even an allowlisted binary execute inline code. Matched
+# by prefix so glued forms (-cimport os, --eval=...) are caught, not just the
+# exact-token form.
+_MCP_CODE_EXEC_SHORT_FLAGS = ("-c", "-e", "-m")
+_MCP_CODE_EXEC_LONG_FLAGS = ("--eval", "--exec", "--print", "--module", "--command", "--require")
+
+_MCP_URL_SCHEMES = ("http://", "https://", "ftp://", "ftps://", "file://", "data:", "jar:", "blob:")
+
+# Shell metacharacters refused in command/args. Args are passed as an argv list
+# (no shell), but refusing these keeps the surface narrow and obvious.
+_MCP_SHELL_METACHARS = set(";|&$`><\n\r")
+
+# Env vars that let a child process load attacker-supplied code before main().
+_MCP_DANGEROUS_ENV = frozenset({
+    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH", "PYTHONPATH", "PYTHONSTARTUP",
+    "PYTHONHOME", "PYTHONEXECUTABLE", "NODE_OPTIONS", "NODE_PATH", "BASH_ENV",
+    "ENV", "SHELLOPTS", "PERL5LIB", "PERL5OPT", "RUBYOPT", "RUBYLIB", "GEM_PATH",
+    "R_PROFILE", "R_HOME", "PATH", "IFS", "PROMPT_COMMAND",
+})
+
+
+def _mcp_allowed_commands() -> set:
+    """Operator-configured allowlist of safe MCP launcher basenames for the agent
+    path. Empty by default; set ODYSSEUS_MCP_ALLOWED_COMMANDS (comma-separated)
+    to opt specific trusted binaries in. Denied commands are rejected even if
+    listed here."""
+    raw = os.environ.get("ODYSSEUS_MCP_ALLOWED_COMMANDS", "")
+    return {c.strip().lower() for c in raw.split(",") if c.strip()}
+
+
+def _validate_mcp_command(command, args, env) -> Optional[str]:
+    """Validate a model-supplied stdio MCP registration. Returns an error string
+    if it must be rejected, else None.
+
+    Closes the RCE where manage_mcp 'add' passed prompt-injection-controlled
+    command/args/env straight to a subprocess spawn (issue #438): a payload
+    smuggled into a skill description, memory entry, fetched page, or email body
+    could register a stdio server running arbitrary code as the app UID.
+    """
+    if not isinstance(command, str) or not command.strip():
+        return "command must be a non-empty string"
+    command = command.strip()
+    if "/" in command or "\\" in command:
+        return "command must be a bare executable name, not a path"
+    if any(ch in _MCP_SHELL_METACHARS for ch in command):
+        return "command contains shell metacharacters"
+    base = command.lower()
+    if base.endswith(".exe") or base.endswith(".cmd") or base.endswith(".bat"):
+        base = base.rsplit(".", 1)[0]
+    if base in _MCP_DENIED_COMMANDS:
+        return (
+            f"command '{command}' is not allowed on the agent MCP path: "
+            "interpreters, runtimes, package runners, and shells can execute "
+            "arbitrary code. Register such a server via the admin route instead."
+        )
+    if base not in _mcp_allowed_commands():
+        return (
+            f"command '{command}' is not in the MCP allowlist. Add it to "
+            "ODYSSEUS_MCP_ALLOWED_COMMANDS if you trust it, or register the "
+            "server via the admin route."
+        )
+
+    if args is not None:
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except Exception:
+                return "args must be a JSON list"
+        if not isinstance(args, list):
+            return "args must be a list"
+        for a in args:
+            if not isinstance(a, str):
+                return "args must all be strings"
+            s = a.strip()
+            low = s.lower()
+            if any(s == f or s.startswith(f) for f in _MCP_CODE_EXEC_SHORT_FLAGS):
+                return f"arg '{a}' is a code-execution flag and is not allowed"
+            if any(low == f or low.startswith(f + "=") for f in _MCP_CODE_EXEC_LONG_FLAGS):
+                return f"arg '{a}' is a code-execution flag and is not allowed"
+            if any(low.startswith(u) for u in _MCP_URL_SCHEMES):
+                return f"arg '{a}' is a remote URL and is not allowed"
+            if any(ch in _MCP_SHELL_METACHARS for ch in a):
+                return f"arg '{a}' contains shell metacharacters"
+
+    if env:
+        if isinstance(env, str):
+            try:
+                env = json.loads(env)
+            except Exception:
+                return "env must be a JSON object"
+        if not isinstance(env, dict):
+            return "env must be an object"
+        for k in env:
+            if str(k).strip().upper() in _MCP_DANGEROUS_ENV:
+                return f"env var '{k}' can inject code into the child process and is not allowed"
+
+    return None
+
+
 async def do_manage_mcp(content: str, owner: Optional[str] = None) -> Dict:
     """Manage MCP servers: list, add, delete, enable, disable, reconnect."""
     try:
@@ -684,6 +808,12 @@ async def do_manage_mcp(content: str, owner: Optional[str] = None) -> Dict:
         env = args.get("env", {})
         if not name or not command:
             return {"error": "name and command are required", "exit_code": 1}
+        # Validate BEFORE any DB write or spawn: a rejected registration must
+        # leave no enabled row (which would otherwise auto-reconnect on restart)
+        # and must not attempt a connection.
+        _mcp_err = _validate_mcp_command(command, cmd_args, env)
+        if _mcp_err:
+            return {"error": f"manage_mcp: refused unsafe server registration: {_mcp_err}", "exit_code": 1}
         sid = str(_uuid.uuid4())[:8]
         db = SessionLocal()
         try:

--- a/src/tool_implementations.py
+++ b/src/tool_implementations.py
@@ -658,9 +658,11 @@ async def do_manage_endpoints(content: str, owner: Optional[str] = None) -> Dict
 _MCP_DENIED_COMMANDS = frozenset({
     "sh", "bash", "zsh", "fish", "dash", "ksh", "csh", "tcsh", "ash", "busybox",
     "cmd", "command.com", "powershell", "pwsh",
-    "python", "python2", "python3", "node", "nodejs", "deno", "bun", "ruby",
-    "perl", "php", "lua", "tclsh", "rscript", "groovy", "scala", "elixir", "erl",
-    "npx", "uvx", "pipx", "npm", "pnpm", "yarn", "pip", "pip2", "pip3", "uv",
+    "python", "pypy", "node", "nodejs", "deno", "bun", "ruby", "jruby",
+    "perl", "raku", "php", "lua", "luajit", "tclsh", "wish", "expect", "rscript",
+    "groovy", "scala", "elixir", "erl", "iex", "java", "javac", "jshell", "jbang",
+    "kotlin", "kotlinc", "dotnet", "mono", "swift", "osascript", "tsx", "ts-node",
+    "npx", "bunx", "uvx", "pipx", "npm", "pnpm", "yarn", "pip", "uv",
     "gem", "cargo", "go", "bundle", "poetry", "conda", "mamba", "brew",
     "apt", "apt-get", "yum", "dnf", "pacman", "apk",
     "env", "xargs", "nohup", "setsid", "nice", "ionice", "time", "timeout",
@@ -719,7 +721,12 @@ def _validate_mcp_command(command, args, env) -> Optional[str]:
     base = command.lower()
     if base.endswith(".exe") or base.endswith(".cmd") or base.endswith(".bat"):
         base = base.rsplit(".", 1)[0]
-    if base in _MCP_DENIED_COMMANDS:
+    # Canonicalize a trailing version suffix so versioned aliases collapse to the
+    # family name (python3.11 -> python, node18 -> node, pip3 -> pip); both the
+    # raw basename and the canonical form are denied, so an operator cannot
+    # accidentally allowlist a runtime alias back into the path.
+    canon = re.sub(r"[-_.]?\d+(?:\.\d+)*$", "", base)
+    if base in _MCP_DENIED_COMMANDS or canon in _MCP_DENIED_COMMANDS:
         return (
             f"command '{command}' is not allowed on the agent MCP path: "
             "interpreters, runtimes, package runners, and shells can execute "

--- a/tests/test_manage_mcp_command_allowlist.py
+++ b/tests/test_manage_mcp_command_allowlist.py
@@ -84,6 +84,24 @@ def test_denied_command_rejected_even_when_operator_allowlists_it():
     assert _validate_mcp_command("python3", ["server.py"], {}) is not None
 
 
+@pytest.mark.parametrize("command", [
+    "python3.11", "python3.12", "node18", "node20", "pip3", "ruby3.2",
+    "java", "javac", "bunx", "tsx", "ts-node", "pypy3", "deno1",
+])
+def test_versioned_and_alias_runtimes_are_denied(command):
+    # Versioned / alias runtime forms must collapse to the family and be denied,
+    # not slip past exact-name matching (RaresKeY review on #4433).
+    assert _validate_mcp_command(command, [], {}) is not None
+
+
+def test_alias_runtime_denied_even_if_operator_allowlists_it(monkeypatch):
+    # The exact scenario from review: an operator allowlists a versioned alias.
+    # Hard-deny by family must still win, before the allowlist is consulted.
+    monkeypatch.setenv("ODYSSEUS_MCP_ALLOWED_COMMANDS", "python3.11,node18,java,bunx")
+    for command in ("python3.11", "node18", "java", "bunx"):
+        assert _validate_mcp_command(command, [], {}) is not None, command
+
+
 def test_command_not_in_allowlist_rejected():
     assert _validate_mcp_command("some-random-binary", [], {}) is not None
 
@@ -112,6 +130,23 @@ def test_add_rejects_rce_with_no_db_write_and_no_connect(monkeypatch):
     db = _TS()
     try:
         assert db.query(McpServer).count() == 0, "rejected add must not persist an enabled row"
+    finally:
+        db.close()
+
+
+def test_add_rejects_versioned_runtime_alias_no_row_no_connect(monkeypatch):
+    # Versioned alias on the real add path must also write no row and not connect.
+    mcp = MagicMock()
+    mcp.connect_server = AsyncMock()
+    monkeypatch.setattr(ti, "get_mcp_manager", lambda: mcp)
+
+    res = _add("python3.11", ["server.py"])
+    assert res["exit_code"] == 1
+    mcp.connect_server.assert_not_called()
+
+    db = _TS()
+    try:
+        assert db.query(McpServer).count() == 0
     finally:
         db.close()
 

--- a/tests/test_manage_mcp_command_allowlist.py
+++ b/tests/test_manage_mcp_command_allowlist.py
@@ -1,0 +1,133 @@
+"""RCE guard for manage_mcp 'add' (#438).
+
+do_manage_mcp("add", ...) used to pass model / prompt-injection-controlled
+command/args/env straight to a stdio subprocess spawn with no allowlist, so a
+payload smuggled into a skill description, memory entry, fetched page, or email
+body could register an MCP server running arbitrary code as the app UID.
+
+_validate_mcp_command now gates the agent path before any DB write or spawn:
+interpreters, runtimes, package runners, shells, and exec-wrappers are
+hard-denied (even if an operator allowlists one); the command must otherwise be
+a bare basename in ODYSSEUS_MCP_ALLOWED_COMMANDS; code-exec flags are rejected
+by prefix (catching glued forms like -cimport os and --eval=); remote-URL args
+and code-injecting env vars (LD_PRELOAD, NODE_OPTIONS, PYTHONPATH, ...) are
+rejected too.
+"""
+import asyncio
+import json
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from tests.helpers.import_state import clear_fake_database_modules
+from tests.helpers.sqlite_db import make_temp_sqlite
+
+clear_fake_database_modules()
+
+import core.database as cdb
+from core.database import McpServer
+import src.tool_implementations as ti
+from src.tool_implementations import _validate_mcp_command
+
+_TS, _ENGINE, _TMPDB = make_temp_sqlite(cdb.Base.metadata)
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setattr(cdb, "SessionLocal", _TS)
+    # Allow one benign launcher (so the positive path is reachable) and also
+    # python3 (to prove the hard-deny still wins over an operator allowlist).
+    monkeypatch.setenv("ODYSSEUS_MCP_ALLOWED_COMMANDS", "mcp-server-demo,python3")
+    db = _TS()
+    try:
+        db.query(McpServer).delete()
+        db.commit()
+    finally:
+        db.close()
+    yield
+
+
+# ── validator: the RCE forms from the #438 review must all be rejected ──
+@pytest.mark.parametrize("command,args", [
+    ("sh", ["-c", "id>/tmp/pwn"]),
+    ("bash", ["-c", "id"]),
+    ("python3", ["/tmp/payload.py"]),                  # interpreter + script path
+    ("python3", ["-m", "pip", "install", "evilpkg"]),  # -m pip
+    ("python3", ["-cimport os; os.system('x')"]),      # glued -c (NubsCarson)
+    ("node", ["-erequire('child_process')"]),          # glued -e
+    ("node", ["--eval=console.log(1)"]),
+    ("node", ["-p", "process.env"]),
+    ("deno", ["eval", "console.log(1)"]),
+    ("npx", ["-y", "evil-mcp"]),
+    ("uvx", ["evil"]),
+    ("pipx", ["run", "evil"]),
+    ("yarn", ["evil"]),
+    ("env", ["sh", "-c", "id"]),                        # exec wrapper
+    ("/tmp/payload", []),                               # path, not a basename
+    ("mcp-server-demo;id", []),                         # shell metachar in command
+    ("mcp-server-demo", ["-c", "code"]),               # code-exec flag on allowed cmd
+    ("mcp-server-demo", ["-cglued()"]),                # glued code-exec flag
+    ("mcp-server-demo", ["--eval=x"]),                 # long glued eval
+    ("mcp-server-demo", ["https://evil.example/x.js"]),# remote URL arg
+])
+def test_validator_rejects_rce_forms(command, args):
+    assert _validate_mcp_command(command, args, {}) is not None
+
+
+@pytest.mark.parametrize("key", ["LD_PRELOAD", "NODE_OPTIONS", "PYTHONPATH", "DYLD_INSERT_LIBRARIES", "PATH"])
+def test_validator_rejects_dangerous_env(key):
+    assert _validate_mcp_command("mcp-server-demo", [], {key: "x"}) is not None
+
+
+def test_denied_command_rejected_even_when_operator_allowlists_it():
+    # python3 is in ODYSSEUS_MCP_ALLOWED_COMMANDS for this test; hard-deny wins.
+    assert _validate_mcp_command("python3", ["server.py"], {}) is not None
+
+
+def test_command_not_in_allowlist_rejected():
+    assert _validate_mcp_command("some-random-binary", [], {}) is not None
+
+
+def test_validator_allows_safe_allowlisted_server():
+    assert _validate_mcp_command("mcp-server-demo", ["--port", "3000"], {"FOO": "bar"}) is None
+
+
+# ── integration: the real do_manage_mcp('add') path ──
+def _add(command, args=None, env=None):
+    payload = {"action": "add", "name": "x", "command": command,
+               "args": args if args is not None else [], "env": env or {}}
+    return asyncio.run(ti.do_manage_mcp(json.dumps(payload)))
+
+
+def test_add_rejects_rce_with_no_db_write_and_no_connect(monkeypatch):
+    mcp = MagicMock()
+    mcp.connect_server = AsyncMock()
+    monkeypatch.setattr(ti, "get_mcp_manager", lambda: mcp)
+
+    res = _add("sh", ["-c", "id>/tmp/pwn"])
+    assert res["exit_code"] == 1
+    assert "refused" in res["error"]
+    mcp.connect_server.assert_not_called()
+
+    db = _TS()
+    try:
+        assert db.query(McpServer).count() == 0, "rejected add must not persist an enabled row"
+    finally:
+        db.close()
+
+
+def test_add_allows_safe_server_writes_row_and_connects(monkeypatch):
+    mcp = MagicMock()
+    mcp.connect_server = AsyncMock()
+    mcp.get_server_status = MagicMock(return_value={"tool_count": 2})
+    monkeypatch.setattr(ti, "get_mcp_manager", lambda: mcp)
+
+    res = _add("mcp-server-demo", ["--port", "3000"])
+    assert res["exit_code"] == 0
+    mcp.connect_server.assert_called_once()
+
+    db = _TS()
+    try:
+        assert db.query(McpServer).count() == 1
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

`do_manage_mcp("add", ...)` passed model- and prompt-injection-controlled `command`/`args`/`env` straight to a stdio subprocess spawn with no allowlist, and persisted an enabled server row before connecting (so a payload also survived to re-execute on startup). A string smuggled into a skill description, memory entry, fetched page, or email body could register a stdio MCP server running arbitrary code as the app UID, e.g. `command="sh", args=["-c", "id>/tmp/pwn"]`. This adds `_validate_mcp_command`, applied on the agent path before any DB write or spawn. The trusted admin route is unchanged.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Closes #2891
Supersedes https://github.com/pewdiepie-archdaemon/odysseus/pull/438

## Type of Change

- [x] Bug fix (security: closes a confirmed RCE on the `manage_mcp` agent tool surface)

## Checklist

- [x] I searched open issues and open PRs, this is not a duplicate (supersedes #438).
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above, no unrelated refactors.
- [x] Behaviour-preserving for safe input; covered by validator unit tests plus integration tests on the real `do_manage_mcp` path (see How to Test).

## How to Test

```
python -m pytest -q tests/test_manage_mcp_command_allowlist.py
```

The guard, on the agent path:
- Hard-denies interpreters, runtimes, package runners, shells, and exec-wrappers (`python`/`node`/`deno`/`bun`/`npx`/`uvx`/`pip`/`uv`/`sh`/`env`/`xargs`/...), even if an operator lists one in `ODYSSEUS_MCP_ALLOWED_COMMANDS`.
- Requires the command to be a bare basename (no path components, no shell metacharacters) present in the operator allowlist (empty by default).
- Rejects code-exec argv flags by prefix so glued forms are caught too (`-c`/`-e`/`-m`/`--eval`/`--exec`/`--print`/`--module`/`--command`/`--require`), remote-URL args, and code-injecting env keys (`LD_PRELOAD`, `NODE_OPTIONS`, `PYTHONPATH`, `DYLD_*`, `PATH`, ...).

A rejected registration returns an error, writes no DB row, and makes no connection (asserted by the integration tests). Stdio servers that need an interpreter or package runner are registered via the admin route, not from the agent tool.

This supersedes #438 and incorporates the bypass forms its reviewers found (interpreter script paths, `-m pip`, glued `-c`/`-e`, `--eval=`, `deno eval`, package runners, remote URLs), plus the requested integration coverage proving rejected input does not persist an enabled row or attempt a connection. Credit to @ErnestHysa for the original work in #438 and to @alteixeira20 / @NubsCarson for the bypass analysis.

## Visual / UI changes

No rendered UI changed.

- [x] No UI styling changed.
- [x] No new component patterns.
- [x] Not a bulk auto-generated PR.
