### PR TITLE
Fix ReferenceError: body is not defined in _showDiagnosis

### DIFF
--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -757,7 +757,7 @@ export function _showDiagnosis(panel, diagnosis, sourceText) {
       });
       row.appendChild(btn);
     }
-    body.appendChild(row);
+    diag.appendChild(row);
   }
 }
 


### PR DESCRIPTION
## Summary

Line 760 referenced a removed 'body' element after the diagnosis UI was refactored to build onto 'diag'. Changed to diag.appendChild(row) so the Cookbook panel renders crashed-serve diagnostics instead of throwing.

## Target branch

- [X] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue
Fixes #4488

## Type of Change

- [X] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [X] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [X] This PR targets `dev`
- [X] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [X] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test
1. Trigger a crashed Cookbook serve (any serve that fails to start produces a diagnosis to render).
2. Open the Cookbook panel. On unpatched `dev`, the panel does not open and the browser console shows `ReferenceError: body is not defined at _showDiagnosis (cookbook-diagnosis.js:760)`.
3. With this change, the Cookbook panel opens and renders the diagnosis (message, suggestion, Copy / Dismiss, and fix buttons) correctly.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [X] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [X] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [X] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [X] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

<img width="778" height="880" alt="image" src="https://github.com/user-attachments/assets/88a95746-2a37-403d-8623-c649b309fb7a" />
<img width="1476" height="313" alt="image" src="https://github.com/user-attachments/assets/0167740d-a1a0-4083-9f14-1fe35670c72b" />
