### PR TITLE
fix(security): show images in HTML emails

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -117,7 +117,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                 f"script-src 'self' 'nonce-{nonce}' https://cdn.jsdelivr.net; "
                 "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
                 "font-src 'self' https://cdn.jsdelivr.net; "
-                "img-src 'self' data: blob:; "
+                # Email HTML embeds remote http(s) images; research reports
+                # already use https: in their route-scoped CSP above.
+                "img-src 'self' data: blob: https: http:; "
                 "media-src 'self' blob:; "
                 "connect-src 'self'; "
                 "frame-src 'self'; "


### PR DESCRIPTION
## Summary

HTML emails embed images from sender-hosted `http://` / `https://` URLs, but the default Content-Security-Policy only allowed `img-src 'self' data: blob:`. The browser blocked every remote image, so receipts/newsletters showed broken placeholders in all HTML emails. This PR adds `https:` and `http:` to `img-src` in `core/middleware.py`.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Part of #3153 (safe mail rendering). No dedicated issue was filed before this fix; discovered while using the email reader in Docker.

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. Rebuild and start the app: `docker compose up -d --build odysseus`
2. Open the Email module and expand any HTML email that includes remote images (e.g. a Bolt receipt or marketing newsletter).
3. **Before:** browser console shows `Loading the image '<URL>' violates the following Content Security Policy directive: "img-src 'self' data: blob:"` and images appear as broken placeholders.
4. **After:** images render; CSP violations for email `<img>` tags are gone.
5. Hard-refresh (`Ctrl+Shift+R`) if the old CSP header is cached.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: no UI/CSS changes in this PR — only the CSP header in middleware.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

## Before
<img width="1276" height="661" alt="telegram-cloud-photo-size-4-5888481784834494079-y" src="https://github.com/user-attachments/assets/523a1570-7eb7-4428-a5a3-6167958c1870" />

## After
<img width="636" height="274" alt="image" src="https://github.com/user-attachments/assets/06531bde-a5f9-4435-af17-711e70f7816b" />
