### PR TITLE
fix(calendar): escape backslashes before quotes in CSS url() escaping

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -12,7 +12,7 @@ import {
   WEEKDAYS, WEEKDAYS_SUN, MONTHS, MON_SHORT,
   CAL_PALETTE, CAL_COLORS, _CAL_CUSTOM_GRADIENT, _TYPE_PALETTE,
   _trashIcon, _moreIcon, _bellIcon,
-  _isCalBgImage, _calBgImageUrl, _calBgCss,
+  _isCalBgImage, _calBgImageUrl, _calBgCss, _cssBgUrl,
   _calReadableTextColor,
   _ds, _addDays, _shiftDT, _tzOffset, _localDateOf,
 } from './calendar/utils.js';
@@ -413,7 +413,7 @@ function _calEventFg(ev) {
 // Returns '' for normal solid-color events.
 function _calItemBgStyle(ev) {
   if (!_isCalBgImage(ev.color)) return '';
-  const url = _calBgImageUrl(ev.color).replace(/'/g, "\\'").replace(/"/g, "%22");
+  const url = _cssBgUrl(_calBgImageUrl(ev.color));
   return `background-image: linear-gradient(color-mix(in srgb, var(--bg) 70%, transparent), color-mix(in srgb, var(--bg) 70%, transparent)), url('${url}'); background-size: cover; background-position: center;`;
 }
 
@@ -1260,7 +1260,7 @@ async function _renderWeek() {
       // events keep the original tinted treatment.
       let bgDecl;
       if (_isCalBgImage(ev.color)) {
-        const _url = _calBgImageUrl(ev.color).replace(/'/g, "\\'").replace(/"/g, "%22");
+        const _url = _cssBgUrl(_calBgImageUrl(ev.color));
         bgDecl = `background-image: linear-gradient(color-mix(in srgb, var(--bg) 55%, transparent), color-mix(in srgb, var(--bg) 55%, transparent)), url('${_url}'); background-size: cover; background-position: center;`;
       } else {
         bgDecl = `background:color-mix(in srgb, ${_calColor(ev)} 18%, var(--bg));`;
@@ -2853,7 +2853,7 @@ function _showEventForm(existing, defaultDate, defaultEndDate) {
             let bg;
             if (isCustom) {
               const url = _calBgImageUrl(cur);
-              bg = url ? `center/cover no-repeat url('${url}')` : _CAL_CUSTOM_GRADIENT;
+              bg = url ? `center/cover no-repeat url('${_cssBgUrl(url)}')` : _CAL_CUSTOM_GRADIENT;
             } else {
               bg = c.hex || 'var(--border)';
             }
@@ -2928,7 +2928,7 @@ function _showEventForm(existing, defaultDate, defaultEndDate) {
       // stays readable. Chrome accent falls back to the theme accent.
       const url = _calBgImageUrl(hex);
       _formCard.style.setProperty('--ev-color', 'var(--accent)');
-      _formCard.style.backgroundImage = `linear-gradient(color-mix(in srgb, var(--panel) 65%, transparent), color-mix(in srgb, var(--panel) 65%, transparent)), url('${url.replace(/'/g, "\\'")}')`;
+      _formCard.style.backgroundImage = `linear-gradient(color-mix(in srgb, var(--panel) 65%, transparent), color-mix(in srgb, var(--panel) 65%, transparent)), url('${_cssBgUrl(url)}')`;
       _formCard.style.backgroundSize = 'cover';
       _formCard.style.backgroundPosition = 'center';
       _formCard.classList.add('cal-form-bg-image');
@@ -2950,7 +2950,7 @@ function _showEventForm(existing, defaultDate, defaultEndDate) {
         if (!url) return;
         const sentinel = 'bg:' + url;
         dot.dataset.color = sentinel;
-        dot.style.background = `center/cover no-repeat url('${url}')`;
+        dot.style.background = `center/cover no-repeat url('${_cssBgUrl(url)}')`;
         document.querySelectorAll('#cal-f-colors .note-color-dot').forEach(d => d.classList.remove('active'));
         dot.classList.add('active');
         _applyFormTint(sentinel);

--- a/static/js/calendar/utils.js
+++ b/static/js/calendar/utils.js
@@ -65,13 +65,20 @@ export function _calBgImageUrl(c) {
   return _isCalBgImage(c) ? c.slice(3) : '';
 }
 
+// Escapes a URL for use inside a CSS url('...') single-quoted string.
+// Backslashes must be escaped before quotes — backslash is the CSS escape
+// character, so an unescaped backslash would neutralise the quote escape.
+export function _cssBgUrl(url) {
+  return url.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 // Returns a value safe to drop into `style="background:..."`. Falls back to
 // the calendar default for bg-image events in spots where an image would be
 // too small to render usefully (small grid dots, multi-day bars).
 export function _calBgCss(c, fallback) {
   if (_isCalBgImage(c)) {
     const u = _calBgImageUrl(c);
-    return u ? `center/cover no-repeat url('${u.replace(/'/g, "\\'")}')` : (fallback || 'var(--accent)');
+    return u ? `center/cover no-repeat url('${_cssBgUrl(u)}')` : (fallback || 'var(--accent)');
   }
   return c || fallback || 'var(--accent)';
 }


### PR DESCRIPTION
## Summary



The calendar's `bg:` image feature embeds CalDAV event URLs inside CSS `url('...')` strings.



The existing code escaped single quotes but did not escape backslashes first. Because a backslash is the CSS escape character, a URL ending in `\` produces:



```css

url('...\')

```



The backslash escapes the closing quote, preventing the string from closing correctly and potentially allowing arbitrary CSS injection.



Because `bg:` URLs can originate from CalDAV-synced events, they must be treated as untrusted external input. This is a real injection surface rather than a theoretical edge case.



## Changes



This PR:



* Adds a shared `_cssBgUrl()` helper in `calendar/utils.js`.

* Escapes backslashes before escaping single quotes, which is the required order.

* Exports the new helper.

* Replaces all six ad hoc inline escaping implementations across `calendar.js` and `utils.js` with calls to `_cssBgUrl()`.



## Target Branch



This PR targets `dev`, not `main`.



All PRs land in `dev`. The maintainer curates changes from `dev` into `main` for each release.



If this PR is targeting `main` by accident, click **Edit** and change the base branch to `dev`.



## Linked Issue



Fixes #4711



## Type of Change



* [x] Bug fix — non-breaking change that fixes a confirmed issue

* [ ] New feature — non-breaking change that adds new behavior

* [ ] Breaking change — changes or removes existing behavior

* [ ] Refactor or cleanup — behavior unchanged

* [ ] Documentation only

* [ ] CI, tooling, or configuration



## Checklist



* [x] I searched open issues and open PRs and confirmed this is not a duplicate.

* [x] This PR targets `dev`.

* [x] My changes are limited to the scope described above. No unrelated refactors or whitespace changes are included.

* [x] I ran the application using `docker compose up` or `uvicorn app:app` and verified the change end-to-end. Type checks and unit tests alone were not used as a substitute for running the application.



## How to Test



1. Start the application.

2. Connect a CalDAV calendar account.

3. Create or sync a calendar event that uses a custom `bg:` image URL.

4. Edit the event's color or background and select a custom image. The stored value should use the following format:



   ```text

   bg:<url>

   ```



### Happy Path



Confirm that the event still renders with its background image in:



* Month view

* Week view

* The event form card



The valid background-image behavior should be visually identical to the behavior before this change.



### Injection Path



Craft a `bg:` URL that ends with a backslash:



```text

bg:https://example.com/img\

```



Before this fix, the generated CSS is:



```css

url('https://example.com/img\')

```



The trailing backslash escapes the closing quote and breaks CSS string parsing.



After this fix, the generated CSS is:



```css

url('https://example.com/img\\')

```



The backslash is safely escaped, and the CSS string closes correctly.



## Visual and UI Changes



* [ ] Screenshot or short clip of the change in the running application attached below

* [x] The change uses Odysseus's existing visual language

* [x] No new styles were introduced

* [x] No new component patterns were introduced

* [x] This is a pure escaping fix in JavaScript string construction

* [x] I am not an LLM agent submitting a bulk PR



## Transparency Note



This fix was developed with assistance from Claude (`claude-sonnet-4-6`) for code analysis and authoring.



The change is a single, narrowly scoped security fix for issue #4711. It is not a bulk or automatically generated PR.



I am happy to discuss the approach or make any adjustments the maintainer prefers.



## Screenshots and Verification



There is no visual change for valid URLs. Events with background images render identically before and after this fix.



The injection path was verified through the browser console against the running application:



| Version    | Input URL                       | Generated CSS                           | Result                                                                            |

| ---------- | ------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------- |

| Before fix | `https://evil.example.com/img\` | `url('https://evil.example.com/img\')`  | ❌ The backslash escapes the closing quote, so the string does not close correctly |

| After fix  | `https://evil.example.com/img\` | `url('https://evil.example.com/img\\')` | ✅ The backslash is escaped, so the string closes correctly                        |



I also confirmed that `/static/js/calendar/utils.js`, as served by the running container, contains the `_cssBgUrl()` helper and the required backslash escaping.
