### PR TITLE
fix: add OpenCode setup provider aliases

### DIFF
--- a/static/js/slashCommands.js
+++ b/static/js/slashCommands.js
@@ -101,6 +101,8 @@ function _setupProviderFromInput(input) {
     xai: 'xai',
     grok: 'xai',
     nvidia: 'nvidia',
+    opencodezen: 'opencode-zen',
+    opencodego: 'opencode-go',
   };
   return SETUP_PROVIDER_URLS[aliases[raw] || raw] || null;
 }
@@ -129,6 +131,8 @@ function _extractSetupProviderCredential(input) {
     ['google', 'gemini'], ['gemini', 'gemini'],
     ['x ai', 'xai'], ['xai', 'xai'], ['grok', 'xai'],
     ['nvidia', 'nvidia'],
+    ['opencode zen', 'opencode-zen'], ['opencode-zen', 'opencode-zen'],
+    ['opencode go', 'opencode-go'], ['opencode-go', 'opencode-go'],
   ];
   for (const [alias, key] of providerAliases) {
     const re = new RegExp('(^|\\s|[,;:])(' + alias.replace(/\s+/g, '\\s+') + ')(?=$|\\s|[,;:])', 'i');

--- a/tests/test_slash_setup_provider_aliases.py
+++ b/tests/test_slash_setup_provider_aliases.py
@@ -1,0 +1,29 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+def test_opencode_setup_provider_aliases_resolve():
+    source = Path("static/js/slashCommands.js").read_text()
+    match = re.search(
+        r"const SETUP_PROVIDER_URLS = \{[\s\S]*?\nfunction _normalizeSetupBaseUrl",
+        source,
+    )
+    assert match, "setup provider helper block not found"
+    helper_source = match.group(0).removesuffix("\nfunction _normalizeSetupBaseUrl")
+    script = helper_source + r"""
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+const zenFromCommand = _setupProviderFromInput('opencode zen');
+assert(zenFromCommand && zenFromCommand.url === 'https://opencode.ai/zen/v1', 'opencode zen command alias failed');
+const goFromCommand = _setupProviderFromInput('opencode-go');
+assert(goFromCommand && goFromCommand.url === 'https://opencode.ai/zen/go/v1', 'opencode-go command alias failed');
+const zenCredential = _extractSetupProviderCredential('opencode-zen sk-test');
+assert(zenCredential && zenCredential.provider.name === 'OpenCode Zen', 'opencode-zen credential provider failed');
+assert(zenCredential.credential === 'sk-test', 'opencode-zen credential extraction failed');
+const goCredential = _extractSetupProviderCredential('opencode go sk-test');
+assert(goCredential && goCredential.provider.name === 'OpenCode Go', 'opencode go credential provider failed');
+assert(goCredential.credential === 'sk-test', 'opencode go credential extraction failed');
+"""
+    subprocess.run(["node", "-e", script], check=True)


### PR DESCRIPTION
## Summary

Fixes the `/setup endpoint` provider-name path for OpenCode Zen and OpenCode Go. The setup guide can list those providers, but pasted values such as `opencode-go sk-...` were not recognized because the provider alias maps did not include the OpenCode slugs.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4699

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched open issues and open PRs — this is not a duplicate.
- [x] This PR targets `dev`.
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. See "How to Test" for what was run in this environment.

## How to Test

A reviewer can verify the fix in three steps:

1. **Static provider alias check** — run the focused regression test, which loads `static/js/slashCommands.js`, extracts the alias tables, and asserts the OpenCode entries are present:

   ```bash
   python3 -m pytest tests/test_slash_setup_provider_aliases.py -q
   ```

   Expected: `1 passed`. This covers both `_setupProviderFromInput` and `_extractSetupProviderCredential` lookup tables.

2. **Manual slash-command round-trip** — confirm the JS providers resolve to the right URL with a Node REPL:

   ```bash
   node -e "const fs = require('fs'); const src = fs.readFileSync('static/js/slashCommands.js','utf8'); /* paste snippet to evaluate */"
   ```

   Expected mappings (after this PR):

   - `opencode-go`   → `https://opencode.ai/zen/go/v1`
   - `opencode go`   → `https://opencode.ai/zen/go/v1`
   - `opencode-zen`  → `https://opencode.ai/zen/v1`
   - `opencode zen`  → `https://opencode.ai/zen/v1`

3. **End-to-end browser test** (optional, requires running Odysseus) — open the `/setup endpoint` flow, type `opencode-go sk-…` as the provider+key, and confirm the dropdown accepts it instead of returning "Provider not recognised."

   This step was **not run in this Linux cron environment** because the in-browser setup wizard needs a running Odysseus instance. It is safe to defer to a maintainer with the local dev stack.

Also run the standard local checks before merging:

```bash
node --check static/js/slashCommands.js
git diff --check origin/dev...HEAD
```

## Visual / UI changes

No CSS, HTML, SVG, layout, or rendering logic changed. This only adds OpenCode provider entries to the existing setup provider data and alias maps.
