### PR TITLE
fix: Real-ESRGAN install + Cookbook deps-panel crash on the Python 3.14 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+# ---- builder: patch + build wheels for Real-ESRGAN's broken-on-3.14 deps ----
+# basicsr/gfpgan/facexlib read their version via exec()+locals()['__version__'],
+# which raises KeyError on Python 3.13+ (PEP 667). Build patched wheels here so
+# the final image / Cookbook never has to compile the broken sdists. See
+# docker/build-realesrgan-wheels.sh for the full rationale.
+FROM python:3.14-slim AS realesrgan-wheels
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+COPY docker/build-realesrgan-wheels.sh /usr/local/bin/build-realesrgan-wheels.sh
+RUN bash /usr/local/bin/build-realesrgan-wheels.sh /wheels
+
 FROM python:3.14-slim
 
 # System deps. tmux is required by Cookbook for background downloads/serves.
@@ -18,7 +29,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tmux \
     openssh-client \
     gosu \
+    libgl1 \
+    libglib2.0-0t64 \
+    libxcb1 \
     && rm -rf /var/lib/apt/lists/*
+
+# libgl1/libglib2.0-0t64/libxcb1 are runtime shared libs (libGL.so.1,
+# libglib-2.0/libgthread, libxcb.so.1) that opencv-python (cv2) loads. The
+# slim base omits them, so the Cookbook "install realesrgan" path imports cv2
+# and dies with `libxcb.so.1: cannot open shared object file` despite a clean
+# pip install. Using full opencv-python (not -headless) because basicsr/gfpgan/
+# facexlib/realesrgan all depend on the `opencv-python` distribution by name.
 
 # Docker CLI (client only — daemon stays on the host via the
 # /var/run/docker.sock mount). The Debian `docker.io` package ships
@@ -45,6 +66,15 @@ ARG INSTALL_OPTIONAL=false
 COPY requirements.txt requirements-optional.txt ./
 RUN pip install --no-cache-dir -r requirements.txt \
     && if [ "$INSTALL_OPTIONAL" = "true" ]; then pip install --no-cache-dir -r requirements-optional.txt; fi
+
+# Pre-install the patched basicsr/gfpgan/facexlib wheels built in the
+# realesrgan-wheels stage (--no-deps keeps the image lean — torch & friends are
+# pulled only when realesrgan is actually installed). With these dists already
+# satisfied, the Cookbook's plain `pip install realesrgan` resolves them from
+# wheels instead of rebuilding the sdists that fail on Python 3.14.
+COPY --from=realesrgan-wheels /wheels/ /tmp/odysseus-wheels/
+RUN pip install --no-cache-dir --no-deps /tmp/odysseus-wheels/*.whl \
+    && rm -rf /tmp/odysseus-wheels
 
 # Copy app code
 COPY . .

--- a/docker/build-realesrgan-wheels.sh
+++ b/docker/build-realesrgan-wheels.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Build patched wheels for Real-ESRGAN's unmaintained dependencies.
+#
+# basicsr / gfpgan / facexlib (xinntao, last released 2022) read their version
+# in setup.py with:
+#
+#     exec(compile(f.read(), version_file, 'exec'))
+#     return locals()['__version__']
+#
+# Python 3.13+ implements PEP 667: locals() inside a function returns an
+# independent snapshot that exec() can no longer mutate, so the read raises
+# `KeyError: '__version__'` and the sdist build fails. That is why the Cookbook
+# "install realesrgan" button dies on the python:3.14 image. The packages have
+# no fixed release, so we patch get_version() to exec into an explicit namespace
+# dict (works on every Python) and build wheels from the patched source.
+#
+# Usage: build-realesrgan-wheels.sh [OUTPUT_DIR]   (default: /wheels)
+set -euo pipefail
+
+OUT="${1:-/wheels}"
+mkdir -p "$OUT"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+
+# Pinned to the versions Real-ESRGAN 0.3.0 resolves to.
+SPECS="basicsr==1.4.2 gfpgan==1.3.8 facexlib==0.3.0"
+
+for spec in $SPECS; do
+  name="${spec%%==*}"
+  ver="${spec##*==}"
+  # pip download builds metadata (and trips the same bug), so fetch the raw
+  # sdist URL from the PyPI JSON API instead.
+  url="$(python - "$name" "$ver" <<'PY'
+import json, sys, urllib.request
+name, ver = sys.argv[1], sys.argv[2]
+data = json.load(urllib.request.urlopen(f"https://pypi.org/pypi/{name}/{ver}/json"))
+for f in data["urls"]:
+    if f["packagetype"] == "sdist":
+        print(f["url"]); break
+else:
+    sys.exit(f"no sdist found for {name}=={ver}")
+PY
+)"
+  echo ">> fetching ${name} ${ver}: ${url}"
+  curl -fsSL "$url" -o "${name}.tar.gz"
+  tar xzf "${name}.tar.gz"
+done
+
+echo ">> patching get_version()"
+python - <<'PY'
+import pathlib
+old_exec = "exec(compile(f.read(), version_file, 'exec'))"
+new_exec = "_ver_ns = {}\n        exec(compile(f.read(), version_file, 'exec'), _ver_ns)"
+old_ret = "return locals()['__version__']"
+new_ret = "return _ver_ns['__version__']"
+patched = 0
+for setup in pathlib.Path(".").glob("*/setup.py"):
+    s = setup.read_text()
+    if old_exec in s and old_ret in s:
+        setup.write_text(s.replace(old_exec, new_exec).replace(old_ret, new_ret))
+        print("   patched", setup)
+        patched += 1
+assert patched == 3, f"expected to patch 3 setup.py files, patched {patched}"
+PY
+
+echo ">> building wheels into ${OUT}"
+pip wheel --no-deps -w "$OUT" ./basicsr-* ./gfpgan-* ./facexlib-*
+ls -l "$OUT"

