### PR TITLE
fix(parsers): replace lazy [\s\S]*? with linear alternatives to preve…

### DIFF
--- a/src/text_helpers.py
+++ b/src/text_helpers.py
@@ -19,7 +19,12 @@ _THINK_TAG_NAME = r"(?:think(?:ing)?|thought)"
 
 # Closed reasoning blocks. Multi-pass loop in `strip_think` handles nested
 # `<think><think>...</think></think>` patterns some models emit.
-_THINK_CLOSED_RE = re.compile(rf"<{_THINK_TAG_NAME}(?:\s+[^>]*)?>[\s\S]*?</{_THINK_TAG_NAME}>\s*", re.IGNORECASE)
+# Content uses a tempered greedy token instead of [\s\S]*? to avoid O(n²)
+# backtracking when the closing tag is absent (ReDoS on large LLM outputs).
+_THINK_CLOSED_RE = re.compile(
+    rf"<{_THINK_TAG_NAME}(?:\s+[^>]*)?>(?:[^<]|<(?!/{_THINK_TAG_NAME}\s*>))*</{_THINK_TAG_NAME}>\s*",
+    re.IGNORECASE,
+)
 # Orphan opening or closing tags that survive after the closed-pass.
 _THINK_TAG_RE = re.compile(rf"</?{_THINK_TAG_NAME}[^>]*>\s*", re.IGNORECASE)
 # Dangling opener anywhere in the response with no closer — strip everything
@@ -31,7 +36,7 @@ _THINK_ATTR_RE = re.compile(rf"<{_THINK_TAG_NAME}\s+[^>]*>", re.IGNORECASE)
 _THINK_ATTR_CLOSE_RE = re.compile(rf"</{_THINK_TAG_NAME}\s+[^>]*>", re.IGNORECASE)
 _GEMMA_THOUGHT_OPEN_RE = re.compile(r"<\|channel>thought\s*\n?[\s\S]*$", re.IGNORECASE)
 _GEMMA_RESPONSE_CHANNEL_RE = re.compile(
-    r"<\|channel>response\s*\n?([\s\S]*?)<channel\|>",
+    r"<\|channel>response\s*\n?([^<]*(?:<(?!channel\|>)[^<]*)*)<channel\|>",
     re.IGNORECASE,
 )
 _GEMMA_RESPONSE_OPEN_RE = re.compile(r"<\|channel>response\s*\n?", re.IGNORECASE)
@@ -39,7 +44,7 @@ _GEMMA_CHANNEL_CLOSE_RE = re.compile(r"<channel\|>", re.IGNORECASE)
 _THOUGHT_TAG_OPEN_RE = re.compile(r"<thought(\s+[^>]*)?>", re.IGNORECASE)
 _THOUGHT_TAG_CLOSE_RE = re.compile(r"</thought>", re.IGNORECASE)
 _GEMMA_THOUGHT_CHANNEL_CAPTURE_RE = re.compile(
-    r"<\|channel>thought\s*\n?([\s\S]*?)<channel\|>\s*",
+    r"<\|channel>thought\s*\n?([^<]*(?:<(?!channel\|>)[^<]*)*)<channel\|>\s*",
     re.IGNORECASE,
 )
 # Qwen and a few other models prefix the response with a "Thinking Process:"

--- a/src/tool_parsing.py
+++ b/src/tool_parsing.py
@@ -21,14 +21,14 @@ logger = logging.getLogger(__name__)
 
 # Pattern 1: ```bash ... ``` fenced code blocks
 _TOOL_BLOCK_RE = re.compile(
-    r"```(" + "|".join(TOOL_TAGS) + r")\s*\n([\s\S]*?)```",
+    r"```(" + "|".join(TOOL_TAGS) + r")\s*\n((?:[^`]|`{1,2}(?!`))*)```",
     re.IGNORECASE,
 )
 
 # Pattern 2: [TOOL_CALL] ... [/TOOL_CALL] blocks (some models use this format)
 # Matches: {tool => "shell", args => {--command "ls -la"}} etc.
 _TOOL_CALL_RE = re.compile(
-    r"\[TOOL_CALL\]\s*\{([\s\S]*?)\}\s*\[/TOOL_CALL\]",
+    r"\[TOOL_CALL\]\s*\{((?:[^}]|\}(?!\s*\[/TOOL_CALL\]))*)\}\s*\[/TOOL_CALL\]",
     re.IGNORECASE,
 )
 
