### PR TITLE
fix(routes): log and cleanly 500 on unreadable HTML page

### DIFF
--- a/app.py
+++ b/app.py
@@ -793,8 +793,11 @@ app.include_router(setup_companion_routes())
 
 def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
     """Read an HTML file and inject the CSP nonce into inline <script> tags."""
-    with open(file_path, "r", encoding="utf-8") as f:
-        html = f.read()
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            html = f.read()
+    except OSError:
+        raise HTTPException(404, "Page not found")
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)
     return HTMLResponse(html)

--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ from typing import Dict
 
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import JSONResponse, FileResponse, HTMLResponse
+from fastapi.responses import JSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -65,7 +65,7 @@ from core.exceptions import (
 
 import bcrypt as _bcrypt
 
-from src.app_helpers import abs_join
+from src.app_helpers import abs_join, serve_html_with_nonce
 from src.generated_images import GENERATED_IMAGE_HEADERS, resolve_generated_image_path
 from starlette.responses import RedirectResponse
 
@@ -791,28 +791,14 @@ app.include_router(setup_companion_routes())
 
 # ========= ROUTES (kept in app.py) =========
 
-def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
-    """Read an HTML file and inject the CSP nonce into inline <script> tags."""
-    try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            html = f.read()
-    except FileNotFoundError:
-        raise HTTPException(404, "Page not found")
-    except OSError:
-        logger.exception("Failed to read page %s", file_path)
-        raise HTTPException(500, "Internal server error")
-    nonce = getattr(request.state, "csp_nonce", "")
-    html = html.replace("{{CSP_NONCE}}", nonce)
-    return HTMLResponse(html)
-
 @app.get("/")
 async def serve_index(request: Request):
     static_path = abs_join(BASE_DIR, "static/index.html")
     if os.path.exists(static_path):
-        return _serve_html_with_nonce(request, static_path)
+        return serve_html_with_nonce(request, static_path)
     root_path = abs_join(BASE_DIR, "index.html")
     if os.path.exists(root_path):
-        return _serve_html_with_nonce(request, root_path)
+        return serve_html_with_nonce(request, root_path)
     raise HTTPException(404, "index.html not found")
 
 @app.get("/notes")
@@ -854,13 +840,13 @@ async def serve_library(request: Request):
 @app.get("/backgrounds")
 async def serve_backgrounds(request: Request):
     """Sandbox page for prototyping background effects. No auth required."""
-    return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/backgrounds.html"))
+    return serve_html_with_nonce(request, abs_join(BASE_DIR, "static/backgrounds.html"))
 
 @app.get("/login")
 async def serve_login(request: Request):
     if not AUTH_ENABLED:
         return RedirectResponse(url="/", status_code=302)
-    return _serve_html_with_nonce(request, abs_join(BASE_DIR, "static/login.html"))
+    return serve_html_with_nonce(request, abs_join(BASE_DIR, "static/login.html"))
 
 @app.get("/api/version")
 async def get_version():

--- a/app.py
+++ b/app.py
@@ -796,8 +796,11 @@ def _serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             html = f.read()
-    except OSError:
+    except FileNotFoundError:
         raise HTTPException(404, "Page not found")
+    except OSError:
+        logger.exception("Failed to read page %s", file_path)
+        raise HTTPException(500, "Internal server error")
     nonce = getattr(request.state, "csp_nonce", "")
     html = html.replace("{{CSP_NONCE}}", nonce)
     return HTMLResponse(html)

--- a/src/app_helpers.py
+++ b/src/app_helpers.py
@@ -1,6 +1,13 @@
 # src/app_helpers.py
-import os
 import base64
+import logging
+import os
+
+from fastapi import HTTPException
+from fastapi.responses import HTMLResponse
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
 
 def read_if_exists(path: str) -> str:
     """Read file if it exists, return empty string otherwise."""
@@ -19,6 +26,28 @@ def file_to_data_url(path: str, mime: str) -> str:
 def abs_join(base_dir: str, rel: str) -> str:
     """Join paths and return absolute path."""
     return os.path.abspath(os.path.join(base_dir, rel))
+
+def serve_html_with_nonce(request: Request, file_path: str) -> HTMLResponse:
+    """Read an app-bundled HTML page and inject the CSP nonce into inline <script> tags.
+
+    Callers pass fixed, server-owned template paths (index/login/backgrounds),
+    never a client-supplied path. So any read failure here — a missing file
+    (broken deployment) or a permission/IO error — is a server fault, not a
+    client "not found": map all of them to a logged 500 so a missing core
+    template surfaces in 5xx alerting instead of hiding behind a 404. If a
+    future caller serves a client-influenced path where 404 is correct, branch
+    that at the call site rather than defaulting this shared helper to 404.
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            html = f.read()
+    except OSError:
+        logger.exception("Failed to read page %s", file_path)
+        raise HTTPException(500, "Internal server error")
+    nonce = getattr(request.state, "csp_nonce", "")
+    html = html.replace("{{CSP_NONCE}}", nonce)
+    return HTMLResponse(html)
+
 
 def inside_base_dir(base_dir: str, path: str) -> bool:
     """Check if path is inside base directory."""

--- a/tests/test_serve_html_with_nonce.py
+++ b/tests/test_serve_html_with_nonce.py
@@ -1,0 +1,52 @@
+"""Behavior tests for src.app_helpers.serve_html_with_nonce.
+
+Every caller of this helper serves a fixed, app-bundled template
+(index/login/backgrounds), never a client-supplied path. So a read failure —
+a missing file (broken deployment) or a permission/IO error — is a server
+fault, not a client "not found", and must surface as a logged 500 rather than
+hiding behind a 404 where 5xx alerting can't see it. These tests lock that
+intent (raised in the PR #4637 review).
+"""
+import types
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("starlette.responses")
+from fastapi import HTTPException
+
+from src.app_helpers import serve_html_with_nonce
+
+
+def _request_with_nonce(nonce: str = ""):
+    """Minimal stand-in for a Starlette Request: only request.state.csp_nonce is read."""
+    return types.SimpleNamespace(state=types.SimpleNamespace(csp_nonce=nonce))
+
+
+def test_missing_fixed_template_returns_500_not_404(tmp_path):
+    missing = tmp_path / "does_not_exist.html"
+    with pytest.raises(HTTPException) as exc_info:
+        serve_html_with_nonce(_request_with_nonce(), str(missing))
+    assert exc_info.value.status_code == 500
+    # Generic detail — no OS error string or absolute path leaked to the client.
+    assert exc_info.value.detail == "Internal server error"
+
+
+def test_unreadable_template_returns_500(tmp_path):
+    # A directory at the path makes open() raise an OSError subtype
+    # (IsADirectoryError on POSIX, PermissionError on Windows) — same branch.
+    a_dir = tmp_path / "a_dir.html"
+    a_dir.mkdir()
+    with pytest.raises(HTTPException) as exc_info:
+        serve_html_with_nonce(_request_with_nonce(), str(a_dir))
+    assert exc_info.value.status_code == 500
+
+
+def test_readable_template_injects_nonce(tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text('<script nonce="{{CSP_NONCE}}">x</script>', encoding="utf-8")
+    resp = serve_html_with_nonce(_request_with_nonce("nonce-abc"), str(page))
+    assert resp.status_code == 200
+    body = resp.body.decode("utf-8")
+    assert "nonce-abc" in body
+    assert "{{CSP_NONCE}}" not in body


### PR DESCRIPTION
## Summary

The page-render helper read its HTML file with no error handling, so a missing or unreadable file raised an unhandled `OSError`. This started out as "serve 404 instead of 500", but review surfaced that every caller serves a **fixed, app-bundled template** (`/` → `index.html`, `/login` → `static/login.html`, `/backgrounds` → `static/backgrounds.html`) with a server-owned path. A missing file there is a broken deployment — a server fault, not a client "not found" — so a 404 would mislabel a server error and hide a missing core template from 5xx alerting.

So instead of 404, the helper now catches `OSError`, logs it with the file path via `logger.exception(...)`, and returns a clean, generic `HTTPException(500, "Internal server error")` with no raw OS error string or absolute path in the response body. The status code for these routes is unchanged from `dev` (it was already a 500, via the unhandled exception); what changes is that the 500 is now intentional, logged, and leak-safe rather than an uncaught error. The CSP-nonce render path is untouched, and all three call sites are covered in one place. If a future caller ever serves a client-influenced path where 404 is genuinely correct, that should branch at the call site rather than defaulting this shared helper.

The helper also moved from `app.py` to `src/app_helpers.serve_html_with_nonce` so the behaviour can be unit-tested directly: the suite stubs `src.database`, so importing the full `app` under pytest isn't viable, and `app.py` is the slim orchestrator anyway.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4594

## Type of Change

- [x] Bug fix (non-breaking — hardens error handling; resolves #4594 by confirming 500 is the correct code here and making it explicit + logged)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] Scope is limited to the fix — the helper move and the now-unused `HTMLResponse` import removed from `app.py` are a direct consequence of making the behaviour testable; no unrelated refactors or whitespace changes.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end (see below).

## How to Test

`static/backgrounds.html` is not shipped, so `/backgrounds` is a live repro (the route serves that path with no existence check).

```bash
AUTH_ENABLED=false python -m uvicorn app:app --host 127.0.0.1 --port 7799
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7799/backgrounds   # 500 (missing template -> server fault)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7799/              # 200 (index.html present)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7799/login         # 302 (AUTH_ENABLED=false redirects)
```

What I ran (Windows native, Python 3.11, project venv):

- Live server: `/backgrounds` → **500**, `/` → **200**, `/login` → **302**, `/api/version` → **200**.
- Confirmed the 500 is logged server-side while the client body stays generic: the server log shows `src.app_helpers - ERROR - Failed to read page ...\static\backgrounds.html` with the full traceback, while the response carries only `Internal server error` (no path leaked).
- `python -m pytest tests/test_serve_html_with_nonce.py` → **3 passed** (missing → 500, unreadable/dir → 500, happy path injects the CSP nonce).
- `python -m pytest` across the `app_helpers` importers + a route test → **21 passed** (no regressions from the move).
- `python -m py_compile app.py src/app_helpers.py tests/test_serve_html_with_nonce.py` → OK.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this is a backend error-handling/logging change plus a helper move. Nothing that renders to the UI (HTML/CSS/SVG/`static/js/`) was touched.
