### PR TITLE
docs(setup): note -BindHost flag for LAN access on native Windows

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -250,6 +250,19 @@ python -m uvicorn app:app --host 127.0.0.1 --port 7000
 If `python` points at an older interpreter, use `py -3.12` (or another installed
 3.11+ version) for the venv step.
 
+**Exposing on a LAN/Tailscale (Windows):** the launcher binds to `127.0.0.1` and
+does **not** read `APP_BIND` / `ODYSSEUS_HOST` from `.env`, so editing `.env`
+alone leaves the native Windows server on loopback. Pass the launcher's
+`-BindHost` flag instead:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1 -BindHost 0.0.0.0
+```
+
+The manual `uvicorn` command takes the same address as `--host 0.0.0.0`. Bind
+outside loopback only for a trusted LAN/VPN such as Tailscale: keep
+`AUTH_ENABLED=true` and do not expose the port directly to the public internet.
+
 **Requirements:** Python 3.11+. The core app (chat, agent, memory, documents,
 email, calendar, deep research) runs fully native. For full **Cookbook** background
 model downloads and the agent shell tool, also install


### PR DESCRIPTION
## Summary

The native Windows launcher (`launch-windows.ps1`) binds via its own `-BindHost` parameter (default `127.0.0.1`) and never reads `APP_BIND` / `ODYSSEUS_HOST` from `.env`, so setting `APP_BIND=0.0.0.0` in `.env` has no effect there — the native Windows server stays on loopback. The `-BindHost` flag already exists; it just wasn't documented. This adds a short "Exposing on a LAN/Tailscale (Windows)" note to the Native Windows section of `docs/setup.md`.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4552

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [x] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. _(Docs-only change — verified by inspecting `launch-windows.ps1` rather than a full app boot; see How to Test.)_

## How to Test

This is a documentation-only change and the behaviour it documents already exists. To verify the documented flag on Windows:

1. Run `powershell -ExecutionPolicy Bypass -File .\launch-windows.ps1 -BindHost 0.0.0.0`.
2. The startup line reads `Starting Odysseus at http://0.0.0.0:7000` and uvicorn binds all interfaces (`netstat -ano | findstr :7000` shows `0.0.0.0:7000`), so another device on a trusted LAN/VPN can reach it.
3. For contrast, setting only `APP_BIND=0.0.0.0` in `.env` and launching **without** the flag leaves the server on `127.0.0.1` — the exact gap this note documents.

Source check: in `launch-windows.ps1`, `$BindHost` (default `127.0.0.1`, line 18) is passed straight to `uvicorn --host $BindHost` (line 169), and the script never reads `APP_BIND` / `ODYSSEUS_HOST` from `.env`.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this is a documentation-only change (`docs/setup.md`). Nothing that renders to the UI (HTML/CSS/SVG/`static/js/`) was touched, so no screenshots apply.
