### PR TITLE
fix(cookbook): pull llama.cpp from the ggml-org GHCR namespace (#4457)

### DIFF
--- a/static/js/cookbook-deps-recipes.js
+++ b/static/js/cookbook-deps-recipes.js
@@ -56,7 +56,7 @@ const _RECIPES = [
     match: () => true,
     variants: {
       pip:    { commands: ['CMAKE_ARGS="-DGGML_CUDA=on" uv pip install -U "llama-cpp-python[server]"'] },
-      docker: { commands: ['docker pull ghcr.io/ggerganov/llama.cpp:server-cuda'] },
+      docker: { commands: ['docker pull ghcr.io/ggml-org/llama.cpp:server-cuda'] },
     },
   },
 ];

--- a/tests/test_cookbook_deps_recipes.py
+++ b/tests/test_cookbook_deps_recipes.py
@@ -1,0 +1,27 @@
+"""Guard the llama.cpp Docker pull recipe surfaced in Cookbook → Dependencies.
+
+The upstream repo moved from github.com/ggerganov/llama.cpp to
+github.com/ggml-org/llama.cpp. The old GHCR namespace
+(ghcr.io/ggerganov/llama.cpp) no longer publishes images, so the
+docker variant in the Dependencies panel returned
+"failed to resolve reference … not found" when copied verbatim (#4457).
+The other llama.cpp reference in routes/cookbook_routes.py already uses
+ggml-org; this guards the JS recipe so the two stay aligned.
+"""
+from pathlib import Path
+
+RECIPES_JS = (
+    Path(__file__).resolve().parent.parent / "static" / "js" / "cookbook-deps-recipes.js"
+)
+
+
+def test_llama_cpp_docker_recipe_uses_ggml_org_namespace():
+    source = RECIPES_JS.read_text(encoding="utf-8")
+
+    assert "ghcr.io/ggml-org/llama.cpp:server-cuda" in source, (
+        "Expected the llama.cpp docker recipe to pull from the ggml-org namespace."
+    )
+    assert "ghcr.io/ggerganov/llama.cpp" not in source, (
+        "The ggerganov GHCR namespace no longer publishes llama.cpp images. "
+        "Use ghcr.io/ggml-org/llama.cpp:server-cuda."
+    )


### PR DESCRIPTION
## Summary

The Dependencies tab's llama.cpp docker recipe surfaced \`docker pull ghcr.io/ggerganov/llama.cpp:server-cuda\`. Upstream moved from github.com/ggerganov/llama.cpp to github.com/ggml-org/llama.cpp and the old GHCR namespace no longer publishes images, so the command copied from the panel failed with \`failed to resolve reference "ghcr.io/ggerganov/llama.cpp:server-cuda": not found\`. This PR points the recipe at \`ghcr.io/ggml-org/llama.cpp:server-cuda\` — already the namespace \`routes/cookbook_routes.py:1415\` uses for the source clone — and adds a regression test in the same shape as \`tests/test_cookbook_diagnosis_js.py\` that pins the new namespace and forbids the dead one. Fixes #4457.

## Target branch

- [x] This PR targets **\`dev\`**, not \`main\`.

## Linked Issue

Fixes #4457

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate. No prior PR addresses the \`ggerganov\` GHCR reference in \`static/js/cookbook-deps-recipes.js\`.
- [x] This PR targets \`dev\`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (\`docker compose up\` or \`uvicorn app:app\`) and verified the change works end-to-end. _Not run end-to-end: docker is unavailable in this dev environment. Verified via the regression test (\`pytest tests/test_cookbook_deps_recipes.py\`), \`node --check\` on the changed JS, and by confirming the new URL matches the namespace already used in \`routes/cookbook_routes.py:1415\`._

## How to Test

1. Inspect the diff: the only production change is one string in \`static/js/cookbook-deps-recipes.js:59\` — \`ghcr.io/ggerganov/llama.cpp\` → \`ghcr.io/ggml-org/llama.cpp\`. No CSS / HTML / SVG / DOM / style changes; this file is a pure data + helper module (\`grep -c 'document\.\|createElement\|innerHTML' static/js/cookbook-deps-recipes.js\` → 0). The same module is consumed by other renderers verbatim, so the only visual difference is the text of the command the panel offers to copy.
2. Run the regression test:
   \`\`\`bash
   pytest tests/test_cookbook_deps_recipes.py
   \`\`\`
   It asserts \`ghcr.io/ggml-org/llama.cpp:server-cuda\` is present and \`ghcr.io/ggerganov/llama.cpp\` is absent.
3. JS sanity per CONTRIBUTING.md:
   \`\`\`bash
   node --check static/js/cookbook-deps-recipes.js
   \`\`\`
4. Manual: open Cookbook → Dependencies → llama_cpp → Docker, copy the suggested command, and run it — \`docker pull ghcr.io/ggml-org/llama.cpp:server-cuda\` resolves and pulls successfully (the reporter confirmed this in the issue).