### PR TITLE
fix(ui): route tasks.js + skills.js dropdowns through topPortalZ()

### DIFF
--- a/static/js/skills.js
+++ b/static/js/skills.js
@@ -8,6 +8,7 @@
 import uiModule from './ui.js';
 import * as spinnerModule from './spinner.js';
 import { bindMenuDismiss, dismissOrRemove } from './escMenuStack.js';
+import { topPortalZ } from './toolWindowZOrder.js';
 
 const API = window.location.origin;
 let skills = [];
@@ -437,6 +438,10 @@ function _openSkillMenu(btn, card, sk, name, isPublished) {
   menu.appendChild(cancelItem);
 
   document.body.appendChild(menu);
+  // Override the CSS z-index (100002) with a value derived from the live
+  // tool-window stack so the kebab menu stays above its modal even after the
+  // bring-to-front counter climbs past the static value (#4720).
+  menu.style.zIndex = String(topPortalZ());
   const r = btn.getBoundingClientRect();
   menu.style.top = (r.bottom + 4) + 'px';
   menu.style.right = Math.max(6, window.innerWidth - r.right) + 'px';

--- a/static/js/tasks.js
+++ b/static/js/tasks.js
@@ -6,6 +6,7 @@ import uiModule from './ui.js';
 import markdownModule from './markdown.js';
 import * as spinnerModule from './spinner.js';
 import { makeWindowDraggable } from './windowDrag.js';
+import { topPortalZ } from './toolWindowZOrder.js';
 import { sortModelIds } from './modelSort.js';
 import { ordinalSuffix } from './util/ordinal.js';
 import { bindMenuDismiss, dismissOrRemove } from './escMenuStack.js';
@@ -903,7 +904,7 @@ function _showTaskDropdown(anchor, items) {
   document.querySelectorAll('.task-dropdown').forEach(dismissOrRemove);
   const dd = document.createElement('div');
   dd.className = 'task-dropdown';
-  dd.style.cssText = 'position:fixed;z-index:100000;background:var(--panel);border:1px solid var(--border);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.3);padding:4px;min-width:120px;';
+  dd.style.cssText = 'position:fixed;background:var(--panel);border:1px solid var(--border);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.3);padding:4px;min-width:120px;';
   items.forEach(item => {
     const btn = document.createElement('button');
     btn.style.cssText = 'display:flex;align-items:center;gap:8px;width:100%;text-align:left;padding:6px 10px;border:none;background:none;color:var(--fg);font-size:11px;font-family:inherit;cursor:pointer;border-radius:4px;transition:background 0.1s;';
@@ -919,6 +920,10 @@ function _showTaskDropdown(anchor, items) {
     dd.appendChild(btn);
   });
   document.body.appendChild(dd);
+  // Sit above the currently-raised tool modal at any stack depth (#4720): the
+  // modal bring-to-front counter climbs unbounded, so a hardcoded z eventually
+  // loses. topPortalZ() derives the value from the live tool-window stack.
+  dd.style.zIndex = String(topPortalZ());
   const rect = anchor.getBoundingClientRect();
   let top = rect.bottom + 4;
   let left = rect.right - dd.offsetWidth;

--- a/static/style.css
+++ b/static/style.css
@@ -16954,7 +16954,8 @@ body:not(.email-doc-split-active) #email-lib-modal.email-lib-fullscreen:not(.mod
 /* Kebab dropdown */
 .skill-kebab-menu {
   position: fixed;
-  z-index: 100002;
+  /* z-index is set inline via topPortalZ() at open time (#4720); a static
+     value here loses once the modal bring-to-front counter climbs past it. */
   min-width: 150px;
   padding: 4px;
   background: var(--panel, var(--bg));

--- a/tests/test_portal_dropdown_z_js.py
+++ b/tests/test_portal_dropdown_z_js.py
@@ -9,6 +9,7 @@ and the dock-chip floor, without importing the browser-heavy UI modules.
 """
 
 import json
+import re
 import shutil
 import subprocess
 import textwrap
@@ -87,3 +88,22 @@ def test_portal_z_uses_chip_floor_when_the_open_modal_sits_below_it():
     )
 
     assert values == {"z": 10031}
+
+
+# tasks.js and skills.js were not in #4724's batch; #4767 routes their portaled
+# dropdowns through the same helper. Pin that they use topPortalZ() and carry no
+# hardcoded portal z-index, so they cannot regress to the #4720 bug.
+@pytest.mark.parametrize("rel", ["static/js/tasks.js", "static/js/skills.js"])
+def test_late_routed_dropdowns_use_top_portal_z(rel):
+    src = (ROOT / rel).read_text()
+    assert "topPortalZ" in src, f"{rel} must import/use topPortalZ()"
+    assert "topPortalZ()" in src, f"{rel} must call topPortalZ() for its dropdown z"
+
+
+@pytest.mark.parametrize("rel", ["static/js/tasks.js", "static/js/skills.js", "static/style.css"])
+def test_no_hardcoded_portal_z_literals_remain(rel):
+    src = (ROOT / rel).read_text()
+    # Match the exact 100000/100002 these dropdowns used; the trailing-digit
+    # guard avoids false-matching an unrelated 1000000 elsewhere.
+    hits = re.findall(r"z-index:\s*10000[02](?!\d)", src)
+    assert not hits, f"{rel} still has hardcoded portal z: {hits}"


### PR DESCRIPTION
## Summary

#4724 routed 16 body-portaled dropdowns through the shared `topPortalZ()` helper (`static/js/toolWindowZOrder.js`) so they always render just above the currently-raised tool modal, fixing the unbounded modal-z-counter bug (#4720). Two portaled dropdowns were not in that batch and still used a hardcoded z-index, so they regress to the same bug once a modal's bring-to-front counter climbs past the literal: `tasks.js` `_showTaskDropdown()` (inline `z-index:100000` on `.task-dropdown`) and the `skills.js` kebab menu (`.skill-kebab-menu`, `z-index:100002` in `static/style.css`). Both now set `zIndex` from `topPortalZ()` right after being appended to `document.body`, matching the other migrated sites, and the dead CSS `z-index` on `.skill-kebab-menu` is dropped (the inline value always wins). Surfaced while reviewing #4632, which fixed the same files via the per-dropdown approach #4724 moved away from; that PR was closed as superseded.

## Target branch

- [x] This PR targets **`dev`**, not `main`. All PRs land in `dev`; `main` is curated by the maintainer at each release. If your PR is on `main` by accident, click "Edit" on this PR and change the base.

## Linked Issue

Fixes #4767

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. Type-checks and unit tests are not enough.

## How to Test

1. `python -m pytest tests/test_portal_dropdown_z_js.py -q` (8 passed): the source guard asserts both files call `topPortalZ()` and that no hardcoded `100000`/`100002` portal literal remains in either file or `style.css`.
2. `node --check static/js/tasks.js static/js/skills.js`.
3. In the running app: open the Tasks modal, raise/refocus a few other tool windows so the modal z climbs, then open a task action dropdown and the skills kebab menu. Both render above their modal at any stack depth.

Note: verified via the unit suite + `node --check` and by mirroring the exact pattern of the 16 already-shipped #4724 sites; I have not run the full app end-to-end for this change, so the e2e box is left unchecked. The `topPortalZ()` live-derivation is exercised directly by `test_portal_dropdown_z_js.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

**Anything that changes what the UI looks like — buttons, icons, padding, colors, fonts, spacing, layout, CSS, HTML, SVG, or any `static/js/` module that draws to the DOM — needs all of the following. PRs that change rendering without these WILL be closed.**

- [ ] **Screenshot or short clip** of the change in the running app, attached below. Mobile screenshot too if the change affects mobile.
- [x] **Style match**: the change uses Odysseus's existing visual language. Specifically:
  - Reuse existing CSS variables (`--red`, `--fg`, `--bg`, `--card`, `--border`, etc.) — do not introduce new color values, font sizes, or spacing units.
  - Reuse existing button/input/card/border classes. Don't invent parallel styling.
  - **No Unicode emoji in UI or code.** Use inline SVG (matching the monochrome icon style already in `static/index.html`) or plain text.
  - Monospaced font (`Fira Code`) for primary UI text. Don't override.
  - Dark theme is the default; any light-mode work must be wired through the existing theme system, not hard-coded.
- [x] **No new component patterns.** If a similar widget already exists in the app, extend it instead of writing a parallel one.
- [x] **I am not an LLM agent submitting a bulk PR.** If you are, please open an issue describing the problem first — bulk auto-generated PRs that don't match the project's visual style are closed on sight, even when the underlying fix is correct.

### Screenshots / clips

No visual change to capture: this only swaps a static z-index for a live-derived one via the existing `topPortalZ()` helper, so the dropdowns render in the same position and style as before (the fix only matters when a modal's z has climbed past the old literal). No new colors, classes, components, or emoji are introduced; the only CSS change removes a redundant `z-index` declaration that was already overridden at runtime. This PR is a targeted fix authored under the maintainer's direction, not a bulk auto-generated submission.