### PR TITLE
fix(auth): tie remember-me cookie lifetime to TOKEN_TTL

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -12,7 +12,7 @@ import re
 from pathlib import Path
 
 from core.atomic_io import atomic_write_json, atomic_write_text
-from core.auth import AuthManager, RESERVED_USERNAMES, SetAdminResult
+from core.auth import AuthManager, RESERVED_USERNAMES, SetAdminResult, TOKEN_TTL
 from src.constants import DEEP_RESEARCH_DIR, MEMORY_FILE, PASSWORD_MIN_LENGTH, SKILLS_DIR
 from src.rate_limiter import RateLimiter
 from src.settings_scrub import scrub_settings
@@ -161,7 +161,7 @@ def setup_auth_routes(auth_manager: AuthManager) -> APIRouter:
             path="/",
         )
         if body.remember:
-            cookie_kwargs["max_age"] = 60 * 60 * 24 * 7  # 7 days
+            cookie_kwargs["max_age"] = TOKEN_TTL
         response.set_cookie(**cookie_kwargs)
         return {"ok": True, "username": username}
 

--- a/tests/test_auth_policy.py
+++ b/tests/test_auth_policy.py
@@ -215,3 +215,58 @@ def test_setup_rejects_seven_char_password(tmp_path):
         asyncio.run(endpoint(body=body, request=request))
 
     assert exc.value.status_code == 400
+
+
+# ── Login "remember me" cookie lifetime ────────────────────────────────
+
+
+class _CapturingResponse:
+    """Stand-in for fastapi.Response that records set_cookie kwargs."""
+
+    def __init__(self):
+        self.cookie_kwargs = None
+
+    def set_cookie(self, **kwargs):
+        self.cookie_kwargs = kwargs
+
+
+def _login_endpoint(auth_manager):
+    sys.modules.pop("routes.auth_routes", None)
+    _real_core_package()
+    from routes.auth_routes import LoginRequest, setup_auth_routes
+
+    router = setup_auth_routes(auth_manager)
+    for route in router.routes:
+        if getattr(route, "path", None) == "/api/auth/login":
+            return route.endpoint, LoginRequest
+    raise AssertionError("login route not found")
+
+
+def test_remember_cookie_max_age_matches_token_ttl(tmp_path):
+    auth_mod = _auth_module()
+    mgr = _make_manager(tmp_path)
+    mgr.create_user("alice", "alice-password", is_admin=False)
+    endpoint, LoginRequest = _login_endpoint(mgr)
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    response = _CapturingResponse()
+    body = LoginRequest(username="alice", password="alice-password", remember=True)
+
+    result = asyncio.run(endpoint(body=body, request=request, response=response))
+
+    assert result == {"ok": True, "username": "alice"}
+    # The persistent cookie must outlive neither more nor less than the token.
+    assert response.cookie_kwargs["max_age"] == auth_mod.TOKEN_TTL
+
+
+def test_no_remember_omits_cookie_max_age(tmp_path):
+    mgr = _make_manager(tmp_path)
+    mgr.create_user("bob", "bob-password", is_admin=False)
+    endpoint, LoginRequest = _login_endpoint(mgr)
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    response = _CapturingResponse()
+    body = LoginRequest(username="bob", password="bob-password", remember=False)
+
+    asyncio.run(endpoint(body=body, request=request, response=response))
+
+    # Without "remember", the cookie is a session cookie (no max_age).
+    assert "max_age" not in response.cookie_kwargs


### PR DESCRIPTION
## Summary

The server-side session lifetime is a single named constant, `TOKEN_TTL` (`core/auth.py`). The token's stored expiry uses it, and the `GET /api/auth/policy` endpoint reports it to the frontend as `session_days = TOKEN_TTL // 86400`. But the "remember me" cookie in the login handler hardcoded the same seven-day value independently (`cookie_kwargs["max_age"] = 60 * 60 * 24 * 7`), so the persistent cookie lifetime could silently drift from the token TTL if `TOKEN_TTL` is ever changed. The browser would keep a cookie for a token the server had already expired, or expire the cookie while the token was still valid.

This PR ties the persistent cookie's `max_age` to `TOKEN_TTL` so there is one source of truth for the session lifetime, matching how `session_days` is already derived from it. No behavior change at the current value (`TOKEN_TTL` is still 7
days); the cookie still renders identically.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4471 

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `python -m pytest tests/test_auth_policy.py` — all pass, including the two new tests: `test_remember_cookie_max_age_matches_token_ttl` and `test_no_remember_omits_cookie_max_age`.
2. Log in normally (the "remember me" toggle is on by default); confirm the `odysseus_session` cookie has a `Max-Age` of `604800` (7 days), unchanged from before.
3. Temporarily change `TOKEN_TTL` in `core/auth.py`; confirm the "remember me" cookie's `Max-Age` and `GET /api/auth/policy`'s `session_days` now move together.


- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.
