### PR TITLE
fix(setup): load .env so a pre-seeded admin password is honored on native installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,15 @@ def check_arch():
 def main():
     print("\n=== Odysseus Setup ===\n")
 
+    # Load .env so pre-seeded ODYSSEUS_ADMIN_USER / ODYSSEUS_ADMIN_PASSWORD (and
+    # other deployment vars) are honored on native installs, not just when they
+    # are exported in the shell. Mirrors app.py: encoding="utf-8-sig" tolerates a
+    # UTF-8 BOM in a Notepad-saved .env. load_dotenv does not override already
+    # exported OS env vars, so the existing precedence is preserved. python-dotenv
+    # is a hard dependency (requirements.txt) and is verified by check_deps below.
+    from dotenv import load_dotenv
+    load_dotenv(os.path.join(BASE_DIR, ".env"), encoding="utf-8-sig")
+
     # Fail fast with a clear message if the CPU architecture is wrong (Apple
     # Silicon under an x86/Rosetta Python) before importing anything native.
     check_arch()

--- a/tests/test_setup_admin_user.py
+++ b/tests/test_setup_admin_user.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 from pathlib import Path
 
 
@@ -23,3 +24,49 @@ def test_create_default_admin_normalizes_env_username(tmp_path, monkeypatch):
     data = json.loads(auth_path.read_text(encoding="utf-8"))
     assert "adminuser" in data["users"]
     assert "AdminUser" not in data["users"]
+
+
+def test_main_loads_admin_password_from_env_file(tmp_path, monkeypatch):
+    """Regression: setup.py must honor an admin password pre-seeded in .env on
+    native installs, even when the var is not exported into the shell
+    (docs/setup.md documents this). Previously setup.py never called
+    load_dotenv(), so os.getenv() saw nothing and a random password was
+    generated instead."""
+    import bcrypt
+
+    setup_module = _load_setup_module()
+
+    # Credentials live ONLY in a .env beside setup.py (written with a UTF-8 BOM,
+    # the Notepad-on-Windows case that utf-8-sig must tolerate) — not exported.
+    monkeypatch.delenv("ODYSSEUS_ADMIN_USER", raising=False)
+    monkeypatch.delenv("ODYSSEUS_ADMIN_PASSWORD", raising=False)
+    (tmp_path / ".env").write_text(
+        "ODYSSEUS_ADMIN_USER=presetuser\nODYSSEUS_ADMIN_PASSWORD=fromenvfile12345\n",
+        encoding="utf-8-sig",
+    )
+
+    # Point setup at the temp dir and neutralize main()'s heavy steps.
+    monkeypatch.setattr(setup_module, "BASE_DIR", str(tmp_path))
+    auth_path = tmp_path / "auth.json"
+    monkeypatch.setattr(setup_module, "AUTH_FILE", str(auth_path))
+    monkeypatch.setattr(setup_module, "check_arch", lambda: None)
+    monkeypatch.setattr(setup_module, "create_dirs", lambda: None)
+    monkeypatch.setattr(setup_module, "create_env", lambda: None)
+    monkeypatch.setattr(setup_module, "check_deps", lambda: None)
+    monkeypatch.setattr(setup_module, "init_database", lambda: None)
+    # Force the non-interactive branch so the test never blocks on a prompt.
+    monkeypatch.setenv("ODYSSEUS_SKIP_ADMIN_PROMPT", "1")
+
+    try:
+        setup_module.main()
+    finally:
+        # load_dotenv writes real os.environ entries; undo so sibling tests
+        # don't inherit them.
+        os.environ.pop("ODYSSEUS_ADMIN_USER", None)
+        os.environ.pop("ODYSSEUS_ADMIN_PASSWORD", None)
+
+    data = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert "presetuser" in data["users"], data
+    assert bcrypt.checkpw(
+        b"fromenvfile12345", data["users"]["presetuser"]["password_hash"].encode()
+    ), "admin password from .env was ignored; a random one was generated"


### PR DESCRIPTION
## Summary

On native (non-Docker) installs, `setup.py` read `ODYSSEUS_ADMIN_USER` / `ODYSSEUS_ADMIN_PASSWORD` via `os.getenv()` (setup.py:101-102) but never called `load_dotenv()`, so a password pre-seeded in `.env` (documented in `docs/setup.md` and `.env.example`) was silently ignored and a random one generated — breaking the intended first login. This adds `load_dotenv(os.path.join(BASE_DIR, ".env"), encoding="utf-8-sig")` at the top of `main()`, mirroring `app.py:31-37`, so `.env`-seeded values are honored. Docker was unaffected because `docker-compose.yml` injects the vars into the container environment. `load_dotenv` does not override already-exported OS env vars, so the existing precedence (exported var > .env > prompt > random) is preserved; `python-dotenv` is already a required dependency.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Fixes #4786

## Type of Change

- [x] Bug fix (non-breaking — fixes a confirmed issue)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate.
- [x] This PR targets `dev`
- [x] My changes are limited to the scope described above — no unrelated refactors or whitespace changes mixed in.
- [ ] I actually ran the app (`docker compose up` or `uvicorn app:app`) and verified the change works end-to-end. _(See How to Test: verified via a regression test that exercises `setup.py`'s `main()` in-process; I did not run a full fresh-install on this machine.)_

## How to Test

**Manual repro (before vs after):**
1. `git checkout fix/setup-load-dotenv`
2. Create a `.env` beside `setup.py` with `ODYSSEUS_ADMIN_USER=me` and `ODYSSEUS_ADMIN_PASSWORD=mychosenpass123`, **without** exporting them into your shell.
3. Run `python setup.py`. On the current code it prints `Temporary password: <random>` and your password is ignored; with this change the admin account uses `mychosenpass123` and first login works.

**Automated:**
- `python -m pytest tests/test_setup_admin_user.py` → 2 passed. The new `test_main_loads_admin_password_from_env_file` writes a UTF-8-BOM `.env`, runs `main()` with the heavy steps monkeypatched out, and asserts via `bcrypt.checkpw` that the stored hash matches the pre-seeded password. It **fails on the current code** (random password generated for `admin`) and **passes with the fix**.
- `python -m py_compile setup.py app.py` → clean.

## Visual / UI changes

N/A — backend-only change (`setup.py`), nothing renders. Disclosure: this is an agent-assisted PR; I opened issue #4786 first per CONTRIBUTING, and it is a single focused fix, not a bulk submission.
