### PR TITLE
fix(contacts): verify UID removal after CardDAV DELETE

### DIFF
--- a/routes/contacts_routes.py
+++ b/routes/contacts_routes.py
@@ -689,15 +689,24 @@ def _delete_contact(uid: str) -> bool:
         url = _resolve_resource_url(uid)
         auth = (cfg["username"], cfg["password"]) if cfg["username"] else None
         r = httpx.delete(url, auth=auth, timeout=10)
-        if r.status_code in (200, 204):
+        if r.status_code in (200, 204, 404):
+            # Invalidate cache so the next fetch sees the server truth.
             _contact_cache["fetched_at"] = None
-            return True
-        if r.status_code == 404:
-            # Resource not found at the resolved URL. With href resolution
-            # this should be rare (genuinely already deleted). Invalidate
-            # the cache and report success so the UI doesn't keep a ghost.
-            logger.info(f"CardDAV DELETE 404 for {uid} — treating as already gone")
-            _contact_cache["fetched_at"] = None
+            # Verify: force a fresh fetch and check the UID is actually gone.
+            # A 404 on the guessed URL ({uid}.vcf) can mean the contact
+            # lives at a different resource URL — the DELETE missed it but
+            # we'd silently report success. This check catches that.
+            fresh = _fetch_contacts(force=True)
+            still_there = any(c.get("uid") == uid for c in fresh)
+            if still_there:
+                logger.warning(
+                    f"CardDAV DELETE reported success for {uid} "
+                    f"but UID still present after re-fetch — "
+                    f"resource URL may differ from {url}"
+                )
+                return False
+            if r.status_code == 404:
+                logger.info(f"CardDAV DELETE 404 for {uid} — already gone")
             return True
         logger.warning(f"CardDAV DELETE returned {r.status_code}: {r.text[:200]}")
         return False


### PR DESCRIPTION
## Summary

After a CardDAV DELETE returns 2xx/404, force-re-fetch the contact list and confirm the UID is actually gone. If the UID is still present, log a warning and return `false` instead of silently reporting success.

This catches the case where `_resolve_resource_url` falls back to the guessed `{uid}.vcf` URL but the contact's real resource URL differs — the DELETE hits the wrong URL, the server returns 404 (treated as success), but the contact remains. Previously this caused silent persistence failures and agent loops.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4643

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Configure CardDAV
2. Create a contact whose resource URL differs from the `{uid}.vcf` pattern (e.g. imported from another client)
3. Delete the contact via `manage_contact` delete
4. Before the fix: tool returns "Contact deleted." but the contact remains
5. After the fix: tool returns "Delete failed." and logs a warning with the mismatched URL

## Visual / UI changes

None — backend-only change to `routes/contacts_routes.py`. No `static/`, HTML, CSS, or DOM changes.