### PR TITLE
fix(chat): keep typed draft when hitting Stop

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -24,6 +24,7 @@ import slashCommands, { initSlashCommands, isCommand, handleSlashCommand, handle
 import createResearchSynapse from './researchSynapse.js';
 import { createStreamRenderer } from './streamingRenderer.js';
 import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composerArrowUpRecall.js';
+import { shouldTreatStopClick } from './composerStopGuard.js';
 
   const RESEARCH_TIMEOUT_MS = 360000;
   const DEFAULT_TIMEOUT_MS = 120000;
@@ -291,8 +292,13 @@ import { wireArrowUpRecall, getLastUserMessageFromChatHistory } from './composer
       return;
     }
 
-    // If currently streaming, stop it
-    if (isStreaming) {
+    // If currently streaming (or the button is visually in Stop mode even
+    // though the streaming flag hasn't re-armed yet — e.g. a run resumed after
+    // a page refresh), treat the click as Stop. Keying off the button's visible
+    // mode as well as the flag prevents the click from falling through to the
+    // send path, which would clear the composer and fire the user's freshly
+    // typed draft as a new message instead of just stopping.
+    if (shouldTreatStopClick(isStreaming, submitBtn)) {
       // Cancel server-side research if in progress
       const _cancelSid = sessionModule.getCurrentSessionId();
       if (_cancelSid && _researchingStreamIds.has(_cancelSid)) {

--- a/static/js/composerStopGuard.js
+++ b/static/js/composerStopGuard.js
@@ -1,0 +1,32 @@
+/**
+ * Decide whether activating the shared send/stop button should be handled as a
+ * STOP (abort the in-flight run) rather than a SEND (submit composer text).
+ *
+ * The chat composer uses ONE `<button type="submit">` for both Send and Stop.
+ * Historically `handleChatSubmit` discriminated the two purely off the
+ * module-level `isStreaming` flag. But the button can visually show the Stop
+ * icon while `isStreaming` is still false — a state desync, most notably a run
+ * that was resumed after a page refresh, before the resume reader re-arms the
+ * flag. In that window a click fell through to the SEND path, which clears the
+ * composer (`messageInput.value = ''`) and fires the user's freshly typed draft
+ * as a brand-new message — silently destroying what they had typed.
+ *
+ * Treat the activation as Stop whenever EITHER signal says a run is active:
+ *   - the streaming flag is set, OR
+ *   - the button is visually in its streaming/stop mode (`dataset.mode`).
+ *
+ * Keying off the button's visible mode (not just the flag) guarantees that a
+ * click on something showing a Stop icon is always handled as a stop, so the
+ * typed draft is preserved instead of being cleared and sent.
+ *
+ * @param {boolean} isStreaming               module-level streaming flag
+ * @param {{ dataset?: { mode?: string } } | null} [submitBtn]  the send/stop button element
+ * @returns {boolean} true → handle as Stop (abort, keep draft); false → proceed to send
+ */
+export function shouldTreatStopClick(isStreaming, submitBtn) {
+  if (isStreaming) return true;
+  const mode = submitBtn && submitBtn.dataset ? submitBtn.dataset.mode : '';
+  return mode === 'streaming';
+}
+
+export default { shouldTreatStopClick };

--- a/tests/test_composer_stop_guard_js.py
+++ b/tests/test_composer_stop_guard_js.py
@@ -1,0 +1,115 @@
+"""Pin the send/stop button's Stop-vs-Send decision (static/js/composerStopGuard.js).
+
+Regression guard for: hitting **Stop** must never clear the freshly typed draft
+in the composer. The composer uses one `<button type="submit">` for both Send and
+Stop; `handleChatSubmit` only enters the (draft-preserving) Stop branch when
+`shouldTreatStopClick()` is true. If that decision were keyed off the
+`isStreaming` flag alone, a click on a button that is *visually* in Stop mode
+while the flag has not re-armed (e.g. a run resumed after a page refresh) would
+fall through to the send path — which clears `#message` and fires the draft as a
+new message.
+
+Driven through `node --input-type=module` so we exercise the real JS without a
+full Vitest/Jest setup (same approach as test_composer_arrow_up_recall_js.py).
+Skips when `node` is not installed rather than failing.
+"""
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_GUARD = _REPO / "static" / "js" / "composerStopGuard.js"
+_GUARD_URL = _GUARD.as_uri()
+_CHAT = _REPO / "static" / "js" / "chat.js"
+_HAS_NODE = shutil.which("node") is not None
+
+_HARNESS = r"""
+import { shouldTreatStopClick } from 'GUARD_PATH';
+
+function btn(mode) {
+  // mode === undefined → no dataset.mode at all
+  return mode === undefined ? { dataset: {} } : { dataset: { mode } };
+}
+
+const cases = CASES_JSON;
+const results = cases.map((c) => {
+  let submitBtn;
+  if (c.btn === 'null') submitBtn = null;
+  else if (c.btn === 'nodataset') submitBtn = {};
+  else submitBtn = btn(c.mode);
+  return shouldTreatStopClick(c.isStreaming, submitBtn);
+});
+console.log(JSON.stringify(results));
+""".replace("GUARD_PATH", _GUARD_URL)
+
+
+def _run(cases: list) -> list:
+    js = _HARNESS.replace("CASES_JSON", json.dumps(cases))
+    proc = subprocess.run(
+        ["node", "--input-type=module"],
+        input=js,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(_REPO),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_streaming_flag_set_is_stop():
+    # Classic case: flag set → always Stop, regardless of button mode.
+    assert _run([{"isStreaming": True, "mode": "streaming"}]) == [True]
+    assert _run([{"isStreaming": True, "mode": ""}]) == [True]
+    assert _run([{"isStreaming": True, "btn": "null"}]) == [True]
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_button_visually_streaming_is_stop_even_when_flag_false():
+    # The core regression: button shows Stop (dataset.mode === 'streaming') but
+    # the streaming flag hasn't re-armed (resume-after-refresh). Must be Stop so
+    # the typed draft is preserved, not cleared+sent.
+    assert _run([{"isStreaming": False, "mode": "streaming"}]) == [True]
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_idle_button_and_flag_false_is_send():
+    # Genuine send: not streaming and button is in a send-capable mode.
+    assert _run([{"isStreaming": False, "mode": ""}]) == [False]
+    assert _run([{"isStreaming": False, "mode": "newchat"}]) == [False]
+    assert _run([{"isStreaming": False, "mode": "mic"}]) == [False]
+    assert _run([{"isStreaming": False, "mode": "recording"}]) == [False]
+
+
+@pytest.mark.skipif(not _HAS_NODE, reason="node binary not on PATH")
+def test_missing_button_or_dataset_defaults_to_send_when_not_streaming():
+    # Defensive: a null button or one without dataset.mode must not crash and,
+    # absent the streaming flag, must NOT be treated as Stop.
+    assert _run([{"isStreaming": False, "btn": "null"}]) == [False]
+    assert _run([{"isStreaming": False, "btn": "nodataset"}]) == [False]
+    assert _run([{"isStreaming": False, "mode": None}]) == [False]
+
+
+def test_chat_js_stop_branch_uses_guard_not_bare_flag():
+    """Static guard: the Stop branch in chat.js must call shouldTreatStopClick,
+    not re-introduce a bare `if (isStreaming)` discriminator that would let a
+    resume-mode click fall through to the send path and wipe the draft.
+    """
+    src = _CHAT.read_text(encoding="utf-8")
+    assert "import { shouldTreatStopClick } from './composerStopGuard.js';" in src, (
+        "chat.js must import the stop-guard helper"
+    )
+    # The guarded stop branch must exist.
+    assert re.search(r"if \(shouldTreatStopClick\(isStreaming, submitBtn\)\) \{", src), (
+        "the Stop branch must be guarded by shouldTreatStopClick(isStreaming, submitBtn)"
+    )
+    # And the old bare-flag stop discriminator must be gone.
+    assert "if (isStreaming) {" not in src, (
+        "the bare `if (isStreaming) {` stop discriminator must be replaced by the guard"
+    )


### PR DESCRIPTION
Closes #4580.

## Problem
The chat composer uses one `<button type="submit">` for both Send and Stop. `handleChatSubmit()` chose between them purely off the module-level `isStreaming` flag. The Stop branch itself never clears the composer — so a normal during-stream Stop already preserves a typed draft. But when the button is *visually* in Stop mode while `isStreaming` is still `false` (a state desync, most notably a run **resumed after a page refresh**), the click falls through to the **send path**, which runs `messageInput.value = ''` and fires the user's freshly typed draft as a brand-new message — silently destroying it.

## Fix
Add `shouldTreatStopClick(isStreaming, submitBtn)` (`static/js/composerStopGuard.js`) and key the Stop branch off it instead of the bare flag:

```js
if (shouldTreatStopClick(isStreaming, submitBtn)) { /* abort; keep composer; return */ }
```

It returns `true` whenever the streaming flag is set **or** the button is visually in streaming mode (`dataset.mode === 'streaming'`). The existing Stop branch already preserves the composer, so the draft survives. Genuine sends (flag false **and** button in send/mic/newchat mode) are unaffected.

## Why a tiny separate module
Mirrors the existing `composerArrowUpRecall.js` pattern so the decision is unit-testable in Node without a browser/Vitest setup.

## Testing
- `tests/test_composer_stop_guard_js.py` — Node-driven unit tests for the helper (flag set ⇒ Stop; button visually streaming + flag false ⇒ Stop; idle/mic/newchat ⇒ Send; null/no-dataset button defaults to Send) **plus a static guard** that `chat.js`'s Stop branch uses the helper and no longer uses a bare `if (isStreaming) {`.
- `node --check` passes on `composerStopGuard.js` and `chat.js` (the required CI gate).
- Existing composer tests still green: `test_composer_arrow_up_recall_js.py`, `test_new_chat_clears_input.py`, `test_modal_dock_composer_clearance.py` (13 passed).

## Scope
Two-line behavioral change in `chat.js` (import + guard) + new helper + new test. No change to the abort/teardown logic itself.