### PR TITLE
fix(ui): escape model name in model-info popup (DOM-XSS) + two latent sinks

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -413,7 +413,7 @@ function _calEventFg(ev) {
 // Returns '' for normal solid-color events.
 function _calItemBgStyle(ev) {
   if (!_isCalBgImage(ev.color)) return '';
-  const url = _calBgImageUrl(ev.color).replace(/'/g, "\\'");
+  const url = _calBgImageUrl(ev.color).replace(/'/g, "\\'").replace(/"/g, "%22");
   return `background-image: linear-gradient(color-mix(in srgb, var(--bg) 70%, transparent), color-mix(in srgb, var(--bg) 70%, transparent)), url('${url}'); background-size: cover; background-position: center;`;
 }
 
@@ -1260,7 +1260,7 @@ async function _renderWeek() {
       // events keep the original tinted treatment.
       let bgDecl;
       if (_isCalBgImage(ev.color)) {
-        const _url = _calBgImageUrl(ev.color).replace(/'/g, "\\'");
+        const _url = _calBgImageUrl(ev.color).replace(/'/g, "\\'").replace(/"/g, "%22");
         bgDecl = `background-image: linear-gradient(color-mix(in srgb, var(--bg) 55%, transparent), color-mix(in srgb, var(--bg) 55%, transparent)), url('${_url}'); background-size: cover; background-position: center;`;
       } else {
         bgDecl = `background:color-mix(in srgb, ${_calColor(ev)} 18%, var(--bg));`;

--- a/static/js/chatRenderer.js
+++ b/static/js/chatRenderer.js
@@ -635,8 +635,8 @@ export function applyModelColor(roleEl, modelName) {
       popup.className = 'ctx-popup';
       let html = '<div style="font-weight:600;margin-bottom:6px;color:var(--fg);display:flex;align-items:center;gap:6px;">';
       if (logoHtml) html += '<span class="role-provider-logo" style="opacity:0.7">' + logoHtml + '</span>';
-      html += short + '</div>';
-      html += '<div><span class="ctx-label">Model</span> ' + modelName.split('/').pop() + '</div>';
+      html += uiModule.esc(short) + '</div>';
+      html += '<div><span class="ctx-label">Model</span> ' + uiModule.esc(modelName.split('/').pop()) + '</div>';
       // Provider = the serving endpoint, distinct from the model vendor/logo
       // (e.g. the same model via OpenRouter vs Copilot vs Anthropic direct).
       const _epUrl = (window.sessionModule && window.sessionModule.getCurrentEndpointUrl)

--- a/static/js/document.js
+++ b/static/js/document.js
@@ -284,8 +284,8 @@ import * as Modals from './modalManager.js';
         ? langIcon(doc.language, 12, { style: 'opacity:0.65;flex-shrink:0;color:currentColor;margin-right:4px;' })
         : '';
       const langChip = `<span class="doc-tab-lang">${lic}</span>`;
-      html += `<div class="doc-tab${isActive ? ' active' : ''}" draggable="true" data-doc-id="${id}" title="${title}">
-        ${verChip}${langChip}<span class="doc-tab-title">${shortTitle}</span>
+      html += `<div class="doc-tab${isActive ? ' active' : ''}" draggable="true" data-doc-id="${id}" title="${_esc(title)}">
+        ${verChip}${langChip}<span class="doc-tab-title">${_esc(shortTitle)}</span>
         <button class="doc-tab-close" data-doc-id="${id}" title="Unlink from chat (kept in the Library)">&times;</button>
       </div>`;
     }


### PR DESCRIPTION
## Summary

The model-info popup in `static/js/chatRenderer.js` (shown when a user clicks an assistant message's role label) builds HTML by string concatenation and assigns it to `popup.innerHTML`. The model name was inserted unescaped at two spots:

```js
html += short + '</div>';                                              // shortModel(modelName)
html += '<div><span class="ctx-label">Model</span> ' + modelName.split('/').pop() + '</div>';
```

`modelName` comes from the streaming response's `model`/`answered_by` field — whatever the serving LLM endpoint reports — so a model advertised as `"><img src=x onerror=...>` runs script when the role label is clicked. This wraps both insertions with the `uiModule.esc()` helper the same function already uses two lines further down. It also applies the existing escape helpers at two latent sinks CodeQL flagged that are fed only by self-authored/server values today: the document-tab `title`/`shortTitle` (`_esc()`), and the calendar event background URL (escaping the `"` that would otherwise break out of the `style="..."` attribute).

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4604

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app end-to-end. (Frontend is plain JS validated with `node --check`; these are pure escaping changes with no behavioural/visual effect for legitimate data — see below. Reproducing the live XSS needs an endpoint reporting a crafted model name.)

## How to Test

1. `node --check static/js/chatRenderer.js static/js/document.js static/js/calendar.js` — all pass.
2. Configure (or mock) an LLM endpoint whose model id is `"><img src=x onerror=alert(1)>`. Send a message, then click the assistant message's role label to open the model-info popup. **Before:** the `onerror` fires. **After:** the payload renders as inert text.
3. Regression: open the popup for a normal model (e.g. `llama3.1:8b`, `openai/gpt-4o`) and confirm the model name still displays correctly.

## Visual / UI changes

None. All three edits only HTML-escape a value before it reaches an existing `innerHTML` sink; for any legitimate model name, document title, or `/api/upload/<id>` background URL the rendered output is byte-identical, so there is nothing to screenshot. No CSS, layout, icon, color, or component change.