### PR TITLE
refactor(exceptions): dedupe src/exceptions via core re-export

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,4 +1,4 @@
-# src/exceptions.py
+# core/exceptions.py
 """Custom exceptions for the application."""
 
 class SessionNotFoundError(Exception):

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,29 +1,22 @@
 # src/exceptions.py
-"""Custom exceptions for the application."""
+"""Backward-compatible shim — the single source of truth is core/exceptions.py.
 
-class SessionNotFoundError(Exception):
-    """Raised when a requested session is not found."""
-    def __init__(self, session_id: str):
-        self.session_id = session_id
-        super().__init__(f"Session '{session_id}' not found")
+Historically this module was a byte-for-byte duplicate of core/exceptions.py,
+which is the canonical definition (imported by app.py, core/__init__.py, and
+routes/chat_routes.py). To kill the drift, this now simply re-exports the
+exception classes from core.exceptions so there is exactly one place that
+defines them. Existing `from src.exceptions import ...` callers keep working.
+"""
+from core.exceptions import (  # noqa: F401
+    SessionNotFoundError,
+    InvalidFileUploadError,
+    LLMServiceError,
+    WebSearchError,
+)
 
-class InvalidFileUploadError(Exception):
-    """Raised when a file upload fails validation."""
-    def __init__(self, message: str, filename: str = None):
-        self.filename = filename
-        self.message = message
-        super().__init__(message)
-
-class LLMServiceError(Exception):
-    """Raised when there is an error communicating with the LLM service."""
-    def __init__(self, message: str, endpoint: str = None):
-        self.endpoint = endpoint
-        self.message = message
-        super().__init__(message)
-
-class WebSearchError(Exception):
-    """Raised when there is an error with web search functionality."""
-    def __init__(self, message: str, query: str = None):
-        self.query = query
-        self.message = message
-        super().__init__(message)
+__all__ = [
+    "SessionNotFoundError",
+    "InvalidFileUploadError",
+    "LLMServiceError",
+    "WebSearchError",
+]


### PR DESCRIPTION
## Summary

`src/exceptions.py` was a byte-for-byte duplicate of the canonical `core/exceptions.py` (same git blob; both even carried the same wrong `# src/exceptions.py` header). `core.exceptions` is canonical — imported by `app.py`, `core/__init__.py`, and `routes/chat_routes.py` — while `src.exceptions` is only used by `tests/test_app.py`. This replaces the duplicated class bodies in `src/exceptions.py` with a thin re-export shim of `core.exceptions` (mirroring the existing `core/constants.py` → `src/constants.py` backward-compat pattern) and fixes the stale `# src/exceptions.py` header comment in `core/exceptions.py`. No behavior change — both import paths resolve to the same class objects, so `except SessionNotFoundError` works regardless of which module it was imported from.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4814

## Type of Change

- [ ] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [x] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. _(Pure import-layer change; verified via `py_compile`, the existing import test, and an identity check — see How to Test.)_

## How to Test

- `python -m py_compile src/exceptions.py core/exceptions.py app.py` → clean.
- `python -m pytest tests/test_app.py` → 12 passed (includes `test_exceptions_importable`, which imports the four classes from `src.exceptions` via the new shim).
- Identity check — confirms the shim re-exports the *same* class objects (so exception handling is unaffected):
  ```
  python -c "import src.exceptions as s, core.exceptions as c; assert all(getattr(s,n) is getattr(c,n) for n in ('SessionNotFoundError','InvalidFileUploadError','LLMServiceError','WebSearchError')); print('OK: identical objects via both paths')"
  ```

## Visual / UI changes

N/A — import-layer/refactor only, nothing renders. Disclosure: this is an agent-assisted PR; issue #4814 was opened first per CONTRIBUTING, and it is a single focused cleanup, not a bulk submission.