--- a/routes/shell_routes.py
+++ b/routes/shell_routes.py
@@ -1377,11 +1377,16 @@ def setup_shell_routes() -> APIRouter:
                     pkg["installed"] = False
                 except importlib_metadata.PackageNotFoundError:
                     pkg["installed"] = False
-                except Exception:
+                except (Exception, SystemExit):
                     # Installed but crashes on import — e.g. a CUDA build of
                     # llama-cpp-python raising FileNotFoundError when the CUDA
-                    # toolkit dir is absent. One broken optional package must not
-                    # 500 the entire packages panel; report it as not usable.
+                    # toolkit dir is absent, or rembg calling sys.exit(1) when no
+                    # onnxruntime backend can be loaded. SystemExit is a
+                    # BaseException, not Exception, so without catching it here a
+                    # single sys.exit-on-import package escapes and takes down the
+                    # whole packages panel / worker (the panel hangs forever). One
+                    # broken optional package must not 500 — or hang — the entire
+                    # panel; report it as not usable.
                     pkg["installed"] = False
 
             # llama_cpp partial-state probe: when the package is installed


### PR DESCRIPTION
## Summary

Two independent fixes that together make the Cookbook's optional-dependency flow work on the `python:3.14-slim` image, found while installing `realesrgan` from **Cookbook → Dependencies**:

1. `basicsr` / `gfpgan` / `facexlib` sdist builds fail on Python 3.13+ — their `setup.py` reads `__version__` via `exec(...); locals()['__version__']`, which PEP 667 broke (`locals()` is now a snapshot `exec()` can't mutate) → `KeyError: '__version__'`. (`import cv2` then also crashes on the slim base with `libxcb.so.1: cannot open shared object file`, so the runtime libs are added too.)
2. `rembg` calls `sys.exit(1)` at import when no onnxruntime backend loads; `SystemExit` is a `BaseException`, not `Exception`, so it escaped the deps probe and hung the whole Dependencies panel.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4695

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

On a fresh `python:3.14` deployment (`docker compose up -d --build`):

1. **Reproduce the build failure (before this PR):** open **Cookbook → Dependencies**, search `realesrgan`, click Install. The build dies with `KeyError: '__version__'` while building `basicsr`.
2. **With this PR:** rebuild the image. The `realesrgan-wheels` builder stage builds patched `basicsr`/`gfpgan`/`facexlib` wheels and the final stage installs them `--no-deps`. Click Install again — `pip install realesrgan` now resolves those from wheels and succeeds (torch is pulled at this point).
3. **Verify recognition:** reload the Dependencies panel — realesrgan shows **installed** (matches the `importlib.metadata` probe in `_package_installed_from_probe`). Confirmed runtime import too:
   ```bash
   docker compose exec odysseus python -c "import importlib.metadata as m; print(m.version('realesrgan'))"
   # 0.3.0
   ```
4. **Verify the panel no longer hangs:** with a `rembg` that has no onnxruntime backend, the Dependencies panel previously loaded forever (a `SystemExit` from `import rembg` escaped the probe). With this PR the probe catches `(Exception, SystemExit)`, reports it not-usable, and the panel loads normally. Simulated the full probe loop over all local packages — none escape with a `BaseException`.
5. **Builder stage in isolation:** `docker build --target realesrgan-wheels .` builds all three patched wheels green.

## Visual / UI changes — REQUIRED if you touched anything that renders

N/A — no UI/rendering changes. Touches only `Dockerfile`, `docker/build-realesrgan-wheels.sh`, and `routes/shell_routes.py` (a `try/except` clause in the deps probe).
