### PR TITLE
fix(markdown): preserve URLs inside inline code spans

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -471,6 +471,7 @@ export function processWithThinking(text) {
 export function mdToHtml(src, opts) {
   const allowedHtmlBlocks = [];
   const codeBlocks = [];
+  const inlineCodeBlocks = [];
   const mermaidBlocks = [];
   let s = (src ?? '');
 
@@ -506,6 +507,19 @@ export function mdToHtml(src, opts) {
     const editBtn = `<button type="button" class="edit-code" title="Edit"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>`;
     codeBlocks.push(`<pre><code${langClass} data-lang="${lang || ''}">${escapeHtml(escaped)}</code>${runBtn}${editBtn}<button type="button" class="copy-code" data-code="${escapeHtml(escaped)}"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></pre>`);
 
+    return placeholder;
+  });
+
+  // Extract inline code spans before the link/autolink/HTML passes, mirroring
+  // the fenced-block handling above. A URL inside `inline code` (e.g.
+  // `irm http://127.0.0.1:3000/x`) is preceded by a space, so the bare-URL
+  // autolink matches it, wraps it in an <a> tag, and swaps that for an
+  // ___ALLOWED_HTML_ placeholder — corrupting the command. The old inline-code
+  // pass ran after those passes, too late to protect it.
+  s = s.replace(/`([^`]+?)`/g, (match, code) => {
+    if (code.startsWith('___CODE_BLOCK_') || code.startsWith('___MERMAID_BLOCK_')) return match;
+    const placeholder = `___INLINE_CODE_${inlineCodeBlocks.length}___`;
+    inlineCodeBlocks.push(`<code>${escapeHtml(code)}</code>`);
     return placeholder;
   });
 
@@ -659,12 +673,6 @@ export function mdToHtml(src, opts) {
     return html;
   });
 
-  // Inline code (but not placeholders)
-  s = s.replace(/`([^`]+?)`/g, (match, code) => {
-    if (code.startsWith('___CODE_BLOCK_') || code.startsWith('___ALLOWED_HTML_')) return match;
-    return `<code>${code}</code>`;
-  });
-
   // Horizontal rules (must come before bold/italic to avoid * conflicts)
   s = s.replace(/^(?:---|\*\*\*|___)\s*$/gm, '<hr>');
 
@@ -735,6 +743,14 @@ export function mdToHtml(src, opts) {
   // CRITICAL: Restore code blocks at the end
   codeBlocks.forEach((block, index) => {
     s = s.replace(`___CODE_BLOCK_${index}___`, block);
+  });
+
+  // Restore inline code spans last, so placeholders carried inside restored
+  // <a>/allowed-HTML blocks are resolved too. The function replacer keeps the
+  // escaped code literal — e.g. a shell snippet like `echo $1` is not treated
+  // as a regex back-reference.
+  inlineCodeBlocks.forEach((block, index) => {
+    s = s.replace(`___INLINE_CODE_${index}___`, () => block);
   });
 
   return _useSvgEmoji() ? svgifyEmoji(s, opts) : s;

--- a/tests/test_markdown_rendering_js.py
+++ b/tests/test_markdown_rendering_js.py
@@ -170,6 +170,36 @@ def test_extract_thinking_blocks_handles_thought_tag(node_available):
     assert result["content"] == "Final answer."
 
 
+def test_url_inside_inline_code_is_not_autolinked(node_available):
+    # A URL inside a backtick span is preceded by a space, so the bare-URL
+    # autolink used to wrap it in an <a> tag (then swap it for an
+    # ___ALLOWED_HTML_ placeholder), corrupting the command shown to the user.
+    html = _run_markdown_case("Run `$j = irm http://127.0.0.1:3000/x` to fetch.")
+
+    assert "<code>$j = irm http://127.0.0.1:3000/x</code>" in html
+    assert "___ALLOWED_HTML_" not in html
+    assert "<a " not in html
+    assert 'href="http://127.0.0.1:3000/x"' not in html
+
+
+def test_url_outside_inline_code_is_still_autolinked(node_available):
+    # Inline code must not disable autolinking for bare URLs elsewhere in the
+    # same line.
+    html = _run_markdown_case("Use `irm` then visit https://example.com/page now.")
+
+    assert "<code>irm</code>" in html
+    assert 'href="https://example.com/page"' in html
+
+
+def test_inline_code_content_is_html_escaped(node_available):
+    # Inline code is now extracted before the global escape pass, so it must be
+    # escaped at extraction time (matching the fenced-code-block handling).
+    html = _run_markdown_case("Render `<b>$1 & 'q'</b>` literally.")
+
+    assert "<code>&lt;b&gt;$1 &amp; &#39;q&#39;&lt;/b&gt;</code>" in html
+    assert "<b>" not in html
+
+
 def test_dotted_python_import_paths_are_not_autolinked(node_available):
     html = _run_markdown_case(
         "from imblearn.combine import SMOTETomek\n"


### PR DESCRIPTION
## Summary

If you put a URL inside inline code, it got turned into a clickable link — so a command like `` `irm http://127.0.0.1:3000/x` `` rendered with the URL wrapped in an `<a>` tag, which is exactly what you don't want when you're showing someone a command to copy.

The reason is ordering in `mdToHtml` (`static/js/markdown.js`). Fenced code blocks get pulled out into placeholders early, before any of the link/autolink/HTML passes run — but inline backtick spans were only turned into `<code>` right at the very end. So by the time the inline-code pass happened, the bare-URL autolink had already grabbed the URL (it's preceded by a space, so the `[\s(<]` prefix matched), wrapped it in an `<a>`, and stashed that as an `___ALLOWED_HTML_` placeholder. The guard on the late inline-code pass only skipped spans that were *entirely* a placeholder, so an embedded one like `irm ___ALLOWED_HTML_0___` slipped right through and the command came out mangled.

Fix is to pull inline code out into placeholders early too, right after the fenced-block extraction and before the link passes — same trick the fenced blocks already use. They get restored last so any placeholder that ended up inside a restored `<a>` block still resolves. Two small details: the code is HTML-escaped at extraction time now (it no longer rides through the global escape pass), and the restore uses a function replacer so a literal `$1` or `$&` in a shell snippet doesn't get eaten as a regex back-reference.

Scoped to the inline-URL rewriting only. The reporter's other point — exact stdout not always being preserved — is model behaviour rather than a rendering bug, so I've left that out and used `Part of` rather than `Fixes` so the issue stays open for that half.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Part of #4625

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. In a chat, render a message with inline code that contains a localhost URL, e.g. `` Run `$j = irm http://127.0.0.1:3000/x` to fetch. ``
2. Before: the URL inside the code span shows up as a clickable link — the command is corrupted.
3. After: the whole command renders verbatim inside `<code>`, no link.
4. Or just run `python -m pytest tests/test_markdown_rendering_js.py` — three new cases cover URL-in-code staying literal, autolinking outside code still working, and code content being HTML-escaped.

## Visual / UI changes — REQUIRED if you touched anything that renders

- [x] **Screenshot or short clip** of the change in the running app, attached below.
- [x] **Style match**: no new CSS, colors, fonts, or components — this only changes the order of existing renderer passes.
- [x] **No new component patterns.**
- [x] **I am not an LLM agent submitting a bulk PR.**

### Screenshots / clips

Same input rendered before and after the fix:

![before and after](https://raw.githubusercontent.com/ashvinctrl/odysseus/pr-assets/_4625_before_after.png)
