### PR TITLE
chore(deps): remove unused @anthropic-ai/sdk dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,32 +4,8 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.105.0"
-      },
       "devDependencies": {
         "@antithesishq/bombadil": "^0.6.1"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.105.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
-      "integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@antithesishq/bombadil": {
@@ -41,56 +17,6 @@
       "bin": {
         "bombadil": "bin/bombadil.js"
       }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,5 @@
   },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.6.1"
-  },
-  "dependencies": {
-    "@anthropic-ai/sdk": "^0.105.0"
   }
 }


### PR DESCRIPTION
## Summary

Removes the unused `@anthropic-ai/sdk` dependency. It is declared in `package.json` `dependencies` but never imported anywhere in the codebase (verified: no `.js`/`.ts`/`.mjs` usage in the tree or in history; unused since v1.0). It is the only root dependency and no other package depends on it, so removing it is safe; the lockfile drops it plus 6 transitive packages (@babel/runtime, @stablelib/base64, fast-sha256, json-schema-to-ts, standardwebhooks, ts-algebra).

Done via `npm uninstall --package-lock-only @anthropic-ai/sdk` (no source changes - nothing referenced it).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4565

## Type of Change

- [x] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs - this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above.
- [x] I verified the change works end-to-end: `grep` shows zero imports of the package across the tree and full git history; `package-lock.json` no longer references it; `node --check` on the JS is unaffected since nothing imported it.

## How to Test

1. `grep -rn "@anthropic-ai" .` (excluding node_modules) - no source hits.
2. `npm ci` resolves cleanly without it; the lockfile has no `@anthropic-ai/sdk` node.

## Visual / UI changes

None. Dependency removal only.
