### PR TITLE
fix: Preserve GPU environment variables in detached child processes (closes #831)

### DIFF
--- a/core/platform_compat.py
+++ b/core/platform_compat.py
@@ -64,12 +64,18 @@ def detached_popen_kwargs() -> dict:
     its own process group (so it isn't killed when the parent's console closes)
     and is detached from any console.
     """
+    # Preserve GPU-related environment variables from the parent process
+    # to ensure CUDA-capable tools (like llama.cpp with GPU offloading) work.
+    gpu_env_vars = ["CUDA_VISIBLE_DEVICES", "CUDA_HOME", "CUDA_PATH", "LD_LIBRARY_PATH", "PATH"]
+    env = os.environ.copy()
+    # Only retain meaningful values (non-empty)
+    env = {k: v for k, v in env.items() if k in gpu_env_vars and v}
     if IS_WINDOWS:
         flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200) | getattr(
             subprocess, "DETACHED_PROCESS", 0x00000008
         )
-        return {"creationflags": flags}
-    return {"start_new_session": True}
+        return {"creationflags": flags, "env": env}
+    return {"start_new_session": True, "env": env}
 
 
 def pid_alive(pid: Optional[int]) -> bool:


### PR DESCRIPTION
## What
When launching a detached subprocess (e.g., llama.cpp server), the child process inherits an incomplete environment. Specifically, GPU-related environment variables such as `CUDA_VISIBLE_DEVICES`, `LD_LIBRARY_PATH`, and `PATH` may be missing or empty, causing CUDA-capable tools to fall back to CPU even though the GPU is available (e.g., nvidia-smi works).

## Fix
Modified `detached_popen_kwargs()` to explicitly pass a filtered set of GPU-relevant environment variables from the parent process to the child. This ensures that CUDA libraries and devices are correctly discovered by the child process, allowing GPU offloading (like '--n-gpu-layers' in llama.cpp) to function as expected.

Closes #831