### PR TITLE
fix(hwfit): repair remote Windows hardware scan over SSH

### DIFF
--- a/services/hwfit/hardware.py
+++ b/services/hwfit/hardware.py
@@ -528,6 +528,32 @@ def _powershell_exe():
     path so we don't depend on a particular PATH ordering."""
     return shutil.which("pwsh") or shutil.which("powershell") or "powershell"
 
+def _powershell_encoded_for_ssh(script: str):
+    """Run a PowerShell script on a remote Windows host over SSH.
+
+    Nested quotes in powershell -Command break when passed through Windows
+    OpenSSH's cmd wrapper; -EncodedCommand avoids that.
+    """
+    import base64
+    encoded = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+    return _run(f"powershell -NoProfile -EncodedCommand {encoded}")
+
+
+def _probe_remote_platform():
+    """Best-effort OS detection over SSH when the caller didn't pass platform."""
+    out = _run("echo %OS%")
+    if out and "Windows_NT" in out:
+        return "windows"
+    uname = (_run(["uname", "-s"]) or "").strip().lower()
+    if uname == "darwin":
+        # Mac uses the linux detection path (_detect_apple_silicon over SSH).
+        return "linux"
+    if uname == "linux":
+        out = _run("test -d /data/data/com.termux && echo termux || echo linux")
+        if out and "termux" in out:
+            return "termux"
+    return "linux"
+
 
 def _detect_windows():
     """Detect Windows hardware via PowerShell/WMI.
@@ -590,9 +616,8 @@ def _detect_windows():
     """
     )
     if _remote_host:
-        # Remote: ship a single command string over SSH. The remote shell parses
-        # the quoting; PowerShell on the far side runs the -Command payload.
-        out = _run(f'powershell -Command "{ps_cmd}"')
+        # Remote: use -EncodedCommand so OpenSSH/cmd quoting does not break the script.
+        out = _powershell_encoded_for_ssh(ps_cmd.strip())
     else:
         # Local: pass a LIST argv straight to subprocess so the OS hands ps_cmd
         # to PowerShell verbatim — no fragile string-level quote escaping. Prefer
@@ -763,6 +788,13 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
     """
     global _remote_host, _remote_port, _remote_platform
 
+    if host and not platform:
+        _remote_host = host
+        _remote_port = ssh_port or None
+        platform = _probe_remote_platform()
+        _remote_host = None
+        _remote_port = None
+
     cache_key = _cache_key(host, ssh_port, platform)
     now = time.time()
     if not fresh and cache_key in _cache_by_host:
@@ -783,8 +815,8 @@ def detect_system(host="", ssh_port="", platform="", fresh=False):
             _remote_platform = None
             _cache_by_host[cache_key] = (now, result)
             return result
-        # If Windows detection failed, return error
-        result = {"error": f"Cannot connect to {host}", "host": host}
+        # SSH may work while the PowerShell hardware probe still fails.
+        result = {"error": f"Windows hardware probe failed for {host}", "host": host}
         _remote_host = None
         _remote_platform = None
         _cache_by_host[cache_key] = (now, result)

--- a/tests/test_hwfit_windows.py
+++ b/tests/test_hwfit_windows.py
@@ -72,3 +72,50 @@ def test_gguf_alternate_still_recommended_on_windows():
     still appear on Windows even though the AWQ variant is hidden."""
     names = {r["name"] for r in rank_models(_windows_system(), limit=900)}
     assert "Qwen/Qwen2.5-3B-Instruct" in names
+
+
+def test_remote_windows_probe_uses_encoded_command(monkeypatch):
+    """Remote Windows hwfit must not use nested -Command quoting over SSH."""
+    from services.hwfit import hardware
+
+    calls = []
+    monkeypatch.setattr(hardware, "_remote_host", "user@winpc")
+    monkeypatch.setattr(hardware, "_remote_port", None)
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        if isinstance(cmd, str) and "EncodedCommand" in cmd:
+            return (
+                '{"ram_gb":64,"avail_gb":32,"cpu_name":"Test CPU",'
+                '"cpu_cores":8,"arch":64}'
+            )
+        return None
+
+    monkeypatch.setattr(hardware, "_run", fake_run)
+    result = hardware._detect_windows()
+    assert result is not None
+    assert result["total_ram_gb"] == 64
+    assert len(calls) == 1
+    assert "EncodedCommand" in calls[0]
+    assert '-Command "' not in calls[0]
+
+
+def test_probe_remote_platform_detects_windows(monkeypatch):
+    from services.hwfit import hardware
+
+    monkeypatch.setattr(hardware, "_run", lambda cmd: "Windows_NT\n")
+    assert hardware._probe_remote_platform() == "windows"
+
+
+def test_probe_remote_platform_detects_darwin(monkeypatch):
+    from services.hwfit import hardware
+
+    def fake_run(cmd):
+        if cmd == "echo %OS%":
+            return "%OS%"
+        if cmd == ["uname", "-s"]:
+            return "Darwin"
+        raise AssertionError(f"unexpected probe cmd: {cmd!r}")
+
+    monkeypatch.setattr(hardware, "_run", fake_run)
+    assert hardware._probe_remote_platform() == "linux"


### PR DESCRIPTION
## Summary

Remote Cookbook hardware scans failed on Windows fleet servers with "Couldn't scan user@host" even when SSH Check succeeded. The remote probe sent a multiline PowerShell script as nested `powershell -Command "..."` over OpenSSH, which Windows cmd quoting mangled. This PR switches the remote path to `-EncodedCommand`, auto-detects OS when Cookbook omits `platform` (including Darwin for Mac SSH hosts), and clarifies the error when SSH works but the probe fails.

## Target branch

- [ ] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4675

Related: [#3113](https://github.com/pewdiepie-archdaemon/odysseus/issues/3113) (Windows hwfit probe performance — separate scope; does not fix remote SSH quoting)

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough. (technically on k3s)

## How to Test

1. Add a Windows host with working SSH key auth to Cookbook (Settings → server → Check passes).
2. Open Cookbook → Download, select that server in the Scan dropdown, click **↻ RESCAN**.
3. Confirm detected hardware chips show RAM/CPU/GPU (e.g. RTX + VRAM) and the model list loads instead of "Couldn't scan …".

**Automated**

```bash
python -m py_compile services/hwfit/hardware.py tests/test_hwfit_windows.py
python -m pytest tests/test_hwfit_windows.py::test_remote_windows_probe_uses_encoded_command -q
python -m pytest tests/test_hwfit_windows.py::test_probe_remote_platform_detects_windows -q
python -m pytest tests/test_hwfit_windows.py::test_probe_remote_platform_detects_darwin -q
```

**Manual API probe** (from a machine/pod that can SSH to the Windows host):

```python
from services.hwfit.hardware import detect_system
detect_system(host="user@192.168.x.x", fresh=True)
# expect total_ram_gb, cpu_name, gpu_name, gpu_vram_gb — no "error" key
```

Verified manually on Windows 10 and Windows 11 hosts; Mac remote scan regression covered by Darwin probe test and re-verified after platform auto-detect change.

## Visual / UI changes — REQUIRED if you touched anything that renders

No UI changes — backend hardware probe only.
