### PR TITLE
fix(agent): recognize Spanish promised tool actions

### DIFF
--- a/src/agent_loop.py
+++ b/src/agent_loop.py
@@ -2257,19 +2257,26 @@ async def stream_agent_loop(
     _MAX_INTENT_NUDGES = 2
 
     # "I said I would, then didn't" detector. The pattern that breaks debug
-    # loops on weak models (deepseek-v4-flash mid-2026): the model writes
-    # "Let me tail the output to see the error" and then ends the turn with
-    # no tool_calls. The intent is sincere but the function call gets dropped.
-    # Match the common phrasings + an action verb that maps to an available
-    # tool, so we don't nudge on harmless transitional text like "let me
-    # know what you think".
+    # loops on weak models (deepseek-v4-flash / Gemma 4): the model writes
+    # "Let me tail the output" or "Voy a reintentar la lectura" and then ends
+    # the turn with no tool_calls. The intent is sincere but the function call
+    # gets dropped. Match common English + Spanish phrasings and an action verb
+    # that maps to an available tool, so harmless transitional text such as
+    # "let me know what you think" / "voy a explicarlo" is not nudged.
     _INTENT_RE = re.compile(
         r"(?:^|\n)\s*(?:let me|i'?ll|i will|i need to|we need to|need to|"
-        r"i should|we should|i must|we must|going to|let's)\s+"
-        r"(?:tail|check|investigate|look at|see|tail|read|fetch|inspect|"
+        r"i should|we should|i must|we must|going to|let's|"
+        r"voy a|vamos a|necesito|necesitamos|debo|debemos|tengo que|"
+        r"tenemos que|déjame|dejame|permíteme|permiteme)\s+"
+        r"(?:tail|check|investigate|look at|see|read|fetch|inspect|"
         r"verify|diagnose|examine|debug|capture|grab|pull|view|run|call|"
         r"trigger|launch|start|kick off|stop|kill|restart|adopt|serve|"
-        r"register|adopt|list|search|find|query|hit|ping|test|use|perform|do)"
+        r"register|list|search|find|query|hit|ping|test|use|perform|do|"
+        r"reintentar|intentar|comprobar|revisar|investigar|mirar|ver|leer|"
+        r"obtener|inspeccionar|verificar|diagnosticar|examinar|depurar|"
+        r"capturar|descargar|consultar|ejecutar|llamar|activar|iniciar|"
+        r"detener|reiniciar|adoptar|servir|registrar|listar|buscar|"
+        r"encontrar|usar|realizar|hacer)"
         r"\b[^.\n]{0,140}",
         re.IGNORECASE,
     )

--- a/tests/test_agent_intent_followthrough.py
+++ b/tests/test_agent_intent_followthrough.py
@@ -1,0 +1,118 @@
+"""Agent promises to use a tool must be followed by a real tool call.
+
+Regression for Gemma 4 in Spanish: after resolving the workspace, the model
+said ``Voy a reintentar la lectura...`` and ended the turn.  The existing
+intent-without-action supervisor only recognized English promises, so the
+agent silently stopped instead of nudging Gemma to emit ``read_file``.
+"""
+
+import asyncio
+import json
+
+import src.agent_loop as agent_loop
+
+
+def _collect(gen):
+    async def _run():
+        return [chunk async for chunk in gen]
+
+    return asyncio.run(_run())
+
+
+def _events(chunks):
+    events = []
+    for chunk in chunks:
+        if chunk.startswith("data: ") and not chunk.startswith("data: [DONE]"):
+            events.append(json.loads(chunk[6:]))
+    return events
+
+
+def _patch_basics(monkeypatch, streams, executed):
+    monkeypatch.setattr(agent_loop, "get_setting", lambda key, default=None: default, raising=False)
+    monkeypatch.setattr(agent_loop, "get_mcp_manager", lambda: None, raising=False)
+    monkeypatch.setattr(agent_loop, "estimate_tokens", lambda *args, **kwargs: 10, raising=False)
+
+    async def fake_stream(_candidates, messages, **kwargs):
+        round_index = len(streams)
+        streams.append(messages)
+        if round_index == 0:
+            text = (
+                "Dado que el workspace actual es `/Users/gabrielpena`, voy a "
+                "intentar leerlo usando la ruta completa.\n\n"
+                "Voy a reintentar la lectura del archivo en la carpeta Desktop."
+            )
+            yield f'data: {json.dumps({"delta": text})}\n\n'
+        elif round_index == 1:
+            call = {
+                "name": "read_file",
+                "arguments": json.dumps({
+                    "path": "/Users/gabrielpena/Desktop/resumen-sincronizacion-rutas-facturas.md"
+                }),
+            }
+            yield f'data: {json.dumps({"type": "tool_calls", "calls": [call]})}\n\n'
+        else:
+            yield f'data: {json.dumps({"delta": "Archivo leído correctamente."})}\n\n'
+        yield "data: [DONE]\n\n"
+
+    async def fake_execute(block, *args, **kwargs):
+        executed.append(block)
+        return ("read_file", {"content": "# Resumen", "exit_code": 0})
+
+    monkeypatch.setattr(agent_loop, "stream_llm_with_fallback", fake_stream, raising=False)
+    monkeypatch.setattr(agent_loop, "execute_tool_block", fake_execute, raising=False)
+
+
+def test_spanish_tool_promise_is_nudged_and_executed(monkeypatch):
+    streams = []
+    executed = []
+    _patch_basics(monkeypatch, streams, executed)
+
+    chunks = _collect(
+        agent_loop.stream_agent_loop(
+            "http://localhost:8000/v1",
+            "gemma-4-E4B-it-Q4_K_M.gguf",
+            [{"role": "user", "content": "Lee el archivo del escritorio."}],
+            relevant_tools={"read_file"},
+            max_rounds=4,
+            _is_teacher_run=True,
+        )
+    )
+    events = _events(chunks)
+
+    assert len(streams) == 3
+    assert len(executed) == 1
+    assert executed[0].tool_type == "read_file"
+    assert "/Users/gabrielpena/Desktop/resumen-sincronizacion-rutas-facturas.md" in executed[0].content
+    assert any(event.get("type") == "agent_step" and event.get("round") == 2 for event in events)
+
+
+def test_spanish_explanation_without_tool_action_is_not_nudged(monkeypatch):
+    streams = []
+    executed = []
+
+    monkeypatch.setattr(agent_loop, "get_setting", lambda key, default=None: default, raising=False)
+    monkeypatch.setattr(agent_loop, "get_mcp_manager", lambda: None, raising=False)
+    monkeypatch.setattr(agent_loop, "estimate_tokens", lambda *args, **kwargs: 10, raising=False)
+
+    async def fake_stream(_candidates, messages, **kwargs):
+        streams.append(messages)
+        yield f'data: {json.dumps({"delta": "Voy a explicarte cómo funciona la lectura de archivos."})}\n\n'
+        yield "data: [DONE]\n\n"
+
+    monkeypatch.setattr(agent_loop, "stream_llm_with_fallback", fake_stream, raising=False)
+
+    chunks = _collect(
+        agent_loop.stream_agent_loop(
+            "http://localhost:8000/v1",
+            "gemma-4-E4B-it-Q4_K_M.gguf",
+            [{"role": "user", "content": "Explícame cómo funciona."}],
+            relevant_tools={"read_file"},
+            max_rounds=3,
+            _is_teacher_run=True,
+        )
+    )
+    events = _events(chunks)
+
+    assert len(streams) == 1
+    assert not executed
+    assert not any(event.get("type") == "agent_step" for event in events)


### PR DESCRIPTION
## Summary

Extend the intent-without-action supervisor to recognize Spanish promises to use a tool, such as `Voy a reintentar la lectura...`. Local models that announce a Spanish action without emitting a tool call now receive the same bounded follow-through nudge already used for English, while explanatory prose remains excluded.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4668

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I ran the macOS app with llama.cpp and Gemma 4 E4B; the reported Spanish no-action turn was reproduced before the fix, and the combined regression suite passes after it.

## How to Test

1. Run Odysseus with a local instruction-following model through llama.cpp.
2. Ask it in Spanish to locate and read a file so that it responds with a promise such as `Voy a reintentar la lectura...`.
3. Confirm the supervisor nudges the model and a real `read_file` tool call follows instead of ending the turn.
4. Ask for a plain explanation and confirm phrases such as `Voy a explicarte...` do not cause a false retry.

Automated validation:

```text
29 passed in the focused follow-through and tool-policy suites
99 passed in the broader combined agent regression suite
python -m py_compile src/agent_loop.py
git diff --check
```

## Visual / UI changes

None. This PR changes backend agent-loop supervision and regression tests only.
