### PR TITLE
fix(cookbook): scope the "Kill vLLM" diagnosis to actual vLLM tracebacks

### DIFF
--- a/static/js/cookbook-diagnosis.js
+++ b/static/js/cookbook-diagnosis.js
@@ -578,23 +578,49 @@ export const ERROR_PATTERNS = [
     ],
   },
   {
-    // Tail-only + healthy-server suppression. tmux capture-pane returns the
-    // entire scrollback every poll, so a one-shot startup traceback would
-    // otherwise stick on the panel forever even while the server happily
-    // serves /v1/models. Only fire if the traceback is in recent output AND
-    // the server isn't currently logging healthy traffic.
+    // Dependency-install (pip) build failure — a required package failed to
+    // build its wheel (common when an old sdist's setup.py breaks on a newer
+    // Python, e.g. basicsr on 3.13). This is an install problem, NOT a serve
+    // problem, so it must never suggest killing vLLM.
+    match: (text) => {
+      const TAIL = text.slice(-6000);
+      // A serve script can run a fallback build and then start serving fine —
+      // don't flag a stale build error once the server is up.
+      if (/Application startup complete|"(?:GET|POST)\s+\/v1\/[^"]+ HTTP\/[\d.]+"\s*2\d\d|Uvicorn running on|server is listening on https?:\/\//i.test(TAIL)) return false;
+      return /Failed to build\b|subprocess-exited-with-error|Could not build wheels|metadata-generation-failed/i.test(TAIL);
+    },
+    message: 'A dependency failed to build during install — usually an older package whose build breaks on this Python version, not a server problem. The install did not finish.',
+    suggestion: 'Suggested action: check the captured output for the package that failed to build; it may need a newer release or a patch to install on this Python version.',
+    fixes: [],
+  },
+  {
+    // vLLM-specific traceback: only offer the kill-processes recovery when the
+    // output is actually about vLLM. Tail-only + healthy-server suppression so
+    // a one-shot startup traceback doesn't stick on the panel forever while
+    // the server happily serves /v1/models.
     match: (text) => {
       const TAIL = text.slice(-4096);
       if (!/Traceback \(most recent call last\)/i.test(TAIL)) return false;
-      // Healthy markers in the tail mean whatever blew up has been recovered
-      // from — the server is up and answering requests.
       if (/Application startup complete|"GET \/v1\/[^"]+ HTTP\/[\d.]+" 2\d\d|Uvicorn running on/i.test(TAIL)) return false;
-      return true;
+      return /vllm/i.test(TAIL);
     },
-    message: 'Python traceback detected — may be a handled error, check logs.',
+    message: 'A vLLM process hit a Python traceback and may be wedged.',
     fixes: [
       { label: 'Kill vLLM processes', action: (panel) => _runQuickCmd(panel, 'pkill -f vllm') },
     ],
+  },
+  {
+    // Generic traceback (not vLLM, not a pip build): surface it without
+    // suggesting an unrelated vLLM kill. Same tail-only + healthy suppression.
+    match: (text) => {
+      const TAIL = text.slice(-4096);
+      if (!/Traceback \(most recent call last\)/i.test(TAIL)) return false;
+      if (/Application startup complete|"GET \/v1\/[^"]+ HTTP\/[\d.]+" 2\d\d|Uvicorn running on/i.test(TAIL)) return false;
+      return true;
+    },
+    message: 'Python traceback detected — check the captured output below for the underlying error.',
+    suggestion: 'Suggested action: read the captured output for the failing step; copy the troubleshooting bundle if you need help.',
+    fixes: [],
   },
 ];
 


### PR DESCRIPTION
## Summary

When a Cookbook task failed with a Python traceback that had nothing to do with
vLLM — most commonly a dependency install whose wheel fails to build on a newer
Python — the diagnosis panel still offered a **"Kill vLLM processes"**
(`pkill -f vllm`) recovery button. That advice is useless for a build failure
and actively harmful if you have a vLLM server running for something else.

The cause is a single catch-all matcher in `ERROR_PATTERNS`
(`static/js/cookbook-diagnosis.js`) that fired on ANY `Traceback (most recent
call last)` and always attached the vLLM-kill fix. This splits it into three
specific matchers, all keeping the existing healthy-server suppression:

1. **pip build failure** (`Failed to build` / `metadata-generation-failed` /
   `subprocess-exited-with-error` / `Could not build wheels`) → "a dependency
   failed to build during install" message, no kill.
2. **vLLM-specific traceback** (tail actually mentions `vllm`) → keeps the
   "Kill vLLM processes" recovery, now correctly scoped.
3. **Any other traceback** → neutral "check the captured output" message, no kill.

One file changed: `static/js/cookbook-diagnosis.js`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4516

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app and verified the change works end-to-end.

## How to Test

1. `node --check static/js/cookbook-diagnosis.js` (passes).
2. Trigger a dependency install that fails to build a wheel (e.g. an old package
   on Python 3.13), or any serve task that hits a non-vLLM traceback. Open its
   diagnosis.
   - **Before:** "Python traceback detected — may be a handled error, check
     logs." with a **Kill vLLM processes** button, regardless of the real cause.
   - **After:** a build failure shows "A dependency failed to build during
     install…" (no kill); a generic traceback shows "Python traceback detected —
     check the captured output below…" (no kill); only an actual vLLM traceback
     still offers the kill.

## Visual / UI changes

This changes the **text** of a diagnosis message (and whether the "Kill vLLM
processes" button is offered), rendered in the existing `.cookbook-diagnosis`
card. No new styling, classes, colors, fonts, layout, components, or emoji — it
reuses the existing diagnosis card exactly. The before/after wording is quoted
in "How to Test" above. Happy to add a before/after screenshot if you'd like one.

---

No new attack surface: client-side diagnosis text/matching only; no auth or
network changes. Issue filed first per CONTRIBUTING; single, human-verified fix.
Co-authored by Claude, code-reviewed by Codex.
