### PR TITLE
fix(routes): 500 (not 404) when the app-shell index.html is missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -806,10 +806,12 @@ async def serve_index(request: Request):
     static_path = abs_join(BASE_DIR, "static/index.html")
     if os.path.exists(static_path):
         return serve_html_with_nonce(request, static_path)
-    root_path = abs_join(BASE_DIR, "index.html")
-    if os.path.exists(root_path):
-        return serve_html_with_nonce(request, root_path)
-    raise HTTPException(404, "index.html not found")
+    # No static bundle — fall back to a root-level index.html if one is shipped.
+    # If neither exists, serve_html_with_nonce logs it and returns a generic 500:
+    # a missing index.html is a broken deployment (server fault), not a client
+    # "not found". This keeps the app-shell route consistent with the other
+    # bundled-template routes instead of mislabelling the fault as a 404.
+    return serve_html_with_nonce(request, abs_join(BASE_DIR, "index.html"))
 
 @app.get("/notes")
 async def serve_notes(request: Request):


### PR DESCRIPTION
## Summary

Follow-up to #4637 (which made unreadable bundled templates return a logged, leak-safe 500). `serve_index` — the handler for `/` **and** the SPA deep-link routes that delegate to it (`/notes`, `/calendar`, `/cookbook`, `/email`, `/memory`, `/gallery`, `/tasks`, `/library`) — still pre-checked `os.path.exists` and raised its own `HTTPException(404, "index.html not found")` when the bundle was missing. So a missing core template returned **404** before `serve_html_with_nonce`'s 500 could fire — the one spot left inconsistent after #4637.

`index.html` is a fixed, app-bundled template; a missing one is a broken deployment (a server fault), not a client "not found", so it should surface as a logged **500** that 5xx alerting can see, not a 404. This keeps the existing static → root fallback, drops the redundant existence guard and the dead-end 404, and lets the shared helper handle the missing case. The happy path is unchanged (static bundle present → 200).

Credit to @vdmkenny for flagging this as a follow-up on #4637.

## Target branch

- [x] This PR targets **`dev`**, not `main`.

## Linked Issue

Follow-up to #4637 (reviewer suggestion). No separate issue.

## Type of Change

- [x] Bug fix (non-breaking — makes the app-shell route consistent with the bundled-template error handling from #4637)
- [ ] New feature (non-breaking — adds new behaviour)
- [ ] Breaking change (changes or removes existing behaviour)
- [ ] Refactor / cleanup (behaviour unchanged)
- [ ] Documentation only
- [ ] CI / tooling / configuration

## Checklist

- [x] I searched [open issues](https://github.com/pewdiepie-archdaemon/odysseus/issues) and [open PRs](https://github.com/pewdiepie-archdaemon/odysseus/pulls) — this is not a duplicate (no existing PR/issue touches `serve_index`).
- [x] This PR targets `dev`.
- [x] Scope is limited to the one-spot fix — no unrelated refactors or whitespace changes.
- [x] I actually ran the app (`uvicorn app:app`) and verified the change works end-to-end (see below).

## How to Test

`static/index.html` is normally present, so `/` returns 200. To exercise the missing case, move it aside temporarily:

```bash
AUTH_ENABLED=false python -m uvicorn app:app --host 127.0.0.1 --port 7801
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7801/        # 200 (bundle present)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7801/notes   # 200 (delegates to serve_index)
mv static/index.html static/index.html.bak
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7801/        # 500 (was 404)
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7801/notes   # 500
mv static/index.html.bak static/index.html
```

What I ran (Windows native, Python 3.11, project venv):

- `/` and `/notes` → **200** with the bundle present, **500** when `index.html` is missing, **200** again after restoring it.
- The 500 is logged server-side while the client body stays generic: the log shows `src.app_helpers - ERROR - Failed to read page ...\index.html` with the traceback; the response carries only `Internal server error`.
- `python -m pytest tests/test_serve_html_with_nonce.py` → **3 passed** (the helper's missing → 500 behaviour this route now relies on).
- `python -m py_compile app.py` → OK.

**Note on automated coverage:** these page routes live in `app.py`, which the suite intentionally cannot import (`tests/conftest.py` stubs `src.database`, so importing `app` under pytest fails). So I verified the route against the running app rather than add a test that imports `app`; the helper's missing → 500 path is unit-tested in `tests/test_serve_html_with_nonce.py`.

## Visual / UI changes — REQUIRED if you touched anything that renders

Not applicable — this is a backend error-handling change in `app.py`. Nothing that renders to the UI (HTML/CSS/SVG/`static/js/`) was touched.
