### PR TITLE
fix(personal): scope RAG file delete to the caller's own upload dir

### DIFF
--- a/routes/personal_routes.py
+++ b/routes/personal_routes.py
@@ -358,11 +358,13 @@ def setup_personal_routes(personal_docs_manager, rag_manager, rag_available):
                 except Exception as e:
                     logger.warning(f"RAG removal failed for {filepath}: {e}")
 
-            # Delete file from disk if it's in uploads dir
+            # Delete file from disk if it's in the caller's own uploads dir.
+            # Scope to the per-owner subdir, not the shared uploads root, so one
+            # admin can't delete another user's personal files by path.
             deleted_from_disk = False
             try:
                 abs_target = os.path.realpath(filepath)
-                base_abs = os.path.realpath(UPLOADS_DIR)
+                base_abs = os.path.realpath(_personal_upload_dir_for_owner(owner, create=False))
                 in_uploads = (
                     abs_target == base_abs
                     or os.path.commonpath([abs_target, base_abs]) == base_abs

--- a/tests/test_personal_delete_file_confinement.py
+++ b/tests/test_personal_delete_file_confinement.py
@@ -72,3 +72,24 @@ def test_delete_file_removes_regular_file_inside_upload_root(tmp_path, monkeypat
     assert not uploaded_file.exists()
     assert docs.excluded == [filepath]
     assert rag.deleted_sources == [filepath]
+
+
+def test_delete_file_refuses_other_owners_upload(tmp_path, monkeypatch):
+    # alice must not be able to delete a file living under bob's per-owner
+    # upload subdir, even though it sits inside the shared uploads root.
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    victim = uploads / "bob" / "secret.txt"
+    victim.parent.mkdir()
+    victim.write_text("keep me", encoding="utf-8")
+
+    docs = _FakePersonalDocs()
+    rag = _FakeRAG()
+    monkeypatch.setattr(personal_routes, "UPLOADS_DIR", str(uploads))
+    monkeypatch.setattr(personal_routes, "get_rag_manager", lambda: rag)
+
+    filepath = str(victim)
+    result = asyncio.run(_delete_endpoint(docs)(filepath=filepath, owner="alice", _admin=None))
+
+    assert result["deleted_from_disk"] is False
+    assert victim.read_text(encoding="utf-8") == "keep me"


### PR DESCRIPTION
## Summary

`DELETE /api/personal/file` deletes an indexed file from RAG and, when the file is in the personal uploads area, from disk. Personal uploads are partitioned per owner under `PERSONAL_UPLOADS_DIR/<owner>/` (`_personal_upload_dir_for_owner`), but the disk-delete containment check compared the target against the **shared** `PERSONAL_UPLOADS_DIR` root (`base_abs = os.path.realpath(UPLOADS_DIR)`). Any path under the shared root passed, so one user could delete another user's personal upload by supplying its path. This scopes the check to the caller's own per-owner subdir. RAG removal (`delete_by_source`) and listing exclusion (`exclude_file`) are unchanged — they also serve non-upload indexed sources and are unrelated to the disk path.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4603

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. (Backend-only authorization fix with no UI surface; verified via the test suite below. Exercising the live delete path needs a multi-user setup with another owner's upload present.)

## How to Test

```
python -m pytest tests/test_personal_delete_file_confinement.py -q
# 3 passed — symlink escape refused, same-owner delete works,
# and the new test confirms a file under uploads/bob/ is NOT deleted when owner=alice.
```

The broader `-k personal` suite (30 tests) passes; `routes/personal_routes.py` compiles clean.

## Visual / UI changes

None — backend authorization fix, no rendering or `static/js/` changes.