### PR TITLE
fix: email poller marks calendar extraction processed on LLM failure

### DIFF
--- a/routes/email_pollers.py
+++ b/routes/email_pollers.py
@@ -683,20 +683,23 @@ async def _auto_summarize_pass_single(days_back: int = 1, account_id: str | None
                                 logger.warning(f"[cal-extract] JSON parse failed: {je} on raw={cal_extract[:200]!r}")
                     except Exception as e:
                         logger.warning(f"[cal-extract] Meeting extraction LLM call failed for uid={uid}: {e}")
-                    # Record we processed this email so we don't re-LLM next run
-                    try:
-                        _cc = _sql3.connect(SCHEDULED_DB)
-                        _cc.execute(
-                            "INSERT OR REPLACE INTO email_calendar_extractions "
-                            "(message_id, owner, uid, events_created, created_at) VALUES (?, ?, ?, ?, ?)",
-                            (message_id, account_owner or "", uid.decode() if isinstance(uid, bytes) else str(uid),
-                             _cal_run_count, datetime.utcnow().isoformat())
-                        )
-                        _cc.commit()
-                        _cc.close()
-                        _cal_existing.add(message_id)
-                    except Exception as ce:
-                        logger.debug(f"Could not cache calendar extraction: {ce}")
+                    else:
+                        # Record we processed this email so we don't re-LLM next run.
+                        # Only mark as processed on success ? transient LLM failures
+                        # are retried on the next poll run (matches summary/reply pattern).
+                        try:
+                            _cc = _sql3.connect(SCHEDULED_DB)
+                            _cc.execute(
+                                "INSERT OR REPLACE INTO email_calendar_extractions "
+                                "(message_id, owner, uid, events_created, created_at) VALUES (?, ?, ?, ?, ?)",
+                                (message_id, account_owner or "", uid.decode() if isinstance(uid, bytes) else str(uid),
+                                 _cal_run_count, datetime.utcnow().isoformat())
+                            )
+                            _cc.commit()
+                            _cc.close()
+                            _cal_existing.add(message_id)
+                        except Exception as ce:
+                            logger.debug(f"Could not cache calendar extraction: {ce}")
 
                 if need_urgent:
                     try:


### PR DESCRIPTION
## Summary

The email poller's calendar extraction was marking emails as processed even when the LLM call failed with a transient error. This caused the poller to permanently skip retrying calendar extraction for those emails, resulting in zero events extracted despite the email being marked as handled.

The fix moves the `INSERT OR REPLACE INTO email_calendar_extractions` statement into an `else` branch on the `except` block, so the processed marker is only written when the LLM call succeeds. This matches the existing retry pattern used for summary and reply generation.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release.

## Linked Issue

Fixes #2187

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end.

## How to Test

1. Start the app with `docker compose up` or `uvicorn app:app`.
2. Send a test email with meeting/invite content to a configured account.
3. Simulate an LLM failure (e.g., temporarily set an invalid API key or stop the LLM service).
4. Trigger the email poller scheduled run (`_auto_summarize_pass_single`).
5. Verify in `email_calendar_extractions` table that **no** row was inserted for the failed email.
6. Restore the LLM service and trigger the poller again.
7. Verify the email is now picked up, processed successfully, and a row appears in `email_calendar_extractions`.

## Visual / UI changes

N/A — no UI changes. Backend-only fix.
