### PR TITLE
feat(helm): single-namespace Kubernetes chart, docs, and OCI publish pipeline

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,52 @@
+# Helm chart lint (gate)
+#
+# Mirrors ci.yml for the chart: catches breakage in charts/odysseus before it
+# reaches a branch, without touching the repo. helm is preinstalled on the
+# GitHub-hosted ubuntu runner, so no third-party setup action is needed (and
+# nothing extra for the workflow-security audit to pin).
+
+name: Helm lint
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helm-lint.yml'
+
+# Default-deny token; the one job only reads the code.
+permissions: {}
+
+concurrency:
+  group: helm-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: helm lint + template
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: helm version
+        run: helm version
+
+      - name: Lint chart
+        run: helm lint charts/odysseus
+
+      # Render the manifests to catch template errors the linter misses.
+      # Default values first, then a few override paths the chart branches on.
+      - name: Render (default values)
+        run: helm template release charts/odysseus --namespace odysseus > /dev/null
+
+      - name: Render (overrides)
+        run: |
+          helm template release charts/odysseus --namespace odysseus \
+            --set odysseus.ingress.enabled=true \
+            --set searxng.secretKey=test \
+            --set chromadb.enabled=false \
+            --set ntfy.enabled=false > /dev/null

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,94 @@
+# Helm chart publish (OCI -> GHCR)
+#
+# Package charts/odysseus and push it as an OCI artifact to GHCR, reusing the
+# same registry + GITHUB_TOKEN path as docker-publish.yml.
+#   push to main -> oci://ghcr.io/<owner>/charts/odysseus:X.Y.Z
+#   push to dev  -> oci://ghcr.io/<owner>/charts/odysseus:X.Y.Z-dev.<sha>
+# X.Y.Z is the chart `version:` in Chart.yaml — bump it when the chart changes,
+# otherwise main re-pushes the same tag. Consume with:
+#   helm install ody oci://ghcr.io/<owner>/charts/odysseus --version X.Y.Z
+#
+# helm is preinstalled on the ubuntu runner, so the only external action is the
+# pinned checkout — keeps the workflow-security (zizmor) audit clean.
+
+name: Helm publish
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helm-publish.yml'
+
+concurrency:
+  group: helm-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default-deny; the job below grants only what it needs.
+permissions: {}
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    name: package + push (OCI -> GHCR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # push the chart artifact to GHCR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Lint chart
+        run: helm lint charts/odysseus
+
+      # main -> bare chart version; dev -> immutable, traceable prerelease pin.
+      - name: Compute chart version
+        id: ver
+        env:
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          base=$(grep -E '^version:' charts/odysseus/Chart.yaml | head -1 | awk '{print $2}' | tr -d '"')
+          [ -n "$base" ] || { echo "chart version not found in Chart.yaml"; exit 1; }
+          if [ "$REF" = "refs/heads/main" ]; then
+            ver="$base"
+          else
+            ver="${base}-dev.${SHA::7}"
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR (OCI)
+        env:
+          ACTOR: ${{ github.actor }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$TOKEN" | helm registry login "$REGISTRY" -u "$ACTOR" --password-stdin
+
+      - name: Package chart
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package charts/odysseus --version "$VERSION" --destination dist
+
+      - name: Push chart to GHCR
+        env:
+          OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # GHCR namespaces must be lowercase.
+          owner_lc=$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')
+          helm push "dist/odysseus-${VERSION}.tgz" "oci://${REGISTRY}/${owner_lc}/charts"
+
+      - name: Logout
+        if: always()
+        run: helm registry logout "$REGISTRY" || true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ docker compose up -d --build
 
 Open `http://localhost:7000` when the containers are healthy. The first admin password is printed in `docker compose logs odysseus`.
 
+Prefer Kubernetes? A Helm chart lives in [`charts/odysseus`](charts/odysseus) — see its [README](charts/odysseus/README.md) or the [setup guide](docs/setup.md#kubernetes-helm).
+
 Native installs, GPU notes, Windows/macOS instructions, HTTPS, and configuration live in the [setup guide](docs/setup.md).
 
 ## Features

--- a/charts/odysseus/.helmignore
+++ b/charts/odysseus/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+.vscode/
+.idea/
+*.swp
+*.bak
+*.orig
+*~

--- a/charts/odysseus/Chart.yaml
+++ b/charts/odysseus/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: odysseus
+description: Odysseus AI assistant — app plus its SearXNG, ChromaDB, and ntfy sidecars, for deployment into a single Kubernetes namespace.
+type: application
+# Chart version. Bump on any chart change.
+version: 0.1.0
+# Application version. Tracks the default odysseus.image.tag (the :latest image
+# published to GHCR by docker-publish.yml). Pin both together for a release.
+appVersion: "latest"
+keywords:
+  - odysseus
+  - llm
+  - ai-assistant
+  - searxng
+  - chromadb
+home: https://github.com/
+sources:
+  - https://github.com/
+maintainers:
+  - name: Lucas Golino

--- a/charts/odysseus/README.md
+++ b/charts/odysseus/README.md
@@ -1,0 +1,54 @@
+# Odysseus Helm chart
+
+Deploys Odysseus and its sidecars into a **single Kubernetes namespace**, mirroring
+`docker-compose.yml`:
+
+| Component | Image | Port | Persistence |
+|-----------|-------|------|-------------|
+| odysseus  | built from repo `Dockerfile` | 7000 | `data` + `logs` PVCs |
+| chromadb  | `chromadb/chroma` | 8000 | PVC `/chroma/chroma` |
+| searxng   | `searxng/searxng` (pinned) | 8080 | PVC `/etc/searxng` |
+| ntfy      | `binwiederhier/ntfy` | 80 | PVC `/var/cache/ntfy` |
+
+Service discovery (`SEARXNG_INSTANCE`, `CHROMADB_HOST`/`PORT`) is injected from the
+in-cluster service names, so the app always points at what the chart deploys.
+
+## Prerequisites
+
+- A namespace (everything lands in the release namespace — `helm install -n <ns>`).
+- A default StorageClass that supports `ReadWriteOnce` (or set `storageClass`/`existingClaim`).
+- An Odysseus image. The chart defaults to `ghcr.io/pewdiepie-archdaemon/odysseus:latest`,
+  published by `.github/workflows/docker-publish.yml`. For a fork, build and push
+  your own and override `odysseus.image.repository`/`tag`:
+
+  ```sh
+  docker build -t <registry>/odysseus:<tag> .
+  docker push <registry>/odysseus:<tag>
+  ```
+
+## Install
+
+```sh
+helm install ody charts/odysseus \
+  --namespace odysseus --create-namespace \
+  --set odysseus.secrets.ODYSSEUS_ADMIN_PASSWORD=<password>
+```
+
+For a fork image, add `--set odysseus.image.repository=<registry>/odysseus --set odysseus.image.tag=<tag>`.
+
+Keep secrets out of git by using `--set`, a private values file, or
+`odysseus.secrets.existingSecret` to reference a Secret you created.
+
+## Notes
+
+- `odysseus.replicaCount` stays at 1: SQLite + `ReadWriteOnce` PVCs allow one writer.
+  To scale, move `DATABASE_URL` to an external DB and the data dirs to RWX storage.
+- The app container starts as root by design — its entrypoint drops to
+  `odysseus.puid`/`pgid` via gosu and chowns the mounted dirs. Don't force a
+  non-root `runAsUser` unless you rebuild the image without gosu.
+- SearXNG auto-generates a secret on first boot if `searxng.secretKey` is unset;
+  it persists in the PVC. Set `searxng.secretKey` for a fixed, managed value.
+- Expose the app via `odysseus.ingress.*` or `kubectl port-forward`.
+
+See also the [setup guide](../../docs/setup.md#kubernetes-helm) and
+[backup notes](../../docs/backup-restore.md#docker-vs-native-vs-kubernetes-installs).

--- a/charts/odysseus/templates/NOTES.txt
+++ b/charts/odysseus/templates/NOTES.txt
@@ -1,0 +1,32 @@
+Odysseus deployed to namespace "{{ .Release.Namespace }}" as release "{{ .Release.Name }}".
+
+Components:
+  - odysseus  (app)        Service {{ include "odysseus.app.fullname" . }}:{{ .Values.odysseus.service.port }}
+{{- if .Values.chromadb.enabled }}
+  - chromadb               Service {{ include "odysseus.chromadb.fullname" . }}:{{ .Values.chromadb.service.port }}
+{{- end }}
+{{- if .Values.searxng.enabled }}
+  - searxng                Service {{ include "odysseus.searxng.fullname" . }}:{{ .Values.searxng.service.port }}
+{{- end }}
+{{- if .Values.ntfy.enabled }}
+  - ntfy                   Service {{ include "odysseus.ntfy.fullname" . }}:{{ .Values.ntfy.service.port }}
+{{- end }}
+
+Reach the app:
+{{- if .Values.odysseus.ingress.enabled }}
+{{- range .Values.odysseus.ingress.hosts }}
+  http://{{ .host }}/
+{{- end }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "odysseus.app.fullname" . }} {{ .Values.odysseus.service.port }}:{{ .Values.odysseus.service.port }}
+  then open http://localhost:{{ .Values.odysseus.service.port }}
+{{- end }}
+
+{{- if not .Values.odysseus.secrets.existingSecret }}
+{{- if not .Values.odysseus.secrets.ODYSSEUS_ADMIN_PASSWORD }}
+
+WARNING: no ODYSSEUS_ADMIN_PASSWORD set. setup.py will generate one on first
+boot — read it from the app logs:
+  kubectl --namespace {{ .Release.Namespace }} logs deploy/{{ include "odysseus.app.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/odysseus/templates/_helpers.tpl
+++ b/charts/odysseus/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/* Base name, overridable. */}}
+{{- define "odysseus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Full release-qualified name. */}}
+{{- define "odysseus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "odysseus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common labels. */}}
+{{- define "odysseus.labels" -}}
+helm.sh/chart: {{ include "odysseus.chart" . }}
+{{ include "odysseus.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/* Base selector labels (no component). */}}
+{{- define "odysseus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "odysseus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Per-component names. */}}
+{{- define "odysseus.app.fullname" -}}{{ include "odysseus.fullname" . }}{{- end -}}
+{{- define "odysseus.chromadb.fullname" -}}{{ include "odysseus.fullname" . }}-chromadb{{- end -}}
+{{- define "odysseus.searxng.fullname" -}}{{ include "odysseus.fullname" . }}-searxng{{- end -}}
+{{- define "odysseus.ntfy.fullname" -}}{{ include "odysseus.fullname" . }}-ntfy{{- end -}}
+
+{{/* ServiceAccount name. */}}
+{{- define "odysseus.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "odysseus.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* odysseus app Secret name (created or existing). */}}
+{{- define "odysseus.app.secretName" -}}
+{{- if .Values.odysseus.secrets.existingSecret -}}
+{{- .Values.odysseus.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "odysseus.app.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/odysseus/templates/chromadb.yaml
+++ b/charts/odysseus/templates/chromadb.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.chromadb.enabled -}}
+{{- $name := include "odysseus.chromadb.fullname" . -}}
+{{- if and .Values.chromadb.persistence.enabled (not .Values.chromadb.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+spec:
+  accessModes:
+    - {{ .Values.chromadb.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.chromadb.persistence.size }}
+  {{- with .Values.chromadb.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: chromadb
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: chromadb
+    spec:
+      serviceAccountName: {{ include "odysseus.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: chromadb
+          image: "{{ .Values.chromadb.image.repository }}:{{ .Values.chromadb.image.tag }}"
+          imagePullPolicy: {{ .Values.chromadb.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            {{- range $k, $v := .Values.chromadb.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- with .Values.chromadb.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /chroma/chroma
+      volumes:
+        - name: data
+          {{- if .Values.chromadb.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.chromadb.persistence.existingClaim | default $name }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.chromadb.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chromadb.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chromadb.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: chromadb
+  ports:
+    - name: http
+      port: {{ .Values.chromadb.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/odysseus/templates/ntfy.yaml
+++ b/charts/odysseus/templates/ntfy.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.ntfy.enabled -}}
+{{- $name := include "odysseus.ntfy.fullname" . -}}
+{{- if and .Values.ntfy.persistence.enabled (not .Values.ntfy.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+spec:
+  accessModes:
+    - {{ .Values.ntfy.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.ntfy.persistence.size }}
+  {{- with .Values.ntfy.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ntfy
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ntfy
+    spec:
+      serviceAccountName: {{ include "odysseus.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ntfy
+          image: "{{ .Values.ntfy.image.repository }}:{{ .Values.ntfy.image.tag }}"
+          imagePullPolicy: {{ .Values.ntfy.image.pullPolicy }}
+          args:
+            - serve
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: NTFY_BASE_URL
+              value: {{ .Values.ntfy.baseUrl | default (printf "http://%s" $name) | quote }}
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- with .Values.ntfy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/ntfy
+      volumes:
+        - name: cache
+          {{- if .Values.ntfy.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.ntfy.persistence.existingClaim | default $name }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.ntfy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ntfy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ntfy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ntfy
+  ports:
+    - name: http
+      port: {{ .Values.ntfy.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/odysseus/templates/odysseus-configmap.yaml
+++ b/charts/odysseus/templates/odysseus-configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "odysseus.app.fullname" . }}-config
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+data:
+  {{- range $k, $v := .Values.odysseus.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  # Service discovery — derived from in-cluster service names so they always
+  # match what this chart actually deploys.
+  {{- if .Values.searxng.enabled }}
+  SEARXNG_INSTANCE: {{ printf "http://%s:%d" (include "odysseus.searxng.fullname" .) (int .Values.searxng.service.port) | quote }}
+  {{- end }}
+  {{- if .Values.chromadb.enabled }}
+  CHROMADB_HOST: {{ include "odysseus.chromadb.fullname" . | quote }}
+  CHROMADB_PORT: {{ .Values.chromadb.service.port | quote }}
+  {{- end }}
+  PUID: {{ .Values.odysseus.puid | quote }}
+  PGID: {{ .Values.odysseus.pgid | quote }}

--- a/charts/odysseus/templates/odysseus-deployment.yaml
+++ b/charts/odysseus/templates/odysseus-deployment.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "odysseus.app.fullname" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+spec:
+  replicas: {{ .Values.odysseus.replicaCount }}
+  strategy:
+    {{- toYaml .Values.odysseus.strategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: odysseus
+  template:
+    metadata:
+      annotations:
+        # Roll the pod when config/secrets change.
+        checksum/config: {{ include (print $.Template.BasePath "/odysseus-configmap.yaml") . | sha256sum }}
+        {{- if not .Values.odysseus.secrets.existingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/odysseus-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.odysseus.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: odysseus
+    spec:
+      serviceAccountName: {{ include "odysseus.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.odysseus.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: odysseus
+          image: "{{ .Values.odysseus.image.repository }}:{{ .Values.odysseus.image.tag }}"
+          imagePullPolicy: {{ .Values.odysseus.image.pullPolicy }}
+          {{- with .Values.odysseus.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 7000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "odysseus.app.fullname" . }}-config
+            - secretRef:
+                name: {{ include "odysseus.app.secretName" . }}
+          {{- with .Values.odysseus.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.odysseus.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.odysseus.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.odysseus.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.odysseus.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.odysseus.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.odysseus.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.odysseus.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.odysseus.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.odysseus.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.odysseus.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- with .Values.odysseus.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            - name: data
+              mountPath: /app/.ssh
+              subPath: ssh
+            - name: data
+              mountPath: /app/.cache/huggingface
+              subPath: huggingface
+            - name: data
+              mountPath: /app/.local
+              subPath: local
+            - name: logs
+              mountPath: /app/logs
+      volumes:
+        - name: data
+          {{- if .Values.odysseus.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.odysseus.persistence.data.existingClaim | default (printf "%s-data" (include "odysseus.app.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: logs
+          {{- if .Values.odysseus.persistence.logs.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.odysseus.persistence.logs.existingClaim | default (printf "%s-logs" (include "odysseus.app.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.odysseus.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.odysseus.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.odysseus.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/odysseus/templates/odysseus-ingress.yaml
+++ b/charts/odysseus/templates/odysseus-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.odysseus.ingress.enabled -}}
+{{- $svc := include "odysseus.app.fullname" . -}}
+{{- $port := .Values.odysseus.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "odysseus.app.fullname" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+  {{- with .Values.odysseus.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.odysseus.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.odysseus.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.odysseus.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $svc }}
+                port:
+                  number: {{ $port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/odysseus/templates/odysseus-pvc.yaml
+++ b/charts/odysseus/templates/odysseus-pvc.yaml
@@ -1,0 +1,39 @@
+{{- $data := .Values.odysseus.persistence.data -}}
+{{- if and $data.enabled (not $data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "odysseus.app.fullname" . }}-data
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+spec:
+  accessModes:
+    - {{ $data.accessMode }}
+  resources:
+    requests:
+      storage: {{ $data.size }}
+  {{- if $data.storageClass }}
+  storageClassName: {{ $data.storageClass }}
+  {{- end }}
+{{- end }}
+{{- $logs := .Values.odysseus.persistence.logs -}}
+{{- if and $logs.enabled (not $logs.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "odysseus.app.fullname" . }}-logs
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+spec:
+  accessModes:
+    - {{ $logs.accessMode }}
+  resources:
+    requests:
+      storage: {{ $logs.size }}
+  {{- if $logs.storageClass }}
+  storageClassName: {{ $logs.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/odysseus/templates/odysseus-secret.yaml
+++ b/charts/odysseus/templates/odysseus-secret.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.odysseus.secrets.existingSecret -}}
+{{- $s := .Values.odysseus.secrets -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "odysseus.app.secretName" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+type: Opaque
+stringData:
+  {{- range $k, $v := $s }}
+  {{- if and (ne $k "existingSecret") $v }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/odysseus/templates/odysseus-service.yaml
+++ b/charts/odysseus/templates/odysseus-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "odysseus.app.fullname" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+spec:
+  type: {{ .Values.odysseus.service.type }}
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: odysseus
+  ports:
+    - name: http
+      port: {{ .Values.odysseus.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/odysseus/templates/searxng.yaml
+++ b/charts/odysseus/templates/searxng.yaml
@@ -1,0 +1,190 @@
+{{- if .Values.searxng.enabled -}}
+{{- $name := include "odysseus.searxng.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}-settings
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+data:
+  # Template rendered at boot by the entrypoint wrapper: __SEARXNG_SECRET__ is
+  # substituted with SEARXNG_SECRET (or an auto-generated value) and written to
+  # the persistent /etc/searxng/settings.yml. Mirrors config/searxng/settings.yml.
+  settings.yml.template: |
+    use_default_settings: true
+
+    server:
+      secret_key: "__SEARXNG_SECRET__"
+
+    search:
+      formats:
+        - html
+        - json
+---
+{{- if .Values.searxng.secretKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+type: Opaque
+stringData:
+  SEARXNG_SECRET: {{ .Values.searxng.secretKey | quote }}
+---
+{{- end }}
+{{- if and .Values.searxng.persistence.enabled (not .Values.searxng.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+spec:
+  accessModes:
+    - {{ .Values.searxng.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.searxng.persistence.size }}
+  {{- with .Values.searxng.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "odysseus.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: searxng
+  template:
+    metadata:
+      labels:
+        {{- include "odysseus.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: searxng
+    spec:
+      serviceAccountName: {{ include "odysseus.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: searxng
+          image: "{{ .Values.searxng.image.repository }}:{{ .Values.searxng.image.tag }}"
+          imagePullPolicy: {{ .Values.searxng.image.pullPolicy }}
+          # The official image runs as the non-root `searxng` user but still
+          # needs to chown /etc/searxng on first boot and drop privs via su-exec.
+          # Mirrors the cap set from the upstream searxng-docker compose file.
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - SETGID
+                - SETUID
+                - DAC_OVERRIDE
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              if [ ! -s /etc/searxng/settings.yml ] || grep -q '__SEARXNG_SECRET__' /etc/searxng/settings.yml; then
+                secret="${SEARXNG_SECRET:-}"
+                if [ -z "$secret" ]; then
+                  secret="$(python -c 'import secrets; print(secrets.token_urlsafe(48))')"
+                fi
+                sed "s|__SEARXNG_SECRET__|$secret|g" /tmp/searxng-settings.yml.template > /etc/searxng/settings.yml
+              fi
+              exec /usr/local/searxng/entrypoint.sh
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: SEARXNG_BASE_URL
+              value: {{ printf "http://%s:%d/" $name (int .Values.searxng.service.port) | quote }}
+            {{- if .Values.searxng.secretKey }}
+            - name: SEARXNG_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: SEARXNG_SECRET
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- with .Values.searxng.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/searxng
+            - name: settings-template
+              mountPath: /tmp/searxng-settings.yml.template
+              subPath: settings.yml.template
+              readOnly: true
+      volumes:
+        - name: config
+          {{- if .Values.searxng.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.searxng.persistence.existingClaim | default $name }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: settings-template
+          configMap:
+            name: {{ $name }}-settings
+      {{- with .Values.searxng.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searxng.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.searxng.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "odysseus.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: searxng
+  ports:
+    - name: http
+      port: {{ .Values.searxng.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/odysseus/templates/serviceaccount.yaml
+++ b/charts/odysseus/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "odysseus.serviceAccountName" . }}
+  labels:
+    {{- include "odysseus.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/odysseus/values.yaml
+++ b/charts/odysseus/values.yaml
@@ -1,0 +1,243 @@
+# Default values for the odysseus chart.
+# Everything deploys into a single namespace (helm install -n <ns>).
+
+# -- Override the chart name portion of resource names.
+nameOverride: ""
+# -- Override the full resource name prefix.
+fullnameOverride: ""
+
+# Image pull secrets applied to every pod's ServiceAccount.
+imagePullSecrets: []
+
+serviceAccount:
+  # Create a dedicated ServiceAccount for the workloads.
+  create: true
+  name: ""
+  annotations: {}
+
+# ---------------------------------------------------------------------------
+# odysseus — the main application (app.py / uvicorn on :7000)
+# ---------------------------------------------------------------------------
+odysseus:
+  image:
+    # Published by .github/workflows/docker-publish.yml:
+    #   ghcr.io/<owner>/<repo>  ->  :latest (main), :dev, :X.Y.Z
+    # Override repository for a fork, or pin tag to a release (e.g. 1.2.3).
+    repository: ghcr.io/pewdiepie-archdaemon/odysseus
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  # SQLite + local PVCs mean only one writer is safe. Keep at 1 unless you move
+  # DATABASE_URL to an external DB and the data dirs to RWX storage.
+  strategy:
+    type: Recreate
+
+  service:
+    type: ClusterIP
+    port: 7000
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      memory: 4Gi
+
+  # The container entrypoint drops privileges to PUID/PGID via gosu and chowns
+  # the mounted data/log dirs, so it must start as root (UID 0). Do not set a
+  # non-root runAsUser here unless you also rebuild the image without gosu.
+  podSecurityContext: {}
+  securityContext: {}
+
+  # PUID/PGID the entrypoint drops to before running uvicorn. Must own the PVC
+  # contents. 1000 matches the first user on most Linux hosts.
+  puid: 1000
+  pgid: 1000
+
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 6
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  persistence:
+    # /app/data — db (when sqlite), ssh keys, hf cache, pip --user installs.
+    data:
+      enabled: true
+      size: 10Gi
+      accessMode: ReadWriteOnce
+      storageClass: ""
+      # Bind to an existing PVC instead of creating one.
+      existingClaim: ""
+    # /app/logs
+    logs:
+      enabled: true
+      size: 1Gi
+      accessMode: ReadWriteOnce
+      storageClass: ""
+      existingClaim: ""
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+
+  # Non-secret application config (mirrors docker-compose `environment:`).
+  # Service-discovery vars (SEARXNG_INSTANCE, CHROMADB_HOST/PORT) are injected
+  # automatically from the in-cluster service names — do not set them here.
+  config:
+    LLM_HOST: "localhost"
+    LLM_HOSTS: ""
+    OLLAMA_BASE_URL: ""
+    RESEARCH_LLM_ENDPOINT: ""
+    DATABASE_URL: "sqlite:///./data/app.db"
+    AUTH_ENABLED: "true"
+    LOCALHOST_BYPASS: "false"
+    ODYSSEUS_ADMIN_USER: "admin"
+    ALLOWED_ORIGINS: "http://localhost,http://127.0.0.1"
+    SECURE_COOKIES: "false"
+    EMBEDDING_URL: ""
+    EMBEDDING_MODEL: ""
+    FASTEMBED_MODEL: "sentence-transformers/all-MiniLM-L6-v2"
+    FASTEMBED_CACHE_PATH: ""
+    CLEANUP_INTERVAL_HOURS: "24"
+    ODYSSEUS_INPROCESS_POLLERS: "1"
+    ODYSSEUS_INPROCESS_TASKS: "1"
+    ODYSSEUS_SCRIPT_HOST: "localhost"
+    ODYSSEUS_CHAT_UPLOAD_MAX_BYTES: "10485760"
+    ODYSSEUS_GALLERY_UPLOAD_MAX_BYTES: "104857600"
+    ODYSSEUS_GALLERY_TRANSFORM_UPLOAD_MAX_BYTES: "26214400"
+    ODYSSEUS_MEMORY_IMPORT_MAX_BYTES: "10485760"
+    ODYSSEUS_PERSONAL_UPLOAD_MAX_BYTES: "26214400"
+    ODYSSEUS_EMAIL_COMPOSE_UPLOAD_MAX_BYTES: "26214400"
+    ODYSSEUS_STT_MAX_AUDIO_BYTES: "26214400"
+    ODYSSEUS_ICS_MAX_BYTES: "10485760"
+    GOOGLE_PSE_CX: ""
+
+  # Secret values (mirrors the sensitive parts of `environment:`). Empty values
+  # are omitted from the rendered Secret. Prefer --set or a values override file
+  # kept out of git; or set existingSecret to supply your own.
+  secrets:
+    existingSecret: ""
+    OPENAI_API_KEY: ""
+    HF_TOKEN: ""
+    HUGGING_FACE_HUB_TOKEN: ""
+    ODYSSEUS_ADMIN_PASSWORD: ""
+    EMBEDDING_API_KEY: ""
+    DATA_BRAVE_API_KEY: ""
+    GOOGLE_API_KEY: ""
+    TAVILY_API_KEY: ""
+    SERPER_API_KEY: ""
+
+  # Extra raw env vars (list of {name, value} / valueFrom maps) if you need more.
+  extraEnv: []
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: odysseus.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+# ---------------------------------------------------------------------------
+# chromadb — vector store
+# ---------------------------------------------------------------------------
+chromadb:
+  enabled: true
+  image:
+    repository: chromadb/chroma
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  service:
+    port: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  persistence:
+    enabled: true
+    size: 5Gi
+    accessMode: ReadWriteOnce
+    storageClass: ""
+    existingClaim: ""
+  env:
+    ANONYMIZED_TELEMETRY: "FALSE"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ---------------------------------------------------------------------------
+# searxng — metasearch backend
+# ---------------------------------------------------------------------------
+searxng:
+  enabled: true
+  image:
+    # Pinned, not :latest — odysseus depends on searxng being healthy and some
+    # upstream tags crash on boot. Bump deliberately after verifying a clean tag.
+    repository: searxng/searxng
+    tag: "2026.5.31-7159b8aed"
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  # Secret key for SearXNG. Leave empty to auto-generate one in the entrypoint
+  # (regenerated on pod restart unless persistence is enabled, which it is).
+  secretKey: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  persistence:
+    enabled: true
+    size: 1Gi
+    accessMode: ReadWriteOnce
+    storageClass: ""
+    existingClaim: ""
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ---------------------------------------------------------------------------
+# ntfy — push notifications
+# ---------------------------------------------------------------------------
+ntfy:
+  enabled: true
+  image:
+    repository: binwiederhier/ntfy
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  service:
+    port: 80
+  # Public base URL clients use to subscribe. Service-internal by default.
+  baseUrl: ""
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+  persistence:
+    enabled: true
+    size: 1Gi
+    accessMode: ReadWriteOnce
+    storageClass: ""
+    existingClaim: ""
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -99,7 +99,7 @@ nightly snapshot copied offsite:
 Swap the `--out` target for `scp`, `rclone`, `s3cmd`, or similar to push the
 snapshot to remote storage.
 
-## Docker vs native installs
+## Docker vs native vs Kubernetes installs
 
 The tool reads `data/` and writes `backups/` relative to the repository root, so
 where you run it matters:
@@ -112,13 +112,25 @@ where you run it matters:
   writes to `./backups` on the host. Running it *inside* the container is not
   recommended, because `backups/` is not a mounted volume and the tarball would
   be lost when the container is recreated.
+- **Kubernetes (Helm)** — `data/` lives in the `*-data` PersistentVolumeClaim, not
+  on a host path. Run the tool **inside the pod** and copy the tarball out, since
+  `backups/` is not a mounted volume:
+  ```bash
+  kubectl -n odysseus exec deploy/ody-odysseus -- \
+    python -m scripts.odysseus_backup snapshot
+  kubectl -n odysseus cp ody-odysseus-<pod>:/app/backups/<file>.tar.gz ./<file>.tar.gz
+  ```
+  Better, snapshot the PVC at the storage layer (e.g. a `VolumeSnapshot`). As in
+  Docker, ChromaDB runs as a separate service with its own PVC and is **not**
+  captured by `odysseus-backup` — see the caveat below.
 
-> **ChromaDB caveat (Docker only).** In the Docker setup, ChromaDB stores its
-> vectors in a separate Compose-managed volume (declared as `chromadb-data`),
-> **not** under `./data`. `odysseus-backup` therefore does not capture the Docker
-> ChromaDB store. Back it up separately if you need it. Compose prefixes the
-> volume with the project name, so find the real name first
-> (`docker volume ls | grep chromadb`), then archive it — for example:
+> **ChromaDB caveat (Docker & Kubernetes).** In both setups ChromaDB stores its
+> vectors in a separate volume — a Compose-managed volume (`chromadb-data`) under
+> Docker, or the `*-chromadb` PVC under Helm — **not** under `./data`.
+> `odysseus-backup` therefore does not capture it. Back it up separately if you
+> need it. On Docker, Compose prefixes the volume with the project name, so find
+> the real name first (`docker volume ls | grep chromadb`), then archive it — for
+> example:
 >
 > ```bash
 > docker run --rm -v <project>_chromadb-data:/data -v "$PWD":/backup \

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,6 +36,33 @@ only when you intentionally want LAN/reverse-proxy access.
 > Cookbook serves local models on CPU only. For GPU-accelerated model serving,
 > run natively instead — see [Apple Silicon](#apple-silicon) below.
 
+### Kubernetes (Helm)
+A Helm chart in [`charts/odysseus`](../charts/odysseus) deploys Odysseus and its
+bundled services (ChromaDB, SearXNG, ntfy) into a single namespace. It defaults
+to the GHCR image published by CI (`ghcr.io/pewdiepie-archdaemon/odysseus:latest`),
+so a basic install is just:
+
+```bash
+helm install ody charts/odysseus \
+  --namespace odysseus --create-namespace \
+  --set odysseus.secrets.ODYSSEUS_ADMIN_PASSWORD=<password>
+```
+
+For a fork, build and push your own image and override the repository/tag:
+
+```bash
+docker build -t <registry>/odysseus:<tag> .
+docker push <registry>/odysseus:<tag>
+# ...then add to the install:
+#   --set odysseus.image.repository=<registry>/odysseus --set odysseus.image.tag=<tag>
+```
+
+Reach the app with `kubectl -n odysseus port-forward svc/ody-odysseus 7000:7000`
+(then open `http://localhost:7000`), or enable an Ingress via `odysseus.ingress.*`.
+`.env` variables map to chart values — non-secret ones under `odysseus.config`,
+secrets under `odysseus.secrets`. See [`charts/odysseus/README.md`](../charts/odysseus/README.md)
+for the full values reference, persistence, and scaling notes.
+
 ### Native Linux / macOS
 ```bash
 git clone https://github.com/pewdiepie-archdaemon/odysseus.git
@@ -346,6 +373,8 @@ Odysseus serves plain HTTP on its app port. Docker Compose binds Odysseus and th
 4. Keep raw service and model ports internal-only.
 
 Cloudflare Access, Tailscale, Caddy, nginx, and Traefik can all fit this pattern; none are required by Odysseus. If your access layer reaches Odysseus on the same host, proxy to `http://127.0.0.1:7000` and keep `AUTH_ENABLED=true`, `LOCALHOST_BYPASS=false`, and `SECURE_COOKIES=true`.
+
+On Kubernetes (Helm), the chart keeps every Service `ClusterIP` (internal-only) by default; expose the app through an Ingress (`odysseus.ingress.*`) or `kubectl port-forward`, not the raw service/model ports. The same hardening applies — set `odysseus.config.SECURE_COOKIES=true` when terminating HTTPS at the ingress and keep `AUTH_ENABLED=true`, `LOCALHOST_BYPASS=false`.
 `ALLOWED_ORIGINS` lists exact permitted origins for cross-origin browser/API clients; ordinary same-origin reverse-proxy access usually does not need a special CORS entry.
 
 Common internal-only ports from the default docs/compose setup:
@@ -362,6 +391,10 @@ Common internal-only ports from the default docs/compose setup:
 ## Configuration
 Most setup is done inside the app with `/setup` or **Settings**. Use `.env`
 for deployment-level defaults and secrets you want present before first boot.
+On Kubernetes these same variables are set through the Helm chart instead of
+`.env` — non-secret ones under `odysseus.config`, secrets under
+`odysseus.secrets`. The chart auto-injects `SEARXNG_INSTANCE` and `CHROMADB_HOST`/`CHROMADB_PORT`
+from its in-cluster service names, so leave those unset there.
 Key settings:
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary
Adds a first-class Kubernetes deployment path alongside the existing Docker Compose setup, with no app-code changes.

- **Helm chart** (`charts/odysseus`) — deploys Odysseus plus its bundled services (ChromaDB, SearXNG, ntfy) into a single namespace. Translates the `docker-compose.yml` topology — service env, volumes, the SearXNG settings/secret boot wrapper, and the PUID/PGID entrypoint — into Deployments, Services, PVCs, ConfigMaps, a Secret, and an optional Ingress.
- **Zero-config image** — defaults to the GHCR artifact already published by `docker-publish.yml` (`ghcr.io/<owner>/odysseus:latest`), so a basic install needs only an admin password.
- **CI** — `helm-lint.yml` lints and renders the chart on PRs touching `charts/**`; `helm-publish.yml` packages and pushes it as an OCI artifact to GHCR on push to `dev`/`main`, reusing the same registry + `GITHUB_TOKEN` pattern as the image publish.
- **Docs** — `README.md`, `docs/setup.md`, and `docs/backup-restore.md` now surface the Helm option, its config mapping, and its backup considerations.

## Linked Issue

Part of #3033

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [x] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [x] CI / tooling / configuration

<!-- Primary: new feature (Helm chart). Also ships CI workflows and docs. -->

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

> Note on the last item: this change adds deployment artifacts, not app code. It
> was verified by rendering and linting the chart and validating the workflows
> (see **How to Test**). The packaged image itself is the unchanged one already
> shipped by `docker-publish.yml`.

## How to Test

1. **Lint + render the chart** (matches `helm-lint.yml`):
   ```bash
   helm lint charts/odysseus
   helm template release charts/odysseus --namespace odysseus > /dev/null
   helm template release charts/odysseus --namespace odysseus \
     --set odysseus.ingress.enabled=true \
     --set searxng.secretKey=test \
     --set chromadb.enabled=false \
     --set ntfy.enabled=false > /dev/null
   ```
   Confirm the default image renders as `ghcr.io/pewdiepie-archdaemon/odysseus:latest`:
   ```bash
   helm template release charts/odysseus -n odysseus | grep 'image: "ghcr.io'
   ```
2. **Install to a cluster** (kind/minikube/k3s):
   ```bash
   helm install ody charts/odysseus \
     --namespace odysseus --create-namespace \
     --set odysseus.secrets.ODYSSEUS_ADMIN_PASSWORD=changeme
   kubectl -n odysseus rollout status deploy/ody-odysseus
   kubectl -n odysseus port-forward svc/ody-odysseus 7000:7000
   ```
   Open `http://localhost:7000`, log in with the admin password, confirm web search
   (SearXNG) and vector memory (ChromaDB) work.
3. **Workflows**: confirm `helm-lint.yml` runs on a PR touching `charts/**`, and that
   `helm-publish.yml` packages and pushes to `oci://ghcr.io/<owner>/charts` on push
   to `dev`/`main`. Both pass `actionlint` and the repo's `workflow-security`
   (zizmor) audit — the only external action is the SHA-pinned `checkout`.