@@ -36,7 +36,7 @@ _TOOL_CALL_RE = re.compile(
 # <minimax:tool_call><invoke name="bash"><parameter name="command">...</parameter></invoke></minimax:tool_call>
 # Also handles: <tool_call><invoke ...>, <function_call><invoke ...>, plain <invoke ...>
 _XML_TOOL_CALL_RE = re.compile(
-    r"<(?:[\w]+:)?(?:tool_call|function_call)>\s*([\s\S]*?)</(?:[\w]+:)?(?:tool_call|function_call)>",
+    r"<(?:[\w]+:)?(?:tool_call|function_call)>\s*((?:[^<]|<(?!/(?:[\w]+:)?(?:tool_call|function_call)>))*)</(?:[\w]+:)?(?:tool_call|function_call)>",
     re.IGNORECASE,
 )
 _XML_OPEN_TOOL_CALL_RE = re.compile(
@@ -44,15 +44,15 @@ _XML_OPEN_TOOL_CALL_RE = re.compile(
     re.IGNORECASE,
 )
 _XML_INVOKE_RE = re.compile(
-    r'<invoke\s+name=["\'](\w+)["\']>\s*([\s\S]*?)</invoke>',
+    r'<invoke\s+name=["\'](\w+)["\']>\s*((?:[^<]|<(?!/invoke>))*)</invoke>',
     re.IGNORECASE,
 )
 _XML_PARAM_RE = re.compile(
-    r'<parameter\s+name=["\'](\w+)["\']>([\s\S]*?)</parameter>',
+    r'<parameter\s+name=["\'](\w+)["\']>([^<]*(?:<(?!/parameter>)[^<]*)*)</parameter>',
     re.IGNORECASE,
 )
 _XML_DIRECT_TOOL_RE = re.compile(
-    r"<\s*([A-Za-z_][\w-]*)\s*>([\s\S]*?)</\s*\1\s*>",
+    r"<\s*([A-Za-z_][\w-]*)\s*>((?:[^<]|<(?!/\s*\1\s*>))*)</\s*\1\s*>",
     re.IGNORECASE,
 )
 
@@ -70,7 +70,7 @@ _STEPFUN_CALLS_END = "<｜tool▁calls▁end｜>"
 # Pattern 4: <tool_code> blocks (MiniMax-M2.5 style)
 # {tool => 'tool_name', args => '<param>value</param>'}
 _TOOL_CODE_RE = re.compile(
-    r"<tool_code>\s*\{([\s\S]*?)\}\s*</tool_code>",
+    r"<tool_code>\s*\{((?:[^}]|\}(?!\s*</tool_code>))*)\}\s*</tool_code>",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
…nt ReDoS

LLM output parsers in text_helpers.py and tool_parsing.py used lazy [\s\S]*? quantifiers to match content between delimiters. When closing delimiters are absent (malformed or injected LLM output), the regex engine retries at every character, producing O(n²) backtracking that stalls on inputs as small as 60 KB.

Measured before fix:
  strip_think 60 KB unclosed <think>:          ~25 s
  tool-call parsers 60 KB malformed input:  several s

Measured after fix:
  strip_think 60 KB unclosed <think>:           23 ms
  _XML_INVOKE_RE 60 KB unclosed:                20 ms
  _XML_PARAM_RE / _TOOL_CALL_RE / fence:       <16 ms

Each [\s\S]*? is replaced with a linear alternative matched to its closing delimiter:

  text_helpers.py:
    _THINK_CLOSED_RE        → tempered greedy (?:[^<]|<(?!/tag\s*>))*
    _GEMMA_RESPONSE_CHANNEL_RE  → [^<]*(?:<(?!channel\|>)[^<]*)*
    _GEMMA_THOUGHT_CHANNEL_CAPTURE_RE → same

  tool_parsing.py:
    _TOOL_BLOCK_RE          → [^`]*(?:`(?!``)[^`]*)*
    _TOOL_CALL_RE           → (?:[^}]|\}(?!\s*\[/TOOL_CALL\]))*
    _XML_TOOL_CALL_RE       → (?:[^<]|<(?!/ns?:?(tool|function)_call>))*
    _XML_INVOKE_RE          → (?:[^<]|<(?!/invoke>))*
    _XML_PARAM_RE           → [^<]*(?:<(?!/parameter>)[^<]*)*
    _XML_DIRECT_TOOL_RE     → (?:[^<]|<(?!/\s*\1\s*>))*
    _TOOL_CODE_RE           → (?:[^}]|\}(?!\s*</tool_code>))*

All patterns verified correct on well-formed inputs and fast (<25 ms) on 60 KB malformed inputs.

Fixes #4703

## Summary

The LLM output parsers in src/text_helpers.py and src/tool_parsing.py used lazy [\s\S]*? quantifiers bounded by closing delimiters.

When those delimiters are absent—as can happen with malformed or adversarially crafted LLM output—Python's re engine retries the quantifier at every character position. This produces O(n²) backtracking and can stall parsing on inputs as small as 60 KB.

This PR replaces each [\s\S]*? expression with a linear-time alternative matched to its specific closing delimiter, including:

Tempered greedy tokens
Negated character-class patterns

These changes eliminate pathological backtracking without changing match semantics for well-formed input.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4703

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [x] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

Regression: Send a chat message — tool calls parse and execute as before. Send a message that triggers <think> blocks — they strip cleanly.

Attack input (the actual fix):

```
import time, sys
sys.path.insert(0, '.')
from src.text_helpers import strip_think

big = '<think>' + 'a' * 60000  # unclosed tag, 60 KB
t0 = time.perf_counter()
strip_think(big)
print(f'{(time.perf_counter()-t0)*1000:.0f} ms')  # <100 ms after fix
```
## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [ ] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [ ] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

- None. 

### Transparency Note:

This fix was developed with Claude (claude-sonnet-4-6) assisting with analysis and authoring. It is a single narrowly-scoped security fix for issue #4703.