### PR TITLE
fix: use aware UTC in health timestamp

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ load_dotenv(encoding="utf-8-sig")
 import asyncio
 import logging
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 
 from contextlib import asynccontextmanager
@@ -863,7 +863,7 @@ async def get_version():
 
 @app.get("/api/health")
 async def health_check() -> Dict[str, str]:
-    return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
+    return {"status": "healthy", "timestamp": datetime.now(timezone.utc).isoformat()}
 
 @app.get("/api/ready")
 async def readiness_check() -> JSONResponse:


### PR DESCRIPTION
## Linked Issue

Closes #4504

## Summary

Updates `/api/health` to emit its timestamp with timezone-aware UTC.

## Problem

The health endpoint currently uses `datetime.utcnow().isoformat()`, which returns a naive datetime string. That makes the timestamp ambiguous for clients and monitoring systems consuming the liveness response.

## Before / after

Before:

```json
{"status":"healthy","timestamp":"2026-06-18T12:34:56.789012"}
```

After:

```json
{"status":"healthy","timestamp":"2026-06-18T12:34:56.789012+00:00"}
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Tests

## How to Test

A reviewer can verify the change by checking `/api/health` and confirming the timestamp includes a UTC offset (`+00:00`) rather than a naive timestamp.

Commands I ran locally:

```bash
python -m compileall app.py
git diff --check
```

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] Kept the change focused on the health endpoint timestamp.
- [x] Ran local syntax/diff checks.